### PR TITLE
fixes #576 test for global post object being set correctly

### DIFF
--- a/tests/wpunit/PostObjectConnectionQueriesTest.php
+++ b/tests/wpunit/PostObjectConnectionQueriesTest.php
@@ -117,6 +117,8 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 						postId
 						title
 						date
+						content
+						excerpt
 					}
 				}
 				nodes {
@@ -714,6 +716,37 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		 * Make sure the author is equal to the user previously created
 		 */
 		$this->assertEquals( $user_id, $actual['author'] );
+
+	}
+
+	/**
+	 * Test to assert that the global post object is being set correctly
+	 */
+	public function testPostExcerptsAreDifferent() {
+
+		$post_1_args = [
+			'post_content' => 'Post content 1',
+			'post_excerpt' => 'Post excerpt 1',
+		];
+
+		$post_2_args = [
+			'post_content' => 'Post content 2',
+			'post_excerpt' => 'Post excerpt 2',
+		];
+
+		$post_1_id = $this->createPostObject( $post_1_args );
+		$post_2_id = $this->createPostObject( $post_2_args );
+
+		$request = $this->postsQuery( [ 'where' => [ 'in' => [ $post_1_id, $post_2_id ] ] ] );
+
+		$this->assertNotEmpty( $request );
+		$this->assertArrayNotHasKey( 'errors', $request );
+
+		$edges = $request['data']['posts']['edges'];
+		$this->assertNotEmpty( $edges );
+
+		$this->assertNotEquals( $edges[0]['node']['excerpt'], $edges[1]['node']['excerpt'] );
+		$this->assertNotEquals( $edges[0]['node']['content'], $edges[1]['node']['content'] );
 
 	}
 	


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds a test to make sure the global post object is set correctly

Does this close any currently open issues?
------------------------------------------
#576

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:**
OSX

**WordPress Version:**
5.0
