### PR TITLE
CI-5745-2 | Fixing user id issue for `run-test-environment` testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,6 +97,7 @@ COPY --from='php-composer-files' /usr/local/bin/composer /usr/local/bin/composer
 
 USER root
 
-RUN ln -s /project "${WP_TEST_CORE_DIR}/wp-content/plugins/wp-graphql"
+RUN ln -s /project "${WP_TEST_CORE_DIR}/wp-content/plugins/wp-graphql" \
+  && echo 'composer install && initialize-wp-test-environment.sh' >> /root/.bashrc
 
 WORKDIR /project

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,22 +91,12 @@ COPY --chown='www-data:www-data' --from='project-files' /project/ "${WP_TEST_COR
 
 # -------------------- STAGE ---------------
 FROM base-tester-environment as tester-shell-environment
-ARG CONTAINER_USER_ID
-ARG CONTAINER_GROUP_ID
 
 # Add PHP Composer
 COPY --from='php-composer-files' /usr/local/bin/composer /usr/local/bin/composer
 
-# Create a user inside of the Docker image that has the same user and group id as the user invoking the Docker task.
-# This is for when developers log into a running container (as this user) to run the tests. This is ensures new files
-# are owned by the user invoking the Docker task.
 USER root
-RUN groupadd --gid "${CONTAINER_USER_ID}" 'tester' \
-  && useradd --uid "${CONTAINER_GROUP_ID}" --gid 'tester' --shell /bin/bash --create-home 'tester' \
-  && chown -R "${CONTAINER_USER_ID}:${CONTAINER_GROUP_ID}" "${WP_TESTS_DIR}" "${WP_TEST_CORE_DIR}" \
-  && echo 'composer install && initialize-wp-test-environment.sh' >> /home/tester/.bashrc
 
 RUN ln -s /project "${WP_TEST_CORE_DIR}/wp-content/plugins/wp-graphql"
 
-USER tester
 WORKDIR /project

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ your tests as you make code changes.
    At this point `composer install` will automatically be run and some extra test initialization will be done. You
    should eventually see a prompt like this:
    ```
-   tester@f70bf1310eda:/project$
+   root@f70bf1310eda:/project$
    ```   
 1. Now you are ready to work in your IDE and test your changes by running any of the following commands in the second
 terminal window):
@@ -183,6 +183,9 @@ terminal window):
    ./vendor/bin/codecept run 'acceptance' --env docker   
    ``` 
 Notes:
+* Because of limitations with Docker bind mounts, the Docker container must be the `root` user. This means the files 
+  created by the container user will also be seen as being owned by `root` on the host OS. Thus, you may occasionally
+  need to use `chown` before you execute some file operations. The `vendor/` directory is most likely to have this issue.
 * Leave the container shell (the second terminal window) by typing `exit`.
 * Shutdown the testing environment (the first terminal window) by typing `Ctrl + c` 
 * Docker artifacts will *usually* be cleaned up automatically when the script completes. In case it doesn't do the job,

--- a/docker-tasks/run-test-environment/docker-compose.yml
+++ b/docker-tasks/run-test-environment/docker-compose.yml
@@ -8,8 +8,6 @@ services:
       args:
         DESIRED_WP_VERSION: "${WP_VERSION}"
         DESIRED_PHP_VERSION: "${PHP_VERSION}"
-        CONTAINER_USER_ID: "${CONTAINER_USER_ID}"
-        CONTAINER_GROUP_ID: "${CONTAINER_GROUP_ID}"
     image: 'tester-shell-cache'
     container_name: 'wp-graphql'
     environment:

--- a/run-docker-test-environment.sh
+++ b/run-docker-test-environment.sh
@@ -6,7 +6,7 @@ source_docker_env() {
 }
 
 run_app() {
-  env DOCKER_TASK='run-test-environment' CONTAINER_USER_ID="$(id -u)" CONTAINER_GROUP_ID="$(id -g)" docker-tasks/run-docker-compose-up.sh --build
+  env DOCKER_TASK='run-test-environment' docker-tasks/run-docker-compose-up.sh --build
 }
 
 main() {


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
The previous Docker code tried to dynamically create a Docker container user based on the user id and group id of the host OS user. This was a problem because sometimes Docker container users with user id and group id of 1000 have extra file permissions which could mask some Docker configuration errors seen by users whose ids are not 1000. 

This fix simply uses the `root` user for the test environment Docker task so that all Docker users experience the same testing behaviors.


Does this close any currently open issues?
------------------------------------------
Nope.

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
N/A


Any other comments?
-------------------
There are some relatively minor file permission issues that have been noted in the README.md file.


Where has this been tested?
---------------------------
**Operating System:** Linux

**WordPress Version:** 4.9.8
