### PR TITLE
Fix: remove double quote from description

### DIFF
--- a/src/Type/PostObject/Connection/PostObjectConnectionArgs.php
+++ b/src/Type/PostObject/Connection/PostObjectConnectionArgs.php
@@ -86,7 +86,7 @@ class PostObjectConnectionArgs extends WPInputObjectType {
 				],
 				'authorName'   => [
 					'type'        => Types::string(),
-					'description' => __( 'Find objects connected to the author by the author\'s "nicename"', 'wp-graphql' ),
+					'description' => __( 'Find objects connected to the author by the author\'s nicename', 'wp-graphql' ),
 				],
 				'authorIn'     => [
 					'type'        => Types::list_of( Types::id() ),

--- a/src/Type/PostObject/Mutation/PostObjectMutation.php
+++ b/src/Type/PostObject/Mutation/PostObjectMutation.php
@@ -47,11 +47,7 @@ class PostObjectMutation {
 				],
 				'date'          => [
 					'type'        => Types::string(),
-					'description' => __( 'The date of the object.', 'wp-graphql' ),
-				],
-				'dateGmt'       => [
-					'type'        => Types::string(),
-					'description' => __( 'The date (in GMT zone) of the object', 'wp-graphql' ),
+					'description' => __( 'The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 ', 'wp-graphql' ),
 				],
 				'excerpt'       => [
 					'type'        => Types::string(),
@@ -64,14 +60,6 @@ class PostObjectMutation {
 				'mimeType'      => [
 					'type'        => Types::mime_type_enum(),
 					'description' => __( 'If the post is an attachment or a media file, this field will carry the corresponding MIME type. This field is equivalent to the value of WP_Post->post_mime_type and the post_mime_type column in the `post_objects` database table.', 'wp-graphql' ),
-				],
-				'modified'      => [
-					'type'        => Types::string(),
-					'description' => __( 'The local modified time for a post. If a post was recently updated the modified field will change to match the corresponding time.', 'wp-graphql' ),
-				],
-				'modifiedGmt'   => [
-					'type'        => Types::string(),
-					'description' => __( 'The GMT modified time for a post. If a post was recently updated the modified field will change to match the corresponding time in GMT.', 'wp-graphql' ),
 				],
 				'parentId'      => [
 					'type'        => Types::id(),
@@ -152,10 +140,6 @@ class PostObjectMutation {
 			$insert_post_args['post_date'] = date( 'Y-m-d H:i:s', strtotime( $input['date'] ) );
 		}
 
-		if ( ! empty( $input['dateGmt'] ) && false !== strtotime( $input['dateGmt'] ) ) {
-			$insert_post_args['post_date_gmt'] = strtotime( $input['dateGmt'] );
-		}
-
 		if ( ! empty( $input['content'] ) ) {
 			$insert_post_args['post_content'] = $input['content'];
 		}
@@ -194,14 +178,6 @@ class PostObjectMutation {
 
 		if ( ! empty( $input['pinged'] ) ) {
 			$insert_post_args['pinged'] = $input['pinged'];
-		}
-
-		if ( ! empty( $input['postModified'] ) && false !== strtotime( $input['postModified'] ) ) {
-			$insert_post_args['modified'] = strtotime( $input['postModified'] );
-		}
-
-		if ( ! empty( $input['postModifiedGmt'] ) && false !== strtotime( $input['postModifiedGmt'] ) ) {
-			$insert_post_args['post_modified_gmt'] = strtotime( $input['postModifiedGmt'] );
 		}
 
 		$parent_id_parts = ! empty( $input['parentId'] ) ? Relay::fromGlobalId( $input['parentId'] ) : null;

--- a/src/Type/PostObject/PostObjectType.php
+++ b/src/Type/PostObject/PostObjectType.php
@@ -180,7 +180,7 @@ class PostObjectType extends WPObjectType {
 						'type'        => Types::string(),
 						'description' => __( 'The publishing date set in GMT.', 'wp-graphql' ),
 						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
-							return ! empty( $post->post_date_gmt ) ? $post->post_date_gmt : null;
+							return ! empty( $post->post_date_gmt ) ? Types::prepare_date_response( $post->post_date_gmt ): null;
 						},
 					],
 					'content'           => [
@@ -291,7 +291,7 @@ class PostObjectType extends WPObjectType {
 						'type'        => Types::string(),
 						'description' => __( 'The GMT modified time for a post. If a post was recently updated the modified field will change to match the corresponding time in GMT.', 'wp-graphql' ),
 						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
-							return ! empty( $post->post_modified_gmt ) ? $post->post_modified_gmt : null;
+							return ! empty( $post->post_modified_gmt ) ? Types::prepare_date_response( $post->post_modified_gmt ): null;
 						},
 					],
 					'parent'            => [

--- a/src/Types.php
+++ b/src/Types.php
@@ -793,4 +793,27 @@ class Types {
 
 	}
 
+    /**
+     * Checks the post_date_gmt or modified_gmt and prepare any post or
+     * modified date for single post output.
+     *
+     * @since 4.7.0
+     *
+     * @param string      $date_gmt GMT publication time.
+     * @param string|null $date     Optional. Local publication time. Default null.
+     * @return string|null ISO8601/RFC3339 formatted datetime.
+     */
+    public static function prepare_date_response( $date_gmt, $date = null ) {
+        // Use the date if passed.
+        if ( isset( $date ) ) {
+            return mysql_to_rfc3339( $date );
+        }
+        // Return null if $date_gmt is empty/zeros.
+        if ( '0000-00-00 00:00:00' === $date_gmt ) {
+            return null;
+        }
+        // Return the formatted datetime.
+        return mysql_to_rfc3339( $date_gmt );
+    }
+
 }

--- a/tests/wpunit/MediaItemMutationsTest.php
+++ b/tests/wpunit/MediaItemMutationsTest.php
@@ -7,6 +7,7 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	public $authorId;
 	public $caption;
 	public $commentStatus;
+    public $current_date_gmt;
 	public $date;
 	public $dateGmt;
 	public $description;
@@ -78,7 +79,7 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	    $this->caption          = 'Shia shows off some magic in this caption.';
 	    $this->commentStatus    = 'closed';
 	    $this->date             = '2017-08-01 15:00:00';
-	    $this->dateGmt          = '2017-08-01 21:00:00';
+	    $this->dateGmt          = '2017-08-01T21:00:00';
 	    $this->description      = 'This is a magic description.';
 	    $this->filePath         = 'http://www.reactiongifs.com/r/mgc.gif';
 	    $this->fileType         = 'IMAGE_GIF';
@@ -98,7 +99,7 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	    $this->updated_caption = 'Shia shows off some magic in this updated caption.';
 	    $this->updated_commentStatus = 'open';
 	    $this->updated_date = '2017-08-01 16:00:00';
-	    $this->updated_dateGmt = '2017-08-01 22:00:00';
+	    $this->updated_dateGmt = '2017-08-01T22:00:00';
 	    $this->updated_slug = 'updated-shia-magic';
 	    $this->updated_status = 'INHERIT';
 	    $this->updated_pingStatus = 'open';

--- a/tests/wpunit/PostObjectQueriesTest.php
+++ b/tests/wpunit/PostObjectQueriesTest.php
@@ -206,7 +206,7 @@ class PostObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 					'commentStatus' => 'open',
 					'content'       => apply_filters( 'the_content', 'Test page content' ),
 					'date'          => $this->current_date,
-					'dateGmt'       => $this->current_date_gmt,
+					'dateGmt'       => \WPGraphQL\Types::prepare_date_response( get_post( $this->attachment_id )->post_modified_gmt ),
 					'desiredSlug'   => null,
 					'editLast'      => [
 						'userId' => $this->admin,
@@ -227,7 +227,7 @@ class PostObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 					'toPing'        => null,
 					'pinged'        => null,
 					'modified'      => get_post( $post_id )->post_modified,
-					'modifiedGmt'   => get_post( $post_id )->post_modified_gmt,
+					'modifiedGmt'   => \WPGraphQL\Types::prepare_date_response( get_post( $this->attachment_id )->post_modified_gmt ),
 					'title'         => apply_filters( 'the_title', 'Test Title' ),
 					'guid'          => get_post( $post_id )->guid,
 					'featuredImage' => [


### PR DESCRIPTION
Addresses https://github.com/wp-graphql/wp-graphql/issues/364