### PR TITLE
No JSON Response when exceptions occur outside of do_graphql_request

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -442,20 +442,10 @@ class Router {
 					 * Send the JSON response
 					 */
 					$server = \WPGraphQL::server();
-					$result = $server->executeRequest();
+					$response = $server->executeRequest();
 
-					self::after_execute( $result, $operation_name, $request, $variables, $graphql_results );
+					self::after_execute( $response, $operation_name, $request, $variables, $graphql_results );
 
-					/**
-					 * Send the response
-					 */
-					wp_send_json( $result );
-
-				} elseif ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
-					/**
-					 * Headers will already be set if this function is called within AJAX.
-					 */
-					wp_send_json( $response );
 				}
 
 			}
@@ -471,6 +461,11 @@ class Router {
 			self::$http_status_code = 500;
 			$response['errors']     = [ FormattedError::createFromException( $error ) ];
 		} // End try().
+
+		/**
+		 * Send the response
+		 */
+		wp_send_json( $response );
 
 	}
 

--- a/src/Router.php
+++ b/src/Router.php
@@ -426,9 +426,6 @@ class Router {
 
 				self::after_execute( $response, $operation_name, $request, $variables, $graphql_results );
 
-				wp_send_json( $response );
-
-
 			} else {
 
 				/**


### PR DESCRIPTION
- This adjusts the `wp_send_json` to happen _after_ the try/catch in the router, allowing for exceptions to properly be returned in the JSON response


What does this implement/fix? Explain your changes.
---------------------------------------------------
This moves the `wp_send_json()` to happen after the try/catch so that exceptions, even those outside of the `do_graphql_request` execution are returned properly in the JSON response.

Does this close any currently open issues?
------------------------------------------
This addresses #442. Thanks for reporting @dlh01!


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
Below is a screenshot showing that a misconfigured post type returns the exception on why the post_type isn't showing in the Schema (the original use case reported by @dlh01)

When registering a post_type with `'show_in_graphql' => true`, but _not_ defining a `graphql_single_name` or `graphql_plural_name` the JSON response now properly shows the exception, explaining that the post_type needs those fields as well.

<img width="1680" alt="screen shot 2018-05-12 at 12 12 58 pm" src="https://user-images.githubusercontent.com/1260765/39960316-f12128ca-55dd-11e8-8bf8-7aa8ebf59143.png">
