### PR TITLE
Remove get_the_excerpt filter for image caption.

### DIFF
--- a/src/Type/MediaItem/MediaItemType.php
+++ b/src/Type/MediaItem/MediaItemType.php
@@ -74,7 +74,7 @@ class MediaItemType {
 				'type'        => Types::string(),
 				'description' => __( 'The caption for the resource', 'wp-graphql' ),
 				'resolve'     => function( \WP_Post $post, $args, $context, ResolveInfo $info ) {
-					$caption = apply_filters( 'the_excerpt', apply_filters( 'get_the_excerpt', $post->post_excerpt, $post ) );
+					$caption = apply_filters( 'the_excerpt', $post->post_excerpt );
 
 					return ! empty( $caption ) ? $caption : null;
 				},

--- a/tests/wpunit/MediaItemQueriesTest.php
+++ b/tests/wpunit/MediaItemQueriesTest.php
@@ -72,9 +72,13 @@ class MediaItemQueriesTest extends \Codeception\TestCase\WPTestCase {
 	 */
 	public function provideImageMeta() {
 		return [
-			[],
 			[
-				'caption' => '',
+				[],
+			],
+			[
+				[
+					'caption' => '',
+				],
 			],
 		];
 	}

--- a/tests/wpunit/MediaItemQueriesTest.php
+++ b/tests/wpunit/MediaItemQueriesTest.php
@@ -68,13 +68,27 @@ class MediaItemQueriesTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	/**
+	 * Data provider for testMediaItemQuery.
+	 */
+	public function provideImageMeta() {
+		return [
+			[],
+			[
+				'caption' => '',
+			],
+		];
+	}
+
+	/**
 	 * testPostQuery
 	 *
 	 * This tests creating a single post with data and retrieving said post via a GraphQL query
 	 *
+	 * @dataProvider provideImageMeta
+	 * @param array $image_meta Image meta to merge into defaults.
 	 * @since 0.0.5
 	 */
-	public function testMediaItemQuery() {
+	public function testMediaItemQuery( $image_meta = [] ) {
 
 		/**
 		 * Create a post to set as the attachment's parent
@@ -91,6 +105,24 @@ class MediaItemQueriesTest extends \Codeception\TestCase\WPTestCase {
 			'post_parent' => $post_id,
 		] );
 
+		$default_image_meta = [
+			'aperture' => 0,
+			'credit' => 'some photographer',
+			'camera' => 'some camera',
+			'caption' => 'some caption',
+			'created_timestamp' => strtotime( $this->current_date ),
+			'copyright' => 'Copyright WPGraphQL',
+			'focal_length' => 0,
+			'iso' => 0,
+			'shutter_speed' => 0,
+			'title' => 'some title',
+			'orientation' => 'some orientation',
+			'keywords' => [
+				'keyword1',
+				'keyword2',
+			],
+		];
+
 		$meta_data = [
 			'width' => 300,
 			'height' => 300,
@@ -104,23 +136,7 @@ class MediaItemQueriesTest extends \Codeception\TestCase\WPTestCase {
 					'source_url' => 'example-thumbnail.jpg',
 				],
 			],
-			'image_meta' => [
-				'aperture' => 0,
-				'credit' => 'some photographer',
-				'camera' => 'some camera',
-				'caption' => 'some caption',
-				'created_timestamp' => strtotime( $this->current_date ),
-				'copyright' => 'Copyright WPGraphQL',
-				'focal_length' => 0,
-				'iso' => 0,
-				'shutter_speed' => 0,
-				'title' => 'some title',
-				'orientation' => 'some orientation',
-				'keywords' => [
-					'keyword1',
-					'keyword2',
-				],
-			],
+			'image_meta' => array_merge( $default_image_meta, $image_meta ),
 		];
 
 		update_post_meta( $attachment_id, '_wp_attachment_metadata', $meta_data );

--- a/tests/wpunit/MediaItemQueriesTest.php
+++ b/tests/wpunit/MediaItemQueriesTest.php
@@ -104,9 +104,11 @@ class MediaItemQueriesTest extends \Codeception\TestCase\WPTestCase {
 		/**
 		 * Create an attachment with a post set as it's parent
 		 */
+		$image_description = 'some description'
 		$attachment_id = $this->createPostObject( [
 			'post_type'   => 'attachment',
 			'post_parent' => $post_id,
+			'post_content' => $image_description,
 		] );
 
 		$default_image_meta = [
@@ -280,6 +282,9 @@ class MediaItemQueriesTest extends \Codeception\TestCase\WPTestCase {
 			],
 			$mediaItem['parent']
 		);
+
+		$this->assertNotEmpty( $mediaItem['description'] );
+		$this->assertEquals( apply_filters( 'the_content', $image_description ), $mediaItem['description'] );
 
 		$this->assertNotEmpty( $mediaItem['mediaDetails'] );
 		$mediaDetails = $mediaItem['mediaDetails'];

--- a/tests/wpunit/MediaItemQueriesTest.php
+++ b/tests/wpunit/MediaItemQueriesTest.php
@@ -104,7 +104,7 @@ class MediaItemQueriesTest extends \Codeception\TestCase\WPTestCase {
 		/**
 		 * Create an attachment with a post set as it's parent
 		 */
-		$image_description = 'some description'
+		$image_description = 'some description';
 		$attachment_id = $this->createPostObject( [
 			'post_type'   => 'attachment',
 			'post_parent' => $post_id,

--- a/tests/wpunit/MediaItemQueriesTest.php
+++ b/tests/wpunit/MediaItemQueriesTest.php
@@ -141,6 +141,13 @@ class MediaItemQueriesTest extends \Codeception\TestCase\WPTestCase {
 					'mime-type' => 'image/jpeg',
 					'source_url' => 'example-thumbnail.jpg',
 				],
+				'full' => [
+					'file' => 'example-full.jpg',
+					'width' => 1500,
+					'height' => 1500,
+					'mime-type' => 'image/jpeg',
+					'source_url' => 'example-full.jpg',
+				],
 			],
 			'image_meta' => array_merge( $default_image_meta, $image_meta ),
 		];


### PR DESCRIPTION
The get_the_excerpt filter calls wp_trim_excerpt which, if the caption / excerpt is empty, uses global $post->post_content (a.k.a., the parent post) as the seed for crafting the excerpt.

This means that if you leave the caption field blank for a featured image, WPGraphQL currently populates the caption field with the excerpt of the parent post (or possibly even a different post).

I think it's safe to assume this isn't going against user's expectations, since you would need to setup post data *for the attachment* to use get_the_excerpt for image captions.