### PR TITLE
Order menu items by post__in instead of menu_order.

### DIFF
--- a/src/Data/MenuItemConnectionResolver.php
+++ b/src/Data/MenuItemConnectionResolver.php
@@ -127,7 +127,7 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 		 * Set the order to match the menu order
 		 */
 		$query_args['order']   = 'ASC';
-		$query_args['orderby'] = 'menu_order';
+		$query_args['orderby'] = 'post__in';
 
 		/**
 		 * Set the posts_per_page, ensuring it doesn't exceed the amount set as the $max_query_amount

--- a/tests/wpunit/MenuItemConnectionQueriesTest.php
+++ b/tests/wpunit/MenuItemConnectionQueriesTest.php
@@ -249,9 +249,6 @@ class MenuItemConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 		$actual = do_graphql_request( $query );
 
-		// Delete a menu item.
-		wp_delete_post( $created['menu_item_ids'][7] );
-
 		// Perform some common assertions. Slice the created IDs to the limit.
 		$menu_item_ids = array_slice( $created['menu_item_ids'], 0, $limit );
 		$post_ids = array_slice( $created['post_ids'], 0, $limit );

--- a/tests/wpunit/MenuItemConnectionQueriesTest.php
+++ b/tests/wpunit/MenuItemConnectionQueriesTest.php
@@ -249,6 +249,9 @@ class MenuItemConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 		$actual = do_graphql_request( $query );
 
+		// Delete a menu item.
+		wp_delete_post( $created['menu_item_ids'][7] );
+
 		// Perform some common assertions. Slice the created IDs to the limit.
 		$menu_item_ids = array_slice( $created['menu_item_ids'], 0, $limit );
 		$post_ids = array_slice( $created['post_ids'], 0, $limit );


### PR DESCRIPTION
Ordering by menu item is unnecessary; we already have the order we want in `post__in`, so we should use that order.

I originally thought I had an edge case that would produce results in the wrong order, but I can't reproduce in tests. This change is now just a minor optimization.