### PR TITLE
#491 - Send Password Reset Mutation

### DIFF
--- a/src/Mutation/SendPasswordResetEmail.php
+++ b/src/Mutation/SendPasswordResetEmail.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace WPGraphQL\Mutation;
+
+use GraphQL\Error\UserError;
+use GraphQL\Type\Definition\ResolveInfo;
+use WPGraphQL\AppContext;
+
+class SendPasswordResetEmail {
+	public static function register_mutation() {
+		register_graphql_mutation( 'sendPasswordResetEmail', [
+			'description'         => __( 'Send password reset email to user', 'wp-graphql' ),
+			'inputFields'         => [
+				'username' => [
+					'type'        => [
+						'non_null' => 'String',
+					],
+					'description' => __( 'A string that contains the user\'s username or email address.', 'wp-graphql' ),
+				],
+			],
+			'outputFields'        => [
+				'user' => [
+					'type'        => 'User',
+					'description' => __( 'The user that the password reset email was sent to', 'wp-graphql' ),
+					'resolve'     => function ( $payload ) {
+						$user = get_user_by( 'ID', absint( $payload['id'] ) );
+
+						return ! empty( $user ) ? $user : null;
+					},
+				],
+			],
+			'mutateAndGetPayload' => function ( $input, AppContext $context, ResolveInfo $info ) {
+
+				if ( ! self::was_username_provided( $input ) ) {
+					throw new UserError( __( 'Enter a username or email address.', 'wp-graphql' ) );
+				}
+				$user_data = self::get_user_data( $input['username'] );
+				if ( ! $user_data ) {
+					throw new UserError( self::get_user_not_found_error_message( $input['username'] ) );
+				}
+				$key = get_password_reset_key( $user_data );
+				if ( is_wp_error( $key ) ) {
+					throw new UserError( __( 'Unable to generate a password reset key.', 'wp-graphql' ) );
+				}
+				$subject    = self::get_email_subject( $user_data );
+				$message    = self::get_email_message( $user_data, $key );
+				$email_sent = wp_mail( $user_data->user_email, wp_specialchars_decode( $subject ), $message );
+				if ( ! $email_sent ) {
+					throw new UserError( __( 'The email could not be sent.' ) . "<br />\n" . __( 'Possible reason: your host may have disabled the mail() function.' ) );
+				}
+
+				/**
+				 * Return the ID of the user
+				 */
+				return [
+					'id' => $user_data->ID,
+				];
+			}
+		] );
+	}
+
+	/**
+	 * Was a username or email address provided?
+	 *
+	 * @param array $input The input args.
+	 *
+	 * @return bool
+	 */
+	private static function was_username_provided( $input ) {
+		return ! empty( $input['username'] ) && is_string( $input['username'] );
+	}
+
+	/**
+	 * Get WP_User object representing this user
+	 *
+	 * @param  string $username The user's username or email address.
+	 *
+	 * @return \WP_User|false WP_User object on success, false on failure.
+	 */
+	private static function get_user_data( $username ) {
+		if ( self::is_email_address( $username ) ) {
+			return get_user_by( 'email', trim( wp_unslash( $username ) ) );
+		}
+
+		return get_user_by( 'login', trim( $username ) );
+	}
+
+	/**
+	 * Get the error message indicating why the user wasn't found
+	 *
+	 * @param  string $username The user's username or email address.
+	 *
+	 * @return string
+	 */
+	private static function get_user_not_found_error_message( $username ) {
+		if ( self::is_email_address( $username ) ) {
+			return __( 'There is no user registered with that email address.', 'wp-graphql' );
+		}
+
+		return __( 'Invalid username.', 'wp-graphql' );
+	}
+
+	/**
+	 * Is the provided username arg an email address?
+	 *
+	 * @param  string $username The user's username or email address.
+	 *
+	 * @return bool
+	 */
+	private static function is_email_address( $username ) {
+		return strpos( $username, '@' );
+	}
+
+	/**
+	 * Get the subject of the password reset email
+	 *
+	 * @param \WP_User $user_data User data
+	 *
+	 * @return string
+	 */
+	private static function get_email_subject( $user_data ) {
+		/* translators: Password reset email subject. %s: Site name */
+		$title = sprintf( __( '[%s] Password Reset' ), self::get_site_name() );
+
+		/**
+		 * Filters the subject of the password reset email.
+		 *
+		 * @param string   $title      Default email title.
+		 * @param string   $user_login The username for the user.
+		 * @param \WP_User $user_data  WP_User object.
+		 */
+		return apply_filters( 'retrieve_password_title', $title, $user_data->user_login, $user_data );
+	}
+
+	/**
+	 * Get the site name.
+	 *
+	 * @return string
+	 */
+	private static function get_site_name() {
+		if ( is_multisite() ) {
+			return get_network()->site_name;
+		}
+
+		/*
+		* The blogname option is escaped with esc_html on the way into the database
+		* in sanitize_option we want to reverse this for the plain text arena of emails.
+		*/
+
+		return wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
+	}
+
+	/**
+	 * Get the message body of the password reset email
+	 *
+	 * @param \WP_User $user_data User data
+	 * @param string   $key       Password reset key
+	 *
+	 * @return string
+	 */
+	private static function get_email_message( $user_data, $key ) {
+		$message = __( 'Someone has requested a password reset for the following account:' ) . "\r\n\r\n";
+		/* translators: %s: site name */
+		$message .= sprintf( __( 'Site Name: %s' ), self::get_site_name() ) . "\r\n\r\n";
+		/* translators: %s: user login */
+		$message .= sprintf( __( 'Username: %s' ), $user_data->user_login ) . "\r\n\r\n";
+		$message .= __( 'If this was a mistake, just ignore this email and nothing will happen.' ) . "\r\n\r\n";
+		$message .= __( 'To reset your password, visit the following address:' ) . "\r\n\r\n";
+		$message .= '<' . network_site_url( "wp-login.php?action=rp&key={$key}&login=" . rawurlencode( $user_data->user_login ), 'login' ) . ">\r\n";
+
+		/**
+		 * Filters the message body of the password reset mail.
+		 *
+		 * If the filtered message is empty, the password reset email will not be sent.
+		 *
+		 * @param string   $message    Default mail message.
+		 * @param string   $key        The activation key.
+		 * @param string   $user_login The username for the user.
+		 * @param \WP_User $user_data  WP_User object.
+		 */
+		return apply_filters( 'retrieve_password_message', $message, $key, $user_data->user_login, $user_data );
+	}
+}

