### PR TITLE
#619 - Throw Better Exceptions in TypeRegistry

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -310,6 +310,7 @@ class Router {
 	 * @since  0.0.1
 	 * @access public
 	 * @return mixed
+	 * @throws \Throwable
 	 */
 	public static function process_http_request() {
 
@@ -466,7 +467,7 @@ class Router {
 			 * @since 0.0.4
 			 */
 			self::$http_status_code = 500;
-			$response['errors']     = [ FormattedError::createFromException( $error ) ];
+			$response['errors']     = [ FormattedError::createFromException( $error, GRAPHQL_DEBUG ) ];
 		} // End try().
 
 		/**

--- a/src/Type/Enum/PostTypeEnum.php
+++ b/src/Type/Enum/PostTypeEnum.php
@@ -13,11 +13,13 @@ $allowed_post_types = \WPGraphQL::get_allowed_post_types();
  * Loop through the taxonomies and create an array
  * of values for use in the enum type.
  */
-foreach ( $allowed_post_types as $post_type ) {
+if ( ! empty( $allowed_post_types ) && is_array( $allowed_post_types ) ) {
+	foreach ( $allowed_post_types as $post_type ) {
 
-	$values[ WPEnumType::get_safe_name( $post_type ) ] = [
-		'value' => $post_type,
-	];
+		$values[ WPEnumType::get_safe_name( $post_type ) ] = [
+			'value' => $post_type,
+		];
+	}
 }
 
 register_graphql_enum_type( 'PostTypeEnum', [

--- a/src/Type/Enum/TaxonomyEnum.php
+++ b/src/Type/Enum/TaxonomyEnum.php
@@ -10,10 +10,14 @@ $values = [];
  * Loop through the taxonomies and create an array
  * of values for use in the enum type.
  */
-foreach ( $allowed_taxonomies as $taxonomy ) {
-	$values[ WPEnumType::get_safe_name( get_taxonomy( $taxonomy )->graphql_single_name ) ] = [
-		'value' => $taxonomy,
-	];
+if ( ! empty( $allowed_taxonomies ) && is_array( $allowed_taxonomies ) ) {
+	foreach ( $allowed_taxonomies as $taxonomy ) {
+		if ( ! isset( $values[ WPEnumType::get_safe_name( get_taxonomy( $taxonomy )->graphql_single_name ) ] ) ) {
+			$values[ WPEnumType::get_safe_name( get_taxonomy( $taxonomy )->graphql_single_name ) ] = [
+				'value' => $taxonomy,
+			];
+		}
+	}
 }
 
 register_graphql_enum_type( 'TaxonomyEnum', [

--- a/src/Type/Object/PostObject.php
+++ b/src/Type/Object/PostObject.php
@@ -41,70 +41,77 @@ function register_post_object_types( $post_type_object ) {
 	}
 
 	/**
-	 * Register fields custom to the MediaItem Type
+	 * Register fields to the Type used for attachments (MediaItem)
 	 */
-	register_graphql_fields( 'MediaItem', [
-		'caption'      => [
-			'type'        => 'String',
-			'description' => __( 'The caption for the resource', 'wp-graphql' ),
-			'resolve'     => function ( \WP_Post $post, $args, $context, $info ) {
-				$caption = apply_filters( 'the_excerpt', apply_filters( 'get_the_excerpt', $post->post_excerpt, $post ) );
+	if ( 'attachment' === $post_type_object->name && true === $post_type_object->show_in_graphql && isset( $post_type_object->graphql_single_name ) ) {
 
-				return ! empty( $caption ) ? $caption : null;
-			},
-		],
-		'altText'      => [
-			'type'        => 'String',
-			'description' => __( 'Alternative text to display when resource is not displayed', 'wp-graphql' ),
-			'resolve'     => function ( \WP_Post $post, $args, $context, $info ) {
-				return get_post_meta( $post->ID, '_wp_attachment_image_alt', true );
-			},
-		],
-		'description'  => [
-			'type'        => 'String',
-			'description' => __( 'Description of the image (stored as post_content)', 'wp-graphql' ),
-			'resolve'     => function ( \WP_Post $post, $args, $context, $info ) {
-				return apply_filters( 'the_content', $post->post_content );
-			},
-		],
-		'mediaType'    => [
-			'type'        => 'String',
-			'description' => __( 'Type of resource', 'wp-graphql' ),
-			'resolve'     => function ( \WP_Post $post, $args, $context, $info ) {
-				return wp_attachment_is_image( $post->ID ) ? 'image' : 'file';
-			},
-		],
-		'sourceUrl'    => [
-			'type'        => 'String',
-			'description' => __( 'Url of the mediaItem', 'wp-graphql' ),
-			'resolve'     => function ( \WP_Post $post, $args, $context, $info ) {
-				return wp_get_attachment_url( $post->ID );
-			},
-		],
-		'mimeType'     => [
-			'type'        => 'String',
-			'description' => __( 'The mime type of the mediaItem', 'wp-graphql' ),
-			'resolve'     => function ( \WP_Post $post, $args, $context, $info ) {
-				return ! empty( $post->post_mime_type ) ? $post->post_mime_type : null;
-			},
-		],
-		'mediaDetails' => [
-			'type'        => 'MediaDetails',
-			'description' => __( 'Details about the mediaItem', 'wp-graphql' ),
-			'resolve'     => function ( \WP_Post $post, $args, $context, $info ) {
-				$media_details = wp_get_attachment_metadata( $post->ID );
+		/**
+		 * Register fields custom to the MediaItem Type
+		 */
+		register_graphql_fields( $post_type_object->graphql_single_name, [
+			'caption'      => [
+				'type'        => 'String',
+				'description' => __( 'The caption for the resource', 'wp-graphql' ),
+				'resolve'     => function ( \WP_Post $post, $args, $context, $info ) {
+					$caption = apply_filters( 'the_excerpt', apply_filters( 'get_the_excerpt', $post->post_excerpt, $post ) );
 
-				if ( ! empty( $media_details ) ) {
-					$media_details['ID'] = $post->ID;
+					return ! empty( $caption ) ? $caption : null;
+				},
+			],
+			'altText'      => [
+				'type'        => 'String',
+				'description' => __( 'Alternative text to display when resource is not displayed', 'wp-graphql' ),
+				'resolve'     => function ( \WP_Post $post, $args, $context, $info ) {
+					return get_post_meta( $post->ID, '_wp_attachment_image_alt', true );
+				},
+			],
+			'description'  => [
+				'type'        => 'String',
+				'description' => __( 'Description of the image (stored as post_content)', 'wp-graphql' ),
+				'resolve'     => function ( \WP_Post $post, $args, $context, $info ) {
+					return apply_filters( 'the_content', $post->post_content );
+				},
+			],
+			'mediaType'    => [
+				'type'        => 'String',
+				'description' => __( 'Type of resource', 'wp-graphql' ),
+				'resolve'     => function ( \WP_Post $post, $args, $context, $info ) {
+					return wp_attachment_is_image( $post->ID ) ? 'image' : 'file';
+				},
+			],
+			'sourceUrl'    => [
+				'type'        => 'String',
+				'description' => __( 'Url of the mediaItem', 'wp-graphql' ),
+				'resolve'     => function ( \WP_Post $post, $args, $context, $info ) {
+					return wp_get_attachment_url( $post->ID );
+				},
+			],
+			'mimeType'     => [
+				'type'        => 'String',
+				'description' => __( 'The mime type of the mediaItem', 'wp-graphql' ),
+				'resolve'     => function ( \WP_Post $post, $args, $context, $info ) {
+					return ! empty( $post->post_mime_type ) ? $post->post_mime_type : null;
+				},
+			],
+			'mediaDetails' => [
+				'type'        => 'MediaDetails',
+				'description' => __( 'Details about the mediaItem', 'wp-graphql' ),
+				'resolve'     => function ( \WP_Post $post, $args, $context, $info ) {
+					$media_details = wp_get_attachment_metadata( $post->ID );
 
-					return $media_details;
-				}
+					if ( ! empty( $media_details ) ) {
+						$media_details['ID'] = $post->ID;
 
-				return null;
-			},
-		],
+						return $media_details;
+					}
 
-	] );
+					return null;
+				},
+			],
+
+		] );
+
+	}
 
 }
 

--- a/src/TypeRegistry.php
+++ b/src/TypeRegistry.php
@@ -287,6 +287,10 @@ class TypeRegistry {
 		add_filter( 'graphql_' . $type_name . '_fields', function ( $fields ) use ( $type_name, $field_name, $config ) {
 
 			if ( isset ( $fields[ $field_name ] ) ) {
+				if ( true === GRAPHQL_DEBUG ) {
+					throw new InvariantViolation( sprintf( __( 'You cannot register duplicate fields on the same Type. The field \'%1$s\' already exists on the type \'%2$s\'. Make sure to give the field a unique name.' ), $field_name, $type_name ) );
+				}
+
 				return $fields;
 			}
 
@@ -320,6 +324,10 @@ class TypeRegistry {
 
 			if ( isset ( $fields[ $field_name ] ) ) {
 				unset( $fields[ $field_name ] );
+			} else {
+				if ( true === GRAPHQL_DEBUG ) {
+					throw new InvariantViolation( sprintf( __( 'The field \'%1$s\' does not exist on the type \'%2$s\' and cannot be deregistered', 'wp-graphql' ), $field_name, $type_name ) );
+				}
 			}
 
 			return $fields;
@@ -339,6 +347,12 @@ class TypeRegistry {
 	 */
 	public static function register_type( $type_name, $config ) {
 		if ( isset( self::$types[ self::format_key( $type_name ) ] ) ) {
+
+			if ( true === GRAPHQL_DEBUG ) {
+				// Translators: The placeholder is the name of the Type in the Schema
+				throw new InvariantViolation( sprintf( __( 'The type \'%s\' already exists and cannot be registered again. Please register a Type with a unique Type name', 'wp-graphql' ), $type_name ) );
+			}
+
 			return;
 		}
 		$prepared_type = self::prepare_type( $type_name, $config );
@@ -455,7 +469,7 @@ class TypeRegistry {
 		}
 
 		if ( ! isset( $field_config['type'] ) ) {
-			throw new InvariantViolation( __( 'The Field needs a Type defined', 'wp-graphql' ) );
+			throw new InvariantViolation( sprintf( __( 'The registered field \'%s\' does not have a Type defined. Make sure to define a type for all fields.', 'wp-graphql' ), $field_name ) );
 		}
 
 		if ( is_string( $field_config['type'] ) ) {

--- a/src/TypeRegistry.php
+++ b/src/TypeRegistry.php
@@ -347,12 +347,6 @@ class TypeRegistry {
 	 */
 	public static function register_type( $type_name, $config ) {
 		if ( isset( self::$types[ self::format_key( $type_name ) ] ) ) {
-
-			if ( true === GRAPHQL_DEBUG ) {
-				// Translators: The placeholder is the name of the Type in the Schema
-				throw new InvariantViolation( sprintf( __( 'The type \'%s\' already exists and cannot be registered again. Please register a Type with a unique Type name', 'wp-graphql' ), $type_name ) );
-			}
-
 			return;
 		}
 		$prepared_type = self::prepare_type( $type_name, $config );

--- a/tests/wpunit/TypesTest.php
+++ b/tests/wpunit/TypesTest.php
@@ -19,6 +19,88 @@ class TypesTest extends \Codeception\TestCase\WPTestCase
         parent::tearDown();
     }
 
+	/**
+	 * This registers a duplicate field to the Schema (posts already exists on RootQuery)
+	 */
+    public function register_duplicate_field() {
+	    register_graphql_field( 'RootQuery', 'posts', [
+		    'description' => 'Duplicate field, should throw exception'
+	    ] );
+    }
+
+	/**
+	 * This registers a field with no Type defined
+	 */
+    public function register_field_without_type() {
+	    register_graphql_field( 'RootQuery', 'newFieldWithoutTypeDefined', [
+		    'description' => 'Duplicate field, should throw exception'
+	    ] );
+    }
+
+    public function register_duplicate_type() {
+    	register_graphql_object_type( 'Post', [
+    		'description' => 'This is a duplicate Type and should throw exception',
+	    ]);
+    }
+
+	/**
+	 * This tries to deregister a non-existent field
+	 */
+    public function deregister_non_existent_field() {
+    	deregister_graphql_field( 'RootQuery', 'nonExistentFieldThatShouldCauseException' );
+    }
+
+	/**
+	 * This registers a field that's already been registered, and asserts that
+	 * an exception is being thrown.
+	 */
+	public function testRegisterDuplicateFieldShouldThrowException() {
+
+    	tests_add_filter( 'graphql_register_types', [ $this, 'register_duplicate_field' ] );
+		$this->expectException( \GraphQL\Error\InvariantViolation::class );
+	    do_graphql_request( '{posts{edges{node{id}}}}' );
+	    remove_filter( 'graphql_register_types', [ $this, 'register_duplicate_field' ] );
+
+    }
+
+	/**
+	 * This registers a field without a type defined, and asserts that
+	 * an exception is being thrown.
+	 */
+	public function testRegisterFieldWithoutTypeShouldThrowException() {
+
+		tests_add_filter( 'graphql_register_types', [ $this, 'register_field_without_type' ] );
+		$this->expectException( \GraphQL\Error\InvariantViolation::class );
+		do_graphql_request( '{posts{edges{node{id}}}}' );
+		remove_filter( 'graphql_register_types', [ $this, 'register_field_without_type' ] );
+
+	}
+
+	/**
+	 * This registers a duplicate Type and should throw an exception.
+	 */
+	public function testRegisterDuplicateTypeShouldThrowException() {
+
+		tests_add_filter( 'graphql_register_types', [ $this, 'register_duplicate_type' ] );
+		$this->expectException( \GraphQL\Error\InvariantViolation::class );
+		do_graphql_request( '{posts{edges{node{id}}}}' );
+		remove_filter( 'graphql_register_types', [ $this, 'register_duplicate_type' ] );
+
+	}
+
+	/**
+	 * This tries to deregister a non-existend field, and asserts that
+	 * an exception is being thrown.
+	 */
+	public function testDeRegisterNonExistentFieldShouldThrowException() {
+
+		tests_add_filter( 'graphql_register_types', [ $this, 'deregister_non_existent_field' ] );
+		$this->expectException( \GraphQL\Error\InvariantViolation::class );
+		do_graphql_request( '{posts{edges{node{id}}}}' );
+		remove_filter( 'graphql_register_types', [ $this, 'deregister_non_existent_field' ] );
+
+	}
+
 	public function testMapInput() {
 
 		/**

--- a/tests/wpunit/TypesTest.php
+++ b/tests/wpunit/TypesTest.php
@@ -20,46 +20,17 @@ class TypesTest extends \Codeception\TestCase\WPTestCase
     }
 
 	/**
-	 * This registers a duplicate field to the Schema (posts already exists on RootQuery)
-	 */
-    public function register_duplicate_field() {
-	    register_graphql_field( 'RootQuery', 'posts', [
-		    'description' => 'Duplicate field, should throw exception'
-	    ] );
-    }
-
-	/**
-	 * This registers a field with no Type defined
-	 */
-    public function register_field_without_type() {
-	    register_graphql_field( 'RootQuery', 'newFieldWithoutTypeDefined', [
-		    'description' => 'Duplicate field, should throw exception'
-	    ] );
-    }
-
-    public function register_duplicate_type() {
-    	register_graphql_object_type( 'Post', [
-    		'description' => 'This is a duplicate Type and should throw exception',
-	    ]);
-    }
-
-	/**
-	 * This tries to deregister a non-existent field
-	 */
-    public function deregister_non_existent_field() {
-    	deregister_graphql_field( 'RootQuery', 'nonExistentFieldThatShouldCauseException' );
-    }
-
-	/**
 	 * This registers a field that's already been registered, and asserts that
 	 * an exception is being thrown.
 	 */
 	public function testRegisterDuplicateFieldShouldThrowException() {
 
-    	tests_add_filter( 'graphql_register_types', [ $this, 'register_duplicate_field' ] );
+		register_graphql_field( 'ExampleType', 'example', [
+			'description' => 'Duplicate field, should throw exception'
+		] );
+
 		$this->expectException( \GraphQL\Error\InvariantViolation::class );
-	    do_graphql_request( '{posts{edges{node{id}}}}' );
-	    remove_filter( 'graphql_register_types', [ $this, 'register_duplicate_field' ] );
+		apply_filters( 'graphql_ExampleType_fields', [ 'example' => [] ] );
 
     }
 
@@ -69,22 +40,13 @@ class TypesTest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testRegisterFieldWithoutTypeShouldThrowException() {
 
-		tests_add_filter( 'graphql_register_types', [ $this, 'register_field_without_type' ] );
+
+		register_graphql_field( 'RootQuery', 'newFieldWithoutTypeDefined', [
+			'description' => 'Field without type, should throw exception'
+		] );
+
 		$this->expectException( \GraphQL\Error\InvariantViolation::class );
-		do_graphql_request( '{posts{edges{node{id}}}}' );
-		remove_filter( 'graphql_register_types', [ $this, 'register_field_without_type' ] );
-
-	}
-
-	/**
-	 * This registers a duplicate Type and should throw an exception.
-	 */
-	public function testRegisterDuplicateTypeShouldThrowException() {
-
-		tests_add_filter( 'graphql_register_types', [ $this, 'register_duplicate_type' ] );
-		$this->expectException( \GraphQL\Error\InvariantViolation::class );
-		do_graphql_request( '{posts{edges{node{id}}}}' );
-		remove_filter( 'graphql_register_types', [ $this, 'register_duplicate_type' ] );
+		apply_filters( 'graphql_RootQuery_fields', [] );
 
 	}
 
@@ -94,10 +56,9 @@ class TypesTest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testDeRegisterNonExistentFieldShouldThrowException() {
 
-		tests_add_filter( 'graphql_register_types', [ $this, 'deregister_non_existent_field' ] );
+		deregister_graphql_field( 'RootQuery', 'nonExistentFieldThatShouldCauseException' );
 		$this->expectException( \GraphQL\Error\InvariantViolation::class );
-		do_graphql_request( '{posts{edges{node{id}}}}' );
-		remove_filter( 'graphql_register_types', [ $this, 'deregister_non_existent_field' ] );
+		apply_filters( 'graphql_RootQuery_fields', [] );
 
 	}
 


### PR DESCRIPTION
- Router.php add the $debug flag to FormattedError::createFromException() so errors are returned with a valuable message other than just "internal server error" when GRAPHQL_DEBUG is true (can't believe how long this has been broken. . .)
- Add some more helpful InvariantViolation exceptions in TypeRegistry.php when fields/types aren't registered properly
- Fix a bug with how the fields were being registered to MediaItems numerous times
- Add some tests to make sure the Exceptions are being thrown as expected when fields are registered poorly

-----

Closes #619 