### PR TITLE
Fixes #543.

### DIFF
--- a/tests/wpunit/NodesTest.php
+++ b/tests/wpunit/NodesTest.php
@@ -253,7 +253,7 @@ class NodesTest extends \Codeception\TestCase\WPTestCase {
 			],
 		];
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual, "Verify you have the plugin Hello Dolly in your WordPress." );
 	}
 
 	/**

--- a/tests/wpunit/PluginObjectQueriesTest.php
+++ b/tests/wpunit/PluginObjectQueriesTest.php
@@ -83,7 +83,7 @@ class PluginObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 		 * and we don't care to maintain the exact match, we just want to make sure we are
 		 * properly getting a plugin back in the query
 		 */
-		$this->assertNotEmpty( $actual['data']['plugin']['id'] );
+		$this->assertNotEmpty( $actual['data']['plugin']['id'], "Verify you have the plugin Hello Dolly in your WordPress." );
 		$this->assertNotEmpty( $actual['data']['plugin']['name'] );
 
 		$plugin_id = $actual['data']['plugin']['id'];


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds a message in case of test failure to the asserts suggesting that an error may occur if hello dolly is not present as a plugin in the WordPress installation


Does this close any currently open issues?
------------------------------------------
**Relates to issue #543 **


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
Example for wpunit/PluginObjectQueriesTest:
```
Codeception PHP Testing Framework v2.4.5
Powered by PHPUnit 7.3.5 by Sebastian Bergmann and contributors.

Wpunit Tests (2) -----------------------------------------------------------------------------------------------------------------------------
✖ PluginObjectQueriesTest: Plugin query (0.87s)
✔ PluginObjectQueriesTest: Plugin query where plugin does not exist (0.02s)
----------------------------------------------------------------------------------------------------------------------------------------------


Time: 5.29 seconds, Memory: 38.25MB

There was 1 failure:

---------
1) PluginObjectQueriesTest: Plugin query
 Test  tests/wpunit/PluginObjectQueriesTest.php:testPluginQuery
Verify you have the plugin Hello Dolly in your WordPress.
Failed asserting that a NULL is not empty.
#1  /srv/www/wordpress-wpgraphql/public_html/wp-content/plugins/wp-graphql/tests/wpunit/PluginObjectQueriesTest.php:86
```



Any other comments?
-------------------
…


Where has this been tested?
---------------------------
Mac OS X with Vagrant.

**WordPress Version:** 4.5.8
