### PR TITLE
Bugfix/528

### DIFF
--- a/src/Type/Setting/SettingType.php
+++ b/src/Type/Setting/SettingType.php
@@ -124,6 +124,7 @@ class SettingType extends WPObjectType {
 									break;
 								case 'string':
 									$option = (string) $option;
+									$option = ! empty( $option ) ? $option : '';
 									break;
 								case 'boolean':
 									$option = (boolean) $option;
@@ -133,7 +134,7 @@ class SettingType extends WPObjectType {
 									break;
 							}
 
-							return ! empty( $option ) ? $option : '';
+							return $option;
 						},
 					];
 

--- a/tests/wpunit/SettingsMutationsTest.php
+++ b/tests/wpunit/SettingsMutationsTest.php
@@ -452,18 +452,18 @@ class WP_GraphQL_Test_Settings_Mutations extends \Codeception\TestCase\WPTestCas
 		 */
 		wp_set_current_user( $this->admin );
 
-		$actual = $this->updateSettingsMutation();
+		/*
+		 * start updating settings with start_of_week=2, then set to 0 and check
+		 */
+		$this->updateSettingsMutation();
 
 		$this->update_variables['input']['generalSettingsStartOfWeek'] = 0;
 
 		$actual = $this->updateSettingsMutation();
 
-		\Codeception\Util\Debug::debug($actual);
-
 		$start_of_week = $actual['data']['updateSettings']['generalSettings']['startOfWeek'];
 
 		$this->assertEquals( 0, $start_of_week);
-
 	}
 
 }

--- a/tests/wpunit/SettingsMutationsTest.php
+++ b/tests/wpunit/SettingsMutationsTest.php
@@ -437,4 +437,33 @@ class WP_GraphQL_Test_Settings_Mutations extends \Codeception\TestCase\WPTestCas
 
 	}
 
+	/**
+	 * This function tests whether we can update and successfully retrieve
+	 * StartOfWeek = 0 (Sunday)
+	 *
+	 * @source wp-content/plugins/wp-graphql/src/Type/Settings/Mutation/SettingsUpdate.php:63
+	 * @access public
+	 * @return void
+	 */
+	public function testUpdateSettingsStartOfWeekMutation() {
+		/**
+		 * Set the current user as the admin role so we
+		 * successfully run the mutation
+		 */
+		wp_set_current_user( $this->admin );
+
+		$actual = $this->updateSettingsMutation();
+
+		$this->update_variables['input']['generalSettingsStartOfWeek'] = 0;
+
+		$actual = $this->updateSettingsMutation();
+
+		\Codeception\Util\Debug::debug($actual);
+
+		$start_of_week = $actual['data']['updateSettings']['generalSettings']['startOfWeek'];
+
+		$this->assertEquals( 0, $start_of_week);
+
+	}
+
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
When a value returned from get_option() is an integer or a boolean do not replace it with an empty string in case it is 0 or false. 

Does this close any currently open issues?
------------------------------------------
fixes #528

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
added new unit test SettingsMutationsTest.php:testUpdateSettingsStartOfWeekMutation


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Mac OS X

**WordPress Version:** 4.9.8
