### PR TITLE
Feature/#435 - featured image field on post mutation

### DIFF
--- a/src/Type/PostObject/Mutation/PostObjectMutation.php
+++ b/src/Type/PostObject/Mutation/PostObjectMutation.php
@@ -105,9 +105,9 @@ class PostObjectMutation {
 				 * Add input for the featuredImage
 				 */
 				$input_fields['featuredImage'] = [
-					'description' => __( 'The featured image attached to the post.', 'wp-graphql' ),
+					'description' => __( 'The mutation input for the featured image attached to the post.', 'wp-graphql' ),
 					'type' => new WPInputObjectType( [
-						'name'        => $post_type_object->graphql_single_name . 'FeaturedImageNode',
+						'name'        => ucfirst( $post_type_object->graphql_single_name ) . 'FeaturedImageNodeInput',
 						'description' => __( 'The featured image node.', 'wp-graphql' ),
 						'fields' => [
 							'id'            => [

--- a/src/Type/PostObject/Mutation/PostObjectMutation.php
+++ b/src/Type/PostObject/Mutation/PostObjectMutation.php
@@ -99,6 +99,86 @@ class PostObjectMutation {
 				],
 			];
 
+			if ( post_type_supports( $post_type_object->name, 'thumbnail' ) ) {
+
+				/**
+				 * Add input for the featuredImage
+				 */
+				$input_fields['featuredImage'] = [
+					'description' => __( 'The featured image attached to the post.', 'wp-graphql' ),
+					'type' => new WPInputObjectType( [
+						'name'        => $post_type_object->graphql_single_name . 'FeaturedImageNode',
+						'description' => __( 'The featured image node.', 'wp-graphql' ),
+						'fields' => [
+							'id'            => [
+								'type'        => Types::id(),
+								'description' => __( 'The global ID of the featured mediaItemId.', 'wp-graphql' ),
+							],
+							'mediaItemId'   => [
+								'type'        => Types::int(),
+								'description' => __( 'The local ID of the featured mediaItem.', 'wp-graphql' ),
+							],
+							'sourceUrl'     => [
+								'type'        => Types::string(),
+								'description' => __( 'The URL or file path to the mediaItem', 'wp-graphql' ),
+							],
+							'altText'       => [
+								'type'        => Types::string(),
+								'description' => __( 'Alternative text to display when mediaItem is not displayed', 'wp-graphql' ),
+							],
+							'authorId'      => [
+								'type'        => Types::id(),
+								'description' => __( 'The userId to assign as the author of the mediaItem', 'wp-graphql' ),
+							],
+							'caption'       => [
+								'type'        => Types::string(),
+								'description' => __( 'The caption for the mediaItem', 'wp-graphql' ),
+							],
+							'commentStatus' => [
+								'type'        => Types::string(),
+								'description' => __( 'The comment status for the mediaItem', 'wp-graphql' ),
+							],
+							'date'          => [
+								'type'        => Types::string(),
+								'description' => __( 'The date of the mediaItem', 'wp-graphql' ),
+							],
+							'dateGmt'       => [
+								'type'        => Types::string(),
+								'description' => __( 'The date (in GMT zone) of the mediaItem', 'wp-graphql' ),
+							],
+							'description'   => [
+								'type'        => Types::string(),
+								'description' => __( 'Description of the mediaItem', 'wp-graphql' ),
+							],
+							'fileType'      => [
+								'type'        => Types::mime_type_enum(),
+								'description' => __( 'The file type of the mediaItem', 'wp-graphql' ),
+							],
+							'slug'          => [
+								'type'        => Types::string(),
+								'description' => __( 'The slug of the mediaItem', 'wp-graphql' ),
+							],
+							'status'        => [
+								'type'        => Types::media_item_status_enum(),
+								'description' => __( 'The status of the mediaItem', 'wp-graphql' ),
+							],
+							'title'         => [
+								'type'        => Types::string(),
+								'description' => __( 'The title of the mediaItem', 'wp-graphql' ),
+							],
+							'pingStatus'    => [
+								'type'        => Types::string(),
+								'description' => __( 'The ping status for the mediaItem', 'wp-graphql' ),
+							],
+							'parentId'      => [
+								'type'        => Types::id(),
+								'description' => __( 'The WordPress post ID or the graphQL postId of the parent object', 'wp-graphql' ),
+							],
+						],
+					] ),
+				];
+			}
+
 			/**
 			 * Add inputs for connected taxonomies
 			 */

--- a/src/Type/PostObject/Mutation/PostObjectMutation.php
+++ b/src/Type/PostObject/Mutation/PostObjectMutation.php
@@ -400,6 +400,13 @@ class PostObjectMutation {
 		}
 
 		/**
+		 * Set the post's featured image
+		 */
+		if ( ! empty( $input['featuredImage'] ) ) {
+			self::handle_featured_image_input( $post_id, $input['featuredImage'] );
+		}
+
+		/**
 		 * Set the object terms
 		 *
 		 * @param int           $post_id          The ID of the postObject being mutated
@@ -664,6 +671,376 @@ class PostObjectMutation {
 		 */
 		return ! empty( $created_term['term_id'] ) ? $created_term['term_id'] : 0;
 
+	}
+
+	/**
+	 * Check whether a file extension type is allowed by WordPress
+	 *
+	 * @access public
+	 *
+	 * @return array
+	 */
+	public static function allowed_file_types() {
+
+
+		$allowed_file_types = [];
+		$mime_types         = get_allowed_mime_types();
+
+		foreach ( $mime_types as $type => $mime_type ) {
+
+			$extras = explode( '|', $type );
+
+			foreach ( $extras as $extra ) {
+				$allowed_file_types[] = $extra;
+			}
+		}
+
+		return $allowed_file_types;
+	}
+
+	/**
+	 * Get the WordPress ID from both global id and mediaItemId
+	 *
+	 * @param $current_id
+	 *
+	 * @return int|string
+	 */
+	public static function get_wp_attachment_id( $current_id ) {
+
+		if ( is_numeric( $current_id ) ) {
+			$wp_id = $current_id;
+		} else {
+			$current_id_parts = Relay::fromGlobalId( $current_id );
+			$wp_id            = $current_id_parts['id'];
+		}
+
+		return absint( $wp_id );
+	}
+
+	/**
+	 * Handle the featured image GraphQL input
+	 *
+	 * @access public
+	 * @param $new_post_id int The WP ID of the post
+	 * @param $featured_image_node
+	 */
+	public static function handle_featured_image_input( $new_post_id, $featured_image_node ) {
+
+		/**
+		 * If the featuredImage node is set to null, the featured image has been removed, so delete it from the post
+		 */
+		if ( is_null( $featured_image_node ) ) {
+			delete_post_meta( $new_post_id, '_thumbnail_id' );
+		}
+
+		/**
+		 * Get the local id of the attachment if it exists
+		 */
+		if ( ! empty( $featured_image_node['id'] ) ) {
+			$wp_featured_image_id = self::get_wp_attachment_id( $featured_image_node['id'] );
+			if ( empty( $wp_featured_image_id ) ) {
+				throw new UserError( __( 'Sorry, we could not find an image that matched that id.', 'dfm-graphql-extensions' ) );
+			}
+		} elseif ( ! empty( $featured_image_node['mediaItemId'] ) ) {
+
+			$wp_featured_image_id = self::get_wp_attachment_id( $featured_image_node['mediaItemId'] );
+			if ( empty( $wp_featured_image_id ) ) {
+				throw new UserError( __( 'Sorry, we could not find an image that matched that mediaItemId.', 'dfm-graphql-extensions' ) );
+			}
+		} else {
+			$wp_featured_image_id = false;
+		}
+
+		/**
+		 * If the file doesn't exist locally then we need the sourceUrl field to upload it
+		 */
+		if ( empty( $wp_featured_image_id ) && ! empty( $featured_image_node['sourceUrl'] ) ) {
+
+			/**
+			 * Create the image using the sourceUrl and inputs
+			 */
+			$image_id = self::create_image( $new_post_id, $featured_image_node );
+			set_post_thumbnail( absint( $new_post_id ), $image_id );
+
+		}
+
+		/**
+		 * If the image exists and the user isn't changing the sourceUrl, update it
+		 */
+		if ( ! empty( $wp_featured_image_id ) && empty( $featured_image_node['sourceUrl'] ) ) {
+
+			/**
+			 * Update the image using the inputs
+			 */
+			$image_id = self::update_image( $wp_featured_image_id, $featured_image_node );
+			set_post_thumbnail( absint( $new_post_id ), $image_id );
+		}
+
+		/**
+		 * Don't let the user change an existing image's sourceUrl
+		 */
+		if ( ! empty( $wp_featured_image_id ) && ! empty( $featured_image_node['sourceUrl'] ) ) {
+			throw new UserError( __( 'Sorry, you cannot change the sourceUrl on an existing image. Either input a sourceUrl to create a new image or add an existing image id', 'dfm-graphql-extensions' ) );
+		}
+
+	}
+
+	/**
+	 * Create an image in WordPress using GraphQL inputs
+	 *
+	 * @param $new_post_id
+	 * @param $input
+	 *
+	 * @return int|\WP_Error
+	 */
+	public static function create_image( $new_post_id, $input ) {
+
+		/**
+		 * Set the file name, whether it's a local file or from a URL.
+		 * Then set the url for the uploaded file
+		 */
+		$uploaded_file_url = $input['sourceUrl'];
+
+		/**
+		 * Require the file.php file from wp-admin. This file includes the
+		 * download_url and wp_handle_sideload methods
+		 */
+		require_once( ABSPATH . 'wp-admin/includes/file.php' );
+
+		$file           = $uploaded_file_url;
+		$filename       = basename( $file );
+		$file_data      = pathinfo( $filename );
+		$file_extension = $file_data['extension'];
+		$allowed_types  = self::allowed_file_types();
+		$type_exists    = in_array( $file_extension, $allowed_types, true );
+
+		if ( false === $type_exists ) {
+			throw new UserError( __( 'Sorry, the URL for this file is invalid, it must be a valid URL', 'dfm-graphql-extensions' ) );
+		}
+
+		/**
+		 * If the file type is allowed, upload it
+		 */
+		$upload_file = wp_upload_bits( $filename, null, file_get_contents( $file ) );
+
+		/**
+		 * Build the file data for side loading
+		 */
+		$file = [
+			'name'     => $filename,
+			'type'     => wp_check_filetype( $upload_file['file'] ),
+			'tmp_name' => basename( $upload_file['file'] ),
+			'error'    => 0,
+			'size'     => filesize( $upload_file['file'] ),
+		];
+
+		/**
+		 * Insert the mediaItem object and get the ID
+		 */
+		$media_item_args = self::prepare_media_item( $new_post_id, $input, $file );
+
+		/**
+		 * Insert the mediaItem
+		 *
+		 * Required Argument defaults are set in prepare_media_item method if they aren't set
+		 * by the user during input, they are:
+		 * post_title (pulled from file if not entered)
+		 * post_content (empty string if not entered)
+		 * post_status (inherit if not entered)
+		 * post_mime_type (pulled from the file if not entered in the mutation)
+		 */
+		$attachment_id = wp_insert_attachment( $media_item_args, $upload_file['file'], $media_item_args['post_parent'] );
+
+		/**
+		 * Check if the wp_generate_attachment_metadata method exists and include it if not
+		 */
+		require_once( ABSPATH . 'wp-admin/includes/image.php' );
+
+		/**
+		 * Generate and update the mediaItem's metadata.
+		 * If we make it this far the file and attachment
+		 * have been validated and we will not receive any errors
+		 */
+		$attachment_data = wp_generate_attachment_metadata( $attachment_id, $upload_file['file'] );
+		wp_update_attachment_metadata( $attachment_id, $attachment_data );
+
+		return $attachment_id;
+
+	}
+
+	/**
+	 * Update an image in WordPress using GraphQL inputs
+	 *
+	 * @param $image_id
+	 * @param $input
+	 *
+	 * @return bool|int|\WP_Error
+	 */
+	public static function update_image( $image_id, $input ) {
+
+		/**
+		 * Set the $update_post_args
+		 */
+		$update_post_args = [];
+
+		/**
+		 * Prepare the data for inserting the mediaItem
+		 * NOTE: These are organized in the same order as: http://v2.wp-api.org/reference/media/#schema-meta
+		 */
+		if ( ! empty( $input['date'] ) && false !== strtotime( $input['date'] ) ) {
+			$update_post_args['post_date'] = date( 'Y-m-d H:i:s', strtotime( $input['date'] ) );
+		}
+
+		if ( ! empty( $input['dateGmt'] ) && false !== strtotime( $input['dateGmt'] ) ) {
+			$update_post_args['post_date_gmt'] = date( 'Y-m-d H:i:s', strtotime( $input['dateGmt'] ) );
+		}
+
+		if ( ! empty( $input['slug'] ) ) {
+			$update_post_args['post_name'] = $input['slug'];
+		}
+
+		if ( ! empty( $input['status'] ) ) {
+			$update_post_args['post_status'] = $input['status'];
+		}
+
+		if ( ! empty( $input['title'] ) ) {
+			$update_post_args['post_title'] = $input['title'];
+		}
+
+		if ( ! empty( $input['authorId'] ) ) {
+			if ( is_numeric( $input['authorId'] ) ) {
+				$update_post_args['post_author'] = $input['authorId'];
+			} else {
+				$id_parts                        = Relay::fromGlobalId( $input['authorId'] );
+				$update_post_args['post_author'] = $id_parts['id'];
+			}
+		}
+
+		if ( ! empty( $input['commentStatus'] ) ) {
+			$update_post_args['comment_status'] = $input['commentStatus'];
+		}
+
+		if ( ! empty( $input['pingStatus'] ) ) {
+			$update_post_args['ping_status'] = $input['pingStatus'];
+		}
+
+		if ( ! empty( $input['caption'] ) ) {
+			// Replace the leftover newline character in the caption
+			$caption = preg_replace( '/(?<=>)(n)/', '', $input['caption'] );
+			// Strip all HTML Tags from the caption and set it as the post_excerpt
+			$insert_post_args['post_excerpt'] = strip_tags( $caption );
+		}
+
+		if ( ! empty( $input['description'] ) ) {
+			$update_post_args['post_content'] = $input['description'];
+		}
+
+		if ( ! empty( $input['parentId'] ) ) {
+			$update_post_args['post_parent'] = absint( $input['parentId'] );
+		}
+
+		if ( ! empty( $update_post_args ) ) {
+			$update_post_args['ID'] = $image_id;
+			$updated_image_id       = wp_update_post( $update_post_args );
+		} else {
+			$updated_image_id = false;
+		}
+
+		return $updated_image_id;
+	}
+
+	/**
+	 * This prepares the media item for insertion
+	 *
+	 * @param int           $post_parent      The ID of the newly created post that we need to attach this image to
+	 * @param array         $input            The input for the mutation from the GraphQL request
+	 * @param mixed         $file             The mediaItem (attachment) file
+	 *
+	 * @return array $media_item_args
+	 */
+	public static function prepare_media_item( $post_parent, $input, $file ) {
+
+		/**
+		 * Set the post_type (attachment) for the insert
+		 */
+		$insert_post_args['post_type'] = 'attachment';
+
+		/**
+		 * Prepare the data for inserting the mediaItem
+		 * NOTE: These are organized in the same order as: http://v2.wp-api.org/reference/media/#schema-meta
+		 */
+		if ( ! empty( $input['date'] ) && false !== strtotime( $input['date'] ) ) {
+			$insert_post_args['post_date'] = date( 'Y-m-d H:i:s', strtotime( $input['date'] ) );
+		}
+
+		if ( ! empty( $input['dateGmt'] ) && false !== strtotime( $input['dateGmt'] ) ) {
+			$insert_post_args['post_date_gmt'] = date( 'Y-m-d H:i:s', strtotime( $input['dateGmt'] ) );
+		}
+
+		if ( ! empty( $input['slug'] ) ) {
+			$insert_post_args['post_name'] = $input['slug'];
+		}
+
+		if ( ! empty( $input['status'] ) ) {
+			$insert_post_args['post_status'] = $input['status'];
+		} else {
+			$insert_post_args['post_status'] = 'inherit';
+		}
+
+		if ( ! empty( $input['title'] ) ) {
+			$insert_post_args['post_title'] = $input['title'];
+		} elseif ( ! empty( $file['name'] ) ) {
+			$insert_post_args['post_title'] = pathinfo( $file['name'], PATHINFO_FILENAME );
+		}
+
+		if ( empty( $input['authorId'] ) ) {
+			$insert_post_args['post_author'] = get_current_user_id();
+		} else {
+			if ( is_numeric( $input['authorId'] ) ) {
+				$insert_post_args['post_author'] = $input['authorId'];
+			} else {
+				$id_parts                        = Relay::fromGlobalId( $input['authorId'] );
+				$insert_post_args['post_author'] = $id_parts['id'];
+			}
+		}
+
+		if ( ! empty( $input['commentStatus'] ) ) {
+			$insert_post_args['comment_status'] = $input['commentStatus'];
+		}
+
+		if ( ! empty( $input['pingStatus'] ) ) {
+			$insert_post_args['ping_status'] = $input['pingStatus'];
+		}
+
+		/**
+		 * Format the caption properly
+		 */
+		if ( ! empty( $input['caption'] ) ) {
+			// Replace the leftover newline character in the caption
+			$caption = preg_replace( '/(?<=>)(n)/', '', $input['caption'] );
+			// Strip all HTML Tags from the caption and set it as the post_excerpt
+			$insert_post_args['post_excerpt'] = strip_tags( $caption );
+		}
+
+		if ( ! empty( $input['description'] ) ) {
+			$insert_post_args['post_content'] = $input['description'];
+		} else {
+			$insert_post_args['post_content'] = '';
+		}
+
+		if ( ! empty( $input['fileType'] ) ) {
+			$insert_post_args['post_mime_type'] = $input['fileType'];
+		} elseif ( ! empty( $file['type']['type'] ) ) {
+			$insert_post_args['post_mime_type'] = $file['type']['type'];
+		}
+
+		if ( ! empty( $input['parentId'] ) ) {
+			$insert_post_args['post_parent'] = absint( $input['parentId'] );
+		} else {
+			$insert_post_args['post_parent'] = $post_parent;
+		}
+
+		return $insert_post_args;
 	}
 
 	/**

--- a/src/Type/PostObject/Mutation/PostObjectMutation.php
+++ b/src/Type/PostObject/Mutation/PostObjectMutation.php
@@ -772,7 +772,8 @@ class PostObjectMutation {
 			/**
 			 * Update the image using the inputs
 			 */
-			$image_id = self::update_image( $wp_featured_image_id, $featured_image_node );
+			$updated_image_id = self::update_image( $wp_featured_image_id, $featured_image_node );
+			$image_id = ! empty( $updated_image_id ) ? $updated_image_id : $wp_featured_image_id;
 			set_post_thumbnail( absint( $new_post_id ), $image_id );
 		}
 

--- a/tests/wpunit/PostObjectMutationsTest.php
+++ b/tests/wpunit/PostObjectMutationsTest.php
@@ -1142,7 +1142,7 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 					'post' => [
 						'featuredImage' => [
 							'title'     => $new_image_variables['featuredImage']['title'],
-							'sourceUrl' => $actual['data']['updatePost']['post']['updatePost']['sourceUrl'],
+							'sourceUrl' => $actual['data']['updatePost']['post']['featuredImage']['sourceUrl'],
 						],
 					],
 				],

--- a/tests/wpunit/PostObjectMutationsTest.php
+++ b/tests/wpunit/PostObjectMutationsTest.php
@@ -1142,7 +1142,7 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 					'post' => [
 						'featuredImage' => [
 							'title'     => $new_image_variables['featuredImage']['title'],
-							'sourceUrl' => 'http://wpgraphql.test/wp-content/uploads/'. date("Y") . '/' . date('m') . '/giphy.gif',
+							'sourceUrl' => $actual['data']['updatePost']['post']['updatePost']['sourceUrl'],
 						],
 					],
 				],
@@ -1150,6 +1150,8 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 		];
 
 		$this->assertEquals( $expected, $actual );
