### PR TITLE
Prevent CORS-error in Chrome when using Apollo

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -203,6 +203,7 @@ class Router {
 		$headers = [
 			'Access-Control-Allow-Origin'  => '*',
 			'Access-Control-Allow-Headers' => implode( ', ', $access_control_allow_headers ),
+			'Access-Control-Allow-Credentials' => 'true',
 			'Content-Type'                 => 'application/json ; charset=' . get_option( 'blog_charset' ),
 			'X-Robots-Tag'                 => 'noindex',
 			'X-Content-Type-Options'       => 'nosniff',


### PR DESCRIPTION
We saw an error in Chrome complaining that the error "Access-Control-Allow-Credentials" was an empty string when it needed to be "true"; this corrects for that.

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
We saw an error in Chrome, when using graphql cross-domain, complaining that the error "Access-Control-Allow-Credentials" was an empty string when it needed to be "true"; this corrects for that.


Does this close any currently open issues?
------------------------------------------
No


Any relevant logs, error output, GraphiQL screenshots, etc?
No


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …
Mac OS, Chrome

**WordPress Version:** …
4.9.4