### PR TITLE
Add docker-compose file for local / user testing.

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,57 @@
+# This file provides a local environment that is *separate* and *isolated* from
+# the one provided by docker-compose.yml. This allows you to have one
+# environment for automated tests and another for user testing / browsing.
+#
+# Edit your /etc/hosts file to add an entry for wpgraphql.example, e.g.:
+#
+# 127.0.0.1 localhost wpgraphql.example
+#
+# Next, start the environment. The `-f` flag is necessary to restrict your
+# commands to this docker-compose file:
+#
+# docker-compose -f docker-compose.dev.yml up -d
+#
+# After about 30 seconds, you will be able to access http://wpgraphql.example
+# in your browser.
+#
+# Stop the environment with:
+#
+# docker-compose -f docker-compose.dev.yml stop
+
+version: "3"
+
+services:
+  wpgraphql:
+    image: "wordpress:${WP_VERSION:-4.9.4}-php${PHP_VERSION:-7.2}-apache"
+    depends_on:
+      - mysql
+    environment:
+      VIRTUAL_HOST: "wpgraphql.example"
+      WORDPRESS_DB_HOST: "mysql"
+      WORDPRESS_DB_NAME: "wpgraphql"
+      WORDPRESS_DB_PASSWORD: "testing"
+      WORDPRESS_DB_USER: "root"
+    networks:
+      - "dev"
+    volumes:
+      - "./:/var/www/html/wp-content/plugins/wp-graphql"
+  mysql:
+    image: "mariadb:10.2"
+    environment:
+      MYSQL_DATABASE: "wpgraphql"
+      MYSQL_ROOT_PASSWORD: "testing"
+    networks:
+      - "dev"
+  proxy:
+    image: "jwilder/nginx-proxy:alpine"
+    ports:
+      - "80:80"
+    networks:
+      dev:
+        aliases:
+          - "wpgraphql.example"
+    volumes:
+      - "/var/run/docker.sock:/tmp/docker.sock:ro"
+
+networks:
+  dev: {}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,7 +6,11 @@
 #
 # 127.0.0.1 localhost wpgraphql.example
 #
-# Next, start the environment. The `-f` flag is necessary to restrict your
+# Next, make sure you're logged into Docker.
+#
+# docker login
+#
+# Then, start the environment. The `-f` flag is necessary to restrict your
 # commands to this docker-compose file:
 #
 # docker-compose -f docker-compose.dev.yml up -d


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Provides a separate, isolated local environment for user testing in the browser, accessible by default at http://wpgraphql.example. Environment can be started with:

```
docker-compose -f docker-compose.dev.yml up -d
```

Where has this been tested?
---------------------------
Docker on OS X