+		$this->assertArrayHasKey( 'sourceUrl', $actual['data']['updatePost']['post']['featuredImage'] );
+		$this->assertInternalType( 'string', $actual['data']['updatePost']['post']['featuredImage']['sourceUrl'] );
 
 		/**
 		 * Create a media item to add to the post

--- a/tests/wpunit/PostObjectMutationsTest.php
+++ b/tests/wpunit/PostObjectMutationsTest.php
@@ -1016,7 +1016,7 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 						'content'       => apply_filters( 'the_content', $new_image_variables['content'] ),
 						'featuredImage' => [
 							'title'     => $new_image_variables['featuredImage']['title'],
-							'sourceUrl' => 'http://wp-graphql.test/wp-content/uploads/'. date("Y") . '/' . date('m') . '/giphy.gif',
+							'sourceUrl' => 'http://wpgraphql.test/wp-content/uploads/'. date("Y") . '/' . date('m') . '/giphy.gif',
 						],
 					],
 				],
@@ -1147,7 +1147,7 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 					'post' => [
 						'featuredImage' => [
 							'title'     => $new_image_variables['featuredImage']['title'],
-							'sourceUrl' => 'http://wp-graphql.test/wp-content/uploads/'. date("Y") . '/' . date('m') . '/giphy.gif',
+							'sourceUrl' => 'http://wpgraphql.test/wp-content/uploads/'. date("Y") . '/' . date('m') . '/giphy.gif',
 						],
 					],
 				],

--- a/tests/wpunit/PostObjectMutationsTest.php
+++ b/tests/wpunit/PostObjectMutationsTest.php
@@ -30,12 +30,6 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 
 	public function setUp() {
 
-		/**
-		 * Clear the uploads folder
-		 */
-		$_wp_content_upload_dir = WP_CONTENT_DIR . '/uploads';
-		system( 'rm -rf ' . escapeshellarg( $_wp_content_upload_dir ), $retval );
-
 		// before
 		parent::setUp();
 
