### PR TITLE
Restore graphql_input_fields filter

### DIFF
--- a/src/Type/WPInputObjectType.php
+++ b/src/Type/WPInputObjectType.php
@@ -15,18 +15,6 @@ use GraphQL\Type\Definition\InputObjectType;
 class WPInputObjectType extends InputObjectType {
 
 	/**
-	 * WPInputObjectType constructor.
-	 *
-	 * @param array $config The configuration for the InputObjectType
-	 */
-	public function __construct( $config = [] ) {
-		if ( ! empty( $config['fields'] ) && is_array( $config['fields'] ) ) {
-			$config['fields'] = self::prepare_fields( $config['fields'], $config['name'], $config );
-		}
-		parent::__construct( $config );
-	}
-
-	/**
 	 * prepare_fields
 	 *
 	 * This function sorts the fields and applies a filter to allow for easily
@@ -52,17 +40,6 @@ class WPInputObjectType extends InputObjectType {
 		$fields = apply_filters( 'graphql_input_fields', $fields, $type_name, $config );
 
 		/**
-		 * Pass the fields through a filter
-		 *
-		 * @param array $fields
-		 * @param string $type_name
-		 * @param array $config
-		 * @since 0.0.5
-		 */
-		$fields = apply_filters( 'graphql_' . lcfirst( $type_name ) . '_fields', $fields, $type_name, $config );
-		$fields = apply_filters( "graphql_{$type_name}_fields", $fields, $type_name, $config );
-
-		/**
 		 * Sort the fields alphabetically by key. This makes reading through docs much easier
 		 * @since 0.0.2
 		 */
@@ -74,18 +51,4 @@ class WPInputObjectType extends InputObjectType {
 		 */
 		return $fields;
 	}
-
-	/**
-	 * format_enum_name
-	 *
-	 * This formats enum_names to be all caps with underscores for spaces/word-breaks
-	 *
-	 * @param $name
-	 * @return string
-	 * @since 0.0.5
-	 */
-	public static function format_enum_name( $name ) {
-		return strtoupper( preg_replace( '/[^A-Za-z0-9]/i', '_', $name ) );
-	}
-
 }

--- a/src/Type/WPObjectType.php
+++ b/src/Type/WPObjectType.php
@@ -3,7 +3,6 @@ namespace WPGraphQL\Type;
 
 use GraphQL\Type\Definition\ObjectType;
 use WPGraphQL\Data\DataSource;
-use WPGraphQL\Type\WPInputObjectType;
 
 /**
  * Class WPObjectType

--- a/src/Type/WPObjectType.php
+++ b/src/Type/WPObjectType.php
@@ -92,12 +92,11 @@ class WPObjectType extends ObjectType {
 	 *
 	 * @param array  $fields
 	 * @param string $type_name
-	 * @param array $config
 	 *
 	 * @return mixed
 	 * @since 0.0.5
 	 */
