### PR TITLE
Check for duplicate declaration of graphql_init

### DIFF
--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -731,17 +731,19 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 	}
 endif;
 
-/**
- * Function that instantiates the plugins main class
- *
- * @since 0.0.1
- */
-function graphql_init() {
-
+if ( ! function_exists( 'graphql_init' ) ) {
 	/**
-	 * Return an instance of the action
+	 * Function that instantiates the plugins main class
+	 *
+	 * @since 0.0.1
 	 */
-	return \WPGraphQL::instance();
+	function graphql_init() {
+
+		/**
+		 * Return an instance of the action
+		 */
+		return \WPGraphQL::instance();
+	}
 }
 graphql_init();
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR prevents a fatal error due to duplicate declaration of the `graphql_init` method in `wp-graphql.php`. This error is a possibility in the case that multiple themes or plugins include `wp-graphql` as a composer repository or the code is otherwise used in multiple locations in a single WP instance. 

Where has this been tested?
---------------------------
**Operating System:** MacOS 10.13.4

**WordPress Version:** 4.9.6
