### PR TITLE
Release/v0.0.31

### DIFF
--- a/cli/wp-cli.php
+++ b/cli/wp-cli.php
@@ -29,6 +29,10 @@ class WPGraphQL_CLI_Command extends WP_CLI_Command {
 		 */
 		$file_path = WPGRAPHQL_PLUGIN_DIR . 'schema.graphql';
 
+		define( 'GRAPHQL_REQUEST', true );
+		do_action( 'do_graphql_request' );
+		do_action( 'graphql_get_schema' );
+
 		/**
 		 * Generate the Schema
 		 */

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "GraphQL API for WordPress",
   "type": "wordpress-plugin",
   "license": "GPL-3.0+",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "authors": [
     {
       "name": "Jason Bahl",

--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace WPGraphQL\Data;
 
 use GraphQL\Deferred;
@@ -70,9 +71,10 @@ class DataSource {
 	 */
 	public static function resolve_comment_author( $author_email ) {
 		global $wpdb;
-		$comment_author = $wpdb->get_row( $wpdb->prepare( "SELECT comment_author_email, comment_author, comment_author_url, comment_author_email from $wpdb->comments WHERE comment_author_email = %s LIMIT 1", esc_sql( $author_email ) ) );
-		$comment_author = ! empty( $comment_author ) ? ( array ) $comment_author : [];
+		$comment_author                      = $wpdb->get_row( $wpdb->prepare( "SELECT comment_author_email, comment_author, comment_author_url, comment_author_email from $wpdb->comments WHERE comment_author_email = %s LIMIT 1", esc_sql( $author_email ) ) );
+		$comment_author                      = ! empty( $comment_author ) ? ( array ) $comment_author : [];
 		$comment_author['is_comment_author'] = true;
+
 		return $comment_author;
 	}
 
@@ -86,6 +88,7 @@ class DataSource {
 	 *
 	 * @return mixed
 	 * @since 0.0.5
+	 * @throws \Exception
 	 */
 	public static function resolve_comments_connection( $source, array $args, $context, ResolveInfo $info ) {
 		$resolver = new CommentConnectionResolver();
@@ -181,6 +184,7 @@ class DataSource {
 		 * post data being set up.
 		 */
 		$GLOBALS['post'] = $post_object;
+		setup_postdata( $post_object );
 
 		return $post_object;
 
@@ -189,15 +193,16 @@ class DataSource {
 	/**
 	 * Wrapper for PostObjectsConnectionResolver
 	 *
-	 * @param string      $post_type Post type of the post we are trying to resolve
 	 * @param             $source
 	 * @param array       $args      Arguments to pass to the resolve method
 	 * @param AppContext  $context   AppContext object to pass down
 	 * @param ResolveInfo $info      The ResolveInfo object
+	 * @param string      $post_type Post type of the post we are trying to resolve
 	 *
 	 * @return mixed
 	 * @since  0.0.5
 	 * @access public
+	 * @throws \Exception
 	 */
 	public static function resolve_post_objects_connection( $source, array $args, AppContext $context, ResolveInfo $info, $post_type ) {
 		$resolver = new PostObjectConnectionResolver( $post_type );
@@ -295,6 +300,7 @@ class DataSource {
 	 * @return array
 	 * @since  0.0.5
 	 * @access public
+	 * @throws \Exception
 	 */
 	public static function resolve_term_objects_connection( $source, array $args, $context, ResolveInfo $info, $taxonomy ) {
 		$resolver = new TermObjectConnectionResolver( $taxonomy );
@@ -349,10 +355,12 @@ class DataSource {
 	public static function resolve_user( $id ) {
 
 		Loader::addOne( 'user', $id );
-		$loader = function() use ( $id ) {
+		$loader = function () use ( $id ) {
 			Loader::loadBuffered( 'user' );
+
 			return Loader::loadOne( 'user', $id );
 		};
+
 		return new Deferred( $loader );
 	}
 
@@ -367,6 +375,7 @@ class DataSource {
 	 * @return array
 	 * @since  0.0.5
 	 * @access public
+	 * @throws \Exception
 	 */
 	public static function resolve_users_connection( $source, array $args, $context, ResolveInfo $info ) {
 		return UserConnectionResolver::resolve( $source, $args, $context, $info );
@@ -389,8 +398,9 @@ class DataSource {
 		if ( null === $role ) {
 			throw new UserError( sprintf( __( 'No user role was found with the name %s', 'wp-graphql' ), $name ) );
 		} else {
-			$role = (array) $role;
+			$role       = (array) $role;
 			$role['id'] = $name;
+
 			return $role;
 		}
 
@@ -415,6 +425,7 @@ class DataSource {
 	 * settings group that matches the group param
 	 *
 	 * @access public
+	 *
 	 * @param string $group
 	 *
 	 * @return array $settings_groups[ $group ]
@@ -451,11 +462,11 @@ class DataSource {
 		foreach ( $registered_settings as $key => $setting ) {
 			if ( ! isset( $setting['show_in_graphql'] ) ) {
 				if ( isset( $setting['show_in_rest'] ) && false !== $setting['show_in_rest'] ) {
-					$setting['key'] = $key;
+					$setting['key']                                         = $key;
 					$allowed_settings_by_group[ $setting['group'] ][ $key ] = $setting;
 				}
 			} else if ( true === $setting['show_in_graphql'] ) {
-				$setting['key'] = $key;
+				$setting['key']                                         = $key;
 				$allowed_settings_by_group[ $setting['group'] ][ $key ] = $setting;
 			}
 		};
@@ -496,11 +507,11 @@ class DataSource {
 		foreach ( $registered_settings as $key => $setting ) {
 			if ( ! isset( $setting['show_in_graphql'] ) ) {
 				if ( isset( $setting['show_in_rest'] ) && false !== $setting['show_in_rest'] ) {
-					$setting['key'] = $key;
+					$setting['key']           = $key;
 					$allowed_settings[ $key ] = $setting;
 				}
 			} else if ( true === $setting['show_in_graphql'] ) {
-				$setting['key'] = $key;
+				$setting['key']           = $key;
 				$allowed_settings[ $key ] = $setting;
 			}
 		};
@@ -541,7 +552,7 @@ class DataSource {
 			$node_definition = Relay::nodeDefinitions(
 
 			// The ID fetcher definition
-				function( $global_id ) {
+				function ( $global_id ) {
 
 					if ( empty( $global_id ) ) {
 						throw new UserError( __( 'An ID needs to be provided to resolve a node.', 'wp-graphql' ) );
@@ -634,7 +645,7 @@ class DataSource {
 				},
 
 				// Type resolver
-				function( $node ) {
+				function ( $node ) {
 
 					if ( true === is_object( $node ) ) {
 
@@ -665,7 +676,7 @@ class DataSource {
 						}
 
 						// Some nodes might return an array instead of an object
-					} elseif ( is_array( $node )  ) {
+					} elseif ( is_array( $node ) ) {
 
 						switch ( $node ) {
 							case array_key_exists( 'PluginURI', $node ):
@@ -722,10 +733,11 @@ class DataSource {
 	 * This is a modified version of the cached function from WordPress.com VIP MU Plugins here.
 	 *
 	 * @param string $uri
-	 * @param string $output Optional. Output type; OBJECT*, ARRAY_N, or ARRAY_A.
+	 * @param string $output    Optional. Output type; OBJECT*, ARRAY_N, or ARRAY_A.
 	 * @param string $post_type Optional. Post type; default is 'post'.
-	 * @return WP_Post|null WP_Post on success or null on failure
-	 * @see https://github.com/Automattic/vip-go-mu-plugins/blob/52549ae9a392fc1343b7ac9dba4ebcdca46e7d55/vip-helpers/vip-caching.php#L186
+	 *
+	 * @return \WP_Post|null WP_Post on success or null on failure
+	 * @see  https://github.com/Automattic/vip-go-mu-plugins/blob/52549ae9a392fc1343b7ac9dba4ebcdca46e7d55/vip-helpers/vip-caching.php#L186
 	 * @link http://vip.wordpress.com/documentation/uncached-functions/ Uncached Functions
 	 */
 	public static function get_post_object_by_uri( $uri, $output = OBJECT, $post_type = 'post' ) {
@@ -738,7 +750,7 @@ class DataSource {
 		$post_id = wp_cache_get( $cache_key, 'get_post_object_by_path' );
 
 		if ( false === $post_id ) {
-			$post = get_page_by_path( $uri, $output, $post_type );
+			$post    = get_page_by_path( $uri, $output, $post_type );
 			$post_id = $post ? $post->ID : 0;
 			if ( 0 === $post_id ) {
 				wp_cache_set( $cache_key, $post_id, 'get_post_object_by_path', ( 1 * HOUR_IN_SECONDS + mt_rand( 0, HOUR_IN_SECONDS ) ) ); // We only store the ID to keep our footprint small
@@ -749,6 +761,7 @@ class DataSource {
 		if ( $post_id ) {
 			return get_post( $post_id, $output );
 		}
+
 		return null;
 
 	}

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -5,7 +5,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 0.0.30
+ * Version: 0.0.31
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 4.7.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  0.0.30
+ * @version  0.0.31
  */
 // Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
@@ -153,7 +153,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 
 			// Plugin version.
 			if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-				define( 'WPGRAPHQL_VERSION', '0.0.30' );
+				define( 'WPGRAPHQL_VERSION', '0.0.31' );
 			}
 
 			// Plugin Folder Path.

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -243,17 +243,37 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 			add_action( 'wp_loaded', [ $this, 'maybe_flush_permalinks' ] );
 
 			/**
-			 * Register default settings available in WordPress so we can use
-			 * the get_registered_settings method
-			 *
-			 * @source https://github.com/WordPress/WordPress/blob/master/wp-includes/default-filters.php#L393
-			 */
-			add_action( 'do_graphql_request', 'register_initial_settings', 10 );
-
-			/**
 			 * Hook in before fields resolve to check field permissions
 			 */
 			add_action( 'graphql_before_resolve_field', [ '\WPGraphQL\Utils\InstrumentSchema', 'check_field_permissions' ], 10, 8 );
+
+			/**
+			 * Determine what to show in graphql
+			 */
+			add_action( 'graphql_get_schema', 'register_initial_settings', 10 );
+			add_action( 'graphql_get_schema', [ $this, 'setup_types' ], 10 );
+
+		}
+
+		/**
+		 * Determine the post_types and taxonomies, etc that should show in GraphQL
+		 */
+		public function setup_types() {
+
+			/**
+			 * Only do this if we're in the context of a GraphQL request (note, this doesn't
+			 * mean just an HTTP request, but even an internal request via "do_graphql_request")
+			 */
+			if ( defined( 'GRAPHQL_REQUEST' ) && true === GRAPHQL_REQUEST ) {
+
+				/**
+				 * Setup the settings, post_types and taxonomies to show_in_graphql
+				 */
+				\WPGraphQL::show_in_graphql();
+				\WPGraphQL::get_allowed_post_types();
+				\WPGraphQL::get_allowed_taxonomies();
+
+			}
 
 		}
 
@@ -559,13 +579,6 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 			if ( ! defined( 'GRAPHQL_REQUEST' ) ) {
 				define( 'GRAPHQL_REQUEST', true );
 			}
-
-			/**
-			 * Setup the post_types and taxonomies to show_in_graphql
-			 */
-			\WPGraphQL::show_in_graphql();
-			\WPGraphQL::get_allowed_post_types();
-			\WPGraphQL::get_allowed_taxonomies();
 
 			/**
 			 * Store the global post so it can be reset after GraphQL execution


### PR DESCRIPTION
# Release Notes:

- Adjust the hooks for where `register_initial_settings` and `setup_types` occur to make sure core post_types are fully setup before building the Schema.
- Adjust the `wp graphql generate-static-schema` cli command to define the request as a `GRAPHQL_REQUEST` and run actions `do_graphql_request` and `graphql_get_schema`
- have the `DataSource::resolve_post_object()` method run `setup_postdata()` to make sure the Post is passing proper context down to it's resolvable fields.