### PR TITLE
Fix $post_type in graphql_map_input_fields_to_wp_query

### DIFF
--- a/src/Type/PostObject/Connection/PostObjectConnectionResolver.php
+++ b/src/Type/PostObject/Connection/PostObjectConnectionResolver.php
@@ -357,16 +357,16 @@ class PostObjectConnectionResolver extends ConnectionResolver {
 		 *
 		 * @param array       $query_args The mapped query arguments
 		 * @param array       $args       Query "where" args
-		 * @param string      $post_type  The post type for the query
 		 * @param mixed       $source     The query results for a query calling this
 		 * @param array       $all_args   All of the arguments for the query (not just the "where" args)
 		 * @param AppContext  $context    The AppContext object
 		 * @param ResolveInfo $info       The ResolveInfo object
+		 * @param string      $post_type  The post type for the query
 		 *
 		 * @since 0.0.5
 		 * @return array
 		 */
-		$query_args = apply_filters( 'graphql_map_input_fields_to_wp_query', $query_args, $args, $source, $all_args, $context, $info );
+		$query_args = apply_filters( 'graphql_map_input_fields_to_wp_query', $query_args, $args, $source, $all_args, $context, $info, self::$post_type );
 
 		/**
 		 * Return the Query Args


### PR DESCRIPTION
Not sure if this is bug but I noticed that the implementation does not match with the doc block of the `graphql_map_input_fields_to_wp_query`.

It states that the post type is passed as the third argument

https://github.com/wp-graphql/wp-graphql/blob/aa69a640b6877292a84a710c7270ac7403680b95/src/Type/PostObject/Connection/PostObjectConnectionResolver.php#L360

but the actual third argument is the `$source`.
