### PR TITLE
Improve speed of PostObjectConnectionQueriesTest

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,8 @@ docker-compose run --rm tests ./vendor/bin/codecept run functional --env docker
 docker-compose run --rm tests ./vendor/bin/codecept run wpunit --env docker
 ```
 
-Code coverage for `wpunit` tests can be generated using `phpdbg`:
+Code coverage for `wpunit` tests can be generated using `phpdbg` (note that Codeception currently segfaults under 
+phpdbg and PHP 7.2):
 
 ```
 docker-compose run --rm tests phpdbg -qrr ./vendor/bin/codecept run wpunit --env docker --coverage --coverage-xml

--- a/tests/wpunit/PostObjectConnectionQueriesTest.php
+++ b/tests/wpunit/PostObjectConnectionQueriesTest.php
@@ -74,13 +74,14 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 	/**
 	 * Creates several posts (with different timestamps) for use in cursor query tests
 	 *
+	 * @param  int $count Number of posts to create.
 	 * @return array
 	 */
-	public function create_posts() {
+	public function create_posts( $count = 20 ) {
 
-		// Create 20 posts
+		// Create posts
 		$created_posts = [];
-		for ( $i = 1; $i <= 200; $i ++ ) {
+		for ( $i = 1; $i <= $count; $i ++ ) {
 			// Set the date 1 minute apart for each post
 			$date                = date( 'Y-m-d H:i:s', strtotime( "-1 day +{$i} minutes" ) );
 			$created_posts[ $i ] = $this->createPostObject( [
@@ -235,6 +236,9 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	public function testMaxQueryAmount() {
+		// Create some additional posts to test a large query.
+		$this->create_posts( 150 );
+
 		$variables = [
 			'first' => 150,
 		];


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Improves the speed of `PostObjectConnectionQueriesTest` by reducing the number of posts that are created in `setUp`. Creating a large number of posts is quite slow (or maybe it's the tear down?). We only need a large number of posts for one test, so this reduces the default number created and creates more inside that one test.

Shaves about 60s off test runs on my computer—more on coverage runs.

It also adds a clarifying note to the README concerning code coverage in PHP 7.2.


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
### Before (72.12s)
```
✔ PostObjectConnectionQueriesTest: First post (4.63s)
✔ PostObjectConnectionQueriesTest: Last post (4.15s)
✔ PostObjectConnectionQueriesTest: Max query amount (4.68s)
✔ PostObjectConnectionQueriesTest: Post has password (5.50s)
✔ PostObjectConnectionQueriesTest: Page with children (4.38s)
✔ PostObjectConnectionQueriesTest: Sanitize input fields author args (4.74s)
✔ PostObjectConnectionQueriesTest: Sanitize input fields category args (4.11s)
✔ PostObjectConnectionQueriesTest: Sanitize input fields tag args (4.29s)
✔ PostObjectConnectionQueriesTest: Sanitize input fields search args (4.71s)
✔ PostObjectConnectionQueriesTest: Sanitize input fields parent args (4.70s)
✔ PostObjectConnectionQueriesTest: Sanitize input fields misc args (4.33s)
✔ PostObjectConnectionQueriesTest: Sanitize input fields list of post status enum (4.61s)
✔ PostObjectConnectionQueriesTest: Get query args (4.21s)
✔ PostObjectConnectionQueriesTest: Get query args attachment (4.59s)
✔ PostObjectConnectionQueriesTest: Get query args post type (3.94s)
✔ PostObjectConnectionQueriesTest: Get query args user (4.55s)
```

### After (10.33s)
```
✔ PostObjectConnectionQueriesTest: First post (0.49s)
✔ PostObjectConnectionQueriesTest: Last post (0.52s)
✔ PostObjectConnectionQueriesTest: Max query amount (4.02s)
✔ PostObjectConnectionQueriesTest: Post has password (0.33s)
✔ PostObjectConnectionQueriesTest: Page with children (0.49s)
✔ PostObjectConnectionQueriesTest: Sanitize input fields author args (0.60s)
✔ PostObjectConnectionQueriesTest: Sanitize input fields category args (0.48s)
✔ PostObjectConnectionQueriesTest: Sanitize input fields tag args (0.48s)
✔ PostObjectConnectionQueriesTest: Sanitize input fields search args (0.47s)
✔ PostObjectConnectionQueriesTest: Sanitize input fields parent args (0.48s)
✔ PostObjectConnectionQueriesTest: Sanitize input fields misc args (0.49s)
✔ PostObjectConnectionQueriesTest: Sanitize input fields list of post status enum (0.47s)
✔ PostObjectConnectionQueriesTest: Get query args (0.24s)
✔ PostObjectConnectionQueriesTest: Get query args attachment (0.20s)
✔ PostObjectConnectionQueriesTest: Get query args post type (0.35s)
✔ PostObjectConnectionQueriesTest: Get query args user (0.22s)
```
