### PR TITLE
Term mutation, absint() error

### DIFF
--- a/src/Type/TermObject/Mutation/TermObjectMutation.php
+++ b/src/Type/TermObject/Mutation/TermObjectMutation.php
@@ -120,12 +120,19 @@ class TermObjectMutation {
 			$parent_id_parts = ! empty( $input['parentId'] ) ? Relay::fromGlobalId( $input['parentId'] ) : null;
 
 			/**
-			 * If the term
+			 * Ensure that the ID passed in is a valid GlobalID
 			 */
-			if ( is_array( $parent_id_parts ) && ! empty( $parent_id_parts['id'] ) && is_int( $parent_id_parts['id'] ) ) {
+			if ( is_array( $parent_id_parts ) && ! empty( $parent_id_parts['id'] ) ) {
+
+				/**
+				 * Get the Term ID from the global ID
+				 */
 				$parent_id = $parent_id_parts['id'];
 
-				$parent_term = get_term( absint( $parent_id, $taxonomy->name ) );
+				/**
+				 * Ensure there's actually a parent term to be associated with
+				 */
+				$parent_term = get_term( absint( $parent_id ), $taxonomy->name );
 
 				if ( ! $parent_term || is_wp_error( $parent_term ) ) {
 					throw new \Exception( __( 'The parent does not exist', 'wp-graphql' ) );

--- a/tests/test-term-object-mutations.php
+++ b/tests/test-term-object-mutations.php
@@ -578,4 +578,42 @@ class Test_Term_Object_Mutations extends WP_UnitTestCase {
 
 	}
 
+	public function testUpdateCategoryParent() {
+
+		wp_set_current_user( $this->admin );
+
+		$parent_term_id = $this->factory->term->create([
+			'taxonomy' => 'category',
+			'name' => 'Parent Category',
+		]);
+
+		$query = '
+		mutation createChildCategory($input: createCategoryInput!) {
+		  createCategory(input: $input) {
+		    category {
+		      parent{
+		        id
+		      }
+		    }
+		  }
+		}
+		';
+
+		$parent_id = \GraphQLRelay\Relay::toGlobalId( 'category', $parent_term_id );
+
+		$variables = [
+			'input' => [
+				'clientMutationId' => 'someId',
+				'name' => 'Child Category',
+				'parentId' => $parent_id,
+			],
+		];
+
+		$actual = do_graphql_request( $query, 'createChildCategory', $variables );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEquals( $parent_id, $actual['data']['createCategory']['category']['parent']['id'] );
+
+	}
+
 }


### PR DESCRIPTION
This fixes a mistake in the termObjectMutation where absint() was getting too many params passed.

That means parent's were never able to actually be set. . .so I fixed this. . .and added a test to make sure that a parent term could actually be set when doing a mutation.

While in there, I also added a "parent" field for hierarchical taxonomies.

So, this pr addresses #183 and #133