### PR TITLE
#504 - Ensure post objects are resolved using DataSource::resolve_pos…

### DIFF
--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -179,6 +179,14 @@ class DataSource {
 		}
 
 		/**
+		 * Mimic core functionality for templates, as seen here:
+		 * https://github.com/WordPress/WordPress/blob/6fd8080e7ee7599b36d4528f72a8ced612130b8c/wp-includes/template-loader.php#L56
+		 */
+		if ( 'attachment' === $post_type ) {
+			remove_filter( 'the_content', 'prepend_attachment' );
+		}
+
+		/**
 		 * Set the resolving post to the global $post. That way any filters that
 		 * might be applied when resolving fields can rely on global post and
 		 * post data being set up.
@@ -759,7 +767,7 @@ class DataSource {
 			}
 		}
 		if ( $post_id ) {
-			return get_post( $post_id, $output );
+			return self::resolve_post_object( $post_id, $post_type );
 		}
 
 		return null;

--- a/src/Type/Comment/CommentType.php
+++ b/src/Type/Comment/CommentType.php
@@ -80,7 +80,13 @@ class CommentType extends WPObjectType {
 						'type'        => Types::post_object_union(),
 						'description' => __( 'The object the comment was added to', 'wp-graphql' ),
 						'resolve'     => function ( \WP_Comment $comment, $args, AppContext $context, ResolveInfo $info ) {
-							return ! empty( $comment->comment_post_ID ) ? get_post( $comment->comment_post_ID ) : null;
+							$post_object = null;
+							if ( ! empty( $comment->comment_post_ID ) ) {
+								$post_object = get_post( $comment->comment_post_ID );
+								$post_object = isset( $post_object->post_type ) && isset( $post_object->ID ) ? DataSource::resolve_post_object( $post_object->ID, $post_object->post_type ) : null;
+							}
+							return $post_object;
+
 						},
 					],
 					'author'      => [

--- a/src/Type/MediaItem/MediaItemType.php
+++ b/src/Type/MediaItem/MediaItemType.php
@@ -74,8 +74,7 @@ class MediaItemType {
 				'type'        => Types::string(),
 				'description' => __( 'The caption for the resource', 'wp-graphql' ),
 				'resolve'     => function( \WP_Post $post, $args, $context, ResolveInfo $info ) {
-					$caption = apply_filters( 'the_excerpt', $post->post_excerpt );
-
+					$caption = apply_filters( 'the_excerpt', apply_filters( 'get_the_excerpt', $post->post_excerpt, $post ) );
 					return ! empty( $caption ) ? $caption : null;
 				},
 			],

--- a/src/Type/MediaItem/MediaItemType.php
+++ b/src/Type/MediaItem/MediaItemType.php
@@ -12,7 +12,8 @@ use WPGraphQL\Types;
  * This class isn't a full definition of a new Type, instead it's used to customize
  * the shape of the mediaItemType (via filter), which is instantiated as a PostObjectType.
  *
- * @see     : wp-graphql.php - add_filter( 'graphql_mediaItem_fields', [ '\WPGraphQL\Type\MediaItem\MediaItemType',
+ * @see     : wp-graphql.php - add_filter( 'graphql_mediaItem_fields', [
+ *          '\WPGraphQL\Type\MediaItem\MediaItemType',
  *          'fields' ], 10, 1 );
  *
  * @package WPGraphQL\Type\MediaItem
@@ -41,10 +42,11 @@ class MediaItemType {
 	private static $media_sizes;
 
 	/**
-	 * This customizes the fields for the mediaItem type ( attachment post_type) as the shape of the mediaItem Schema
-	 * is different than a standard post
+	 * This customizes the fields for the mediaItem type ( attachment post_type) as the shape of
+	 * the mediaItem Schema is different than a standard post
 	 *
-	 * @see: wp-graphql.php - add_filter( 'graphql_mediaItem_fields' );add_filter( 'graphql_mediaItem_fields', [
+	 * @see: wp-graphql.php - add_filter( 'graphql_mediaItem_fields' );add_filter(
+	 *       'graphql_mediaItem_fields', [
 	 *       '\WPGraphQL\Type\MediaItem\MediaItemType', 'fields' ], 10, 1 );
 	 *
 	 * @param array $fields
@@ -73,52 +75,54 @@ class MediaItemType {
 			'caption'      => [
 				'type'        => Types::string(),
 				'description' => __( 'The caption for the resource', 'wp-graphql' ),
-				'resolve'     => function( \WP_Post $post, $args, $context, ResolveInfo $info ) {
+				'resolve'     => function ( \WP_Post $post, $args, $context, ResolveInfo $info ) {
 					$caption = apply_filters( 'the_excerpt', apply_filters( 'get_the_excerpt', $post->post_excerpt, $post ) );
+
 					return ! empty( $caption ) ? $caption : null;
 				},
 			],
 			'altText'      => [
 				'type'        => Types::string(),
 				'description' => __( 'Alternative text to display when resource is not displayed', 'wp-graphql' ),
-				'resolve'     => function( \WP_Post $post, $args, $context, ResolveInfo $info ) {
+				'resolve'     => function ( \WP_Post $post, $args, $context, ResolveInfo $info ) {
 					return get_post_meta( $post->ID, '_wp_attachment_image_alt', true );
 				},
 			],
 			'description'  => [
 				'type'        => Types::string(),
 				'description' => __( 'Description of the image (stored as post_content)', 'wp-graphql' ),
-				'resolve'     => function( \WP_Post $post, $args, $context, ResolveInfo $info ) {
+				'resolve'     => function ( \WP_Post $post, $args, $context, ResolveInfo $info ) {
 					return apply_filters( 'the_content', $post->post_content );
 				},
 			],
 			'mediaType'    => [
 				'type'        => Types::string(),
 				'description' => __( 'Type of resource', 'wp-graphql' ),
-				'resolve'     => function( \WP_Post $post, $args, $context, ResolveInfo $info ) {
+				'resolve'     => function ( \WP_Post $post, $args, $context, ResolveInfo $info ) {
 					return wp_attachment_is_image( $post->ID ) ? 'image' : 'file';
 				},
 			],
 			'sourceUrl'    => [
 				'type'        => Types::string(),
 				'description' => __( 'Url of the mediaItem', 'wp-graphql' ),
-				'resolve'     => function( \WP_Post $post, $args, $context, ResolveInfo $info ) {
+				'resolve'     => function ( \WP_Post $post, $args, $context, ResolveInfo $info ) {
 					return wp_get_attachment_url( $post->ID );
 				},
 			],
-			'mimeType' => [
+			'mimeType'     => [
 				'type'        => Types::string(),
 				'description' => __( 'The mime type of the mediaItem', 'wp-graphql' ),
-				'resolve'     =>function( \WP_Post $post, $args, $context, ResolveInfo $info ) {
+				'resolve'     => function ( \WP_Post $post, $args, $context, ResolveInfo $info ) {
 					return ! empty( $post->post_mime_type ) ? $post->post_mime_type : null;
 				},
 			],
 			'mediaDetails' => [
 				'type'        => self::media_details(),
 				'description' => __( 'Details about the mediaItem', 'wp-graphql' ),
-				'resolve'     => function( \WP_Post $post, $args, $context, ResolveInfo $info ) {
-					$media_details = wp_get_attachment_metadata( $post->ID );
+				'resolve'     => function ( \WP_Post $post, $args, $context, ResolveInfo $info ) {
+					$media_details       = wp_get_attachment_metadata( $post->ID );
 					$media_details['ID'] = $post->ID;
+
 					return $media_details;
 				},
 			],
@@ -140,7 +144,7 @@ class MediaItemType {
 		if ( null === self::$media_details ) {
 			self::$media_details = new WPObjectType( [
 				'name'   => 'MediaDetails',
-				'fields' => function() {
+				'fields' => function () {
 					$fields = [
 						'width'  => [
 							'type'        => Types::int(),
@@ -157,20 +161,21 @@ class MediaItemType {
 						'sizes'  => [
 							'type'        => Types::list_of( self::media_sizes() ),
 							'description' => __( 'The available sizes of the mediaItem', 'wp-graphql' ),
-							'resolve'     => function( $media_details, $args, $context, ResolveInfo $info ) {
+							'resolve'     => function ( $media_details, $args, $context, ResolveInfo $info ) {
 								if ( ! empty( $media_details['sizes'] ) ) {
 									foreach ( $media_details['sizes'] as $size_name => $size ) {
-										$size['ID']     = $media_details['ID'];
-										$size['name']   = $size_name;
-										$sizes[]        = $size;
+										$size['ID']   = $media_details['ID'];
+										$size['name'] = $size_name;
+										$sizes[]      = $size;
 									}
 								}
+
 								return ! empty( $sizes ) ? $sizes : null;
 							},
 						],
 						'meta'   => [
 							'type'    => self::media_item_meta(),
-							'resolve' => function( $media_details, $args, $context, ResolveInfo $info ) {
+							'resolve' => function ( $media_details, $args, $context, ResolveInfo $info ) {
 								return ! empty( $media_details['image_meta'] ) ? $media_details['image_meta'] : null;
 							},
 						],
@@ -210,7 +215,7 @@ class MediaItemType {
 					],
 					'createdTimestamp' => [
 						'type'    => Types::int(),
-						'resolve' => function( $meta, $args, $context, ResolveInfo $info ) {
+						'resolve' => function ( $meta, $args, $context, ResolveInfo $info ) {
 							return ! empty( $meta['created_timestamp'] ) ? $meta['created_timestamp'] : null;
 						},
 					],
@@ -219,7 +224,7 @@ class MediaItemType {
 					],
 					'focalLength'      => [
 						'type'    => Types::int(),
-						'resolve' => function( $meta, $args, $context, ResolveInfo $info ) {
+						'resolve' => function ( $meta, $args, $context, ResolveInfo $info ) {
 							return ! empty( $meta['focal_length'] ) ? $meta['focal_length'] : null;
 						},
 					],
@@ -228,7 +233,7 @@ class MediaItemType {
 					],
 					'shutterSpeed'     => [
 						'type'    => Types::float(),
-						'resolve' => function( $meta, $args, $context, ResolveInfo $info ) {
+						'resolve' => function ( $meta, $args, $context, ResolveInfo $info ) {
 							return ! empty( $meta['shutter_speed'] ) ? $meta['shutter_speed'] : null;
 						},
 					],
@@ -279,14 +284,14 @@ class MediaItemType {
 					'mimeType'  => [
 						'type'        => Types::string(),
 						'description' => __( 'The mime type of the resource', 'wp-graphql' ),
-						'resolve'     => function( $image, $args, $context, ResolveInfo $info ) {
+						'resolve'     => function ( $image, $args, $context, ResolveInfo $info ) {
 							return ! empty( $image['mime-type'] ) ? $image['mime-type'] : null;
 						},
 					],
 					'sourceUrl' => [
 						'type'        => Types::string(),
 						'description' => __( 'The url of the for the referenced size', 'wp-graphql' ),
-						'resolve'     => function( $image, $args, $context, ResolveInfo $info ) {
+						'resolve'     => function ( $image, $args, $context, ResolveInfo $info ) {
 
 							$src_url = null;
 

--- a/src/Type/MediaItem/Mutation/MediaItemCreate.php
+++ b/src/Type/MediaItem/Mutation/MediaItemCreate.php
@@ -6,6 +6,7 @@ use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
+use WPGraphQL\Data\DataSource;
 use WPGraphQL\Types;
 
 /**
@@ -44,7 +45,7 @@ class MediaItemCreate {
 				'mediaItem' => [
 					'type' => Types::post_object( $post_type_object->name ),
 					'resolve' => function( $payload ) {
-						return get_post( $payload['id'] );
+						return DataSource::resolve_post_object( $payload['id'], 'attachment' );
 					},
 				],
 			],

--- a/src/Type/MediaItem/Mutation/MediaItemCreate.php
+++ b/src/Type/MediaItem/Mutation/MediaItemCreate.php
@@ -38,18 +38,18 @@ class MediaItemCreate {
 		$mutation_name = 'CreateMediaItem';
 
 		self::$mutation['mediaItem'] = Relay::mutationWithClientMutationId( [
-			'name' => esc_html( $mutation_name ),
-			'description' => __( 'Create mediaItems', 'wp-graphql' ),
-			'inputFields' => self::input_fields( $post_type_object ),
-			'outputFields' => [
+			'name'                => esc_html( $mutation_name ),
+			'description'         => __( 'Create mediaItems', 'wp-graphql' ),
+			'inputFields'         => self::input_fields( $post_type_object ),
+			'outputFields'        => [
 				'mediaItem' => [
-					'type' => Types::post_object( $post_type_object->name ),
-					'resolve' => function( $payload ) {
+					'type'    => Types::post_object( $post_type_object->name ),
+					'resolve' => function ( $payload ) {
 						return DataSource::resolve_post_object( $payload['id'], 'attachment' );
 					},
 				],
 			],
-			'mutateAndGetPayload' => function( $input, AppContext $context, ResolveInfo $info ) use ( $post_type_object, $mutation_name ) {
+			'mutateAndGetPayload' => function ( $input, AppContext $context, ResolveInfo $info ) use ( $post_type_object, $mutation_name ) {
 
 				/**
 				 * Stop now if a user isn't allowed to upload a mediaItem
@@ -62,7 +62,7 @@ class MediaItemCreate {
 				 * Set the file name, whether it's a local file or from a URL.
 				 * Then set the url for the uploaded file
 				 */