@@ -1016,7 +1010,7 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 						'content'       => apply_filters( 'the_content', $new_image_variables['content'] ),
 						'featuredImage' => [
 							'title'     => $new_image_variables['featuredImage']['title'],
-							'sourceUrl' => 'http://wpgraphql.test/wp-content/uploads/'. date("Y") . '/' . date('m') . '/giphy.gif',
+							'sourceUrl' => $actual['data']['createPost']['post']['featuredImage']['sourceUrl'],
 						],
 					],
 				],
@@ -1024,7 +1018,8 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 		];
 
 		$this->assertEquals( $expected, $actual );
-
+		$this->assertArrayHasKey( 'sourceUrl', $actual['data']['createPost']['post']['featuredImage'] );
+		$this->assertInternalType( 'string', $actual['data']['createPost']['post']['featuredImage']['sourceUrl'] );
 
 		/**
 		 * Create a media item to add to the post

--- a/tests/wpunit/PostObjectMutationsTest.php
+++ b/tests/wpunit/PostObjectMutationsTest.php
@@ -798,4 +798,130 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
         $this->assertNotNull( $results['data']['post']['dateGmt'] );
     }
 
+	/**
+	 * This processes a mutation to create a post with a featured image
+	 *
+	 * @return array
+	 */
+	public function testCreatePostMutationWithFeaturedImage() {
+
+		wp_set_current_user( $this->admin );
+
+		$mutation = '
+		mutation createPostWithImage( $clientMutationId:String!, $title:String!, $content:String!, $featuredImage:PostFeaturedImageNodeInput! ){
+		  createPost(
+		    input:{
+		      clientMutationId:$clientMutationId,
+		      title:$title
+		      content:$content
+		      featuredImage: $featuredImage
+		    }
+		  ){
+		    clientMutationId
+		    post{
+		      title
+		      content
+		      featuredImage {
+		        title
+		        sourceUrl
+		      }
+		    }
+		  }
+		}
+		';
+
+		$variables = [
+			'clientMutationId' => $this->client_mutation_id,
+			'title'            => 'Post with an Awesome Photo',
+			'content'          => $this->content,
+			'featuredImage'    => [
+				'title' => 'Awesome Photo',
+				'sourceUrl' => 'https://media.giphy.com/media/Z6f7vzq3iP6Mw/giphy.gif',
+			],
+		];
+
+		$actual = do_graphql_request( $mutation, 'createPostWithImage', $variables );
+
+		$expected = [
+			'data' => [
+				'createPost' => [
+					'clientMutationId' => $variables['clientMutationId'],
+					'post' => [
+						'title'         => apply_filters( 'the_title', $variables['title'] ),
+						'content'       => apply_filters( 'the_content', $variables['content'] ),
+						'featuredImage' => [
+							'title'     => $variables['featuredImage']['title'],
+							'sourceUrl' => 'http://wp-graphql.test/wp-content/uploads/'. date("Y") . '/' . date('m') . '/giphy.gif',
+						],
+					],
+				],
+			],
+		];
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * This processes a mutation to create a post with a featured image
+	 *
+	 * @return array
+	 */
+	public function testUpdatePostMutationWithFeaturedImage() {
+
+		wp_set_current_user( $this->admin );
+
+		$mutation = '
+		mutation createPostWithImage( $clientMutationId:String!, $title:String!, $content:String!, $featuredImage:PostFeaturedImageNodeInput! ){
+		  createPost(
+		    input:{
+		      clientMutationId:$clientMutationId,
+		      title:$title
+		      content:$content
+		      featuredImage: $featuredImage
+		    }
+		  ){
+		    clientMutationId
+		    post{
+		      title
+		      content
+		      featuredImage {
+		        title
+		        sourceUrl
+		      }
+		    }
+		  }
+		}
+		';
+
+		$variables = [
+			'clientMutationId' => $this->client_mutation_id,
+			'title'            => 'Post with an Awesome Photo',
+			'content'          => $this->content,
+			'featuredImage'    => [
+				'title' => 'Awesome Photo',
+				'sourceUrl' => 'https://media.giphy.com/media/Z6f7vzq3iP6Mw/giphy.gif',
+			],
+		];
+
+		$actual = do_graphql_request( $mutation, 'createPostWithImage', $variables );
+
+		$expected = [
+			'data' => [
+				'createPost' => [
+					'clientMutationId' => $variables['clientMutationId'],
+					'post' => [
+						'title'         => apply_filters( 'the_title', $variables['title'] ),
+						'content'       => apply_filters( 'the_content', $variables['content'] ),
+						'featuredImage' => [
+							'title'     => $variables['featuredImage']['title'],
+							'sourceUrl' => 'http://wp-graphql.test/wp-content/uploads/'. date("Y") . '/' . date('m') . '/giphy.gif',
+						],
+					],
+				],
+			],
+		];
+
+		$this->assertEquals( $expected, $actual );
+	}
+
 }

