### PR TITLE
Feature/#491 add send password reset email mutation

### DIFF
--- a/src/Type/RootMutationType.php
+++ b/src/Type/RootMutationType.php
@@ -19,6 +19,7 @@ use WPGraphQL\Type\TermObject\Mutation\TermObjectUpdate;
 use WPGraphQL\Type\User\Mutation\UserCreate;
 use WPGraphQL\Type\User\Mutation\UserDelete;
 use WPGraphQL\Type\User\Mutation\UserUpdate;
+use WPGraphQL\Type\User\Mutation\SendPasswordResetEmail;
 
 /**
  * Class RootMutationType
@@ -138,9 +139,10 @@ class RootMutationType extends WPObjectType {
 			/**
 			 * User Mutations
 			 */
-			$fields[ 'createUser' ] = UserCreate::mutate();
-			$fields[ 'updateUser' ] = UserUpdate::mutate();
-			$fields[ 'deleteUser' ] = UserDelete::mutate();
+			$fields[ 'createUser' ]             = UserCreate::mutate();
+			$fields[ 'updateUser' ]             = UserUpdate::mutate();
+			$fields[ 'deleteUser' ]             = UserDelete::mutate();
+			$fields[ 'sendPasswordResetEmail' ] = SendPasswordResetEmail::mutate();
 
 			self::$fields = $fields;
 

