### PR TITLE
Fix error message for non-existent post

### DIFF
--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -175,7 +175,7 @@ class DataSource {
 
 		$post_object = \WP_Post::get_instance( $id );
 		if ( empty( $post_object ) ) {
-			throw new UserError( sprintf( __( 'No %1$s was found with the ID: %2$s', 'wp-graphql' ), $id, $post_type ) );
+			throw new UserError( sprintf( __( 'No %1$s was found with the ID: %2$s', 'wp-graphql' ), $post_type, $id ) );
 		}
 
 		/**

--- a/tests/wpunit/PostObjectQueriesTest.php
+++ b/tests/wpunit/PostObjectQueriesTest.php
@@ -241,6 +241,61 @@ class PostObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	/**
+	 * testPostQueryWherePostDoesNotExist
+	 *
+	 * Tests a query for non existant post.
+	 *
+	 * @since 0.0.34
+	 */
+	public function testPostQueryWherePostDoesNotExist() {
+		/**
+		 * Create the global ID based on the plugin_type and the created $id
+		 */
+		$global_id = \GraphQLRelay\Relay::toGlobalId( 'post', 'doesNotExist' );
+
+		/**
+		 * Create the query string to pass to the $query
+		 */
+		$query = "
+		query {
+			post(id: \"{$global_id}\") {
+				slug
+			}
+		}";
+
+		/**
+		 * Run the GraphQL query
+		 */
+		$actual = do_graphql_request( $query );
+
+		/**
+		 * Establish the expectation for the output of the query
+		 */
+		$expected = [
+			'data' => [
+				'post' => null,
+			],
+			'errors' => [
+				[
+					'message' => 'No post was found with the ID: doesNotExist',
+					'locations' => [
+						[
+							'line' => 3,
+							'column' => 4,
+						],
+					],
+					'path' => [
+						'post',
+					],
+					'category' => 'user',
+				],
+			],
+		];
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
 	 * testPostQueryWithComments
 	 *
 	 * This tests creating a single post with comments.


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes a grammatical error in an error message that has been bugging me for a long time. 😂

It's worth noting that this is actually a breaking change for us! This error corresponds to a 404 response for us on the client. But because this is a error and not an empty response, we have to catch all errors and inspect them in order to determine whether we should 404. The only way to do this is to regex the string, making it a bit fragile.

Have we considered implementing error codes (either on the error object or leading the message)?


Any other comments?
-------------------
Added test, which would at least catch future changes to the message.