--- a/tests/wpunit/PostObjectMutationsTest.php
+++ b/tests/wpunit/PostObjectMutationsTest.php
@@ -12,8 +12,30 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 	public $media_item_id;
 	public $post;
 	public $post_uid;
+	public $create_media_item_variables;
+	public $altText;
+	public $authorId;
+	public $caption;
+	public $commentStatus;
+	public $current_date_gmt;
+	public $date;
+	public $dateGmt;
+	public $description;
+	public $filePath;
+	public $fileType;
+	public $slug;
+	public $status;
+	public $pingStatus;
+	public $parentId;
 
 	public function setUp() {
+
+		/**
+		 * Clear the uploads folder
+		 */
+		$_wp_content_upload_dir = WP_CONTENT_DIR . '/uploads';
+		system( 'rm -rf ' . escapeshellarg( $_wp_content_upload_dir ), $retval );
+
 		// before
 		parent::setUp();
 
@@ -46,7 +68,48 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 		$this->post = $this->factory()->post->create( [
 			'post_author' => $this->admin,
 		] );
-		$this->post_uid = \GraphQLRelay\Relay::toGlobalId( 'post', $this->attachment_id );
+		$this->post_uid = \GraphQLRelay\Relay::toGlobalId( 'post', $this->post );
+
+		/**
+		 * Populate the mediaItem input fields
+		 */
+		$this->altText          = 'A gif of Shia doing Magic.';
+		$this->authorId         = \GraphQLRelay\Relay::toGlobalId( 'user', $this->admin );
+		$this->caption          = 'Shia shows off some magic in this caption.';
+		$this->commentStatus    = 'closed';
+		$this->date             = '2017-08-01 15:00:00';
+		$this->dateGmt          = '2017-08-01T21:00:00';
+		$this->description      = 'This is a magic description.';
+		$this->filePath         = 'http://www.reactiongifs.com/r/mgc.gif';
+		$this->fileType         = 'IMAGE_GIF';
+		$this->slug             = 'magic-shia';
+		$this->status           = 'INHERIT';
+		$this->title            = 'Magic Shia Gif';
+		$this->pingStatus       = 'closed';
+		$this->parentId         = null;
+
+		/**
+		 * Set the createMediaItem mutation input variables
+		 */
+		$this->create_media_item_variables = [
+			'input' => [
+				'filePath'         => $this->filePath,
+				'fileType'         => $this->fileType,
+				'clientMutationId' => $this->client_mutation_id,
+				'title'            => $this->title,
+				'description'      => $this->description,
+				'altText'          => $this->altText,
+				'parentId'         => $this->parentId,
+				'caption'          => $this->caption,
+				'commentStatus'    => $this->commentStatus,
+				'date'             => $this->date,
+				'dateGmt'          => $this->dateGmt,
+				'slug'             => $this->slug,
+				'status'           => $this->status,
+				'pingStatus'       => $this->pingStatus,
+				'authorId'         => $this->authorId,
+			],
+		];
 	}
 
 
