### PR TITLE
fix bug with setting the parentId for postObjects

### DIFF
--- a/src/Type/PostObject/Mutation/PostObjectMutation.php
+++ b/src/Type/PostObject/Mutation/PostObjectMutation.php
@@ -238,7 +238,7 @@ class PostObjectMutation {
 		}
 
 		$parent_id_parts = ! empty( $input['parentId'] ) ? Relay::fromGlobalId( $input['parentId'] ) : null;
-		if ( is_array( $parent_id_parts ) && ! empty( $parent_id_parts['id'] ) && is_int( $parent_id_parts['id'] ) ) {
+		if ( is_array( $parent_id_parts ) && ! empty( $parent_id_parts['id'] ) && absint( $parent_id_parts['id'] ) ) {
 			$insert_post_args['post_parent'] = absint( $parent_id_parts['id'] );
 		}
 


### PR DESCRIPTION
This fixes a bug when setting a parentId for postObjectMutations. 

The global ID isn't always cast as an integer, sometimes it's a string. This makes sure to respect integers and integers cast as strings.