### PR TITLE
#573 - adding the "children" connection to TermObjects

### DIFF
--- a/src/Connection/TermObjects.php
+++ b/src/Connection/TermObjects.php
@@ -49,6 +49,13 @@ class TermObjects {
 					}
 				}
 
+				if ( true === $tax_object->hierarchical ) {
+					register_graphql_connection( self::get_connection_config( $tax_object, [
+						'fromType' => $tax_object->graphql_single_name,
+						'fromFieldName' => 'children',
+					] ));
+				}
+
 			}
 		}
 


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
This adds the `children` field to TermObjects of hierarchical Taxonomies. The field was left commented out during the refactor to v0.1.0 🤦‍♂️ 


Does this close any currently open issues?
------------------------------------------
#573


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
<img width="915" alt="screen shot 2018-11-06 at 7 46 13 am" src="https://user-images.githubusercontent.com/1260765/48071664-0fbb1e80-e198-11e8-86de-a51afb6e1e68.png">



Any other comments?
-------------------
This query works with this fix in place.

```
{
  categories {
    nodes {
      id
      name
      children {
        nodes {
          name
          id
        }
      }
    }
  }
}
```


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