-	public static function prepare_fields( $fields, $type_name, $config = [] ) {
+	public static function prepare_fields( $fields, $type_name ) {
 
 		if ( null === self::$prepared_fields ) {
 			self::$prepared_fields = [];
@@ -141,16 +140,6 @@ class WPObjectType extends ObjectType {
 			 * @param array $fields The array of fields for the object config
 			 */
 			$fields = apply_filters( "graphql_{$uc_type_name}_fields", $fields );
-
-			/**
-			 * If the object defines input fields, apply a centralized filter for
-			 * input fields. This was previously handled by WPInputObjectType, but
-			 * the fields definition is now trapped in a closure so all filters need
-			 * to happen in one place.
-			 */
-			if ( isset( $config['kind'] ) && 'input' === $config['kind'] ) {
-				$fields = WPInputObjectType::prepare_fields( $fields, $type_name, $config );
-			}
 
 			/**
 			 * This sorts the fields alphabetically by the key, which is super handy for making the schema readable,

--- a/src/Type/WPObjectType.php
+++ b/src/Type/WPObjectType.php
@@ -3,6 +3,7 @@ namespace WPGraphQL\Type;
 
 use GraphQL\Type\Definition\ObjectType;
 use WPGraphQL\Data\DataSource;
+use WPGraphQL\Type\WPInputObjectType;
 
 /**
  * Class WPObjectType
@@ -91,11 +92,12 @@ class WPObjectType extends ObjectType {
 	 *
 	 * @param array  $fields
 	 * @param string $type_name
+	 * @param array $config
 	 *
 	 * @return mixed
 	 * @since 0.0.5
 	 */
-	public static function prepare_fields( $fields, $type_name ) {
+	public static function prepare_fields( $fields, $type_name, $config = [] ) {
 
 		if ( null === self::$prepared_fields ) {
 			self::$prepared_fields = [];
@@ -139,6 +141,16 @@ class WPObjectType extends ObjectType {
 			 * @param array $fields The array of fields for the object config
 			 */
 			$fields = apply_filters( "graphql_{$uc_type_name}_fields", $fields );
+
+			/**
+			 * If the object defines input fields, apply a centralized filter for
+			 * input fields. This was previously handled by WPInputObjectType, but
+			 * the fields definition is now trapped in a closure so all filters need
+			 * to happen in one place.
+			 */
+			if ( isset( $config['kind'] ) && 'input' === $config['kind'] ) {
+				$fields = WPInputObjectType::prepare_fields( $fields, $type_name, $config );
+			}
 
 			/**
 			 * This sorts the fields alphabetically by the key, which is super handy for making the schema readable,

--- a/src/TypeRegistry.php
+++ b/src/TypeRegistry.php
@@ -363,9 +363,17 @@ class TypeRegistry {
 			$config['name'] = ucfirst( $type_name );
 
 			if ( ! empty( $config['fields'] ) && is_array( $config['fields'] ) ) {
-				$config['fields'] = function () use ( $config, $type_name ) {
+				$config['fields'] = function () use ( $config, $kind, $type_name ) {
 					$prepared_fields = self::prepare_fields( $config['fields'], $type_name );
-					$prepared_fields = WPObjectType::prepare_fields( $prepared_fields, $type_name, $config );
+					$prepared_fields = WPObjectType::prepare_fields( $prepared_fields, $type_name );
+
+					/**
+					 * If the object defines input fields, additionally apply a
+					 * centralized filter for all input fields.
+					 */
+					if ( 'input' === $kind ) {
+						$prepared_fields = WPInputObjectType::prepare_fields( $prepared_fields, $type_name, $config );
+					}
 
 					return $prepared_fields;
 				};

--- a/src/TypeRegistry.php
+++ b/src/TypeRegistry.php
@@ -365,7 +365,7 @@ class TypeRegistry {
 			if ( ! empty( $config['fields'] ) && is_array( $config['fields'] ) ) {
 				$config['fields'] = function () use ( $config, $type_name ) {
 					$prepared_fields = self::prepare_fields( $config['fields'], $type_name );
-					$prepared_fields = WPObjectType::prepare_fields( $prepared_fields, $type_name );
+					$prepared_fields = WPObjectType::prepare_fields( $prepared_fields, $type_name, $config );
 
 					return $prepared_fields;
 				};


### PR DESCRIPTION
- [X] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [X] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
I'm not sure how I missed this in reviewing the Type registry changes or if this snuck in after I reviewed them, but the `graphql_input_fields` filter (what we use to implement custom `where` args) is now fairly broken.

The issue is that the `fields` definition for every object type is now wrapped in a closure (see [TypeRegistry#L366](https://github.com/wp-graphql/wp-graphql/blob/develop/src/TypeRegistry.php#L366)), which delegates to `WPObjectType::prepare_fields` to apply various filters. Then `WPInputObjectType` attempts to apply its own filters by calling `self::prepare_fields` in its constructor, but `fields` is now a closure (not an array) and the method call is skipped. As a result, the `graphql_input_fields` filter is never applied.

This PR adds logic to `WPObjectType::prepare_fields` to call `WPInputObjectType::prepare_fields` if the object `kind` is `input`. This is a little inelegant but preserves the API of `WPInputObjectType` which could be used by implementors (it is by us).

It may make more sense to move `graphql_input_fields` into `WPObjectType::prepare_fields`, but this would make `WPInputObjectType` an empty shell (the `format_enum_name` method was completely unused).

We could also eliminate the `graphql_input_fields` filter and force users to the individual type filters, but this central filter is rather useful so that `where` args can be easily added across multiple types (e.g., all custom post types).