### PR TITLE
#436 - fix orderby mapping of post__in, post_name__in and post_parent__in

### DIFF
--- a/src/Type/PostObject/Connection/PostObjectConnectionResolver.php
+++ b/src/Type/PostObject/Connection/PostObjectConnectionResolver.php
@@ -157,16 +157,21 @@ class PostObjectConnectionResolver extends ConnectionResolver {
 		/**
 		 * Map the orderby inputArgs to the WP_Query
 		 */
-		if ( ! empty( $args['where']['orderby'] ) && is_array( $args['where']['orderby'] ) ) {
-			$query_args['orderby'] = [];
-			foreach ( $args['where']['orderby'] as $orderby_input ) {
-				if ( ! empty( $orderby_input['field'] ) ) {
-					$query_args['orderby'] = [
-						esc_sql( $orderby_input['field'] ) => esc_sql( $orderby_input['order'] ),
-					];
-				}
-			}
-		}
+		 if ( ! empty( $args['where']['orderby'] ) && is_array( $args['where']['orderby'] ) ) {
+ 			$query_args['orderby'] = [];
+ 			foreach ( $args['where']['orderby'] as $orderby_input ) {
+ 				/**
+ 				 * These orderby options should not include the order parameter.
+ 				 */
+ 				if ( in_array( $orderby_input['field'], [ 'post__in', 'post_name__in', 'post_parent__in' ], true ) ) {
+ 					$query_args['orderby'] = esc_sql( $orderby_input['field'] );
+ 				} else if ( ! empty( $orderby_input['field'] ) ) {
+ 					$query_args['orderby'] = [
+ 						esc_sql( $orderby_input['field'] ) => esc_sql( $orderby_input['order'] ),
+ 					];
+ 				}
+ 			}
+ 		}
 
 		/**
 		 * If there's no orderby params in the inputArgs, set order based on the first/last argument


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This fixes the orderby mapping of post__in, post_name__in and post_parent__in so that the order value is not included as that is not respected by WP_Query. See: https://codex.wordpress.org/Class_Reference/WP_Query#Order_.26_Orderby_Parameters



Does this close any currently open issues?
------------------------------------------
addresses #436


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
Here's screenshots of before/after showing the order not properly working, then working with the fix in place.

![screen shot 2018-05-02 at 10 01 51 am](https://user-images.githubusercontent.com/1260765/39534927-ebbd098a-4def-11e8-97dc-206b46aa7c5b.png)

![screen shot 2018-05-02 at 10 02 12 am](https://user-images.githubusercontent.com/1260765/39534930-ec69eb82-4def-11e8-86fc-4f22f0323746.png)
