### PR TITLE
Add TERM_ORDER as TermsOrderby enum.

### DIFF
--- a/src/Type/TermObject/Connection/TermObjectConnectionArgs.php
+++ b/src/Type/TermObject/Connection/TermObjectConnectionArgs.php
@@ -65,6 +65,9 @@ class TermObjectConnectionArgs extends WPInputObjectType {
 							'TERM_ID' => [
 								'value' => 'term_id',
 							],
+							'TERM_ORDER' => [
+								'value' => 'term_order',
+							],
 							'DESCRIPTION' => [
 								'value' => 'description',
 							],


### PR DESCRIPTION
When writing a WPGraphQL plugin for CoAuthors Plus, the only way to return the authors in the correct order (as added by the editor) was to order by `term_order`. This is seldom-used but I think perfectly valid `ORDERBY` value. It is documented in `wp_get_object_terms`:

https://codex.wordpress.org/Function_Reference/wp_get_object_terms