### PR TITLE
Make the post object field format enums filterable

### DIFF
--- a/src/Type/Enum/PostObjectFieldFormatEnumType.php
+++ b/src/Type/Enum/PostObjectFieldFormatEnumType.php
@@ -43,7 +43,7 @@ class PostObjectFieldFormatEnumType extends WPEnumType {
 			 *
 			 * @since 0.0.18
 			 */
-			self::$values = [
+			self::$values = apply_filters('graphql_post_object_field_format_enum_values', [
 				'RAW' => [
 					'name'  => 'RAW',
 					'description' => __( 'Provide the field value directly from database', 'wp-graphql' ),
@@ -54,7 +54,7 @@ class PostObjectFieldFormatEnumType extends WPEnumType {
 					'description' => __( 'Apply the default WordPress rendering', 'wp-graphql' ),
 					'value' => 'rendered',
 				],
-			];
+			]);
 
 		}
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This allows the post object format enum values to be filterable, if you'd like to have more post content formats available to query (AMP, in our case).

Where has this been tested?
---------------------------
**Operating System:**  CentOS 7

**WordPress Version:**  4.9.8
