### PR TITLE
Fix PostObjectType term and termName resolvers

### DIFF
--- a/src/Type/PostObject/PostObjectType.php
+++ b/src/Type/PostObject/PostObjectType.php
@@ -383,7 +383,14 @@ class PostObjectType extends WPObjectType {
 							$allowed_taxonomies = ! empty( $args['taxonomy'] ) ? [ $args['taxonomy'] ] : $allowed_taxonomies;
 							if ( ! empty( $allowed_taxonomies ) && is_array( $allowed_taxonomies ) ) {
 								foreach ( $allowed_taxonomies as $taxonomy ) {
-									$tax_terms = get_the_terms( $post->ID, $taxonomy );
+
+									$term_query = new \WP_Term_Query([
+										'taxonomy' => $taxonomy,
+										'object_ids' => [ $post->ID ],
+									]);
+
+									$tax_terms = $term_query->get_terms();
+
 									if ( ! empty( $tax_terms ) && is_array( $tax_terms ) ) {
 										$terms = array_merge( $terms, $tax_terms );
 									}
@@ -413,7 +420,14 @@ class PostObjectType extends WPObjectType {
 							$allowed_taxonomies = ! empty( $args['taxonomy'] ) ? [ $args['taxonomy'] ] : $allowed_taxonomies;
 							if ( ! empty( $allowed_taxonomies ) && is_array( $allowed_taxonomies ) ) {
 								foreach ( $allowed_taxonomies as $taxonomy ) {
-									$tax_terms = get_the_terms( $post->ID, $taxonomy );
+
+									$term_query = new \WP_Term_Query([
+										'taxonomy' => $taxonomy,
+										'object_ids' => [ $post->ID ],
+									]);
+
+									$tax_terms = $term_query->get_terms();
+
 									if ( ! empty( $tax_terms ) && is_array( $tax_terms ) ) {
 										$terms = array_merge( $terms, $tax_terms );
 									}

--- a/tests/wpunit/PostObjectQueriesTest.php
+++ b/tests/wpunit/PostObjectQueriesTest.php
@@ -433,7 +433,7 @@ class PostObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 						}
 					}
 				}
-				tagNames:termNames(taxonomy:TAG)
+				tagNames:termNames(taxonomies:[TAG])
 				terms{
 				  ...on Tag{
 				    name
@@ -477,6 +477,96 @@ class PostObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 		];
 
 		$this->assertEquals( $expected, $actual );
+	}
+
+	public function testPostQueryWithTermFields() {
+
+		$post_title = uniqid();
+		$cat_name = uniqid();
+		$tag_name = uniqid();
+
+		/**
+		 * Create a post
+		 */
+		$post_id = $this->createPostObject( [
+			'post_type' => 'post',
+			'post_title' => $post_title
+		] );
+
+		// Create a comment and assign it to post.
+		$category_id = $this->factory()->category->create( [
+			'name' => $cat_name,
+			'slug' => $cat_name,
+		] );
+
+		$tag_id = $this->factory()->tag->create( [
+			'name' => $tag_name,
+			'slug' => $tag_name,
+		] );
+
+		wp_set_object_terms( $post_id, $category_id, 'category' );
+		wp_set_object_terms( $post_id, $tag_id, 'post_tag' );
+
+		$query = '
+		query getPostWithTermFields( $id:ID! ){
+			post( id:$id ) {
+			  postId
+			  title
+			  tagSlugs:termSlugs(taxonomies:[TAG])
+			  catSlugs:termSlugs(taxonomies:[TAG])
+			  termNames(taxonomies:[TAG, CATEGORY])
+			  tags:terms(taxonomies:[TAG]) {
+			     ... on Tag {
+			       slug
+			       name
+			     }
+			  }
+			  cats:terms(taxonomies:[CATEGORY]) {
+			    ... on Category {
+			       slug
+			       name
+			     }
+			  }
+			  allTerms:terms(taxonomies:[TAG,CATEGORY]) {
+			     ... on Tag {
+			       slug
+			       name
+			     }
+			     ... on Category {
+			       slug
+			       name
+			     }
+			  }
+			}
+		}
+		';
+
+		$variables = [
+			'id' => \GraphQLRelay\Relay::toGlobalId( 'post', $post_id ),
+		];
+
+		$actual = do_graphql_request( $query, 'getPostWithTermFields', $variables );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+
+		$post = $actual['data']['post'];
+
+		$this->assertEquals( $post_id, $post['postId'] );
+		$this->assertEquals( $post_title, $post['title'] );
+		$this->assertTrue( in_array( $tag_name, $post['tagSlugs'], true ) );
+		$this->assertTrue( in_array( $tag_name, $post['termNames'], true ) );
+		$this->assertTrue( in_array( $cat_name, $post['termNames'], true ) );
+		$this->assertTrue( in_array( $cat_name, $post['termNames'], true ) );
+
+		$tag_names = wp_list_pluck( $post['tags'], 'name' );
+		$cat_names = wp_list_pluck( $post['cats'], 'name' );
+		$all_term_names = wp_list_pluck( $post['allTerms'], 'name' );
+
+		$this->assertTrue( in_array( $tag_name, $tag_names, true ) );
+		$this->assertTrue( in_array( $cat_name, $cat_names, true ) );
+		$this->assertTrue( in_array( $tag_name, $all_term_names, true ) );
+		$this->assertTrue( in_array( $cat_name, $all_term_names, true ) );
+
 	}
 
 	/**


### PR DESCRIPTION
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
This fixes an issue inside the `terms` and `termNames` resolvers for the PostObjectType. 

The `get_the_terms()` function was returning a WP_Error with the message "Invalid Taxonomy" occasionally, providing inconsistent results.

This fix uses WP_Term_Query instead of `get_the_terms()` and is providing the expected results. 

Does this close any currently open issues?
------------------------------------------
addresses #400  (I believe)


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

## Admin of the Post in the below queries
<img width="1342" alt="screen shot 2018-02-14 at 5 27 21 pm" src="https://user-images.githubusercontent.com/1260765/36235189-6893453a-11ac-11e8-961d-f812c446557a.png">

## Current behavior, before this fix
Notice the null values on the categories and tags fields. This isn't expected behavior.

<img width="836" alt="screen shot 2018-02-14 at 5 21 09 pm" src="https://user-images.githubusercontent.com/1260765/36235133-09fe2706-11ac-11e8-82cf-b9c28a95a780.png">

## Behavior after this fix
Notice how the categories and tags fields all resolve properly

<img width="1440" alt="screen shot 2018-02-14 at 5 21 39 pm" src="https://user-images.githubusercontent.com/1260765/36235169-45cbecf0-11ac-11e8-9a6c-c45f9169ebbb.png">


Any other comments?
-------------------
@hews does this fix the unexpected behavior you were seeing? Or do we still have an issue that you're experiencing?