### PR TITLE
#207 - Get Post Objects by Global ID, Database ID, or URI.

### DIFF
--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -532,7 +532,7 @@ class DataSource {
 	 *
 	 * This is a modified version of the cached function from WordPress.com VIP MU Plugins here.
 	 *
-	 * @param string $path
+	 * @param string $uri
 	 * @param string $output Optional. Output type; OBJECT*, ARRAY_N, or ARRAY_A.
 	 * @param string $post_type Optional. Post type; default is 'post'.
 	 * @return WP_Post|null WP_Post on success or null on failure

--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -527,4 +527,40 @@ class DataSource {
 		return self::$node_definition;
 	}
 
+	/**
+	 * Cached version of get_page_by_path so that we're not making unnecessary SQL all the time
+	 *
+	 * This is a modified version of the cached function from WordPress.com VIP MU Plugins here.
+	 *
+	 * @param string $path
+	 * @param string $output Optional. Output type; OBJECT*, ARRAY_N, or ARRAY_A.
+	 * @param string $post_type Optional. Post type; default is 'post'.
+	 * @return WP_Post|null WP_Post on success or null on failure
+	 * @see https://github.com/Automattic/vip-go-mu-plugins/blob/52549ae9a392fc1343b7ac9dba4ebcdca46e7d55/vip-helpers/vip-caching.php#L186
+	 * @link http://vip.wordpress.com/documentation/uncached-functions/ Uncached Functions
+	 */
+	public static function get_post_object_by_uri( $uri, $output = OBJECT, $post_type = 'post' ) {
+
+		if ( is_array( $post_type ) ) {
+			$cache_key = sanitize_key( $uri ) . '_' . md5( serialize( $post_type ) );
+		} else {
+			$cache_key = $post_type . '_' . sanitize_key( $uri );
+		}
+		$post_id = wp_cache_get( $cache_key, 'get_post_object_by_path' );
+
+		if ( false === $post_id ) {
+			$post = get_page_by_path( $uri, $output, $post_type );
+			$post_id = $post ? $post->ID : 0;
+			if ( 0 === $post_id ) {
+				wp_cache_set( $cache_key, $post_id, 'get_post_object_by_path', ( 1 * HOUR_IN_SECONDS + mt_rand( 0, HOUR_IN_SECONDS ) ) ); // We only store the ID to keep our footprint small
+			} else {
+				wp_cache_set( $cache_key, $post_id, 'get_post_object_by_path', 0 ); // We only store the ID to keep our footprint small
+			}
+		}
+		if ( $post_id ) {
+			return get_post( $post_id, $output );
+		}
+		return null;
+
+	}
 }

