### PR TITLE
CI-4215 - Adding tests for sanitize_input_fields and get_query_args in PostObject Connection

### DIFF
--- a/src/Type/PostObject/Connection/PostObjectConnectionResolver.php
+++ b/src/Type/PostObject/Connection/PostObjectConnectionResolver.php
@@ -145,8 +145,6 @@ class PostObjectConnectionResolver extends ConnectionResolver {
 				case $source instanceof \WP_User:
 					$query_args['author'] = $source->ID;
 					break;
-				default:
-					break;
 			}
 		endif;
 

--- a/tests/test-post-connection-queries.php
+++ b/tests/test-post-connection-queries.php
@@ -332,4 +332,198 @@ class WP_GraphQL_Test_Post_Connection_Queries extends WP_UnitTestCase {
 
 	}
 
+	public function testSanitizeInputFieldsAuthorArgs() {
+		$mock_args = [
+			'authorName' => 'testAuthorName',
+			'authorIn' => [1, 2, 3],
+			'authorNotIn' => [4, 5, 6],
+		];
+
+		$app_context = new \WPGraphQL\AppContext();
+		
+		$app_info = new \GraphQL\Type\Definition\ResolveInfo( array() );
+
+		$actual = \WPGraphQL\Type\PostObject\Connection\PostObjectConnectionResolver::sanitize_input_fields( $mock_args, null, [], $app_context, $app_info );
+
+		/**
+		 * Make sure the returned values are equal to mock args
+		 */
+		$this->assertEquals( 'testAuthorName', $actual['author_name'] );
+		$this->assertEquals( [1, 2, 3], $actual['author__in'] );
+		$this->assertEquals( [4, 5, 6], $actual['author__not_in'] );
+
+		/**
+		 * Make sure the query didn't return these array values
+		 */
+		$this->assertArrayNotHasKey( 'authorName', $actual );
+		$this->assertArrayNotHasKey( 'authorIn', $actual );
+		$this->assertArrayNotHasKey( 'authorNotIn', $actual );
+	}
+
+	public function testSanitizeInputFieldsCategoryArgs() {
+		$mock_args = [
+			'categoryId' => 1,
+			'categoryName' => 'testCategory',
+			'categoryIn' => [4, 5, 6],
+		];
+
+		$app_context = new \WPGraphQL\AppContext();
+		
+		$app_info = new \GraphQL\Type\Definition\ResolveInfo( array() );
+
+		$actual = \WPGraphQL\Type\PostObject\Connection\PostObjectConnectionResolver::sanitize_input_fields( $mock_args, null, [], $app_context, $app_info );
+
+		/**
+		 * Make sure the returned values are equal to mock args
+		 */
+		$this->assertEquals( 1, $actual['cat'] );
+		$this->assertEquals( 'testCategory', $actual['category_name'] );
+		$this->assertEquals( [4, 5, 6], $actual['category__in'] );
+
+		/**
+		 * Make sure the query didn't return these array values
+		 */
+		$this->assertArrayNotHasKey( 'categoryId', $actual );
+		$this->assertArrayNotHasKey( 'categoryName', $actual );
+		$this->assertArrayNotHasKey( 'categoryIn', $actual );
+	}
+
+	public function testSanitizeInputFieldsTagArgs() {
+		$mock_args = [
+			'tagId' => 1,
+			'tagIds' => [1, 2, 3],
+			'tagSlugAnd' => [4, 5, 6],
+			'tagSlugIn' => [6, 7, 8],
+		];
+
+		$app_context = new \WPGraphQL\AppContext();
+		
+		$app_info = new \GraphQL\Type\Definition\ResolveInfo( array() );
+
+		$actual = \WPGraphQL\Type\PostObject\Connection\PostObjectConnectionResolver::sanitize_input_fields( $mock_args, null, [], $app_context, $app_info );
+
+		/**
+		 * Make sure the returned values are equal to mock args
+		 */
+		$this->assertEquals( 1, $actual['tag_id'] );
+		$this->assertEquals( [1, 2, 3], $actual['tag__and'] );
+		$this->assertEquals( [4, 5, 6], $actual['tag_slug__and'] );
+		$this->assertEquals( [6, 7, 8], $actual['tag_slug__in'] );
+
+		/**
+		 * Make sure the query didn't return these array values
+		 */
+		$this->assertArrayNotHasKey( 'tagId', $actual );
+		$this->assertArrayNotHasKey( 'tagIds', $actual );
+		$this->assertArrayNotHasKey( 'tagSlugAnd', $actual );
+		$this->assertArrayNotHasKey( 'tagSlugIn', $actual );
+	}
+
+	public function testSanitizeInputFieldsSearchArgs() {
+		$mock_args = [
+			'search' => 'testSearchString',
+			'id' => 1,
+		];
+
+		$app_context = new \WPGraphQL\AppContext();
+		
+		$app_info = new \GraphQL\Type\Definition\ResolveInfo( array() );
+
+		$actual = \WPGraphQL\Type\PostObject\Connection\PostObjectConnectionResolver::sanitize_input_fields( $mock_args, null, [], $app_context, $app_info );
+
+		/**
+		 * Make sure the returned values are equal to mock args
+		 */
+		$this->assertEquals( 'testSearchString', $actual['s'] );
+		$this->assertEquals( 1, $actual['p'] );
+
+		/**
+		 * Make sure the query didn't return these array values
+		 */
+		$this->assertArrayNotHasKey( 'search', $actual );
+		$this->assertArrayNotHasKey( 'id', $actual );
+	}
+
+	public function testSanitizeInputFieldsParentArgs() {
+		$mock_args = [
+			'parent' => 2,
+			'parentIn' => [3, 4, 5],
+			'parentNotIn' => [6, 7, 8],
+			'in' => [9, 10, 11],
+			'notIn' => [12, 13, 14],
+			'nameIn' => ['testPost1', 'testPost2', 'testPost3'],
+		];
+
+		$app_context = new \WPGraphQL\AppContext();
+		
+		$app_info = new \GraphQL\Type\Definition\ResolveInfo( array() );
+
+		$actual = \WPGraphQL\Type\PostObject\Connection\PostObjectConnectionResolver::sanitize_input_fields( $mock_args, null, [], $app_context, $app_info );
+
+		/**
+		 * Make sure the returned values are equal to mock args
+		 */
+		$this->assertEquals( 2, $actual['post_parent'] );
+		$this->assertEquals( [3, 4, 5], $actual['post_parent__in'] );
+		$this->assertEquals( [6, 7, 8], $actual['post_parent__not_in'] );
+		$this->assertEquals( [9, 10, 11], $actual['post__in'] );
+		$this->assertEquals( [12, 13, 14], $actual['post__not_in'] );
+		$this->assertEquals( ['testPost1', 'testPost2', 'testPost3'], $actual['post_name__in'] );
+
+		/**
+		 * Make sure the query didn't return these array values
+		 */
+		$this->assertArrayNotHasKey( 'parent', $actual );
+		$this->assertArrayNotHasKey( 'parentIn', $actual );
+		$this->assertArrayNotHasKey( 'parentNotIn', $actual );
+		$this->assertArrayNotHasKey( 'in', $actual );
+		$this->assertArrayNotHasKey( 'notIn', $actual );
+		$this->assertArrayNotHasKey( 'nameIn', $actual );
+	}
+
+	public function testSanitizeInputFieldsMiscArgs() {
+		$mock_args = [
+			'hasPassword' => true,
+			'password' => 'myPostPassword123',
+			'status' => ['publish', 'private' ],
+			'dateQuery'=> array( 
+				array(
+					'year'  => 2012,
+					'month' => 12,
+					'day'   => 12,
+				),
+			),
+		];
+
+		$app_context = new \WPGraphQL\AppContext();
+		
+		$app_info = new \GraphQL\Type\Definition\ResolveInfo( array() );
+
+		$actual = \WPGraphQL\Type\PostObject\Connection\PostObjectConnectionResolver::sanitize_input_fields( $mock_args, null, [], $app_context, $app_info );
+
+		/**
+		 * Make sure the returned values are equal to mock args
+		 */
+		$this->assertTrue( $actual['has_password'] );
+		$this->assertEquals( 'myPostPassword123', $actual['post_password'] );
+		$this->assertEquals( ['publish', 'private' ], $actual['post_status'] );
+		$this->assertEquals( 
+			array( 
+				array(
+					'year'  => 2012,
+					'month' => 12,
+					'day'   => 12,
+				),
+			)
+		, $actual['date_query'] );
+
+		/**
+		 * Make sure the query didn't return these array values
+		 */
+		$this->assertArrayNotHasKey( 'hasPassword', $actual );
+		$this->assertArrayNotHasKey( 'password', $actual );
+		$this->assertArrayNotHasKey( 'status', $actual );
+		$this->assertArrayNotHasKey( 'dateQuery', $actual );
+	}
+
 }

