### PR TITLE
ISSUE-507 map tagIn->tag__in

### DIFF
--- a/src/Type/PostObject/Connection/PostObjectConnectionResolver.php
+++ b/src/Type/PostObject/Connection/PostObjectConnectionResolver.php
@@ -327,6 +327,7 @@ class PostObjectConnectionResolver extends ConnectionResolver {
 			'categoryIn'   => 'category__in',
 			'tagId'        => 'tag_id',
 			'tagIds'       => 'tag__and',
+			'tagIn'       => 'tag__in',
 			'tagSlugAnd'   => 'tag_slug__and',
 			'tagSlugIn'    => 'tag_slug__in',
 			'search'       => 's',


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
 Add row to the map inside
 `wp-graphql/src/Type/PostObject/Connection/PostObjectConnectionResolver.php`
allowing the `where` argument `tagIn` to function properly.


Does this close any currently open issues?
------------------------------------------
Fixes #507 


Where has this been tested?
---------------------------
**Operating System:** Alpine Linux, Ubuntu  Linux

**WordPress Version:** 4.9.8
