### PR TITLE
Return a user friendly error on an empty query

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -238,7 +238,7 @@ class Router {
 
 	/**
 	 * This processes the graphql requests that come into the /graphql endpoint via an HTTP request
-	 * 
+	 *
 	 * @since  0.0.1
 	 * @access public
 	 * @return mixed
@@ -302,7 +302,6 @@ class Router {
 
 				$data['variables'] = ! empty( $decoded_variables ) && is_array( $decoded_variables ) ? $decoded_variables : null;
 
-
 			} else {
 				if ( ! isset( $_SERVER['REQUEST_METHOD'] ) || 'POST' !== $_SERVER['REQUEST_METHOD'] ) {
 					$response['errors'] = __( 'WPGraphQL requires POST requests', 'wp-graphql' );
@@ -318,13 +317,13 @@ class Router {
 				 * @since 0.0.5
 				 */
 				$data = json_decode( self::get_raw_data(), true );
-			}
+			}// End if().
 
 			/**
 			 * If the $data is empty, catch an error.
 			 */
-			if ( empty( $data ) ) {
-				$response['errors'] = __( 'GraphQL Queries must be a POST Request with a valid query', 'wp-graphql' );
+			if ( empty( $data ) || ( empty( $data['query'] ) && empty( $data['operationName'] ) && empty( $data['variables'] ) ) ) {
+				throw new \Exception( __( 'GraphQL Queries must be a POST Request with a valid query', 'wp-graphql' ), 10 );
 			}
 
 			/**
@@ -375,7 +374,11 @@ class Router {
 			if ( defined( 'GRAPHQL_DEBUG' ) && true === GRAPHQL_DEBUG ) {
 				$response['extensions']['exception'] = FormattedError::createFromException( $error );
 			} else {
-				$response['errors'] = [ FormattedError::create( 'Unexpected error' ) ];
+				if ( 10 == $error->getCode() ) {
+					$response['errors'] = [ FormattedError::create( $error->getMessage() ) ];
+				} else {
+					$response['errors'] = [ FormattedError::create( 'Unexpected error' ) ];
+				}
 			}
 		} // End try().
 

--- a/src/Router.php
+++ b/src/Router.php
@@ -405,7 +405,7 @@ class Router {
 			 * Send the JSON response
 			 */
 			wp_send_json( $response );
-		} else {
+		} elseif (defined( 'DOING_AJAX' ) && DOING_AJAX) {
 			/**
 			 * Headers will already be set if this function is called within AJAX.
 			 */

--- a/src/Router.php
+++ b/src/Router.php
@@ -405,6 +405,11 @@ class Router {
 			 * Send the JSON response
 			 */
 			wp_send_json( $response );
+		} else {
+			/**
+			 * Headers will already be set if this function is called within AJAX.
+			 */
+			wp_send_json( $response );
 		}
 
 	}

