### PR TITLE
local-app file upload limit size pushed to 64MB

### DIFF
--- a/docker-tasks/run-local-app/docker-compose.yml
+++ b/docker-tasks/run-local-app/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   wpgraphql.test:
     image: "wordpress:${WP_VERSION}-php${PHP_VERSION}-apache"
     ports:
-      - '80:80'
+      - '8000:80'
     environment:
       WORDPRESS_DB_HOST: 'mysql_test'
       WORDPRESS_DB_NAME: 'wpgraphql_test'
@@ -12,6 +12,7 @@ services:
       WORDPRESS_DB_PASSWORD: 'testing'
     volumes:
       - "${PWD}:/var/www/html/wp-content/plugins/wp-graphql:ro"
+      - ./uploads.txt:/usr/local/etc/php/conf.d/uploads.ini
 
   mysql_test:
     image: "${MYSQL_DOCKER_IMAGE}"

--- a/docker-tasks/run-local-app/uploads.txt
+++ b/docker-tasks/run-local-app/uploads.txt
@@ -1,0 +1,5 @@
+file_uploads = On
+memory_limit = 64M
+upload_max_filesize = 64M
+post_max_size = 64M
+max_execution_time = 600


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
- Moves docker `local-app` proxy port to `8000`
- Raises upload file max-size to 64MB

Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
