### PR TITLE
Correct issue #533

### DIFF
--- a/src/Type/PostObject/Connection/PostObjectConnectionResolver.php
+++ b/src/Type/PostObject/Connection/PostObjectConnectionResolver.php
@@ -232,8 +232,8 @@ class PostObjectConnectionResolver extends ConnectionResolver {
 		/**
 		 * Set whether there is or is not another page
 		 */
-		$has_previous_page = ( ! empty( $args['last'] ) && ( $info['total_items'] >= self::get_query_amount( $source, $args, $context, $info ) ) ) ? true : false;
-		$has_next_page     = ( ! empty( $args['first'] ) && ( $info['total_items'] >= self::get_query_amount( $source, $args, $context, $info ) ) ) ? true : false;
+		$has_previous_page = ( ! empty( $args['last'] ) && ( $info['total_items'] > self::get_query_amount( $source, $args, $context, $info ) ) ) ? true : false;
+		$has_next_page     = ( ! empty( $args['first'] ) && ( $info['total_items'] > self::get_query_amount( $source, $args, $context, $info ) ) ) ? true : false;
 
 		/**
 		 * Slice the array to the amount of items that were requested


### PR DESCRIPTION
Correct get_connection function to return corect value for &has_previous_page and &has_next_page even if we query all pages

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
Correct get_connection function to return corect value for &has_previous_page and &has_next_page even if we query all pages


Does this close any currently open issues?
------------------------------------------
#533


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
