### PR TITLE
#416 - pass more context to filters for input args

### DIFF
--- a/src/Type/Comment/Connection/CommentConnectionArgs.php
+++ b/src/Type/Comment/Connection/CommentConnectionArgs.php
@@ -22,7 +22,7 @@ class CommentConnectionArgs extends WPInputObjectType {
 	 * @var array $fields
 	 * @since 0.0.5
 	 */
-	public static $fields;
+	public static $fields = [];
 
 	/**
 	 * Holds the orderby Enum definition
@@ -32,13 +32,21 @@ class CommentConnectionArgs extends WPInputObjectType {
 	private static $comments_orderby_enum;
 
 	/**
+	 * Holds the order Enum definition
+	 * @var EnumType
+	 */
+	private static $comments_order;
+
+	/**
 	 * CommentConnectionArgs constructor.
-	 *
+	 * @param array $config
+	 * @param string $connection
 	 * @since 0.0.5
 	 */
-	public function __construct( $config = [] ) {
-		$config['name'] = 'CommentArgs';
-		$config['fields'] = self::fields();
+	public function __construct( $config = [], $connection ) {
+		$config['name'] = ucfirst( $connection ) . 'CommentArgs';
+		$config['queryClass'] = 'WP_Comment_Query';
+		$config['fields'] = self::fields( $connection );
 		parent::__construct( $config );
 	}
 
@@ -50,147 +58,136 @@ class CommentConnectionArgs extends WPInputObjectType {
 	 * @return array
 	 * @since 0.0.5
 	 */
-	private static function fields() {
+	private static function fields( $connection ) {
 
-		if ( null === self::$fields ) :
+		if ( empty( self::$fields[ $connection ] ) ) {
 			$fields = [
-				'authorEmail' => [
-					'type' => Types::string(),
+				'authorEmail'        => [
+					'type'        => Types::string(),
 					'description' => __( 'Comment author email address.', 'wp-graphql' ),
 				],
-				'authorUrl' => [
-					'type' => Types::string(),
+				'authorUrl'          => [
+					'type'        => Types::string(),
 					'description' => __( 'Comment author URL.', 'wp-graphql' ),
 				],
-				'authorIn' => [
-					'type' => Types::list_of( Types::int() ),
+				'authorIn'           => [
+					'type'        => Types::list_of( Types::int() ),
 					'description' => __( 'Array of author IDs to include comments for.', 'wp-graphql' ),
 				],
-				'authorNotIn' => [
-					'type' => Types::list_of( Types::int() ),
+				'authorNotIn'        => [
+					'type'        => Types::list_of( Types::int() ),
 					'description' => __( 'Array of author IDs to exclude comments for.', 'wp-graphql' ),
 				],
-				'commentIn' => [
-					'type' => Types::list_of( Types::int() ),
+				'commentIn'          => [
+					'type'        => Types::list_of( Types::int() ),
 					'description' => __( 'Array of comment IDs to include.', 'wp-graphql' ),
 				],
-				'commentNotIn' => [
-					'type' => Types::list_of( Types::int() ),
+				'commentNotIn'       => [
+					'type'        => Types::list_of( Types::int() ),
 					'description' => __( 'Array of IDs of users whose unapproved comments will be returned by the 
 							query regardless of status.', 'wp-graphql' ),
 				],
-				'includeUnapproved' => [
-					'type' => Types::list_of( Types::int() ),
+				'includeUnapproved'  => [
+					'type'        => Types::list_of( Types::int() ),
 					'description' => __( 'Array of author IDs to include comments for.', 'wp-graphql' ),
 				],
-				'karma' => [
-					'type' => Types::int(),
+				'karma'              => [
+					'type'        => Types::int(),
 					'description' => __( 'Karma score to retrieve matching comments for.', 'wp-graphql' ),
 				],
-				'orderby' => [
-					'type' => self::comments_orderby_enum(),
+				'orderby'            => [
+					'type'        => self::comments_orderby_enum(),
 					'description' => __( 'Field to order the comments by.', 'wp-graphql' ),
 				],
-				'order' => [
-					'type' => new WPEnumType([
-						'name' => 'CommentsOrder',
-						'values' => [
-							'ASC' => [
-								'value' => 'ASC',
-							],
-							'DESC' => [
-								'value' => 'DESC',
-							],
-						],
-						'defaultValue' => 'DESC',
-					]),
+				'order'              => [
+					'type' => self::comment_order(),
 				],
-				'parent' => [
-					'type' => Types::int(),
+				'parent'             => [
+					'type'        => Types::int(),
 					'description' => __( 'Parent ID of comment to retrieve children of.', 'wp-graphql' ),
 				],
-				'parentIn' => [
-					'type' => Types::list_of( Types::int() ),
+				'parentIn'           => [
+					'type'        => Types::list_of( Types::int() ),
 					'description' => __( 'Array of parent IDs of comments to retrieve children for.', 'wp-graphql' ),
 				],
-				'parentNotIn' => [
-					'type' => Types::list_of( Types::int() ),
+				'parentNotIn'        => [
+					'type'        => Types::list_of( Types::int() ),
 					'description' => __( 'Array of parent IDs of comments *not* to retrieve children 
 							for.', 'wp-graphql' ),
 				],
-				'contentAuthorIn' => [
-					'type' => Types::list_of( Types::int() ),
+				'contentAuthorIn'    => [
+					'type'        => Types::list_of( Types::int() ),
 					'description' => __( 'Array of author IDs to retrieve comments for.', 'wp-graphql' ),
 				],
 				'contentAuthorNotIn' => [
-					'type' => Types::list_of( Types::int() ),
+					'type'        => Types::list_of( Types::int() ),
 					'description' => __( 'Array of author IDs *not* to retrieve comments for.', 'wp-graphql' ),
 				],
-				'contentId' => [
-					'type' => Types::int(),
+				'contentId'          => [
+					'type'        => Types::int(),
 					'description' => __( 'Limit results to those affiliated with a given content object 
 							ID.', 'wp-graphql' ),
 				],
-				'contentIdIn' => [
-					'type' => Types::list_of( Types::int() ),
+				'contentIdIn'        => [
+					'type'        => Types::list_of( Types::int() ),
 					'description' => __( 'Array of content object IDs to include affiliated comments 
 							for.', 'wp-graphql' ),
 				],
-				'contentIdNotIn' => [
-					'type' => Types::list_of( Types::int() ),
+				'contentIdNotIn'     => [
+					'type'        => Types::list_of( Types::int() ),
 					'description' => __( 'Array of content object IDs to exclude affiliated comments 
 							for.', 'wp-graphql' ),
 				],
-				'contentAuthor' => [
-					'type' => Types::list_of( Types::int() ),
+				'contentAuthor'      => [
+					'type'        => Types::list_of( Types::int() ),
 					'description' => __( 'Content object author ID to limit results by.', 'wp-graphql' ),
 				],
-				'contentStatus' => [
-					'type' => Types::list_of( Types::post_status_enum() ),
+				'contentStatus'      => [
+					'type'        => Types::list_of( Types::post_status_enum() ),
 					'description' => __( 'Array of content object statuses to retrieve affiliated comments for. 
 							Pass \'any\' to match any value.', 'wp-graphql' ),
 				],
-				'contentType' => [
-					'type' => Types::list_of( Types::post_type_enum() ),
+				'contentType'        => [
+					'type'        => Types::list_of( Types::post_type_enum() ),
 					'description' => __( 'Content object type or array of types to retrieve affiliated comments for. Pass \'any\' to match any value.', 'wp-graphql' ),
 				],
-				'contentName' => [
-					'type' => Types::string(),
+				'contentName'        => [
+					'type'        => Types::string(),
 					'description' => __( 'Content object name to retrieve affiliated comments for.', 'wp-graphql' ),
 				],
-				'contentParent' => [
-					'type' => Types::int(),
+				'contentParent'      => [
+					'type'        => Types::int(),
 					'description' => __( 'Content Object parent ID to retrieve affiliated comments for.', 'wp-graphql' ),
 				],
-				'search' => [
-					'type' => Types::string(),
+				'search'             => [
+					'type'        => Types::string(),
 					'description' => __( 'Search term(s) to retrieve matching comments for.', 'wp-graphql' ),
 				],
-				'status' => [
-					'type' => Types::string(),
+				'status'             => [
+					'type'        => Types::string(),
 					'description' => __( 'Comment status to limit results by.', 'wp-graphql' ),
 				],
-				'commentType' => [
-					'type' => Types::string(),
+				'commentType'        => [
+					'type'        => Types::string(),
 					'description' => __( 'Include comments of a given type.', 'wp-graphql' ),
 				],
-				'commentTypeIn' => [
-					'type' => Types::list_of( Types::string() ),
+				'commentTypeIn'      => [
+					'type'        => Types::list_of( Types::string() ),
 					'description' => __( 'Include comments from a given array of comment types.', 'wp-graphql' ),
 				],
-				'commentTypeNotIn' => [
-					'type' => Types::string(),
+				'commentTypeNotIn'   => [
+					'type'        => Types::string(),
 					'description' => __( 'Exclude comments from a given array of comment types.', 'wp-graphql' ),
 				],
-				'userId' => [
-					'type' => Types::int(),
+				'userId'             => [
+					'type'        => Types::int(),
 					'description' => __( 'Include comments for a specific user ID.', 'wp-graphql' ),
 				],
 			];
 
-			self::$fields = self::prepare_fields( $fields, 'CommentArgs' );
-		endif;
-		return self::$fields;
+			self::$fields[ $connection ] = self::prepare_fields( $fields, ucfirst( $connection ) . 'CommentArgs' );
+		}
+		return ! empty( self::$fields[ $connection ] ) ? self::$fields[ $connection ] : null;
 
 	}
 
@@ -204,62 +201,83 @@ class CommentConnectionArgs extends WPInputObjectType {
 	 */
 	private static function comments_orderby_enum() {
 
-		if ( null === self::$comments_orderby_enum ) :
-			self::$comments_orderby_enum = new WPEnumType([
-				'name' => 'CommentsOrderby',
+		if ( null === self::$comments_orderby_enum ) {
+			self::$comments_orderby_enum = new WPEnumType( [
+				'name'   => 'CommentsOrderby',
 				'values' => [
-					'COMMENT_AGENT' => [
+					'COMMENT_AGENT'        => [
 						'value' => 'comment_agent',
 					],
-					'COMMENT_APPROVED' => [
+					'COMMENT_APPROVED'     => [
 						'value' => 'comment_approved',
 					],
-					'COMMENT_AUTHOR' => [
+					'COMMENT_AUTHOR'       => [
 						'value' => 'comment_author',
 					],
 					'COMMENT_AUTHOR_EMAIL' => [
 						'value' => 'comment_author_email',
 					],
-					'COMMENT_AUTHOR_IP' => [
+					'COMMENT_AUTHOR_IP'    => [
 						'value' => 'comment_author_IP',
 					],
-					'COMMENT_AUTHOR_URL' => [
+					'COMMENT_AUTHOR_URL'   => [
 						'value' => 'comment_author_url',
 					],
-					'COMMENT_CONTENT' => [
+					'COMMENT_CONTENT'      => [
 						'value' => 'comment_content',
 					],
-					'COMMENT_DATE' => [
+					'COMMENT_DATE'         => [
 						'value' => 'comment_date',
 					],
-					'COMMENT_DATE_GMT' => [
+					'COMMENT_DATE_GMT'     => [
 						'value' => 'comment_date_gmt',
 					],
-					'COMMENT_ID' => [
+					'COMMENT_ID'           => [
 						'value' => 'comment_ID',
 					],
-					'COMMENT_KARMA' => [
+					'COMMENT_KARMA'        => [
 						'value' => 'comment_karma',
 					],
-					'COMMENT_PARENT' => [
+					'COMMENT_PARENT'       => [
 						'value' => 'comment_parent',
 					],
-					'COMMENT_POST_ID' => [
+					'COMMENT_POST_ID'      => [
 						'value' => 'comment_post_ID',
 					],
-					'COMMENT_TYPE' => [
+					'COMMENT_TYPE'         => [
 						'value' => 'comment_type',
 					],
-					'USER_ID' => [
+					'USER_ID'              => [
 						'value' => 'user_id',
 					],
-					'COMMENT_IN' => [
+					'COMMENT_IN'           => [
 						'value' => 'comment__in',
 					],
 				],
-			]);
-		endif;
+			] );
+		}
 		return self::$comments_orderby_enum;
+	}
+
+	private static function comment_order() {
+
+		if ( null === self::$comments_order ) {
+			self::$comments_order = new WPEnumType( [
+				'name'         => 'CommentsOrder',
+				'values'       => [
+					'ASC'  => [
+						'value' => 'ASC',
+					],
+					'DESC' => [
+						'value' => 'DESC',
+					],
+				],
+				'defaultValue' => 'DESC',
+			] );
+		}
+
+		return self::$comments_order;
+
 	}
 
 }

--- a/src/Type/PostObject/Connection/PostObjectConnectionArgs.php
+++ b/src/Type/PostObject/Connection/PostObjectConnectionArgs.php
@@ -33,7 +33,7 @@ class PostObjectConnectionArgs extends WPInputObjectType {
 	 * @var array $fields
 	 * @since 0.0.5
 	 */
-	public static $fields;
+	public static $fields = [];
 
 	/**
 	 * This holds the orderby_field input object type
@@ -51,12 +51,14 @@ class PostObjectConnectionArgs extends WPInputObjectType {
 
 	/**
 	 * PostObjectConnectionArgs constructor.
-	 *
+	 * @param array $config Array of Config data for the Input Type
+	 * @param string $connection The name of the connection the args belong to
 	 * @since 0.0.5
 	 */
-	public function __construct( $config = [] ) {
-		$config['name'] = 'QueryArgs';
-		$config['fields'] = self::fields();
+	public function __construct( $config = [], $connection ) {
+		$config['name'] = ucfirst( $connection ) . 'QueryArgs';
+		$config['queryClass'] = 'WP_Query';
+		$config['fields'] = self::fields( $connection );
 		parent::__construct( $config );
 	}
 
@@ -65,12 +67,13 @@ class PostObjectConnectionArgs extends WPInputObjectType {
 	 *
 	 * This defines the fields that make up the PostObjectConnectionArgs
 	 *
+	 * @param string $connection The name of the connection the fields belong to
 	 * @return array
 	 * @since 0.0.5
 	 */
-	private static function fields() {
+	private static function fields( $connection ) {
 
-		if ( null === self::$fields ) :
+		if ( empty( self::$fields[ $connection ] ) ) {
 			$fields = [
 
 				/**
@@ -212,7 +215,7 @@ class PostObjectConnectionArgs extends WPInputObjectType {
 				 * @since 0.0.2
 				 */
 				'hasPassword'  => [
-					'type'        => Types::string(),
+					'type'        => Types::boolean(),
 					'description' => __( 'True for objects with passwords; False for objects without passwords; 
 							null for all objects with or without passwords', 'wp-graphql' ),
 				],
@@ -257,10 +260,9 @@ class PostObjectConnectionArgs extends WPInputObjectType {
 				],
 			];
 
-			self::$fields = self::prepare_fields( $fields, 'QueryArgs' );
-		endif;
-		return self::$fields;
-
+			self::$fields[ $connection ] = self::prepare_fields( $fields, ucfirst( $connection ) . 'QueryArgs' );
+		}
+		return ! empty( self::$fields[ $connection ] ) ? self::$fields[ $connection ] : null;
 	}
 
 	/**
@@ -310,49 +312,49 @@ class PostObjectConnectionArgs extends WPInputObjectType {
 	 */
 	private static function orderby_enum() {
 
-		if ( null === self::$orderby_enum ) :
-			self::$orderby_enum = new WPEnumType([
-				'name' => 'OrderBy',
+		if ( null === self::$orderby_enum ) {
+			self::$orderby_enum = new WPEnumType( [
+				'name'   => 'OrderBy',
 				'values' => [
-					'AUTHOR' => [
+					'AUTHOR'     => [
 						'value'       => 'post_author',
 						'description' => __( 'Order by author', 'wp-graphql' ),
 					],
-					'TITLE' => [
+					'TITLE'      => [
 						'value'       => 'post_title',
 						'description' => __( 'Order by title', 'wp-graphql' ),
 					],
-					'SLUG' => [
+					'SLUG'       => [
 						'value'       => 'post_name',
 						'description' => __( 'Order by slug', 'wp-graphql' ),
 					],
-					'MODIFIED' => [
+					'MODIFIED'   => [
 						'value'       => 'post_modified',
 						'description' => __( 'Order by last modified date', 'wp-graphql' ),
 					],
-					'DATE' => [
+					'DATE'       => [
 						'value'       => 'post_date',
 						'description' => __( 'Order by publish date', 'wp-graphql' ),
 					],
-					'PARENT' => [
+					'PARENT'     => [
 						'value'       => 'post_parent',
 						'description' => __( 'Order by parent ID', 'wp-graphql' ),
 					],
-					'IN' => [
+					'IN'         => [
 						'value'       => 'post__in',
 						'description' => __( 'Preserve the ID order given in the IN array', 'wp-graphql' ),
 					],
-					'NAME_IN' => [
+					'NAME_IN'    => [
 						'value'       => 'post_name__in',
 						'description' => __( 'Preserve slug order given in the NAME_IN array', 'wp-graphql' ),
 					],
 					'MENU_ORDER' => [
 						'value'       => 'menu_order',
 						'description' => __( 'Order by the menu order value', 'wp-graphql' ),
-					],					
+					],
 				],
-			]);
-		endif;
+			] );
+		}
 		return self::$orderby_enum;
 	}
 

--- a/src/Type/TermObject/Connection/TermObjectConnectionArgs.php
+++ b/src/Type/TermObject/Connection/TermObjectConnectionArgs.php
@@ -21,15 +21,26 @@ class TermObjectConnectionArgs extends WPInputObjectType {
 	 * @var array $fields
 	 * @since 0.0.5
 	 */
-	public static $fields;
+	public static $fields = [];
+
+	/**
+	 * Holds the orderby enum definition
+	 * @var $orderby_enum
+	 */
+	protected static $orderby_enum;
 
 	/**
 	 * TermObjectConnectionArgs constructor.
+	 *
+	 * @param array $config Array of config details for the Input Object Type
+	 * @param string $connection The name of the connection the args belong to
+	 *
 	 * @since 0.0.5
 	 */
-	public function __construct( $config = [] ) {
-		$config['name'] = 'TermArgs';
-		$config['fields'] = self::fields();
+	public function __construct( $config = [], $connection ) {
+		$config['name'] = ucfirst( $connection ) . 'TermArgs';
+		$config['queryClass'] = 'WP_Tax_Query';
+		$config['fields'] = self::fields( $connection );
 		parent::__construct( $config );
 	}
 
@@ -38,117 +49,150 @@ class TermObjectConnectionArgs extends WPInputObjectType {
 	 *
 	 * This defines the fields that make up the TermObjectConnectionArgs
 	 *
+	 * @param string $connection The name of the connection that the fields args belong to
 	 * @return array
 	 * @since 0.0.5
 	 */
-	private static function fields() {
+	private static function fields( $connection ) {
 
-		if ( null === self::$fields ) :
-			self::$fields = [
-				'objectIds' => [
-					'type' => Types::list_of( Types::int() ),
+		if ( empty( self::$fields[ $connection ] ) ) {
+			self::$fields[ $connection ] = [
+				'objectIds'           => [
+					'type'        => Types::list_of( Types::int() ),
 					'description' => __( 'Array of object IDs. Results will be limited to terms associated with these objects.', 'wp-graphql' ),
 				],
-				'orderby' => [
-					'type' => new WPEnumType( [
-						'name' => 'TermsOrderby',
-						'values' => [
-							'NAME' => [
-								'value' => 'name',
-							],
-							'SLUG' => [
-								'value' => 'slug',
-							],
-							'TERM_GROUP' => [
-								'value' => 'term_group',
-							],
-							'TERM_ID' => [
-								'value' => 'term_id',
-							],
-							'TERM_ORDER' => [
-								'value' => 'term_order',
-							],
-							'DESCRIPTION' => [
-								'value' => 'description',
-							],
-							'COUNT' => [
-								'value' => 'count',
-							],
-						],
-					] ),
+				'orderby'             => [
+					'type'        => self::orderby_enum(),
 					'description' => __( 'Field(s) to order terms by. Defaults to \'name\'.', 'wp-graphql' ),
 				],
-				'hideEmpty' => [
-					'type' => Types::boolean(),
+				'hideEmpty'           => [
+					'type'        => Types::boolean(),
 					'description' => __( 'Whether to hide terms not assigned to any posts. Accepts true or false. Default true', 'wp-graphql' ),
 				],
-				'include' => [
-					'type' => Types::list_of( Types::int() ),
+				'include'             => [
+					'type'        => Types::list_of( Types::int() ),
 					'description' => __( 'Array of term ids to include. Default empty array.', 'wp-graphql' ),
 				],
-				'exclude' => [
-					'type' => Types::list_of( Types::int() ),
+				'exclude'             => [
+					'type'        => Types::list_of( Types::int() ),
 					'description' => __( 'Array of term ids to exclude. If $include is non-empty, $exclude is ignored. Default empty array.', 'wp-graphql' ),
 				],
-				'excludeTree' => [
-					'type' => Types::list_of( Types::int() ),
+				'excludeTree'         => [
+					'type'        => Types::list_of( Types::int() ),
 					'description' => __( 'Array of term ids to exclude along with all of their descendant terms. If $include is non-empty, $exclude_tree is ignored. Default empty array.', 'wp-graphql' ),
 				],
-				'name' => [
-					'type' => Types::list_of( Types::string() ),
+				'name'                => [
+					'type'        => Types::list_of( Types::string() ),
 					'description' => __( 'Array of names to return term(s) for. Default empty.', 'wp-graphql' ),
 				],
-				'slug' => [
-					'type' => Types::list_of( Types::string() ),
+				'slug'                => [
+					'type'        => Types::list_of( Types::string() ),
 					'description' => __( 'Array of slugs to return term(s) for. Default empty.', 'wp-graphql' ),
 				],
-				'termTaxonomId' => [
-					'type' => Types::list_of( Types::int() ),
+				'termTaxonomId'       => [
+					'type'        => Types::list_of( Types::int() ),
 					'description' => __( 'Array of term taxonomy IDs, to match when querying terms.', 'wp-graphql' ),
 				],
-				'hierarchical' => [
-					'type' => Types::boolean(),
+				'hierarchical'        => [
+					'type'        => Types::boolean(),
 					'description' => __( 'Whether to include terms that have non-empty descendants (even if $hide_empty is set to true). Default true.', 'wp-graphql' ),
 				],
-				'search' => [
-					'type' => Types::string(),
+				'search'              => [
+					'type'        => Types::string(),
 					'description' => __( 'Search criteria to match terms. Will be SQL-formatted with wildcards before and after. Default empty.', 'wp-graphql' ),
 				],
-				'nameLike' => [
-					'type' => Types::string(),
+				'nameLike'            => [
+					'type'        => Types::string(),
 					'description' => __( 'Retrieve terms with criteria by which a term is LIKE `$name__like`. Default empty.', 'wp-graphql' ),
 				],
-				'descriptionLike' => [
-					'type' => Types::string(),
+				'descriptionLike'     => [
+					'type'        => Types::string(),
 					'description' => __( 'Retrieve terms where the description is LIKE `$description__like`. Default empty.', 'wp-graphql' ),
 				],
-				'padCounts' => [
-					'type' => Types::boolean(),
+				'padCounts'           => [
+					'type'        => Types::boolean(),
 					'description' => __( 'Whether to pad the quantity of a term\'s children in the quantity of each term\'s "count" object variable. Default false.', 'wp-graphql' ),
 				],
-				'childOf' => [
-					'type' => Types::int(),
+				'childOf'             => [
+					'type'        => Types::int(),
 					'description' => __( 'Term ID to retrieve child terms of. If multiple taxonomies are passed, $child_of is ignored. Default 0.', 'wp-graphql' ),
 				],
-				'parent' => [
-					'type' => Types::int(),
+				'parent'              => [
+					'type'        => Types::int(),
 					'description' => __( 'Parent term ID to retrieve direct-child terms of. Default empty.', 'wp-graphql' ),
 				],
-				'childless' => [
-					'type' => Types::boolean(),
+				'childless'           => [
+					'type'        => Types::boolean(),
 					'description' => __( 'True to limit results to terms that have no children. This parameter has no effect on non-hierarchical taxonomies. Default false.', 'wp-graphql' ),
 				],
-				'cacheDomain' => [
-					'type' => Types::string(),
+				'cacheDomain'         => [
+					'type'        => Types::string(),
 					'description' => __( 'Unique cache key to be produced when this query is stored in an object cache. Default is \'core\'.', 'wp-graphql' ),
 				],
 				'updateTermMetaCache' => [
-					'type' => Types::boolean(),
+					'type'        => Types::boolean(),
 					'description' => __( 'Whether to prime meta caches for matched terms. Default true.', 'wp-graphql' ),
 				],
 			];
-		endif;
-		return self::prepare_fields( self::$fields, 'TermArgs' );
+
+			/**
+			 * Add these fields to non-root connections
+			 *
+			 * @todo: possibly consider only adding these args to certain connections, like non-Root connections?
+			 */
+			self::$fields[ $connection ]['shouldOnlyIncludeConnectedItems'] = [
+				'type'        => Types::boolean(),
+				'description' => __( 'Default false. If true, only the items connected to the source item will be returned. If false, all items will be returned regardless of connection to the source', 'wp-graphql' ),
+			];
+
+			self::$fields[ $connection ]['shouldOutputInFlatList'] = [
+				'type'        => Types::boolean(),
+				'description' => __( 'Default false. If true, the connection will be output in a flat list instead of the hierarchical list. So child terms will be output in the same level as the parent terms', 'wp-graphql' ),
+			];
+
+		}
+
+		return ! empty( self::$fields[ $connection ] ) ? self::prepare_fields( self::$fields[ $connection ], ucfirst( $connection ) . 'TermArgs' ) : null;
+	}
+
+	/**
+	 * Sets up the definition of the TermsOrderby enum
+	 * @return null|WPEnumType
+	 */
+	protected static function orderby_enum() {
+
+		if ( null === self::$orderby_enum ) {
+
+			self::$orderby_enum = new WPEnumType( [
+				'name'   => 'TermsOrderby',
+				'values' => [
+					'NAME'        => [
+						'value' => 'name',
+					],
+					'SLUG'        => [
+						'value' => 'slug',
+					],
+					'TERM_GROUP'  => [
+						'value' => 'term_group',
+					],
+					'TERM_ID'     => [
+						'value' => 'term_id',
+					],
+					'TERM_ORDER'  => [
+						'value' => 'term_order',
+					],
+					'DESCRIPTION' => [
+						'value' => 'description',
+					],
+					'COUNT'       => [
+						'value' => 'count',
+					],
+				],
+			] );
+
+		}
+
+		return ! empty( self::$orderby_enum ) ? self::$orderby_enum : null;
 	}
 
 }


### PR DESCRIPTION
 Update Connection Args to have more context for filters to take advantage of (WPGraphQL Tax Query and WPGraphQL Meta Query should work now!)
 
closes #416 