### PR TITLE
Add tests for post object queries.

### DIFF
--- a/tests/test-post-object-queries.php
+++ b/tests/test-post-object-queries.php
@@ -101,8 +101,8 @@ class WP_GraphQL_Test_Post_Object_Queries extends WP_UnitTestCase {
 		 * Create the query string to pass to the $query
 		 */
 		$query = "
-		query { 
-			post(id: \"{$global_id}\") { 
+		query {
+			post(id: \"{$global_id}\") {
 				id
 				author{
 					userId
@@ -131,7 +131,7 @@ class WP_GraphQL_Test_Post_Object_Queries extends WP_UnitTestCase {
 				slug
 				toPing
 				title
-			} 
+			}
 		}";
 
 		/**
@@ -181,83 +181,195 @@ class WP_GraphQL_Test_Post_Object_Queries extends WP_UnitTestCase {
 	}
 
 	/**
-	 * testPostsConnectionQuery
+	 * testPostQueryWithComments
 	 *
-	 * This tests creating a 3 posts with data and retrieving said posts via a GraphQL query
+	 * This tests creating a single post with comments.
 	 *
 	 * @since 0.0.5
 	 */
-	public function testPostsConnectionQuery() {
+	public function testPostQueryWithComments() {
 
 		/**
-		 * Create 3 new pages to query against
+		 * Create a post
 		 */
-		$page_1 = $this->createPostObject( [ 'post_type' => 'page' ] );
-		$page_2 = $this->createPostObject( [ 'post_type' => 'page' ] );
-		$page_3 = $this->createPostObject( [ 'post_type' => 'page' ] );
+		$post_id = $this->createPostObject( [ 'post_type' => 'post' ] );
+
+		// Create a comment and assign it to post.
+		$comment_id = $this->factory->comment->create( [ 'comment_post_ID' => $post_id ] );
 
 		/**
-		 * Get the global IDs from the pages
+		 * Create the global ID based on the post_type and the created $id
 		 */
-		$global_id_1 = \GraphQLRelay\Relay::toGlobalId( 'page', $page_1 );
-		$global_id_2 = \GraphQLRelay\Relay::toGlobalId( 'page', $page_2 );
-		$global_id_3 = \GraphQLRelay\Relay::toGlobalId( 'page', $page_3 );
+		$global_id = \GraphQLRelay\Relay::toGlobalId( 'post', $post_id );
 
 		/**
 		 * Create the query string to pass to the $query
 		 */
-		$query = '
-		query{
-		  pages {
-		    edges {
-		      node {
-		        id
-		        pageId
-		        author {
-		          userId
-		        }
-		      }
-		    }
-		  }
-		}
-		';
+		$query = "
+		query {
+			post(id: \"{$global_id}\") {
+				id
+				commentCount
+				commentStatus
+				comments {
+					edges {
+						node {
+							commentId
+						}
+					}
+				}
+			}
+		}";
 
 		/**
 		 * Run the GraphQL query
 		 */
-		$actual = $actual = do_graphql_request( $query );
+		$actual = do_graphql_request( $query );
 
 		/**
 		 * Establish the expectation for the output of the query
 		 */
 		$expected = [
 			'data' => [
-				'pages' => [
-					'edges' => [
-						[
-							'node' => [
-								'id' => $global_id_1,
-								'pageId' => $page_1,
-								'author' => [
-									'userId' => $this->admin,
+				'post' => [
+					'id' => $global_id,
+					'comments' => [
+						'edges' => [
+							[
+								'node' => [
+									'commentId' => $comment_id,
 								],
 							],
 						],
-						[
-							'node' => [
-								'id' => $global_id_2,
-								'pageId' => $page_2,
-								'author' => [
-									'userId' => $this->admin,
-								],
-							],
-						],
-						[
-							'node' => [
-								'id' => $global_id_3,
-								'pageId' => $page_3,
-								'author' => [
-									'userId' => $this->admin,
+					],
+					'commentCount' => 1,
+					'commentStatus' => 'open',
+				],
+			],
+		];
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * testPageQueryWithParent
+	 *
+	 * This tests a hierarchical post type assigned a parent.
+	 *
+	 * @since 0.0.5
+	 */
+	public function testPageQueryWithParent() {
+
+		// Parent post.
+		$parent_id = $this->createPostObject( [ 'post_type' => 'page' ] );
+
+		/**
+		 * Create a post
+		 */
+		$post_id = $this->createPostObject( [ 'post_type' => 'page', 'post_parent' => $parent_id ] );
+
+		/**
+		 * Create the global ID based on the post_type and the created $id
+		 */
+		$global_id = \GraphQLRelay\Relay::toGlobalId( 'page', $post_id );
+
+		/**
+		 * Create the query string to pass to the $query
+		 */
+		$query = "
+		query {
+			page(id: \"{$global_id}\") {
+				id
+				parent {
+					... on page {
+						pageId
+					}
+				}
+			}
+		}";
+
+		/**
+		 * Run the GraphQL query
+		 */
+		$actual = do_graphql_request( $query );
+
+		/**
+		 * Establish the expectation for the output of the query
+		 */
+		$expected = [
+			'data' => [
+				'page' => [
+					'id' => $global_id,
+					'parent' => [
+						'pageId' => $parent_id,
+					],
+				],
+			],
+		];
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * testPostQueryWithTags
+	 *
+	 * This tests creating a single post with assigned post tags.
+	 *
+	 * @since 0.0.5
+	 */
+	public function testPostQueryWithTags() {
+
+		/**
+		 * Create a post
+		 */
+		$post_id = $this->createPostObject( [ 'post_type' => 'post' ] );
+
+		// Create a comment and assign it to post.
+		$tag_id = $this->factory->tag->create( [ 'name' => 'A tag' ] );
+
+		wp_set_object_terms( $post_id, $tag_id, 'post_tag' );
+
+		/**
+		 * Create the global ID based on the post_type and the created $id
+		 */
+		$global_id = \GraphQLRelay\Relay::toGlobalId( 'post', $post_id );
+
+		/**
+		 * Create the query string to pass to the $query
+		 */
+		$query = "
+		query {
+			post(id: \"{$global_id}\") {
+				id
+				postTags {
+					edges {
+						node {
+							postTagId
+							name
+						}
+					}
+				}
+			}
+		}";
+
+		/**
+		 * Run the GraphQL query
+		 */
+		$actual = do_graphql_request( $query );
+
+		/**
+		 * Establish the expectation for the output of the query
+		 */
+		$expected = [
+			'data' => [
+				'post' => [
+					'id' => $global_id,
+					'postTags' => [
+						'edges' => [
+							[
+								'node' => [
+									'postTagId' => $tag_id,
+									'name' => 'A tag',
 								],
 							],
 						],
@@ -267,7 +379,76 @@ class WP_GraphQL_Test_Post_Object_Queries extends WP_UnitTestCase {
 		];
 
 		$this->assertEquals( $expected, $actual );
-
 	}
 
+	/**
+	 * testPostQueryWithCategories
+	 *
+	 * This tests creating a single post with categories assigned.
+	 *
+	 * @since 0.0.5
+	 */
+	public function testPostQueryWithCategories() {
+
+		/**
+		 * Create a post
+		 */
+		$post_id = $this->createPostObject( [ 'post_type' => 'post' ] );
+
+		// Create a comment and assign it to post.
+		$category_id = $this->factory->category->create( [ 'name' => 'A category' ] );
+
+		wp_set_object_terms( $post_id, $category_id, 'category' );
+
+		/**
+		 * Create the global ID based on the post_type and the created $id
+		 */
+		$global_id = \GraphQLRelay\Relay::toGlobalId( 'post', $post_id );
+
+		/**
+		 * Create the query string to pass to the $query
+		 */
+		$query = "
+		query {
+			post(id: \"{$global_id}\") {
+				id
+				categories {
+					edges {
+						node {
+							categoryId
+							name
+						}
+					}
+				}
+			}
+		}";
+
+		/**
+		 * Run the GraphQL query
+		 */
+		$actual = do_graphql_request( $query );
+
+		/**
+		 * Establish the expectation for the output of the query
+		 */
+		$expected = [
+			'data' => [
+				'post' => [
+					'id' => $global_id,
+					'categories' => [
+						'edges' => [
+							[
+								'node' => [
+									'categoryId' => $category_id,
+									'name' => 'A category',
+								],
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$this->assertEquals( $expected, $actual );
+	}
 }


### PR DESCRIPTION
Closes #66. This covers the basic needs present for testing the
PostObjectType.