### PR TITLE
Clean up WPObjectType constructor

### DIFF
--- a/src/Type/WPObjectType.php
+++ b/src/Type/WPObjectType.php
@@ -53,11 +53,6 @@ class WPObjectType extends ObjectType {
 		$config = apply_filters( 'graphql_wp_object_type_config', $config, $this );
 
 		/**
-		 * Filter the Type config
-		 */
-		apply_filters( 'graphql_type_config', $config );
-
-		/**
 		 * Run an action when the WPObjectType is instantiating
 		 *
 		 * @param array $config Array of configuration options passed to the WPObjectType when instantiating a new type

--- a/src/Type/WPObjectType.php
+++ b/src/Type/WPObjectType.php
@@ -40,17 +40,17 @@ class WPObjectType extends ObjectType {
 	public function __construct( $config ) {
 
 		/**
+		 * Set the Types to start with capitals
+		 */
+		$config['name'] = ucfirst( $config['name'] );
+
+		/**
 		 * Filter the config of WPObjectType
 		 *
 		 * @param array $config Array of configuration options passed to the WPObjectType when instantiating a new type
 		 * @param Object $this The instance of the WPObjectType class
 		 */
 		$config = apply_filters( 'graphql_wp_object_type_config', $config, $this );
-
-		/**
-		 * Set the Types to start with capitals
-		 */
-		$config['name'] = ucfirst( $config['name'] );
 
 		/**
 		 * Filter the Type config


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
When creating WPUnionType, I noticed a pointless filter (unused result). Also moved the name change above the filter so that it could be changed in filter if needed.

The PR diff is a bit obtuse, take a look at individual commits for simple version.