### PR TITLE
CI-5884 | Docker test shell no longer changes files on host OS; misc Docker cleanup

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+# Docker image settings to be shared by various Docker tasks. These values can be overridden with shell values.
+MYSQL_DOCKER_IMAGE=mariadb:10.2.18-bionic
+WP_VERSION=4.9.8
+PHP_VERSION=7.2

--- a/README.md
+++ b/README.md
@@ -221,9 +221,10 @@ Notes:
    
 
 #### Updating WP Docker image
-Please make sure this file refers to the latest specific versions of WordPress and PHP that are available as a Docker image: 
+Please make sure this file refers to the latest specific versions of WordPress and PHP that are available as a Docker
+image. These values will serve as default values if no environment variables have been explicitly set. 
   ```
-  docker-tasks/common/env-files/env.sh
+  .env
   ```
 Please avoid using the `latest` tag because the WP Docker image is published a few days after the PHP code
 is made available and that can result in inaccurate test results.

--- a/README.md
+++ b/README.md
@@ -169,22 +169,20 @@ your tests as you make code changes.
    ```
    ./run-docker-shell.sh 'wp-graphql'
    ```
-   At this point `composer install` will automatically be run and some extra test initialization will be done. You
-   should eventually see a prompt like this:
+   At this point some extra test initialization will be done. You should eventually see a prompt like this:
    ```
-   root@f70bf1310eda:/project$
+   root@bb953c1da8d7:/tester-shell-dir
    ```   
 1. Now you are ready to work in your IDE and test your changes by running any of the following commands in the second
 terminal window):
    ```
-   ./vendor/bin/codecept run 'wpunit' --env docker
-   ./vendor/bin/codecept run 'functional' --env docker
-   ./vendor/bin/codecept run 'acceptance' --env docker   
+   run-codeception.sh run 'wpunit' --env docker
+   run-codeception.sh run 'functional' --env docker
+   run-codeception.sh run 'acceptance' --env docker   
    ``` 
 Notes:
-* Because of limitations with Docker bind mounts, the Docker container must be the `root` user. This means the files 
-  created by the container user will also be seen as being owned by `root` on the host OS. Thus, you may occasionally
-  need to use `chown` before you execute some file operations. The `vendor/` directory is most likely to have this issue.
+* If you make a change that requires `composer install` to be rerun, shutdown the testing environment and restart it to 
+automatically rerun the `composer install` in the testing environment.
 * Leave the container shell (the second terminal window) by typing `exit`.
 * Shutdown the testing environment (the first terminal window) by typing `Ctrl + c` 
 * Docker artifacts will *usually* be cleaned up automatically when the script completes. In case it doesn't do the job,

--- a/README.md
+++ b/README.md
@@ -205,7 +205,6 @@ try these solutions:
    ```
    env PHP_VERSION='7.1' ./run-docker-tests.sh wpunit
    env PHP_VERSION='7.1' COVERAGE='true' ./run-docker-tests.sh functional
-   env PHP_VERSION='7.0' WP_VERSION='4.9.4' ./run-docker-tests.sh acceptance
    ```
 If `COVERAGE='true'` is set, results will appear in `docker-output/`.
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ your tests as you make code changes.
 terminal window):
    ```
    run-codeception.sh run 'wpunit' --env docker
+   run-codeception.sh run 'wpunit' 'WPGraphQLTest' --env docker
    run-codeception.sh run 'functional' --env docker
    run-codeception.sh run 'acceptance' --env docker   
    ``` 

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Notes:
    ```
    ./run-docker-local-app.sh
    ```
-1. Visit http://localhost:80.
+1. Visit http://localhost:8000.
    
 
 #### Updating WP Docker image

--- a/docker-entrypoints/run-codeception.sh
+++ b/docker-entrypoints/run-codeception.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -e
+
+sync_files_from_bind_mounts() {
+  rsync -av --delete /project/ /tester-shell-dir/
+}
+
+restore_vendor_files() {
+  rsync -av --delete /pristine-tester-plugin/vendor/ /tester-shell-dir/vendor/
+}
+
+run_codeception() {
+  ./vendor/bin/codecept "$@"
+}
+
+main() {
+  sync_files_from_bind_mounts
+  restore_vendor_files
+  run_codeception "$@"
+}
+
+main "$@"

