### PR TITLE
#405 - PostObject Types should only have fields they have support for

### DIFF
--- a/src/Type/MediaItem/MediaItemType.php
+++ b/src/Type/MediaItem/MediaItemType.php
@@ -54,17 +54,6 @@ class MediaItemType {
 	public static function fields( $fields ) {
 
 		/**
-		 * Deprecate fields for the mediaItem type.
-		 * These fields can still be queried, but are just not preferred for the mediaItem type
-		 *
-		 * @since 0.0.6
-		 */
-		$fields['excerpt']['isDeprecated']      = true;
-		$fields['excerpt']['deprecationReason'] = __( 'Use the caption field instead of excerpt', 'wp-graphql' );
-		$fields['content']['isDeprecated']      = true;
-		$fields['content']['deprecationReason'] = __( 'Use the description field instead of content', 'wp-graphql' );
-
-		/**
 		 * Add new fields to the mediaItem type
 		 *
 		 * @since 0.0.6

--- a/src/Type/PostObject/Mutation/PostObjectMutation.php
+++ b/src/Type/PostObject/Mutation/PostObjectMutation.php
@@ -33,29 +33,9 @@ class PostObjectMutation {
 		if ( ! empty( $post_type_object->graphql_single_name ) && empty( self::$input_fields[ $post_type_object->graphql_single_name ] ) ) {
 
 			$input_fields = [
-				'authorId'      => [
-					'type'        => Types::id(),
-					'description' => __( 'The userId to assign as the author of the post', 'wp-graphql' ),
-				],
-				'commentCount'  => [
-					'type'        => Types::int(),
-					'description' => __( 'The number of comments. Even though WPGraphQL denotes this field as an integer, in WordPress this field should be saved as a numeric string for compatability.', 'wp-graphql' ),
-				],
-				'commentStatus' => [
-					'type'        => Types::string(),
-					'description' => __( 'The comment status for the object', 'wp-graphql' ),
-				],
-				'content'       => [
-					'type'        => Types::string(),
-					'description' => __( 'The content of the object', 'wp-graphql' ),
-				],
 				'date'          => [
 					'type'        => Types::string(),
 					'description' => __( 'The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 ', 'wp-graphql' ),
-				],
-				'excerpt'       => [
-					'type'        => Types::string(),
-					'description' => __( 'The excerpt of the object', 'wp-graphql' ),
 				],
 				'menuOrder'     => [
 					'type'        => Types::int(),
@@ -67,7 +47,7 @@ class PostObjectMutation {
 				],
 				'parentId'      => [
 					'type'        => Types::id(),
-					'description' => __( 'The ID of the parent object', 'wp-graphql' ),
+					'description' => __( 'The ID of the parent object. Even non-hierarchical post types can have a parent, so this field is supported even for non-hierarchical types.', 'wp-graphql' ),
 				],
 				'password'      => [
 					'type'        => Types::string(),
@@ -89,15 +69,52 @@ class PostObjectMutation {
 					'type'        => Types::post_status_enum(),
 					'description' => __( 'The status of the object', 'wp-graphql' ),
 				],
-				'title'         => [
-					'type'        => Types::string(),
-					'description' => __( 'The title of the post', 'wp-graphql' ),
-				],
 				'toPing'        => [
 					'type'        => Types::list_of( Types::string() ),
 					'description' => __( 'URLs queued to be pinged.', 'wp-graphql' ),
 				],
 			];
+
+			if ( post_type_supports( $post_type_object->name, 'author' ) ) {
+				$input_fields['title'] = [
+					'type'        => Types::string(),
+					'description' => __( 'The title of the post', 'wp-graphql' ),
+				];
+			}
+
+			if ( post_type_supports( $post_type_object->name, 'editor' ) ) {
+				$input_fields['content'] = [
+					'type'        => Types::string(),
+					'description' => __( 'The content of the object', 'wp-graphql' ),
+				];
+			}
+
+			if ( post_type_supports( $post_type_object->name, 'author' ) ) {
+				$input_fields['author'] = [
+					'type'        => Types::id(),
+					'description' => __( 'The userId to assign as the author of the post', 'wp-graphql' ),
+				];
+			}
+
+			if ( post_type_supports( $post_type_object->name, 'excerpt' ) ) {
+				$input_fields['excerpt'] = [
+					'type'        => Types::string(),
+					'description' => __( 'The excerpt of the object', 'wp-graphql' ),
+				];
+			}
+
+			if ( post_type_supports( $post_type_object->name, 'comments' ) ) {
+				$input_fields['commentCount']  = [
+					'type'        => Types::int(),
+					'description' => __( 'The number of comments. Even though WPGraphQL denotes this field as an integer, in WordPress this field should be saved as a numeric string for compatability.', 'wp-graphql' ),
+				];
+				$input_fields['commentStatus'] = [
+					'type'        => Types::string(),
+					'description' => __( 'The comment status for the object', 'wp-graphql' ),
+				];
+			}
+
+
 
 			/**
 			 * Add inputs for connected taxonomies

--- a/src/Type/PostObject/PostObjectType.php
+++ b/src/Type/PostObject/PostObjectType.php
@@ -39,7 +39,7 @@ class PostObjectType extends WPObjectType {
 	/**
 	 * Holds the post_type_object
 	 *
-	 * @var object $post_type_object
+	 * @var \WP_Post_Type $post_type_object
 	 */
 	private static $post_type_object;
 
@@ -565,8 +565,9 @@ class PostObjectType extends WPObjectType {
 				/**
 				 * If the post_type is Hierarchical, there should be a children field
 				 */
-				if ( true === $post_type_object->hierarchical ) {
-					$fields[ 'child' . ucfirst( $post_type_object->graphql_plural_name ) ] = PostObjectConnectionDefinition::connection( $post_type_object, 'Children' );
+				if ( isset( $post_type_object->hierarchical ) && true === $post_type_object->hierarchical ) {
+					$field_name            = 'child' . ucfirst( $post_type_object->graphql_plural_name );
+					$fields[ $field_name ] = PostObjectConnectionDefinition::connection( $post_type_object, 'Children' );
 				}
 
 				if ( post_type_supports( $post_type_object->name, 'thumbnail' ) ) {

--- a/src/Type/PostObject/PostObjectType.php
+++ b/src/Type/PostObject/PostObjectType.php
@@ -510,7 +510,7 @@ class PostObjectType extends WPObjectType {
 						},
 					],
 				];
-				
+
 				/**
 				 * If the post_type is Hierarchical, there should be a children field
 				 */
@@ -588,14 +588,19 @@ class PostObjectType extends WPObjectType {
 					'excerpt' => [
 						'excerpt',
 					],
+					'trackbacks' => [],
+					'custom-fields' => [],
 					'comments' => [
 						'comments',
 						'commentCount',
 						'commentStatus',
 					],
+					'revisions' => [],
+					'page-attributes' => [],
+					'post-formats' => []
 				];
 
-				/**
+				/**0
 				 * Loop through the supported features, and if the post_type doesn't support
 				 * the feature, unset the fields related to the feature
 				 */

--- a/tests/wpunit/MediaItemQueriesTest.php
+++ b/tests/wpunit/MediaItemQueriesTest.php
@@ -180,7 +180,6 @@ class MediaItemQueriesTest extends \Codeception\TestCase\WPTestCase {
 				    }
 				  }
 				}
-				content
 				date
 				dateGmt
 				description
@@ -192,7 +191,6 @@ class MediaItemQueriesTest extends \Codeception\TestCase\WPTestCase {
 				  editTime
 				}
 				enclosure
-				excerpt
 				guid
 				id
 				link
@@ -258,7 +256,6 @@ class MediaItemQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertTrue( ( null === $mediaItem['commentCount'] || is_int( $mediaItem['commentCount'] ) ) );
 		$this->assertTrue( ( null === $mediaItem['commentStatus'] || is_string( $mediaItem['commentStatus'] ) ) );
 		$this->assertTrue( ( empty( $mediaItem['comments']['edges'] ) || is_string( $mediaItem['comments']['edges'] ) ) );
-		$this->assertTrue( ( null === $mediaItem['content'] || is_string( $mediaItem['content'] ) ) );
 		$this->assertTrue( ( null === $mediaItem['date'] || is_string( $mediaItem['date'] ) ) );
 		$this->assertTrue( ( null === $mediaItem['dateGmt'] || is_string( $mediaItem['dateGmt'] ) ) );
 		$this->assertTrue( ( null === $mediaItem['description'] || is_string( $mediaItem['description'] ) ) );
@@ -266,7 +263,6 @@ class MediaItemQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertTrue( ( empty( $mediaItem['editLast'] ) || is_integer( $mediaItem['editLast']['userId'] ) ) );
 		$this->assertTrue( ( empty( $mediaItem['editLock'] ) || is_string( $mediaItem['editLock']['editTime'] ) ) );
 		$this->assertTrue( ( null === $mediaItem['enclosure'] || is_string( $mediaItem['enclosure'] ) ) );
-		$this->assertTrue( ( null === $mediaItem['excerpt'] || is_string( $mediaItem['excerpt'] ) ) );
 		$this->assertTrue( ( null === $mediaItem['guid'] || is_string( $mediaItem['guid'] ) ) );
 		$this->assertEquals( $attachment_global_id, $mediaItem['id'] );
 		$this->assertEquals( $attachment_id, $mediaItem['mediaItemId'] );


### PR DESCRIPTION
# BREAKING CHANGE

This is a breaking change as it removes fields from the Schema. (both query fields and mutation input field)

What does this implement/fix? Explain your changes.
---------------------------------------------------
This adjusts the schema for PostObjects to only expose fields if the post_type registry registers support for them. 

The fields affected are those that `post_type_supports` allows: https://codex.wordpress.org/Function_Reference/post_type_supports

Some fields (comments, thumbnail) were already added conditionally based on post_type support, but this carries that logic to the other post_types.  

Does this close any currently open issues?
------------------------------------------
closes #405 

