### PR TITLE
Bug when querying categories children

### DIFF
--- a/src/Type/TermObject/Connection/TermObjectConnectionResolver.php
+++ b/src/Type/TermObject/Connection/TermObjectConnectionResolver.php
@@ -130,7 +130,7 @@ class TermObjectConnectionResolver extends ConnectionResolver {
 					$query_args['object_ids'] = $source->ID;
 					break;
 				case $source instanceof \WP_Term:
-					$query_args['object_ids'] = $GLOBALS['post']->ID;
+					$query_args['object_ids'] = $GLOBALS['post'] ? $GLOBALS['post']->ID : null;
 					$query_args['parent'] = ! empty( $source->term_id ) ? $source->term_id : 0;
 					break;
 				default:


### PR DESCRIPTION
$GLOBALS["post"] sometimes happens to be null and throws an error.Query exmaple:
categories {
    nodes {
      slug
      children {
        nodes {
          id
        }
      }
    }
  }

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
…


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
