### PR TITLE
Feature/#493 add user password reset mutation

### DIFF
--- a/src/Type/RootMutationType.php
+++ b/src/Type/RootMutationType.php
@@ -20,6 +20,7 @@ use WPGraphQL\Type\User\Mutation\UserCreate;
 use WPGraphQL\Type\User\Mutation\UserDelete;
 use WPGraphQL\Type\User\Mutation\UserUpdate;
 use WPGraphQL\Type\User\Mutation\UserRegister;
+use WPGraphQL\Type\User\Mutation\ResetUserPassword;
 
 /**
  * Class RootMutationType
@@ -139,10 +140,11 @@ class RootMutationType extends WPObjectType {
 			/**
 			 * User Mutations
 			 */
-			$fields[ 'createUser' ]   = UserCreate::mutate();
-			$fields[ 'updateUser' ]   = UserUpdate::mutate();
-			$fields[ 'deleteUser' ]   = UserDelete::mutate();
-			$fields[ 'registerUser' ] = UserRegister::mutate();
+			$fields[ 'createUser' ]        = UserCreate::mutate();
+			$fields[ 'updateUser' ]        = UserUpdate::mutate();
+			$fields[ 'deleteUser' ]        = UserDelete::mutate();
+			$fields[ 'registerUser' ]      = UserRegister::mutate();
+			$fields[ 'resetUserPassword' ] = ResetUserPassword::mutate();
 
 			self::$fields = $fields;
 

--- a/src/Type/User/Mutation/ResetUserPassword.php
+++ b/src/Type/User/Mutation/ResetUserPassword.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace WPGraphQL\Type\User\Mutation;
+
+use GraphQL\Error\UserError;
+use GraphQL\Type\Definition\ResolveInfo;
+use GraphQLRelay\Relay;
+use WPGraphQL\AppContext;
+use WPGraphQL\Types;
+
+/**
+ * Class ResetUserPassword
+ *
+ * @package WPGraphQL\Type\User\Mutation
+ */
+class ResetUserPassword {
+
+	/**
+	 * Stores the user register mutation
+	 *
+	 * @var array $mutation
+	 * @access private
+	 */
+	private static $mutation;
+
+	/**
+	 * Process the user register mutation
+	 *
+	 * @return array|null
+	 * @access public
+	 */
+	public static function mutate() {
+
+		if ( empty( self::$mutation ) ) {
+
+			self::$mutation = Relay::mutationWithClientMutationId( [
+				'name' => 'ResetUserPassword',
+				'description' => __( 'Reset a user\'s password', 'wp-graphql' ),
+				'inputFields' => self::input_fields(),
+				'outputFields' => [
+					'user' => [
+						'type' => Types::user(),
+						'resolve' => function( $payload ) {
+							return get_user_by( 'ID', $payload['id'] );
+						}
+					]
+				],
+				'mutateAndGetPayload' => function( $input, AppContext $context, ResolveInfo $info ) {
+
+					if ( ! self::was_arg_provided( $input, 'key' ) ) {
+						throw new UserError( __( 'A password reset key is required.', 'wp-graphql' ) );
+					}
+
+					if ( ! self::was_arg_provided( $input, 'login' ) ) {
+						throw new UserError( __( 'A user login is required.', 'wp-graphql' ) );
+					}
+
+					if ( ! self::was_arg_provided( $input, 'password' ) ) {
+						throw new UserError( __( 'A new password is required.', 'wp-graphql' ) );
+					}
+
+					$user = check_password_reset_key( $input['key'], $input['login'] );
+
+					if ( is_wp_error( $user ) ) {
+						throw new UserError( self::get_invalid_key_error_message( $user ) );
+					}
+
+					reset_password( $user, $input['password'] );
+
+					/**
+					 * Return the user ID
+					 */
+					return [
+						'id' => $user->ID,
+					];
+
+				}
+
+			] );
+		}
+
+		return ( ! empty( self::$mutation ) ) ? self::$mutation : null;
+
+	}
+
+	/**
+	 * Was this arg provided in the user input?
+	 *
+	 * @param array  $input User input.
+	 * @param string $arg   The array key to check for.
+	 *
+	 * @return bool
+	 */
+	private static function was_arg_provided( $input, $arg ) {
+
+		return ! empty( $input[ $arg ] ) && is_string( $input[ $arg ] );
+
+	}
+
+	/**
+	 * Get error message for an expired/invalid password reset link.
+	 *
+	 * @param \WP_Error $wp_error Error object.
+	 *
+	 * @return string
+	 */
+	private static function get_invalid_key_error_message( $wp_error ) {
+
+		if ( 'expired_key' === $wp_error->get_error_code() ) {
+			return __( 'Password reset link has expired.', 'wp-graphql' );
+		}
+
+		return __( 'Password reset link is invalid.', 'wp-graphql' );
+	}
+
+	/**
+	 * Add the fields required for a password reset.
+	 *
+	 * @return array
+	 */
+	private static function input_fields() {
+
+		/**
+		 * A password reset requires a reset key, login and password to be passed.
+		 */
+		return [
+			'key'      => [
+				'type'        => Types::string(),
+				'description' => __( 'Password reset key', 'wp-graphql' ),
+			],
+			'login'    => [
+				'type'        => Types::string(),
+				'description' => __( 'The user\'s login (username).', 'wp-graphql' ),
+			],
+			'password' => [
+				'type'        => Types::string(),
+				'description' => __( 'The new password.', 'wp-graphql' ),
+			],
+		];
+
+	}
+
+}


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds a mutation to handle user password resets.


Does this close any currently open issues?
------------------------------------------
Closes #493 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
Here is a gif showing this new mutation in action:
![resetuserpassword](https://user-images.githubusercontent.com/5306336/44343219-5b90de00-a45b-11e8-9e69-4e8e2e8bf7d4.gif)


Where has this been tested?
---------------------------
**Operating System:** macOS 10.13.6

**WordPress Version:** 4.9.8


Any other comments?
-------------------
Please see #493 for a description of how I envision this mutation being used.

Question on input types –
I notice that some WPGraphQL mutations have `Types::non_null( Types::string() )`,`Types::non_null( Types::id() )`, etc. where the type is wrapped in a `non_null()` type. Can someone let me know when that's necessary? It seems like if you're stating that something has to be a string or an int, you've already ruled out the possibility of it being set to null. Is that maybe for optional fields? I want to make sure I understand it. Thanks!