-				$file_name = basename( $input['filePath'] );
+				$file_name         = basename( $input['filePath'] );
 				$uploaded_file_url = $input['filePath'];
 
 				/**
@@ -75,7 +75,7 @@ class MediaItemCreate {
 				 * If the mediaItem file is from a local server, use wp_upload_bits before saving it to the uploads folder
 				 */
 				if ( 'file' === parse_url( $input['filePath'], PHP_URL_SCHEME ) ) {
-					$uploaded_file = wp_upload_bits( $file_name, null, file_get_contents( $input['filePath'] ) );
+					$uploaded_file     = wp_upload_bits( $file_name, null, file_get_contents( $input['filePath'] ) );
 					$uploaded_file_url = ( empty ( $uploaded_file['error'] ) ? $uploaded_file['url'] : null );
 				}
 
@@ -84,7 +84,7 @@ class MediaItemCreate {
 				 * https://developer.wordpress.org/reference/functions/download_url/
 				 */
 				$timeout_seconds = 300;
-				$temp_file = download_url( $uploaded_file_url, $timeout_seconds );
+				$temp_file       = download_url( $uploaded_file_url, $timeout_seconds );
 
 				/**
 				 * Handle the error from download_url if it occurs
@@ -177,7 +177,7 @@ class MediaItemCreate {
 				 * If we make it this far the file and attachment
 				 * have been validated and we will not receive any errors
 				 */
-				$attachment_data = wp_generate_attachment_metadata( $attachment_id, $file['file'] );
+				$attachment_data        = wp_generate_attachment_metadata( $attachment_id, $file['file'] );
 				$attachment_data_update = wp_update_attachment_metadata( $attachment_id, $attachment_data );
 
 				/**
@@ -211,7 +211,7 @@ class MediaItemCreate {
 		 */
 		return array_merge(
 			[
-				'filePath'      => [
+				'filePath' => [
 					'type'        => Types::non_null( Types::string() ),
 					'description' => __( 'The URL or file path to the mediaItem', 'wp-graphql' ),
 				],

--- a/src/Type/MediaItem/Mutation/MediaItemDelete.php
+++ b/src/Type/MediaItem/Mutation/MediaItemDelete.php
@@ -52,16 +52,17 @@ class MediaItemDelete {
 				'deletedId' => [
 					'type'        => Types::id(),
 					'description' => __( 'The ID of the deleted mediaItem', 'wp-graphql' ),
-					'resolve'     => function( $payload ) use ( $post_type_object ) {
+					'resolve'     => function ( $payload ) use ( $post_type_object ) {
 						$deleted = (object) $payload['mediaItemObject'];
 						$deleted = isset( $deleted->ID ) && isset( $post_type_object->ID ) ? DataSource::resolve_post_object( $deleted->ID, $post_type_object->name ) : $deleted;
+
 						return ! empty( $deleted->ID ) ? Relay::toGlobalId( $post_type_object->name, absint( $deleted->ID ) ) : null;
 					},
 				],
 				'mediaItem' => [
 					'type'        => Types::post_object( $post_type_object->name ),
 					'description' => __( 'The mediaItem before it was deleted', 'wp-graphql' ),
-					'resolve'     => function( $payload ) use ( $post_type_object ) {
+					'resolve'     => function ( $payload ) use ( $post_type_object ) {
 						$deleted = (object) $payload['mediaItemObject'];
 						$deleted = isset( $deleted->ID ) && isset( $post_type_object->name ) ? DataSource::resolve_post_object( $deleted->ID, $post_type_object->name ) : $deleted;
 
@@ -69,12 +70,12 @@ class MediaItemDelete {
 					},
 				],
 			],
-			'mutateAndGetPayload' => function( $input ) use ( $post_type_object, $mutation_name ) {
+			'mutateAndGetPayload' => function ( $input ) use ( $post_type_object, $mutation_name ) {
 
 				/**
 				 * Get the ID from the global ID
 				 */
-				$id_parts = Relay::fromGlobalId( $input['id'] );
+				$id_parts            = Relay::fromGlobalId( $input['id'] );
 				$existing_media_item = get_post( absint( $id_parts['id'] ) );
 
 				/**

--- a/src/Type/MediaItem/Mutation/MediaItemDelete.php
+++ b/src/Type/MediaItem/Mutation/MediaItemDelete.php
@@ -54,7 +54,6 @@ class MediaItemDelete {
 					'description' => __( 'The ID of the deleted mediaItem', 'wp-graphql' ),
 					'resolve'     => function ( $payload ) use ( $post_type_object ) {
 						$deleted = (object) $payload['mediaItemObject'];
-						$deleted = isset( $deleted->ID ) && isset( $post_type_object->ID ) ? DataSource::resolve_post_object( $deleted->ID, $post_type_object->name ) : $deleted;
 
 						return ! empty( $deleted->ID ) ? Relay::toGlobalId( $post_type_object->name, absint( $deleted->ID ) ) : null;
 					},
@@ -64,7 +63,6 @@ class MediaItemDelete {
 					'description' => __( 'The mediaItem before it was deleted', 'wp-graphql' ),
 					'resolve'     => function ( $payload ) use ( $post_type_object ) {
 						$deleted = (object) $payload['mediaItemObject'];
-						$deleted = isset( $deleted->ID ) && isset( $post_type_object->name ) ? DataSource::resolve_post_object( $deleted->ID, $post_type_object->name ) : $deleted;
 
 						return ! empty( $deleted ) ? $deleted : null;
 					},
@@ -101,6 +99,8 @@ class MediaItemDelete {
 				 * Get the mediaItem object before deleting it
 				 */
 				$media_item_before_delete = get_post( absint( $id_parts['id'] ) );
+				$media_item_before_delete = isset( $media_item_before_delete->ID ) && isset( $media_item_before_delete->ID ) ? DataSource::resolve_post_object( $media_item_before_delete->ID, $post_type_object->name ) : $media_item_before_delete;
+
 
 				/**
 				 * If the mediaItem isn't of the attachment post type, throw an error

--- a/src/Type/MediaItem/Mutation/MediaItemDelete.php
+++ b/src/Type/MediaItem/Mutation/MediaItemDelete.php
@@ -4,6 +4,7 @@ namespace WPGraphQL\Type\MediaItem\Mutation;
 
 use GraphQL\Error\UserError;
 use GraphQLRelay\Relay;
+use WPGraphQL\Data\DataSource;
 use WPGraphQL\Types;
 
 /**
@@ -53,14 +54,17 @@ class MediaItemDelete {
 					'description' => __( 'The ID of the deleted mediaItem', 'wp-graphql' ),
 					'resolve'     => function( $payload ) use ( $post_type_object ) {
 						$deleted = (object) $payload['mediaItemObject'];
+						$deleted = isset( $deleted->ID ) && isset( $post_type_object->ID ) ? DataSource::resolve_post_object( $deleted->ID, $post_type_object->name ) : $deleted;
 						return ! empty( $deleted->ID ) ? Relay::toGlobalId( $post_type_object->name, absint( $deleted->ID ) ) : null;
 					},
 				],
 				'mediaItem' => [
 					'type'        => Types::post_object( $post_type_object->name ),
 					'description' => __( 'The mediaItem before it was deleted', 'wp-graphql' ),
-					'resolve'     => function( $payload ) {
+					'resolve'     => function( $payload ) use ( $post_type_object ) {
 						$deleted = (object) $payload['mediaItemObject'];
+						$deleted = isset( $deleted->ID ) && isset( $post_type_object->name ) ? DataSource::resolve_post_object( $deleted->ID, $post_type_object->name ) : $deleted;
+
 						return ! empty( $deleted ) ? $deleted : null;
 					},
 				],

--- a/src/Type/MediaItem/Mutation/MediaItemUpdate.php
+++ b/src/Type/MediaItem/Mutation/MediaItemUpdate.php
@@ -6,6 +6,7 @@ use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
+use WPGraphQL\Data\DataSource;
 use WPGraphQL\Types;
 
 /**
@@ -44,7 +45,7 @@ class MediaItemUpdate {
 				'mediaItem' => [
 					'type'    => Types::post_object( $post_type_object->name ),
 					'resolve' => function( $payload ) {
-						return get_post( $payload['postObjectId'] );
+						return DataSource::resolve_post_object( $payload['postObjectId'], 'attachment' );
 					},
 				],
 			],

--- a/src/Type/MediaItem/Mutation/MediaItemUpdate.php
+++ b/src/Type/MediaItem/Mutation/MediaItemUpdate.php
@@ -37,21 +37,21 @@ class MediaItemUpdate {
 		 */
 		$mutation_name = 'UpdateMediaItem';
 
-		self::$mutation['mediaItem'] = Relay::mutationWithClientMutationId([
+		self::$mutation['mediaItem'] = Relay::mutationWithClientMutationId( [
 			'name'                => esc_html( $mutation_name ),
 			'description'         => __( 'Updates mediaItem objects', 'wp-graphql' ),
 			'inputFields'         => self::input_fields( $post_type_object ),
 			'outputFields'        => [
 				'mediaItem' => [
 					'type'    => Types::post_object( $post_type_object->name ),
-					'resolve' => function( $payload ) {
+					'resolve' => function ( $payload ) {
 						return DataSource::resolve_post_object( $payload['postObjectId'], 'attachment' );
 					},
 				],
 			],
-			'mutateAndGetPayload' => function( $input, AppContext $context, ResolveInfo $info ) use ( $post_type_object, $mutation_name ) {
+			'mutateAndGetPayload' => function ( $input, AppContext $context, ResolveInfo $info ) use ( $post_type_object, $mutation_name ) {
 
-				$id_parts      = ! empty( $input['id'] ) ? Relay::fromGlobalId( $input['id'] ) : null;
+				$id_parts            = ! empty( $input['id'] ) ? Relay::fromGlobalId( $input['id'] ) : null;
 				$existing_media_item = get_post( absint( $id_parts['id'] ) );
 
 				/**
@@ -84,7 +84,7 @@ class MediaItemUpdate {
 				 **/
 				if ( ! empty( $input['authorId'] ) ) {
 					$author_id_parts = Relay::fromGlobalId( $input['authorId'] );
-					$author_id = $author_id_parts['id'];
+					$author_id       = $author_id_parts['id'];
 				}
 
 				/**
@@ -98,8 +98,8 @@ class MediaItemUpdate {
 				/**
 				 * insert the post object and get the ID
 				 */
-				$post_args = MediaItemMutation::prepare_media_item( $input, $post_type_object, $mutation_name, false );
-				$post_args['ID'] = absint( $id_parts['id'] );
+				$post_args                = MediaItemMutation::prepare_media_item( $input, $post_type_object, $mutation_name, false );
+				$post_args['ID']          = absint( $id_parts['id'] );
 				$post_args['post_author'] = $author_id;
 
 				/**
@@ -126,7 +126,7 @@ class MediaItemUpdate {
 				];
 
 			},
-		]);
+		] );
 
 		return ! empty( self::$mutation[ $post_type_object->graphql_single_name ] ) ? self::$mutation[ $post_type_object->graphql_single_name ] : null;
 

--- a/src/Type/MenuItem/MenuItemType.php
+++ b/src/Type/MenuItem/MenuItemType.php
@@ -5,6 +5,7 @@ namespace WPGraphQL\Type\MenuItem;
 use GraphQLRelay\Relay;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
+use WPGraphQL\Data\DataSource;
 use WPGraphQL\Type\WPObjectType;
 use WPGraphQL\Types;
 use WPGraphQL\Type\MenuItem\Connection\MenuItemConnectionDefinition;
@@ -82,11 +83,13 @@ class MenuItemType extends WPObjectType {
 								// Post object
 								case 'post_type':
 									$resolved_object = get_post( $object_id );
+									$resolved_object = isset( $resolved_object->post_type ) && isset( $resolved_object->ID ) ? DataSource::resolve_post_object( $resolved_object->ID, $resolved_object->post_type ) : $resolved_object;
 									break;
 
 								// Taxonomy term
 								case 'taxonomy':
 									$resolved_object = get_term( $object_id );
+									$resolved_object = isset( $resolved_object->term_id ) && isset( $resolved_object->taxonomy ) ? DataSource::resolve_term_object( $resolved_object->term_id, $resolved_object->taxonomy ) : $resolved_object;
 									break;
 							}
 

--- a/src/Type/MenuItem/MenuItemType.php
+++ b/src/Type/MenuItem/MenuItemType.php
@@ -58,20 +58,20 @@ class MenuItemType extends WPObjectType {
 
 		if ( null === self::$fields ) {
 
-			self::$fields = function() {
+			self::$fields = function () {
 				$fields = [
-					'id' => [
+					'id'               => [
 						'type'        => Types::non_null( Types::id() ),
 						'description' => __( 'Relay ID of the menu item.', 'wp-graphql' ),
-						'resolve'     => function( \WP_Post $menu_item ) {
+						'resolve'     => function ( \WP_Post $menu_item ) {
 							return ! empty( $menu_item->ID ) ? Relay::toGlobalId( self::$type_name, $menu_item->ID ) : null;
 						},
 					],
-					'childItems' => MenuItemConnectionDefinition::connection(),
-					'connectedObject' => [
+					'childItems'       => MenuItemConnectionDefinition::connection(),
+					'connectedObject'  => [
 						'type'        => Types::menu_item_object_union(),
 						'description' => __( 'The object connected to this menu item.', 'wp-graphql' ),
-						'resolve' => function( \WP_Post $menu_item, array $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => function ( \WP_Post $menu_item, array $args, AppContext $context, ResolveInfo $info ) {
 							$object_id   = intval( get_post_meta( $menu_item->ID, '_menu_item_object_id', true ) );
 							$object_type = get_post_meta( $menu_item->ID, '_menu_item_type', true );
 
@@ -100,11 +100,11 @@ class MenuItemType extends WPObjectType {
 							 * e.g., a linked post object (or vice-versa).
 							 *
 							 * @param \WP_Post|\WP_Term $resolved_object Post or term connected to MenuItem
-							 * @param array           $args            Array of arguments input in the field as part of the GraphQL query
-							 * @param AppContext      $context         Object containing app context that gets passed down the resolve tree
-							 * @param ResolveInfo     $info            Info about fields passed down the resolve tree
-							 * @param int             $object_id       Post or term ID of connected object
-							 * @param string          $object_type     Type of connected object ("post_type" or "taxonomy")
+							 * @param array             $args            Array of arguments input in the field as part of the GraphQL query
+							 * @param AppContext        $context         Object containing app context that gets passed down the resolve tree
+							 * @param ResolveInfo       $info            Info about fields passed down the resolve tree
+							 * @param int               $object_id       Post or term ID of connected object
+							 * @param string            $object_type     Type of connected object ("post_type" or "taxonomy")
 							 *
 							 * @since 0.0.30
 							 */
@@ -119,10 +119,10 @@ class MenuItemType extends WPObjectType {
 							);
 						},
 					],
-					'cssClasses' => [
+					'cssClasses'       => [
 						'type'        => Types::list_of( Types::string() ),
 						'description' => __( 'Class attribute for the menu item link', 'wp-graphql' ),
-						'resolve'     => function( \WP_Post $menu_item ) {
+						'resolve'     => function ( \WP_Post $menu_item ) {
 
 							// If all we have is a non-array or an array with one empty
 							// string, return an empty array.
@@ -133,52 +133,52 @@ class MenuItemType extends WPObjectType {
 							return $menu_item->classes;
 						},
 					],
-					'description' => [
+					'description'      => [
 						'type'        => Types::string(),
 						'description' => __( 'Description of the menu item.', 'wp-graphql' ),
-						'resolve'     => function( \WP_Post $menu_item ) {
+						'resolve'     => function ( \WP_Post $menu_item ) {
 							return ( ! empty( $menu_item->description ) ) ? $menu_item->description : null;
 						},
 					],
-					'label' => [
+					'label'            => [
 						'type'        => Types::string(),
 						'description' => __( 'Label or title of the menu item.', 'wp-graphql' ),
-						'resolve'     => function( \WP_Post $menu_item ) {
+						'resolve'     => function ( \WP_Post $menu_item ) {
 							return ( ! empty( $menu_item->title ) ) ? $menu_item->title : null;
 						},
 					],
 					'linkRelationship' => [
 						'type'        => Types::string(),
 						'description' => __( 'Link relationship (XFN) of the menu item.', 'wp-graphql' ),
-						'resolve'     => function( \WP_Post $menu_item ) {
+						'resolve'     => function ( \WP_Post $menu_item ) {
 							return ! empty( $menu_item->xfn ) ? $menu_item->xfn : null;
 						},
 					],
-					'menuItemId' => [
+					'menuItemId'       => [
 						'type'        => Types::int(),
 						'description' => __( 'WP ID of the menu item.', 'wp-graphql' ),
-						'resolve'     => function( \WP_Post $menu_item ) {
+						'resolve'     => function ( \WP_Post $menu_item ) {
 							return ! empty( $menu_item->ID ) ? $menu_item->ID : null;
 						},
 					],
-					'target' => [
+					'target'           => [
 						'type'        => Types::string(),
 						'description' => __( 'Target attribute for the menu item link.', 'wp-graphql' ),
-						'resolve'     => function( \WP_Post $menu_item ) {
+						'resolve'     => function ( \WP_Post $menu_item ) {
 							return ! empty( $menu_item->target ) ? $menu_item->target : null;
 						},
 					],
-					'title' => [
+					'title'            => [
 						'type'        => Types::string(),
 						'description' => __( 'Title attribute for the menu item link', 'wp-graphql' ),
-						'resolve'     => function( \WP_Post $menu_item ) {
+						'resolve'     => function ( \WP_Post $menu_item ) {
 							return ( ! empty( $menu_item->attr_title ) ) ? $menu_item->attr_title : null;
 						},
 					],
-					'url' => [
+					'url'              => [
 						'type'        => Types::string(),
 						'description' => __( 'URL or destination of the menu item.', 'wp-graphql' ),
-						'resolve'     => function( \WP_Post $menu_item ) {
+						'resolve'     => function ( \WP_Post $menu_item ) {
 							return ! empty( $menu_item->url ) ? $menu_item->url : null;
 						},
 					],

--- a/src/Type/PostObject/Mutation/PostObjectCreate.php
+++ b/src/Type/PostObject/Mutation/PostObjectCreate.php
@@ -6,6 +6,7 @@ use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
+use WPGraphQL\Data\DataSource;
 use WPGraphQL\Type\WPInputObjectType;
 use WPGraphQL\Types;
 
@@ -50,8 +51,8 @@ class PostObjectCreate {
 				'outputFields'        => [
 					$post_type_object->graphql_single_name => [
 						'type'    => Types::post_object( $post_type_object->name ),
-						'resolve' => function( $payload ) {
-							return get_post( $payload['id'] );
+						'resolve' => function( $payload ) use ( $post_type_object ) {
+							return DataSource::resolve_post_object( $payload['id'], $post_type_object->name );
 						},
 					],
 				],

--- a/src/Type/PostObject/Mutation/PostObjectCreate.php
+++ b/src/Type/PostObject/Mutation/PostObjectCreate.php
@@ -51,12 +51,12 @@ class PostObjectCreate {
 				'outputFields'        => [
 					$post_type_object->graphql_single_name => [
 						'type'    => Types::post_object( $post_type_object->name ),
-						'resolve' => function( $payload ) use ( $post_type_object ) {
+						'resolve' => function ( $payload ) use ( $post_type_object ) {
 							return DataSource::resolve_post_object( $payload['id'], $post_type_object->name );
 						},
 					],
 				],
-				'mutateAndGetPayload' => function( $input, AppContext $context, ResolveInfo $info ) use ( $post_type_object, $mutation_name ) {
+				'mutateAndGetPayload' => function ( $input, AppContext $context, ResolveInfo $info ) use ( $post_type_object, $mutation_name ) {
 
 					/**
 					 * Throw an exception if there's no input

--- a/src/Type/PostObject/Mutation/PostObjectDelete.php
+++ b/src/Type/PostObject/Mutation/PostObjectDelete.php
@@ -4,6 +4,7 @@ namespace WPGraphQL\Type\PostObject\Mutation;
 
 use GraphQL\Error\UserError;
 use GraphQLRelay\Relay;
+use WPGraphQL\Data\DataSource;
 use WPGraphQL\Types;
 
 /**
@@ -67,10 +68,9 @@ class PostObjectDelete {
 					$post_type_object->graphql_single_name => [
 						'type'        => Types::post_object( $post_type_object->name ),
 						'description' => __( 'The object before it was deleted', 'wp-graphql' ),
-						'resolve'     => function( $payload ) {
+						'resolve'     => function( $payload ) use ( $post_type_object ) {
 							$deleted = (object) $payload['postObject'];
-
-							return ! empty( $deleted ) ? $deleted : null;
+							return isset( $deleted->ID ) && isset( $deleted->post_type ) ? DataSource::resolve_post_object( $deleted->ID, $deleted->post_type ) : null;
 						},
 					],
 				],

--- a/src/Type/PostObject/Mutation/PostObjectDelete.php
+++ b/src/Type/PostObject/Mutation/PostObjectDelete.php
@@ -59,7 +59,7 @@ class PostObjectDelete {
 					'deletedId'                            => [
 						'type'        => Types::id(),
 						'description' => __( 'The ID of the deleted object', 'wp-graphql' ),
-						'resolve'     => function( $payload ) use ( $post_type_object ) {
+						'resolve'     => function ( $payload ) use ( $post_type_object ) {
 							$deleted = (object) $payload['postObject'];
 
 							return ! empty( $deleted->ID ) ? Relay::toGlobalId( $post_type_object->name, absint( $deleted->ID ) ) : null;
@@ -68,13 +68,14 @@ class PostObjectDelete {
 					$post_type_object->graphql_single_name => [
 						'type'        => Types::post_object( $post_type_object->name ),
 						'description' => __( 'The object before it was deleted', 'wp-graphql' ),
-						'resolve'     => function( $payload ) use ( $post_type_object ) {
+						'resolve'     => function ( $payload ) use ( $post_type_object ) {
 							$deleted = (object) $payload['postObject'];
-							return isset( $deleted->ID ) && isset( $deleted->post_type ) ? DataSource::resolve_post_object( $deleted->ID, $deleted->post_type ) : null;
+
+							return ! empty( $deleted ) ? $deleted : null;
 						},
 					],
 				],
-				'mutateAndGetPayload' => function( $input ) use ( $post_type_object, $mutation_name ) {
+				'mutateAndGetPayload' => function ( $input ) use ( $post_type_object, $mutation_name ) {
 
 					/**
 					 * Get the ID from the global ID
@@ -98,6 +99,8 @@ class PostObjectDelete {
 					 * Get the post object before deleting it
 					 */
 					$post_before_delete = get_post( absint( $id_parts['id'] ) );
+					$post_before_delete = isset( $post_before_delete->ID ) && isset( $post_before_delete->post_type ) ? DataSource::resolve_post_object( $post_before_delete->ID, $post_before_delete->post_type ) : $post_before_delete;
+
 
 					/**
 					 * If the post is already in the trash, and the forceDelete input was not passed,

--- a/src/Type/PostObject/Mutation/PostObjectUpdate.php
+++ b/src/Type/PostObject/Mutation/PostObjectUpdate.php
@@ -6,6 +6,7 @@ use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
+use WPGraphQL\Data\DataSource;
 use WPGraphQL\Type\WPInputObjectType;
 use WPGraphQL\Types;
 
@@ -50,8 +51,8 @@ class PostObjectUpdate {
 				'outputFields'        => [
 					$post_type_object->graphql_single_name => [
 						'type'    => Types::post_object( $post_type_object->name ),
-						'resolve' => function( $payload ) {
-							return get_post( $payload['postObjectId'] );
+						'resolve' => function( $payload ) use ( $post_type_object ) {
+							return DataSource::resolve_post_object( $payload['postObjectId'], $post_type_object->name );
 						},
 					],
 				],

--- a/src/Type/PostObject/Mutation/PostObjectUpdate.php
+++ b/src/Type/PostObject/Mutation/PostObjectUpdate.php
@@ -51,12 +51,12 @@ class PostObjectUpdate {
 				'outputFields'        => [
 					$post_type_object->graphql_single_name => [
 						'type'    => Types::post_object( $post_type_object->name ),
-						'resolve' => function( $payload ) use ( $post_type_object ) {
+						'resolve' => function ( $payload ) use ( $post_type_object ) {
 							return DataSource::resolve_post_object( $payload['postObjectId'], $post_type_object->name );
 						},
 					],
 				],
-				'mutateAndGetPayload' => function( $input, AppContext $context, ResolveInfo $info ) use ( $post_type_object, $mutation_name ) {
+				'mutateAndGetPayload' => function ( $input, AppContext $context, ResolveInfo $info ) use ( $post_type_object, $mutation_name ) {
 
 					$id_parts      = ! empty( $input['id'] ) ? Relay::fromGlobalId( $input['id'] ) : null;
 					$existing_post = get_post( absint( $id_parts['id'] ) );

--- a/src/Type/PostObject/PostObjectType.php
+++ b/src/Type/PostObject/PostObjectType.php
@@ -18,13 +18,14 @@ use WPGraphQL\Types;
 /**
  * Class PostObjectType
  *
- * This sets up the base PostObjectType. Custom Post Types that are set to "show_in_graphql" automatically
- * use the PostObjectType and inherit the fields that are defined here. The fields get passed through a
- * filter unique to each type, so each post_type can modify it's type schema via field filters.
+ * This sets up the base PostObjectType. Custom Post Types that are set to "show_in_graphql"
+ * automatically use the PostObjectType and inherit the fields that are defined here. The fields
+ * get passed through a filter unique to each type, so each post_type can modify it's type schema
+ * via field filters.
  *
- * NOTE: In some cases the shape of a Custom Post Type's schema is so drastically different from the standard
- * PostObjectType shape it might make more sense for the custom post type to register a different type
- * altogether instead of utilizing the PostObjectType.
+ * NOTE: In some cases the shape of a Custom Post Type's schema is so drastically different from
+ * the standard PostObjectType shape it might make more sense for the custom post type to register
+ * a different type altogether instead of utilizing the PostObjectType.
  *
  * @package WPGraphQL\Type
  * @since   0.0.5
@@ -113,19 +114,19 @@ class PostObjectType extends WPObjectType {
 			 * @return mixed
 			 * @since 0.0.5
 			 */
-			self::$fields[ $single_name ] = function() use ( $single_name, $post_type_object, $allowed_taxonomies ) {
+			self::$fields[ $single_name ] = function () use ( $single_name, $post_type_object, $allowed_taxonomies ) {
 				$fields = [
 					'id'                => [
 						'type'        => Types::non_null( Types::id() ),
 						'description' => __( 'The globally unique ID for the object', 'wp-graphql' ),
-						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => function ( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							return ( ! empty( $post->post_type ) && ! empty( $post->ID ) ) ? Relay::toGlobalId( $post->post_type, $post->ID ) : null;
 						},
 					],
 					$single_name . 'Id' => [
 						'type'        => Types::non_null( Types::int() ),
 						'description' => __( 'The id field matches the WP_Post->ID field.', 'wp-graphql' ),
-						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => function ( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							return absint( $post->ID );
 						},
 					],
@@ -138,7 +139,7 @@ class PostObjectType extends WPObjectType {
 								'description' => __( 'The types of ancestors to check for. Defaults to the same type as the current object', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => function ( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							$ancestors    = [];
 							$types        = ! empty( $args['types'] ) ? $args['types'] : [ $post->post_type ];
 							$ancestor_ids = get_ancestors( $post->ID, $post->post_type );
@@ -157,21 +158,21 @@ class PostObjectType extends WPObjectType {
 					'author'            => [
 						'type'        => Types::user(),
 						'description' => __( "The author field will return a queryable User type matching the post's author.", 'wp-graphql' ),
-						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => function ( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							return DataSource::resolve_user( $post->post_author );
 						},
 					],
 					'date'              => [
 						'type'        => Types::string(),
 						'description' => __( 'Post publishing date.', 'wp-graphql' ),
-						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => function ( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post->post_date ) ? $post->post_date : null;
 						},
 					],
 					'dateGmt'           => [
 						'type'        => Types::string(),
 						'description' => __( 'The publishing date set in GMT.', 'wp-graphql' ),
-						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => function ( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post->post_date_gmt ) ? Types::prepare_date_response( $post->post_date_gmt ) : null;
 						},
 					],
@@ -181,7 +182,7 @@ class PostObjectType extends WPObjectType {
 						'args'        => [
 							'format' => self::post_object_format_arg(),
 						],
-						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => function ( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 
 							$content = ! empty( $post->post_content ) ? $post->post_content : null;
 
@@ -199,9 +200,9 @@ class PostObjectType extends WPObjectType {
 						'args'        => [
 							'format' => self::post_object_format_arg(),
 						],
-						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => function ( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 
-							$id = ! empty( $post->ID ) ? $post->ID : null;
+							$id    = ! empty( $post->ID ) ? $post->ID : null;
 							$title = ! empty( $post->post_title ) ? $post->post_title : null;
 
 							// If the raw format is requested, don't apply any filters.
@@ -218,7 +219,7 @@ class PostObjectType extends WPObjectType {
 						'args'        => [
 							'format' => self::post_object_format_arg(),
 						],
-						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => function ( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 
 							$excerpt = ! empty( $post->post_excerpt ) ? $post->post_excerpt : null;
 
@@ -235,71 +236,72 @@ class PostObjectType extends WPObjectType {
 					'status'            => [
 						'type'        => Types::string(),
 						'description' => __( 'The current status of the object', 'wp-graphql' ),
-						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => function ( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post->post_status ) ? $post->post_status : null;
 						},
 					],
 					'commentStatus'     => array(
 						'type'        => Types::string(),
 						'description' => __( 'Whether the comments are open or closed for this particular post.', 'wp-graphql' ),
-						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => function ( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post->comment_status ) ? $post->comment_status : null;
 						},
 					),
 					'pingStatus'        => [
 						'type'        => Types::string(),
 						'description' => __( 'Whether the pings are open or closed for this particular post.', 'wp-graphql' ),
-						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => function ( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post->ping_status ) ? $post->ping_status : null;
 						},
 					],
 					'slug'              => [
 						'type'        => Types::string(),
 						'description' => __( 'The uri slug for the post. This is equivalent to the WP_Post->post_name field and the post_name column in the database for the `post_objects` table.', 'wp-graphql' ),
-						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => function ( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post->post_name ) ? $post->post_name : null;
 						},
 					],
 					'toPing'            => [
 						'type'        => Types::list_of( Types::string() ),
 						'description' => __( 'URLs queued to be pinged.', 'wp-graphql' ),
-						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => function ( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post->to_ping ) ? implode( ',', $post->to_ping ) : null;
 						},
 					],
 					'pinged'            => [
 						'type'        => Types::list_of( Types::string() ),
 						'description' => __( 'URLs that have been pinged.', 'wp-graphql' ),
-						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => function ( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post->pinged ) ? implode( ',', $post->pinged ) : null;
 						},
 					],
 					'modified'          => [
 						'type'        => Types::string(),
 						'description' => __( 'The local modified time for a post. If a post was recently updated the modified field will change to match the corresponding time.', 'wp-graphql' ),
-						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => function ( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post->post_modified ) ? $post->post_modified : null;
 						},
 					],
 					'modifiedGmt'       => [
 						'type'        => Types::string(),
 						'description' => __( 'The GMT modified time for a post. If a post was recently updated the modified field will change to match the corresponding time in GMT.', 'wp-graphql' ),
-						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => function ( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post->post_modified_gmt ) ? Types::prepare_date_response( $post->post_modified_gmt ) : null;
 						},
 					],
 					'parent'            => [
 						'type'        => Types::post_object_union(),
 						'description' => __( 'The parent of the object. The parent object can be of various types', 'wp-graphql' ),
-						'resolve'     => function( \WP_Post $post, array $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => function ( \WP_Post $post, array $args, AppContext $context, ResolveInfo $info ) {
 							$parent_post = ! empty( $post->post_parent ) ? get_post( $post->post_parent ) : null;
+
 							return isset( $parent_post->ID ) && isset( $parent_post->post_type ) ? DataSource::resolve_post_object( $parent_post->ID, $parent_post->post_type ) : $parent_post;
 						},
 					],
 					'editLast'          => [
 						'type'        => Types::user(),
 						'description' => __( 'The user that most recently edited the object', 'wp-graphql' ),
-						'resolve'     => function( \WP_Post $post, array $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => function ( \WP_Post $post, array $args, AppContext $context, ResolveInfo $info ) {
 							$edit_last = get_post_meta( $post->ID, '_edit_last', true );
 
 							return ! empty( $edit_last ) ? DataSource::resolve_user( absint( $edit_last ) ) : null;
@@ -308,7 +310,7 @@ class PostObjectType extends WPObjectType {
 					'editLock'          => [
 						'type'        => Types::edit_lock(),
 						'description' => __( 'If a user has edited the object within the past 15 seconds, this will return the user and the time they last edited. Null if the edit lock doesn\'t exist or is greater than 15 seconds', 'wp-graphql' ),
-						'resolve'     => function( \WP_Post $post, array $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => function ( \WP_Post $post, array $args, AppContext $context, ResolveInfo $info ) {
 							$edit_lock       = get_post_meta( $post->ID, '_edit_lock', true );
 							$edit_lock_parts = explode( ':', $edit_lock );
 
@@ -318,7 +320,7 @@ class PostObjectType extends WPObjectType {
 					'enclosure'         => [
 						'type'        => Types::string(),
 						'description' => __( 'The RSS enclosure for the object', 'wp-graphql' ),
-						'resolve'     => function( \WP_Post $post, array $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => function ( \WP_Post $post, array $args, AppContext $context, ResolveInfo $info ) {
 							$enclosure = get_post_meta( $post->ID, 'enclosure', true );
 
 							return ! empty( $enclosure ) ? $enclosure : null;
@@ -327,21 +329,21 @@ class PostObjectType extends WPObjectType {
 					'guid'              => [
 						'type'        => Types::string(),
 						'description' => __( 'The global unique identifier for this post. This currently matches the value stored in WP_Post->guid and the guid column in the `post_objects` database table.', 'wp-graphql' ),
-						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => function ( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post->guid ) ? $post->guid : null;
 						},
 					],
 					'menuOrder'         => [
 						'type'        => Types::int(),
 						'description' => __( 'A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types.', 'wp-graphql' ),
-						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => function ( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post->menu_order ) ? absint( $post->menu_order ) : null;
 						},
 					],
 					'desiredSlug'       => [
 						'type'        => Types::string(),
 						'description' => __( 'The desired slug of the post', 'wp-graphql' ),
-						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => function ( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							$desired_slug = get_post_meta( $post->ID, '_wp_desired_post_slug', true );
 
 							return ! empty( $desired_slug ) ? $desired_slug : null;
@@ -350,7 +352,7 @@ class PostObjectType extends WPObjectType {
 					'link'              => [
 						'type'        => Types::string(),
 						'description' => __( 'The permalink of the post', 'wp-graphql' ),
-						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => function ( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							$link = get_permalink( $post->ID );
 
 							return ! empty( $link ) ? $link : null;
@@ -359,7 +361,7 @@ class PostObjectType extends WPObjectType {
 					'uri'               => [
 						'type'        => Types::string(),
 						'description' => __( 'URI path for the resource', 'wp-graphql' ),
-						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => function ( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							$uri = get_page_uri( $post->ID );
 
 							return ! empty( $uri ) ? $uri : null;
@@ -375,7 +377,7 @@ class PostObjectType extends WPObjectType {
 						],
 						// Translators: placeholder is the name of the post_type
 						'description' => sprintf( __( 'Terms connected to the %1$s', 'wp-graphql' ), $single_name ),
-						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) use ( $allowed_taxonomies ) {
+						'resolve'     => function ( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) use ( $allowed_taxonomies ) {
 
 							/**
 							 * If the $arg for taxonomies is populated, use it as the $allowed_taxonomies
@@ -386,7 +388,7 @@ class PostObjectType extends WPObjectType {
 								$taxonomies = $args['taxonomies'];
 							} else {
 								$connected_taxonomies = get_object_taxonomies( $post, 'names' );
-								foreach( $connected_taxonomies as $taxonomy ) {
+								foreach ( $connected_taxonomies as $taxonomy ) {
 									if ( in_array( $taxonomy, \WPGraphQL::$allowed_taxonomies ) ) {
 										$taxonomies[] = $taxonomy;
 									}
@@ -418,7 +420,7 @@ class PostObjectType extends WPObjectType {
 						],
 						// Translators: placeholder is the name of the post_type
 						'description' => sprintf( __( 'Terms connected to the %1$s', 'wp-graphql' ), $single_name ),
-						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) use ( $allowed_taxonomies ) {
+						'resolve'     => function ( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) use ( $allowed_taxonomies ) {
 
 							/**
 							 * If the $arg for taxonomies is populated, use it as the $allowed_taxonomies
@@ -429,7 +431,7 @@ class PostObjectType extends WPObjectType {
 								$taxonomies = $args['taxonomies'];
 							} else {
 								$connected_taxonomies = get_object_taxonomies( $post, 'names' );
-								foreach( $connected_taxonomies as $taxonomy ) {
+								foreach ( $connected_taxonomies as $taxonomy ) {
 									if ( in_array( $taxonomy, \WPGraphQL::$allowed_taxonomies ) ) {
 										$taxonomies[] = $taxonomy;
 									}
@@ -462,7 +464,7 @@ class PostObjectType extends WPObjectType {
 						],
 						// Translators: placeholder is the name of the post_type
 						'description' => sprintf( __( 'Terms connected to the %1$s', 'wp-graphql' ), $single_name ),
-						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) use ( $allowed_taxonomies ) {
+						'resolve'     => function ( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) use ( $allowed_taxonomies ) {
 
 							/**
 							 * If the $arg for taxonomies is populated, use it as the $allowed_taxonomies
@@ -473,7 +475,7 @@ class PostObjectType extends WPObjectType {
 								$taxonomies = $args['taxonomies'];
 							} else {
 								$connected_taxonomies = get_object_taxonomies( $post, 'names' );
-								foreach( $connected_taxonomies as $taxonomy ) {
+								foreach ( $connected_taxonomies as $taxonomy ) {
 									if ( in_array( $taxonomy, \WPGraphQL::$allowed_taxonomies ) ) {
 										$taxonomies[] = $taxonomy;
 									}
@@ -508,7 +510,7 @@ class PostObjectType extends WPObjectType {
 					$fields['commentCount'] = [
 						'type'        => Types::int(),
 						'description' => __( 'The number of comments. Even though WPGraphQL denotes this field as an integer, in WordPress this field should be saved as a numeric string for compatability.', 'wp-graphql' ),
-						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => function ( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $post->comment_count ) ? absint( $post->comment_count ) : null;
 						},
 					];
@@ -541,8 +543,9 @@ class PostObjectType extends WPObjectType {
 					$fields['featuredImage'] = [
 						'type'        => Types::post_object( 'attachment' ),
 						'description' => __( 'The featured image for the object', 'wp-graphql' ),
-						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => function ( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							$thumbnail_id = get_post_thumbnail_id( $post->ID );
+
 							return isset( $thumbnail_id ) ? DataSource::resolve_post_object( $thumbnail_id, 'attachment' ) : get_post( absint( $thumbnail_id ) );
 
 						},

--- a/src/Type/PostObject/PostObjectType.php
+++ b/src/Type/PostObject/PostObjectType.php
@@ -146,7 +146,7 @@ class PostObjectType extends WPObjectType {
 								foreach ( $ancestor_ids as $ancestor_id ) {
 									$ancestor_obj = get_post( $ancestor_id );
 									if ( in_array( $ancestor_obj->post_type, $types, true ) ) {
-										$ancestors[] = $ancestor_obj;
+										$ancestors[] = DataSource::resolve_post_object( $ancestor_obj->ID, $ancestor_obj->post_type );
 									}
 								}
 							}
@@ -292,7 +292,8 @@ class PostObjectType extends WPObjectType {
 						'type'        => Types::post_object_union(),
 						'description' => __( 'The parent of the object. The parent object can be of various types', 'wp-graphql' ),
 						'resolve'     => function( \WP_Post $post, array $args, AppContext $context, ResolveInfo $info ) {
-							return ! empty( $post->post_parent ) ? get_post( $post->post_parent ) : null;
+							$parent_post = ! empty( $post->post_parent ) ? get_post( $post->post_parent ) : null;
+							return isset( $parent_post->ID ) && isset( $parent_post->post_type ) ? DataSource::resolve_post_object( $parent_post->ID, $parent_post->post_type ) : $parent_post;
 						},
 					],
 					'editLast'          => [
@@ -542,8 +543,8 @@ class PostObjectType extends WPObjectType {
 						'description' => __( 'The featured image for the object', 'wp-graphql' ),
 						'resolve'     => function( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							$thumbnail_id = get_post_thumbnail_id( $post->ID );
+							return isset( $thumbnail_id ) ? DataSource::resolve_post_object( $thumbnail_id, 'attachment' ) : get_post( absint( $thumbnail_id ) );
 
-							return ! empty( $thumbnail_id ) ? get_post( absint( $thumbnail_id ) ) : null;
 						},
 					];
 				}


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This ensures post objects are resolved using DataSource::resolve_post_object() to make sure the global $post is properly set and setup_postdata is properly run. This ensures filters that rely on the Global post object, etc to run properly.


Does this close any currently open issues?
------------------------------------------
closes #504 