--- a/src/Type/User/Mutation/SendPasswordResetEmail.php
+++ b/src/Type/User/Mutation/SendPasswordResetEmail.php
@@ -73,11 +73,6 @@ class SendPasswordResetEmail {
 					}
 
 					/**
-					 * Update additional user data
-					 */
-					UserMutation::update_additional_user_object_data( $user_data->ID, $input, 'sentPasswordResetEmail', $context, $info );
-
-					/**
 					 * Return the ID of the user
 					 */
 					return [
@@ -229,7 +224,7 @@ class SendPasswordResetEmail {
 	}
 
 	/**
-	 * Add the username and email fields for the send password reset email mutation
+	 * Add the username field for the send password reset email mutation
 	 *
 	 * @return array
 	 */
@@ -238,16 +233,12 @@ class SendPasswordResetEmail {
 		/**
 		 * A username or email address is required to send a password reset email
 		 */
-		return array_merge(
-			[
-				'username' => [
-					'type'        => Types::non_null( Types::string() ),
-					// translators: the placeholder is the name of the type of object being updated
-					'description' => __( 'A string that contains the user\'s username or email address.', 'wp-graphql' ),
-				],
+		return [
+			'username' => [
+				'type'        => Types::non_null( Types::string() ),
+				'description' => __( 'A string that contains the user\'s username or email address.', 'wp-graphql' ),
 			],
-			UserMutation::input_fields()
-		);
+		];
 
 	}
 

--- a/src/Type/User/Mutation/SendPasswordResetEmail.php
+++ b/src/Type/User/Mutation/SendPasswordResetEmail.php
@@ -1,0 +1,254 @@
+<?php
+
+namespace WPGraphQL\Type\User\Mutation;
+
+use GraphQL\Error\UserError;
+use GraphQL\Type\Definition\ResolveInfo;
+use GraphQLRelay\Relay;
+use WPGraphQL\AppContext;
+use WPGraphQL\Types;
+
+/**
+ * Class SendPasswordResetEmail
+ *
+ * @package WPGraphQL\Type\User\Mutation
+ */
+class SendPasswordResetEmail {
+
+	/**
+	 * Stores the send password reset email mutation
+	 *
+	 * @var array $mutation
+	 * @access private
+	 */
+	private static $mutation;
+
+	/**
+	 * Process the send password reset email mutation
+	 *
+	 * @return array|null
+	 * @access public
+	 */
+	public static function mutate() {
+
+		if ( empty( self::$mutation ) ) {
+
+			self::$mutation = Relay::mutationWithClientMutationId( [
+				'name' => 'SendPasswordResetEmail',
+				'description' => __( 'Send password reset email to user', 'wp-graphql' ),
+				'inputFields' => self::input_fields(),
+				'outputFields' => [
+					'user' => [
+						'type' => Types::user(),
+						'description' => __( 'The user that the password reset email was sent to', 'wp-graphql' ),
+						'resolve' => function( $payload ) {
+							return get_user_by( 'ID', $payload['id'] );
+						}
+					]
+				],
+				'mutateAndGetPayload' => function( $input, AppContext $context, ResolveInfo $info ) {
+
+					if ( ! self::was_username_provided( $input ) ) {
+						throw new UserError( __( 'Enter a username or email address.', 'wp-graphql' ) );
+					}
+
+					$user_data = self::get_user_data( $input['username'] );
+
+					if ( ! $user_data ) {
+						throw new UserError( self::get_user_not_found_error_message( $input['username'] ) );
+					}
+
+					$key = get_password_reset_key( $user_data );
+
+					if ( is_wp_error( $key ) ) {
+						throw new UserError( __( 'Unable to generate a password reset key.', 'wp-graphql' ) );
+					}
+
+					$subject    = self::get_email_subject( $user_data );
+					$message    = self::get_email_message( $user_data, $key );
+					$email_sent = wp_mail( $user_data->user_email, wp_specialchars_decode( $subject ), $message );
+
+					if ( ! $email_sent ) {
+						throw new UserError( __( 'The email could not be sent.' ) . "<br />\n" . __( 'Possible reason: your host may have disabled the mail() function.' ) );
+					}
+
+					/**
+					 * Update additional user data
+					 */
+					UserMutation::update_additional_user_object_data( $user_data->ID, $input, 'sentPasswordResetEmail', $context, $info );
+
+					/**
+					 * Return the ID of the user
+					 */
+					return [
+						'id' => $user_data->ID,
+					];
+
+				}
+
+			] );
+		}
+
+		return ( ! empty( self::$mutation ) ) ? self::$mutation : null;
+
+	}
+
+	/**
+	 * Was a username or email address provided?
+	 *
+	 * @param array $input The input args.
+	 *
+	 * @return bool
+	 */
+	private static function was_username_provided( $input ) {
+
+		return ! empty( $input['username'] ) && is_string( $input['username'] );
+
+	}
+
+	/**
+	 * Get WP_User object representing this user
+	 *
+	 * @param  string $username The user's username or email address.
+	 *
+	 * @return \WP_User|false WP_User object on success, false on failure.
+	 */
+	private static function get_user_data( $username ) {
+
+		if ( self::is_email_address( $username ) ) {
+			return get_user_by( 'email', trim( wp_unslash( $username ) ) );
+		}
+
+		return get_user_by( 'login', trim( $username ) );
+
+	}
+
+	/**
+	 * Get the error message indicating why the user wasn't found
+	 *
+	 * @param  string $username The user's username or email address.
+	 *
+	 * @return string
+	 */
+	private static function get_user_not_found_error_message( $username ) {
+
+		if ( self::is_email_address( $username ) ) {
+			return __( 'There is no user registered with that email address.', 'wp-graphql' );
+		}
+
+		return __( 'Invalid username.', 'wp-graphql' );
+
+	}
+
+	/**
+	 * Is the provided username arg an email address?
+	 *
+	 * @param  string $username The user's username or email address.
+	 *
+	 * @return bool
+	 */
+	private static function is_email_address( $username ) {
+
+		return strpos( $username, '@' );
+
+	}
+
+	/**
+	 * Get the subject of the password reset email
+	 *
+	 * @param \WP_User $user_data  User data
+	 *
+	 * @return string
+	 */
+	private static function get_email_subject( $user_data ) {
+
+		/* translators: Password reset email subject. %s: Site name */
+		$title = sprintf( __( '[%s] Password Reset' ), self::get_site_name() );
+
+		/**
+		 * Filters the subject of the password reset email.
+		 *
+		 * @param string  $title      Default email title.
+		 * @param string  $user_login The username for the user.
+		 * @param WP_User $user_data  WP_User object.
+		 */
+		return apply_filters( 'retrieve_password_title', $title, $user_data->user_login, $user_data );
+
+	}
+
+	/**
+	 * Get the site name.
+	 *
+	 * @return string
+	 */
+	private static function get_site_name() {
+
+		if ( is_multisite() ) {
+			return get_network()->site_name;
+		}
+
+		/*
+		 * The blogname option is escaped with esc_html on the way into the database
+		 * in sanitize_option we want to reverse this for the plain text arena of emails.
+		 */
+		return wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
+
+	}
+
+	/**
+	 * Get the message body of the password reset email
+	 *
+	 * @param \WP_User $user_data  User data
+	 * @param string   $key        Password reset key
+	 *
+	 * @return string
+	 */
+	private static function get_email_message( $user_data, $key ) {
+
+		$message = __( 'Someone has requested a password reset for the following account:' ) . "\r\n\r\n";
+		/* translators: %s: site name */
+		$message .= sprintf( __( 'Site Name: %s'), self::get_site_name() ) . "\r\n\r\n";
+		/* translators: %s: user login */
+		$message .= sprintf( __( 'Username: %s'), $user_data->user_login ) . "\r\n\r\n";
+		$message .= __( 'If this was a mistake, just ignore this email and nothing will happen.' ) . "\r\n\r\n";
+		$message .= __( 'To reset your password, visit the following address:' ) . "\r\n\r\n";
+		$message .= '<' . network_site_url( "wp-login.php?action=rp&key={$key}&login=" . rawurlencode( $user_data->user_login ), 'login' ) . ">\r\n";
+
+		/**
+		 * Filters the message body of the password reset mail.
+		 *
+		 * If the filtered message is empty, the password reset email will not be sent.
+		 *
+		 * @param string  $message    Default mail message.
+		 * @param string  $key        The activation key.
+		 * @param string  $user_login The username for the user.
+		 * @param WP_User $user_data  WP_User object.
+		 */
+		return apply_filters( 'retrieve_password_message', $message, $key, $user_data->user_login, $user_data );
+
+	}
+
+	/**
+	 * Add the username and email fields for the send password reset email mutation
+	 *
+	 * @return array
+	 */
+	private static function input_fields() {
+
+		/**
+		 * A username or email address is required to send a password reset email
+		 */
+		return array_merge(
+			[
+				'username' => [
+					'type'        => Types::non_null( Types::string() ),
+					// translators: the placeholder is the name of the type of object being updated
+					'description' => __( 'A string that contains the user\'s username or email address.', 'wp-graphql' ),
+				],
+			],
+			UserMutation::input_fields()
+		);
+
+	}
+
+}

--- a/tests/wpunit/UserObjectMutationsTest.php
+++ b/tests/wpunit/UserObjectMutationsTest.php
@@ -722,8 +722,8 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 
 	public function testSendPasswordResetEmailResponseWithEmail() {
 
-		$old_user_obj = get_userdata( $this->subscriber );
-		$email        = $old_user_obj->user_email;
+		$user  = get_userdata( $this->subscriber );
+		$email = $user->user_email;
 
 		// Run the mutation, passing in a valid email address.
 		$actual   = $this->sendPasswordResetEmailMutation( $email );
@@ -748,9 +748,9 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 				'sendPasswordResetEmail' => [
 					'clientMutationId' => $this->client_mutation_id,
 					'user'             => [
-						'username'  => $username,
-						'email'     => $email,
-						'roles'     => $roles,
+						'username' => $username,
+						'email'    => $email,
+						'roles'    => $roles,
 					]
 				]
 			]


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds a mutation for sending password reset emails to users and provides tests for it.


Does this close any currently open issues?
------------------------------------------
Yes, #491


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
Here is a gif demonstrating this mutation's functionality:
![sendpasswordresetemail](https://user-images.githubusercontent.com/5306336/44218490-cc788300-a147-11e8-8ef7-908de758e214.gif)


Where has this been tested?
---------------------------
**Operating System:** macOS 10.13.6

**WordPress Version:** 4.9.8


Any other comments?
-------------------
I'd love some feedback on this PR.


**The Name**
It was tough to find a good name for this mutation. I was toying with the idea of `userLostPassword`, but decided against it, since that doesn't describe what the mutation does.  WP's function for doing this is named `retrieve_password()`, but I think that's misleading, since it doesn't actually retrieve the user's password – it just emails them a link that can be used to reset it. So I ultimately went with `sendPasswordResetEmail` since I think that most accurately reflects what the mutation does.

I plan to also submit a PR for a `resetUserPassword` mutation that will accept the key and username and perform the reset. See #493.


**The Functionality compared to `retrieve_password()`**
I would have loved to leverage WP's `retrieve_password()` function for handling the bulk of the functionality for this feature, but there are a few things that made it unsuitable:

1. It assumes that the username/password is always in `$_POST['user_login']`. That's inconsistent with the rest of the WPGraphQL user mutations that use `username` as the key, though. My code uses `username` to stay consistent with all other user mutations.
2. Toward the end of the function, if the password reset email doesn't send, `wp_die()` is called. When used in a GraphQL context, that results in a 500 Internal Server Error. In my code, I'm throwing an 'The email could not be sent.' UserError instead in that case, so the GraphQL client always gets a response with usable data rather than a 500 error.

So I based my code on WP's `retrieve_password()`, but put the changes mentioned above in place, and broke up the logic into many smaller methods rather than one very long one.


**The args**
`retrieve_password()` works whether `$_POST['user_login']` is set to a user's username or their email address. I considered making `sendPasswordResetEmail` accept either a `username` arg which would always be the username or an `email` arg which would always be the email. I decided against it though, since doing it that way would require you to know in the GraphQL client whether what the user had entered is their username or their email ahead of time and pass it through as the appropriate arg. So I kept things simple and stuck with a single "username" field. It works like this:

1. The user is presented with a password reset form with a single field in which they can enter their username or password
2. When it's submitted, the value of that field can be sent to the `sendPasswordResetEmail` mutation as the `username` arg without the need to know whether it's the user's username or email – they'll get the password reset email regardless and be on their way.


Thanks!