@@ -55,6 +118,80 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 
 		// then
 		parent::tearDown();
+	}
+
+	/**
+	 * This function tests the createMediaItem mutation
+	 * and is reused throughout the createMediaItem tests
+	 *
+	 * @source wp-content/plugins/wp-graphql/src/Type/MediaItem/Mutation/MediaItemCreate.php
+	 * @access public
+	 * @return array $actual
+	 */
+	public function createMediaItemMutation() {
+
+		/**
+		 * Set up the createMediaItem mutation
+		 */
+		$mutation = '
+			mutation createMediaItem( $input: CreateMediaItemInput! ){
+			  createMediaItem(input: $input){
+			    clientMutationId
+			    mediaItem{
+			      id
+			      mediaItemId
+			      mediaType
+			      date
+			      dateGmt
+			      slug
+			      status
+			      title
+			      commentStatus
+			      pingStatus
+			      altText
+			      caption
+			      description
+			      mimeType
+			      parent {
+			        ... on Post {
+			          id
+			        }
+			      }
+			      sourceUrl
+			      mediaDetails {
+			          file
+			          height
+			          meta {
+			            aperture
+			            credit
+			            camera
+			            caption
+			            createdTimestamp
+			            copyright
+			            focalLength
+			            iso
+			            shutterSpeed
+			            title
+			            orientation
+			          }
+			          width
+			          sizes {
+			            name
+			            file
+			            width
+			            height
+			            mimeType
+			            sourceUrl
+			          }
+			        }
+			    }
+			  }
+			}
+		';
+
+		$actual = do_graphql_request( $mutation, 'createMediaItem', $this->create_media_item_variables );
+
+		return $actual;
 	}
 
 	/**
@@ -580,9 +717,9 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 
 	public function createPostWithDatesMutation( $input ) {
 
-        wp_set_current_user( $this->admin );
+		wp_set_current_user( $this->admin );
 
-        $mutation = 'mutation createPost( $input:CreatePostInput! ) {
+		$mutation = 'mutation createPost( $input:CreatePostInput! ) {
           createPost(input: $input) {
             post {
               id
@@ -597,161 +734,161 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 		}
         ';
 
-        $defaults = [
-            'clientMutationId' => uniqid(),
-            'title' => 'New Post',
-            'status' => 'PUBLISH',
-        ];
+		$defaults = [
+			'clientMutationId' => uniqid(),
+			'title' => 'New Post',
+			'status' => 'PUBLISH',
+		];
 
-        $input = array_merge( $defaults, $input );
+		$input = array_merge( $defaults, $input );
 
-        $variables = [
-            'input' => $input,
-        ];
+		$variables = [
+			'input' => $input,
+		];
 
-        /**
-         * Run the mutation.
-         */
+		/**
+		 * Run the mutation.
+		 */
 
-        $results = do_graphql_request( $mutation, 'createPost', $variables );
+		$results = do_graphql_request( $mutation, 'createPost', $variables );
 
-	    return $results;
+		return $results;
 	}
 
