### PR TITLE
#152-translations-late-escaping

### DIFF
--- a/src/Type/Avatar/AvatarType.php
+++ b/src/Type/Avatar/AvatarType.php
@@ -47,7 +47,7 @@ class AvatarType extends WPObjectType {
 		$config = [
 			'name'        => self::$type_name,
 			'fields'      => self::fields(),
-			'description' => esc_html__( 'Avatars are profile images for users. WordPress by default uses the Gravatar service to host and fetch avatars from.', 'wp-graphql' ),
+			'description' => __( 'Avatars are profile images for users. WordPress by default uses the Gravatar service to host and fetch avatars from.', 'wp-graphql' ),
 		];
 
 		parent::__construct( $config );
@@ -70,52 +70,52 @@ class AvatarType extends WPObjectType {
 				$fields = [
 					'size'         => [
 						'type'        => Types::int(),
-						'description' => esc_html__( 'The size of the avatar in pixels. A value of 96 will match a 96px x 96px gravatar image.', 'wp-graphql' ),
+						'description' => __( 'The size of the avatar in pixels. A value of 96 will match a 96px x 96px gravatar image.', 'wp-graphql' ),
 					],
 					'height'       => [
 						'type'        => Types::int(),
-						'description' => esc_html__( 'Height of the avatar image.', 'wp-graphql' ),
+						'description' => __( 'Height of the avatar image.', 'wp-graphql' ),
 					],
 					'width'        => [
 						'type'        => Types::int(),
-						'description' => esc_html__( 'Width of the avatar image.', 'wp-graphql' ),
+						'description' => __( 'Width of the avatar image.', 'wp-graphql' ),
 					],
 					'default'      => [
 						'type'        => Types::string(),
-						'description' => esc_html__( "URL for the default image or a default type. Accepts '404' (return a 404 instead of a default image), 'retro' (8bit), 'monsterid' (monster), 'wavatar' (cartoon face), 'indenticon' (the 'quilt'), 'mystery', 'mm', or 'mysteryman' (The Oyster Man), 'blank' (transparent GIF), or 'gravatar_default' (the Gravatar logo).", 'wp-graphql' ),
+						'description' => __( "URL for the default image or a default type. Accepts '404' (return a 404 instead of a default image), 'retro' (8bit), 'monsterid' (monster), 'wavatar' (cartoon face), 'indenticon' (the 'quilt'), 'mystery', 'mm', or 'mysteryman' (The Oyster Man), 'blank' (transparent GIF), or 'gravatar_default' (the Gravatar logo).", 'wp-graphql' ),
 					],
 					'forceDefault' => [
 						'type'        => Types::boolean(),
-						'description' => esc_html__( 'Whether to always show the default image, never the Gravatar.', 'wp-graphql' ),
+						'description' => __( 'Whether to always show the default image, never the Gravatar.', 'wp-graphql' ),
 						'resolve'     => function( $avatar, array $args, AppContext $context, ResolveInfo $info ) {
 							return ( ! empty( $avatar['force_default'] ) && true === $avatar['force_default'] ) ? true : false;
 						},
 					],
 					'rating'       => [
 						'type'        => Types::string(),
-						'description' => esc_html__( "What rating to display avatars up to. Accepts 'G', 'PG', 'R', 'X', and are judged in that order.", 'wp-graphql' ),
+						'description' => __( "What rating to display avatars up to. Accepts 'G', 'PG', 'R', 'X', and are judged in that order.", 'wp-graphql' ),
 					],
 					'scheme'       => [
 						'type'        => Types::string(),
-						'description' => esc_html__( 'Type of url scheme to use. Typically HTTP vs. HTTPS.', 'wp-graphql' ),
+						'description' => __( 'Type of url scheme to use. Typically HTTP vs. HTTPS.', 'wp-graphql' ),
 					],
 					'extraAttr'    => [
 						'type'        => Types::string(),
-						'description' => esc_html__( 'HTML attributes to insert in the IMG element. Is not sanitized.', 'wp-graphql' ),
+						'description' => __( 'HTML attributes to insert in the IMG element. Is not sanitized.', 'wp-graphql' ),
 						'resolve'     => function( $avatar, array $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $avatar['extra_attr'] ) ? $avatar['extra_attr'] : null;
 						},
 					],
 					'foundAvatar'  => [
 						'type'        => Types::boolean(),
-						'description' => esc_html__( 'Whether the avatar was successfully found.', 'wp-graphql' ),
+						'description' => __( 'Whether the avatar was successfully found.', 'wp-graphql' ),
 						'resolve' => function( $avatar, array $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $avatar['found_avatar'] && true === $avatar['found_avatar'] ) ? true : false;
 						},
 					],
 					'url'          => [
 						'type'        => Types::string(),
-						'description' => esc_html__( 'URL for the gravatar image source.', 'wp-graphql' ),
+						'description' => __( 'URL for the gravatar image source.', 'wp-graphql' ),
 					],
 				];
 

--- a/src/Type/Comment/CommentType.php
+++ b/src/Type/Comment/CommentType.php
@@ -79,7 +79,7 @@ class CommentType extends WPObjectType {
 					],
 					'author' => [
 						'type' => Types::user(),
-						'description' => esc_html__( 'The post field for comments matches the post id the comment is assigned to. This field is equivalent to WP_Comment->comment_post_ID and the value matching the `comment_post_ID` column in SQL.', 'wp-graphql' ),
+						'description' => __( 'The post field for comments matches the post id the comment is assigned to. This field is equivalent to WP_Comment->comment_post_ID and the value matching the `comment_post_ID` column in SQL.', 'wp-graphql' ),
 						'resolve' => function( \WP_Comment $comment, $args, AppContext $context, ResolveInfo $info ) {
 							$author = new \WP_User( $comment->user_id );
 
@@ -88,63 +88,63 @@ class CommentType extends WPObjectType {
 					],
 					'authorIp' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'IP address for the author. This field is equivalent to WP_Comment->comment_author_IP and the value matching the `comment_author_IP` column in SQL.', 'wp-graphql' ),
+						'description' => __( 'IP address for the author. This field is equivalent to WP_Comment->comment_author_IP and the value matching the `comment_author_IP` column in SQL.', 'wp-graphql' ),
 						'resolve' => function( \WP_Comment $comment, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $comment->comment_author_IP ) ? $comment->comment_author_IP : '';
 						},
 					],
 					'date' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'Date the comment was posted in local time. This field is equivalent to WP_Comment->date and the value matching the `date` column in SQL.', 'wp-graphql' ),
+						'description' => __( 'Date the comment was posted in local time. This field is equivalent to WP_Comment->date and the value matching the `date` column in SQL.', 'wp-graphql' ),
 						'resolve' => function( \WP_Comment $comment, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $comment->comment_date ) ? $comment->comment_date : '';
 						},
 					],
 					'dateGmt' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'Date the comment was posted in GMT. This field is equivalent to WP_Comment->date_gmt and the value matching the `date_gmt` column in SQL.', 'wp-graphql' ),
+						'description' => __( 'Date the comment was posted in GMT. This field is equivalent to WP_Comment->date_gmt and the value matching the `date_gmt` column in SQL.', 'wp-graphql' ),
 						'resolve' => function( \WP_Comment $comment, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $comment->comment_date_gmt ) ? $comment->comment_date_gmt : '';
 						},
 					],
 					'content' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'Content of the comment. This field is equivalent to WP_Comment->comment_content and the value matching the `comment_content` column in SQL.', 'wp-graphql' ),
+						'description' => __( 'Content of the comment. This field is equivalent to WP_Comment->comment_content and the value matching the `comment_content` column in SQL.', 'wp-graphql' ),
 						'resolve' => function( \WP_Comment $comment, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $comment->comment_content ) ? $comment->comment_content : '';
 						},
 					],
 					'karma' => [
 						'type' => Types::int(),
-						'description' => esc_html__( 'Karma value for the comment. This field is equivalent to WP_Comment->comment_karma and the value matching the `comment_karma` column in SQL.', 'wp-graphql' ),
+						'description' => __( 'Karma value for the comment. This field is equivalent to WP_Comment->comment_karma and the value matching the `comment_karma` column in SQL.', 'wp-graphql' ),
 						'resolve' => function( \WP_Comment $comment, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $comment->comment_karma ) ? $comment->comment_karma : 0;
 						},
 					],
 					'approved' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'The approval status of the comment. This field is equivalent to WP_Comment->comment_approved and the value matching the `comment_approved` column in SQL.', 'wp-graphql' ),
