### PR TITLE
Add WPUnionType.

### DIFF
--- a/src/Type/Union/CommentAuthorUnionType.php
+++ b/src/Type/Union/CommentAuthorUnionType.php
@@ -2,8 +2,8 @@
 
 namespace WPGraphQL\Type\Union;
 
-use GraphQL\Type\Definition\UnionType;
 use WPGraphQL\Types;
+use WPGraphQL\Type\WPUnionType;
 
 /**
  * Class CommentAuthorUnionType
@@ -13,7 +13,7 @@ use WPGraphQL\Types;
  *
  * @package WPGraphQL\Type\Union
  */
-class CommentAuthorUnionType extends UnionType {
+class CommentAuthorUnionType extends WPUnionType {
 
 	/**
 	 * This holds an array of the possible types that can be resolved by this union
@@ -61,17 +61,6 @@ class CommentAuthorUnionType extends UnionType {
 			'user'          => Types::user(),
 			'commentAuthor' => Types::comment_author(),
 		];
-
-		/**
-		 * Filter the possible_types as it's possible some systems might set things like "parent_id" to a different
-		 * object than a post_type, and might want to be able to hook in and add a non postObject type to the possible
-		 * resolveTypes.
-		 *
-		 * @param array $possible_types An array of possible types that can be resolved for the union
-		 *
-		 * @since 0.0.6
-		 */
-		self::$possible_types = apply_filters( 'graphql_comment_author_union_possible_types', self::$possible_types );
 
 		return ! empty( self::$possible_types ) ? self::$possible_types : null;
 

--- a/src/Type/Union/PostObjectUnionType.php
+++ b/src/Type/Union/PostObjectUnionType.php
@@ -1,8 +1,8 @@
 <?php
 namespace WPGraphQL\Type\Union;
 
-use GraphQL\Type\Definition\UnionType;
 use WPGraphQL\Types;
+use WPGraphQL\Type\WPUnionType;
 
 /**
  * Class PostObjectUnionType
@@ -20,7 +20,7 @@ use WPGraphQL\Types;
  * @package WPGraphQL\Type\Union
  * @since 0.0.6
  */
-class PostObjectUnionType extends UnionType {
+class PostObjectUnionType extends WPUnionType {
 
 	/**
 	 * This holds an array of the possible types that can be resolved by this union
@@ -69,16 +69,6 @@ class PostObjectUnionType extends UnionType {
 				}
 			}
 		}
-
-		/**
-		 * Filter the possible_types as it's possible some systems might set things like "parent_id" to a different
-		 * object than a post_type, and might want to be able to hook in and add a non postObject type to the possible
-		 * resolveTypes.
-		 *
-		 * @param array $possible_types  An array of possible types that can be resolved for the union
-		 * @since 0.0.6
-		 */
-		self::$possible_types = apply_filters( 'graphql_post_object_union_possible_types', self::$possible_types );
 
 		return ! empty( self::$possible_types ) ? self::$possible_types : null;
 

--- a/src/Type/Union/TermObjectUnionType.php
+++ b/src/Type/Union/TermObjectUnionType.php
@@ -1,8 +1,8 @@
 <?php
 namespace WPGraphQL\Type\Union;
 
-use GraphQL\Type\Definition\UnionType;
 use WPGraphQL\Types;
+use WPGraphQL\Type\WPUnionType;
 
 /**
  * Class TermObjectUnionType
@@ -12,7 +12,7 @@ use WPGraphQL\Types;
  *
  * @package WPGraphQL\Type\Union
  */
-class TermObjectUnionType extends UnionType {
+class TermObjectUnionType extends WPUnionType {
 
 	/**
 	 * This holds an array of the possible types that can be resolved by this union
@@ -58,16 +58,6 @@ class TermObjectUnionType extends UnionType {
 				}
 			}
 		}
-
-		/**
-		 * Filter the possible_types as it's possible some systems might set things like "parent_id" to a different
-		 * object than a post_type, and might want to be able to hook in and add a non postObject type to the possible
-		 * resolveTypes.
-		 *
-		 * @param array $possible_types  An array of possible types that can be resolved for the union
-		 * @since 0.0.6
-		 */
-		self::$possible_types = apply_filters( 'graphql_term_object_union_possible_types', self::$possible_types );
 
 		return ! empty( self::$possible_types ) ? self::$possible_types : null;
 

--- a/src/Type/WPUnionType.php
+++ b/src/Type/WPUnionType.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace WPGraphQL\Type;
+
+use GraphQL\Type\Definition\UnionType;
+
+/**
+ * Class WPUnionType
+ *
+ * Union Types should extend this class to take advantage of the helper methods
+ * and consistent filters.
+ *
+ * @package WPGraphQL\Type\Union
+ * @since   0.0.30
+ */
+class WPUnionType extends UnionType {
+	/**
+	 * WPUnionType constructor.
+	 *
+	 * @since 0.0.30
+	 */
+	public function __construct( $config ) {
+		/**
+		 * Set the Types to start with capitals
+		 */
+		$config['name'] = ucfirst( $config['name'] );
+
+		/**
+		 * Filter the possible_types to allow systems to add to the possible resolveTypes.
+		 *
+		 * @param array $possible_types An array of possible types that can be resolved for the union
+		 * @since 0.0.30
+		 */
+		$config['types'] = apply_filters( "graphql_{$config['name']}_possible_types", $config['types'] );
+
+		/**
+		 * Filter the config of WPUnionType
+		 *
+		 * @param array       $config Array of configuration options passed to the WPUnionType when instantiating a new type
+		 * @param WPUnionType $this   The instance of the WPObjectType class
+		 * @since 0.0.30
+		 */
+		$config = apply_filters( 'graphql_wp_union_type_config', $config, $this );
+
+		/**
+		 * Run an action when the WPObjectType is instantiating
+		 *
+		 * @param array       $config Array of configuration options passed to the WPUnionType when instantiating a new type
+		 * @param WPUnionType $this   The instance of the WPObjectType class
+		 */
+		do_action( 'graphql_wp_union_type', $config, $this );
+
+		parent::__construct( $config );
+	}
+}


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds WPUnionType. Much like WPObjectType and WPEnumType, etc., which allows for filters and other helpers to be centralized in one spot.


Does this close any currently open issues?
------------------------------------------
Fixes #432.


Any other comments?
-------------------
If approved, can be added to NavMenu PR.
