### PR TITLE
#147 - Change postTags to tags

### DIFF
--- a/tests/test-post-object-queries.php
+++ b/tests/test-post-object-queries.php
@@ -353,10 +353,10 @@ class WP_GraphQL_Test_Post_Object_Queries extends WP_UnitTestCase {
 		query {
 			post(id: \"{$global_id}\") {
 				id
-				postTags {
+				tags {
 					edges {
 						node {
-							postTagId
+							tagId
 							name
 						}
 					}
@@ -376,11 +376,11 @@ class WP_GraphQL_Test_Post_Object_Queries extends WP_UnitTestCase {
 			'data' => [
 				'post' => [
 					'id' => $global_id,
-					'postTags' => [
+					'tags' => [
 						'edges' => [
 							[
 								'node' => [
-									'postTagId' => $tag_id,
+									'tagId' => $tag_id,
 									'name' => 'A tag',
 								],
 							],

--- a/tests/test-post-type-object-queries.php
+++ b/tests/test-post-type-object-queries.php
@@ -107,7 +107,7 @@ class WP_GraphQL_Test_PostType_Object_Queries extends WP_UnitTestCase {
 					menuIcon
 					menuPosition
 					name
-					postTags {
+					tags {
 						edges {
 							node {
 								name
@@ -187,7 +187,7 @@ class WP_GraphQL_Test_PostType_Object_Queries extends WP_UnitTestCase {
 						'menuIcon' => null,
 						'menuPosition' => 5,
 						'name' => 'post',
-						'postTags' => [
+						'tags' => [
 							'edges' => [],
 						],
 						'public' => true,
@@ -236,10 +236,10 @@ class WP_GraphQL_Test_PostType_Object_Queries extends WP_UnitTestCase {
 		query {
 			posts {
 				postTypeInfo {
-					postTags {
+					tags {
 						edges {
 							node {
-								postTagId
+								tagId
 								name
 							}
 						}
@@ -268,11 +268,11 @@ class WP_GraphQL_Test_PostType_Object_Queries extends WP_UnitTestCase {
 			'data' => [
 				'posts' => [
 					'postTypeInfo' => [
-						'postTags' => [
+						'tags' => [
 							'edges' => [
 								[
 									'node' => [
-										'postTagId' => $tag_id,
+										'tagId' => $tag_id,
 										'name' => 'A tag',
 									],
 								],
@@ -340,7 +340,7 @@ class WP_GraphQL_Test_PostType_Object_Queries extends WP_UnitTestCase {
 					menuIcon
 					menuPosition
 					name
-					postTags {
+					tags {
 						edges {
 							node {
 								name
@@ -391,7 +391,7 @@ class WP_GraphQL_Test_PostType_Object_Queries extends WP_UnitTestCase {
 						'menuIcon' => null,
 						'menuPosition' => 20,
 						'name' => 'page',
-						'postTags' => [
+						'tags' => [
 							'edges' => [],
 						],
 						'public' => true,
@@ -440,10 +440,10 @@ class WP_GraphQL_Test_PostType_Object_Queries extends WP_UnitTestCase {
 		query {
 			pages {
 				postTypeInfo {
-					postTags {
+					tags {
 						edges {
 							node {
-								postTagId
+								tagId
 								name
 							}
 						}
@@ -472,7 +472,7 @@ class WP_GraphQL_Test_PostType_Object_Queries extends WP_UnitTestCase {
 			'data' => [
 				'pages' => [
 					'postTypeInfo' => [
-						'postTags' => [
+						'tags' => [
 							'edges' => [],
 						],
 						'categories' => [
@@ -530,7 +530,7 @@ class WP_GraphQL_Test_PostType_Object_Queries extends WP_UnitTestCase {
 					menuIcon
 					menuPosition
 					name
-					postTags {
+					tags {
 						edges {
 							node {
 								name
@@ -581,7 +581,7 @@ class WP_GraphQL_Test_PostType_Object_Queries extends WP_UnitTestCase {
 						'menuIcon' => null,
 						'menuPosition' => null,
 						'name' => 'attachment',
-						'postTags' => [
+						'tags' => [
 							'edges' => [],
 						],
 						'public' => true,
@@ -630,10 +630,10 @@ class WP_GraphQL_Test_PostType_Object_Queries extends WP_UnitTestCase {
 		query {
 			pages {
 				postTypeInfo {
-					postTags {
+					tags {
 						edges {
 							node {
-								postTagId
+								tagId
 								name
 							}
 						}
@@ -662,7 +662,7 @@ class WP_GraphQL_Test_PostType_Object_Queries extends WP_UnitTestCase {
 			'data' => [
 				'pages' => [
 					'postTypeInfo' => [
-						'postTags' => [
+						'tags' => [
 							'edges' => [],
 						],
 						'categories' => [

--- a/tests/test-taxonomy-object-queries.php
+++ b/tests/test-taxonomy-object-queries.php
@@ -138,7 +138,7 @@ class WP_GraphQL_Test_Taxonomy_Object_Queries extends WP_UnitTestCase {
 		 */
 		$query = "
 		query {
-			postTags {
+			tags {
 				taxonomyInfo {
 					connectedPostTypeNames
 					connectedPostTypes {
@@ -185,13 +185,13 @@ class WP_GraphQL_Test_Taxonomy_Object_Queries extends WP_UnitTestCase {
 		 */
 		$expected = [
 			'data' => [
-				'postTags' => [
+				'tags' => [
 					'taxonomyInfo' => [
 						'connectedPostTypeNames' => [ 'post' ],
 						'connectedPostTypes' => [ [ 'name' => 'post'] ],
 						'description' => '',
-						'graphqlPluralName' => 'postTags',
-						'graphqlSingleName' => 'postTag',
+						'graphqlPluralName' => 'tags',
+						'graphqlSingleName' => 'tag',
 						'hierarchical' => false,
 						'id' => $global_id,
 						'label' => 'Tags',
@@ -304,7 +304,7 @@ class WP_GraphQL_Test_Taxonomy_Object_Queries extends WP_UnitTestCase {
 		 */
 		$query = "
 		query {
-			postTags {
+			tags {
 				taxonomyInfo {
 					name
 					posts {
@@ -330,7 +330,7 @@ class WP_GraphQL_Test_Taxonomy_Object_Queries extends WP_UnitTestCase {
 		 */
 		$expected = [
 			'data' => [
-				'postTags' => [
+				'tags' => [
 					'taxonomyInfo' => [
 						'name' => 'post_tag',
 						'posts' => [

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -254,8 +254,8 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 			// Adds GraphQL support for tags
 			if ( isset( $wp_taxonomies['post_tag'] ) ) {
 				$wp_taxonomies['post_tag']->show_in_graphql     = true;
-				$wp_taxonomies['post_tag']->graphql_single_name = 'postTag';
-				$wp_taxonomies['post_tag']->graphql_plural_name = 'postTags';
+				$wp_taxonomies['post_tag']->graphql_single_name = 'tag';
+				$wp_taxonomies['post_tag']->graphql_plural_name = 'tags';
 			}
 		}
 


### PR DESCRIPTION
**NOTE**: This is a breaking change.

Since tags can be connected to anything, not just posts, having the GraphQL Scheme use `postTags` as the naming just didn't make sense.

This PR changes the naming for the "post_tag" taxonomy to use "tag" and "tags". 

If you already have consumers consuming tags via the `postTag` naming convention, this change will break their queries, but you can use the action below to bring back the postTag naming convention for your system. 

```
add_action( 'graphql_generate_schema', function() {

	global $wp_taxonomies;

	if ( isset( $wp_taxonomies['post_tag'] ) ) {
		$wp_taxonomies['post_tag']->graphql_single_name = 'postTag';
		$wp_taxonomies['post_tag']->graphql_plural_name = 'postTags';
	}

} );
```