### PR TITLE
#186 - Fix default "parent" arg for comment connection resolver

### DIFF
--- a/src/Type/Comment/Connection/CommentConnectionResolver.php
+++ b/src/Type/Comment/Connection/CommentConnectionResolver.php
@@ -46,7 +46,7 @@ class CommentConnectionResolver extends ConnectionResolver {
 		/**
 		 * Set the default comment_parent for Comment Queries to be "0" to only get top level comments
 		 */
-		$query_args['comment_parent'] = 0;
+		$query_args['parent'] = 0;
 
 		/**
 		 * Set the number, ensuring it doesn't exceed the amount set as the $max_query_amount


### PR DESCRIPTION
Comment Parent Query Arg gets improperly set as “comment_parent” instead of “parent”