### PR TITLE
Release/v0.0.26

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "GraphQL API for WordPress",
   "type": "wordpress-plugin",
   "license": "GPLv3",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "authors": [
     {
       "name": "Jason Bahl",

--- a/src/Type/MediaItem/Mutation/MediaItemCreate.php
+++ b/src/Type/MediaItem/Mutation/MediaItemCreate.php
@@ -3,7 +3,9 @@
 namespace WPGraphQL\Type\MediaItem\Mutation;
 
 use GraphQL\Error\UserError;
+use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
+use WPGraphQL\AppContext;
 use WPGraphQL\Types;
 
 /**
@@ -46,7 +48,7 @@ class MediaItemCreate {
 					},
 				],
 			],
-			'mutateAndGetPayload' => function( $input ) use ( $post_type_object, $mutation_name ) {
+			'mutateAndGetPayload' => function( $input, AppContext $context, ResolveInfo $info ) use ( $post_type_object, $mutation_name ) {
 
 				/**
 				 * Stop now if a user isn't allowed to upload a mediaItem
@@ -180,7 +182,7 @@ class MediaItemCreate {
 				/**
 				 * Update alt text postmeta for mediaItem
 				 */
-				MediaItemMutation::update_additional_media_item_data( $attachment_id, $input, $post_type_object, $mutation_name );
+				MediaItemMutation::update_additional_media_item_data( $attachment_id, $input, $post_type_object, $mutation_name, $context, $info );
 
 				return [
 					'id' => $attachment_id,

--- a/src/Type/MediaItem/Mutation/MediaItemMutation.php
+++ b/src/Type/MediaItem/Mutation/MediaItemMutation.php
@@ -1,7 +1,10 @@
 <?php
+
 namespace WPGraphQL\Type\MediaItem\Mutation;
 
+use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
+use WPGraphQL\AppContext;
 use WPGraphQL\Types;
 
 /**
@@ -202,12 +205,14 @@ class MediaItemMutation {
 	/**
 	 * This updates additional data related to a mediaItem, such as postmeta.
 	 *
-	 * @param int           $media_item_id
-	 * @param array         $input
-	 * @param \WP_Post_Type $post_type_object
-	 * @param string        $mutation_name
+	 * @param int           $media_item_id    The ID of the media item being mutated
+	 * @param array         $input            The input on the mutation
+	 * @param \WP_Post_Type $post_type_object The Post Type Object for the item being mutated
+	 * @param string        $mutation_name    The name of the mutation
+	 * @param AppContext    $context          The AppContext that is passed down the resolve tree
+	 * @param ResolveInfo   $info             The ResolveInfo that is passed down the resolve tree
 	 */
-	public static function update_additional_media_item_data( $media_item_id, $input, $post_type_object, $mutation_name ) {
+	public static function update_additional_media_item_data( $media_item_id, $input, $post_type_object, $mutation_name, AppContext $context, ResolveInfo $info ) {
 
 		/**
 		 * Update alt text postmeta for the mediaItem
@@ -219,14 +224,16 @@ class MediaItemMutation {
 		/**
 		 * Run an action after the additional data has been updated. This is a great spot to hook into to
 		 * update additional data related to mediaItems, such as updating additional postmeta,
-		 * or sending emails to Jason. . .whatever you need to do with the mediaItem.
+		 * or sending emails to Kevin. . .whatever you need to do with the mediaItem.
 		 *
 		 * @param int           $media_item_id    The ID of the mediaItem being mutated
 		 * @param array         $input            The input for the mutation
 		 * @param \WP_Post_Type $post_type_object The Post Type Object for the type of post being mutated
 		 * @param string        $mutation_name    The name of the mutation (ex: create, update, delete)
+		 * @param AppContext    $context          The AppContext that is passed down the resolve tree
+		 * @param ResolveInfo   $info             The ResolveInfo that is passed down the resolve tree
 		 */
-		do_action( 'graphql_media_item_mutation_update_additional_data', $media_item_id, $input, $post_type_object, $mutation_name );
+		do_action( 'graphql_media_item_mutation_update_additional_data', $media_item_id, $input, $post_type_object, $mutation_name, $context, $info );
 
 	}
 

--- a/src/Type/MediaItem/Mutation/MediaItemUpdate.php
+++ b/src/Type/MediaItem/Mutation/MediaItemUpdate.php
@@ -3,7 +3,9 @@
 namespace WPGraphQL\Type\MediaItem\Mutation;
 
 use GraphQL\Error\UserError;
+use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
+use WPGraphQL\AppContext;
 use WPGraphQL\Types;
 
 /**
@@ -46,7 +48,7 @@ class MediaItemUpdate {
 					},
 				],
 			],
-			'mutateAndGetPayload' => function( $input ) use ( $post_type_object, $mutation_name ) {
+			'mutateAndGetPayload' => function( $input, AppContext $context, ResolveInfo $info ) use ( $post_type_object, $mutation_name ) {
 
 				$id_parts      = ! empty( $input['id'] ) ? Relay::fromGlobalId( $input['id'] ) : null;
 				$existing_media_item = get_post( absint( $id_parts['id'] ) );
@@ -113,7 +115,7 @@ class MediaItemUpdate {
 				 * The input for the postObjectMutation will be passed, along with the $new_post_id for the
 				 * postObject that was updated so that relations can be set, meta can be updated, etc.
 				 */
-				MediaItemMutation::update_additional_media_item_data( $post_id, $input, $post_type_object, $mutation_name );
+				MediaItemMutation::update_additional_media_item_data( $post_id, $input, $post_type_object, $mutation_name, $context, $info );
 
 				/**
 				 * Return the payload

--- a/src/Type/PostObject/Mutation/PostObjectCreate.php
+++ b/src/Type/PostObject/Mutation/PostObjectCreate.php
@@ -3,7 +3,9 @@
 namespace WPGraphQL\Type\PostObject\Mutation;
 
 use GraphQL\Error\UserError;
+use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
+use WPGraphQL\AppContext;
 use WPGraphQL\Type\WPInputObjectType;
 use WPGraphQL\Types;
 
@@ -53,7 +55,7 @@ class PostObjectCreate {
 						},
 					],
 				],
-				'mutateAndGetPayload' => function( $input ) use ( $post_type_object, $mutation_name ) {
+				'mutateAndGetPayload' => function( $input, AppContext $context, ResolveInfo $info ) use ( $post_type_object, $mutation_name ) {
 
 					/**
 					 * Throw an exception if there's no input
@@ -91,6 +93,31 @@ class PostObjectCreate {
 					$post_args = PostObjectMutation::prepare_post_object( $input, $post_type_object, $mutation_name );
 
 					/**
+					 * Filter the default post status to use when the post is initially created. Pass through a filter to
+					 * allow other plugins to override the default (for example, Edit Flow, which provides control over
+					 * customizing stati or various E-commerce plugins that make heavy use of custom stati)
+					 *
+					 * @param string        $default_status   The default status to be used when the post is initially inserted
+					 * @param \WP_Post_Type $post_type_object The Post Type that is being inserted
+					 * @param string        $mutation_name    The name of the mutation currently in progress
+					 */
+					$default_post_status = apply_filters( 'graphql_post_object_create_default_post_status', 'draft', $post_type_object, $mutation_name );
+
+					/**
+					 * We want to cache the "post_status" and set the status later. We will set the initial status
+					 * of the inserted post as the default status for the site, allow side effects to process with the
+					 * inserted post (set term object connections, set meta input, sideload images if necessary, etc)
+					 * Then will follow up with setting the status as what it was declared to be later
+					 */
+					$intended_post_status = ! empty( $post_args['post_status'] ) ? $post_args['post_status'] : $default_post_status;
+
+					/**
+					 * Set the post_status as the default for the initial insert. The intended $post_status will be set after
+					 * side effects are complete.
+					 */
+					$post_args['post_status'] = $default_post_status;
+
+					/**
 					 * Insert the post and retrieve the ID
 					 */
 					$post_id = wp_insert_post( wp_slash( (array) $post_args ), true );
@@ -120,7 +147,60 @@ class PostObjectCreate {
 					 * The input for the postObjectMutation will be passed, along with the $new_post_id for the
 					 * postObject that was created so that relations can be set, meta can be updated, etc.
 					 */
-					PostObjectMutation::update_additional_post_object_data( $post_id, $input, $post_type_object, $mutation_name );
+					PostObjectMutation::update_additional_post_object_data( $post_id, $input, $post_type_object, $mutation_name, $context, $info, $default_post_status, $intended_post_status );
+
+					/**
+					 * Determine whether the intended status should be set or not.
+					 *
+					 * By filtering to false, the $intended_post_status will not be set at the completion of the mutation.
+					 *
+					 * This allows for side-effect actions to set the status later. For example, if a post
+					 * was being created via a GraphQL Mutation, the post had additional required assets, such as images
+					 * that needed to be sideloaded or some other semi-time-consuming side effect, those actions could
+					 * be deferred (cron or whatever), and when those actions complete they could come back and set
+					 * the $intended_status.
+					 *
+					 * @param boolean       $should_set_intended_status Whether to set the intended post_status or not. Default true.
+					 * @param \WP_Post_Type $post_type_object           The Post Type Object for the post being mutated
+					 * @param string        $mutation_name              The name of the mutation currently in progress
+					 * @param AppContext    $context                    The AppContext passed down to all resolvers
+					 * @param ResolveInfo   $info                       The ResolveInfo passed down to all resolvers
+					 * @param string        $intended_post_status       The intended post_status the post should have according to the mutation input
+					 * @param string        $default_post_status        The default status posts should use if an intended status wasn't set
+					 */
+					$should_set_intended_status = apply_filters( 'graphql_post_object_create_should_set_intended_post_status', true, $post_type_object, $mutation_name, $context, $info, $intended_post_status, $default_post_status );
+
+					/**
+					 * If the intended post status and the default post status are not the same,
+					 * update the post with the intended status now that side effects are complete.
+					 */
+					if ( $intended_post_status !== $default_post_status && true === $should_set_intended_status ) {
+
+						/**
+						 * If the post was deleted by a side effect action before getting here,
+						 * don't proceed.
+						 */
+						if ( ! $new_post = get_post( $post_id ) ) {
+							throw new UserError( sprintf( __( 'The status of the post could not be set', 'wp-graphql' ) ) );
+						}
+
+						/**
+						 * If the $intended_post_status is different than the current status of the post
+						 * proceed and update the status.
+						 */
+						if ( $intended_post_status !== $new_post->post_status ) {
+							$update_args = [
+								'ID'          => $post_id,
+								'post_status' => $intended_post_status,
+								// Prevent the post_date from being reset if the date was included in the create post $args
+								// see: https://core.trac.wordpress.org/browser/tags/4.9/src/wp-includes/post.php#L3637
+								'edit_date'   => ! empty( $post_args['post_date'] ) ? $post_args['post_date'] : false,
+							];
+
+							wp_update_post( $update_args );
+						}
+
+					}
 
 					/**
 					 * Return the post object

--- a/src/Type/PostObject/Mutation/PostObjectUpdate.php
+++ b/src/Type/PostObject/Mutation/PostObjectUpdate.php
@@ -3,7 +3,9 @@
 namespace WPGraphQL\Type\PostObject\Mutation;
 
 use GraphQL\Error\UserError;
+use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
+use WPGraphQL\AppContext;
 use WPGraphQL\Type\WPInputObjectType;
 use WPGraphQL\Types;
 
@@ -53,7 +55,7 @@ class PostObjectUpdate {
 						},
 					],
 				],
-				'mutateAndGetPayload' => function( $input ) use ( $post_type_object, $mutation_name ) {
+				'mutateAndGetPayload' => function( $input, AppContext $context, ResolveInfo $info ) use ( $post_type_object, $mutation_name ) {
 
 					$id_parts      = ! empty( $input['id'] ) ? Relay::fromGlobalId( $input['id'] ) : null;
 					$existing_post = get_post( absint( $id_parts['id'] ) );
@@ -134,7 +136,7 @@ class PostObjectUpdate {
 					 * The input for the postObjectMutation will be passed, along with the $new_post_id for the
 					 * postObject that was updated so that relations can be set, meta can be updated, etc.
 					 */
-					PostObjectMutation::update_additional_post_object_data( $post_id, $input, $post_type_object, $mutation_name );
+					PostObjectMutation::update_additional_post_object_data( $post_id, $input, $post_type_object, $mutation_name, $context, $info );
 
 					/**
 					 * Return the payload

--- a/src/Type/TermObject/Mutation/TermObjectCreate.php
+++ b/src/Type/TermObject/Mutation/TermObjectCreate.php
@@ -3,7 +3,9 @@
 namespace WPGraphQL\Type\TermObject\Mutation;
 
 use GraphQL\Error\UserError;
+use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
+use WPGraphQL\AppContext;
 use WPGraphQL\Types;
 
 class TermObjectCreate {
@@ -49,7 +51,7 @@ class TermObjectCreate {
 						},
 					],
 				],
-				'mutateAndGetPayload' => function( $input ) use ( $taxonomy, $mutation_name ) {
+				'mutateAndGetPayload' => function( $input, AppContext $context, ResolveInfo $info ) use ( $taxonomy, $mutation_name ) {
 
 					/**
 					 * Ensure the user can edit_terms
@@ -101,11 +103,13 @@ class TermObjectCreate {
 					 *
 					 * The dynamic portion of the hook name, `$taxonomy->name` refers to the taxonomy of the term being mutated
 					 *
-					 * @param int    $term_id       Inserted term object
-					 * @param array  $args          The args used to insert the term
-					 * @param string $mutation_name The name of the mutation being performed
+					 * @param int         $term_id       Inserted term object
+					 * @param array       $args          The args used to insert the term
+					 * @param string      $mutation_name The name of the mutation being performed
+					 * @param AppContext  $context       The AppContext passed down the resolve tree
+					 * @param ResolveInfo $info          The ResolveInfo passed down the resolve tree
 					 */
-					do_action( "graphql_insert_{$taxonomy->name}", $term['term_id'], $args, $mutation_name );
+					do_action( "graphql_insert_{$taxonomy->name}", $term['term_id'], $args, $mutation_name, $context, $info );
 
 					return [
 						'id' => $term['term_id'],

--- a/src/Type/TermObject/Mutation/TermObjectUpdate.php
+++ b/src/Type/TermObject/Mutation/TermObjectUpdate.php
@@ -3,7 +3,9 @@
 namespace WPGraphQL\Type\TermObject\Mutation;
 
 use GraphQL\Error\UserError;
+use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
+use WPGraphQL\AppContext;
 use WPGraphQL\Types;
 
 class TermObjectUpdate {
@@ -44,7 +46,7 @@ class TermObjectUpdate {
 						},
 					],
 				],
-				'mutateAndGetPayload' => function( $input ) use ( $taxonomy, $mutation_name ) {
+				'mutateAndGetPayload' => function( $input, AppContext $context, ResolveInfo $info ) use ( $taxonomy, $mutation_name ) {
 
 					/**
 					 * Get the ID parts
@@ -109,11 +111,13 @@ class TermObjectUpdate {
 					/**
 					 * Fires an action when a term is updated via a GraphQL Mutation
 					 *
-					 * @param int    $term_id       The ID of the term object that was mutated
-					 * @param array  $args          The args used to update the term
-					 * @param string $mutation_name The name of the mutation being performed (create, update, delete, etc)
+					 * @param int         $term_id       The ID of the term object that was mutated
+					 * @param array       $args          The args used to update the term
+					 * @param string      $mutation_name The name of the mutation being performed (create, update, delete, etc)
+					 * @param AppContext  $context       The AppContext passed down the resolve tree
+					 * @param ResolveInfo $info          The ResolveInfo passed down the resolve tree
 					 */
-					do_action( "graphql_update_{$taxonomy->name}", $existing_term->term_id, $args, $mutation_name );
+					do_action( "graphql_update_{$taxonomy->name}", $existing_term->term_id, $args, $mutation_name, $context, $info );
 
 					/**
 					 * Return the payload
@@ -127,7 +131,7 @@ class TermObjectUpdate {
 
 		}
 
-		return ! empty( self::$mutation[ $taxonomy->graphql_single_name ] ) ?  self::$mutation[ $taxonomy->graphql_single_name ] : null;
+		return ! empty( self::$mutation[ $taxonomy->graphql_single_name ] ) ? self::$mutation[ $taxonomy->graphql_single_name ] : null;
 
 	}
 
@@ -150,8 +154,8 @@ class TermObjectUpdate {
 					// Translators: The placeholder is the name of the taxonomy for the object being mutated
 					'description' => sprintf( __( 'The name of the %1$s object to mutate', 'wp-graphql' ), $taxonomy->name ),
 				],
-				'id' => [
-					'type' => Types::non_null( Types::id() ),
+				'id'   => [
+					'type'        => Types::non_null( Types::id() ),
 					// Translators: The placeholder is the taxonomy of the term being updated
 					'description' => sprintf( __( 'The ID of the %1$s object to update', 'wp-graphql' ), $taxonomy->graphql_single_name ),
 				],

--- a/src/Type/User/Mutation/UserCreate.php
+++ b/src/Type/User/Mutation/UserCreate.php
@@ -3,7 +3,9 @@
 namespace WPGraphQL\Type\User\Mutation;
 
 use GraphQL\Error\UserError;
+use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
+use WPGraphQL\AppContext;
 use WPGraphQL\Types;
 
 /**
@@ -43,7 +45,7 @@ class UserCreate {
 						}
 					]
 				],
-				'mutateAndGetPayload' => function( $input ) {
+				'mutateAndGetPayload' => function( $input, AppContext $context, ResolveInfo $info ) {
 
 					if ( ! current_user_can( 'create_users' ) ) {
 						throw new UserError( __( 'Sorry, you are not allowed to create a new user.', 'wp-graphql' ) );
@@ -81,7 +83,7 @@ class UserCreate {
 					/**
 					 * Update additional user data
 					 */
-					UserMutation::update_additional_user_object_data( $user_id, $input, 'create' );
+					UserMutation::update_additional_user_object_data( $user_id, $input, 'create', $context, $info );
 
 					/**
 					 * Return the new user ID

--- a/src/Type/User/Mutation/UserMutation.php
+++ b/src/Type/User/Mutation/UserMutation.php
@@ -3,6 +3,8 @@
 namespace WPGraphQL\Type\User\Mutation;
 
 use GraphQL\Error\UserError;
+use GraphQL\Type\Definition\ResolveInfo;
+use WPGraphQL\AppContext;
 use WPGraphQL\Types;
 
 /**
@@ -205,11 +207,13 @@ class UserMutation {
 	/**
 	 * This updates additional data related to the user object after the initial mutation has happened
 	 *
-	 * @param int    $user_id       The ID of the user being mutated
-	 * @param array  $input         The input data from the GraphQL query
-	 * @param string $mutation_name Name of the mutation currently being run
+	 * @param int         $user_id       The ID of the user being mutated
+	 * @param array       $input         The input data from the GraphQL query
+	 * @param string      $mutation_name Name of the mutation currently being run
+	 * @param AppContext  $context       The AppContext passed down the resolve tree
+	 * @param ResolveInfo $info          The ResolveInfo passed down the Resolve Tree
 	 */
-	public static function update_additional_user_object_data( $user_id, $input, $mutation_name ) {
+	public static function update_additional_user_object_data( $user_id, $input, $mutation_name, AppContext $context, ResolveInfo $info ) {
 
 		$roles = ! empty( $input['roles'] ) ? $input['roles'] : [];
 		self::add_user_roles( $user_id, $roles );
@@ -219,11 +223,13 @@ class UserMutation {
 		 * update additional data related to users, such as setting relationships, updating additional usermeta,
 		 * or sending emails to Kevin... whatever you need to do with the userObject.
 		 *
-		 * @param int    $user_id       The ID of the user being mutated
-		 * @param array  $input         The input for the mutation
-		 * @param string $mutation_name The name of the mutation (ex: create, update, delete)
+		 * @param int         $user_id       The ID of the user being mutated
+		 * @param array       $input         The input for the mutation
+		 * @param string      $mutation_name The name of the mutation (ex: create, update, delete)
+		 * @param AppContext  $context       The AppContext passed down the resolve tree
+		 * @param ResolveInfo $info          The ResolveInfo passed down the Resolve Tree
 		 */
-		do_action( 'graphql_user_object_mutation_update_additional_data', $user_id, $input, $mutation_name );
+		do_action( 'graphql_user_object_mutation_update_additional_data', $user_id, $input, $mutation_name, $context, $info );
 
 	}
 

--- a/src/Type/User/Mutation/UserUpdate.php
+++ b/src/Type/User/Mutation/UserUpdate.php
@@ -3,7 +3,9 @@
 namespace WPGraphQL\Type\User\Mutation;
 
 use GraphQL\Error\UserError;
+use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
+use WPGraphQL\AppContext;
 use WPGraphQL\Types;
 
 /**
@@ -42,7 +44,7 @@ class UserUpdate {
 							return get_user_by( 'ID', $payload['userId'] );
 						}
 					]
-				], 'mutateAndGetPayload' => function( $input ) {
+				], 'mutateAndGetPayload' => function( $input, AppContext $context, ResolveInfo $info ) {
 
 					$id_parts      = ! empty( $input['id'] ) ? Relay::fromGlobalId( $input['id'] ) : null;
 					$existing_user = get_user_by( 'ID', $id_parts['id'] );
@@ -95,7 +97,7 @@ class UserUpdate {
 					/**
 					 * Update additional user data
 					 */
-					UserMutation::update_additional_user_object_data( $user_id, $input, 'update' );
+					UserMutation::update_additional_user_object_data( $user_id, $input, 'update', $context, $info );
 
 					/**
 					 * Return the new user ID

--- a/tests/_data/config.php
+++ b/tests/_data/config.php
@@ -4,4 +4,5 @@
  * suite already bootstraps the autoloader and creates
  * fatal errors when the autoloader is loaded twice
  */
+define( 'GRAPHQL_DEBUG', true );
 define( 'WPGRAPHQL_AUTOLOAD', false );

--- a/tests/wpunit/PostObjectMutationsTest.php
+++ b/tests/wpunit/PostObjectMutationsTest.php
@@ -626,8 +626,8 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 
         $this->assertEquals( $dateExpected, $results['data']['createPost']['post']['date'] );
         $this->assertEquals( $dateGmtExpected, $results['data']['createPost']['post']['dateGmt'] );
-        $this->assertEquals( $dateExpected, $results['data']['createPost']['post']['modified'] );
-        $this->assertEquals( $dateGmtExpected, $results['data']['createPost']['post']['modifiedGmt'] );
+        $this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modified'] );
+        $this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modifiedGmt'] );
 
     }
 
@@ -663,8 +663,8 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 
         $this->assertEquals( $dateExpected, $results['data']['createPost']['post']['date'] );
         $this->assertEquals( $dateGmtExpected, $results['data']['createPost']['post']['dateGmt'] );
-        $this->assertEquals( $dateExpected, $results['data']['createPost']['post']['modified'] );
-        $this->assertEquals( $dateGmtExpected, $results['data']['createPost']['post']['modifiedGmt'] );
+	    $this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modified'] );
+	    $this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modifiedGmt'] );
 
     }
 
@@ -701,8 +701,8 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 
         $this->assertEquals( $dateExpected, $results['data']['createPost']['post']['date'] );
         $this->assertEquals( $dateGmtExpected, $results['data']['createPost']['post']['dateGmt'] );
-        $this->assertEquals( $dateExpected, $results['data']['createPost']['post']['modified'] );
-        $this->assertEquals( $dateGmtExpected, $results['data']['createPost']['post']['modifiedGmt'] );
+	    $this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modified'] );
+	    $this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modifiedGmt'] );
 
     }
 

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -5,7 +5,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 0.0.25
+ * Version: 0.0.26
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 4.7.0
@@ -17,7 +17,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  0.0.25
+ * @version  0.0.26
  */
 // Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
@@ -152,7 +152,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 
 			// Plugin version.
 			if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-				define( 'WPGRAPHQL_VERSION', '0.0.25' );
+				define( 'WPGRAPHQL_VERSION', '0.0.26' );
 			}
 
 			// Plugin Folder Path.


### PR DESCRIPTION
# Release Notes

### Updates:
- Adding more params to Mutation hooks, such as AppContext and ResolveInfo
- Adjust PostObjectCreate mutations to set the status from the mutation input later in the mutation, allowing for side effects to be triggered before the mutation completes. See #396  
