### PR TITLE
[#332] Added support for stati parameter as list of enums

### DIFF
--- a/src/Type/PostObject/Connection/PostObjectConnectionArgs.php
+++ b/src/Type/PostObject/Connection/PostObjectConnectionArgs.php
@@ -244,6 +244,13 @@ class PostObjectConnectionArgs extends WPInputObjectType {
 				],
 
 				/**
+				 * List of post status parameters
+				 */
+				'stati' => [
+					'type' => Types::list_of( Types::post_status_enum() ),
+				],
+
+				/**
 				 * Order & Orderby parameters
 				 *
 				 * @see   : https://codex.wordpress.org/Class_Reference/WP_Query#Order_.26_Orderby_Parameters

--- a/src/Type/PostObject/Connection/PostObjectConnectionResolver.php
+++ b/src/Type/PostObject/Connection/PostObjectConnectionResolver.php
@@ -335,6 +335,7 @@ class PostObjectConnectionResolver extends ConnectionResolver {
 			'hasPassword'  => 'has_password',
 			'password'     => 'post_password',
 			'status'       => 'post_status',
+			'stati'        => 'post_status',
 			'dateQuery'    => 'date_query',
 		];
 

--- a/tests/functional/PostListWithDifferentStatusCept.php
+++ b/tests/functional/PostListWithDifferentStatusCept.php
@@ -1,0 +1,58 @@
+<?php
+
+$I = new FunctionalTester( $scenario );
+$I->wantTo( 'Get posts with different post_status' );
+
+/**
+ * Clear posts table.
+ */
+$I->dontHavePostInDatabase([], true);
+
+$test_posts_statuses = ['publish', 'draft', 'future'];
+foreach ($test_posts_statuses as $post_status) {
+	// Add post for each type.
+	$I->havePostInDatabase( [
+		'post_type'    => 'post',
+		'post_status'  => $post_status,
+		'post_title'   => "test {$post_status} post",
+		'post_content' => "test {$post_status} content"
+	] );
+}
+
+/**
+ * Set the content-type so we get only posts with status published and draft.
+ */
+$I->haveHttpHeader( 'Content-Type', 'application/json' );
+$I->sendPOST( 'http://wpgraphql.test/graphql', json_encode( [
+	'query' => '
+	{
+		posts( where: { stati: [ PUBLISH, DRAFT ] } ){
+			edges {
+				node {
+				    title
+					status
+				}
+			}
+		}
+	}'
+] ) );
+
+$I->seeResponseCodeIs( 200 );
+$I->seeResponseIsJson();
+$response       = $I->grabResponse();
+$response_array = json_decode( $response, true );
+
+/**
+ * Make sure query is valid and has no errors
+ */
+$I->assertArrayNotHasKey( 'errors', $response_array );
+
+/**
+ * Make sure response is properly returning data as expected
+ */
+$I->assertArrayHasKey( 'data', $response_array );
+
+// Only 2 posts are returned
+$I->assertEquals( 2, count( $response_array['data']['posts']['edges'] ) );
+$I->assertEquals( 'test publish post', $response_array['data']['posts']['edges'][0]['node']['title'] );
+$I->assertEquals( 'test draft post', $response_array['data']['posts']['edges'][1]['node']['title'] );

--- a/tests/wpunit/PostObjectConnectionQueriesTest.php
+++ b/tests/wpunit/PostObjectConnectionQueriesTest.php
@@ -501,7 +501,7 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$mock_args = [
 			'hasPassword' => true,
 			'password'    => 'myPostPassword123',
-			'status'      => [ 'publish', 'private' ],
+			'status'      => 'publish',
 			'dateQuery'   => array(
 				array(
 					'year'  => 2012,
@@ -518,7 +518,7 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		 */
 		$this->assertTrue( $actual['has_password'] );
 		$this->assertEquals( 'myPostPassword123', $actual['post_password'] );
-		$this->assertEquals( [ 'publish', 'private' ], $actual['post_status'] );
+		$this->assertEquals( 'publish', $actual['post_status'] );
 		$this->assertEquals(
 			array(
 				array(
@@ -536,6 +536,24 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertArrayNotHasKey( 'password', $actual );
 		$this->assertArrayNotHasKey( 'status', $actual );
 		$this->assertArrayNotHasKey( 'dateQuery', $actual );
+	}
+
+	public function testSanitizeInputFieldsListOfPostStatusEnum() {
+		$mock_args = [
+			'stati'      =>  [ 'publish', 'private' ],
+		];
+
+		$actual = \WPGraphQL\Type\PostObject\Connection\PostObjectConnectionResolver::sanitize_input_fields( $mock_args, null, [], $this->app_context, $this->app_info );
+
+		/**
+		 * Make sure the returned values are equal to mock args
+		 */
+		$this->assertEquals( ['publish', 'private'], $actual['post_status'] );
+
+		/**
+		 * Make sure the query didn't return these array values
+		 */
+		$this->assertArrayNotHasKey( 'status', $actual );
 	}
 
 	/**


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Added query parameter `stati` as listOf enums for post_status
```
{
  posts( where: { stati: [ PUBLISH, DRAFT ] } ) {
    ...
  }
}
```

Does this close any currently open issues?
------------------------------------------
#332 

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
https://drive.google.com/file/d/1WcQesulilsDYzdp_PBLzYSaqMDZ_er02/view

Where has this been tested?
---------------------------
Testing was done using Docker.

WordPress: 4.9.4
PHP: 7.2
Apache