### PR TITLE
Add post object field format arg

### DIFF
--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -156,6 +156,16 @@ class DataSource {
 			throw new \Exception( sprintf( __( 'No %1$s was found with the ID: %2$s', 'wp-graphql' ), $id, $post_type ) );
 		}
 
+		/**
+		 * Set the resolved post to the global $post. That way any filters that
+		 * might be applied when resolving fields can rely on global post and
+		 * post data being set up.
+		 *
+		 * @since 0.0.18
+		 */
+		$GLOBALS['post'] = $post_object;
+		setup_postdata( $post_object );
+
 		return $post_object;
 
 	}

--- a/src/Type/Enum/PostObjectFieldFilterEnumType.php
+++ b/src/Type/Enum/PostObjectFieldFilterEnumType.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace WPGraphQL\Type\Enum;
+
+use WPGraphQL\Type\WPEnumType;
+
+/**
+ * Class PostObjectFieldFilterEnumType
+ *
+ * This defines an EnumType with allowed WordPress filters that can be applied
+ * to post field data.
+ *
+ * @package WPGraphQL\Type\Enum
+ * @since   0.0.18
+ */
+class PostObjectFieldFilterEnumType extends WPEnumType {
+
+	/**
+	 * This holds the enum values array.
+	 *
+	 * @var array $values
+	 */
+	private static $values;
+
+	public function __construct() {
+		$config = [
+			'name'        => 'postObjectFieldFilter',
+			'description' => __( 'The allowed WordPress filters on post field data.', 'wp-graphql' ),
+			'values'      => self::values(),
+		];
+		parent::__construct( $config );
+	}
+
+	/**
+	 * Creates a list of filters that can be used to filter post field data.
+	 *
+	 * @return array
+	 */
+	private static function values() {
+
+		if ( null === self::$values ) {
+
+			/**
+			 * Provide some default filters that are in WP Core.
+			 *
+			 * @since 0.0.18
+			 */
+			self::$values = [
+				'the_content' => [
+					'name'  => 'THE_CONTENT',
+					'description' => __( 'WordPress Core the_content filter', 'wp-graphql' ),
+					'value' => 'the_content',
+				],
+				'get_the_excerpt' => [
+					'name'  => 'GET_THE_EXCERPT',
+					'description' => __( 'WordPress Core get_the_excerpt filter', 'wp-graphql' ),
+					'value' => 'get_the_excerpt',
+				],
+				'the_excerpt' => [
+					'name'  => 'THE_EXCERPT',
+					'description' => __( 'WordPress Core the_excerpt filter', 'wp-graphql' ),
+					'value' => 'the_excerpt',
+				],
+				'the_title' => [
+					'name'  => 'THE_TITLE',
+					'description' => __( 'WordPress Core the_title filter', 'wp-graphql' ),
+					'value' => 'the_title',
+				],
+			];
+
+		}
+
+		/**
+		 * Return the $values
+		 */
+		return self::$values;
+	}
+}

--- a/src/Type/Enum/PostObjectFieldFilterEnumType.php
+++ b/src/Type/Enum/PostObjectFieldFilterEnumType.php
@@ -5,15 +5,14 @@ namespace WPGraphQL\Type\Enum;
 use WPGraphQL\Type\WPEnumType;
 
 /**
- * Class PostObjectFieldFilterEnumType
+ * Class PostObjectFieldFormatEnumType
  *
- * This defines an EnumType with allowed WordPress filters that can be applied
- * to post field data.
+ * This defines an EnumType with allowed formats of post field data.
  *
  * @package WPGraphQL\Type\Enum
  * @since   0.0.18
  */
