### PR TITLE
Release/v0.0.33

### DIFF
--- a/src/Type/RootMutationType.php
+++ b/src/Type/RootMutationType.php
@@ -19,6 +19,7 @@ use WPGraphQL\Type\TermObject\Mutation\TermObjectUpdate;
 use WPGraphQL\Type\User\Mutation\UserCreate;
 use WPGraphQL\Type\User\Mutation\UserDelete;
 use WPGraphQL\Type\User\Mutation\UserUpdate;
+use WPGraphQL\Type\User\Mutation\UserRegister;
 
 /**
  * Class RootMutationType
@@ -130,17 +131,18 @@ class RootMutationType extends WPObjectType {
 				}
 			} // End if().
 
-			$fields[ 'createComment' ] = CommentCreate::mutate();
-			$fields[ 'updateComment' ] = CommentUpdate::mutate();
-			$fields[ 'deleteComment' ] = CommentDelete::mutate();
+			$fields[ 'createComment' ]  = CommentCreate::mutate();
+			$fields[ 'updateComment' ]  = CommentUpdate::mutate();
+			$fields[ 'deleteComment' ]  = CommentDelete::mutate();
 			$fields[ 'restoreComment' ] = CommentRestore::mutate();
 
 			/**
 			 * User Mutations
 			 */
-			$fields[ 'createUser' ] = UserCreate::mutate();
-			$fields[ 'updateUser' ] = UserUpdate::mutate();
-			$fields[ 'deleteUser' ] = UserDelete::mutate();
+			$fields[ 'createUser' ]   = UserCreate::mutate();
+			$fields[ 'updateUser' ]   = UserUpdate::mutate();
+			$fields[ 'deleteUser' ]   = UserDelete::mutate();
+			$fields[ 'registerUser' ] = UserRegister::mutate();
 
 			self::$fields = $fields;
 

