### PR TITLE
#360 - Query Batching

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -286,6 +286,8 @@ class Router {
 
 	}
 
+
+
 	/**
 	 * This processes the graphql requests that come into the /graphql endpoint via an HTTP request
 	 *
@@ -317,119 +319,230 @@ class Router {
 
 		try {
 
+//			/**
+//			 * Respond to pre-flight requests.
+//			 *
+//			 * @see: https://apollographql.slack.com/archives/C10HTKHPC/p1507649812000123
+//			 * @see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Preflighted_requests
+//			 */
+//			if ( 'OPTIONS' === $_SERVER['REQUEST_METHOD'] ) {
+//
+//				self::$http_status_code = 200;
+//				self::set_headers( self::$http_status_code );
+//				exit;
+//
+//			} else if ( isset( $_SERVER['REQUEST_METHOD'] ) && $_SERVER['REQUEST_METHOD'] === 'GET' ) {
+//
+//				$data = [
+//					'query'         => isset( $_GET['query'] ) ? sanitize_text_field( $_GET['query'] ) : '',
+//					'operationName' => isset( $_GET['operationName'] ) ? sanitize_text_field( $_GET['operationName'] ) : '',
+//					'variables'     => isset( $_GET['variables'] ) ? $_GET['variables'] : '',
+//				];
+//
+//				/**
+//				 * Allow the data to be filtered
+//				 *
+//				 * @param array $data An array containing the pieces of the data of the GraphQL request
+//				 */
+//				$data = apply_filters( 'graphql_request_data', $data );
+//
+//				/**
+//				 * If the variables are already formatted as an array use them.
+//				 *
+//				 * Example:
+//				 * ?query=query getPosts($first:Int){posts(first:$first){edges{node{id}}}}&variables[first]=1
+//				 */
+//				if ( is_array( $data['variables'] ) ) {
+//					$sanitized_variables = [];
+//					foreach ( $data['variables'] as $key => $value ) {
+//						$sanitized_variables[ $key ] = sanitize_text_field( $value );
+//					}
+//					$decoded_variables = $sanitized_variables;
+//
+//					/**
+//					 * If the variables are not an array, let's attempt to decode them and convert them to an array for
+//					 * use in the executor.
+//					 */
+//				} else {
+//					$decoded_variables = json_decode( $data['variables'] );
+//				}
+//
+//				$data['variables'] = ! empty( $decoded_variables ) && is_array( $decoded_variables ) ? $decoded_variables : null;
+//
+//			} else {
+//
+//				if ( ! isset( $_SERVER['REQUEST_METHOD'] ) || 'POST' !== $_SERVER['REQUEST_METHOD'] ) {
+//					$response['errors'] = __( 'WPGraphQL requires POST requests', 'wp-graphql' );
+//				}
+//
+//				if ( ! isset( $_SERVER['CONTENT_TYPE'] ) || false === strpos( $_SERVER['CONTENT_TYPE'], 'application/json' ) ) {
+//					$response['errors'] = __( 'The Content-Type for the request must be set to "application/json"', 'wp-graphql' );
+//				}
+//
+//				/**
+//				 * Retrieve the raw data from the request and encode it to JSON
+//				 *
+//				 * @since 0.0.5
+//				 */
+//				$data = json_decode( self::get_raw_data(), true );
+//			}// End if().
+//
+//			/**
+//			 * If the $data is empty, catch an error.
+//			 */
+//			if ( empty( $data ) || ( empty( $data['query'] ) ) ) {
+//				throw new UserError( __( 'GraphQL requests must be a POST or GET Request with a valid query', 'wp-graphql' ), 10 );
+//			}
+//
+//			/**
+//			 * Allow the data to be filtered
+//			 *
+//			 * @param array $data An array containing the pieces of the data of the GraphQL request
+//			 */
+//			$data = apply_filters( 'graphql_request_data', $data );
+//
+//			/**
+//			 * Get the pieces of the request from the data
+//			 */
+//			$request        = isset( $data['query'] ) ? $data['query'] : '';
+//			$operation_name = isset( $data['operationName'] ) ? $data['operationName'] : '';
+//			$variables      = isset( $data['variables'] ) ? $data['variables'] : '';
+//
+//			/**
+//			 * Process the GraphQL request
+//			 *
+//			 * @since 0.0.5
+//			 */
+//			$graphql_results = do_graphql_request( $request, $operation_name, $variables );
+//
+//			/**
+//			 * Ensure the $graphql_request is returned as a proper, populated array,
+//			 * otherwise add an error to the result
+//			 */
+//			if ( ! empty( $graphql_results ) && is_array( $graphql_results ) ) {
+//				$response = $graphql_results;
+//			} else {
+//				$response['errors'] = __( 'The GraphQL request returned an invalid response', 'wp-graphql' );
+//			}
+//
+//			/**
+//			 * If the request is properly authenticated (a user has been set by some authentication mechanism),
+//			 * set the status code to 200.
+//			 */
+//			$user = wp_get_current_user();
+//			if ( $user && 0 !== $user->ID ) {
+//				self::$http_status_code = 200;
+//			}
+
 			/**
-			 * Respond to pre-flight requests.
+			 * Run an action after the HTTP Response is ready to be sent back. This might be a good place for tools
+			 * to hook in to track metrics, such as how long the process took from `graphql_process_http_request`
+			 * to here, etc.
 			 *
-			 * @see: https://apollographql.slack.com/archives/C10HTKHPC/p1507649812000123
-			 * @see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Preflighted_requests
-			 */
-			if ( 'OPTIONS' === $_SERVER['REQUEST_METHOD'] ) {
-
-				self::$http_status_code = 200;
-				self::set_headers( self::$http_status_code );
-				exit;
-
-			} else if ( isset( $_SERVER['REQUEST_METHOD'] ) && $_SERVER['REQUEST_METHOD'] === 'GET' ) {
-
-				$data = [
-					'query'         => isset( $_GET['query'] ) ? sanitize_text_field( $_GET['query'] ) : '',
-					'operationName' => isset( $_GET['operationName'] ) ? sanitize_text_field( $_GET['operationName'] ) : '',
-					'variables'     => isset( $_GET['variables'] ) ? $_GET['variables'] : '',
-				];
-
-				/**
-				 * Allow the data to be filtered
-				 *
-				 * @param array $data An array containing the pieces of the data of the GraphQL request
-				 */
-				$data = apply_filters( 'graphql_request_data', $data );
-
-				/**
-				 * If the variables are already formatted as an array use them.
-				 *
-				 * Example:
-				 * ?query=query getPosts($first:Int){posts(first:$first){edges{node{id}}}}&variables[first]=1
-				 */
-				if ( is_array( $data['variables'] ) ) {
-					$sanitized_variables = [];
-					foreach ( $data['variables'] as $key => $value ) {
-						$sanitized_variables[ $key ] = sanitize_text_field( $value );
-					}
-					$decoded_variables = $sanitized_variables;
-
-					/**
-					 * If the variables are not an array, let's attempt to decode them and convert them to an array for
-					 * use in the executor.
-					 */
-				} else {
-					$decoded_variables = json_decode( $data['variables'] );
-				}
-
-				$data['variables'] = ! empty( $decoded_variables ) && is_array( $decoded_variables ) ? $decoded_variables : null;
-
-			} else {
-
-				if ( ! isset( $_SERVER['REQUEST_METHOD'] ) || 'POST' !== $_SERVER['REQUEST_METHOD'] ) {
-					$response['errors'] = __( 'WPGraphQL requires POST requests', 'wp-graphql' );
-				}
-
-				if ( ! isset( $_SERVER['CONTENT_TYPE'] ) || false === strpos( $_SERVER['CONTENT_TYPE'], 'application/json' ) ) {
-					$response['errors'] = __( 'The Content-Type for the request must be set to "application/json"', 'wp-graphql' );
-				}
-
-				/**
-				 * Retrieve the raw data from the request and encode it to JSON
-				 *
-				 * @since 0.0.5
-				 */
-				$data = json_decode( self::get_raw_data(), true );
-			}// End if().
-
-			/**
-			 * If the $data is empty, catch an error.
-			 */
-			if ( empty( $data ) || ( empty( $data['query'] ) ) ) {
-				throw new UserError( __( 'GraphQL requests must be a POST or GET Request with a valid query', 'wp-graphql' ), 10 );
-			}
-
-			/**
-			 * Allow the data to be filtered
-			 *
-			 * @param array $data An array containing the pieces of the data of the GraphQL request
-			 */
-			$data = apply_filters( 'graphql_request_data', $data );
-
-			/**
-			 * Get the pieces of the request from the data
-			 */
-			$request        = isset( $data['query'] ) ? $data['query'] : '';
-			$operation_name = isset( $data['operationName'] ) ? $data['operationName'] : '';
-			$variables      = isset( $data['variables'] ) ? $data['variables'] : '';
-
-			/**
-			 * Process the GraphQL request
+			 * @param array $response
+			 * @param array $graphql_results
 			 *
 			 * @since 0.0.5
 			 */