--- a/src/Type/PostObject/PostObjectQuery.php
+++ b/src/Type/PostObject/PostObjectQuery.php
@@ -88,7 +88,7 @@ class PostObjectQuery {
 					if ( ! empty( $args['id'] ) ) {
 						$id_components = Relay::fromGlobalId( $args['id'] );
 						if ( empty( $id_components['id'] ) || empty( $id_components[ 'type' ] ) ) {
-							throw new \Exception( 'The "id" is invalid', 'wp-graphql' );
+							throw new \Exception( __( 'The "id" is invalid', 'wp-graphql' ) );
 						}
 						$post_object = DataSource::resolve_post_object( absint( $id_components['id'] ), $post_type_object->name );
 					} elseif ( ! empty( $args[ $post_type_object->graphql_single_name . 'Id' ] ) ) {

--- a/src/Type/PostObject/PostObjectQuery.php
+++ b/src/Type/PostObject/PostObjectQuery.php
@@ -5,6 +5,7 @@ use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
 use WPGraphQL\Data\DataSource;
+use WPGraphQL\Type\WPInputObjectType;
 use WPGraphQL\Types;
 
 /**
@@ -20,6 +21,18 @@ class PostObjectQuery {
 	 * @since 0.0.5
 	 */
 	private static $root_query;
+
+	/**
+	 * Holds the definition of the $post_object_by field
+	 * @var array $post_object_by
+	 */
+	private static $post_object_by;
+
+	/**
+	 * Holds the definition for the args that can be input on the $post_object_by field
+	 * @var array $post_object_by_args
+	 */
+	private static $post_object_by_args;
 
 	/**
 	 * Method that returns the root query field definition for the post object type
@@ -43,13 +56,114 @@ class PostObjectQuery {
 				],
 				'resolve' => function( $source, array $args, AppContext $context, ResolveInfo $info ) use ( $post_type_object ) {
 					$id_components = Relay::fromGlobalId( $args['id'] );
-
 					return DataSource::resolve_post_object( $id_components['id'], $post_type_object->name );
 				},
 			];
-
-			return self::$root_query[ $post_type_object->name ];
 		endif;
+
+		return ! empty( self::$root_query[ $post_type_object->name ] ) ? self::$root_query[ $post_type_object->name ] : null;
+	}
+	
+	/**
+	 * Method that returns the "post_object_by" field definition to get a post object by id, postId or slug.
+	 *
+	 * @param \WP_Post_Type $post_type_object
+	 * @return array
+	 */
+	public static function post_object_by( \WP_Post_Type $post_type_object ) {
+
+		if ( null === self::$post_object_by ) {
+			self::$post_object_by = [];
+		}
+
+		if ( ! empty( $post_type_object->name ) && empty( self::$post_object_by[ $post_type_object->name ] ) ) :
+			self::$post_object_by[ $post_type_object->name ] = [
+				'type' => Types::post_object( $post_type_object->name ),
+				'description' => sprintf( __( 'A %s object', 'wp-graphql' ), $post_type_object->graphql_single_name ),
+				'args' => self::post_object_by_args( $post_type_object ),
+				'resolve' => function( $source, array $args, AppContext $context, ResolveInfo $info ) use ( $post_type_object ) {
+
+					$post_object = null;
+			
+					if ( ! empty( $args['id'] ) ) {
+						$id_components = Relay::fromGlobalId( $args['id'] );
+						if ( empty( $id_components['id'] ) || empty( $id_components[ 'type' ] ) ) {
+							throw new \Exception( 'The "id" is invalid', 'wp-graphql' );
+						}
+						$post_object = DataSource::resolve_post_object( absint( $id_components['id'] ), $post_type_object->name );
+					} elseif ( ! empty( $args[ $post_type_object->graphql_single_name . 'Id' ] ) ) {
+						$id = $args[ $post_type_object->graphql_single_name . 'Id' ];
+						$post_object =  DataSource::resolve_post_object( $id, $post_type_object->name );
+					} elseif ( ! empty( $args['uri'] ) ) {
+						$uri = esc_html( $args['uri'] );
+						$post_object = DataSource::get_post_object_by_uri( $uri, 'OBJECT', $post_type_object->name );
+					} elseif ( ! empty( $args['slug'] ) ) {
+						$slug = esc_html( $args['slug'] );
+						$post_object = DataSource::get_post_object_by_uri( $slug, 'OBJECT', $post_type_object->name );
+					}
+
+					if ( empty( $post_object ) || is_wp_error( $post_object ) ) {
+						throw new \Exception( __( 'No resource could by found', 'wp-graphql' ) );
+					}
+
+					if ( ! is_a( $post_object, 'WP_Post' ) ) {
+						throw new \Exception( __( 'The queried resource is not valid', 'wp-graphql' ) );
+					}
+
+					if ( $post_type_object->name !== $post_object->post_type ) {
+						throw new \Exception( __( 'The queried resource is not the correct type', 'wp-graphql' ) );
+					}
+
+					return $post_object;
+
+				},
+			];
+		endif;
+		return ! empty( self::$post_object_by[ $post_type_object->name ] ) ? self::$post_object_by[ $post_type_object->name ] : null;
+	}
+
+	/**
+	 * Define the args to be used by the $postObject.By field
+	 * @param \WP_Post_Type $post_type_object
+	 *
+	 * @return mixed
+	 */
+	public static function post_object_by_args( \WP_Post_Type $post_type_object ) {
+
+		if ( null === self::$post_object_by_args ) {
+			self::$post_object_by_args = [];
+		}
+
+		if ( empty( self::$post_object_by_args[ $post_type_object->name . 'ByArgs' ] ) ) {
+
+			$args = [
+				'id' => [
+					'type'        => Types::string(),
+					'description' => sprintf( __( 'Get the object by it\'s global ID', 'wp-graphql' ), $post_type_object->graphql_single_name ),
+				],
+				$post_type_object->graphql_single_name . 'Id' => [
+					'type'        => Types::int(),
+					'description' => sprintf( __( 'Get the %s by it\'s database ID', 'wp-graphql' ), $post_type_object->graphql_single_name ),
+				],
+				'uri' => [
+					'type'        => Types::string(),
+					'description' => sprintf( __( 'Get the %s by it\'s uri', 'wp-graphql' ), $post_type_object->graphql_single_name ),
+				]
+			];
+
+			if ( false === $post_type_object->hierarchical ) {
+				$args['slug'] = [
+					'type' => Types::string(),
+					'description' => sprintf( __( 'Get the %s by it\'s slug (only available for non-hierarchical types)', 'wp-graphql' ), $post_type_object->graphql_single_name ),
+				];
+			}
+
+			self::$post_object_by_args[ $post_type_object->name . 'ByArgs' ] = WPInputObjectType::prepare_fields( $args, $post_type_object->name . 'ByArgs' );
+
+		}
+
+		return self::$post_object_by_args[ $post_type_object->name . 'ByArgs' ];
+
 	}
 
 }

--- a/src/Type/PostObject/PostObjectType.php
+++ b/src/Type/PostObject/PostObjectType.php
@@ -347,6 +347,14 @@ class PostObjectType extends WPObjectType {
 							return ! empty( $link ) ? $link : null;
 						},
 					],
+					'uri' => [
+						'type' => Types::string(),
+						'description' => __( 'URI path for the resource', 'wp-graphql' ),
+						'resolve' => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
+							$uri = get_page_uri( $post->ID );
+							return ! empty( $uri ) ? $uri : null;
+						},
+					],
 					'terms' => [
 						'type' => Types::list_of( Types::term_object_union() ),
 						'args' => [

--- a/src/Type/RootQueryType.php
+++ b/src/Type/RootQueryType.php
@@ -121,6 +121,7 @@ class RootQueryType extends ObjectType {
 				 * @since 0.0.5
 				 */
 				$fields[ $post_type_object->graphql_single_name ] = PostObjectQuery::root_query( $post_type_object );
+				$fields[ $post_type_object->graphql_single_name . 'By' ] = PostObjectQuery::post_object_by( $post_type_object );
 
 				/**
 				 * Root query for collections of posts (of the specified post_type)


### PR DESCRIPTION
This exposes a new “uri” field on the postObjectType, which resolves to `get_page_uri()`

Then, this adds a new `postBy, pageBy, mediaItemBy` field that allows single postObjects to be queried `by` one of 3 fields, ID, GlobalID or URI.

To resolve based on the URI, a cached version of `get_page_by_path` was added to the DataSource (borrowed and modified from VIP’s mu plugins)

This includes unit tests to ensure these queries work and that the nodes returned match each time.