### PR TITLE
Featured image and media details bug fix

### DIFF
--- a/src/Type/MediaItem/MediaItemType.php
+++ b/src/Type/MediaItem/MediaItemType.php
@@ -121,9 +121,12 @@ class MediaItemType {
 				'description' => __( 'Details about the mediaItem', 'wp-graphql' ),
 				'resolve'     => function ( \WP_Post $post, $args, $context, ResolveInfo $info ) {
 					$media_details       = wp_get_attachment_metadata( $post->ID );
-					$media_details['ID'] = $post->ID;
+					if(!empty($media_details)) {
+						$media_details['ID'] = $post->ID;
+						return $media_details;
+					}
 
-					return $media_details;
+					return null;
 				},
 			],
 

--- a/src/Type/PostObject/PostObjectType.php
+++ b/src/Type/PostObject/PostObjectType.php
@@ -546,7 +546,7 @@ class PostObjectType extends WPObjectType {
 						'resolve'     => function ( \WP_Post $post, $args, AppContext $context, ResolveInfo $info ) {
 							$thumbnail_id = get_post_thumbnail_id( $post->ID );
 
-							return isset( $thumbnail_id ) ? DataSource::resolve_post_object( $thumbnail_id, 'attachment' ) : get_post( absint( $thumbnail_id ) );
+							return !empty( $thumbnail_id ) ? DataSource::resolve_post_object( $thumbnail_id, 'attachment' ) : null;
 
 						},
 					];

--- a/tests/wpunit/PostObjectQueriesTest.php
+++ b/tests/wpunit/PostObjectQueriesTest.php
@@ -296,6 +296,125 @@ class PostObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	/**
+	 * testP0stQueryWithoutFeaturedImage
+	 * 
+	 * This tests querying featuredImage on a post wihtout one.
+	 * 
+	 * @since 0.0.34
+	 */
+	public function testPostQueryWithoutFeaturedImage()
+	{
+		/**
+		 * Create Post
+		 */
+		$post_id = $this->createPostObject( [
+			'post_type' => 'post'
+		] );
+
+		/**
+		 * Create the global ID based on the post_type and the created $id
+		 */
+		$global_id = \GraphQLRelay\Relay::toGlobalId( 'post', $post_id );
+
+		$query = "
+		query {
+			post(id: \"{$global_id}\") {
+        id
+				featuredImage {
+					altText
+					author {
+						id
+					}
+					caption
+					commentCount
+					commentStatus
+					comments {
+						edges {
+						  node {
+							  id
+						  }
+						}
+					}
+					content
+					date
+					dateGmt
+					description
+					desiredSlug
+					editLast {
+						userId
+					}
+					editLock {
+						editTime
+					}
+					enclosure
+					excerpt
+					guid
+					id
+					link
+					mediaDetails {
+					  file
+						height
+						meta {
+              aperture
+              credit
+              camera
+              caption
+              createdTimestamp
+              copyright
+              focalLength
+              iso
+              shutterSpeed
+              title
+              orientation
+              keywords
+					  }
+						sizes {
+              name
+              file
+              width
+              height
+              mimeType
+              sourceUrl
+						}
+						width
+					}
+					mediaItemId
+					mediaType
+					menuOrder
+					mimeType
+					modified
+					modifiedGmt
+					parent {
+						...on Post {
+						  id
+						}
+					}
+					pingStatus
+					slug
+					sourceUrl
+					status
+					title
+					toPing
+				}
+			}
+		}
+    ";
+    
+    $actual = do_graphql_request( $query );
+
+    $expected = [
+      "data" => [
+        "post" => [
+          "id" => $global_id,
+          "featuredImage" => null
+        ]
+      ]
+    ];
+
+    $this->assertEquals( $expected, $actual );
+	}
+
+	/**
 	 * testPostQueryWithComments
 	 *
 	 * This tests creating a single post with comments.


### PR DESCRIPTION
Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the guidelines for contributing to this repository.

  Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
  Make sure you are requesting to pull request from a topic/feature/bugfix branch (right side). Don't pull request from your master!
What does this implement/fix? Explain your changes.
…
This fixes the issue where when querying featuredImage that doesn't exist, returns null instead of throwing an error. It also fixes the same issue for the mediaDetails field. When you have an SVG image that doesn't have media details, it returns null instead of throwing an error.

Does this close any currently open issues?
…
It can close this pull request #516

Any relevant logs, error output, GraphiQL screenshots, etc?
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)

Any other comments?
…

Where has this been tested?
Operating System: …
Mac O.S 10.14

WordPress Version: …
4.9.8