### PR TITLE
#475: Re-arrange setup of Types (post_types, taxonomies, etc) that are registered to show_in_graphql

### DIFF
--- a/cli/wp-cli.php
+++ b/cli/wp-cli.php
@@ -29,6 +29,10 @@ class WPGraphQL_CLI_Command extends WP_CLI_Command {
 		 */
 		$file_path = WPGRAPHQL_PLUGIN_DIR . 'schema.graphql';
 
+		define( 'GRAPHQL_REQUEST', true );
+		do_action( 'do_graphql_request' );
+		do_action( 'graphql_get_schema' );
+
 		/**
 		 * Generate the Schema
 		 */

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -250,8 +250,8 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 			/**
 			 * Determine what to show in graphql
 			 */
-			add_action( 'do_graphql_request', 'register_initial_settings', 10 );
-			add_action( 'do_graphql_request', [ $this, 'setup_types' ], 10 );
+			add_action( 'graphql_get_schema', 'register_initial_settings', 10 );
+			add_action( 'graphql_get_schema', [ $this, 'setup_types' ], 10 );
 
 		}
 

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -243,17 +243,37 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 			add_action( 'wp_loaded', [ $this, 'maybe_flush_permalinks' ] );
 
 			/**
-			 * Register default settings available in WordPress so we can use
-			 * the get_registered_settings method
-			 *
-			 * @source https://github.com/WordPress/WordPress/blob/master/wp-includes/default-filters.php#L393
-			 */
-			add_action( 'do_graphql_request', 'register_initial_settings', 10 );
-
-			/**
 			 * Hook in before fields resolve to check field permissions
 			 */
 			add_action( 'graphql_before_resolve_field', [ '\WPGraphQL\Utils\InstrumentSchema', 'check_field_permissions' ], 10, 8 );
+
+			/**
+			 * Determine what to show in graphql
+			 */
+			add_action( 'init', [ $this, 'setup_types' ], 10 );
+
+		}
+
+		/**
+		 * Determine the post_types and taxonomies, etc that should show in GraphQL
+		 */
+		public function setup_types() {
+
+			/**
+			 * Only do this if we're in the context of a GraphQL request (note, this doesn't
+			 * mean just an HTTP request, but even an internal request via "do_graphql_request")
+			 */
+			if ( defined( 'GRAPHQL_REQUEST' ) && true === GRAPHQL_REQUEST ) {
+
+				/**
+				 * Setup the settings, post_types and taxonomies to show_in_graphql
+				 */
+				register_initial_settings();
+				\WPGraphQL::show_in_graphql();
+				\WPGraphQL::get_allowed_post_types();
+				\WPGraphQL::get_allowed_taxonomies();
+
+			}
 
 		}
 
@@ -559,13 +579,6 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 			if ( ! defined( 'GRAPHQL_REQUEST' ) ) {
 				define( 'GRAPHQL_REQUEST', true );
 			}
-
-			/**
-			 * Setup the post_types and taxonomies to show_in_graphql
-			 */
-			\WPGraphQL::show_in_graphql();
-			\WPGraphQL::get_allowed_post_types();
-			\WPGraphQL::get_allowed_taxonomies();
 
 			/**
 			 * Store the global post so it can be reset after GraphQL execution

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -250,7 +250,8 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 			/**
 			 * Determine what to show in graphql
 			 */
-			add_action( 'init', [ $this, 'setup_types' ], 10 );
+			add_action( 'do_graphql_request', 'register_initial_settings', 10 );
+			add_action( 'do_graphql_request', [ $this, 'setup_types' ], 10 );
 
 		}
 
@@ -268,7 +269,6 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 				/**
 				 * Setup the settings, post_types and taxonomies to show_in_graphql
 				 */
-				register_initial_settings();
 				\WPGraphQL::show_in_graphql();
 				\WPGraphQL::get_allowed_post_types();
 				\WPGraphQL::get_allowed_taxonomies();


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
This re-arranges the setting up of the post_types and taxonomies to `show_in_graphql` to happen later in the WordPress setup cycle to make sure post_types like `attachments` have properly been setup already.

@rasmustaarnby: With this change in place, `wp graphql generate-static-schema` can be run without errors.

Does this close any currently open issues?
------------------------------------------
closes #475 

Where has this been tested?
---------------------------
**Operating System:**

MAC OSX 10.13.6

**WordPress Version:**
4.9.7