-			$graphql_results = do_graphql_request( $request, $operation_name, $variables );
+			do_action( 'graphql_process_http_request_response', $response, $graphql_results );
 
 			/**
-			 * Ensure the $graphql_request is returned as a proper, populated array,
-			 * otherwise add an error to the result
+			 * If headers haven't been sent already, let's set the headers and return the JSON response
 			 */
-			if ( ! empty( $graphql_results ) && is_array( $graphql_results ) ) {
-				$response = $graphql_results;
-			} else {
-				$response['errors'] = __( 'The GraphQL request returned an invalid response', 'wp-graphql' );
-			}
+			if ( false === headers_sent() ) {
 
-			/**
-			 * If the request is properly authenticated (a user has been set by some authentication mechanism),
-			 * set the status code to 200.
-			 */
-			$user = wp_get_current_user();
-			if ( $user && 0 !== $user->ID ) {
-				self::$http_status_code = 200;
+				/**
+				 * Filter the $status_code before setting the headers
+				 *
+				 * @param int      $status_code     The status code to apply to the headers
+				 * @param array    $response        The response of the GraphQL Request
+				 * @param array    $graphql_results The results of the GraphQL execution
+				 * @param string   $request         The GraphQL Request
+				 * @param string   $operation_name  The operation name of the GraphQL Request
+				 * @param array    $variables       The variables applied to the GraphQL Request
+				 * @param \WP_User $user            The current user object
+				 */
+				$status_code = apply_filters( 'graphql_response_status_code', self::$http_status_code, $response, $graphql_results, $request, $operation_name, $variables, $user );
+
+				/**
+				 * Set the response headers
+				 */
+				self::set_headers( $status_code );
+
+				/**
+				 * Send the JSON response
+				 */
+				//			wp_send_json( $response );
+				$server = \WPGraphQL::server();
+				$result = $server->executeRequest();
+
+				/**
+				 * Run an action. This is a good place for debug tools to hook in to log things, etc.
+				 *
+				 * @since 0.0.4
+				 *
+				 * @param array      $result         The result of your GraphQL request
+				 * @param            Schema          object $schema The schema object for the root request
+				 * @param string     $operation_name The name of the operation
+				 * @param string     $request        The request that GraphQL executed
+				 * @param array|null $variables      Variables to passed to your GraphQL query
+				 */
+				do_action( 'graphql_execute', $result, \WPGraphQL::get_schema(), $operation_name, $request, $variables );
+
+				/**
+				 * Filter the $result of the GraphQL execution. This allows for the response to be filtered before
+				 * it's returned, allowing granular control over the response at the latest point.
+				 *
+				 * POSSIBLE USAGE EXAMPLES:
+				 * This could be used to ensure that certain fields never make it to the response if they match
+				 * certain criteria, etc. For example, this filter could be used to check if a current user is
+				 * allowed to see certain things, and if they are not, the $result could be filtered to remove
+				 * the data they should not be allowed to see.
+				 *
+				 * Or, perhaps some systems want the result to always include some additional piece of data in
+				 * every response, regardless of the request that was sent to it, this could allow for that
+				 * to be hooked in and included in the $result
+				 *
+				 * @since 0.0.5
+				 *
+				 * @param array      $result         The result of your GraphQL query
+				 * @param            Schema          object $schema The schema object for the root query
+				 * @param string     $operation_name The name of the operation
+				 * @param string     $request        The request that GraphQL executed
+				 * @param array|null $variables      Variables to passed to your GraphQL request
+				 */
+				$filtered_result = apply_filters( 'graphql_request_results', $result,  \WPGraphQL::get_schema(), $operation_name, $request, $variables );
+
+				/**
+				 * Run an action after the result has been filtered, as the response is being returned.
+				 * This is a good place for debug tools to hook in to log things, etc.
+				 *
+				 * @param array      $filtered_result The filtered_result of the GraphQL request
+				 * @param array      $result          The result of your GraphQL request
+				 * @param            Schema           object $schema The schema object for the root request
+				 * @param string     $operation_name  The name of the operation
+				 * @param string     $request         The request that GraphQL executed
+				 * @param array|null $variables       Variables to passed to your GraphQL query
+				 */
+				do_action( 'graphql_return_response', $filtered_result, $result,  \WPGraphQL::get_schema(), $operation_name, $request, $variables );
+
+				/**
+				 * Reset the global post after execution
+				 *
+				 * This allows for a GraphQL query to be used in the middle of post content, such as in a Shortcode
+				 * without disrupting the flow of the post as the global POST before and after GraphQL execution will be
+				 * the same.
+				 */
+				if ( ! empty( $global_post ) ) {
+					$GLOBALS['post'] = $global_post;
+				}
+
+				wp_send_json( $result );
+			} elseif ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+				/**
+				 * Headers will already be set if this function is called within AJAX.
+				 */
+				wp_send_json( $response );
 			}
 
 		} catch ( \Exception $error ) {
@@ -443,52 +556,6 @@ class Router {
 			self::$http_status_code = 500;
 			$response['errors']     = [ FormattedError::createFromException( $error ) ];
 		} // End try().
-
-		/**
-		 * Run an action after the HTTP Response is ready to be sent back. This might be a good place for tools
-		 * to hook in to track metrics, such as how long the process took from `graphql_process_http_request`
-		 * to here, etc.
-		 *
-		 * @param array $response
-		 * @param array $graphql_results
-		 *
-		 * @since 0.0.5
-		 */
-		do_action( 'graphql_process_http_request_response', $response, $graphql_results );
-
-		/**
-		 * If headers haven't been sent already, let's set the headers and return the JSON response
-		 */
-		if ( false === headers_sent() ) {
-
-			/**
-			 * Filter the $status_code before setting the headers
-			 *
-			 * @param int      $status_code     The status code to apply to the headers
-			 * @param array    $response        The response of the GraphQL Request
-			 * @param array    $graphql_results The results of the GraphQL execution
-			 * @param string   $request         The GraphQL Request
-			 * @param string   $operation_name  The operation name of the GraphQL Request
-			 * @param array    $variables       The variables applied to the GraphQL Request
-			 * @param \WP_User $user            The current user object
-			 */
-			$status_code = apply_filters( 'graphql_response_status_code', self::$http_status_code, $response, $graphql_results, $request, $operation_name, $variables, $user );
-
-			/**
-			 * Set the response headers
-			 */
-			self::set_headers( $status_code );
-
-			/**
-			 * Send the JSON response
-			 */
-			wp_send_json( $response );
-		} elseif ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
-			/**
-			 * Headers will already be set if this function is called within AJAX.
-			 */
-			wp_send_json( $response );
-		}
 
 	}
 