--- a/src/Router.php
+++ b/src/Router.php
@@ -374,7 +374,7 @@ class Router {
 			if ( defined( 'GRAPHQL_DEBUG' ) && true === GRAPHQL_DEBUG ) {
 				$response['extensions']['exception'] = FormattedError::createFromException( $error );
 			} else {
-				if ( 10 == $error->getCode() ) {
+				if ( 10 === $error->getCode() ) {
 					$response['errors'] = [ FormattedError::create( $error->getMessage() ) ];
 				} else {
 					$response['errors'] = [ FormattedError::create( 'Unexpected error' ) ];

--- a/tests/test-json-responses.php
+++ b/tests/test-json-responses.php
@@ -4,7 +4,7 @@
  *
  * @group ajax
  */
-class WPGraphQL_Test_Router extends WP_Ajax_UnitTestCase {
+class WPGraphQL_JSON_Responses extends WP_Ajax_UnitTestCase {
 
 	public function setUp() {
 		parent::setUp();
@@ -31,6 +31,8 @@ class WPGraphQL_Test_Router extends WP_Ajax_UnitTestCase {
 		set_query_var( 'graphql', true );
 		$GLOBALS['wp']->query_vars['graphql'] = true;
 
+		define( 'DOING_AJAX', true );
+
 		/**
 		 * Instantiate the router
 		 */
@@ -43,7 +45,6 @@ class WPGraphQL_Test_Router extends WP_Ajax_UnitTestCase {
 		try {
 			$this->_handleAjax( 'graphql_resolve_http_request' );
 		} catch ( WPAjaxDieContinueException $e ) {}
-		// $router::resolve_http_request();
 		/**
 		 * Make sure the constant gets defined when it's a GraphQL Request
 		 */

--- a/tests/test-json-responses.php
+++ b/tests/test-json-responses.php
@@ -13,7 +13,12 @@ class WPGraphQL_JSON_Responses extends WP_Ajax_UnitTestCase {
 	public function tearDown() {
 		parent::tearDown();
 	}
-
+	/**
+	 * [testResolveHttpRequestWithEmptyQuery description]
+	 *
+	 * @runInSeparateProcess
+	 * @return [type] [description]
+	 */
 	public function testResolveHttpRequestWithEmptyQuery() {
 		/**
 		 * Filter the request data

--- a/tests/test-json-responses.php
+++ b/tests/test-json-responses.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Test case for Basic Router responses.
+ *
+ * @group ajax
+ */
+class WPGraphQL_Test_Router extends WP_Ajax_UnitTestCase {
+
+	public function setUp() {
+		parent::setUp();
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+	}
+
+	public function testResolveHttpRequestWithEmptyQuery() {
+		/**
+		 * Filter the request data
+		 */
+		add_filter( 'graphql_request_data', function( $data ) {
+			$data['query'] = null;
+			$data['variables'] = null;
+			$data['operationName'] = null;
+			return $data;
+		} );
+
+		/**
+		 * Set the query var to "graphql" so we can mock like we're visiting the endpoint via
+		 */
+		set_query_var( 'graphql', true );
+		$GLOBALS['wp']->query_vars['graphql'] = true;
+
+		/**
+		 * Instantiate the router
+		 */
+		$router = new \WPGraphQL\Router();
+
+		add_action( 'wp_ajax_graphql_resolve_http_request', [ '\WPGraphQL\Router', 'resolve_http_request' ] );
+		/**
+		 * Process the request using our filtered data
+		 */
+		try {
+			$this->_handleAjax( 'graphql_resolve_http_request' );
+		} catch ( WPAjaxDieContinueException $e ) {}
+		// $router::resolve_http_request();
+		/**
+		 * Make sure the constant gets defined when it's a GraphQL Request
+		 */
+		$this->assertTrue( defined( 'GRAPHQL_HTTP_REQUEST' ) );
+		$this->assertEquals( true, GRAPHQL_HTTP_REQUEST );
+
+		/**
+		 * Make sure the actions we expect to be firing are firing
+		 */
+		$this->assertNotFalse( did_action( 'graphql_resolve_http_request' ) );
+		$this->assertNotFalse( did_action( 'graphql_process_http_request_response' ) );
+		/**
+		 * Pull out last AJAX response received by this test class.
+		 *
+		 * @var string
+		 */
+		$this->assertTrue( isset( $this->_last_response ) );
+		$result = $this->_last_response;
+		$expected = '{"errors":[{"message":"GraphQL Queries must be a POST Request with a valid query"}]}';
+		$this->assertSame( $expected, $result );
+
+	}
+
+}

--- a/tests/test-router.php
+++ b/tests/test-router.php
@@ -49,7 +49,6 @@ class WPGraphQL_Test_Router extends WP_UnitTestCase {
 
 	/**
 	 * Test the "send_header" method in the Router class
-	 *
 	 * @see: https://github.com/sebastianbergmann/phpunit/issues/720
 	 * @runInSeparateProcess
 	 */
@@ -124,9 +123,7 @@ class WPGraphQL_Test_Router extends WP_UnitTestCase {
 		 */
 		add_filter( 'graphql_request_data', function( $data ) {
 			$data['query'] = 'query getPosts($first:Int){ posts(first:$first){ edges{ node{ id } } } }';
-			$data['variables'] = [
-				'first' => 1,
-			];
+			$data['variables'] = [ 'first' => 1 ];
 			$data['operationName'] = 'getPosts';
 			return $data;
 		} );
@@ -176,9 +173,7 @@ class WPGraphQL_Test_Router extends WP_UnitTestCase {
 		 */
 		add_filter( 'graphql_request_data', function( $data ) {
 			$data['query'] = 'query getPosts($first:Int){ posts(first:$first){ edges{ node{ id } } } }';
-			$data['variables'] = wp_json_encode( [
-				'first' => 1,
-			] );
+			$data['variables'] = wp_json_encode( [ 'first' => 1 ] );
 			$data['operationName'] = 'getPosts';
 			return $data;
 		} );


### PR DESCRIPTION
This assures that if the user hits the namespace with no query they are
presented with a friendly well-formatted error. Noted in ticket #200