--- a/docker-tasks/bin/run-docker-compose-up.sh
+++ b/docker-tasks/bin/run-docker-compose-up.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# The master copy of this file is here: https://github.com/dfmedia/docker-cookbook
+# If this script requires changes please notify the maintainer(s) of the master copy.
+
 set -e
 
 show_usage() {
@@ -37,13 +40,6 @@ initialize_env_var() {
 
   readonly DOCKER_COMPOSE_PROJECT_NAME="$(build_docker_name 'docker-compose')"
   readonly CONTAINER_NAME="$(build_docker_name 'container')"
-
-  echo "Using Docker Compose file: ${DOCKER_COMPOSE_FILE}"
-  echo "Going to copy data from container path: ${CONTAINER_DATA_PATH}"
-  echo "Going to copy data to host dir: ${HOST_DATA_PATH}"
-  echo "Randomly generated project name for Docker Compose: ${DOCKER_COMPOSE_PROJECT_NAME}"
-  echo "Randomly generated container name for Docker Compose: ${CONTAINER_NAME}"
-  echo "Params to be passed to 'docker compose up' $@"
 }
 
 
@@ -73,7 +69,6 @@ main() {
 
   copy_data_from_docker_container_to_host
 
-  echo "Looks like docker compose is exiting with with code: ${exit_code}"
   exit $((exit_code))
 }
 

--- a/docker-tasks/bin/run-docker-compose-up.sh
+++ b/docker-tasks/bin/run-docker-compose-up.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-# The master copy of this file is here: https://github.com/dfmedia/docker-cookbook
-# If this script requires changes please notify the maintainer(s) of the master copy.
-
 set -e
 
 show_usage() {

--- a/docker-tasks/common/env-files/env.sh
+++ b/docker-tasks/common/env-files/env.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-# These variables should refer to latest WP and PHP versions supported by the WP Docker images:
-# https://hub.docker.com/_/wordpress/
-export WP_VERSION="${WP_VERSION:-4.9.8}"
-export PHP_VERSION="${PHP_VERSION:-7.2}"
-export MYSQL_DOCKER_IMAGE='mariadb:10.2.18-bionic'

--- a/docker-tasks/run-local-app/docker-compose.yml
+++ b/docker-tasks/run-local-app/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       WORDPRESS_DB_PASSWORD: 'testing'
     volumes:
       - "${PWD}:/var/www/html/wp-content/plugins/wp-graphql:ro"
-      - ./uploads.txt:/usr/local/etc/php/conf.d/uploads.ini
+      - './uploads.txt:/usr/local/etc/php/conf.d/uploads.ini:ro'
 
   mysql_test:
     image: "${MYSQL_DOCKER_IMAGE}"

--- a/docker-tasks/run-test-environment/docker-compose.yml
+++ b/docker-tasks/run-test-environment/docker-compose.yml
@@ -3,8 +3,8 @@ version: "3.4"
 services:
   main:
     build:
-      context: '../../.'
-      target: 'tester-shell-environment'
+      context: '../..'
+      target: 'tester-shell'
       args:
         DESIRED_WP_VERSION: "${WP_VERSION}"
         DESIRED_PHP_VERSION: "${PHP_VERSION}"
@@ -19,10 +19,6 @@ services:
       # Using "delegated" option to improve disk performance for "Docker for Mac" users:
       # https://docs.docker.com/docker-for-mac/osxfs-caching/#delegated
       - "${PWD}:/project:delegated"
-    entrypoint:
-      # Doing this to prevent the container exiting prematurely. This service needs to hang around for someone to access
-      # its shell.
-      [ "sleep", "9999d" ]
 
   wpgraphql.test:
     image: "wordpress:${WP_VERSION}-php${PHP_VERSION}-apache"

--- a/docker-tasks/run-test-environment/docker-compose.yml
+++ b/docker-tasks/run-test-environment/docker-compose.yml
@@ -16,9 +16,7 @@ services:
       DB_USER: 'root'
       DB_PASSWORD: 'testing'
     volumes:
-      # Using "delegated" option to improve disk performance for "Docker for Mac" users:
-      # https://docs.docker.com/docker-for-mac/osxfs-caching/#delegated
-      - "${PWD}:/project:delegated"
+      - "${PWD}:/project:ro"
 
   wpgraphql.test:
     image: "wordpress:${WP_VERSION}-php${PHP_VERSION}-apache"

--- a/docker-tasks/run-tests/docker-compose.yml
+++ b/docker-tasks/run-tests/docker-compose.yml
@@ -3,8 +3,8 @@ version: "3.4"
 services:
   main:
     build:
-      context: '../../.'
-      target: 'tester-environment'
+      context: '../..'
+      target: 'tester'
       args:
         DESIRED_WP_VERSION: "${WP_VERSION}"
         DESIRED_PHP_VERSION: "${PHP_VERSION}"
@@ -19,13 +19,11 @@ services:
       WP_VERSION: "${WP_VERSION}"
       TEST_TYPE: "${TEST_TYPE}"
       COVERAGE: "${COVERAGE}"
-    entrypoint:
-      [ "docker-entrypoint.tests.sh" ]
 
   wpgraphql.test:
     build:
-      context: '../../.'
-      target: 'wordpress-sut-environment'
+      context: '../..'
+      target: 'wordpress-sut-code-coverage'
       args:
         DESIRED_WP_VERSION: "${WP_VERSION}"
         DESIRED_PHP_VERSION: "${PHP_VERSION}"

--- a/run-docker-local-app.sh
+++ b/run-docker-local-app.sh
@@ -1,16 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
-source_docker_env() {
-  source docker-tasks/common/env-files/env.sh
-}
-
 run_app() {
-  env DOCKER_TASK='run-local-app' docker-tasks/run-docker-compose-up.sh --build
+  env DOCKER_TASK='run-local-app' docker-tasks/bin/run-docker-compose-up.sh --build
 }
 
 main() {
-  source_docker_env
   run_app
 }
 

--- a/run-docker-shell.sh
+++ b/run-docker-shell.sh
@@ -9,7 +9,7 @@ fi
 readonly CONTAINER_ID="${1}"
 
 main() {
-  sudo docker exec -it "${CONTAINER_ID}" /bin/bash
+  docker exec -it "${CONTAINER_ID}" /bin/bash
 }
 
 main

--- a/run-docker-test-environment.sh
+++ b/run-docker-test-environment.sh
@@ -1,16 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
-source_docker_env() {
-  source docker-tasks/common/env-files/env.sh
-}
-
 run_app() {
-  env DOCKER_TASK='run-test-environment' docker-tasks/run-docker-compose-up.sh --build
+  env DOCKER_TASK='run-test-environment' docker-tasks/bin/run-docker-compose-up.sh --build
 }
 
 main() {
-  source_docker_env
   run_app
 }
 

--- a/run-docker-tests.sh
+++ b/run-docker-tests.sh
@@ -9,27 +9,20 @@ fi
 readonly TEST_TYPE="${1}"
 readonly TEST_RESULTS_DIR="./docker-output/${TEST_TYPE}"
 
-source_docker_env() {
-  source docker-tasks/common/env-files/env.sh
-}
-
 initialize_test_results_dir() {
   rm -rf "${TEST_RESULTS_DIR}"
   mkdir -p "${TEST_RESULTS_DIR}"
 }
 
 run_tests() {
-  echo "Going to run with WP version: ${WP_VERSION} and PHP version: ${PHP_VERSION}"
-
   env DOCKER_TASK='run-tests' \
     CONTAINER_DATA_PATH=/tmp/wordpress/wp-content/plugins/wp-graphql/tests/_output/ \
     HOST_DATA_PATH="${TEST_RESULTS_DIR}" \
     TEST_TYPE="${TEST_TYPE}" \
-    docker-tasks/run-docker-compose-up.sh --build --exit-code-from 'main'
+    docker-tasks/bin/run-docker-compose-up.sh --build --exit-code-from 'main'
 }
 
 main() {
-  source_docker_env
   initialize_test_results_dir
   run_tests
 }


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
- Use of the test shell no longer changes files on the host OS so the `chown` workaround is no longer needed
- run-docker-shell no longer uses `sudo` itself
- Ensuring all Docker bind mounts are read-only by default
- using Docker Compose's built-in `.env` feature instead reinventing the wheel with the `env.sh` file.
- added more comments to Dockerfile
- Updated Docker misc configuration according to best practices
- updated `README.md`


Does this close any currently open issues?
------------------------------------------
N/A


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
N/A


Any other comments?
-------------------
N/A


Where has this been tested?
---------------------------
**Operating System:** Linux

**WordPress Version:** 4.9.8
