### PR TITLE
Release/v0.0.31

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "GraphQL API for WordPress",
   "type": "wordpress-plugin",
   "license": "GPL-3.0+",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "authors": [
     {
       "name": "Jason Bahl",

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -5,7 +5,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 0.0.30
+ * Version: 0.0.31
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 4.7.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  0.0.30
+ * @version  0.0.31
  */
 // Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
@@ -153,7 +153,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 
 			// Plugin version.
 			if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-				define( 'WPGRAPHQL_VERSION', '0.0.30' );
+				define( 'WPGRAPHQL_VERSION', '0.0.31' );
 			}
 
 			// Plugin Folder Path.


### PR DESCRIPTION
# Release Notes:

- fix #475: 
   - Adjust the hooks for where `register_initial_settings` and `setup_types` occur to make sure core post_types are fully setup before building the Schema.
   - Adjust the `wp graphql generate-static-schema` cli command to define the request as a `GRAPHQL_REQUEST` and run actions `do_graphql_request` and `graphql_get_schema`
- fix: #464: 
   - have the `DataSource::resolve_post_object()` method run `setup_postdata()` to make sure the Post is passing proper context down to it's resolvable fields.