### PR TITLE
#333 - Set term connections as nested input in PostObjectMutations

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -196,7 +196,7 @@ class Router {
 			'Content-Type'                 => 'application/json ; charset=' . get_option( 'blog_charset' ),
 			'X-Robots-Tag'                 => 'noindex',
 			'X-Content-Type-Options'       => 'nosniff',
-			'X-hacker' 										 => __( 'If you\'re reading this, you should visit github.com/wp-graphql and contribute!', 'wp-graphql' ),
+			'X-hacker'                     => __( 'If you\'re reading this, you should visit github.com/wp-graphql and contribute!', 'wp-graphql' ),
 		];
 
 		/**

--- a/src/Type/PostObject/Mutation/PostObjectCreate.php
+++ b/src/Type/PostObject/Mutation/PostObjectCreate.php
@@ -4,6 +4,7 @@ namespace WPGraphQL\Type\PostObject\Mutation;
 
 use GraphQL\Error\UserError;
 use GraphQLRelay\Relay;
+use WPGraphQL\Type\WPInputObjectType;
 use WPGraphQL\Types;
 
 /**
@@ -37,10 +38,10 @@ class PostObjectCreate {
 			$mutation_name = 'Create' . ucwords( $post_type_object->graphql_single_name );
 
 			self::$mutation[ $post_type_object->graphql_single_name ] = Relay::mutationWithClientMutationId( [
-				'name'                => esc_html( $mutation_name ),
+				'name'                => $mutation_name,
 				// translators: The placeholder is the name of the object type
 				'description'         => sprintf( __( 'Create %1$s objects', 'wp-graphql' ), $post_type_object->graphql_single_name ),
-				'inputFields'         => PostObjectMutation::input_fields( $post_type_object ),
+				'inputFields'         => WPInputObjectType::prepare_fields( PostObjectMutation::input_fields( $post_type_object ), $mutation_name ),
 				'outputFields'        => [
 					$post_type_object->graphql_single_name => [
 						'type'    => Types::post_object( $post_type_object->name ),

--- a/src/Type/PostObject/Mutation/PostObjectMutation.php
+++ b/src/Type/PostObject/Mutation/PostObjectMutation.php
@@ -447,7 +447,7 @@ class PostObjectMutation {
 								 * during a post object mutation, create the term to connect based on the
 								 * input
 								 */
-								if ( false === $term_exists && true === $allow_term_creation ) {
+								if ( ! $term_exists && true === $allow_term_creation ) {
 
 									/**
 									 * If the current user cannot edit terms, don't create terms to connect
@@ -527,10 +527,14 @@ class PostObjectMutation {
 			$created_term = wp_insert_term( $term_to_create['name'], $taxonomy, $term_args );
 		}
 
+		if ( is_wp_error( $created_term ) && isset( $created_term->error_data['term_exists'] ) ) {
+			return $created_term->error_data['term_exists'];
+		}
+
 		/**
 		 * Return the created term, or 0
 		 */
-		return ! is_wp_error( $created_term ) && ! empty( $created_term['term_id'] ) ? $created_term['term_id'] : 0;
+		return ! empty( $created_term['term_id'] ) ? $created_term['term_id'] : 0;
 
 	}
 

--- a/src/Type/PostObject/Mutation/PostObjectMutation.php
+++ b/src/Type/PostObject/Mutation/PostObjectMutation.php
@@ -120,11 +120,11 @@ class PostObjectMutation {
 									'description' => sprintf( __( 'The slug of the %1$s. If no ID is present, this field will be used to make a connection. If no existing term exists with this slug, this field will be used as a fallback to the Name field when creating a new term to connect to, if term creation is enabled as a nested mutation.', 'wp-graphql' ), $tax_object->graphql_single_name ),
 								],
 								'description'   => [
-									'type'        => Types::id(),
+									'type'        => Types::string(),
 									'description' => sprintf( __( 'The description of the %1$s. This field is used to set a description of the %1$s if a new one is created during the mutation.', 'wp-graphql' ), $tax_object->graphql_single_name ),
 								],
 								'name'   => [
-									'type'        => Types::id(),
+									'type'        => Types::string(),
 									'description' => sprintf( __( 'The name of the %1$s. This field is used to create a new term, if term creation is enabled in nested mutations, and if one does not already exist with the provided slug or ID or if a slug or ID is not provided. If no name is included and a term is created, the creation will fallback to the slug field.', 'wp-graphql' ), $tax_object->graphql_single_name ),
 								],
 							],