--- a/tests/test-post-connection-queries.php
+++ b/tests/test-post-connection-queries.php
@@ -510,7 +510,9 @@ class WP_GraphQL_Test_Post_Connection_Queries extends WP_UnitTestCase {
 	 * @group get_query_args
 	 */
 	public function testGetQueryArgs() {
-		
+		/**
+		 * Mock args
+		 */
 		$mock_args = array(
 			'orderby' => 'DESC',
 			'where' => array(
@@ -523,16 +525,22 @@ class WP_GraphQL_Test_Post_Connection_Queries extends WP_UnitTestCase {
 			),
 		);
 
+		/**
+		 * Create post
+		 */
 		$test_post = $this->factory->post->create();
 
 		$source = get_post( $test_post );
 
+		/**
+		 * New page
+		 */
 		$actual = new \WPGraphQL\Type\PostObject\Connection\PostObjectConnectionResolver( 'page' );
 
 		$actual = $actual::get_query_args( $source, $mock_args, $this->app_context, $this->app_info );
 
 		/**
-		 * Expected result of actual call
+		 * Expected result
 		 */
 		$expected = array(
 			'post_type' => 'page',
@@ -569,10 +577,16 @@ class WP_GraphQL_Test_Post_Connection_Queries extends WP_UnitTestCase {
 	 */
 	public function testGetQueryArgsAttachment() {
 		
+		/**
+		 * Mock args
+		 */
 		$mock_args = array(
 			'post_status' => 'publish',
 		);
 
+		/**
+		 * Create attachment
+		 */
 		$child_id = $this->factory->post->create([
 			'post_type' => 'attachment',
 		]);
@@ -581,12 +595,15 @@ class WP_GraphQL_Test_Post_Connection_Queries extends WP_UnitTestCase {
 
 		$source = get_post( $child_id );
 
+		/**
+		 * New post type attachment
+		 */
 		$actual = new \WPGraphQL\Type\PostObject\Connection\PostObjectConnectionResolver( $post_type );
 
 		$actual = $actual->get_query_args( $source, $mock_args, $this->app_context, $this->app_info );
 
 		/**
-		 * Make sure post_parent is not set and the post status is equal to inherit
+		 * Make sure the post status is equal to inherit
 		 */
 		$this->assertEquals( 'inherit', $actual['post_status'] );
 
@@ -600,6 +617,9 @@ class WP_GraphQL_Test_Post_Connection_Queries extends WP_UnitTestCase {
 	 * @group get_query_args
 	 */
 	public function testGetQueryArgsTerms() {
+		/**
+		 * Create a term
+		 */
 		$term_id = $this->factory->term->create();
 
 		$source = get_term( $term_id );
@@ -612,6 +632,9 @@ class WP_GraphQL_Test_Post_Connection_Queries extends WP_UnitTestCase {
 
 		$actual_terms = \WPGraphQL\Type\PostObject\Connection\PostObjectConnectionResolver::get_query_args( $source, $mock_args, $this->app_context, $this->app_info );
 
+		/**
+		 * Make sure the function returned our mock_args in the tax_query key
+		 */
 		$this->assertEquals( $mock_args, $actual_terms['tax_query'][0] );
 	}
 	
@@ -620,12 +643,18 @@ class WP_GraphQL_Test_Post_Connection_Queries extends WP_UnitTestCase {
 	 */
 	public function testGetQueryArgsPostType() {
 
+		/**
+		 * Get post type object
+		 */
 		$source = get_post_type_object( 'post' );
 
 		$mock_args = array();
 
 		$actual = \WPGraphQL\Type\PostObject\Connection\PostObjectConnectionResolver::get_query_args( $source, $mock_args, $this->app_context, $this->app_info );
 
+		/**
+		 * Make sure that post type is equals to post
+		 */
 		$this->assertEquals( 'post', $actual['post_type'] );
 	}
 
@@ -633,6 +662,9 @@ class WP_GraphQL_Test_Post_Connection_Queries extends WP_UnitTestCase {
 	 * @group get_query_args
 	 */
 	public function testGetQueryArgsUser() {
+		/**
+		 * Create a user
+		 */
 		$user_id = $this->factory->user->create();
 
 		$source = get_user_by( 'ID', $user_id );
@@ -641,17 +673,11 @@ class WP_GraphQL_Test_Post_Connection_Queries extends WP_UnitTestCase {
 
 		$actual = \WPGraphQL\Type\PostObject\Connection\PostObjectConnectionResolver::get_query_args( $source, $mock_args, $this->app_context, $this->app_info );
 
+		/**
+		 * Make sure the author is equal to the user previously created
+		 */
 		$this->assertEquals( $user_id, $actual['author'] );
 
 	}
-
-	// public function testGetQueryArgsNullObject() {
-
-	// 	$actual = \WPGraphQL\Type\PostObject\Connection\PostObjectConnectionResolver::get_query_args( null, array(), $this->app_context, $this->app_info );
-
-	// 	$this->assertArrayNotHasKey( 'author', $actual);
-	// 	$this->assertArrayNotHasKey( 'tax_query', $actual);
-	// }
-
 
 }

--- a/tests/test-post-connection-queries.php
+++ b/tests/test-post-connection-queries.php
@@ -31,6 +31,10 @@ class WP_GraphQL_Test_Post_Connection_Queries extends WP_UnitTestCase {
 		] );
 		$this->created_post_ids = $this->create_posts();
 
+		$this->app_context = new \WPGraphQL\AppContext();
+		
+		$this->app_info = new \GraphQL\Type\Definition\ResolveInfo( array() );
+
 	}
 
 	/**
@@ -339,11 +343,7 @@ class WP_GraphQL_Test_Post_Connection_Queries extends WP_UnitTestCase {
 			'authorNotIn' => [4, 5, 6],
 		];
 
-		$app_context = new \WPGraphQL\AppContext();
-		
-		$app_info = new \GraphQL\Type\Definition\ResolveInfo( array() );
-
-		$actual = \WPGraphQL\Type\PostObject\Connection\PostObjectConnectionResolver::sanitize_input_fields( $mock_args, null, [], $app_context, $app_info );
+		$actual = \WPGraphQL\Type\PostObject\Connection\PostObjectConnectionResolver::sanitize_input_fields( $mock_args, null, [], $this->app_context, $this->app_info );
 
 		/**
 		 * Make sure the returned values are equal to mock args
@@ -367,11 +367,7 @@ class WP_GraphQL_Test_Post_Connection_Queries extends WP_UnitTestCase {
 			'categoryIn' => [4, 5, 6],
 		];
 
-		$app_context = new \WPGraphQL\AppContext();
-		
-		$app_info = new \GraphQL\Type\Definition\ResolveInfo( array() );
-
-		$actual = \WPGraphQL\Type\PostObject\Connection\PostObjectConnectionResolver::sanitize_input_fields( $mock_args, null, [], $app_context, $app_info );
+		$actual = \WPGraphQL\Type\PostObject\Connection\PostObjectConnectionResolver::sanitize_input_fields( $mock_args, null, [], $this->app_context, $this->app_info );
 
 		/**
 		 * Make sure the returned values are equal to mock args
@@ -395,12 +391,8 @@ class WP_GraphQL_Test_Post_Connection_Queries extends WP_UnitTestCase {
 			'tagSlugAnd' => [4, 5, 6],
 			'tagSlugIn' => [6, 7, 8],
 		];
-
-		$app_context = new \WPGraphQL\AppContext();
 		
-		$app_info = new \GraphQL\Type\Definition\ResolveInfo( array() );
-
-		$actual = \WPGraphQL\Type\PostObject\Connection\PostObjectConnectionResolver::sanitize_input_fields( $mock_args, null, [], $app_context, $app_info );
+		$actual = \WPGraphQL\Type\PostObject\Connection\PostObjectConnectionResolver::sanitize_input_fields( $mock_args, null, [], $this->app_context, $this->app_info );
 
 		/**
 		 * Make sure the returned values are equal to mock args
@@ -425,11 +417,7 @@ class WP_GraphQL_Test_Post_Connection_Queries extends WP_UnitTestCase {
 			'id' => 1,
 		];
 
-		$app_context = new \WPGraphQL\AppContext();
-		
-		$app_info = new \GraphQL\Type\Definition\ResolveInfo( array() );
-
-		$actual = \WPGraphQL\Type\PostObject\Connection\PostObjectConnectionResolver::sanitize_input_fields( $mock_args, null, [], $app_context, $app_info );
+		$actual = \WPGraphQL\Type\PostObject\Connection\PostObjectConnectionResolver::sanitize_input_fields( $mock_args, null, [], $this->app_context, $this->app_info );
 
 		/**
 		 * Make sure the returned values are equal to mock args
@@ -454,11 +442,7 @@ class WP_GraphQL_Test_Post_Connection_Queries extends WP_UnitTestCase {
 			'nameIn' => ['testPost1', 'testPost2', 'testPost3'],
 		];
 
-		$app_context = new \WPGraphQL\AppContext();
-		
-		$app_info = new \GraphQL\Type\Definition\ResolveInfo( array() );
-
-		$actual = \WPGraphQL\Type\PostObject\Connection\PostObjectConnectionResolver::sanitize_input_fields( $mock_args, null, [], $app_context, $app_info );
+		$actual = \WPGraphQL\Type\PostObject\Connection\PostObjectConnectionResolver::sanitize_input_fields( $mock_args, null, [], $this->app_context, $this->app_info );
 
 		/**
 		 * Make sure the returned values are equal to mock args
@@ -495,11 +479,7 @@ class WP_GraphQL_Test_Post_Connection_Queries extends WP_UnitTestCase {
 			),
 		];
 
-		$app_context = new \WPGraphQL\AppContext();
-		
-		$app_info = new \GraphQL\Type\Definition\ResolveInfo( array() );
-
-		$actual = \WPGraphQL\Type\PostObject\Connection\PostObjectConnectionResolver::sanitize_input_fields( $mock_args, null, [], $app_context, $app_info );
+		$actual = \WPGraphQL\Type\PostObject\Connection\PostObjectConnectionResolver::sanitize_input_fields( $mock_args, null, [], $this->app_context, $this->app_info );
 
 		/**
 		 * Make sure the returned values are equal to mock args


### PR DESCRIPTION
Testing every single parameter of sanitize_input_fields, also testing get_query_args.