-    public function testDateInputsForCreatePost() {
+	public function testDateInputsForCreatePost() {
 
-        /**
-         * Set the current user as the admin role so we
-         * can test the mutation
-         */
+		/**
+		 * Set the current user as the admin role so we
+		 * can test the mutation
+		 */
 
-        wp_set_current_user( $this->admin );
+		wp_set_current_user( $this->admin );
 
-        /**
-         * Set the expected date outcome
-         */
+		/**
+		 * Set the expected date outcome
+		 */
 
-        $dateExpected = '2017-01-03 00:00:00';
-        $dateGmtExpected = '2017-01-03T00:00:00';
+		$dateExpected = '2017-01-03 00:00:00';
+		$dateGmtExpected = '2017-01-03T00:00:00';
 
-        $results = $this->createPostWithDatesMutation([
-            'date' => '1/3/2017',
-            'status' => 'PUBLISH'
-        ]);
+		$results = $this->createPostWithDatesMutation([
+			'date' => '1/3/2017',
+			'status' => 'PUBLISH'
+		]);
 
-        /**
-         * Make sure there are no errors
-         */
-        $this->assertArrayNotHasKey( 'errors', $results );
+		/**
+		 * Make sure there are no errors
+		 */
+		$this->assertArrayNotHasKey( 'errors', $results );
 
-        /**
-         * We're expecting the date variable to match the date entry regardless of the way user enters it
-         */
+		/**
+		 * We're expecting the date variable to match the date entry regardless of the way user enters it
+		 */
 
-        $this->assertEquals( $dateExpected, $results['data']['createPost']['post']['date'] );
-        $this->assertEquals( $dateGmtExpected, $results['data']['createPost']['post']['dateGmt'] );
-        $this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modified'] );
-        $this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modifiedGmt'] );
+		$this->assertEquals( $dateExpected, $results['data']['createPost']['post']['date'] );
+		$this->assertEquals( $dateGmtExpected, $results['data']['createPost']['post']['dateGmt'] );
+		$this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modified'] );
+		$this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modifiedGmt'] );
 
-    }
+	}
 
-    public function testDateInputsWithSlashFormattingForCreatePost() {
+	public function testDateInputsWithSlashFormattingForCreatePost() {
 
-        /**
-         * Set the current user as the admin role so we
-         * can test the mutation
-         */
+		/**
+		 * Set the current user as the admin role so we
+		 * can test the mutation
+		 */
 
-        wp_set_current_user( $this->admin );
+		wp_set_current_user( $this->admin );
 
-        /**
-         * Set the input and expected date outcome
-         */
+		/**
+		 * Set the input and expected date outcome
+		 */
 
-        $dateExpected = '2017-01-03 00:00:00';
-        $dateGmtExpected = '2017-01-03T00:00:00';
+		$dateExpected = '2017-01-03 00:00:00';
+		$dateGmtExpected = '2017-01-03T00:00:00';
 
-        $results = $this->createPostWithDatesMutation([
-            'date' => '2017/01/03',
-        ]);
+		$results = $this->createPostWithDatesMutation([
+			'date' => '2017/01/03',
+		]);
 
-        /**
-         * Make sure there are no errors
-         */
+		/**
+		 * Make sure there are no errors
+		 */
 
-        $this->assertArrayNotHasKey( 'errors', $results );
+		$this->assertArrayNotHasKey( 'errors', $results );
 
-        /**
-         * We're expecting the date variable to match the date entry regardless of the way user enters it
-         */
+		/**
+		 * We're expecting the date variable to match the date entry regardless of the way user enters it
+		 */
 
-        $this->assertEquals( $dateExpected, $results['data']['createPost']['post']['date'] );
-        $this->assertEquals( $dateGmtExpected, $results['data']['createPost']['post']['dateGmt'] );
-	    $this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modified'] );
-	    $this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modifiedGmt'] );
+		$this->assertEquals( $dateExpected, $results['data']['createPost']['post']['date'] );
+		$this->assertEquals( $dateGmtExpected, $results['data']['createPost']['post']['dateGmt'] );
+		$this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modified'] );
+		$this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modifiedGmt'] );
 
-    }
+	}
 
-    public function testDateInputsWithStatusPendingAndDashesCreatePost() {
+	public function testDateInputsWithStatusPendingAndDashesCreatePost() {
 
-        /**
-         * Set the current user as the admin role so we
-         * can test the mutation
-         */
+		/**
+		 * Set the current user as the admin role so we
+		 * can test the mutation
+		 */
 
-        wp_set_current_user( $this->admin );
+		wp_set_current_user( $this->admin );
 
-        /**
-         * Set the input and expected date outcome
-         */
+		/**
+		 * Set the input and expected date outcome
+		 */
 
-        $dateExpected = '2017-01-03 00:00:00';
-        $dateGmtExpected = null;
+		$dateExpected = '2017-01-03 00:00:00';
+		$dateGmtExpected = null;
 
-        $results = $this->createPostWithDatesMutation([
-            'date' => '3-1-2017',
-            'status' => 'PENDING'
-        ]);
+		$results = $this->createPostWithDatesMutation([
+			'date' => '3-1-2017',
+			'status' => 'PENDING'
+		]);
 
-        /**
-         * Make sure there are no errors
-         */
+		/**
+		 * Make sure there are no errors
+		 */
 
-        $this->assertArrayNotHasKey( 'errors', $results );
+		$this->assertArrayNotHasKey( 'errors', $results );
 
-        /**
-         * We're expecting the date variable to match the date entry regardless of the way user enters it
-         */
+		/**
+		 * We're expecting the date variable to match the date entry regardless of the way user enters it
+		 */
 
-        $this->assertEquals( $dateExpected, $results['data']['createPost']['post']['date'] );
-        $this->assertEquals( $dateGmtExpected, $results['data']['createPost']['post']['dateGmt'] );
-	    $this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modified'] );
-	    $this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modifiedGmt'] );
+		$this->assertEquals( $dateExpected, $results['data']['createPost']['post']['date'] );
+		$this->assertEquals( $dateGmtExpected, $results['data']['createPost']['post']['dateGmt'] );
+		$this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modified'] );
+		$this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modifiedGmt'] );
 
-    }
+	}
 
