### PR TITLE
Populate $request variable for POST requests

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -441,6 +441,9 @@ class Router {
 					$server = \WPGraphQL::server();
 					$response = $server->executeRequest();
 
+					$helper = new \GraphQL\Server\Helper();
+					$request = $helper->parseHttpRequest();
+
 					self::after_execute( $response, $operation_name, $request, $variables, $graphql_results );
 
 				}


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
In the `WPGraphQL\Router` class currently the `after_execute` function receives an empty `$request` parameter for POST requests. GET requests are fine. Now the variable will contain the original request data. This will be useful for filters such as `graphql_request_results`


Does this close any currently open issues?
------------------------------------------
No


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
Currently, if you add this filter: 
```
function filter_result( $result, $schema, $operation, $request, $variables ) {
  error_log( print_r( [ 'request' => $request, 'result' => $result ], true ) );
  return true;
}
add_filter( 'graphql_request_results', 'filter_result', 10, 5);
```

You get this output (an empty variable): https://ghostbin.com/paste/2cyte


Where has this been tested?
---------------------------
**WordPress Version:** 4.9.6