+						'description' => __( 'The approval status of the comment. This field is equivalent to WP_Comment->comment_approved and the value matching the `comment_approved` column in SQL.', 'wp-graphql' ),
 						'resolve' => function( \WP_Comment $comment, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $comment->comment_approved ) ? $comment->comment_approved : '';
 						},
 					],
 					'agent' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'User agent used to post the comment. This field is equivalent to WP_Comment->comment_agent and the value matching the `comment_agent` column in SQL.', 'wp-graphql' ),
+						'description' => __( 'User agent used to post the comment. This field is equivalent to WP_Comment->comment_agent and the value matching the `comment_agent` column in SQL.', 'wp-graphql' ),
 						'resolve' => function( \WP_Comment $comment, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $comment->comment_agent ) ? $comment->comment_agent : '';
 						},
 					],
 					'type' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'Type of comment. This field is equivalent to WP_Comment->comment_type and the value matching the `comment_type` column in SQL.', 'wp-graphql' ),
+						'description' => __( 'Type of comment. This field is equivalent to WP_Comment->comment_type and the value matching the `comment_type` column in SQL.', 'wp-graphql' ),
 						'resolve' => function( \WP_Comment $comment, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $comment->comment_type ) ? $comment->comment_type : '';
 						},
 					],
 					'parent' => [
 						'type' => Types::comment(),
-						'description' => esc_html__( 'Parent comment of current comment. This field is equivalent to the WP_Comment instance matching the WP_Comment->comment_parent ID.', 'wp-graphql' ),
+						'description' => __( 'Parent comment of current comment. This field is equivalent to the WP_Comment instance matching the WP_Comment->comment_parent ID.', 'wp-graphql' ),
 						'resolve' => function( \WP_Comment $comment, $args, AppContext $context, ResolveInfo $info ) {
 							return get_comment( $comment->comment_parent );
 						},

--- a/src/Type/Comment/Connection/CommentConnectionResolver.php
+++ b/src/Type/Comment/Connection/CommentConnectionResolver.php
@@ -123,7 +123,7 @@ class CommentConnectionResolver extends ConnectionResolver {
 		 * Ensure that the query is ordered by ID in addition to any other orderby options
 		 */
 		$query_args['orderby'] = array_merge( $query_args['orderby'], [
-			'ID' => esc_html( $id_order ),
+			'ID' => esc_sql( $id_order ),
 		] );
 
 		return $query_args;

--- a/src/Type/MediaItem/MediaItemType.php
+++ b/src/Type/MediaItem/MediaItemType.php
@@ -72,7 +72,7 @@ class MediaItemType {
 		$new_fields = [
 			'caption'      => [
 				'type'        => Types::string(),
-				'description' => esc_html__( 'The caption for the resource', 'wp-graphql' ),
+				'description' => __( 'The caption for the resource', 'wp-graphql' ),
 				'resolve'     => function( \WP_Post $post, $args, $context, ResolveInfo $info ) {
 					$caption = apply_filters( 'the_excerpt', apply_filters( 'get_the_excerpt', $post->post_excerpt, $post ) );
 
@@ -81,28 +81,28 @@ class MediaItemType {
 			],
 			'altText'      => [
 				'type'        => Types::string(),
-				'description' => esc_html__( 'Alternative text to display when resource is not displayed', 'wp-graphql' ),
+				'description' => __( 'Alternative text to display when resource is not displayed', 'wp-graphql' ),
 				'resolve'     => function( \WP_Post $post, $args, $context, ResolveInfo $info ) {
 					return get_post_meta( $post->ID, '_wp_attachment_image_alt', true );
 				},
 			],
 			'description'  => [
 				'type'        => Types::string(),
-				'description' => esc_html__( 'Description of the image (stored as post_content)', 'wp-graphql' ),
+				'description' => __( 'Description of the image (stored as post_content)', 'wp-graphql' ),
 				'resolve'     => function( \WP_Post $post, $args, $context, ResolveInfo $info ) {
 					return apply_filters( 'the_content', $post->post_content );
 				},
 			],
 			'mediaType'    => [
 				'type'        => Types::string(),
-				'description' => esc_html__( 'Type of resource', 'wp-graphql' ),
+				'description' => __( 'Type of resource', 'wp-graphql' ),
 				'resolve'     => function( \WP_Post $post, $args, $context, ResolveInfo $info ) {
 					return wp_attachment_is_image( $post->ID ) ? 'image' : 'file';
 				},
 			],
 			'sourceUrl'    => [
 				'type'        => Types::string(),
-				'description' => esc_html__( 'Url of the mediaItem', 'wp-graphql' ),
+				'description' => __( 'Url of the mediaItem', 'wp-graphql' ),
 				'resolve'     => function( \WP_Post $post, $args, $context, ResolveInfo $info ) {
 					return wp_get_attachment_url( $post->ID );
 				},

--- a/src/Type/Plugin/PluginType.php
+++ b/src/Type/Plugin/PluginType.php
@@ -72,42 +72,42 @@ class PluginType extends WPObjectType {
 					],
 					'name' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'Display name of the plugin.', 'wp-graphql' ),
+						'description' => __( 'Display name of the plugin.', 'wp-graphql' ),
 						'resolve' => function( array $plugin, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $plugin['Name'] ) ? $plugin['Name'] : '';
 						},
 					],
 					'pluginUri' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'URI for the plugin website. This is useful for directing users for support requests etc.', 'wp-graphql' ),
+						'description' => __( 'URI for the plugin website. This is useful for directing users for support requests etc.', 'wp-graphql' ),
 						'resolve' => function( array $plugin, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $plugin['PluginURI'] ) ? $plugin['PluginURI'] : '';
 						},
 					],
 					'description' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'Description of the plugin.', 'wp-graphql' ),
+						'description' => __( 'Description of the plugin.', 'wp-graphql' ),
 						'resolve' => function( array $plugin, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $plugin['Description'] ) ? $plugin['Description'] : '';
 						},
 					],
 					'author' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'Name of the plugin author(s), may also be a company name.', 'wp-graphql' ),
+						'description' => __( 'Name of the plugin author(s), may also be a company name.', 'wp-graphql' ),
 						'resolve' => function( array $plugin, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $plugin['Author'] ) ? $plugin['Author'] : '';
 						},
 					],
 					'authorUri' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'URI for the related author(s)/company website.', 'wp-graphql' ),
+						'description' => __( 'URI for the related author(s)/company website.', 'wp-graphql' ),
 						'resolve' => function( array $plugin, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $plugin['AuthorURI'] ) ? $plugin['AuthorURI'] : '';
 						},
 					],
 					'version' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'Current version of the plugin.', 'wp-graphql' ),
+						'description' => __( 'Current version of the plugin.', 'wp-graphql' ),
 						'resolve' => function( array $plugin, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $plugin['Version'] ) ? $plugin['Version'] : '';
 						},

