### PR TITLE
#247 - Add nodes to connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ vendor/ivome/graphql-relay-php/*
 vendor/composer/installed.json
 !/tests
 build/
+/coverage

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@ vendor/ivome/graphql-relay-php/*
 vendor/composer/installed.json
 !/tests
 build/
-/coverage
+coverage/*

--- a/src/Data/ConnectionResolver.php
+++ b/src/Data/ConnectionResolver.php
@@ -78,6 +78,7 @@ abstract class ConnectionResolver implements ConnectionResolverInterface {
 
 		$meta       = self::get_array_meta( $query, $args );
 		$connection = ArrayConnection::connectionFromArraySlice( $array, $args, $meta );
+		$connection['nodes'] = $array;
 
 		return $connection;
 

--- a/src/Type/Comment/Connection/CommentConnectionDefinition.php
+++ b/src/Type/Comment/Connection/CommentConnectionDefinition.php
@@ -39,6 +39,17 @@ class CommentConnectionDefinition {
 			$connection = Relay::connectionDefinitions( [
 				'nodeType' => Types::comment(),
 				'name' => 'comments',
+				'connectionFields' => function() {
+					return [
+						'nodes' => [
+							'type' => Types::list_of( Types::comment() ),
+							'description' => __( 'The nodes of the connection, without the edges', 'wp-graphql' ),
+							'resolve' => function( $source, $args, $context, $info ) {
+								return ! empty( $source['nodes'] ) ? $source['nodes'] : [];
+							},
+						],
+					];
+				},
 			] );
 
 			/**

--- a/src/Type/Comment/Connection/CommentConnectionResolver.php
+++ b/src/Type/Comment/Connection/CommentConnectionResolver.php
@@ -200,6 +200,7 @@ class CommentConnectionResolver extends ConnectionResolver {
 				'startCursor'     => ! empty( $first_edge['cursor'] ) ? $first_edge['cursor'] : null,
 				'endCursor'       => ! empty( $last_edge['cursor'] ) ? $last_edge['cursor'] : null,
 			],
+			'nodes' => $items,
 		];
 
 		return $connection;

--- a/src/Type/Plugin/Connection/PluginConnectionDefinition.php
+++ b/src/Type/Plugin/Connection/PluginConnectionDefinition.php
@@ -37,6 +37,17 @@ class PluginConnectionDefinition {
 			$connection = Relay::connectionDefinitions( [
 				'nodeType' => Types::plugin(),
 				'name' => 'plugins',
+				'connectionFields' => function() {
+					return [
+						'nodes' => [
+							'type' => Types::list_of( Types::plugin() ),
+							'description' => __( 'The nodes of the connection, without the edges', 'wp-graphql' ),
+							'resolve' => function( $source, $args, $context, $info ) {
+								return ! empty( $source['nodes'] ) ? $source['nodes'] : [];
+							},
+						],
+					];
+				},
 			] );
 
 			/**

--- a/src/Type/Plugin/Connection/PluginConnectionResolver.php
+++ b/src/Type/Plugin/Connection/PluginConnectionResolver.php
@@ -39,7 +39,14 @@ class PluginConnectionResolver {
 		}
 
 		$connection = Relay::connectionFromArray( $plugins_array, $args );
-		$connection['nodes'] = ! empty( $plugins_array ) ? $plugins_array : null;
+
+		$nodes = [];
+		if ( ! empty( $connection['edges'] ) && is_array( $connection['edges'] ) ) {
+			foreach ( $connection['edges'] as $edge ) {
+				$nodes[] = ! empty( $edge['node'] ) ? $edge['node'] : null;
+			}
+		}
+		$connection['nodes'] = ! empty( $nodes ) ? $nodes : null;
 
 		return ! empty( $plugins_array ) ? $connection : null;
 

--- a/src/Type/Plugin/Connection/PluginConnectionResolver.php
+++ b/src/Type/Plugin/Connection/PluginConnectionResolver.php
@@ -38,7 +38,10 @@ class PluginConnectionResolver {
 			}
 		}
 
-		return ! empty( $plugins_array ) ? Relay::connectionFromArray( $plugins_array, $args ) : null;
+		$connection = Relay::connectionFromArray( $plugins_array, $args );
+		$connection['nodes'] = ! empty( $plugins_array ) ? $plugins_array : null;
+
+		return ! empty( $plugins_array ) ? $connection : null;
 
 	}
 

--- a/src/Type/PostObject/Connection/PostObjectConnectionDefinition.php
+++ b/src/Type/PostObject/Connection/PostObjectConnectionDefinition.php
@@ -59,6 +59,13 @@ class PostObjectConnectionDefinition {
 								return $post_type_object;
 							},
 						],
+						'nodes' => [
+							'type' => Types::list_of( Types::post_object( $post_type_object->name ) ),
+							'description' => __( 'The nodes of the connection, without the edges', 'wp-graphql' ),
+							'resolve' => function( $source, $args, $context, $info ) {
+								return ! empty( $source['nodes'] ) ? $source['nodes'] : [];
+							},
+						],
 					];
 				},
 			] );

--- a/src/Type/PostObject/Connection/PostObjectConnectionResolver.php
+++ b/src/Type/PostObject/Connection/PostObjectConnectionResolver.php
@@ -262,6 +262,7 @@ class PostObjectConnectionResolver extends ConnectionResolver {
 				'startCursor'     => ! empty( $first_edge['cursor'] ) ? $first_edge['cursor'] : null,
 				'endCursor'       => ! empty( $last_edge['cursor'] ) ? $last_edge['cursor'] : null,
 			],
+			'nodes' => $items,
 		];
 
 		return $connection;

--- a/src/Type/TermObject/Connection/TermObjectConnectionDefinition.php
+++ b/src/Type/TermObject/Connection/TermObjectConnectionDefinition.php
@@ -53,6 +53,13 @@ class TermObjectConnectionDefinition {
 								return $taxonomy_object;
 							},
 						],
+						'nodes' => [
+							'type' => Types::list_of( Types::term_object( $taxonomy_object->name ) ),
+							'description' => __( 'The nodes of the connection, without the edges', 'wp-graphql' ),
+							'resolve' => function( $source, $args, $context, $info ) {
+								return ! empty( $source['nodes'] ) ? $source['nodes'] : [];
+							},
+						],
 					];
 				},
 			] );

--- a/src/Type/TermObject/Connection/TermObjectConnectionResolver.php
+++ b/src/Type/TermObject/Connection/TermObjectConnectionResolver.php
@@ -215,6 +215,7 @@ class TermObjectConnectionResolver extends ConnectionResolver {
 				'startCursor'     => ! empty( $first_edge['cursor'] ) ? $first_edge['cursor'] : null,
 				'endCursor'       => ! empty( $last_edge['cursor'] ) ? $last_edge['cursor'] : null,
 			],
+			'nodes' => $items,
 		];
 
 		return $connection;

--- a/src/Type/Theme/Connection/ThemeConnectionDefinition.php
+++ b/src/Type/Theme/Connection/ThemeConnectionDefinition.php
@@ -39,6 +39,17 @@ class ThemeConnectionDefinition {
 			$connection = Relay::connectionDefinitions( [
 				'nodeType' => Types::theme(),
 				'name' => 'themes',
+				'connectionFields' => function() {
+					return [
+						'nodes' => [
+							'type' => Types::list_of( Types::theme() ),
+							'description' => __( 'The nodes of the connection, without the edges', 'wp-graphql' ),
+							'resolve' => function( $source, $args, $context, $info ) {
+								return ! empty( $source['nodes'] ) ? $source['nodes'] : [];
+							},
+						],
+					];
+				},
 			] );
 
 			/**

--- a/src/Type/Theme/Connection/ThemeConnectionResolver.php
+++ b/src/Type/Theme/Connection/ThemeConnectionResolver.php
@@ -35,7 +35,15 @@ class ThemeConnectionResolver {
 		}
 
 		$connection = Relay::connectionFromArray( $themes_array, $args );
-		$connection['nodes'] = ! empty( $themes_array ) ? $themes_array : null;
+
+		$nodes = [];
+		if ( ! empty( $connection['edges'] ) && is_array( $connection['edges'] ) ) {
+			foreach ( $connection['edges'] as $edge ) {
+				$nodes[] = ! empty( $edge['node'] ) ? $edge['node'] : null;
+			}
+		}
+
+		$connection['nodes'] = ! empty( $nodes ) ? $nodes : null;
 
 		return ! empty( $themes_array ) ? $connection : null;
 	}

--- a/src/Type/Theme/Connection/ThemeConnectionResolver.php
+++ b/src/Type/Theme/Connection/ThemeConnectionResolver.php
@@ -34,7 +34,10 @@ class ThemeConnectionResolver {
 			}
 		}
 
-		return ! empty( $themes_array ) ? Relay::connectionFromArray( $themes_array, $args ) : null;
+		$connection = Relay::connectionFromArray( $themes_array, $args );
+		$connection['nodes'] = ! empty( $themes_array ) ? $themes_array : null;
+
+		return ! empty( $themes_array ) ? $connection : null;
 	}
 
 }

--- a/src/Type/User/Connection/UserConnectionDefinition.php
+++ b/src/Type/User/Connection/UserConnectionDefinition.php
@@ -34,6 +34,17 @@ class UserConnectionDefinition {
 		if ( null === self::$connection ) :
 			$connection = Relay::connectionDefinitions( [
 				'nodeType' => Types::user(),
+				'connectionFields' => function() {
+					return [
+						'nodes' => [
+							'type' => Types::list_of( Types::user() ),
+							'description' => __( 'The nodes of the connection, without the edges', 'wp-graphql' ),
+							'resolve' => function( $source, $args, $context, $info ) {
+								return ! empty( $source['nodes'] ) ? $source['nodes'] : [];
+							},
+						],
+					];
+				},
 			] );
 
 			/**

--- a/tests/test-comment-connection-queries.php
+++ b/tests/test-comment-connection-queries.php
@@ -102,6 +102,9 @@ class WP_GraphQL_Test_Comment_Connection_Queries extends WP_UnitTestCase {
 						date
 					}
 				}
+				nodes {
+				  commentId
+				}
 			}
 		}';
 
@@ -133,6 +136,7 @@ class WP_GraphQL_Test_Comment_Connection_Queries extends WP_UnitTestCase {
 		$this->assertEquals( $expected_cursor, $results['data']['comments']['edges'][0]['cursor'] );
 		$this->assertEquals( $expected_cursor, $results['data']['comments']['pageInfo']['startCursor'] );
 		$this->assertEquals( $expected_cursor, $results['data']['comments']['pageInfo']['endCursor'] );
+		$this->assertEquals( $first_comment->comment_ID, $results['data']['comments']['nodes'][0]['commentId'] );
 
 	}
 

--- a/tests/test-plugin-queries.php
+++ b/tests/test-plugin-queries.php
@@ -49,12 +49,15 @@ class WP_GraphQL_Test_Plugin_Queries extends WP_UnitTestCase {
 
 		$query = '
 		{
-		  plugins(last: 1){
-		    edges{
-		      node{
+		  plugins {
+		    edges {
+		      node {
 		        id
 		        name
 		      }
+		    }
+		    nodes {
+		      id
 		    }
 		  }
 		}
@@ -70,7 +73,12 @@ class WP_GraphQL_Test_Plugin_Queries extends WP_UnitTestCase {
 		$this->assertNotEmpty( $actual['data']['plugins']['edges'] );
 		$this->assertNotEmpty( $actual['data']['plugins']['edges'][0]['node']['id'] );
 		$this->assertNotEmpty( $actual['data']['plugins']['edges'][0]['node']['name'] );
+		$this->assertNotEmpty( $actual['data']['plugins']['nodes'][0]['id'] );
+		$this->assertEquals( $actual['data']['plugins']['nodes'][0]['id'], $actual['data']['plugins']['edges'][0]['node']['id'] );
 
+		foreach ( $actual['data']['plugins']['edges'] as $key => $edge ) {
+			$this->assertEquals( $actual['data']['plugins']['nodes'][ $key ]['id'], $edge['node']['id'] );
+		}
 
 	}
 

--- a/tests/test-post-connection-queries.php
+++ b/tests/test-post-connection-queries.php
@@ -127,6 +127,10 @@ class WP_GraphQL_Test_Post_Connection_Queries extends WP_UnitTestCase {
 						date
 					}
 				}
+				nodes {
+				  id
+				  postId
+				}
 			}
 		}';
 
@@ -158,6 +162,7 @@ class WP_GraphQL_Test_Post_Connection_Queries extends WP_UnitTestCase {
 		$this->assertEquals( $expected_cursor, $results['data']['posts']['edges'][0]['cursor'] );
 		$this->assertEquals( $expected_cursor, $results['data']['posts']['pageInfo']['startCursor'] );
 		$this->assertEquals( $expected_cursor, $results['data']['posts']['pageInfo']['endCursor'] );
+		$this->assertEquals( $first_post_id, $results['data']['posts']['nodes'][0]['postId'] );
 
 		$this->forwardPagination( $expected_cursor );
 

--- a/tests/test-term-object-connection-queries.php
+++ b/tests/test-term-object-connection-queries.php
@@ -107,6 +107,9 @@ class WP_GraphQL_Test_Term_Object_Connection_Queries extends WP_UnitTestCase {
 				        slug
 					}
 				}
+				nodes {
+				  categoryId
+				}
 			}
 		}';
 
@@ -144,7 +147,7 @@ class WP_GraphQL_Test_Term_Object_Connection_Queries extends WP_UnitTestCase {
 		$this->assertEquals( $expected_cursor, $results['data']['categories']['edges'][0]['cursor'] );
 		$this->assertEquals( $expected_cursor, $results['data']['categories']['pageInfo']['startCursor'] );
 		$this->assertEquals( $expected_cursor, $results['data']['categories']['pageInfo']['endCursor'] );
-
+		$this->assertEquals( $first_term_id, $results['data']['categories']['nodes'][0]['categoryId'] );
 		$this->forwardPagination( $expected_cursor );
 
 	}

--- a/tests/test-theme-connection-queries.php
+++ b/tests/test-theme-connection-queries.php
@@ -51,6 +51,9 @@ class WP_GraphQL_Test_Theme_Queries extends WP_UnitTestCase {
 		        name
 		      }
 		    }
+		    nodes {
+		      id
+		    }
 		  }
 		}
 		';
@@ -65,6 +68,13 @@ class WP_GraphQL_Test_Theme_Queries extends WP_UnitTestCase {
 		$this->assertNotEmpty( $actual['data']['themes']['edges'] );
 		$this->assertNotEmpty( $actual['data']['themes']['edges'][0]['node']['id'] );
 		$this->assertNotEmpty( $actual['data']['themes']['edges'][0]['node']['name'] );
+		$this->assertNotEmpty( $actual['data']['themes']['nodes'][0]['id'] );
+		$this->assertEquals( $actual['data']['themes']['nodes'][0]['id'], $actual['data']['themes']['edges'][0]['node']['id'] );
+
+		foreach ( $actual['data']['themes']['edges'] as $key => $edge ) {
+			$this->assertEquals( $actual['data']['themes']['nodes'][ $key ]['id'], $edge['node']['id'] );
+		}
+
 	}
 
 }


### PR DESCRIPTION
Addresses #247 

This adds "nodes" field to connections so that queries can query for the nodes directly without edge data. FYI, this is also how Github does it.

Ex:

```
{
  plugins {
    edges {
      node {
        id
      }
    }
    nodes {
      id
      name
    }
  }
  users {
    nodes {
      id
    }
    edges {
      node {
        id
      }
    }
  }
  themes {
    nodes {
      id
      version
    }
    edges {
      node {
        id
      }
    }
  }
  comments {
    edges {
      node {
        id
      }
    }
    nodes {
      id
    }
  }
  posts {
    pageInfo {
      startCursor
      endCursor
    }
    nodes {
      id
      title
      comments {
        nodes {
          id
          content
        }
      }
    }
  }
  tags {
    nodes {
      name
      id
    }
  }
}

```