### PR TITLE
#209 children connection for post objects.

### DIFF
--- a/src/Type/PostObject/PostObjectType.php
+++ b/src/Type/PostObject/PostObjectType.php
@@ -8,6 +8,7 @@ use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
 use WPGraphQL\Data\DataSource;
 use WPGraphQL\Type\Comment\Connection\CommentConnectionDefinition;
+use WPGraphQL\Type\PostObject\Connection\PostObjectConnectionDefinition;
 use WPGraphQL\Type\TermObject\Connection\TermObjectConnectionDefinition;
 use WPGraphQL\Type\WPObjectType;
 use WPGraphQL\Types;
@@ -424,6 +425,13 @@ class PostObjectType extends WPObjectType {
 							return ! empty( $post->comment_count ) ? absint( $post->comment_count ) : null;
 						},
 					];
+				}
+
+				/**
+				 * If the post_type is Hierarchical, there should be a children field
+				 */
+				if ( true === $post_type_object->hierarchical ) {
+					$fields[ 'child' . ucfirst( $post_type_object->graphql_plural_name ) ] = PostObjectConnectionDefinition::connection( $post_type_object );
 				}
 
 				/**


### PR DESCRIPTION
This adds a child{PluralName} to hierarchical post_types.

For example:

```
{
  pages {
    edges {
      node {
        id
        title
        childPages {
          edges {
            node {
              id
              title
              date
            }
          }
        }
      }
    }
  }
}
```

The field is intentionally _not_ labeled as “children”, as children of a post _can_ be of any type (posts can have parents of different post_types), so we’ll have to think through how to add a generic "children" field a bit more as it will need to be a union of some sort. . .