--- a/src/Type/PostObject/Connection/PostObjectConnectionResolver.php
+++ b/src/Type/PostObject/Connection/PostObjectConnectionResolver.php
@@ -86,7 +86,7 @@ class PostObjectConnectionResolver extends ConnectionResolver {
 		 */
 		$id_order              = ! empty( $query_args['graphql_cursor_compare'] ) && '>' === $query_args['graphql_cursor_compare'] ? 'ASC' : 'DESC';
 		$query_args['orderby'] = [
-			'date' => esc_html( $id_order ),
+			'date' => esc_sql( $id_order ),
 		];
 
 		/**
@@ -123,7 +123,7 @@ class PostObjectConnectionResolver extends ConnectionResolver {
 		if ( ! empty( $args['where']['orderby'] ) && is_array( $args['where']['orderby'] ) ) {
 			foreach ( $args['where']['orderby'] as $orderby_input ) {
 				if ( ! empty( $orderby_input['field'] ) ) {
-					$query_args['orderby'][ esc_html( $orderby_input['field'] ) ] = ! empty( $orderby_input['order'] ) ? esc_html( $orderby_input['order'] ) : 'DESC';
+					$query_args['orderby'][ esc_sql( $orderby_input['field'] ) ] = ! empty( $orderby_input['order'] ) ? esc_sql( $orderby_input['order'] ) : 'DESC';
 				}
 			}
 		}
@@ -164,7 +164,7 @@ class PostObjectConnectionResolver extends ConnectionResolver {
 		 * Ensure that the query is ordered by ID in addition to any other orderby options
 		 */
 		$query_args['orderby'] = array_merge( $query_args['orderby'], [
-			'ID' => esc_html( $id_order ),
+			'ID' => esc_sql( $id_order ),
 		] );
 
 		/**

--- a/src/Type/PostObject/Mutation/PostObjectCreate.php
+++ b/src/Type/PostObject/Mutation/PostObjectCreate.php
@@ -39,7 +39,7 @@ class PostObjectCreate {
 			self::$mutation[ $post_type_object->graphql_single_name ] = Relay::mutationWithClientMutationId( [
 				'name'                => esc_html( $mutation_name ),
 				// translators: The placeholder is the name of the object type
-				'description'         => sprintf( esc_html__( 'Create %1$s objects', 'wp-graphql' ), $post_type_object->graphql_single_name ),
+				'description'         => sprintf( __( 'Create %1$s objects', 'wp-graphql' ), $post_type_object->graphql_single_name ),
 				'inputFields'         => PostObjectMutation::input_fields( $post_type_object ),
 				'outputFields'        => [
 					$post_type_object->graphql_single_name => [

--- a/src/Type/PostObject/Mutation/PostObjectDelete.php
+++ b/src/Type/PostObject/Mutation/PostObjectDelete.php
@@ -38,7 +38,7 @@ class PostObjectDelete {
 			self::$mutation[ $post_type_object->graphql_single_name ] = Relay::mutationWithClientMutationId( [
 				'name'                => esc_html( $mutation_name ),
 				// translators: The placeholder is the name of the object type
-				'description'         => sprintf( esc_html__( 'Delete %1$s objects. By default %1$s objects will be moved to the trash unless the forceDelete is used', 'wp-graphql' ), $post_type_object->graphql_single_name ),
+				'description'         => sprintf( __( 'Delete %1$s objects. By default %1$s objects will be moved to the trash unless the forceDelete is used', 'wp-graphql' ), $post_type_object->graphql_single_name ),
 				'inputFields'         => [
 					'id'          => [
 						'type'        => Types::non_null( Types::id() ),

--- a/src/Type/PostObject/Mutation/PostObjectMutation.php
+++ b/src/Type/PostObject/Mutation/PostObjectMutation.php
@@ -31,79 +31,79 @@ class PostObjectMutation {
 			$input_fields = [
 				'authorId'      => [
 					'type'        => Types::id(),
-					'description' => esc_html__( 'The userId to assign as the author of the post', 'wp-graphql' ),
+					'description' => __( 'The userId to assign as the author of the post', 'wp-graphql' ),
 				],
 				'commentCount'  => [
 					'type'        => Types::int(),
-					'description' => esc_html__( 'The number of comments. Even though WPGraphQL denotes this field as an integer, in WordPress this field should be saved as a numeric string for compatability.', 'wp-graphql' ),
+					'description' => __( 'The number of comments. Even though WPGraphQL denotes this field as an integer, in WordPress this field should be saved as a numeric string for compatability.', 'wp-graphql' ),
 				],
 				'commentStatus' => [
 					'type'        => Types::string(),
-					'description' => esc_html__( 'The comment status for the object', 'wp-graphql' ),
+					'description' => __( 'The comment status for the object', 'wp-graphql' ),
 				],
 				'content'       => [
 					'type'        => Types::string(),
-					'description' => esc_html__( 'The content of the object', 'wp-graphql' ),
+					'description' => __( 'The content of the object', 'wp-graphql' ),
 				],
 				'date'          => [
 					'type'        => Types::string(),
-					'description' => esc_html__( 'The date of the object', 'wp-graphql' ),
+					'description' => __( 'The date of the object', 'wp-graphql' ),
 				],
 				'dateGmt'       => [
 					'type'        => Types::string(),
-					'description' => esc_html__( 'The date (in GMT zone) of the object', 'wp-graphql' ),
+					'description' => __( 'The date (in GMT zone) of the object', 'wp-graphql' ),
 				],
 				'excerpt'       => [
 					'type'        => Types::string(),
-					'description' => esc_html__( 'The excerpt of the object', 'wp-graphql' ),
+					'description' => __( 'The excerpt of the object', 'wp-graphql' ),
 				],
 				'menuOrder'     => [
 					'type'        => Types::int(),
-					'description' => esc_html__( 'A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types.', 'wp-graphql' ),
+					'description' => __( 'A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types.', 'wp-graphql' ),
 				],
 				'mimeType'      => [
 					'type'        => Types::mime_type_enum(),
-					'description' => esc_html__( 'If the post is an attachment or a media file, this field will carry the corresponding MIME type. This field is equivalent to the value of WP_Post->post_mime_type and the post_mime_type column in the `post_objects` database table.', 'wp-graphql' ),
+					'description' => __( 'If the post is an attachment or a media file, this field will carry the corresponding MIME type. This field is equivalent to the value of WP_Post->post_mime_type and the post_mime_type column in the `post_objects` database table.', 'wp-graphql' ),
 				],
 				'modified'      => [
 					'type'        => Types::string(),
-					'description' => esc_html__( 'The local modified time for a post. If a post was recently updated the modified field will change to match the corresponding time.', 'wp-graphql' ),
+					'description' => __( 'The local modified time for a post. If a post was recently updated the modified field will change to match the corresponding time.', 'wp-graphql' ),
 				],
 				'modifiedGmt'   => [
 					'type'        => Types::string(),
-					'description' => esc_html__( 'The GMT modified time for a post. If a post was recently updated the modified field will change to match the corresponding time in GMT.', 'wp-graphql' ),
+					'description' => __( 'The GMT modified time for a post. If a post was recently updated the modified field will change to match the corresponding time in GMT.', 'wp-graphql' ),
 				],
 				'parentId'      => [
 					'type'        => Types::id(),
-					'description' => esc_html__( 'The ID of the parent object', 'wp-graphql' ),
+					'description' => __( 'The ID of the parent object', 'wp-graphql' ),
 				],
 				'password'      => [
 					'type'        => Types::string(),
-					'description' => esc_html__( 'The password used to protect the content of the object', 'wp-graphql' ),
+					'description' => __( 'The password used to protect the content of the object', 'wp-graphql' ),
 				],
 				'pinged'        => [
 					'type'        => Types::list_of( Types::string() ),
-					'description' => esc_html__( 'URLs that have been pinged.', 'wp-graphql' ),
+					'description' => __( 'URLs that have been pinged.', 'wp-graphql' ),
 				],
 				'pingStatus'    => [
 					'type'        => Types::string(),
-					'description' => esc_html__( 'The ping status for the object', 'wp-graphql' ),
+					'description' => __( 'The ping status for the object', 'wp-graphql' ),
 				],
 				'slug'          => [
 					'type'        => Types::string(),
-					'description' => esc_html__( 'The slug of the object', 'wp-graphql' ),
+					'description' => __( 'The slug of the object', 'wp-graphql' ),
 				],
 				'status'        => [
 					'type'        => Types::post_status_enum(),
-					'description' => esc_html__( 'The status of the object', 'wp-graphql' ),
+					'description' => __( 'The status of the object', 'wp-graphql' ),
 				],
 				'title'         => [
 					'type'        => Types::string(),
-					'description' => esc_html__( 'The title of the post', 'wp-graphql' ),
+					'description' => __( 'The title of the post', 'wp-graphql' ),
 				],
 				'toPing'        => [
 					'type'        => Types::list_of( Types::string() ),
-					'description' => esc_html__( 'URLs queued to be pinged.', 'wp-graphql' ),
+					'description' => __( 'URLs queued to be pinged.', 'wp-graphql' ),
 				],
 			];
 

--- a/src/Type/PostObject/Mutation/PostObjectUpdate.php
+++ b/src/Type/PostObject/Mutation/PostObjectUpdate.php
@@ -39,7 +39,7 @@ class PostObjectUpdate {
 			self::$mutation[ $post_type_object->graphql_single_name ] = Relay::mutationWithClientMutationId( array(
 				'name'                => esc_html( $mutation_name ),
 				// translators: The placeholder is the name of the post type being updated
-				'description'         => sprintf( esc_html__( 'Updates %1$s objects', 'wp-graphql' ), $post_type_object->graphql_single_name ),
+				'description'         => sprintf( __( 'Updates %1$s objects', 'wp-graphql' ), $post_type_object->graphql_single_name ),
 				'inputFields'         => self::input_fields( $post_type_object ),
 				'outputFields'        => array(
 					$post_type_object->graphql_single_name => array(
@@ -158,7 +158,7 @@ class PostObjectUpdate {
 				'id' => [
 					'type'        => Types::non_null( Types::id() ),
 					// translators: the placeholder is the name of the type of post object being updated
-					'description' => sprintf( esc_html__( 'The ID of the %1$s object', 'wp-graphql' ), $post_type_object->graphql_single_name ),
+					'description' => sprintf( __( 'The ID of the %1$s object', 'wp-graphql' ), $post_type_object->graphql_single_name ),
 				],
 			],
 			PostObjectMutation::input_fields( $post_type_object )

--- a/src/Type/PostObject/PostObjectType.php
+++ b/src/Type/PostObject/PostObjectType.php
@@ -129,49 +129,49 @@ class PostObjectType extends WPObjectType {
 					],
 					$single_name . 'Id' => [
 						'type'        => Types::non_null( Types::int() ),
-						'description' => esc_html__( 'The id field matches the WP_Post->ID field.', 'wp-graphql' ),
+						'description' => __( 'The id field matches the WP_Post->ID field.', 'wp-graphql' ),
 						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							return absint( $post->ID );
 						},
 					],
 					'author'            => [
 						'type'        => Types::user(),
-						'description' => esc_html__( "The author field will return a queryable User type matching the post's author.", 'wp-graphql' ),
+						'description' => __( "The author field will return a queryable User type matching the post's author.", 'wp-graphql' ),
 						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post->post_author ) ? new \WP_User( $post->post_author ) : null;
 						},
 					],
 					'date'              => [
 						'type'        => Types::string(),
-						'description' => esc_html__( 'Post publishing date.', 'wp-graphql' ),
+						'description' => __( 'Post publishing date.', 'wp-graphql' ),
 						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post->post_date ) ? $post->post_date : null;
 						},
 					],
 					'dateGmt'           => [
 						'type'        => Types::string(),
-						'description' => esc_html__( 'The publishing date set in GMT.', 'wp-graphql' ),
+						'description' => __( 'The publishing date set in GMT.', 'wp-graphql' ),
 						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post->post_date_gmt ) ? $post->post_date_gmt : null;
 						},
 					],
 					'content'           => [
 						'type'        => Types::string(),
-						'description' => esc_html__( 'The content of the post. This is currently just the raw content. An amendment to support rendered content needs to be made.', 'wp-graphql' ),
+						'description' => __( 'The content of the post. This is currently just the raw content. An amendment to support rendered content needs to be made.', 'wp-graphql' ),
 						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							return apply_filters( 'the_content', $post->post_content );
 						},
 					],
 					'title'             => [
 						'type'        => Types::string(),
-						'description' => esc_html__( 'The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made.', 'wp-graphql' ),
+						'description' => __( 'The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made.', 'wp-graphql' ),
 						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post->post_title ) ? $post->post_title : null;
 						},
 					],
 					'excerpt'           => [
 						'type'        => Types::string(),
-						'description' => esc_html__( 'The excerpt of the post. This is currently just the raw excerpt. An amendment to support rendered excerpts needs to be made.', 'wp-graphql' ),
+						'description' => __( 'The excerpt of the post. This is currently just the raw excerpt. An amendment to support rendered excerpts needs to be made.', 'wp-graphql' ),
 						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							$excerpt = apply_filters( 'the_excerpt', apply_filters( 'get_the_excerpt', $post->post_excerpt, $post ) );
 
@@ -180,56 +180,56 @@ class PostObjectType extends WPObjectType {
 					],
 					'status'            => [
 						'type'        => Types::string(),
-						'description' => esc_html__( 'The current status of the object', 'wp-graphql' ),
+						'description' => __( 'The current status of the object', 'wp-graphql' ),
 						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post->post_status ) ? $post->post_status : null;
 						},
 					],
 					'commentStatus'     => array(
 						'type'        => Types::string(),
-						'description' => esc_html__( 'Whether the comments are open or closed for this particular post.', 'wp-graphql' ),
+						'description' => __( 'Whether the comments are open or closed for this particular post.', 'wp-graphql' ),
 						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post->comment_status ) ? $post->comment_status : null;
 						},
 					),
 					'pingStatus'        => [
 						'type'        => Types::string(),
-						'description' => esc_html__( 'Whether the pings are open or closed for this particular post.', 'wp-graphql' ),
+						'description' => __( 'Whether the pings are open or closed for this particular post.', 'wp-graphql' ),
 						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post->ping_status ) ? $post->ping_status : null;
 						},
 					],
 					'slug'              => [
 						'type'        => Types::string(),
-						'description' => esc_html__( 'The uri slug for the post. This is equivalent to the WP_Post->post_name field and the post_name column in the database for the `post_objects` table.', 'wp-graphql' ),
+						'description' => __( 'The uri slug for the post. This is equivalent to the WP_Post->post_name field and the post_name column in the database for the `post_objects` table.', 'wp-graphql' ),
 						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post->post_name ) ? $post->post_name : null;
 						},
 					],
 					'toPing'            => [
 						'type'        => Types::list_of( Types::string() ),
-						'description' => esc_html__( 'URLs queued to be pinged.', 'wp-graphql' ),
+						'description' => __( 'URLs queued to be pinged.', 'wp-graphql' ),
 						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post->to_ping ) ? implode( ',', $post->to_ping ) : null;
 						},
 					],
 					'pinged'            => [
 						'type'        => Types::list_of( Types::string() ),
-						'description' => esc_html__( 'URLs that have been pinged.', 'wp-graphql' ),
+						'description' => __( 'URLs that have been pinged.', 'wp-graphql' ),
 						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post->pinged ) ? implode( ',', $post->pinged ) : null;
 						},
 					],
 					'modified'          => [
 						'type'        => Types::string(),
-						'description' => esc_html__( 'The local modified time for a post. If a post was recently updated the modified field will change to match the corresponding time.', 'wp-graphql' ),
+						'description' => __( 'The local modified time for a post. If a post was recently updated the modified field will change to match the corresponding time.', 'wp-graphql' ),
 						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post->post_modified ) ? $post->post_modified : null;
 						},
 					],
 					'modifiedGmt'       => [
 						'type'        => Types::string(),
-						'description' => esc_html__( 'The GMT modified time for a post. If a post was recently updated the modified field will change to match the corresponding time in GMT.', 'wp-graphql' ),
+						'description' => __( 'The GMT modified time for a post. If a post was recently updated the modified field will change to match the corresponding time in GMT.', 'wp-graphql' ),
 						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post->post_modified_gmt ) ? $post->post_modified_gmt : null;
 						},
@@ -293,21 +293,21 @@ class PostObjectType extends WPObjectType {
 					],
 					'guid'              => [
 						'type'        => Types::string(),
-						'description' => esc_html__( 'The global unique identifier for this post. This currently matches the value stored in WP_Post->guid and the guid column in the `post_objects` database table.', 'wp-graphql' ),
+						'description' => __( 'The global unique identifier for this post. This currently matches the value stored in WP_Post->guid and the guid column in the `post_objects` database table.', 'wp-graphql' ),
 						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post->guid ) ? $post->guid : null;
 						},
 					],
 					'menuOrder'         => [
 						'type'        => Types::int(),
-						'description' => esc_html__( 'A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types.', 'wp-graphql' ),
+						'description' => __( 'A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types.', 'wp-graphql' ),
 						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post->menu_order ) ? absint( $post->menu_order ) : null;
 						},
 					],
 					'desiredSlug' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'The desired slug of the post', 'wp-graphql' ),
+						'description' => __( 'The desired slug of the post', 'wp-graphql' ),
 						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							$desired_slug = get_post_meta( $post->ID, '_wp_desired_post_slug', true );
 
@@ -316,7 +316,7 @@ class PostObjectType extends WPObjectType {
 					],
 					'link'              => [
 						'type'        => Types::string(),
-						'description' => esc_html__( 'The permalink of the post', 'wp-graphql' ),
+						'description' => __( 'The permalink of the post', 'wp-graphql' ),
 						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							$link = get_permalink( $post->ID );
 
@@ -334,7 +334,7 @@ class PostObjectType extends WPObjectType {
 					$fields['comments']     = CommentConnectionDefinition::connection();
 					$fields['commentCount'] = [
 						'type'        => Types::int(),
-						'description' => esc_html__( 'The number of comments. Even though WPGraphQL denotes this field as an integer, in WordPress this field should be saved as a numeric string for compatability.', 'wp-graphql' ),
+						'description' => __( 'The number of comments. Even though WPGraphQL denotes this field as an integer, in WordPress this field should be saved as a numeric string for compatability.', 'wp-graphql' ),
 						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post->comment_count ) ? absint( $post->comment_count ) : null;
 						},

--- a/src/Type/PostType/PostTypeType.php
+++ b/src/Type/PostType/PostTypeType.php
@@ -85,11 +85,11 @@ class PostTypeType extends WPObjectType {
 					],
 					'name' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'The internal name of the post type. This should not be used for display purposes.', 'wp-graphql' ),
+						'description' => __( 'The internal name of the post type. This should not be used for display purposes.', 'wp-graphql' ),
 					],
 					'label' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'Display name of the content type.', 'wp-graphql' ),
+						'description' => __( 'Display name of the content type.', 'wp-graphql' ),
 					],
 					'labels' => [
 						'type'        => self::labels_details(),
@@ -100,131 +100,131 @@ class PostTypeType extends WPObjectType {
 					],
 					'description' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'Description of the content type.', 'wp-graphql' ),
+						'description' => __( 'Description of the content type.', 'wp-graphql' ),
 					],
 					'public' => [
 						'type' => Types::boolean(),
-						'description' => esc_html__( 'Whether a post type is intended for use publicly either via the admin interface or by front-end users. While the default settings of exclude_from_search, publicly_queryable, show_ui, and show_in_nav_menus are inherited from public, each does not rely on this relationship and controls a very specific intention.', 'wp-graphql' ),
+						'description' => __( 'Whether a post type is intended for use publicly either via the admin interface or by front-end users. While the default settings of exclude_from_search, publicly_queryable, show_ui, and show_in_nav_menus are inherited from public, each does not rely on this relationship and controls a very specific intention.', 'wp-graphql' ),
 					],
 					'hierarchical' => [
 						'type' => Types::boolean(),
-						'description' => esc_html__( 'Whether the post type is hierarchical, for example pages.', 'wp-graphql' ),
+						'description' => __( 'Whether the post type is hierarchical, for example pages.', 'wp-graphql' ),
 					],
 					'excludeFromSearch' => [
 						'type' => Types::boolean(),
-						'description' => esc_html__( 'Whether to exclude posts with this post type from front end search results.', 'wp-graphql' ),
+						'description' => __( 'Whether to exclude posts with this post type from front end search results.', 'wp-graphql' ),
 						'resolve' => function( \WP_Post_Type $post_type, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post_type->exclude_from_search ) ? $post_type->exclude_from_search : false;
 						},
 					],
 					'publiclyQueryable' => [
 						'type' => Types::boolean(),
-						'description' => esc_html__( 'Whether queries can be performed on the front end for the post type as part of parse_request().', 'wp-graphql' ),
+						'description' => __( 'Whether queries can be performed on the front end for the post type as part of parse_request().', 'wp-graphql' ),
 						'resolve' => function( \WP_Post_Type $post_type, array $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post_type->publicly_queryable ) ? $post_type->publicly_queryable : null;
 						},
 					],
 					'showUi' => [
 						'type' => Types::boolean(),
-						'description' => esc_html__( 'Whether to generate and allow a UI for managing this post type in the admin.', 'wp-graphql' ),
+						'description' => __( 'Whether to generate and allow a UI for managing this post type in the admin.', 'wp-graphql' ),
 						'resolve' => function( \WP_Post_Type $post_type, array $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post_type->show_ui ) ? $post_type->show_ui : null;
 						},
 					],
 					'showInMenu' => [
 						'type' => Types::boolean(),
-						'description' => esc_html__( 'Where to show the post type in the admin menu. To work, $show_ui must be true. If true, the post type is shown in its own top level menu. If false, no menu is shown. If a string of an existing top level menu (eg. "tools.php" or "edit.php?post_type=page"), the post type will be placed as a sub-menu of that.', 'wp-graphql' ),
+						'description' => __( 'Where to show the post type in the admin menu. To work, $show_ui must be true. If true, the post type is shown in its own top level menu. If false, no menu is shown. If a string of an existing top level menu (eg. "tools.php" or "edit.php?post_type=page"), the post type will be placed as a sub-menu of that.', 'wp-graphql' ),
 						'resolve' => function( \WP_Post_Type $post_type, array $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post_type->show_in_menu ) ? $post_type->show_in_menu : null;
 						},
 					],
 					'showInNavMenus' => [
 						'type' => Types::boolean(),
-						'description' => esc_html__( 'Makes this post type available for selection in navigation menus.', 'wp-graphql' ),
+						'description' => __( 'Makes this post type available for selection in navigation menus.', 'wp-graphql' ),
 						'resolve' => function( \WP_Post_Type $post_type, array $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post_type->show_in_nav_menus ) ? $post_type->show_in_nav_menus : null;
 						},
 					],
 					'showInAdminBar' => [
 						'type' => Types::boolean(),
-						'description' => esc_html__( 'Makes this post type available via the admin bar.', 'wp-graphql' ),
+						'description' => __( 'Makes this post type available via the admin bar.', 'wp-graphql' ),
 						'resolve' => function( \WP_Post_Type $post_type, array $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post_type->show_in_admin_bar ) ? $post_type->show_in_admin_bar : null;
 						},
 					],
 					'menuPosition' => [
 						'type' => Types::int(),
-						'description' => esc_html__( 'The position of this post type in the menu. Only applies if show_in_menu is true.', 'wp-graphql' ),
+						'description' => __( 'The position of this post type in the menu. Only applies if show_in_menu is true.', 'wp-graphql' ),
 						'resolve' => function( \WP_Post_Type $post_type, array $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post_type->menu_position ) ? $post_type->menu_position : null;
 						},
 					],
 					'menuIcon' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'The name of the icon file to display as a menu icon.', 'wp-graphql' ),
+						'description' => __( 'The name of the icon file to display as a menu icon.', 'wp-graphql' ),
 						'resolve' => function( \WP_Post_Type $post_type, array $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post_type->menu_icon ) ? $post_type->menu_icon : null;
 						},
 					],
 					'hasArchive' => [
 						'type' => Types::boolean(),
-						'description' => esc_html__( 'Whether this content type should have archives. Content archives are generated by type and by date.', 'wp-graphql' ),
+						'description' => __( 'Whether this content type should have archives. Content archives are generated by type and by date.', 'wp-graphql' ),
 						'resolve' => function( \WP_Post_Type $post_type, array $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post_type->has_archive ) ? $post_type->has_archive : null;
 						},
 					],
 					'canExport' => [
 						'type' => Types::boolean(),
-						'description' => esc_html__( 'Whether this content type should can be exported.', 'wp-graphql' ),
+						'description' => __( 'Whether this content type should can be exported.', 'wp-graphql' ),
 						'resolve' => function( \WP_Post_Type $post_type, array $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post_type->can_export ) ? $post_type->can_export : null;
 						},
 					],
 					'deleteWithUser' => [
 						'type' => Types::boolean(),
-						'description' => esc_html__( 'Whether delete this type of content when the author of it is deleted from the system.', 'wp-graphql' ),
+						'description' => __( 'Whether delete this type of content when the author of it is deleted from the system.', 'wp-graphql' ),
 						'resolve' => function( \WP_Post_Type $post_type, array $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post_type->delete_with_user ) ? $post_type->delete_with_user : null;
 						},
 					],
 					'showInRest' => [
 						'type' => Types::boolean(),
-						'description' => esc_html__( 'Whether to add the post type route in the REST API `wp/v2` namespace.', 'wp-graphql' ),
+						'description' => __( 'Whether to add the post type route in the REST API `wp/v2` namespace.', 'wp-graphql' ),
 						'resolve' => function( \WP_Post_Type $post_type, array $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post_type->show_in_rest ) ? $post_type->show_in_rest : null;
 						},
 					],
 					'restBase' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'Name of content type to diplay in REST API `wp/v2` namespace.', 'wp-graphql' ),
+						'description' => __( 'Name of content type to diplay in REST API `wp/v2` namespace.', 'wp-graphql' ),
 						'resolve' => function( \WP_Post_Type $post_type, array $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post_type->rest_base ) ? $post_type->rest_base : null;
 						},
 					],
 					'restControllerClass' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'The REST Controller class assigned to handling this content type.', 'wp-graphql' ),
+						'description' => __( 'The REST Controller class assigned to handling this content type.', 'wp-graphql' ),
 						'resolve' => function( \WP_Post_Type $post_type, array $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post_type->rest_controller_class ) ? $post_type->rest_controller_class : null;
 						},
 					],
 					'showInGraphql' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'Whether to add the post type to the GraphQL Schema.', 'wp-graphql' ),
+						'description' => __( 'Whether to add the post type to the GraphQL Schema.', 'wp-graphql' ),
 						'resolve' => function( \WP_Post_Type $post_type, array $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post_type->show_in_graphql ) ? $post_type->show_in_graphql : null;
 						},
 					],
 					'graphqlSingleName' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'The singular name of the post type within the GraphQL Schema.', 'wp-graphql' ),
+						'description' => __( 'The singular name of the post type within the GraphQL Schema.', 'wp-graphql' ),
 						'resolve' => function( \WP_Post_Type $post_type, array $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post_type->graphql_single_name ) ? $post_type->graphql_single_name : null;
 						},
 					],
 					'graphqlPluralName' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'The plural name of the post type within the GraphQL Schema.', 'wp-graphql' ),
+						'description' => __( 'The plural name of the post type within the GraphQL Schema.', 'wp-graphql' ),
 						'resolve' => function( \WP_Post_Type $post_type, array $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post_type->graphql_plural_name ) ? $post_type->graphql_plural_name : null;
 						},
@@ -248,7 +248,7 @@ class PostTypeType extends WPObjectType {
 					],
 					'connectedTaxonomies' => [
 						'type' => Types::list_of( Types::taxonomy() ),
-						'description' => esc_html__( 'List of Taxonomies connected to the Post Type', 'wp-graphql' ),
+						'description' => __( 'List of Taxonomies connected to the Post Type', 'wp-graphql' ),
 						'resolve' => function( \WP_Post_Type $post_type_object, array $args, AppContext $context, ResolveInfo $info ) use ( $allowed_taxonomies ) {
 							$tax_objects = [];
 							if ( ! empty( $allowed_taxonomies ) && is_array( $allowed_taxonomies ) ) {

--- a/src/Type/Taxonomy/TaxonomyType.php
+++ b/src/Type/Taxonomy/TaxonomyType.php
@@ -79,112 +79,112 @@ class TaxonomyType extends WPObjectType {
 					],
 					'name' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'The display name of the taxonomy. This field is equivalent to WP_Taxonomy->label', 'wp-graphql' ),
+						'description' => __( 'The display name of the taxonomy. This field is equivalent to WP_Taxonomy->label', 'wp-graphql' ),
 					],
 					'label' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'Name of the taxonomy shown in the menu. Usually plural.', 'wp-graphql' ),
+						'description' => __( 'Name of the taxonomy shown in the menu. Usually plural.', 'wp-graphql' ),
 					],
 					//@todo: add "labels" field
 					'description' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'Description of the taxonomy. This field is equivalent to WP_Taxonomy->description', 'wp-graphql' ),
+						'description' => __( 'Description of the taxonomy. This field is equivalent to WP_Taxonomy->description', 'wp-graphql' ),
 					],
 					'public' => [
 						'type' => Types::boolean(),
-						'description' => esc_html__( 'Whether the taxonomy is publicly queryable', 'wp-graphql' ),
+						'description' => __( 'Whether the taxonomy is publicly queryable', 'wp-graphql' ),
 					],
 					'hierarchical' => [
 						'type' => Types::boolean(),
-						'description' => esc_html__( 'Whether the taxonomy is hierarchical', 'wp-graphql' ),
+						'description' => __( 'Whether the taxonomy is hierarchical', 'wp-graphql' ),
 					],
 					'showUi' => [
 						'type' => Types::boolean(),
-						'description' => esc_html__( 'Whether to generate and allow a UI for managing terms in this taxonomy in the admin', 'wp-graphql' ),
+						'description' => __( 'Whether to generate and allow a UI for managing terms in this taxonomy in the admin', 'wp-graphql' ),
 						'resolve' => function( \WP_Taxonomy $taxonomy, array $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $taxonomy->show_ui ) ? $taxonomy->show_ui : null;
 						},
 					],
 					'showInMenu' => [
 						'type' => Types::boolean(),
-						'description' => esc_html__( 'Whether to show the taxonomy in the admin menu', 'wp-graphql' ),
+						'description' => __( 'Whether to show the taxonomy in the admin menu', 'wp-graphql' ),
 						'resolve' => function( \WP_Taxonomy $taxonomy, array $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $taxonomy->show_in_menu ) ? $taxonomy->show_in_menu : null;
 						},
 					],
 					'showInNavMenus' => [
 						'type' => Types::boolean(),
-						'description' => esc_html__( 'Whether the taxonomy is available for selection in navigation menus.', 'wp-graphql' ),
+						'description' => __( 'Whether the taxonomy is available for selection in navigation menus.', 'wp-graphql' ),
 						'resolve' => function( \WP_Taxonomy $taxonomy, array $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $taxonomy->show_in_nav_menus ) ? $taxonomy->show_in_nav_menus : null;
 						},
 					],
 					'showCloud' => [
 						'type' => Types::boolean(),
-						'description' => esc_html__( 'Whether to show the taxonomy as part of a tag cloud widget. This field is equivalent to WP_Taxonomy->show_tagcloud', 'wp-graphql' ),
+						'description' => __( 'Whether to show the taxonomy as part of a tag cloud widget. This field is equivalent to WP_Taxonomy->show_tagcloud', 'wp-graphql' ),
 						'resolve' => function( \WP_Taxonomy $taxonomy, array $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $taxonomy->show_tagcloud ) ? $taxonomy->show_tagcloud : null;
 						},
 					],
 					'showInQuickEdit' => [
 						'type' => Types::boolean(),
-						'description' => esc_html__( 'Whether to show the taxonomy in the quick/bulk edit panel.', 'wp-graphql' ),
+						'description' => __( 'Whether to show the taxonomy in the quick/bulk edit panel.', 'wp-graphql' ),
 						'resolve' => function( \WP_Taxonomy $taxonomy, array $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $taxonomy->show_in_quick_edit ) ? $taxonomy->show_in_quick_edit : null;
 						},
 					],
 					'showInAdminColumn' => [
 						'type' => Types::boolean(),
-						'description' => esc_html__( 'Whether to display a column for the taxonomy on its post type listing screens.', 'wp-graphql' ),
+						'description' => __( 'Whether to display a column for the taxonomy on its post type listing screens.', 'wp-graphql' ),
 						'resolve' => function( \WP_Taxonomy $taxonomy, array $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $taxonomy->show_admin_column ) ? $taxonomy->show_admin_column : null;
 						},
 					],
 					'showInRest' => [
 						'type' => Types::boolean(),
-						'description' => esc_html__( 'Whether to add the post type route in the REST API `wp/v2` namespace.', 'wp-graphql' ),
+						'description' => __( 'Whether to add the post type route in the REST API `wp/v2` namespace.', 'wp-graphql' ),
 						'resolve' => function( \WP_Taxonomy $taxonomy, array $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $taxonomy->show_in_rest ) ? $taxonomy->show_in_rest : null;
 						},
 					],
 					'restBase' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'Name of content type to diplay in REST API `wp/v2` namespace.', 'wp-graphql' ),
+						'description' => __( 'Name of content type to diplay in REST API `wp/v2` namespace.', 'wp-graphql' ),
 						'resolve' => function( \WP_Taxonomy $taxonomy, array $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : null;
 						},
 					],
 					'restControllerClass' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'The REST Controller class assigned to handling this content type.', 'wp-graphql' ),
+						'description' => __( 'The REST Controller class assigned to handling this content type.', 'wp-graphql' ),
 						'resolve' => function( \WP_Taxonomy $taxonomy, array $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $taxonomy->rest_controller_class ) ? $taxonomy->rest_controller_class : null;
 						},
 					],
 					'showInGraphql' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'Whether to add the post type to the GraphQL Schema.', 'wp-graphql' ),
+						'description' => __( 'Whether to add the post type to the GraphQL Schema.', 'wp-graphql' ),
 						'resolve' => function( \WP_Taxonomy $taxonomy, array $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $taxonomy->show_in_graphql ) ? $taxonomy->show_in_graphql : null;
 						},
 					],
 					'graphqlSingleName' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'The singular name of the post type within the GraphQL Schema.', 'wp-graphql' ),
+						'description' => __( 'The singular name of the post type within the GraphQL Schema.', 'wp-graphql' ),
 						'resolve' => function( \WP_Taxonomy $taxonomy, array $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $taxonomy->graphql_single_name ) ? $taxonomy->graphql_single_name : null;
 						},
 					],
 					'graphqlPluralName' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'The plural name of the post type within the GraphQL Schema.', 'wp-graphql' ),
+						'description' => __( 'The plural name of the post type within the GraphQL Schema.', 'wp-graphql' ),
 						'resolve' => function( \WP_Taxonomy $taxonomy, array $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $taxonomy->graphql_plural_name ) ? $taxonomy->graphql_plural_name : null;
 						},
 					],
 					'connectedPostTypeNames' => [
 						'type' => Types::list_of( Types::string() ),
-						'description' => esc_html__( 'A list of Post Types associated with the taxonomy', 'wp-graphql' ),
+						'description' => __( 'A list of Post Types associated with the taxonomy', 'wp-graphql' ),
 						'resolve' => function( \WP_Taxonomy $taxonomy, array $args, AppContext $context, ResolveInfo $info ) use ( $allowed_post_types ) {
 							$post_type_names = [];
 							$connected_post_types = $taxonomy->object_type;
@@ -200,7 +200,7 @@ class TaxonomyType extends WPObjectType {
 					],
 					'connectedPostTypes' => [
 						'type' => Types::list_of( Types::post_type() ),
-						'description' => esc_html__( 'List of Post Types connected to the Taxonomy', 'wp-graphql' ),
+						'description' => __( 'List of Post Types connected to the Taxonomy', 'wp-graphql' ),
 						'resolve' => function( \WP_Taxonomy $taxonomy, array $args, AppContext $context, ResolveInfo $info ) use ( $allowed_post_types ) {
 							$post_type_objects = [];
 							$connected_post_types = ! empty( $taxonomy->object_type ) ? $taxonomy->object_type : [];

--- a/src/Type/TermObject/TermObjectType.php
+++ b/src/Type/TermObject/TermObjectType.php
@@ -125,7 +125,7 @@ class TermObjectType extends WPObjectType {
 					],
 					$single_name . 'Id' => [
 						'type'        => Types::int(),
-						'description' => esc_html__( 'The id field matches the WP_Post->ID field.', 'wp-graphql' ),
+						'description' => __( 'The id field matches the WP_Post->ID field.', 'wp-graphql' ),
 						'resolve'     => function( \WP_Term $term, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $term->term_id ) ? absint( $term->term_id ) : null;
 						},

--- a/src/Type/Theme/ThemeType.php
+++ b/src/Type/Theme/ThemeType.php
@@ -74,7 +74,7 @@ class ThemeType extends WPObjectType {
 					],
 					'slug' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'The theme slug is used to internally match themes. Theme slugs can have subdirectories like: my-theme/sub-theme. This field is equivalent to WP_Theme->get_stylesheet().', 'wp-graphql' ),
+						'description' => __( 'The theme slug is used to internally match themes. Theme slugs can have subdirectories like: my-theme/sub-theme. This field is equivalent to WP_Theme->get_stylesheet().', 'wp-graphql' ),
 						'resolve' => function( \WP_Theme $theme, $args, AppContext $context, ResolveInfo $info ) {
 							$stylesheet = $theme->get_stylesheet();
 
@@ -83,7 +83,7 @@ class ThemeType extends WPObjectType {
 					],
 					'name' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'Display name of the theme. This field is equivalent to WP_Theme->get( "Name" ).', 'wp-graphql' ),
+						'description' => __( 'Display name of the theme. This field is equivalent to WP_Theme->get( "Name" ).', 'wp-graphql' ),
 						'resolve' => function( \WP_Theme $theme, $args, AppContext $context, ResolveInfo $info ) {
 							$name = $theme->get( 'Name' );
 
@@ -92,7 +92,7 @@ class ThemeType extends WPObjectType {
 					],
 					'screenshot' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'The URL of the screenshot for the theme. The screenshot is intended to give an overview of what the theme looks like. This field is equivalent to WP_Theme->get_screenshot().', 'wp-graphql' ),
+						'description' => __( 'The URL of the screenshot for the theme. The screenshot is intended to give an overview of what the theme looks like. This field is equivalent to WP_Theme->get_screenshot().', 'wp-graphql' ),
 						'resolve' => function( \WP_Theme $theme, $args, AppContext $context, ResolveInfo $info ) {
 							$screenshot = $theme->get_screenshot();
 
@@ -101,7 +101,7 @@ class ThemeType extends WPObjectType {
 					],
 					'themeUri' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'A URI if the theme has a website associated with it. The Theme URI is handy for directing users to a theme site for support etc. This field is equivalent to WP_Theme->get( "ThemeURI" ).', 'wp-graphql' ),
+						'description' => __( 'A URI if the theme has a website associated with it. The Theme URI is handy for directing users to a theme site for support etc. This field is equivalent to WP_Theme->get( "ThemeURI" ).', 'wp-graphql' ),
 						'resolve' => function( \WP_Theme $theme, $args, AppContext $context, ResolveInfo $info ) {
 							$theme_uri = $theme->get('ThemeURI');
 
@@ -110,15 +110,15 @@ class ThemeType extends WPObjectType {
 					],
 					'description' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'The description of the theme. This field is equivalent to WP_Theme->get( "Description" ).', 'wp-graphql' ),
+						'description' => __( 'The description of the theme. This field is equivalent to WP_Theme->get( "Description" ).', 'wp-graphql' ),
 					],
 					'author' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'Name of the theme author(s), could also be a company name. This field is equivalent to WP_Theme->get( "Author" ).', 'wp-graphql' ),
+						'description' => __( 'Name of the theme author(s), could also be a company name. This field is equivalent to WP_Theme->get( "Author" ).', 'wp-graphql' ),
 					],
 					'authorUri' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'URI for the author/company website. This field is equivalent to WP_Theme->get( "AuthorURI" ).', 'wp-graphql' ),
+						'description' => __( 'URI for the author/company website. This field is equivalent to WP_Theme->get( "AuthorURI" ).', 'wp-graphql' ),
 						'resolve' => function( \WP_Theme $theme, $args, AppContext $context, ResolveInfo $info ) {
 							$author_uri = $theme->get('AuthorURI');
 
@@ -127,11 +127,11 @@ class ThemeType extends WPObjectType {
 					],
 					'tags' => [
 						'type' => Types::list_of( Types::string() ),
-						'description' => esc_html__( 'URI for the author/company website. This field is equivalent to WP_Theme->get( "Tags" ).', 'wp-graphql' ),
+						'description' => __( 'URI for the author/company website. This field is equivalent to WP_Theme->get( "Tags" ).', 'wp-graphql' ),
 					],
 					'version' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'The current version of the theme. This field is equivalent to WP_Theme->get( "Version" ).', 'wp-graphql' ),
+						'description' => __( 'The current version of the theme. This field is equivalent to WP_Theme->get( "Version" ).', 'wp-graphql' ),
 					],
 				];
 

--- a/src/Type/User/UserType.php
+++ b/src/Type/User/UserType.php
@@ -111,7 +111,7 @@ class UserType extends WPObjectType {
 					],
 					'firstName' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'First name of the user. This is equivalent to the WP_User->user_first_name property.', 'wp-graphql' ),
+						'description' => __( 'First name of the user. This is equivalent to the WP_User->user_first_name property.', 'wp-graphql' ),
 						'resolve' => function( \WP_User $user, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $user->first_name ) ? $user->first_name : null;
 						},
@@ -119,21 +119,21 @@ class UserType extends WPObjectType {
 					'lastName' => [
 						'name' => 'last_name',
 						'type' => Types::string(),
-						'description' => esc_html__( 'Last name of the user. This is equivalent to the WP_User->user_last_name property.', 'wp-graphql' ),
+						'description' => __( 'Last name of the user. This is equivalent to the WP_User->user_last_name property.', 'wp-graphql' ),
 						'resolve' => function( \WP_User $user, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $user->last_name ) ? $user->last_name : null;
 						},
 					],
 					'extraCapabilities' => [
 						'type' => Types::list_of( Types::string() ),
-						'description' => esc_html__( 'A complete list of capabilities including capabilities inherited from a role. This is equivalent to the array keys of WP_User->allcaps.', 'wp-graphql' ),
+						'description' => __( 'A complete list of capabilities including capabilities inherited from a role. This is equivalent to the array keys of WP_User->allcaps.', 'wp-graphql' ),
 						'resolve' => function( \WP_User $user, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $user->allcaps ) ? array_keys( $user->allcaps ) : null;
 						},
 					],
 					'description' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'Description of the user.', 'wp-graphql' ),
+						'description' => __( 'Description of the user.', 'wp-graphql' ),
 						'resolve' => function( \WP_User $user, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $user->description ) ? $user->description : null;
 						},
@@ -147,42 +147,42 @@ class UserType extends WPObjectType {
 					],
 					'name' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'Display name of the user. This is equivalent to the WP_User->dispaly_name property.', 'wp-graphql' ),
+						'description' => __( 'Display name of the user. This is equivalent to the WP_User->dispaly_name property.', 'wp-graphql' ),
 						'resolve' => function( \WP_User $user, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $user->display_name ) ? $user->display_name : null;
 						},
 					],
 					'registeredDate' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'The date the user registered or was created. The field follows a full ISO8601 date string format.', 'wp-graphql' ),
+						'description' => __( 'The date the user registered or was created. The field follows a full ISO8601 date string format.', 'wp-graphql' ),
 						'resolve' => function( \WP_User $user, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $user->user_registered ) ? date( 'c', strtotime( $user->user_registered ) ) : null;
 						},
 					],
 					'nickname' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'Nickname of the user.', 'wp-graphql' ),
+						'description' => __( 'Nickname of the user.', 'wp-graphql' ),
 						'resolve' => function( \WP_User $user, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $user->nickname ) ? $user->nickname : null;
 						},
 					],
 					'url' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'A website url that is associated with the user.', 'wp-graphql' ),
+						'description' => __( 'A website url that is associated with the user.', 'wp-graphql' ),
 						'resolve' => function( \WP_User $user, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $user->user_url ) ? $user->user_url : null;
 						},
 					],
 					'slug' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'The slug for the user. This field is equivalent to WP_User->user_nicename', 'wp-graphql' ),
+						'description' => __( 'The slug for the user. This field is equivalent to WP_User->user_nicename', 'wp-graphql' ),
 						'resolve' => function( \WP_User $user, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $user->user_nicename ) ? $user->user_nicename : null;
 						},
 					],
 					'locale' => [
 						'type' => Types::string(),
-						'description' => esc_html__( 'The preferred language locale set for the user. Value derived from get_user_locale().', 'wp-graphql' ),
+						'description' => __( 'The preferred language locale set for the user. Value derived from get_user_locale().', 'wp-graphql' ),
 						'resolve' => function( \WP_User $user, $args, AppContext $context, ResolveInfo $info ) {
 							$user_locale = get_user_locale( $user );
 
@@ -250,7 +250,7 @@ class UserType extends WPObjectType {
 							}
 
 							if ( ! empty( $args['rating'] ) ) {
-								$avatar_args['rating'] = esc_html( $args['rating'] );
+								$avatar_args['rating'] = esc_sql( $args['rating'] );
 							}
 
 							$avatar = get_avatar_data( $user->ID, $avatar_args );

--- a/src/WPSchema.php
+++ b/src/WPSchema.php
@@ -38,4 +38,51 @@ class WPSchema extends Schema {
 		parent::__construct( $this->filterable_config );
 	}
 
+	/**
+	 * This takes in the Schema and escapes it before it's returned to the executor.
+	 *
+	 * @param \WPGraphQL\WPSchema $schema
+	 *
+	 * @return mixed
+	 */
+	public static function sanitize_schema( \WPGraphQL\WPSchema $schema ) {
+
+		/**
+		 * Get the prepared TypeMap
+		 */
+		$types = $schema->getTypeMap();
+
+		/**
+		 * Ensure there are types
+		 */
+		if ( ! empty( $types ) && is_array( $types ) ) {
+
+			/**
+			 * Loop through the types
+			 */
+			foreach ( $types as $type_name => $type_object ) {
+
+				/**
+				 * esc the values
+				 */
+				$sanitized_types[ $type_name ] = $type_object;
+				$sanitized_types[ $type_name ]->name = esc_html( $type_object->name );
+				$sanitized_types[ $type_name ]->description = esc_html( $type_object->description );
+				$sanitized_types[ $type_name ]->deprecationReason = esc_html( $type_object->description );
+			}
+		}
+
+		/**
+		 * Ensure there are $sanitized_types, and set the config's types as the sanitized types
+		 */
+		if ( ! empty( $sanitized_types ) && is_array( $sanitized_types ) ) {
+			$schema->filterable_config['types'] = $sanitized_types;
+		}
+
+		/**
+		 * Return the $schema with the sanitized types
+		 */
+		return $schema;
+
+	}
 }

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -433,10 +433,15 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 			$schema = apply_filters( 'graphql_schema', $schema, $request, $operation_name, $variables, $app_context );
 
 			/**
+			 * Sanitize the Schema as late as possible before execution
+			 */
+			$sanitized_schema = \WPGraphQL\WPSchema::sanitize_schema( $schema );
+
+			/**
 			 * Executes the request and captures the result
 			 */
 			$result = \GraphQL\GraphQL::execute(
-				$schema,
+				$sanitized_schema,
 				$request,
 				null,
 				$app_context,


### PR DESCRIPTION
This adjusts instances of translated strings to use `__()` instead of `esc_html__()` and adds a `sanitize_schema` method that runs just before the Schema is sent to the Executor, which does the escaping on the description, name and deprecationReason as late as possible.