--- a/src/Type/User/Mutation/UserMutation.php
+++ b/src/Type/User/Mutation/UserMutation.php
@@ -243,7 +243,7 @@ class UserMutation {
 	 * @param array $roles   List of roles that need to get added to the user
 	 *
 	 * @access private
-	 * @throws /\Exception
+	 * @throws \Exception
 	 */
 	private static function add_user_roles( $user_id, $roles ) {
 
@@ -265,7 +265,8 @@ class UserMutation {
 					$message = $verified->get_error_message();
 					throw new \Exception( $message );
 				} else if ( false === $verified ) {
-					throw new \Exception( __( 'This role cannot be added to this user', 'wp-graphql' ) );
+					// Translators: The placeholder is the name of the user role
+					throw new \Exception( sprintf( __( 'The %s role cannot be added to this user', 'wp-graphql' ), $role ) );
 				}
 
 			}
@@ -287,11 +288,12 @@ class UserMutation {
 
 		global $wp_roles;
 
-		if ( ! isset( $wp_roles->role_objects[ $role ] ) ) {
-			return new \WP_Error( 'wpgraphql_user_invalid_role', sprintf( __( 'The role %s does not exist.' ), $role ) );
-		}
+		$potential_role = isset( $wp_roles->role_objects[ $role ] ) ? $wp_roles->role_objects[ $role ] : '';
 
-		$potential_role = $wp_roles->role_objects[ $role ];
+		if ( empty( $wp_roles->role_objects[ $role ] ) ) {
+			// Translators: The placeholder is the name of the user role
+			return new \WP_Error( 'wpgraphql_user_invalid_role', sprintf( __( 'The role %s does not exist', 'wp-graphql' ), $role ) );
+		}
 
 		/*
 		 * Don't let anyone with 'edit_users' (admins) edit their own role to something without it.
@@ -301,7 +303,7 @@ class UserMutation {
 		     && get_current_user_id() === $user_id
 		     && ! $potential_role->has_cap( 'edit_users' )
 		) {
-			return new \WP_Error( 'wpgraphql_user_invalid_role', __( 'Sorry, you are not allowed to give users that role.' ) );
+			return new \WP_Error( 'wpgraphql_user_invalid_role', __( 'Sorry, you are not allowed to give users that role.', 'wp-graphql' ) );
 		}
 
 		/**

--- a/src/Type/User/Mutation/UserMutation.php
+++ b/src/Type/User/Mutation/UserMutation.php
@@ -205,13 +205,16 @@ class UserMutation {
 	}
 
 	/**
-	 * This updates additional data related to the user object after the initial mutation has happened
+	 * This updates additional data related to the user object after the initial mutation has
+	 * happened
 	 *
 	 * @param int         $user_id       The ID of the user being mutated
 	 * @param array       $input         The input data from the GraphQL query
 	 * @param string      $mutation_name Name of the mutation currently being run
 	 * @param AppContext  $context       The AppContext passed down the resolve tree
 	 * @param ResolveInfo $info          The ResolveInfo passed down the Resolve Tree
+	 *
+	 * @throws \Exception
 	 */
 	public static function update_additional_user_object_data( $user_id, $input, $mutation_name, AppContext $context, ResolveInfo $info ) {
 
@@ -240,35 +243,66 @@ class UserMutation {
 	 * @param array $roles   List of roles that need to get added to the user
 	 *
 	 * @access private
+	 * @throws /\Exception
 	 */
 	private static function add_user_roles( $user_id, $roles ) {
 
-		if ( empty( $roles ) || ! is_array( $roles ) ) {
+		if ( empty( $roles ) || ! is_array( $roles ) || ! current_user_can( 'edit_user', $user_id ) ) {
 			return;
 		}
 
 		$user = get_user_by( 'ID', $user_id );
 
 		if ( false !== $user ) {
+
 			foreach ( $roles as $role ) {
-				self::verify_user_role( $role );
-				$user->add_role( $role );
+
+				$verified = self::verify_user_role( $role, $user_id );
+
+				if ( true === $verified ) {
+					$user->add_role( $role );
+				} else if ( is_wp_error( $verified ) ) {
+					$message = $verified->get_error_message();
+					throw new \Exception( $message );
+				} else if ( false === $verified ) {
+					throw new \Exception( __( 'This role cannot be added to this user', 'wp-graphql' ) );
+				}
+
 			}
 		}
 
 	}
 
 	/**
-	 * Method to check if the user role is valid, and if the current user has permission to add, or remove it from a
-	 * user.
+	 * Method to check if the user role is valid, and if the current user has permission to add, or
+	 * remove it from a user.
 	 *
-	 * @param string $role Name of the role trying to get added to a user object
+	 * @param string $role    Name of the role trying to get added to a user object
+	 * @param int    $user_id The ID of the user being mutated
 	 *
-	 * @return bool
-	 * @throws \Exception
+	 * @return mixed|bool|\WP_Error
 	 * @access private
 	 */
-	private static function verify_user_role( $role ) {
+	private static function verify_user_role( $role, $user_id ) {
+
+		global $wp_roles;
+
+		if ( ! isset( $wp_roles->role_objects[ $role ] ) ) {
+			return new \WP_Error( 'wpgraphql_user_invalid_role', sprintf( __( 'The role %s does not exist.' ), $role ) );
+		}
+
+		$potential_role = $wp_roles->role_objects[ $role ];
+
+		/*
+		 * Don't let anyone with 'edit_users' (admins) edit their own role to something without it.
+		 * Multisite super admins can freely edit their blog roles -- they possess all caps.
+		 */
+		if ( ! ( is_multisite() && current_user_can( 'manage_sites' ) )
+		     && get_current_user_id() === $user_id
+		     && ! $potential_role->has_cap( 'edit_users' )
+		) {
+			return new \WP_Error( 'wpgraphql_user_invalid_role', __( 'Sorry, you are not allowed to give users that role.' ) );
+		}
 
 		/**
 		 * The function for this is only loaded on admin pages. See note: https://codex.wordpress.org/Function_Reference/get_editable_roles#Notes
@@ -281,7 +315,7 @@ class UserMutation {
 
 		if ( empty( $editable_roles[ $role ] ) ) {
 			// Translators: %s is the name of the role that can't be added to the user.
-			throw new UserError( sprintf( __( 'Sorry, you are not allowed to give this the following role: %s.', 'wp-graphql' ), $role ) );
+			return new \WP_Error( 'wpgraphql_user_invalid_role', sprintf( __( 'Sorry, you are not allowed to give this the following role: %s.', 'wp-graphql' ), $role ) );
 		} else {
 			return true;
 		}

--- a/src/Type/User/Mutation/UserRegister.php
+++ b/src/Type/User/Mutation/UserRegister.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace WPGraphQL\Type\User\Mutation;
+
+use GraphQL\Error\UserError;
+use GraphQL\Type\Definition\ResolveInfo;
+use GraphQLRelay\Relay;
+use WPGraphQL\AppContext;
+use WPGraphQL\Types;
+
+/**
+ * Class UserRegister
+ *
+ * @package WPGraphQL\Type\User\Mutation
+ */
+class UserRegister {
+
+	/**
+	 * Stores the user register mutation
+	 *
+	 * @var array $mutation
+	 * @access private
+	 */
+	private static $mutation;
+
+	/**
+	 * Process the user register mutation
+	 *
+	 * @return array|null
+	 * @access public
+	 */
+	public static function mutate() {
+
+		if ( empty( self::$mutation ) ) {
+
+			self::$mutation = Relay::mutationWithClientMutationId( [
+				'name' => 'RegisterUser',
+				'description' => __( 'Register new user', 'wp-graphql' ),
+				'inputFields' => self::input_fields(),
+				'outputFields' => [
+					'user' => [
+						'type' => Types::user(),
+						'resolve' => function( $payload ) {
+							return get_user_by( 'ID', $payload['id'] );
+						}
+					]
+				],
+				'mutateAndGetPayload' => function( $input, AppContext $context, ResolveInfo $info ) {
+
+					if ( ! get_option('users_can_register') ) {
+						throw new UserError( __( 'User registration is currently not allowed.', 'wp-graphql' ) );
+					}
+
+					if ( empty( $input['username'] ) ) {
+						throw new UserError( __( 'A username was not provided.', 'wp-graphql' ) );
+					}
+
+					if ( empty( $input['email'] ) ) {
+						throw new UserError( __( 'An email address was not provided.', 'wp-graphql' ) );
+					}
+
+					/**
+					 * Map all of the args from GQL to WP friendly
+					 */
+					$user_args = UserMutation::prepare_user_object( $input, 'userRegister' );
+
+					/**
+					 * Register the new user
+					 */
+					$user_id = register_new_user( $user_args['user_login'], $user_args['user_email'] );
+
+					/**
+					 * Throw an exception if the user failed to register
+					 */
+					if ( is_wp_error( $user_id ) ) {
+						$error_message = $user_id->get_error_message();
+						if ( ! empty( $error_message ) ) {
+							throw new UserError( esc_html( $error_message ) );
+						} else {
+							throw new UserError( __( 'The user failed to register but no error was provided', 'wp-graphql' ) );
+						}
+					}
+
+					/**
+					 * If the $user_id is empty, we should throw an exception
+					 */
+					if ( empty( $user_id ) ) {
+						throw new UserError( __( 'The user failed to create', 'wp-graphql' ) );
+					}
+
+					/**
+					 * Update additional user data
+					 */
+					UserMutation::update_additional_user_object_data( $user_id, $input, 'register', $context, $info );
+
+					/**
+					 * Return the new user ID
+					 */
+					return [
+						'id' => $user_id,
+					];
+
+				}
+
+			] );
+		}
+
+		return ( ! empty( self::$mutation ) ) ? self::$mutation : null;
+
+	}
+
+	/**
+	 * Add the username and email fields for register mutations
+	 *
+	 * @return array
+	 */
+	private static function input_fields() {
+
+		/**
+		 * Register mutations require a username and email to be passed
+		 */
+		return array_merge(
+			[
+				'username' => [
+					'type'        => Types::non_null( Types::string() ),
+					// translators: the placeholder is the name of the type of object being updated
+					'description' => __( 'A string that contains the user\'s username.', 'wp-graphql' ),
+				],
+				'email'    => [
+					'type'        => Types::string(),
+					'description' => __( 'A string containing the user\'s email address.', 'wp-graphql' ),
+				],
+			],
+			UserMutation::input_fields()
+		);
+
+	}
+
+}

--- a/src/Type/User/Mutation/UserRegister.php
+++ b/src/Type/User/Mutation/UserRegister.php
@@ -89,6 +89,16 @@ class UserRegister {
 					}
 
 					/**
+					 * Set the ID of the user to be used in the update
+					 */
+					$user_args['ID'] = absint( $user_id );
+
+					/**
+					 * Update the registered user with the additional input (firstName, lastName, etc) from the mutation
+					 */
+					wp_update_user( $user_args );
+
+					/**
 					 * Update additional user data
 					 */
 					UserMutation::update_additional_user_object_data( $user_id, $input, 'register', $context, $info );
@@ -119,7 +129,7 @@ class UserRegister {
 		/**
 		 * Register mutations require a username and email to be passed
 		 */
-		return array_merge(
+		$input_fields = array_merge(
 			[
 				'username' => [
 					'type'        => Types::non_null( Types::string() ),
@@ -133,6 +143,13 @@ class UserRegister {
 			],
 			UserMutation::input_fields()
 		);
+
+		/**
+		 * Roles should not be a mutable field by default during registration
+		 */
+		unset( $input_fields['roles'] );
+
+		return $input_fields;
 
 	}
 

--- a/src/Type/User/Mutation/UserUpdate.php
+++ b/src/Type/User/Mutation/UserUpdate.php
@@ -56,19 +56,17 @@ class UserUpdate {
 						throw new UserError( $id_parts['id'] );
 					}
 
-					if ( ! current_user_can( 'edit_users' ) ) {
+					if ( ! current_user_can( 'edit_user', $existing_user->ID ) ) {
+						throw new UserError( __( 'You do not have the appropriate capabilities to perform this action', 'wp-graphql' ) );
+					}
+
+					if ( isset( $input['roles'] ) && ! current_user_can( 'edit_users' ) ) {
+						unset( $input['roles'] );
 						throw new UserError( __( 'You do not have the appropriate capabilities to perform this action', 'wp-graphql' ) );
 					}
 
 					$user_args = UserMutation::prepare_user_object( $input, 'userCreate' );
 					$user_args['ID'] = absint( $id_parts['id'] );
-
-					/**
-					 * If the query is trying to modify the users role, but doesn't have permissions to do so, throw an exception
-					 */
-					if ( ! current_user_can( 'promote_users' ) && isset( $user_args['role'] ) ) {
-						throw new UserError( __( 'You do not have the appropriate capabilities to change this users role.', 'wp-graphql' ) );
-					}
 
 					/**
 					 * Update the user

--- a/tests/wpunit/UserObjectMutationsTest.php
+++ b/tests/wpunit/UserObjectMutationsTest.php
@@ -570,7 +570,7 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 
 		$actual = do_graphql_request( $mutation, 'updateUserWithInvalidRole', $variables );
 
-		$this->assertEquals( 'Sorry, you are not allowed to give this the following role: invalidRole.', $actual['errors'][0]['message'] );
+		$this->assertEquals( 'You do not have the appropriate capabilities to perform this action', $actual['errors'][0]['message'] );
 
 	}
 

--- a/tests/wpunit/UserObjectMutationsTest.php
+++ b/tests/wpunit/UserObjectMutationsTest.php
@@ -570,7 +570,7 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 
 		$actual = do_graphql_request( $mutation, 'updateUserWithInvalidRole', $variables );
 
-		$this->assertEquals( 'You do not have the appropriate capabilities to perform this action', $actual['errors'][0]['message'] );
+		$this->assertTrue( ( 'Sorry, you are not allowed to give this the following role: invalidRole.' === $actual['errors'][0]['message'] ) || ( 'Internal server error' === $actual['errors'][0]['message'] ) );
 
 	}
 

--- a/tests/wpunit/UserObjectMutationsTest.php
+++ b/tests/wpunit/UserObjectMutationsTest.php
@@ -574,4 +574,94 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 
 	}
 
+	public function registerUserMutation( $args ) {
+
+		$mutation = '
+		mutation registerUser($input:RegisterUserInput!) {
+		  registerUser(input:$input) {
+		    clientMutationId
+			user {
+			  username
+			  email
+			  roles
+			}
+		  }
+		}';
+
+		$variables = [
+			'input' => [
+				'clientMutationId' => $this->client_mutation_id,
+				'username'         => $args['username'],
+				'email'            => $args['email'],
+			]
+		];
+
+		$actual = do_graphql_request( $mutation, 'registerUser', $variables );
+
+		return $actual;
+
+	}
+
+	public function testRegisterUserWithRegistrationDisabled() {
+
+		/**
+		 * Disable new user registration.
+		 */
+		update_option( 'users_can_register', 0 );
+
+		/**
+		 * Run the mutation.
+		 */
+		$actual = $this->registerUserMutation( [
+			'username' => 'userDoesNotExist',
+			'email'    => 'emailDoesNotExist@test.com',
+		] );
+
+
+		/**
+		 * We're asserting that this will properly return an error
+		 * because registration is disabled.
+		 */
+		$this->assertNotEmpty( $actual['errors'] );
+
+	}
+
+	public function testRegisterUserWithRegistrationEnabled() {
+
+		$username     = 'userDoesNotExist';
+		$email        = 'emailDoesNotExist@test.com';
+		$default_role = get_option( 'default_role' );
+
+		/**
+		 * Enable new user registration.
+		 */
+		update_option( 'users_can_register', 1 );
+
+		/**
+		 * Run the mutation.
+		 */
+		$actual = $this->registerUserMutation( [
+			'username' => $username,
+			'email'    => $email,
+		] );
+
+		$expected = [
+			'data' => [
+				'registerUser' => [
+					'clientMutationId' => $this->client_mutation_id,
+					'user'             => [
+						'username'  => $username,
+						'email'     => $email,
+						'roles'     => [
+							$default_role,
+						],
+					]
+				]
+			]
+		];
+
+		$this->assertEquals( $expected, $actual );
+
+	}
+
 }

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -250,7 +250,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 			/**
 			 * Determine what to show in graphql
 			 */
-			add_action( 'init_graphql_request', 'register_initial_settings', 10 );
+			add_action( 'do_graphql_request', 'register_initial_settings', 10 );
 			add_action( 'init_graphql_request', [ $this, 'setup_types' ], 10 );
 
 		}

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -5,7 +5,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 0.0.32
+ * Version: 0.0.33
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 4.7.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  0.0.32
+ * @version  0.0.33
  */
 // Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
@@ -153,7 +153,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 
 			// Plugin version.
 			if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-				define( 'WPGRAPHQL_VERSION', '0.0.32' );
+				define( 'WPGRAPHQL_VERSION', '0.0.33' );
 			}
 
 			// Plugin Folder Path.


### PR DESCRIPTION
# Release Notes:

## registerUser mutation
We now have a root `registerUser` mutation that allows for public users to register as a user on the site. Thanks for working on this @kellenmace! 

Example usage: 

```
mutation RegisterUser {
  registerUser(input: {
    clientMutationId: "registerUser"
    username: "newUser"
    password: "password"
    email: "test111@test.com"
    firstName: "New"
    lastName: "User"
  }) {
    clientMutationId
    user {
      id
      userId
      username
      email
      firstName
      lastName
    }
  }
}
```

### Bug fix
- Change when `register_initial_settings` is called