-class PostObjectFieldFilterEnumType extends WPEnumType {
+class PostObjectFieldFormatEnumType extends WPEnumType {
 
 	/**
 	 * This holds the enum values array.
@@ -24,15 +23,15 @@ class PostObjectFieldFilterEnumType extends WPEnumType {
 
 	public function __construct() {
 		$config = [
-			'name'        => 'postObjectFieldFilter',
-			'description' => __( 'The allowed WordPress filters on post field data.', 'wp-graphql' ),
+			'name'        => 'postObjectFieldFormat',
+			'description' => __( 'The format of post field data.', 'wp-graphql' ),
 			'values'      => self::values(),
 		];
 		parent::__construct( $config );
 	}
 
 	/**
-	 * Creates a list of filters that can be used to filter post field data.
+	 * Creates a list of formats of post field data.
 	 *
 	 * @return array
 	 */
@@ -41,30 +40,20 @@ class PostObjectFieldFilterEnumType extends WPEnumType {
 		if ( null === self::$values ) {
 
 			/**
-			 * Provide some default filters that are in WP Core.
+			 * Post object field formats.
 			 *
 			 * @since 0.0.18
 			 */
 			self::$values = [
-				'the_content' => [
-					'name'  => 'THE_CONTENT',
-					'description' => __( 'WordPress Core the_content filter', 'wp-graphql' ),
-					'value' => 'the_content',
+				'raw' => [
+					'name'  => 'RAW',
+					'description' => __( 'Provide the field value directly from database', 'wp-graphql' ),
+					'value' => 'raw',
 				],
-				'get_the_excerpt' => [
-					'name'  => 'GET_THE_EXCERPT',
-					'description' => __( 'WordPress Core get_the_excerpt filter', 'wp-graphql' ),
-					'value' => 'get_the_excerpt',
-				],
-				'the_excerpt' => [
-					'name'  => 'THE_EXCERPT',
-					'description' => __( 'WordPress Core the_excerpt filter', 'wp-graphql' ),
-					'value' => 'the_excerpt',
-				],
-				'the_title' => [
-					'name'  => 'THE_TITLE',
-					'description' => __( 'WordPress Core the_title filter', 'wp-graphql' ),
-					'value' => 'the_title',
+				'rendered' => [
+					'name'  => 'RENDERED',
+					'description' => __( 'Apply the default WordPress rendering', 'wp-graphql' ),
+					'value' => 'rendered',
 				],
 			];
 

--- a/src/Type/Enum/PostObjectFieldFormatEnumType.php
+++ b/src/Type/Enum/PostObjectFieldFormatEnumType.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace WPGraphQL\Type\Enum;
 
 use WPGraphQL\Type\WPEnumType;

--- a/src/Type/PostObject/Connection/PostObjectConnectionResolver.php
+++ b/src/Type/PostObject/Connection/PostObjectConnectionResolver.php
@@ -6,6 +6,7 @@ use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Connection\ArrayConnection;
 use WPGraphQL\AppContext;
 use WPGraphQL\Data\ConnectionResolver;
+use WPGraphQL\Data\DataSource;
 use WPGraphQL\Types;
 
 /**
@@ -289,7 +290,7 @@ class PostObjectConnectionResolver extends ConnectionResolver {
 			foreach ( $items as $item ) {
 				$edges[] = [
 					'cursor' => ArrayConnection::offsetToCursor( $item->ID ),
-					'node'   => $item,
+					'node'   => DataSource::resolve_post_object( $item->ID, $item->post_type ),
 				];
 			}
 		}

--- a/src/Type/PostObject/PostObjectType.php
+++ b/src/Type/PostObject/PostObjectType.php
@@ -182,70 +182,60 @@ class PostObjectType extends WPObjectType {
 					],
 					'content'           => [
 						'type'        => Types::string(),
-						'description' => __( 'The content of the post. This is currently just the raw content. An amendment to support rendered content needs to be made.', 'wp-graphql' ),
+						'description' => __( 'The content of the post.', 'wp-graphql' ),
 						'args' => [
-							'filters' => [
-								'type' => Types::list_of( Types::post_object_field_filter_enum() ),
-								'description' => __( 'Filters to apply to the content', 'wp-graphql' ),
-							],
+							'format' => self::post_object_format_arg(),
 						],
 						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
-							// By default, if no filters are passed, apply the_content filter.
-							if ( ! isset( $args['filters'] ) ) {
-								return apply_filters( 'the_content', $post->post_content );
+							if ( empty( $post->post_content ) ) {
+								return null;
 							}
 
-							// Apply all the filters provided in args, in order.
-							return array_reduce( $args['filters'], function( $content, $filter ) {
-								return apply_filters( $filter, $content );
-							}, $post->post_content );
+							// If the raw format is requested, don't apply any filters.
+							if ( isset( $args['format'] ) && 'raw' === $args['format'] ) {
+								return $post->post_content;
+							}
+
+							return apply_filters( 'the_content', $post->post_content );
 						},
 					],
 					'title'             => [
 						'type'        => Types::string(),
 						'description' => __( 'The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made.', 'wp-graphql' ),
 						'args' => [
-							'filters' => [
-								'type' => Types::list_of( Types::string() ),
-								'description' => __( 'Filters to apply to the content', 'wp-graphql' ),
-							],
+							'format' => self::post_object_format_arg(),
 						],
 						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							if ( empty( $post->post_title ) ) {
 								return null;
 							}
 
-							// By default, if no filters are passed, apply the_title filter.
-							if ( ! isset( $args['filters'] ) ) {
-								return apply_filters( 'the_title', $post->post_title );
+							// If the raw format is requested, don't apply any filters.
+							if ( isset( $args['format'] ) && 'raw' === $args['format'] ) {
+								return $post->post_title;
 							}
 
-							// Apply all the filters provided in args, in order.
-							return array_reduce( $args['filters'], function( $content, $filter ) {
-								return apply_filters( $filter, $content );
-							}, $post->post_title );
+							return apply_filters( 'the_title', $post->post_title );
 						},
 					],
 					'excerpt'           => [
 						'type'        => Types::string(),
 						'description' => __( 'The excerpt of the post. This is currently just the raw excerpt. An amendment to support rendered excerpts needs to be made.', 'wp-graphql' ),
 						'args' => [
-							'filters' => [
-								'type' => Types::list_of( Types::string() ),
-								'description' => __( 'Filters to apply to the content', 'wp-graphql' ),
-							],
+							'format' => self::post_object_format_arg(),
 						],
 						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
-							// By default, if no filters are passed, apply the_excerpt filter.
-							if ( ! isset( $args['filters'] ) ) {
-								$excerpt = apply_filters( 'the_excerpt', apply_filters( 'get_the_excerpt', $post->post_excerpt, $post ) );
-								return ! empty( $excerpt ) ? $excerpt : null;
+							// If the raw format is requested, don't apply any filters.
+							if ( isset( $args['format'] ) && 'raw' === $args['format'] ) {
+								return ! empty( $post->post_excerpt ) ? $post->post_excerpt : null;
 							}
 
-							// Apply all the filters provided in args, in order.
-							return array_reduce( $args['filters'], function( $content, $filter ) {
-								return apply_filters( $filter, $content );
-							}, $post->post_excerpt );
+							$excerpt = apply_filters( 'get_the_excerpt', $post->post_excerpt, $post );
+							if ( empty( $excerpt ) ) {
+								return null;
+							}
+
+							return apply_filters( 'the_excerpt', $excerpt );
 						},
 					],
 					'status'            => [
@@ -528,4 +518,15 @@ class PostObjectType extends WPObjectType {
 		return ! empty( self::$fields[ $single_name ] ) ? self::$fields[ $single_name ] : null;
 	}
 
+	/**
+	 * Define the args to be used by post object fields.
+	 *
+	 * @return mixed
+	 */
+	public static function post_object_format_arg() {
+		return [
+			'type' => Types::post_object_field_format_enum(),
+			'description' => __( 'Format of ', 'wp-graphql' ),
+		];
+	}
 }

--- a/src/Types.php
+++ b/src/Types.php
@@ -8,7 +8,7 @@ use GraphQL\Type\Definition\Type;
 use WPGraphQL\Type\Avatar\AvatarType;
 use WPGraphQL\Type\Comment\CommentType;
 use WPGraphQL\Type\Enum\MimeTypeEnumType;
-use WPGraphQL\Type\Enum\PostObjectFieldFilterEnumType;
+use WPGraphQL\Type\Enum\PostObjectFieldFormatEnumType;
 use WPGraphQL\Type\Enum\PostStatusEnumType;
 use WPGraphQL\Type\Enum\MediaItemStatusEnumType;
 use WPGraphQL\Type\Enum\PostTypeEnumType;
@@ -106,13 +106,13 @@ class Types {
 	private static $post_object_union;
 
 	/**
-	 * Stores the post object field filter enum type object
+	 * Stores the post object field format enum type object
 	 *
-	 * @var PostObjectFieldFilterEnumType object $post_object_field_filter_enum
+	 * @var PostObjectFieldFormatEnumType object $post_object_field_format_enum
 	 * @since  0.0.18
 	 * @access private
 	 */
-	private static $post_object_field_filter_enum;
+	private static $post_object_field_format_enum;
 
 	/**
 	 * Stores the post status enum type object
@@ -326,14 +326,14 @@ class Types {
 	}
 
 	/**
-	 * This returns the definition for the PostObjectFieldFilterEnumType
+	 * This returns the definition for the PostObjectFieldFormatEnumType
 	 *
-	 * @return PostObjectFieldFilterEnumType object
+	 * @return PostObjectFieldFormatEnumType object
 	 * @since  0.1.18
 	 * @access public
 	 */
-	public static function post_object_field_filter_enum() {
-		return self::$post_object_field_filter_enum ? : ( self::$post_object_field_filter_enum = new PostObjectFieldFilterEnumType() );
+	public static function post_object_field_format_enum() {
+		return self::$post_object_field_format_enum ? : ( self::$post_object_field_format_enum = new PostObjectFieldFormatEnumType() );
 	}
 
 	/**

--- a/src/Types.php
+++ b/src/Types.php
@@ -8,6 +8,7 @@ use GraphQL\Type\Definition\Type;
 use WPGraphQL\Type\Avatar\AvatarType;
 use WPGraphQL\Type\Comment\CommentType;
 use WPGraphQL\Type\Enum\MimeTypeEnumType;
+use WPGraphQL\Type\Enum\PostObjectFieldFilterEnumType;
 use WPGraphQL\Type\Enum\PostStatusEnumType;
 use WPGraphQL\Type\Enum\MediaItemStatusEnumType;
 use WPGraphQL\Type\Enum\PostTypeEnumType;
@@ -105,10 +106,19 @@ class Types {
 	private static $post_object_union;
 
 	/**
+	 * Stores the post object field filter enum type object
+	 *
+	 * @var PostObjectFieldFilterEnumType object $post_object_field_filter_enum
+	 * @since  0.0.18
+	 * @access private
+	 */
+	private static $post_object_field_filter_enum;
+
+	/**
 	 * Stores the post status enum type object
 	 *
 	 * @var PostStatusEnumType object $post_status_enum
-	 * @since  0.5.0
+	 * @since  0.0.5
 	 * @access private
 	 */
 	private static $post_status_enum;
@@ -313,6 +323,17 @@ class Types {
 	 */
 	public static function post_object_union() {
 		return self::$post_object_union ? : ( self::$post_object_union = new PostObjectUnionType() );
+	}
+
+	/**
+	 * This returns the definition for the PostObjectFieldFilterEnumType
+	 *
+	 * @return PostObjectFieldFilterEnumType object
+	 * @since  0.1.18
+	 * @access public
+	 */
+	public static function post_object_field_filter_enum() {
+		return self::$post_object_field_filter_enum ? : ( self::$post_object_field_filter_enum = new PostObjectFieldFilterEnumType() );
 	}
 
 	/**

--- a/tests/test-media-item-mutations.php
+++ b/tests/test-media-item-mutations.php
@@ -357,7 +357,7 @@ class WP_GraphQL_Test_Media_Item_Mutations extends WP_UnitTestCase {
 					'mediaItem' => [
 						'id'               => $media_item_id,
 						'mediaItemId'      => $attachment_id,
-						'title'            => $this->title,
+						'title'            => apply_filters( 'the_title', $this->title ),
 						'description'      => apply_filters( 'the_content', $this->description ),
 						'altText'          => $this->altText,
 						'caption'          => apply_filters( 'the_content', $this->caption ),
@@ -398,7 +398,7 @@ class WP_GraphQL_Test_Media_Item_Mutations extends WP_UnitTestCase {
 					'mediaItem' => [
 						'id'               => $media_item_id,
 						'mediaItemId'      => $attachment_id,
-						'title'            => $this->title,
+						'title'            => apply_filters( 'the_title', $this->title ),
 						'description'      => apply_filters( 'the_content', $this->description ),
 						'altText'          => $this->altText,
 						'caption'          => apply_filters( 'the_content', $this->caption ),
@@ -499,7 +499,7 @@ class WP_GraphQL_Test_Media_Item_Mutations extends WP_UnitTestCase {
 					'mediaItem' => [
 						'id'               => $media_item_id,
 						'mediaItemId'      => $attachment_id,
-						'title'            => $this->title,
+						'title'            => apply_filters( 'the_title', $this->title ),
 						'description'      => apply_filters( 'the_content', $this->description ),
 						'altText'          => $this->altText,
 						'caption'          => apply_filters( 'the_content', $this->caption ),
@@ -684,7 +684,7 @@ class WP_GraphQL_Test_Media_Item_Mutations extends WP_UnitTestCase {
 					'clientMutationId' => $this->updated_clientMutationId,
 					'mediaItem'             => [
 						'id'               => $this->media_item_id,
-						'title'            => $this->updated_title,
+						'title'            => apply_filters( 'the_title', $this->updated_title ),
 						'description'      => apply_filters( 'the_content', $this->updated_description ),
 						'mediaItemId'      => $this->attachment_id,
 						'altText'          => $this->updated_altText,

--- a/tests/test-post-object-mutations.php
+++ b/tests/test-post-object-mutations.php
@@ -227,7 +227,7 @@ class WP_GraphQL_Test_Post_Object_Mutations extends WP_UnitTestCase {
 					'clientMutationId' => 'someId',
 					'page'             => [
 						'id'      => \GraphQLRelay\Relay::toGlobalId( 'page', $page_id ),
-						'title'   => 'Some updated title',
+						'title'   => apply_filters( 'the_title', 'Some updated title' ),
 						'content' => apply_filters( 'the_content', 'Some updated content' ),
 						'pageId'  => $page_id,
 					],
@@ -334,7 +334,7 @@ class WP_GraphQL_Test_Post_Object_Mutations extends WP_UnitTestCase {
 					'deletedId'        => \GraphQLRelay\Relay::toGlobalId( 'page', $page_id ),
 					'page'             => [
 						'id'      => \GraphQLRelay\Relay::toGlobalId( 'page', $page_id ),
-						'title'   => 'Original Title',
+						'title'   => apply_filters( 'the_title', 'Original Title' ),
 						'content' => apply_filters( 'the_content', 'Original Content' ),
 						'pageId'  => $page_id,
 					],
@@ -531,7 +531,7 @@ class WP_GraphQL_Test_Post_Object_Mutations extends WP_UnitTestCase {
 				'createPage' => [
 					'clientMutationId' => $this->client_mutation_id,
 					'page'             => [
-						'title'   => $this->title,
+						'title'   => apply_filters( 'the_title', $this->title ),
 						'content' => apply_filters( 'the_content', $this->content ),
 					],
 				],

--- a/tests/test-post-object-queries.php
+++ b/tests/test-post-object-queries.php
@@ -615,7 +615,7 @@ class WP_GraphQL_Test_Post_Object_Queries extends WP_UnitTestCase {
 		/**
 		 * Create the GraphQL query.
 		 */
-		$graphql_query = "
+		$query = "
 		query {
 			postBy(slug: \"{$slug}\") {
 				id

--- a/tests/test-post-object-queries.php
+++ b/tests/test-post-object-queries.php
@@ -13,6 +13,13 @@ class WP_GraphQL_Test_Post_Object_Queries extends WP_UnitTestCase {
 	public $current_date_gmt;
 	public $admin;
 
+	public function __construct() {
+		/**
+		 * Add post object field filter enums that will be used in tests below.
+		 */
+		$this->addPostObjectFieldFilterEnums();
+	}
+
 	/**
 	 * This function is run before each method
 	 * @since 0.0.5
@@ -26,11 +33,6 @@ class WP_GraphQL_Test_Post_Object_Queries extends WP_UnitTestCase {
 		$this->admin = $this->factory->user->create( [
 			'role' => 'administrator',
 		] );
-
-		/**
-		 * Add post object field filter enums that will be used in tests below.
-		 */
-		$this->addPostObjectFieldFilterEnums();
 	}
 
 	/**
@@ -84,7 +86,7 @@ class WP_GraphQL_Test_Post_Object_Queries extends WP_UnitTestCase {
 
 	/**
 	 * Register some post object field filters enums that we will use in tests.
-	 * This needs to be called in test setup (while tests are running is too late).
+	 * This needs to be called in test constructor (setup is too late).
 	 */
 	private function addPostObjectFieldFilterEnums() {
 		$filters = [
@@ -945,7 +947,7 @@ class WP_GraphQL_Test_Post_Object_Queries extends WP_UnitTestCase {
 		/**
 		 * Add a filter that will be called when the content field from the query
 		 * above is resolved. Note that we defined this filter as an enum in the
-		 * test setup method.
+		 * addPostObjectFieldFilterEnums method.
 		 */
 		add_filter( 'test_post_data_field_filter', function() {
 			return 'Overridden for testPostObjectValidFieldFilter';
@@ -991,7 +993,7 @@ class WP_GraphQL_Test_Post_Object_Queries extends WP_UnitTestCase {
 		/**
 		 * Add a filter that will be called when the content field from the query
 		 * above is resolved. Note that we defined this filter as an enum in the
-		 * test setup method.
+		 * addPostObjectFieldFilterEnums method.
 		 */
 		add_filter( 'test_post_data_field_filter', function() use ( $graphql_query_post_id ) {
 			/**

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -173,7 +173,7 @@ return array(
     'WPGraphQL\\Type\\Comment\\Connection\\CommentConnectionResolver' => $baseDir . '/src/Type/Comment/Connection/CommentConnectionResolver.php',
     'WPGraphQL\\Type\\Enum\\MediaItemStatusEnumType' => $baseDir . '/src/Type/Enum/MediaItemStatusEnumType.php',
     'WPGraphQL\\Type\\Enum\\MimeTypeEnumType' => $baseDir . '/src/Type/Enum/MimeTypeEnumType.php',
-    'WPGraphQL\\Type\\Enum\\PostObjectFieldFilterEnumType' => $baseDir . '/src/Type/Enum/PostObjectFieldFilterEnumType.php',
+    'WPGraphQL\\Type\\Enum\\PostObjectFieldFormatEnumType' => $baseDir . '/src/Type/Enum/PostObjectFieldFormatEnumType.php',
     'WPGraphQL\\Type\\Enum\\PostStatusEnumType' => $baseDir . '/src/Type/Enum/PostStatusEnumType.php',
     'WPGraphQL\\Type\\Enum\\PostTypeEnumType' => $baseDir . '/src/Type/Enum/PostTypeEnumType.php',
     'WPGraphQL\\Type\\Enum\\RelationEnumType' => $baseDir . '/src/Type/Enum/RelationEnumType.php',

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -173,6 +173,7 @@ return array(
     'WPGraphQL\\Type\\Comment\\Connection\\CommentConnectionResolver' => $baseDir . '/src/Type/Comment/Connection/CommentConnectionResolver.php',
     'WPGraphQL\\Type\\Enum\\MediaItemStatusEnumType' => $baseDir . '/src/Type/Enum/MediaItemStatusEnumType.php',
     'WPGraphQL\\Type\\Enum\\MimeTypeEnumType' => $baseDir . '/src/Type/Enum/MimeTypeEnumType.php',
+    'WPGraphQL\\Type\\Enum\\PostObjectFieldFilterEnumType' => $baseDir . '/src/Type/Enum/PostObjectFieldFilterEnumType.php',
     'WPGraphQL\\Type\\Enum\\PostStatusEnumType' => $baseDir . '/src/Type/Enum/PostStatusEnumType.php',
     'WPGraphQL\\Type\\Enum\\PostTypeEnumType' => $baseDir . '/src/Type/Enum/PostTypeEnumType.php',
     'WPGraphQL\\Type\\Enum\\RelationEnumType' => $baseDir . '/src/Type/Enum/RelationEnumType.php',

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -535,6 +535,14 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 			do_action( 'graphql_return_response', $filtered_result, $result, $schema, $operation_name, $request, $variables );
 
 			/**
+			 * Make sure we reset the post data after the query is executed to avoid disrupting
+			 * other queries.
+			 *
+			 * @since 0.0.18
+			 */
+			wp_reset_postdata();
+
+			/**
 			 * Return the result of the request
 			 */
 			return $filtered_result->toArray();


### PR DESCRIPTION
_Edited to reflect discussion and changes:_

This provides a method to request `RAW` or `RENDERED` format of post object fields:

```
query {
  post(id: "...") {
    content(format: RAW)
  }
}
```

The `format` arg is available on `content`, `title`, and `excerpt`. If the `format` arg is omitted, then the default behavior will be `RENDERED` (which is simply to apply these filters: `the_content` on `content`, `the_title` on `title`, and `get_the_excerpt` and `the_excerpt` on `excerpt`).

It introduces a new enum type, `PostObjectFieldFormatEnumType`.

Perhaps more significantly, it sets up and resets post data during post object field resolution, so that any custom resolution undertaken by the user will have that done for them.