--- a/src/Type/PostObject/Mutation/PostObjectMutation.php
+++ b/src/Type/PostObject/Mutation/PostObjectMutation.php
@@ -2,7 +2,9 @@
 
 namespace WPGraphQL\Type\PostObject\Mutation;
 
+use GraphQL\Error\UserError;
 use GraphQLRelay\Relay;
+use WPGraphQL\Type\WPInputObjectType;
 use WPGraphQL\Types;
 
 /**
@@ -94,6 +96,59 @@ class PostObjectMutation {
 					'description' => __( 'URLs queued to be pinged.', 'wp-graphql' ),
 				],
 			];
+
+			/**
+			 * Add inputs for connected taxonomies
+			 */
+			$allowed_taxonomies = \WPGraphQL::$allowed_taxonomies;
+			if ( ! empty( $allowed_taxonomies ) && is_array( $allowed_taxonomies ) ) {
+				foreach ( $allowed_taxonomies as $taxonomy ) {
+					// If the taxonomy is in the array of taxonomies registered to the post_type
+					if ( in_array( $taxonomy, get_object_taxonomies( $post_type_object->name ), true ) ) {
+						$tax_object                                       = get_taxonomy( $taxonomy );
+
+						$node_input = new WPInputObjectType( [
+							'name'   => $post_type_object->graphql_single_name . ucfirst( $tax_object->graphql_plural_name ) . 'Nodes',
+							'description' => sprintf( __( 'List of %1$s to connect the %2$s to. If an ID is set, it will be used to create the connection. If not, it will look for a slug. If neither are valid existing terms, and the site is configured to allow terms to be created during post mutations, a term will be created using the Name if it exists in the input, then fallback to the slug if it exists.', 'wp-graphql' ), $tax_object->graphql_plural_name, $post_type_object->graphql_single_name ),
+							'fields' => [
+								'id'   => [
+									'type'        => Types::id(),
+									'description' => sprintf( __( 'The ID of the %1$s. If present, this will be used to connect to the %2$s. If no existing %1$s exists with this ID, no connection will be made.', 'wp-graphql' ), $tax_object->graphql_single_name, $post_type_object->graphql_single_name ),
+								],
+								'slug' => [
+									'type'        => Types::string(),
+									'description' => sprintf( __( 'The slug of the %1$s. If no ID is present, this field will be used to make a connection. If no existing term exists with this slug, this field will be used as a fallback to the Name field when creating a new term to connect to, if term creation is enabled as a nested mutation.', 'wp-graphql' ), $tax_object->graphql_single_name ),
+								],
+								'description'   => [
+									'type'        => Types::id(),
+									'description' => sprintf( __( 'The description of the %1$s. This field is used to set a description of the %1$s if a new one is created during the mutation.', 'wp-graphql' ), $tax_object->graphql_single_name ),
+								],
+								'name'   => [
+									'type'        => Types::id(),
+									'description' => sprintf( __( 'The name of the %1$s. This field is used to create a new term, if term creation is enabled in nested mutations, and if one does not already exist with the provided slug or ID or if a slug or ID is not provided. If no name is included and a term is created, the creation will fallback to the slug field.', 'wp-graphql' ), $tax_object->graphql_single_name ),
+								],
+							],
+						] );
+
+						$input_fields[ $tax_object->graphql_plural_name ] = [
+							'description' => sprintf( __( 'Set connections between the %1$s and %2$s', 'wp-graphql' ), $post_type_object->graphql_single_name, $tax_object->graphql_plural_name ),
+							'type' => new WPInputObjectType( [
+								'name'        => ucfirst( $post_type_object->graphql_single_name ) . ucfirst( $tax_object->graphql_plural_name ),
+								'description' => sprintf( __( 'Set relationships between the %1$s to %2$s', 'wp-graphql' ), $post_type_object->graphql_single_name, $tax_object->graphql_plural_name ),
+								'fields'      => [
+									'append' => [
+										'type'        => Types::boolean(),
+										'description' => sprintf( __( 'If true, this will append the %1$s to existing related %2$s. If false, this will replace existing relationships. Default true.', 'wp-graphql' ), $tax_object->graphql_single_name, $tax_object->graphql_plural_name ),
+									],
+									'nodes'  => [
+										'type' => Types::list_of( $node_input ),
+									],
+								],
+							] ),
+						];
+					}
+				}
+			}
 
 			/**
 			 * Filters the mutation input fields for the object type
@@ -217,41 +272,265 @@ class PostObjectMutation {
 	/**
 	 * This updates additional data related to a post object, such as postmeta, term relationships, etc.
 	 *
-	 * @param $new_post_id
-	 * @param $input
-	 * @param $post_type_object
-	 * @param $mutation_name
+	 * @param int           $post_id          $post_id      The ID of the postObject being mutated
+	 * @param array         $input            The input for the mutation
+	 * @param \WP_Post_Type $post_type_object The Post Type Object for the type of post being mutated
+	 * @param string        $mutation_name    The name of the mutation (ex: create, update, delete)
 	 */
