### PR TITLE
#612 - move `graphql_register_types` to the end of TypeRegistry::init()

### DIFF
--- a/src/TypeRegistry.php
+++ b/src/TypeRegistry.php
@@ -200,13 +200,6 @@ class TypeRegistry {
 		require_once( WPGRAPHQL_PLUGIN_DIR . 'src/Type/Union/PostObjectUnion.php' );
 		require_once( WPGRAPHQL_PLUGIN_DIR . 'src/Type/Union/TermObjectUnion.php' );
 
-		if ( ! did_action( 'graphql_register_types' ) ) {
-
-			/**
-			 * Hook to extend the schema by registering new types
-			 */
-			do_action( 'graphql_register_types' );
-		}
 
 		/**
 		 * Register core connections
@@ -238,6 +231,13 @@ class TypeRegistry {
 		UserUpdate::register_mutation();
 		UserRegister::register_mutation();
 		UpdateSettings::register_mutation();
+
+		/**
+		 * Hook to register connections
+		 */
+		if ( ! did_action( 'graphql_register_types' ) ) {
+			do_action( 'graphql_register_types' );
+		}
 
 	}
 


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
---------------------------------------------------
- this allows all core types (connections, unions, mutations included) to be registered prior to custom Types being registered.


## Does this close any currently open issues?
------------------------------------------
closes #612 

## Any other comments?
-------------------
Currently, the hook `graphql_register_types` is fired before connections, unions, and mutations are registered. 

This moves the hook later, so all Types, (including connections, mutations, and unions) have been registered by this time. 

Now, when hooking into `graphql_register_types`, all core types registered by the plugin exist already, so filtering the types, etc can happen now when also hooking into said hook. 