--- a/src/TypeRegistry.php
+++ b/src/TypeRegistry.php
@@ -25,6 +25,7 @@ use WPGraphQL\Mutation\PostObjectCreate;
 use WPGraphQL\Mutation\PostObjectDelete;
 use WPGraphQL\Mutation\PostObjectUpdate;
 use WPGraphQL\Mutation\ResetUserPassword;
+use WPGraphQL\Mutation\SendPasswordResetEmail;
 use WPGraphQL\Mutation\TermObjectCreate;
 use WPGraphQL\Mutation\TermObjectDelete;
 use WPGraphQL\Mutation\TermObjectUpdate;
@@ -222,6 +223,7 @@ class TypeRegistry {
 		MediaItemDelete::register_mutation();
 		MediaItemUpdate::register_mutation();
 		ResetUserPassword::register_mutation();
+		SendPasswordResetEmail::register_mutation();
 		UserCreate::register_mutation();
 		UserDelete::register_mutation();
 		UserUpdate::register_mutation();

--- a/tests/wpunit/UserObjectMutationsTest.php
+++ b/tests/wpunit/UserObjectMutationsTest.php
@@ -46,7 +46,8 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	/**
-	 * This filters the capabilities so that our test user can create/edit/delete users in multisite.
+	 * This filters the capabilities so that our test user can create/edit/delete users in
+	 * multisite.
 	 *
 	 * @param $caps
 	 * @param $cap
@@ -650,9 +651,9 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 				'registerUser' => [
 					'clientMutationId' => $this->client_mutation_id,
 					'user'             => [
-						'username'  => $username,
-						'email'     => $email,
-						'roles'     => [
+						'username' => $username,
+						'email'    => $email,
+						'roles'    => [
 							$default_role,
 						],
 					]
@@ -711,7 +712,7 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 
 	public function testResetUserPasswordWithInvalidKey() {
 
-		$user = get_userdata( $this->subscriber );
+		$user  = get_userdata( $this->subscriber );
 		$login = $user->user_login;
 
 		$args = [
@@ -794,6 +795,155 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 		 */
 		$this->assertTrue( $was_reset_successful );
 
+	}
+
+	public function sendPasswordResetEmailMutation( $username ) {
+		$mutation  = '
+		mutation sendPasswordResetEmail( $input:SendPasswordResetEmailInput! ) {
+			sendPasswordResetEmail( input: $input ) {
+				clientMutationId
+				user {
+					username
+					email
+					roles
+				} 
+			}
+		}
+		';
+		$variables = [
+			'input' => [
+				'clientMutationId' => $this->client_mutation_id,
+				'username'         => $username,
+			],
+		];
+
+		return do_graphql_request( $mutation, 'sendPasswordResetEmail', $variables );
+	}
+
+	public function testSendPasswordResetEmailWithInvalidUsername() {
+		$username = 'userDoesNotExist';
+		// Run the mutation, passing in an invalid username.
+		$actual = $this->sendPasswordResetEmailMutation( $username );
+		/**
+		 * We're asserting that this will properly return an error
+		 * because this user does not exist.
+		 */
+		$this->assertNotEmpty( $actual['errors'] );
+	}
+
+	public function testSendPasswordResetEmailResponseWithUsername() {
+		$user     = get_userdata( $this->subscriber );
+		$username = $user->user_login;
+		// Run the mutation, passing in a valid username.
+		$actual   = $this->sendPasswordResetEmailMutation( $username );
+		$expected = $this->getSendPasswordResetEmailExpected();
+		/**
+		 * Assert that the expected user data was returned.
+		 */
+		$this->assertEquals( $expected, $actual );
+	}
+
+	public function testSendPasswordResetEmailResponseWithEmail() {
+		$user  = get_userdata( $this->subscriber );
+		$email = $user->user_email;
+		// Run the mutation, passing in a valid email address.
+		$actual   = $this->sendPasswordResetEmailMutation( $email );
+		$expected = $this->getSendPasswordResetEmailExpected();
+		/**
+		 * Assert that the expected user data was returned.
+		 */
+		$this->assertEquals( $expected, $actual );
+	}
+
+	public function getSendPasswordResetEmailExpected() {
+		$user     = get_userdata( $this->subscriber );
+		$username = $user->user_login;
+		$email    = $user->user_email;
+		$roles    = $user->roles;
+
+		return [
+			'data' => [
+				'sendPasswordResetEmail' => [
+					'clientMutationId' => $this->client_mutation_id,
+					'user'             => [
+						'username' => $username,
+						'email'    => $email,
+						'roles'    => $roles,
+					]
+				]
+			]
+		];
+	}
+
+	public function testSendPasswordResetEmailActivationKeyWithUsername() {
+		$user     = get_userdata( $this->subscriber );
+		$username = $user->user_login;
+		$old_key  = $this->get_user_activation_key( $username );
+		// Run the mutation, passing in a valid username.
+		$this->sendPasswordResetEmailMutation( $username );
+		$new_key = $this->get_user_activation_key( $username );
+		/**
+		 * Assert that the user activation key in the DB was updated.
+		 */
+		$this->assertNotEquals( $old_key, $new_key );
+	}
+
+	public function testSendPasswordResetEmailActivationKeyWithEmail() {
+		$user     = get_userdata( $this->subscriber );
+		$username = $user->user_login;
+		$email    = $user->user_email;
+		$old_key  = $this->get_user_activation_key( $username );
+		// Run the mutation, passing in a valid email.
+		$this->sendPasswordResetEmailMutation( $email );
+		$new_key = $this->get_user_activation_key( $username );
+		/**
+		 * Assert that the user activation key in the DB was updated.
+		 */
+		$this->assertNotEquals( $old_key, $new_key );
+	}
+
+	public function get_user_activation_key( $username ) {
+		global $wpdb;
+
+		/**
+		 * We can't use the WP_User object here, since it returns the cached
+		 * activation key. Run a fresh DB query instead.
+		 */
+		return $wpdb->get_var( $wpdb->prepare( 'SELECT user_activation_key FROM wp_users WHERE user_login = %s', $username ) );
+	}
+
+	public function testSendPasswordResetEmailSentWithUsername() {
+		$user     = get_userdata( $this->subscriber );
+		$username = $user->user_login;
+		// Run the mutation, passing in a valid username.
+		$email_sent = $this->runSendPasswordResetEmailSentTest( $username );
+		/**
+		 * Assert that the password reset email was sent (did not fail).
+		 */
+		$this->assertTrue( $email_sent );
+	}
+
+	public function testSendPasswordResetEmailSentWithEmail() {
+		$user  = get_userdata( $this->subscriber );
+		$email = $user->user_email;
+		// Run the mutation, passing in a valid email.
+		$email_sent = $this->runSendPasswordResetEmailSentTest( $email );
+		/**
+		 * Assert that the password reset email was sent (did not fail).
+		 */
+		$this->assertTrue( $email_sent );
+	}
+
+	public function runSendPasswordResetEmailSentTest( $mutation_arg ) {
+		$email_sent        = true;
+		$update_email_sent = function () use ( &$email_sent ) {
+			$email_sent = false;
+		};
+		add_action( 'wp_mail_failed', $update_email_sent );
+		$this->sendPasswordResetEmailMutation( $mutation_arg );
+		remove_action( 'wp_mail_failed', $update_email_sent );
+
+		return $email_sent;
 	}
 
 }

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -215,6 +215,7 @@ return array(
     'WPGraphQL\\Mutation\\PostObjectDelete' => $baseDir . '/src/Mutation/PostObjectDelete.php',
     'WPGraphQL\\Mutation\\PostObjectUpdate' => $baseDir . '/src/Mutation/PostObjectUpdate.php',
     'WPGraphQL\\Mutation\\ResetUserPassword' => $baseDir . '/src/Mutation/ResetUserPassword.php',
+    'WPGraphQL\\Mutation\\SendPasswordResetEmail' => $baseDir . '/src/Mutation/SendPasswordResetEmail.php',
     'WPGraphQL\\Mutation\\TermObjectCreate' => $baseDir . '/src/Mutation/TermObjectCreate.php',
     'WPGraphQL\\Mutation\\TermObjectDelete' => $baseDir . '/src/Mutation/TermObjectDelete.php',
     'WPGraphQL\\Mutation\\TermObjectUpdate' => $baseDir . '/src/Mutation/TermObjectUpdate.php',

--- a/vendor/composer/autoload_framework_classmap.php
+++ b/vendor/composer/autoload_framework_classmap.php
@@ -215,6 +215,7 @@ return array(
     'WPGraphQL\\Mutation\\PostObjectDelete' => $baseDir . '/src/Mutation/PostObjectDelete.php', 
     'WPGraphQL\\Mutation\\PostObjectUpdate' => $baseDir . '/src/Mutation/PostObjectUpdate.php', 
     'WPGraphQL\\Mutation\\ResetUserPassword' => $baseDir . '/src/Mutation/ResetUserPassword.php', 
+    'WPGraphQL\\Mutation\\SendPasswordResetEmail' => $baseDir . '/src/Mutation/SendPasswordResetEmail.php', 
     'WPGraphQL\\Mutation\\TermObjectCreate' => $baseDir . '/src/Mutation/TermObjectCreate.php', 
     'WPGraphQL\\Mutation\\TermObjectDelete' => $baseDir . '/src/Mutation/TermObjectDelete.php', 
     'WPGraphQL\\Mutation\\TermObjectUpdate' => $baseDir . '/src/Mutation/TermObjectUpdate.php', 

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -242,6 +242,7 @@ class ComposerStaticInit66c4826911a72a5b725e04123579db72
         'WPGraphQL\\Mutation\\PostObjectDelete' => __DIR__ . '/../..' . '/src/Mutation/PostObjectDelete.php',
         'WPGraphQL\\Mutation\\PostObjectUpdate' => __DIR__ . '/../..' . '/src/Mutation/PostObjectUpdate.php',
         'WPGraphQL\\Mutation\\ResetUserPassword' => __DIR__ . '/../..' . '/src/Mutation/ResetUserPassword.php',
+        'WPGraphQL\\Mutation\\SendPasswordResetEmail' => __DIR__ . '/../..' . '/src/Mutation/SendPasswordResetEmail.php',
         'WPGraphQL\\Mutation\\TermObjectCreate' => __DIR__ . '/../..' . '/src/Mutation/TermObjectCreate.php',
         'WPGraphQL\\Mutation\\TermObjectDelete' => __DIR__ . '/../..' . '/src/Mutation/TermObjectDelete.php',
         'WPGraphQL\\Mutation\\TermObjectUpdate' => __DIR__ . '/../..' . '/src/Mutation/TermObjectUpdate.php',


### PR DESCRIPTION
- Original work by @kellenmace, this just updates it to fit with the v0.1.0 refactored architecture

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
This adds a `sendPasswordResetEmail` mutation

Does this close any currently open issues?
------------------------------------------
closes #491 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
see: https://github.com/wp-graphql/wp-graphql/pull/494


Any other comments?
-------------------
The bulk of the work was done by @kellenmace. . .see https://github.com/wp-graphql/wp-graphql/pull/494

This PR just updates his work to fit with the v0.1.0 re-architecture of the plugin