-	public static function update_additional_post_object_data( $new_post_id, $input, $post_type_object, $mutation_name ) {
+	public static function update_additional_post_object_data( $post_id, $input, $post_type_object, $mutation_name ) {
 
 		/**
 		 * Set the post_lock for the $new_post_id
 		 */
-		self::set_edit_lock( $new_post_id );
+		self::set_edit_lock( $post_id );
 
 		/**
 		 * Update the _edit_last field
 		 */
-		update_post_meta( $new_post_id, '_edit_last', get_current_user_id() );
+		update_post_meta( $post_id, '_edit_last', get_current_user_id() );
 
 		/**
 		 * Update the postmeta fields
 		 */
 		if ( ! empty( $input['desiredSlug'] ) ) {
-			update_post_meta( $new_post_id, '_wp_desired_post_slug', $input['desiredSlug'] );
+			update_post_meta( $post_id, '_wp_desired_post_slug', $input['desiredSlug'] );
 		}
+
+		/**
+		 * Set the object terms
+		 *
+		 * @param int           $post_id          The ID of the postObject being mutated
+		 * @param array         $input            The input for the mutation
+		 * @param \WP_Post_Type $post_type_object The Post Type Object for the type of post being mutated
+		 * @param string        $mutation_name    The name of the mutation (ex: create, update, delete)
+		 */
+		self::set_object_terms( $post_id, $input, $post_type_object, $mutation_name );
 
 		/**
 		 * Run an action after the additional data has been updated. This is a great spot to hook into to
 		 * update additional data related to postObjects, such as setting relationships, updating additional postmeta,
 		 * or sending emails to Kevin. . .whatever you need to do with the postObject.
 		 *
-		 * @param int           $new_post_id      The ID of the postObject being mutated
+		 * @param int           $post_id          $post_id      The ID of the postObject being mutated
 		 * @param array         $input            The input for the mutation
 		 * @param \WP_Post_Type $post_type_object The Post Type Object for the type of post being mutated
 		 * @param string        $mutation_name    The name of the mutation (ex: create, update, delete)
 		 */
-		do_action( 'graphql_post_object_mutation_update_additional_data', $new_post_id, $input, $post_type_object, $mutation_name );
+		do_action( 'graphql_post_object_mutation_update_additional_data', $post_id, $input, $post_type_object, $mutation_name );
+
+	}
+
+	/**
+	 * Given a $post_id and $input from the mutation, check to see if any term associations are being made, and
+	 * properly set the relationships
+	 *
+	 * @param int           $post_id          The ID of the postObject being mutated
+	 * @param array         $input            The input for the mutation
+	 * @param \WP_Post_Type $post_type_object The Post Type Object for the type of post being mutated
+	 * @param string        $mutation_name    The name of the mutation (ex: create, update, delete)
+	 */
+	protected static function set_object_terms( $post_id, $input, $post_type_object, $mutation_name ) {
+
+		/**
+		 * Fire an action before setting object terms during a GraphQL Post Object Mutation.
+		 *
+		 * One example use for this hook would be to create terms from the input that may not exist yet, so that they can be set as a relation below.
+		 *
+		 * @param int           $post_id          The ID of the postObject being mutated
+		 * @param array         $input            The input for the mutation
+		 * @param \WP_Post_Type $post_type_object The Post Type Object for the type of post being mutated
+		 * @param string        $mutation_name    The name of the mutation (ex: create, update, delete)
+		 */
+		do_action( 'graphql_post_object_mutation_set_object_terms', $post_id, $input, $post_type_object, $mutation_name );
+
+		/**
+		 * Get the allowed taxonomies and iterate through them to find the term inputs to use for setting relationships
+		 */
+		$allowed_taxonomies = \WPGraphQL::$allowed_taxonomies;
+
+		if ( ! empty( $allowed_taxonomies ) && is_array( $allowed_taxonomies ) ) {
+
+			foreach ( $allowed_taxonomies as $taxonomy ) {
+
+				/**
+				 * If the taxonomy is in the array of taxonomies registered to the post_type
+				 */
+				if ( in_array( $taxonomy, get_object_taxonomies( $post_type_object->name ), true ) ) {
+
+					/**
+					 * Get the tax object
+					 */
+					$tax_object = get_taxonomy( $taxonomy );
+
+					/**
+					 * If there is input for the taxonomy, process it
+					 */
+					if ( ! empty( $tax_object->graphql_plural_name ) && ! empty( $input[ $tax_object->graphql_plural_name ] ) ) {
+
+						$term_input = $input[ $tax_object->graphql_plural_name ];
+
+						/**
+						 * Default append to true, but allow input to set it to false.
+						 */
+						$append = isset( $term_input['append'] ) && false === $term_input['append'] ? false : true;
+
+						/**
+						 * Start an array of terms to connect
+						 */
+						$terms_to_connect = [];
+
+						/**
+						 * Filter whether to allow terms to be created during a post mutation.
+						 *
+						 * If a post mutation includes term input for a term that does not already exist,
+						 * this will allow terms to be created in order to connect the term to the post object,
+						 * but if filtered to false, this will prevent the term that doesn't already exist
+						 * from being created during the mutation of the post.
+						 *
+						 * @param bool $allow_term_creation Whether new terms should be created during the post object mutation
+						 * @param \WP_Taxonomy $tax_object The Taxonomy object for the term being added to the Post Object
+						 */
+						$allow_term_creation = apply_filters( 'graphql_post_object_mutations_allow_term_creation', true, $tax_object );
+
+						/**
+						 * If there are nodes in the term_input
+						 */
+						if ( ! empty( $term_input['nodes'] ) && is_array( $term_input['nodes'] ) ) {
+
+							foreach( $term_input['nodes'] as $node ) {
+
+								$term_exists = false;
+
+								/**
+								 * Handle the input for ID first.
+								 */
+								if ( ! empty( $node['id'] ) ) {
+
+									if ( ! absint( $node['id'] ) ) {
+
+										$id_parts = Relay::fromGlobalId( $node['id'] );
+
+										if ( $id_parts['type'] !== $tax_object->name ) {
+											return;
+										}
+
+										if ( ! empty( $id_parts['id'] ) ) {
+											$term_exists = get_term_by( 'id', absint( $id_parts['id'] ), $tax_object->name );
+											if ( $term_exists ) {
+												$terms_to_connect[] = $term_exists->term_id;
+											}
+										}
+									} else {
+										$term_exists = get_term_by( 'id', absint( $node['id'] ), $tax_object->name );
+										if ( $term_exists ) {
+											$terms_to_connect[] = $term_exists->term_id;
+										}
+									}
+
+								/**
+								 * Next, handle the input for slug if there wasn't an ID input
+								 */
+								} elseif ( ! empty( $node['slug'] ) ) {
+									$sanitized_slug = sanitize_text_field( $node['slug'] );
+									$term_exists = get_term_by( 'slug', $sanitized_slug, $tax_object->name );
+									if ( $term_exists ) {
+										$terms_to_connect[] = $term_exists->term_id;
+									}
+								/**
+								 * If the input for the term isn't an existing term, check to make sure
+								 * we're allowed to create new terms during a Post Object mutation
+								 */
+								}
+
+								/**
+								 * If no term exists so far, and terms are set to be allowed to be created
+								 * during a post object mutation, create the term to connect based on the
+								 * input
+								 */
+								if ( false === $term_exists && true === $allow_term_creation ) {
+
+									/**
+									 * If the current user cannot edit terms, don't create terms to connect
+									 */
+									if ( ! current_user_can( $tax_object->cap->edit_terms ) ) {
+										return;
+									}
+
+									$created_term = self::create_term_to_connect( $node, $tax_object->name );
+
+									if ( ! empty( $created_term ) ) {
+										$terms_to_connect[] = $created_term;
+									}
+
+								}
+
+							}
+						}
+
+
+						/**
+						 * If there are terms to connect, set the connection
+						 */
+						if ( ! empty( $terms_to_connect ) && is_array( $terms_to_connect ) ) {
+
+							/**
+							 * If the current user cannot edit terms, don't create terms to connect
+							 */
+							if ( ! current_user_can( $tax_object->cap->assign_terms ) ) {
+								return;
+							}
+
+							wp_set_object_terms( $post_id, $terms_to_connect, $tax_object->name, $append );
+						}
+					}
+
+				}
+
+			}
+		}
+
+	}
+
+	/**
+	 * Given an array of Term properties (slug, name, description, etc), create the term and return a term_id
+	 *
+	 * @param array $node The node input for the term
+	 * @param string $taxonomy The taxonomy the term input is for
+	 *
+	 * @return int $term_id The ID of the created term. 0 if no term was created.
+	 */
+	protected static function create_term_to_connect( $node, $taxonomy ) {
+
+		$created_term = [];
+		$term_to_create = [];
+		$term_args = [];
+
+		if ( ! empty( $node['name'] ) ) {
+			$term_to_create['name'] = sanitize_text_field( $node['name'] );
+		} elseif ( ! empty( $node['slug'] ) ) {
+			$term_to_create['name'] = sanitize_text_field( $node['slug'] );
+		}
+
+		if ( ! empty( $node['slug'] ) ) {
+			$term_args['slug'] = sanitize_text_field( $node['slug'] );
+		}
+
+		if ( ! empty( $node['description'] ) ) {
+			$term_args['description'] = sanitize_text_field( $node['description'] );
+		}
+
+		/**
+		 * @todo: consider supporting "parent" input in $term_args
+		 */
+
+		if ( ! empty( $term_to_create['name'] ) ) {
+			$created_term = wp_insert_term( $term_to_create['name'], $taxonomy, $term_args );
+		}
+
+		/**
+		 * Return the created term, or 0
+		 */
+		return ! is_wp_error( $created_term ) && ! empty( $created_term['term_id'] ) ? $created_term['term_id'] : 0;
 
 	}
 

--- a/src/Type/PostObject/Mutation/PostObjectUpdate.php
+++ b/src/Type/PostObject/Mutation/PostObjectUpdate.php
@@ -4,6 +4,7 @@ namespace WPGraphQL\Type\PostObject\Mutation;
 
 use GraphQL\Error\UserError;
 use GraphQLRelay\Relay;
+use WPGraphQL\Type\WPInputObjectType;
 use WPGraphQL\Types;
 
 /**
@@ -37,10 +38,10 @@ class PostObjectUpdate {
 			$mutation_name = 'Update' . ucwords( $post_type_object->graphql_single_name );
 
 			self::$mutation[ $post_type_object->graphql_single_name ] = Relay::mutationWithClientMutationId([
-				'name'                => esc_html( $mutation_name ),
+				'name'                => $mutation_name,
 				// translators: The placeholder is the name of the post type being updated
 				'description'         => sprintf( __( 'Updates %1$s objects', 'wp-graphql' ), $post_type_object->graphql_single_name ),
-				'inputFields'         => self::input_fields( $post_type_object ),
+				'inputFields'         => WPInputObjectType::prepare_fields( self::input_fields( $post_type_object ), $mutation_name ),
 				'outputFields'        => [
 					$post_type_object->graphql_single_name => [
 						'type'    => Types::post_object( $post_type_object->name ),

--- a/src/Type/WPInputObjectType.php
+++ b/src/Type/WPInputObjectType.php
@@ -20,6 +20,9 @@ class WPInputObjectType extends InputObjectType {
 	 * @param array $config The configuration for the InputObjectType
 	 */
 	public function __construct( $config = [] ) {
+		if ( ! empty( $config['fields'] ) && is_array( $config['fields'] ) ) {
+			$config['fields'] = self::prepare_fields( $config['fields'], $config['name'] );
+		}
 		parent::__construct( $config );
 	}
 

--- a/tests/wpunit/PostObjectNestedMutationsTest.php
+++ b/tests/wpunit/PostObjectNestedMutationsTest.php
@@ -1,0 +1,279 @@
+<?php
+
+class PostObjectNestedMutationsTest extends \Codeception\TestCase\WPTestCase {
+
+	public $title;
+	public $content;
+	public $client_mutation_id;
+	public $admin;
+	public $subscriber;
+	public $author;
+
+	public function setUp() {
+		// before
+		parent::setUp();
+
+		$this->title              = 'some title';
+		$this->content            = 'some content';
+		$this->client_mutation_id = 'someUniqueId';
+
+		$this->author = $this->factory()->user->create( [
+			'role' => 'author',
+		] );
+
+		$this->admin = $this->factory()->user->create( [
+			'role' => 'administrator',
+		] );
+
+		$this->subscriber = $this->factory()->user->create( [
+			'role' => 'subscriber',
+		] );
+
+	}
+
+
+	public function tearDown() {
+		parent::tearDown();
+	}
+
+	public function createPostMutation( $args = [] ) {
+
+		$mutation = '
+		mutation CreatePostWithTerms( $input: CreatePostInput! ) {
+			createPost( input: $input ) {
+			  post {
+			    id
+			    postId
+			    title
+			    tags {
+			      edges {
+			        node {
+			          id
+			          tagId
+			          name
+			          description
+			          slug
+			        }
+			      }
+			    }
+			    categories {
+			      edges {
+			         node {
+			           id
+			           categoryId
+			           name
+			           description
+			           slug
+			         }
+			      }
+			    }
+			  }
+			}
+		}
+		';
+
+		$default = [
+			'clientMutationId' => uniqid(),
+			'title' => 'Test Title',
+			'status' => 'PUBLISH',
+		];
+
+		$input = array_merge( $default, $args );
+
+		$variables = [
+			'input' => $input,
+		];
+
+		$response = do_graphql_request( $mutation, 'CreatePostWithTerms', $variables );
+		return $response;
+
+	}
+
+	public function testCreatePostAndAttachCategories() {
+
+		$tag_slug = uniqid();
+		$tag = wp_insert_term( $tag_slug, 'post_tag' );
+		$expected_tag_id = \GraphQLRelay\Relay::toGlobalId( 'post_tag', absint( $tag['term_id'] ) );
+
+		$category_slug = uniqid();
+		$category = wp_insert_term( $category_slug, 'category' );
+		$expected_category_id = \GraphQLRelay\Relay::toGlobalId( 'category', absint( $category['term_id']  ) );
+
+		wp_set_current_user( $this->admin );
+		$results = $this->createPostMutation([
+			'tags' => [
+				'append' => false,
+				'nodes' => [
+					[
+						'slug' => $tag_slug
+					],
+				]
+
+			],
+			'categories' => [
+				'append' => false,
+				'nodes' => [
+					[
+						'slug' => $category_slug
+					],
+				]
+			]
+		]);
+
+		$this->assertArrayNotHasKey( 'errors', $results );
+
+		$createdPost = $results['data']['createPost']['post'];
+		$this->assertEquals( 'Test Title', $createdPost['title'] );
+		$this->assertEquals( $expected_tag_id, $createdPost['tags']['edges'][0]['node']['id'] );
+		$this->assertEquals( $expected_category_id, $createdPost['categories']['edges'][0]['node']['id'] );
+
+
+	}
+
+	public function testCreatePostAndAttachTagByID() {
+
+		wp_set_current_user( $this->admin );
+
+		$new_term = $this->factory->term->create([
+			'name' => 'Test Term',
+			'taxonomy' => 'post_tag'
+		]);
+
+		$new_term_global_id = \GraphQLRelay\Relay::toGlobalId( 'post_tag', $new_term );
+
+		$results = $this->createPostMutation([
+			'tags' => [
+				'append' => false,
+				'nodes' => [
+					[
+						'id' => $new_term_global_id
+					],
+				]
+
+			],
+		]);
+
+
+		$this->assertArrayNotHasKey( 'errors', $results );
+
+
+		$createdPost = $results['data']['createPost']['post'];
+		$this->assertEquals( 'Test Title', $createdPost['title'] );
+		$this->assertEquals( $new_term, $createdPost['tags']['edges'][0]['node']['tagId'] );
+		$this->assertEquals( $new_term_global_id, $createdPost['tags']['edges'][0]['node']['id'] );
+
+	}
+
+	public function testCreatePostAndAttachTagByTagID() {
+
+		wp_set_current_user( $this->admin );
+
+		$new_term = $this->factory->term->create([
+			'name' => 'Test Term',
+			'taxonomy' => 'post_tag'
+		]);
+
+		$new_term_global_id = \GraphQLRelay\Relay::toGlobalId( 'post_tag', $new_term );
+
+		$results = $this->createPostMutation([
+			'tags' => [
+				'append' => false,
+				'nodes' => [
+					[
+						'id' => (int) $new_term
+					],
+				]
+
+			],
+		]);
+
+
+		$this->assertArrayNotHasKey( 'errors', $results );
+
+
+		$createdPost = $results['data']['createPost']['post'];
+		$this->assertEquals( 'Test Title', $createdPost['title'] );
+		$this->assertEquals( $new_term, $createdPost['tags']['edges'][0]['node']['tagId'] );
+		$this->assertEquals( $new_term_global_id, $createdPost['tags']['edges'][0]['node']['id'] );
+
+	}
+
+	public function testCreatePostWithInvalidTagId() {
+
+		wp_set_current_user( $this->admin );
+
+		$new_term = $this->factory->term->create([
+			'name' => 'Test Term',
+			'taxonomy' => 'category'
+		]);
+
+		$new_term_global_id = \GraphQLRelay\Relay::toGlobalId( 'category', $new_term );
+
+		$results = $this->createPostMutation([
+			'tags' => [
+				'append' => false,
+				'nodes' => [
+					[
+						'id' => $new_term_global_id
+					],
+				],
+			],
+		]);
+
+		$this->assertArrayNotHasKey( 'errors', $results );
+
+		$createdPost = $results['data']['createPost']['post'];
+		$this->assertEquals( 'Test Title', $createdPost['title'] );
+
+		/**
+		 * The tags edges _should_ be empty because we tried to add a tag
+		 * with an invalid id.
+		 */
+		$this->assertEmpty( $createdPost['tags']['edges'] );
+
+
+	}
+
+	public function testCreatePostAndCreateTerms() {
+
+		wp_set_current_user( $this->admin );
+
+		$results = $this->createPostMutation([
+			'tags' => [
+				'append' => false,
+				'nodes' => [
+					[
+						'name' => 'Test Tag',
+						'slug' => 'test-tag',
+						'description' => 'Test Tag Description',
+					],
+				],
+			],
+			'categories' => [
+				'append' => false,
+				'nodes' => [
+					[
+						'slug' => 'test-category',
+						'description' => 'Test Category Description',
+					],
+				],
+			],
+		]);
+
+		$this->assertArrayNotHasKey( 'errors', $results );
+
+
+		$createdPost = $results['data']['createPost']['post'];
+		$this->assertEquals( 'Test Title', $createdPost['title'] );
+
+		/**
+		 * The tags edges _should_ be empty because we tried to add a tag
+		 * with an invalid id.
+		 */
+		$this->assertEquals( 'Test Tag Description', $createdPost['tags']['edges'][0]['node']['description'] );
+		$this->assertEquals( 'Test Category Description', $createdPost['categories']['edges'][0]['node']['description'] );
+
+
+	}
+
+}


### PR DESCRIPTION
This adds support to set term connections via nested input in PostObjectMutations.

For example: 

```
mutation CreatePostWithNewCategoryAndTag {
  createPost(
    input: {
      title: "New Post", 
      status: PUBLISH, 
      tags: {
        append: true, 
        nodes: [
          {
            name: "My New Tag", 
            description: "New Tag Description"
          }
        ]
      }, 
      categories: {
        append: true, 
        nodes: [
          {
            name: "My New Category", 
            description: "New Category Description"
          }
        ]
      }, 
      clientMutationId: "uniqueId"
    }) {
    post {
      id
      title
      tags {
        edges {
          node {
            id
            name
            slug
            description
          }
        }
      }
      categories {
        edges {
          node {
            id
            name
            slug
            description
          }
        }
      }
    }
  }
}
```

Outputs: 

```
{
  "data": {
    "createPost": {
      "post": {
        "id": "cG9zdDo2NTE3",
        "title": "New Post",
        "tags": {
          "edges": [
            {
              "node": {
                "id": "cG9zdF90YWc6Mzc3",
                "name": "My New Tag",
                "slug": "my-new-tag",
                "description": "New Tag Description"
              }
            }
          ]
        },
        "categories": {
          "edges": [
            {
              "node": {
                "id": "Y2F0ZWdvcnk6Mzc2",
                "name": "My New Category",
                "slug": "my-new-category",
                "description": "New Category Description"
              }
            },
            {
              "node": {
                "id": "Y2F0ZWdvcnk6MQ==",
                "name": "Uncategorized",
                "slug": "uncategorized",
                "description": null
              }
            }
          ]
        }
      }
    }
  }
}
```

When creating or updating a post (or custom post type) each connected taxonomy will have a root input, which accepts `append` as a bool value, and `nodes` which expects an array of term nodes. 

The terms will be connected to existing terms based on the node's ID field, if present, then the slug field if present. If neither fields exist, the Name field will be used to either create a new term (if allowed) or connect to any existing term with that name. The description input field will be used only if a new term is created.