### PR TITLE
Set post status for Post Object Create mutations late, to allow for side-effects before final status is set

### DIFF
--- a/src/Type/PostObject/Mutation/PostObjectCreate.php
+++ b/src/Type/PostObject/Mutation/PostObjectCreate.php
@@ -91,6 +91,31 @@ class PostObjectCreate {
 					$post_args = PostObjectMutation::prepare_post_object( $input, $post_type_object, $mutation_name );
 
 					/**
+					 * Filter the default post status to use when the post is initially created. Pass through a filter to
+					 * allow other plugins to override the default (for example, Edit Flow, which provides control over
+					 * customizing stati or various E-commerce plugins that make heavy use of custom stati)
+					 *
+					 * @param string $default_status The default status to be used when the post is initially inserted
+					 * @param \WP_Post_Type $post_type_object The Post Type that is being inserted
+					 * @param string $mutation_name The name of the mutation currently in progress
+					 */
+					$default_post_status = apply_filters( 'graphql_post_object_create_default_post_status', 'draft', $post_type_object, $mutation_name );
+
+					/**
+					 * We want to cache the "post_status" and set the status later. We will set the initial status
+					 * of the inserted post as the default status for the site, allow side effects to process with the
+					 * inserted post (set term object connections, set meta input, sideload images if necessary, etc)
+					 * Then will follow up with setting the status as what it was declared to be later
+					 */
+					$intended_post_status = ! empty( $post_args['post_status'] ) ? $post_args['post_status'] : $default_post_status;
+
+					/**
+					 * Set the post_status as the default for the initial insert. The intended $post_status will be set after
+					 * side effects are complete.
+					 */
+					$post_args['post_status'] = $default_post_status;
+
+					/**
 					 * Insert the post and retrieve the ID
 					 */
 					$post_id = wp_insert_post( wp_slash( (array) $post_args ), true );
@@ -121,6 +146,43 @@ class PostObjectCreate {
 					 * postObject that was created so that relations can be set, meta can be updated, etc.
 					 */
 					PostObjectMutation::update_additional_post_object_data( $post_id, $input, $post_type_object, $mutation_name );
+
+					/**
+					 * Determine whether the intended status should be set or not.
+					 *
+					 * By filtering to false, the $intended_post_status will not be set at the completion of the mutation.
+					 *
+					 * This allows for side-effect actions to set the status later. For example, if a post
+					 * was being created via a GraphQL Mutation, the post had additional required assets, such as images
+					 * that needed to be sideloaded or some other semi-time-consuming side effect, those actions could
+					 * be deferred (cron or whatever), and when those actions complete they could come back and set
+					 * the $intended_status.
+					 *
+					 * @param boolean $should_set_intended_status Whether to set the intended post_status or not. Default true.
+					 * @param \WP_Post_Type $post_type_object The Post Type Object for the post being mutated
+					 * @param string $mutation_name The name of the mutation currently in progress
+					 * @param string $intended_post_status The intended post_status the post should have according to the mutation input
+					 * @param string $default_post_status The default status posts should use if an intended status wasn't set
+					 */
+					$should_set_intended_status = apply_filters( 'graphql_post_object_create_should_set_intended_post_status', true, $post_type_object, $mutation_name, $intended_post_status, $default_post_status  );
+
+					/**
+					 * If the intended post status and the default post status are not the same,
+					 * update the post with the intended status now that side effects are complete.
+					 */
+					if ( $intended_post_status !== $default_post_status && true === $should_set_intended_status ) {
+
+						$update_args = [
+							'ID' => $post_id,
+							'post_status' => $intended_post_status,
+							// Prevent the post_date from being reset if the date was included in the create post $args
+							// see: https://core.trac.wordpress.org/browser/tags/4.9/src/wp-includes/post.php#L3637
+							'edit_date' => ! empty( $post_args['post_date'] ) ? $post_args['post_date'] : false,
+						];
+
+						$update_args = array_merge( $update_args );
+						wp_update_post( $update_args );
+					}
 
 					/**
 					 * Return the post object

--- a/src/Type/PostObject/Mutation/PostObjectMutation.php
+++ b/src/Type/PostObject/Mutation/PostObjectMutation.php
@@ -284,7 +284,7 @@ class PostObjectMutation {
 	 *                                            mutation input
 	 * @param string        $default_post_status  The default status posts should use if an intended status wasn't set
 	 */
-	public static function update_additional_post_object_data( $post_id, $input, $post_type_object, $mutation_name, AppContext $context, ResolveInfo $info, $default_post_status, $intended_post_status ) {
+	public static function update_additional_post_object_data( $post_id, $input, $post_type_object, $mutation_name, AppContext $context, ResolveInfo $info, $default_post_status = null, $intended_post_status = null ) {
 
 		/**
 		 * Set the post_lock for the $new_post_id

--- a/src/Type/PostObject/Mutation/PostObjectMutation.php
+++ b/src/Type/PostObject/Mutation/PostObjectMutation.php
@@ -3,7 +3,9 @@
 namespace WPGraphQL\Type\PostObject\Mutation;
 
 use GraphQL\Error\UserError;
+use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
+use WPGraphQL\AppContext;
 use WPGraphQL\Type\WPInputObjectType;
 use WPGraphQL\Types;
 
@@ -105,25 +107,25 @@ class PostObjectMutation {
 				foreach ( $allowed_taxonomies as $taxonomy ) {
 					// If the taxonomy is in the array of taxonomies registered to the post_type
 					if ( in_array( $taxonomy, get_object_taxonomies( $post_type_object->name ), true ) ) {
-						$tax_object                                       = get_taxonomy( $taxonomy );
+						$tax_object = get_taxonomy( $taxonomy );
 
 						$node_input = new WPInputObjectType( [
-							'name'   => $post_type_object->graphql_single_name . ucfirst( $tax_object->graphql_plural_name ) . 'Nodes',
+							'name'        => $post_type_object->graphql_single_name . ucfirst( $tax_object->graphql_plural_name ) . 'Nodes',
 							'description' => sprintf( __( 'List of %1$s to connect the %2$s to. If an ID is set, it will be used to create the connection. If not, it will look for a slug. If neither are valid existing terms, and the site is configured to allow terms to be created during post mutations, a term will be created using the Name if it exists in the input, then fallback to the slug if it exists.', 'wp-graphql' ), $tax_object->graphql_plural_name, $post_type_object->graphql_single_name ),
-							'fields' => [
-								'id'   => [
+							'fields'      => [
+								'id'          => [
 									'type'        => Types::id(),
 									'description' => sprintf( __( 'The ID of the %1$s. If present, this will be used to connect to the %2$s. If no existing %1$s exists with this ID, no connection will be made.', 'wp-graphql' ), $tax_object->graphql_single_name, $post_type_object->graphql_single_name ),
 								],
-								'slug' => [
+								'slug'        => [
 									'type'        => Types::string(),
 									'description' => sprintf( __( 'The slug of the %1$s. If no ID is present, this field will be used to make a connection. If no existing term exists with this slug, this field will be used as a fallback to the Name field when creating a new term to connect to, if term creation is enabled as a nested mutation.', 'wp-graphql' ), $tax_object->graphql_single_name ),
 								],
-								'description'   => [
+								'description' => [
 									'type'        => Types::string(),
 									'description' => sprintf( __( 'The description of the %1$s. This field is used to set a description of the %1$s if a new one is created during the mutation.', 'wp-graphql' ), $tax_object->graphql_single_name ),
 								],
-								'name'   => [
+								'name'        => [
 									'type'        => Types::string(),
 									'description' => sprintf( __( 'The name of the %1$s. This field is used to create a new term, if term creation is enabled in nested mutations, and if one does not already exist with the provided slug or ID or if a slug or ID is not provided. If no name is included and a term is created, the creation will fallback to the slug field.', 'wp-graphql' ), $tax_object->graphql_single_name ),
 								],
@@ -132,7 +134,7 @@ class PostObjectMutation {
 
 						$input_fields[ $tax_object->graphql_plural_name ] = [
 							'description' => sprintf( __( 'Set connections between the %1$s and %2$s', 'wp-graphql' ), $post_type_object->graphql_single_name, $tax_object->graphql_plural_name ),
-							'type' => new WPInputObjectType( [
+							'type'        => new WPInputObjectType( [
 								'name'        => ucfirst( $post_type_object->graphql_single_name ) . ucfirst( $tax_object->graphql_plural_name ),
 								'description' => sprintf( __( 'Set relationships between the %1$s to %2$s', 'wp-graphql' ), $post_type_object->graphql_single_name, $tax_object->graphql_plural_name ),
 								'fields'      => [
@@ -272,12 +274,17 @@ class PostObjectMutation {
 	/**
 	 * This updates additional data related to a post object, such as postmeta, term relationships, etc.
 	 *
-	 * @param int           $post_id          $post_id      The ID of the postObject being mutated
-	 * @param array         $input            The input for the mutation
-	 * @param \WP_Post_Type $post_type_object The Post Type Object for the type of post being mutated
-	 * @param string        $mutation_name    The name of the mutation (ex: create, update, delete)
+	 * @param int           $post_id              $post_id      The ID of the postObject being mutated
+	 * @param array         $input                The input for the mutation
+	 * @param \WP_Post_Type $post_type_object     The Post Type Object for the type of post being mutated
+	 * @param string        $mutation_name        The name of the mutation (ex: create, update, delete)
+	 * @param AppContext    $context              The AppContext passed down to all resolvers
+	 * @param ResolveInfo   $info                 The ResolveInfo passed down to all resolvers
+	 * @param string        $intended_post_status The intended post_status the post should have according to the
+	 *                                            mutation input
+	 * @param string        $default_post_status  The default status posts should use if an intended status wasn't set
 	 */
-	public static function update_additional_post_object_data( $post_id, $input, $post_type_object, $mutation_name ) {
+	public static function update_additional_post_object_data( $post_id, $input, $post_type_object, $mutation_name, AppContext $context, ResolveInfo $info, $default_post_status, $intended_post_status ) {
 
 		/**
 		 * Set the post_lock for the $new_post_id
@@ -311,12 +318,16 @@ class PostObjectMutation {
 		 * update additional data related to postObjects, such as setting relationships, updating additional postmeta,
 		 * or sending emails to Kevin. . .whatever you need to do with the postObject.
 		 *
-		 * @param int           $post_id          $post_id      The ID of the postObject being mutated
-		 * @param array         $input            The input for the mutation
-		 * @param \WP_Post_Type $post_type_object The Post Type Object for the type of post being mutated
-		 * @param string        $mutation_name    The name of the mutation (ex: create, update, delete)
+		 * @param int           $post_id              The ID of the postObject being mutated
+		 * @param array         $input                The input for the mutation
+		 * @param \WP_Post_Type $post_type_object     The Post Type Object for the type of post being mutated
+		 * @param string        $mutation_name        The name of the mutation (ex: create, update, delete)
+		 * @param AppContext    $context              The AppContext passed down to all resolvers
+		 * @param ResolveInfo   $info                 The ResolveInfo passed down to all resolvers
+		 * @param string        $intended_post_status The intended post_status the post should have according to the mutation input
+		 * @param string        $default_post_status  The default status posts should use if an intended status wasn't set
 		 */
-		do_action( 'graphql_post_object_mutation_update_additional_data', $post_id, $input, $post_type_object, $mutation_name );
+		do_action( 'graphql_post_object_mutation_update_additional_data', $post_id, $input, $post_type_object, $mutation_name, $context, $info, $default_post_status, $intended_post_status );
 
 	}
 
@@ -387,8 +398,8 @@ class PostObjectMutation {
 						 * but if filtered to false, this will prevent the term that doesn't already exist
 						 * from being created during the mutation of the post.
 						 *
-						 * @param bool $allow_term_creation Whether new terms should be created during the post object mutation
-						 * @param \WP_Taxonomy $tax_object The Taxonomy object for the term being added to the Post Object
+						 * @param bool         $allow_term_creation Whether new terms should be created during the post object mutation
+						 * @param \WP_Taxonomy $tax_object          The Taxonomy object for the term being added to the Post Object
 						 */
 						$allow_term_creation = apply_filters( 'graphql_post_object_mutations_allow_term_creation', true, $tax_object );
 
@@ -397,7 +408,7 @@ class PostObjectMutation {
 						 */
 						if ( ! empty( $term_input['nodes'] ) && is_array( $term_input['nodes'] ) ) {
 
-							foreach( $term_input['nodes'] as $node ) {
+							foreach ( $term_input['nodes'] as $node ) {
 
 								$term_exists = false;
 
@@ -427,19 +438,19 @@ class PostObjectMutation {
 										}
 									}
 
-								/**
-								 * Next, handle the input for slug if there wasn't an ID input
-								 */
+									/**
+									 * Next, handle the input for slug if there wasn't an ID input
+									 */
 								} elseif ( ! empty( $node['slug'] ) ) {
 									$sanitized_slug = sanitize_text_field( $node['slug'] );
-									$term_exists = get_term_by( 'slug', $sanitized_slug, $tax_object->name );
+									$term_exists    = get_term_by( 'slug', $sanitized_slug, $tax_object->name );
 									if ( $term_exists ) {
 										$terms_to_connect[] = $term_exists->term_id;
 									}
-								/**
-								 * If the input for the term isn't an existing term, check to make sure
-								 * we're allowed to create new terms during a Post Object mutation
-								 */
+									/**
+									 * If the input for the term isn't an existing term, check to make sure
+									 * we're allowed to create new terms during a Post Object mutation
+									 */
 								}
 
 								/**
@@ -494,16 +505,16 @@ class PostObjectMutation {
 	/**
 	 * Given an array of Term properties (slug, name, description, etc), create the term and return a term_id
 	 *
-	 * @param array $node The node input for the term
+	 * @param array  $node     The node input for the term
 	 * @param string $taxonomy The taxonomy the term input is for
 	 *
 	 * @return int $term_id The ID of the created term. 0 if no term was created.
 	 */
 	protected static function create_term_to_connect( $node, $taxonomy ) {
 
-		$created_term = [];
+		$created_term   = [];
 		$term_to_create = [];
-		$term_args = [];
+		$term_args      = [];
 
 		if ( ! empty( $node['name'] ) ) {
 			$term_to_create['name'] = sanitize_text_field( $node['name'] );

--- a/src/Type/PostObject/Mutation/PostObjectUpdate.php
+++ b/src/Type/PostObject/Mutation/PostObjectUpdate.php
@@ -3,7 +3,9 @@
 namespace WPGraphQL\Type\PostObject\Mutation;
 
 use GraphQL\Error\UserError;
+use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
+use WPGraphQL\AppContext;
 use WPGraphQL\Type\WPInputObjectType;
 use WPGraphQL\Types;
 
@@ -53,7 +55,7 @@ class PostObjectUpdate {
 						},
 					],
 				],
-				'mutateAndGetPayload' => function( $input ) use ( $post_type_object, $mutation_name ) {
+				'mutateAndGetPayload' => function( $input, AppContext $context, ResolveInfo $info ) use ( $post_type_object, $mutation_name ) {
 
 					$id_parts      = ! empty( $input['id'] ) ? Relay::fromGlobalId( $input['id'] ) : null;
 					$existing_post = get_post( absint( $id_parts['id'] ) );
@@ -134,7 +136,7 @@ class PostObjectUpdate {
 					 * The input for the postObjectMutation will be passed, along with the $new_post_id for the
 					 * postObject that was updated so that relations can be set, meta can be updated, etc.
 					 */
-					PostObjectMutation::update_additional_post_object_data( $post_id, $input, $post_type_object, $mutation_name );
+					PostObjectMutation::update_additional_post_object_data( $post_id, $input, $post_type_object, $mutation_name, $context, $info );
 
 					/**
 					 * Return the payload

--- a/tests/wpunit/PostObjectMutationsTest.php
+++ b/tests/wpunit/PostObjectMutationsTest.php
@@ -626,8 +626,8 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 
         $this->assertEquals( $dateExpected, $results['data']['createPost']['post']['date'] );
         $this->assertEquals( $dateGmtExpected, $results['data']['createPost']['post']['dateGmt'] );
-        $this->assertEquals( $dateExpected, $results['data']['createPost']['post']['modified'] );
-        $this->assertEquals( $dateGmtExpected, $results['data']['createPost']['post']['modifiedGmt'] );
+        $this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modified'] );
+        $this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modifiedGmt'] );
 
     }
 
@@ -663,8 +663,8 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 
         $this->assertEquals( $dateExpected, $results['data']['createPost']['post']['date'] );
         $this->assertEquals( $dateGmtExpected, $results['data']['createPost']['post']['dateGmt'] );
-        $this->assertEquals( $dateExpected, $results['data']['createPost']['post']['modified'] );
-        $this->assertEquals( $dateGmtExpected, $results['data']['createPost']['post']['modifiedGmt'] );
+	    $this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modified'] );
+	    $this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modifiedGmt'] );
 
     }
 
@@ -701,8 +701,8 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 
         $this->assertEquals( $dateExpected, $results['data']['createPost']['post']['date'] );
         $this->assertEquals( $dateGmtExpected, $results['data']['createPost']['post']['dateGmt'] );
-        $this->assertEquals( $dateExpected, $results['data']['createPost']['post']['modified'] );
-        $this->assertEquals( $dateGmtExpected, $results['data']['createPost']['post']['modifiedGmt'] );
+	    $this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modified'] );
+	    $this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modifiedGmt'] );
 
     }
 


### PR DESCRIPTION
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
During PostObjectMutations, any post_status input will be cached, and the post will be created with the default status (draft, but filterable to accompany plugins like Edit Flow, etc).

Then the side-effects will be triggered via `PostObjectMutation::update_additional_post_object_data()`. 

Then, if `$should_set_intended_status` is true (filterable), the post_status that was input with the mutation (if different than the default) will be set as the status of the post.

This allows for side effects that may take a long time (sideloading images, etc) to happen in a deferred process (like a WPCron or a WP Queue Task - https://github.com/dfmedia/wp-queue-tasks) and those side effects can come back later and set the status when they complete.

Does this close any currently open issues?
------------------------------------------
closes #394 
closes #393 

Where has this been tested?
---------------------------
**Operating System:**
Mac OSX 10.12.6

**WordPress Version:**
4.9.4
