### PR TITLE
Fixes #545

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,10 @@ Perhaps someone who's more of a Composer expert could lend some advise?:
     - You can specify which tests to run like: 
         - `vendor/bin/codecept run wpunit`
         - `vendor/bin/codecept run functional`
-        - `vendor/bin/codecept run unit`
         - `vendor/bin/codecept run acceptance`
+    - If you're working on a class, or with a specific test, you can run that class/test with:
+        - `vendor/bin/codecept run tests/wpunit/NodesTest.php`
+        - `vendor/bin/codecept run tests/wpunit/NodesTest.php:testPluginNodeQuery`
 
 
 ### Using Docker


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- Adds to the README instructions on how to run specific tests.
- Removes the `unit`group of tests since it doesn't exist. It is not listed in the Docker section either.

Does this close any currently open issues?
------------------------------------------
Issue #545 

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
…


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Mac OS X

**WordPress Version:** 4.9.8
