### PR TITLE
`featuredImage` bugfix

### DIFF
--- a/src/Type/PostObject/PostObjectType.php
+++ b/src/Type/PostObject/PostObjectType.php
@@ -546,7 +546,7 @@ class PostObjectType extends WPObjectType {
 						'resolve'     => function ( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							$thumbnail_id = get_post_thumbnail_id( $post->ID );
 
-							return isset( $thumbnail_id ) ? DataSource::resolve_post_object( $thumbnail_id, 'attachment' ) : get_post( absint( $thumbnail_id ) );
+							return ! empty( $thumbnail_id ) ? DataSource::resolve_post_object( $thumbnail_id, 'attachment' ) : get_post( absint( $thumbnail_id ) );
 
 						},
 					];

--- a/tests/wpunit/PostObjectQueriesTest.php
+++ b/tests/wpunit/PostObjectQueriesTest.php
@@ -310,6 +310,11 @@ class PostObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$post_id = $this->createPostObject( [
 			'post_type' => 'post',
 		] );
+		
+		/**
+		 * Remove Featured Image
+		 */
+		delete_post_meta( $post_id, '_thumbnail_id' );
 
 		// Create a comment and assign it to post.
 		$comment_id = $this->factory()->comment->create( [


### PR DESCRIPTION
`get_post_thumbnail_id()` returns a empty string `''` when no image is found.

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
This prevents GraphQL request from returning an error with an empty string is given to 
`DataSource::resolve_post_object()`



Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
