### PR TITLE
Bug when querying categories children

### DIFF
--- a/src/Type/TermObject/Connection/TermObjectConnectionResolver.php
+++ b/src/Type/TermObject/Connection/TermObjectConnectionResolver.php
@@ -33,7 +33,8 @@ class TermObjectConnectionResolver extends ConnectionResolver {
 	}
 
 	/**
-	 * Returns an array of query_args to use in the WP_Term_Query to fetch the necessary terms for the connection
+	 * Returns an array of query_args to use in the WP_Term_Query to fetch the necessary terms for
+	 * the connection
 	 *
 	 * @param             $source
 	 * @param array       $args
@@ -125,12 +126,16 @@ class TermObjectConnectionResolver extends ConnectionResolver {
 		if ( true === is_object( $source ) ) {
 			switch ( true ) {
 				case $source instanceof \WP_Post:
-					$post = $source;
+					$post                                  = $source;
 					$post->shouldOnlyIncludeConnectedItems = isset( $input_fields['shouldOnlyIncludeConnectedItems'] ) ? $input_fields['shouldOnlyIncludeConnectedItems'] : true;
-					$query_args['object_ids'] = $source->ID;
+					$query_args['object_ids']              = $source->ID;
 					break;
 				case $source instanceof \WP_Term:
-					$query_args['object_ids'] = $GLOBALS['post'] ? $GLOBALS['post']->ID : null;
+
+					if ( is_a( $GLOBALS['post'], 'WP_Post' ) && isset( $GLOBALS['post']->ID ) ) {
+						$query_args['object_ids'] = $GLOBALS['post']->ID;
+					}
+
 					$query_args['parent'] = ! empty( $source->term_id ) ? $source->term_id : 0;
 					break;
 				default:
@@ -148,9 +153,9 @@ class TermObjectConnectionResolver extends ConnectionResolver {
 		/**
 		 * If the connection is set to output in a flat list, unset the parent
 		 */
-		if ( isset( $input_fields['shouldOutputInFlatList'] ) && true === $input_fields['shouldOutputInFlatList'] ){
+		if ( isset( $input_fields['shouldOutputInFlatList'] ) && true === $input_fields['shouldOutputInFlatList'] ) {
 			unset( $query_args['parent'] );
-			$connected = wp_get_object_terms( $source->ID, self::$taxonomy, ['fields' => 'ids'] );
+			$connected             = wp_get_object_terms( $source->ID, self::$taxonomy, [ 'fields' => 'ids' ] );
 			$query_args['include'] = ! empty( $connected ) ? $connected : [];
 		}
 
@@ -181,6 +186,7 @@ class TermObjectConnectionResolver extends ConnectionResolver {
 	 */
 	public static function get_query( $query_args ) {
 		$query = new \WP_Term_Query( $query_args );
+
 		return $query;
 	}
 
@@ -239,7 +245,7 @@ class TermObjectConnectionResolver extends ConnectionResolver {
 				'startCursor'     => ! empty( $first_edge['cursor'] ) ? $first_edge['cursor'] : null,
 				'endCursor'       => ! empty( $last_edge['cursor'] ) ? $last_edge['cursor'] : null,
 			],
-			'nodes' => $items,
+			'nodes'    => $items,
 		];
 
 		return $connection;

--- a/src/Type/TermObject/Connection/TermObjectConnectionResolver.php
+++ b/src/Type/TermObject/Connection/TermObjectConnectionResolver.php
@@ -130,7 +130,7 @@ class TermObjectConnectionResolver extends ConnectionResolver {
 					$query_args['object_ids'] = $source->ID;
 					break;
 				case $source instanceof \WP_Term:
-					$query_args['object_ids'] = $GLOBALS['post']->ID;
+					$query_args['object_ids'] = $GLOBALS['post'] ? $GLOBALS['post']->ID : null;
 					$query_args['parent'] = ! empty( $source->term_id ) ? $source->term_id : 0;
 					break;
 				default:


### PR DESCRIPTION
When querying categories children it throws an error as $GLOBALS['post'] is null.
Query example:
categories {
    nodes {
      slug
      children {
        nodes {
          slug
        }
      }
    }
  }

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
…


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
