### PR TITLE
#425 - filter access control headers

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -190,9 +190,19 @@ class Router {
 	 */
 	protected static function get_response_headers() {
 
+		/**
+		 * Filtered list of access control headers.
+		 *
+		 * @param array $access_control_headers Array of headers to allow.
+		 */
+		$access_control_allow_headers = apply_filters( 'graphql_access_control_allow_headers', [
+			'Authorization',
+			'Content-Type'
+		] );
+
 		$headers = [
 			'Access-Control-Allow-Origin'  => '*',
-			'Access-Control-Allow-Headers' => 'Authorization, Content-Type',
+			'Access-Control-Allow-Headers' => implode( ', ', $access_control_allow_headers ),
 			'Content-Type'                 => 'application/json ; charset=' . get_option( 'blog_charset' ),
 			'X-Robots-Tag'                 => 'noindex',
 			'X-Content-Type-Options'       => 'nosniff',
@@ -285,7 +295,6 @@ class Router {
 		return $HTTP_RAW_POST_DATA;
 
 	}
-
 
 
 	/**
@@ -391,11 +400,11 @@ class Router {
 				 */
 				$request        = isset( $data['query'] ) ? $data['query'] : '';
 				$operation_name = isset( $data['operationName'] ) ? $data['operationName'] : '';
-				$variables      = isset( $data['variables'] ) ? $data['variables'] : '';
+				$variables      = isset( $data['variables'] ) ? $data['variables'] : [];
 
 
 				if ( false === headers_sent() ) {
-					self::prepare_headers();
+					self::prepare_headers( $response, $graphql_results, $request, $operation_name, $variables, $user );
 				}
 
 				/**
@@ -427,7 +436,7 @@ class Router {
 				 */
 				if ( false === headers_sent() ) {
 
-					self::prepare_headers();
+					self::prepare_headers( $response, $graphql_results, $request, $operation_name, $variables, $user );
 
 					/**
 					 * Send the JSON response
@@ -465,7 +474,18 @@ class Router {
 
 	}
 
-	protected static function prepare_headers() {
+
+	/**
+	 * Prepare headers for response
+	 *
+	 * @param array    $response        The response of the GraphQL Request
+	 * @param array    $graphql_results The results of the GraphQL execution
+	 * @param string   $request         The GraphQL Request
+	 * @param string   $operation_name  The operation name of the GraphQL Request
+	 * @param array    $variables       The variables applied to the GraphQL Request
+	 * @param \WP_User $user            The current user object
+	 */
+	protected static function prepare_headers( $response, $graphql_results, $request, $operation_name, $variables, $user ) {
 
 		/**
 		 * Filter the $status_code before setting the headers
@@ -487,6 +507,14 @@ class Router {
 
 	}
 
+	/**
+	 * Apply filters and do actions after GraphQL Execution
+	 *
+	 * @param array      $result         The result of your GraphQL request
+	 * @param string     $operation_name The name of the operation
+	 * @param string     $request        The request that GraphQL executed
+	 * @param array|null $variables      Variables to passed to your GraphQL query
+	 */
 	protected static function after_execute( $result, $operation_name, $request, $variables ) {
 
 		/**
@@ -532,7 +560,7 @@ class Router {
 		 *
 		 * @param array      $filtered_result The filtered_result of the GraphQL request
 		 * @param array      $result          The result of your GraphQL request
-		 * @param            Schema           object $schema The schema object for the root request
+		 * @param WPSchema   $schema          The schema object for the root request
 		 * @param string     $operation_name  The name of the operation
 		 * @param string     $request         The request that GraphQL executed
 		 * @param array|null $variables       Variables to passed to your GraphQL query
@@ -555,12 +583,15 @@ class Router {
 		 * to hook in to track metrics, such as how long the process took from `graphql_process_http_request`
 		 * to here, etc.
 		 *
-		 * @param array $response
-		 * @param array $graphql_results
+		 * @param array  $result         The result of the GraphQL Query
+		 * @param array  $filtered_result
+		 * @param string $operation_name The name of the operation
+		 * @param string $request        The request that GraphQL executed
+		 * @param array  $variables      Variables to passed to your GraphQL query
 		 *
 		 * @since 0.0.5
 		 */
-		do_action( 'graphql_process_http_request_response', $result, $graphql_results );
+		do_action( 'graphql_process_http_request_response', $filtered_result, $result, $operation_name, $request, $variables );
 
 	}
 


### PR DESCRIPTION

What does this implement/fix? Explain your changes.
---------------------------------------------------
This makes it easier to filter the list of "access control allowed headers"

usage: 

```
add_filter( 'graphql_access_control_allow_headers', function( $headers ) {
  $headers[] = "YourNewHeader";
  return $headers;
} );
```


Does this close any currently open issues?
------------------------------------------
closes #425 