--- a/src/Router.php
+++ b/src/Router.php
@@ -472,7 +472,6 @@ class Router {
 				/**
 				 * Send the JSON response
 				 */
-				//			wp_send_json( $response );
 				$server = \WPGraphQL::server();
 				$result = $server->executeRequest();
 

--- a/src/Router.php
+++ b/src/Router.php
@@ -319,229 +319,311 @@ class Router {
 
 		try {
 
-//			/**
-//			 * Respond to pre-flight requests.
-//			 *
-//			 * @see: https://apollographql.slack.com/archives/C10HTKHPC/p1507649812000123
-//			 * @see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Preflighted_requests
-//			 */
-//			if ( 'OPTIONS' === $_SERVER['REQUEST_METHOD'] ) {
-//
-//				self::$http_status_code = 200;
-//				self::set_headers( self::$http_status_code );
-//				exit;
-//
-//			} else if ( isset( $_SERVER['REQUEST_METHOD'] ) && $_SERVER['REQUEST_METHOD'] === 'GET' ) {
-//
-//				$data = [
-//					'query'         => isset( $_GET['query'] ) ? sanitize_text_field( $_GET['query'] ) : '',
-//					'operationName' => isset( $_GET['operationName'] ) ? sanitize_text_field( $_GET['operationName'] ) : '',
-//					'variables'     => isset( $_GET['variables'] ) ? $_GET['variables'] : '',
-//				];
-//
-//				/**
-//				 * Allow the data to be filtered
-//				 *
-//				 * @param array $data An array containing the pieces of the data of the GraphQL request
-//				 */
-//				$data = apply_filters( 'graphql_request_data', $data );
-//
-//				/**
-//				 * If the variables are already formatted as an array use them.
-//				 *
-//				 * Example:
-//				 * ?query=query getPosts($first:Int){posts(first:$first){edges{node{id}}}}&variables[first]=1
-//				 */
-//				if ( is_array( $data['variables'] ) ) {
-//					$sanitized_variables = [];
-//					foreach ( $data['variables'] as $key => $value ) {
-//						$sanitized_variables[ $key ] = sanitize_text_field( $value );
-//					}
-//					$decoded_variables = $sanitized_variables;
-//
-//					/**
-//					 * If the variables are not an array, let's attempt to decode them and convert them to an array for
-//					 * use in the executor.
-//					 */
-//				} else {
-//					$decoded_variables = json_decode( $data['variables'] );
-//				}
-//
-//				$data['variables'] = ! empty( $decoded_variables ) && is_array( $decoded_variables ) ? $decoded_variables : null;
-//
-//			} else {
-//
-//				if ( ! isset( $_SERVER['REQUEST_METHOD'] ) || 'POST' !== $_SERVER['REQUEST_METHOD'] ) {
-//					$response['errors'] = __( 'WPGraphQL requires POST requests', 'wp-graphql' );
-//				}
-//
-//				if ( ! isset( $_SERVER['CONTENT_TYPE'] ) || false === strpos( $_SERVER['CONTENT_TYPE'], 'application/json' ) ) {
-//					$response['errors'] = __( 'The Content-Type for the request must be set to "application/json"', 'wp-graphql' );
-//				}
-//
-//				/**
-//				 * Retrieve the raw data from the request and encode it to JSON
-//				 *
-//				 * @since 0.0.5
-//				 */
-//				$data = json_decode( self::get_raw_data(), true );
-//			}// End if().
-//
-//			/**
-//			 * If the $data is empty, catch an error.
-//			 */
-//			if ( empty( $data ) || ( empty( $data['query'] ) ) ) {
-//				throw new UserError( __( 'GraphQL requests must be a POST or GET Request with a valid query', 'wp-graphql' ), 10 );
-//			}
-//
-//			/**
-//			 * Allow the data to be filtered
-//			 *
-//			 * @param array $data An array containing the pieces of the data of the GraphQL request
-//			 */
-//			$data = apply_filters( 'graphql_request_data', $data );
-//
-//			/**
-//			 * Get the pieces of the request from the data
-//			 */
-//			$request        = isset( $data['query'] ) ? $data['query'] : '';
-//			$operation_name = isset( $data['operationName'] ) ? $data['operationName'] : '';
-//			$variables      = isset( $data['variables'] ) ? $data['variables'] : '';
-//
-//			/**
-//			 * Process the GraphQL request
-//			 *
-//			 * @since 0.0.5
-//			 */
-//			$graphql_results = do_graphql_request( $request, $operation_name, $variables );
-//
-//			/**
-//			 * Ensure the $graphql_request is returned as a proper, populated array,
-//			 * otherwise add an error to the result
-//			 */
-//			if ( ! empty( $graphql_results ) && is_array( $graphql_results ) ) {
-//				$response = $graphql_results;
-//			} else {
-//				$response['errors'] = __( 'The GraphQL request returned an invalid response', 'wp-graphql' );
-//			}
-//
-//			/**
-//			 * If the request is properly authenticated (a user has been set by some authentication mechanism),
-//			 * set the status code to 200.
-//			 */
-//			$user = wp_get_current_user();
-//			if ( $user && 0 !== $user->ID ) {
-//				self::$http_status_code = 200;
-//			}
+			/**
+			 * Store the global post so it can be reset after GraphQL execution
+			 *
+			 * This allows for a GraphQL query to be used in the middle of post content, such as in a Shortcode
+			 * without disrupting the flow of the post as the global POST before and after GraphQL execution will be
+			 * the same.
+			 */
+			$global_post = ! empty( $GLOBALS['post'] ) ? $GLOBALS['post'] : null;
 
 			/**
-			 * Run an action after the HTTP Response is ready to be sent back. This might be a good place for tools
-			 * to hook in to track metrics, such as how long the process took from `graphql_process_http_request`
-			 * to here, etc.
+			 * Respond to pre-flight requests.
 			 *
-			 * @param array $response
-			 * @param array $graphql_results
-			 *
-			 * @since 0.0.5
+			 * @see: https://apollographql.slack.com/archives/C10HTKHPC/p1507649812000123
+			 * @see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Preflighted_requests
 			 */
-			do_action( 'graphql_process_http_request_response', $response, $graphql_results );
+			if ( 'OPTIONS' === $_SERVER['REQUEST_METHOD'] ) {
 
-			/**
-			 * If headers haven't been sent already, let's set the headers and return the JSON response
-			 */
-			if ( false === headers_sent() ) {
+				self::$http_status_code = 200;
+				self::set_headers( self::$http_status_code );
+				exit;
 
-				/**
-				 * Filter the $status_code before setting the headers
-				 *
-				 * @param int      $status_code     The status code to apply to the headers
-				 * @param array    $response        The response of the GraphQL Request
-				 * @param array    $graphql_results The results of the GraphQL execution
-				 * @param string   $request         The GraphQL Request
-				 * @param string   $operation_name  The operation name of the GraphQL Request
-				 * @param array    $variables       The variables applied to the GraphQL Request
-				 * @param \WP_User $user            The current user object
-				 */
-				$status_code = apply_filters( 'graphql_response_status_code', self::$http_status_code, $response, $graphql_results, $request, $operation_name, $variables, $user );
+			} else if ( isset( $_SERVER['REQUEST_METHOD'] ) && $_SERVER['REQUEST_METHOD'] === 'GET' ) {
+
+				$data = [
+					'query'         => isset( $_GET['query'] ) ? sanitize_text_field( $_GET['query'] ) : '',
+					'operationName' => isset( $_GET['operationName'] ) ? sanitize_text_field( $_GET['operationName'] ) : '',
+					'variables'     => isset( $_GET['variables'] ) ? $_GET['variables'] : '',
+				];
 
 				/**
-				 * Set the response headers
+				 * Allow the data to be filtered
+				 *
+				 * @param array $data An array containing the pieces of the data of the GraphQL request
 				 */
-				self::set_headers( $status_code );
+				$data = apply_filters( 'graphql_request_data', $data );
 
 				/**
-				 * Send the JSON response
+				 * If the variables are already formatted as an array use them.
+				 *
+				 * Example:
+				 * ?query=query getPosts($first:Int){posts(first:$first){edges{node{id}}}}&variables[first]=1
 				 */
-				$server = \WPGraphQL::server();
-				$result = $server->executeRequest();
+				if ( is_array( $data['variables'] ) ) {
+					$sanitized_variables = [];
+					foreach ( $data['variables'] as $key => $value ) {
+						$sanitized_variables[ $key ] = sanitize_text_field( $value );
+					}
+					$decoded_variables = $sanitized_variables;
 
-				/**
-				 * Run an action. This is a good place for debug tools to hook in to log things, etc.
-				 *
-				 * @since 0.0.4
-				 *
-				 * @param array      $result         The result of your GraphQL request
-				 * @param            Schema          object $schema The schema object for the root request
-				 * @param string     $operation_name The name of the operation
-				 * @param string     $request        The request that GraphQL executed
-				 * @param array|null $variables      Variables to passed to your GraphQL query
-				 */
-				do_action( 'graphql_execute', $result, \WPGraphQL::get_schema(), $operation_name, $request, $variables );
-
-				/**
-				 * Filter the $result of the GraphQL execution. This allows for the response to be filtered before
-				 * it's returned, allowing granular control over the response at the latest point.
-				 *
-				 * POSSIBLE USAGE EXAMPLES:
-				 * This could be used to ensure that certain fields never make it to the response if they match
-				 * certain criteria, etc. For example, this filter could be used to check if a current user is
-				 * allowed to see certain things, and if they are not, the $result could be filtered to remove
-				 * the data they should not be allowed to see.
-				 *
-				 * Or, perhaps some systems want the result to always include some additional piece of data in
-				 * every response, regardless of the request that was sent to it, this could allow for that
-				 * to be hooked in and included in the $result
-				 *
-				 * @since 0.0.5
-				 *
-				 * @param array      $result         The result of your GraphQL query
-				 * @param            Schema          object $schema The schema object for the root query
-				 * @param string     $operation_name The name of the operation
-				 * @param string     $request        The request that GraphQL executed
-				 * @param array|null $variables      Variables to passed to your GraphQL request
-				 */
-				$filtered_result = apply_filters( 'graphql_request_results', $result,  \WPGraphQL::get_schema(), $operation_name, $request, $variables );
-
-				/**
-				 * Run an action after the result has been filtered, as the response is being returned.
-				 * This is a good place for debug tools to hook in to log things, etc.
-				 *
-				 * @param array      $filtered_result The filtered_result of the GraphQL request
-				 * @param array      $result          The result of your GraphQL request
-				 * @param            Schema           object $schema The schema object for the root request
-				 * @param string     $operation_name  The name of the operation
-				 * @param string     $request         The request that GraphQL executed
-				 * @param array|null $variables       Variables to passed to your GraphQL query
-				 */
-				do_action( 'graphql_return_response', $filtered_result, $result,  \WPGraphQL::get_schema(), $operation_name, $request, $variables );
-
-				/**
-				 * Reset the global post after execution
-				 *
-				 * This allows for a GraphQL query to be used in the middle of post content, such as in a Shortcode
-				 * without disrupting the flow of the post as the global POST before and after GraphQL execution will be
-				 * the same.
-				 */
-				if ( ! empty( $global_post ) ) {
-					$GLOBALS['post'] = $global_post;
+					/**
+					 * If the variables are not an array, let's attempt to decode them and convert them to an array for
+					 * use in the executor.
+					 */
+				} else {
+					$decoded_variables = json_decode( $data['variables'] );
 				}
 
-				wp_send_json( $result );
-			} elseif ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+				$data['variables'] = ! empty( $decoded_variables ) && is_array( $decoded_variables ) ? $decoded_variables : null;
+
+
 				/**
-				 * Headers will already be set if this function is called within AJAX.
+				 * Allow the data to be filtered
+				 *
+				 * @param array $data An array containing the pieces of the data of the GraphQL request
 				 */
-				wp_send_json( $response );
+				$data = apply_filters( 'graphql_request_data', $data );
+
+				/**
+				 * Get the pieces of the request from the data
+				 */
+				$request        = isset( $data['query'] ) ? $data['query'] : '';
+				$operation_name = isset( $data['operationName'] ) ? $data['operationName'] : '';
+				$variables      = isset( $data['variables'] ) ? $data['variables'] : '';
+
+				/**
+				 * Process the GraphQL request
+				 *
+				 * @since 0.0.5
+				 */
+				$graphql_results = do_graphql_request( $request, $operation_name, $variables );
+
+				/**
+				 * Ensure the $graphql_request is returned as a proper, populated array,
+				 * otherwise add an error to the result
+				 */
+				if ( ! empty( $graphql_results ) && is_array( $graphql_results ) ) {
+					$response = $graphql_results;
+				} else {
+					$response['errors'] = __( 'The GraphQL request returned an invalid response', 'wp-graphql' );
+				}
+
+				if ( false === headers_sent() ) {
+
+					/**
+					 * Filter the $status_code before setting the headers
+					 *
+					 * @param int      $status_code     The status code to apply to the headers
+					 * @param array    $response        The response of the GraphQL Request
+					 * @param array    $graphql_results The results of the GraphQL execution
+					 * @param string   $request         The GraphQL Request
+					 * @param string   $operation_name  The operation name of the GraphQL Request
+					 * @param array    $variables       The variables applied to the GraphQL Request
+					 * @param \WP_User $user            The current user object
+					 */
+					$status_code = apply_filters( 'graphql_response_status_code', self::$http_status_code, $response, $graphql_results, $request, $operation_name, $variables, $user );
+
+					/**
+					 * Set the response headers
+					 */
+					self::set_headers( $status_code );
+
+					wp_send_json( $response );
+
+					/**
+					 * Run an action. This is a good place for debug tools to hook in to log things, etc.
+					 *
+					 * @since 0.0.4
+					 *
+					 * @param array      $result         The result of your GraphQL request
+					 * @param            Schema          object $schema The schema object for the root request
+					 * @param string     $operation_name The name of the operation
+					 * @param string     $request        The request that GraphQL executed
+					 * @param array|null $variables      Variables to passed to your GraphQL query
+					 */
+					do_action( 'graphql_execute', $response, \WPGraphQL::get_schema(), $operation_name, $request, $variables );
+
+					/**
+					 * Filter the $result of the GraphQL execution. This allows for the response to be filtered before
+					 * it's returned, allowing granular control over the response at the latest point.
+					 *
+					 * POSSIBLE USAGE EXAMPLES:
+					 * This could be used to ensure that certain fields never make it to the response if they match
+					 * certain criteria, etc. For example, this filter could be used to check if a current user is
+					 * allowed to see certain things, and if they are not, the $result could be filtered to remove
+					 * the data they should not be allowed to see.
+					 *
+					 * Or, perhaps some systems want the result to always include some additional piece of data in
+					 * every response, regardless of the request that was sent to it, this could allow for that
+					 * to be hooked in and included in the $result
+					 *
+					 * @since 0.0.5
+					 *
+					 * @param array      $result         The result of your GraphQL query
+					 * @param            Schema          object $schema The schema object for the root query
+					 * @param string     $operation_name The name of the operation
+					 * @param string     $request        The request that GraphQL executed
+					 * @param array|null $variables      Variables to passed to your GraphQL request
+					 */
+					$filtered_result = apply_filters( 'graphql_request_results', $response, \WPGraphQL::get_schema(), $operation_name, $request, $variables );
+
+					/**
+					 * Run an action after the result has been filtered, as the response is being returned.
+					 * This is a good place for debug tools to hook in to log things, etc.
+					 *
+					 * @param array      $filtered_result The filtered_result of the GraphQL request
+					 * @param array      $result          The result of your GraphQL request
+					 * @param            Schema           object $schema The schema object for the root request
+					 * @param string     $operation_name  The name of the operation
+					 * @param string     $request         The request that GraphQL executed
+					 * @param array|null $variables       Variables to passed to your GraphQL query
+					 */
+					do_action( 'graphql_return_response', $filtered_result, $response, \WPGraphQL::get_schema(), $operation_name, $request, $variables );
+
+					/**
+					 * Reset the global post after execution
+					 *
+					 * This allows for a GraphQL query to be used in the middle of post content, such as in a Shortcode
+					 * without disrupting the flow of the post as the global POST before and after GraphQL execution will be
+					 * the same.
+					 */
+					if ( ! empty( $global_post ) ) {
+						$GLOBALS['post'] = $global_post;
+					}
+
+					/**
+					 * Run an action after the HTTP Response is ready to be sent back. This might be a good place for tools
+					 * to hook in to track metrics, such as how long the process took from `graphql_process_http_request`
+					 * to here, etc.
+					 *
+					 * @param array $response
+					 * @param array $graphql_results
+					 *
+					 * @since 0.0.5
+					 */
+					do_action( 'graphql_process_http_request_response', $response, $graphql_results );
+
+				}
+
+
+			} else {
+
+				/**
+				 * If headers haven't been sent already, let's set the headers and return the JSON response
+				 */
+				if ( false === headers_sent() ) {
+
+					/**
+					 * Filter the $status_code before setting the headers
+					 *
+					 * @param int      $status_code     The status code to apply to the headers
+					 * @param array    $response        The response of the GraphQL Request
+					 * @param array    $graphql_results The results of the GraphQL execution
+					 * @param string   $request         The GraphQL Request
+					 * @param string   $operation_name  The operation name of the GraphQL Request
+					 * @param array    $variables       The variables applied to the GraphQL Request
+					 * @param \WP_User $user            The current user object
+					 */
+					$status_code = apply_filters( 'graphql_response_status_code', self::$http_status_code, $response, $graphql_results, $request, $operation_name, $variables, $user );
+
+					/**
+					 * Set the response headers
+					 */
+					self::set_headers( $status_code );
+
+					/**
+					 * Send the JSON response
+					 */
+					$server = \WPGraphQL::server();
+					$result = $server->executeRequest();
+
+					/**
+					 * Run an action. This is a good place for debug tools to hook in to log things, etc.
+					 *
+					 * @since 0.0.4
+					 *
+					 * @param array      $result         The result of your GraphQL request
+					 * @param            Schema          object $schema The schema object for the root request
+					 * @param string     $operation_name The name of the operation
+					 * @param string     $request        The request that GraphQL executed
+					 * @param array|null $variables      Variables to passed to your GraphQL query
+					 */
+					do_action( 'graphql_execute', $result, \WPGraphQL::get_schema(), $operation_name, $request, $variables );
+
+					/**
+					 * Filter the $result of the GraphQL execution. This allows for the response to be filtered before
+					 * it's returned, allowing granular control over the response at the latest point.
+					 *
+					 * POSSIBLE USAGE EXAMPLES:
+					 * This could be used to ensure that certain fields never make it to the response if they match
+					 * certain criteria, etc. For example, this filter could be used to check if a current user is
+					 * allowed to see certain things, and if they are not, the $result could be filtered to remove
+					 * the data they should not be allowed to see.
+					 *
+					 * Or, perhaps some systems want the result to always include some additional piece of data in
+					 * every response, regardless of the request that was sent to it, this could allow for that
+					 * to be hooked in and included in the $result
+					 *
+					 * @since 0.0.5
+					 *
+					 * @param array      $result         The result of your GraphQL query
+					 * @param            Schema          object $schema The schema object for the root query
+					 * @param string     $operation_name The name of the operation
+					 * @param string     $request        The request that GraphQL executed
+					 * @param array|null $variables      Variables to passed to your GraphQL request
+					 */
+					$filtered_result = apply_filters( 'graphql_request_results', $result, \WPGraphQL::get_schema(), $operation_name, $request, $variables );
+
+					/**
+					 * Run an action after the result has been filtered, as the response is being returned.
+					 * This is a good place for debug tools to hook in to log things, etc.
+					 *
+					 * @param array      $filtered_result The filtered_result of the GraphQL request
+					 * @param array      $result          The result of your GraphQL request
+					 * @param            Schema           object $schema The schema object for the root request
+					 * @param string     $operation_name  The name of the operation
+					 * @param string     $request         The request that GraphQL executed
+					 * @param array|null $variables       Variables to passed to your GraphQL query
+					 */
+					do_action( 'graphql_return_response', $filtered_result, $result, \WPGraphQL::get_schema(), $operation_name, $request, $variables );
+
+					/**
+					 * Reset the global post after execution
+					 *
+					 * This allows for a GraphQL query to be used in the middle of post content, such as in a Shortcode
+					 * without disrupting the flow of the post as the global POST before and after GraphQL execution will be
+					 * the same.
+					 */
+					if ( ! empty( $global_post ) ) {
+						$GLOBALS['post'] = $global_post;
+					}
+
+					/**
+					 * Run an action after the HTTP Response is ready to be sent back. This might be a good place for tools
+					 * to hook in to track metrics, such as how long the process took from `graphql_process_http_request`
+					 * to here, etc.
+					 *
+					 * @param array $response
+					 * @param array $graphql_results
+					 *
+					 * @since 0.0.5
+					 */
+					do_action( 'graphql_process_http_request_response', $result, $graphql_results );
+
+					/**
+					 * Send the response
+					 */
+					wp_send_json( $result );
+
+				} elseif ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+					/**
+					 * Headers will already be set if this function is called within AJAX.
+					 */
+					wp_send_json( $response );
+				}
+
 			}
 
 		} catch ( \Exception $error ) {

--- a/src/Type/MediaItem/Mutation/MediaItemMutation.php
+++ b/src/Type/MediaItem/Mutation/MediaItemMutation.php
@@ -178,11 +178,10 @@ class MediaItemMutation {
 
 			$parent_id_parts = ( ! empty( $input['parentId'] ) ? Relay::fromGlobalId( $input['parentId'] ) : null );
 
-			if ( is_array( $parent_id_parts ) && ! empty( $parent_id_parts['id'] ) ) {
+			if ( is_array( $parent_id_parts ) && absint( $parent_id_parts['id'] ) ) {
 				$insert_post_args['post_parent'] = absint( $parent_id_parts['id'] );
 			} else {
-				$insert_post_args['post_parent'] = $input['parentId'];
-
+				$insert_post_args['post_parent'] = absint( $input['parentId'] );
 			}
 
 		}

--- a/tests/wpunit/MediaItemMutationsTest.php
+++ b/tests/wpunit/MediaItemMutationsTest.php
@@ -407,7 +407,7 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 		$post = $this->factory()->post->create( [
 			'post_author' => $this->admin,
 		] );
-		$this->create_variables['input']['parentId'] = $post;
+		$this->create_variables['input']['parentId'] = absint( $post );
 
 		/**
 		 * Test the mutation as someone who can't edit the parent post,
@@ -481,7 +481,7 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 			],
 		];
 
-		$this->assertEquals( $actual, $expected );
+		$this->assertEquals( $expected, $actual );
 		$this->create_variables['input']['parentId'] = $this->parentId;
 
 	}

--- a/tests/wpunit/PostObjectConnectionQueriesTest.php
+++ b/tests/wpunit/PostObjectConnectionQueriesTest.php
@@ -648,31 +648,6 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 	/**
 	 * @group get_query_args
 	 */
-	public function testGetQueryArgsTerms() {
-		/**
-		 * Create a term
-		 */
-		$term_id = $this->factory->term->create();
-
-		$source = get_term( $term_id );
-
-		$mock_args = array(
-			'taxonomy' => 'post_tag',
-			'terms'    => array( 2 ),
-			'field'    => 'term_id',
-		);
-
-		$actual_terms = \WPGraphQL\Type\PostObject\Connection\PostObjectConnectionResolver::get_query_args( $source, $mock_args, $this->app_context, $this->app_info );
-
-		/**
-		 * Make sure the function returned our mock_args in the tax_query key
-		 */
-		$this->assertEquals( $mock_args, $actual_terms['tax_query'][0] );
-	}
-
-	/**
-	 * @group get_query_args
-	 */
 	public function testGetQueryArgsPostType() {
 
 		/**

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -457,6 +457,11 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 		 */
 		public static function get_schema() {
 
+			/**
+			 * Fire an action when the Schema is returned
+			 */
+			do_action( 'graphql_get_schema', self::$schema );
+
 			if ( null === self::$schema ) {
 
 				/**
@@ -675,6 +680,46 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 			return $result->toArray( GRAPHQL_DEBUG );
 
 		}
+
+		public static function server( $request = null ) {
+
+			/**
+			 * Whether it's a GraphQL Request (http or internal)
+			 *
+			 * @since 0.0.5
+			 */
+			if ( ! defined( 'GRAPHQL_REQUEST' ) ) {
+				define( 'GRAPHQL_REQUEST', true );
+			}
+
+			/**
+			 * Setup the post_types and taxonomies to show_in_graphql
+			 */
+			\WPGraphQL::show_in_graphql();
+			\WPGraphQL::get_allowed_post_types();
+			\WPGraphQL::get_allowed_taxonomies();
+
+			/**
+			 * Run an action as soon when do_graphql_request begins.
+			 */
+			$helper = new \GraphQL\Server\Helper();
+			$query = $helper->parseHttpRequest()->query;
+			$operation = $helper->parseHttpRequest()->operation;
+			$variables = $helper->parseHttpRequest()->variables;
+			do_action( 'do_graphql_request', $query, $operation, $variables );
+
+			$config = new \GraphQL\Server\ServerConfig();
+			$config
+				->setDebug( GRAPHQL_DEBUG )
+				->setSchema( self::get_schema() )
+				->setContext( self::get_app_context() )
+				->setQueryBatching(true);
+
+			$server = new \GraphQL\Server\StandardServer( $config );
+
+			return $server;
+		}
+
 	}
 endif;
 

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -706,6 +706,14 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 			$query = $helper->parseHttpRequest()->query;
 			$operation = $helper->parseHttpRequest()->operation;
 			$variables = $helper->parseHttpRequest()->variables;
+
+			/**
+			 * Run an action as soon when do_graphql_request begins.
+			 *
+			 * @param string $request        The GraphQL request to be run
+			 * @param string $operation_name The name of the operation
+			 * @param string $variables      Variables to be passed to your GraphQL request
+			 */
 			do_action( 'do_graphql_request', $query, $operation, $variables );
 
 			$config = new \GraphQL\Server\ServerConfig();


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
This adds Query Batching support for remote HTTP GraphQL requests.

Apollo Query batching (https://dev-blog.apollodata.com/query-batching-in-apollo-63acfd859862) will now work with this. 

Now you can send an array of Queries in the HTTP request and get an array of responses back. Here's an example in Postman:

<img width="1130" alt="screen shot 2018-02-04 at 12 05 26 am" src="https://user-images.githubusercontent.com/1260765/35775145-97dc5c42-0940-11e8-98a0-90e8f7cad1ac.png">

Does this close any currently open issues?
------------------------------------------
closes #360 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
See above.

Any other comments?
-------------------
`do_graphql_request()` still works the same as it did before, but this now adds a new way for HTTP requests to be executed. 

For internal PHP use of GraphQL, you can make as many calls to `do_graphql_request()` as you like, so batching has always existed internally.

For external HTTP requests, this now makes use of the GraphQL StandardServer

Where has this been tested?
---------------------------
**Operating System:** 
Mac OS 10.12.6

**WordPress Version:**
4.9.2