-    public function testDateInputsWithDraftAndPublishUpdatePost() {
+	public function testDateInputsWithDraftAndPublishUpdatePost() {
 
-        /**
-         * Set the current user as the admin role so we
-         * can test the mutation
-         */
-        wp_set_current_user( $this->admin );
+		/**
+		 * Set the current user as the admin role so we
+		 * can test the mutation
+		 */
+		wp_set_current_user( $this->admin );
 
-        /**
-         * Create a post to test against and set global ID
-         */
-        $test_post = $this->factory()->post->create( [
-            'post_title' => 'My Test Post',
-            'post_status' => 'draft',
-        ] );
+		/**
+		 * Create a post to test against and set global ID
+		 */
+		$test_post = $this->factory()->post->create( [
+			'post_title' => 'My Test Post',
+			'post_status' => 'draft',
+		] );
 
-        $global_id = \GraphQLRelay\Relay::toGlobalId( 'post', $test_post );
+		$global_id = \GraphQLRelay\Relay::toGlobalId( 'post', $test_post );
 
-        /**
-         * Prepare mutation for GQL request
-         */
-        $request = '
+		/**
+		 * Prepare mutation for GQL request
+		 */
+		$request = '
         {
             post( id: "'. $global_id . '" ) {
               id
@@ -765,63 +902,63 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
         }
         ';
 
-        /**
-         * Run GQl request
-         */
-        $results = do_graphql_request( $request );
+		/**
+		 * Run GQl request
+		 */
+		$results = do_graphql_request( $request );
 
-        /**
-         * Set the expected dateGmt outcome
-         */
-        $dateGmtExpected = null;
+		/**
+		 * Set the expected dateGmt outcome
+		 */
+		$dateGmtExpected = null;
 
-        /**
-         * Assert results dateGmt equals the expected outcome
-         */
-        $this->assertEquals( $dateGmtExpected, $results['data']['post']['dateGmt'] );
+		/**
+		 * Assert results dateGmt equals the expected outcome
+		 */
+		$this->assertEquals( $dateGmtExpected, $results['data']['post']['dateGmt'] );
 
-        /**
-         * Update post to test against status: published
-         */
-        wp_update_post( [
-            'ID'          => $test_post,
-            'post_status' => 'publish',
-        ] );
+		/**
+		 * Update post to test against status: published
+		 */
+		wp_update_post( [
+			'ID'          => $test_post,
+			'post_status' => 'publish',
+		] );
 
-        /**
-         * Run GQl request
-         */
-        $results = do_graphql_request( $request );
+		/**
+		 * Run GQl request
+		 */
+		$results = do_graphql_request( $request );
 
-        /**
-         * Assert timestamp is not null
-         */
-        $this->assertNotNull( $results['data']['post']['dateGmt'] );
+		/**
+		 * Assert timestamp is not null
+		 */
+		$this->assertNotNull( $results['data']['post']['dateGmt'] );
 
-        /**
-         * Update post back to draft
-         */
-        wp_update_post( [
-            'ID' => $test_post,
-            'post_status' => 'draft'
-        ] );
+		/**
+		 * Update post back to draft
+		 */
+		wp_update_post( [
+			'ID' => $test_post,
+			'post_status' => 'draft'
+		] );
 
-        /**
-         * Run GQl request
-         */
-        $results = do_graphql_request( $request );
+		/**
+		 * Run GQl request
+		 */
+		$results = do_graphql_request( $request );
 
-        /**
-         * Assert timestamp is STILL not null
-         */
-        $this->assertNotNull( $results['data']['post']['dateGmt'] );
-    }
+		/**
+		 * Assert timestamp is STILL not null
+		 */
+		$this->assertNotNull( $results['data']['post']['dateGmt'] );
+	}
 
 	/**
 	 * This processes a mutation to create a post with an existing mediaItem and
 	 * a new mediaItem for the featured image
 	 *
-	 * @return array
+	 * @return void
 	 */
 	public function testCreatePostMutationWithFeaturedImage() {
 
@@ -829,61 +966,6 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 		 * Set the current user to admin
 		 */
 		wp_set_current_user( $this->admin );
-
-		/**
-		 * ADD EXISTING IMAGE on create
-		 *
-		 * Create a test post with an existing featured image
-		 */
-		$existing_image_mutation = '
-		mutation createPostWithExistingImage( $clientMutationId:String!, $title:String!, $content:String!, $featuredImage:PostFeaturedImageNodeInput! ){
-		  createPost(
-		    input:{
-		      clientMutationId:$clientMutationId,
-		      title:$title
-		      content:$content
-		      featuredImage: $featuredImage
-		    }
-		  ){
-		    clientMutationId
-		    post{
-		      title
-		      content
-		      featuredImage {
-		        id
-		      }
-		    }
-		  }
-		}
-		';
-
-		$existing_image_variables = [
-			'clientMutationId' => $this->client_mutation_id,
-			'title'            => 'Post with an Awesome Photo',
-			'content'          => $this->content,
-			'featuredImage'    => [
-				'id' => $this->media_item_id,
-			],
-		];
-
-		$actual = do_graphql_request( $existing_image_mutation, 'createPostWithExistingImage', $existing_image_variables );
-
-		$expected = [
-			'data' => [
-				'createPost' => [
-					'clientMutationId' => $existing_image_variables['clientMutationId'],
-					'post' => [
-						'title'         => apply_filters( 'the_title', $existing_image_variables['title'] ),
-						'content'       => apply_filters( 'the_content', $existing_image_variables['content'] ),
-						'featuredImage' => [
-							'id'     => $this->media_item_id,
-						],
-					],
-				],
-			],
-		];
-
-		$this->assertEquals( $expected, $actual );
 
 		/**
 		 * ADD NEW IMAGE on create
@@ -942,38 +1024,33 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 		];
 
 		$this->assertEquals( $expected, $actual );
-	}
 
-	/**
-	 * This processes a mutation to create a post with a featured image
-	 *
-	 * @return array
-	 */
-	public function testUpdatePostMutationWithFeaturedImage() {
 
 		/**
-		 * Set the current user to admin
+		 * Create a media item to add to the post
 		 */
-		wp_set_current_user( $this->admin );
-
+		$media_item = $this->createMediaItemMutation();
+		$media_item_uid = $media_item['data']['createMediaItem']['mediaItem']['id'];
 
 		/**
-		 * ADD EXISTING IMAGE on update
+		 * ADD EXISTING IMAGE on create
 		 *
-		 * Update the factory created test post with an existing featured image
+		 * Create a test post with an existing featured image
 		 */
 		$existing_image_mutation = '
-		mutation updatePostWithExistingImage( $id:String!, $clientMutationId:String!, $featuredImage:PostFeaturedImageNodeInput! ){
-		  updatePost(
+		mutation createPostWithExistingImage( $clientMutationId:String!, $title:String!, $content:String!, $featuredImage:PostFeaturedImageNodeInput! ){
+		  createPost(
 		    input:{
 		      clientMutationId:$clientMutationId,
-		      id:$id
-		      featuredImage:$featuredImage
+		      title:$title
+		      content:$content
+		      featuredImage: $featuredImage
 		    }
 		  ){
 		    clientMutationId
 		    post{
-		      id
+		      title
+		      content
 		      featuredImage {
 		        id
 		      }
@@ -982,26 +1059,26 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 		}
 		';
 
-		/**
-		 * Variables for the already created featured image
-		 */
 		$existing_image_variables = [
-			'id'               => $this->post_uid,
 			'clientMutationId' => $this->client_mutation_id,
+			'title'            => 'Post with an Awesome Photo',
+			'content'          => $this->content,
 			'featuredImage'    => [
-				'id' => $this->media_item_id,
+				'id' => $media_item_uid,
 			],
 		];
 
-		$actual = do_graphql_request( $existing_image_mutation, 'updatePostWithExistingImage', $existing_image_variables );
+		$actual = do_graphql_request( $existing_image_mutation, 'createPostWithExistingImage', $existing_image_variables );
 
 		$expected = [
 			'data' => [
-				'updatePost' => [
+				'createPost' => [
 					'clientMutationId' => $existing_image_variables['clientMutationId'],
 					'post' => [
+						'title'         => apply_filters( 'the_title', $existing_image_variables['title'] ),
+						'content'       => apply_filters( 'the_content', $existing_image_variables['content'] ),
 						'featuredImage' => [
-							'id'     => $this->media_item_id,
+							'id'     => $media_item_uid,
 						],
 					],
 				],
@@ -1010,13 +1087,27 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->assertEquals( $expected, $actual );
 
+	}
+
+	/**
+	 * This processes a mutation to create a post with a featured image
+	 *
+	 * @return void
+	 */
+	public function testUpdatePostMutationWithFeaturedImage() {
+
+		/**
+		 * Set the current user to admin
+		 */
+		wp_set_current_user( $this->admin );
+
 		/**
 		 * CREATE FEATURED IMAGE on update
 		 *
 		 * Update the factory created test post with an existing featured image
 		 */
 		$new_image_mutation = '
-		mutation updatePostWithNewImage( $id:String!, $clientMutationId:String!, $featuredImage:PostFeaturedImageNodeInput! ){
+		mutation updatePostWithNewImage( $id:ID!, $clientMutationId:String!, $featuredImage:PostFeaturedImageNodeInput! ){
 		  updatePost(
 		    input:{
 		      clientMutationId:$clientMutationId,
@@ -1026,7 +1117,6 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 		  ){
 		    clientMutationId
 		    post{
-		      id
 		      featuredImage {
 		        title
 		        sourceUrl
@@ -1065,6 +1155,65 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 		];
 
 		$this->assertEquals( $expected, $actual );
+
+		/**
+		 * Create a media item to add to the post
+		 */
+		$media_item = $this->createMediaItemMutation();
+		$media_item_uid = $media_item['data']['createMediaItem']['mediaItem']['id'];
+
+		/**
+		 * ADD EXISTING IMAGE on update
+		 *
+		 * Update the factory created test post with an existing featured image
+		 */
+		$existing_image_mutation = '
+		mutation updatePostWithExistingImage( $id:ID!, $clientMutationId:String!, $featuredImage:PostFeaturedImageNodeInput! ){
+		  updatePost(
+		    input:{
+		      clientMutationId:$clientMutationId,
+		      id:$id
+		      featuredImage:$featuredImage
+		    }
+		  ){
+		    clientMutationId
+		    post{
+		      featuredImage {
+		        id
+		      }
+		    }
+		  }
+		}
+		';
+
+		/**
+		 * Variables for the already created featured image
+		 */
+		$existing_image_variables = [
+			'id'               => $this->post_uid,
+			'clientMutationId' => $this->client_mutation_id,
+			'featuredImage'    => [
+				'id' => $media_item_uid,
+			],
+		];
+
+		$actual = do_graphql_request( $existing_image_mutation, 'updatePostWithExistingImage', $existing_image_variables );
+
+		$expected = [
+			'data' => [
+				'updatePost' => [
+					'clientMutationId' => $existing_image_variables['clientMutationId'],
+					'post' => [
+						'featuredImage' => [
+							'id'     => $media_item_uid,
+						],
+					],
+				],
+			],
+		];
+
+		$this->assertEquals( $expected, $actual );
+
 	}
 
 }

--- a/tests/wpunit/PostObjectMutationsTest.php
+++ b/tests/wpunit/PostObjectMutationsTest.php
@@ -871,10 +871,10 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 		$expected = [
 			'data' => [
 				'createPost' => [
-					'clientMutationId' => $variables['clientMutationId'],
+					'clientMutationId' => $existing_image_variables['clientMutationId'],
 					'post' => [
-						'title'         => apply_filters( 'the_title', $variables['title'] ),
-						'content'       => apply_filters( 'the_content', $variables['content'] ),
+						'title'         => apply_filters( 'the_title', $existing_image_variables['title'] ),
+						'content'       => apply_filters( 'the_content', $existing_image_variables['content'] ),
 						'featuredImage' => [
 							'id'     => $this->media_item_id,
 						],
@@ -928,12 +928,12 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 		$expected = [
 			'data' => [
 				'createPost' => [
-					'clientMutationId' => $variables['clientMutationId'],
+					'clientMutationId' => $new_image_variables['clientMutationId'],
 					'post' => [
-						'title'         => apply_filters( 'the_title', $variables['title'] ),
-						'content'       => apply_filters( 'the_content', $variables['content'] ),
+						'title'         => apply_filters( 'the_title', $new_image_variables['title'] ),
+						'content'       => apply_filters( 'the_content', $new_image_variables['content'] ),
 						'featuredImage' => [
-							'title'     => $variables['featuredImage']['title'],
+							'title'     => $new_image_variables['featuredImage']['title'],
 							'sourceUrl' => 'http://wp-graphql.test/wp-content/uploads/'. date("Y") . '/' . date('m') . '/giphy.gif',
 						],
 					],

--- a/tests/wpunit/_bootstrap.php
+++ b/tests/wpunit/_bootstrap.php
@@ -1,7 +1,0 @@
-<?php
-
-/**
- * Clear the uploads folder
- */
-$_wp_content_upload_dir = WP_CONTENT_DIR . '/uploads';
-system( 'rm -rf ' . escapeshellarg( $_wp_content_upload_dir ), $retval );

--- a/tests/wpunit/_bootstrap.php
+++ b/tests/wpunit/_bootstrap.php
@@ -1,0 +1,7 @@
+<?php
+
+/**
+ * Clear the uploads folder
+ */
+$_wp_content_upload_dir = WP_CONTENT_DIR . '/uploads';
+system( 'rm -rf ' . escapeshellarg( $_wp_content_upload_dir ), $retval );


### PR DESCRIPTION
# Add the `featuredImage` field to the post object if it supports featured images
This PR resolves issue #435.


## Example Post Mutations with the `featuredImage` field added to the Schema

### Featured Image creation on the createPost mutation
```graphql
mutation createPostWithFeaturedImage {
  createPost(input: {
  "input": {
    "title": "A post with a Featured Image",
    "content": "This is a post that was created with a featured image attached to it.",
    "featuredImage": {
      "sourceUrl": "https://media.giphy.com/media/Z6f7vzq3iP6Mw/giphy.gif",
      "title": "Awesome"
    },
    "clientMutationId": "createThatPostandImage"
  }
}) {
    post {
      id
      postId
      title
      link
      featuredImage {
        id
        mediaItemId
        title
        sourceUrl
      }
    }
  }
}
```

### Featured Image creation on the updatePost mutation
```graphql
mutation updatePostWithFeaturedImage($input: UpdatePostInput!) {
  updatePost(input: {
    "id": "cG9zdDoyNA==",
    "featuredImage": {
      "sourceUrl": "https://media.giphy.com/media/Z6f7vzq3iP6Mw/giphy.gif",
      "title": "Awesome"
    },
    "clientMutationId": "updateThatPostandCreateAnImage"
  }) {
    post {
      id
      postId
      title
      link
      featuredImage {
        id
        mediaItemId
        title
        sourceUrl
      }
    }
  }
}
```

Where has this been tested?
---------------------------
**Operating System:** Mac OSX (Sierra)

**WordPress Version:** 4.9.6
