### PR TITLE
Ability to sort by menu_order

### DIFF
--- a/src/Type/PostObject/Connection/PostObjectConnectionArgs.php
+++ b/src/Type/PostObject/Connection/PostObjectConnectionArgs.php
@@ -346,6 +346,10 @@ class PostObjectConnectionArgs extends WPInputObjectType {
 						'value'       => 'post_name__in',
 						'description' => __( 'Preserve slug order given in the NAME_IN array', 'wp-graphql' ),
 					],
+					'MENU_ORDER' => [
+						'value'       => 'menu_order',
+						'description' => __( 'Order by the menu order value', 'wp-graphql' ),
+					],					
 				],
 			]);
 		endif;


### PR DESCRIPTION
A few WP plugins (ex: [SCPOrder](https://en-gb.wordpress.org/plugins/simple-custom-post-order/)) allow users to re-arrange the sort order of the posts, and then assigns a value to the `menu_order` field in the database.

This PR would allow the GraphQL endpoint to return the posts in that specified order


```graphql
# Example query

posts(where: { 
  categoryName: "projects"
  orderby: { field: MENU_ORDER, order: ASC }
}) {
  menuOrder
  title
  link
} 
```