### PR TITLE
#598 - searching for terms doesn't include children in results

### DIFF
--- a/src/Data/PostObjectConnectionResolver.php
+++ b/src/Data/PostObjectConnectionResolver.php
@@ -153,6 +153,15 @@ class PostObjectConnectionResolver extends ConnectionResolver {
 		}
 
 		/**
+		 * If the query is a search, the source is not another Post, and the parent input $arg is not
+		 * explicitly set in the query, unset the $query_args['post_parent'] so the search
+		 * can search all posts, not just top level posts.
+		 */
+		if ( ! $source instanceof \WP_Post && isset( $query_args['search'] ) && ! isset( $input_fields['parent'] ) ) {
+			unset( $query_args['post_parent'] );
+		}
+
+		/**
 		 * Map the orderby inputArgs to the WP_Query
 		 */
 		 if ( ! empty( $args['where']['orderby'] ) && is_array( $args['where']['orderby'] ) ) {

--- a/src/Data/TermObjectConnectionResolver.php
+++ b/src/Data/TermObjectConnectionResolver.php
@@ -152,10 +152,20 @@ class TermObjectConnectionResolver extends ConnectionResolver {
 		/**
 		 * If the connection is set to output in a flat list, unset the parent
 		 */
-		if ( $source instanceof \WP_Post && isset( $input_fields['shouldOutputInFlatList'] ) && true === $input_fields['shouldOutputInFlatList'] ) {
+		if ( isset( $input_fields['shouldOutputInFlatList'] ) && true === $input_fields['shouldOutputInFlatList'] ) {
 			unset( $query_args['parent'] );
-			$connected             = wp_get_object_terms( $source->ID, self::$taxonomy, [ 'fields' => 'ids' ] );
-			$query_args['include'] = ! empty( $connected ) ? $connected : [];
+			if ( $source instanceof \WP_Post ) {
+				$connected             = wp_get_object_terms( $source->ID, self::$taxonomy, [ 'fields' => 'ids' ] );
+				$query_args['include'] = ! empty( $connected ) ? $connected : [];
+			}
+		}
+
+		/**
+		 * If the query is a search, the source isn't another Term, and the parent $arg is not explicitly set in the query,
+		 * unset the $query_args['parent'] so the search can search all posts, not just top level posts.
+		 */
+		if ( ! $source instanceof \WP_Term && isset( $query_args['search'] ) && ! isset( $input_fields['parent'] ) ) {
+			unset( $query_args['parent'] );
 		}
 
 		/**


### PR DESCRIPTION
- This adjusts the PostObjectConnectionResolver and the TermObjectConnectionResolver to ensure that search queries include terms that don't have the parent set to 0.

