### PR TITLE
#611 update mutation config

### DIFF
--- a/src/Mutation/CommentCreate.php
+++ b/src/Mutation/CommentCreate.php
@@ -11,86 +11,9 @@ class CommentCreate {
 	public static function register_mutation() {
 		register_graphql_mutation( 'createComment', [
 			'inputFields'         => self::get_input_fields(),
-			'outputFields'        => [
-				'comment' => [
-					'type'        => 'Comment',
-					'description' => __( 'The comment that was created', 'wp-graphql' ),
-					'resolve'     => function ( $payload ) {
-						return get_comment( $payload['id'] );
-					},
-				]
-			],
-			'mutateAndGetPayload' => function ( $input, AppContext $context, ResolveInfo $info ) {
-				/**
-				 * Throw an exception if there's no input
-				 */
-				if ( ( empty( $input ) || ! is_array( $input ) ) ) {
-					throw new UserError( __( 'Mutation not processed. There was no input for the mutation or the comment_object was invalid', 'wp-graphql' ) );
-				}
-
-				/**
-				 * Stop if post not open to comments
-				 */
-				if ( get_post( $input['postId'] )->post_status === 'closed' ) {
-					throw new UserError( __( 'Sorry, this post is closed to comments at the moment', 'wp-graphql' ) );
-				}
-
-				/**
-				 * Map all of the args from GraphQL to WordPress friendly args array
-				 */
-				$comment_args = [
-					'comment_author_url' => '',
-					'comment_type'       => '',
-					'comment_parent'     => 0,
-					'user_id'            => 0,
-					'comment_author_IP'  => ':1',
-					'comment_agent'      => '',
-					'comment_date'       => date( 'Y-m-d H:i:s' ),
-				];
-
-				CommentMutation::prepare_comment_object( $input, $comment_args, 'createComment' );
-
-				/**
-				 * Insert the comment and retrieve the ID
-				 */
-				$comment_id = wp_new_comment( $comment_args, true );
-
-				/**
-				 * Throw an exception if the comment failed to be created
-				 */
-				if ( is_wp_error( $comment_id ) ) {
-					$error_message = $comment_id->get_error_message();
-					if ( ! empty( $error_message ) ) {
-						throw new UserError( esc_html( $error_message ) );
-					} else {
-						throw new UserError( __( 'The object failed to create but no error was provided', 'wp-graphql' ) );
-					}
-				}
-
-				/**
-				 * If the $comment_id is empty, we should throw an exception
-				 */
-				if ( empty( $comment_id ) ) {
-					throw new UserError( __( 'The object failed to create', 'wp-graphql' ) );
-				}
-
-				/**
-				 * This updates additional data not part of the comments table ( commentmeta, other relations, etc )
-				 *
-				 * The input for the commentMutation will be passed, along with the $new_comment_id for the
-				 * comment that was created so that relations can be set, meta can be updated, etc.
-				 */
-				CommentMutation::update_additional_comment_data( $comment_id, $input, 'createComment', $context, $info );
-
-				/**
-				 * Return the comment object
-				 */
-				return [
-					'id' => $comment_id,
-				];
-
-			},
-		] );
+			'outputFields'        => self::get_output_fields(),
+			'mutateAndGetPayload' => self::mutate_and_get_payload(),
+		]);
 	}
 
 	public static function get_input_fields() {
@@ -144,5 +67,89 @@ class CommentCreate {
 				'description' => __( 'The approval status of the comment.', 'wp-graphql' ),
 			],
 		];
+	}
+
+	public static function get_output_fields() {
+		return [
+			'comment' => [
+				'type'        => 'Comment',
+				'description' => __( 'The comment that was created', 'wp-graphql' ),
+				'resolve'     => function ( $payload ) {
+					return get_comment( $payload['id'] );
+				},
+			]
+		];
+	}
+
+	public static function mutate_and_get_payload() {
+		return function ( $input, AppContext $context, ResolveInfo $info ) {
+			/**
+			 * Throw an exception if there's no input
+			 */
+			if ( ( empty( $input ) || ! is_array( $input ) ) ) {
+				throw new UserError( __( 'Mutation not processed. There was no input for the mutation or the comment_object was invalid', 'wp-graphql' ) );
+			}
+
+			/**
+			 * Stop if post not open to comments
+			 */
+			if ( get_post( $input['postId'] )->post_status === 'closed' ) {
+				throw new UserError( __( 'Sorry, this post is closed to comments at the moment', 'wp-graphql' ) );
+			}
+
+			/**
+			 * Map all of the args from GraphQL to WordPress friendly args array
+			 */
+			$comment_args = [
+				'comment_author_url' => '',
+				'comment_type'       => '',
+				'comment_parent'     => 0,
+				'user_id'            => 0,
+				'comment_author_IP'  => ':1',
+				'comment_agent'      => '',
+				'comment_date'       => date( 'Y-m-d H:i:s' ),
+			];
+
+			CommentMutation::prepare_comment_object( $input, $comment_args, 'createComment' );
+
+			/**
+			 * Insert the comment and retrieve the ID
+			 */
+			$comment_id = wp_new_comment( $comment_args, true );
+
+			/**
+			 * Throw an exception if the comment failed to be created
+			 */
+			if ( is_wp_error( $comment_id ) ) {
+				$error_message = $comment_id->get_error_message();
+				if ( ! empty( $error_message ) ) {
+					throw new UserError( esc_html( $error_message ) );
+				} else {
+					throw new UserError( __( 'The object failed to create but no error was provided', 'wp-graphql' ) );
+				}
+			}
+
+			/**
+			 * If the $comment_id is empty, we should throw an exception
+			 */
+			if ( empty( $comment_id ) ) {
+				throw new UserError( __( 'The object failed to create', 'wp-graphql' ) );
+			}
+
+			/**
+			 * This updates additional data not part of the comments table ( commentmeta, other relations, etc )
+			 *
+			 * The input for the commentMutation will be passed, along with the $new_comment_id for the
+			 * comment that was created so that relations can be set, meta can be updated, etc.
+			 */
+			CommentMutation::update_additional_comment_data( $comment_id, $input, 'createComment', $context, $info );
+
+			/**
+			 * Return the comment object
+			 */
+			return [
+				'id' => $comment_id,
+			];
+		};
 	}
 }

--- a/src/Mutation/CommentCreate.php
+++ b/src/Mutation/CommentCreate.php
@@ -8,148 +8,166 @@ use WPGraphQL\AppContext;
 use WPGraphQL\Data\CommentMutation;
 
 class CommentCreate {
-	public static function register_mutation() {
-		register_graphql_mutation( 'createComment', [
-			'inputFields'         => self::get_input_fields(),
-			'outputFields'        => self::get_output_fields(),
-			'mutateAndGetPayload' => self::mutate_and_get_payload(),
-		]);
-	}
+    /**
+     * Registers the CommentCreate mutation.
+     */
+    public static function register_mutation() {
+        register_graphql_mutation( 'createComment', [
+            'inputFields'         => self::get_input_fields(),
+            'outputFields'        => self::get_output_fields(),
+            'mutateAndGetPayload' => self::mutate_and_get_payload(),
+        ] );
+    }
 
-	public static function get_input_fields() {
-		return [
-			'postId'      => [
-				'type'        => 'Int',
-				'description' => __( 'The ID of the post the comment belongs to.', 'wp-graphql' ),
-			],
-			'userId'      => [
-				'type'        => 'Int',
-				'description' => __( 'The userID of the comment\'s author.', 'wp-graphql' ),
-			],
-			'author'      => [
-				'type'        => 'String',
-				'description' => __( 'The name of the comment\'s author.', 'wp-graphql' ),
-			],
-			'authorEmail' => [
-				'type'        => 'String',
-				'description' => __( 'The email of the comment\'s author.', 'wp-graphql' ),
-			],
-			'authorUrl'   => [
-				'type'        => 'String',
-				'description' => __( 'The url of the comment\'s author.', 'wp-graphql' ),
-			],
-			'authorIp'    => [
-				'type'        => 'String',
-				'description' => __( 'IP address for the comment\'s author.', 'wp-graphql' ),
-			],
-			'content'     => [
-				'type'        => 'String',
-				'description' => __( 'Content of the comment.', 'wp-graphql' ),
-			],
-			'type'        => [
-				'type'        => 'String',
-				'description' => __( 'Type of comment.', 'wp-graphql' ),
-			],
-			'parent'      => [
-				'type'        => 'ID',
-				'description' => __( 'Parent comment of current comment.', 'wp-graphql' ),
-			],
-			'agent'       => [
-				'type'        => 'String',
-				'description' => __( 'User agent used to post the comment.', 'wp-graphql' ),
-			],
-			'date'        => [
-				'type'        => 'String',
-				'description' => __( 'The date of the object. Preferable to enter as year/month/day ( e.g. 01/31/2017 ) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 ', 'wp-graphql' ),
-			],
-			'approved'    => [
-				'type'        => 'String',
-				'description' => __( 'The approval status of the comment.', 'wp-graphql' ),
-			],
-		];
-	}
+    /**
+     * Defines the mutation input field configuration.
+     *
+     * @return array
+     */
+    public static function get_input_fields() {
+        return [
+            'postId'      => [
+                'type'        => 'Int',
+                'description' => __( 'The ID of the post the comment belongs to.', 'wp-graphql' ),
+            ],
+            'userId'      => [
+                'type'        => 'Int',
+                'description' => __( 'The userID of the comment\'s author.', 'wp-graphql' ),
+            ],
+            'author'      => [
+                'type'        => 'String',
+                'description' => __( 'The name of the comment\'s author.', 'wp-graphql' ),
+            ],
+            'authorEmail' => [
+                'type'        => 'String',
+                'description' => __( 'The email of the comment\'s author.', 'wp-graphql' ),
+            ],
+            'authorUrl'   => [
+                'type'        => 'String',
+                'description' => __( 'The url of the comment\'s author.', 'wp-graphql' ),
+            ],
+            'authorIp'    => [
+                'type'        => 'String',
+                'description' => __( 'IP address for the comment\'s author.', 'wp-graphql' ),
+            ],
+            'content'     => [
+                'type'        => 'String',
+                'description' => __( 'Content of the comment.', 'wp-graphql' ),
+            ],
+            'type'        => [
+                'type'        => 'String',
+                'description' => __( 'Type of comment.', 'wp-graphql' ),
+            ],
+            'parent'      => [
+                'type'        => 'ID',
+                'description' => __( 'Parent comment of current comment.', 'wp-graphql' ),
+            ],
+            'agent'       => [
+                'type'        => 'String',
+                'description' => __( 'User agent used to post the comment.', 'wp-graphql' ),
+            ],
+            'date'        => [
+                'type'        => 'String',
+                'description' => __( 'The date of the object. Preferable to enter as year/month/day ( e.g. 01/31/2017 ) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 ', 'wp-graphql' ),
+            ],
+            'approved'    => [
+                'type'        => 'String',
+                'description' => __( 'The approval status of the comment.', 'wp-graphql' ),
+            ],
+        ];
+    }
 
-	public static function get_output_fields() {
-		return [
-			'comment' => [
-				'type'        => 'Comment',
-				'description' => __( 'The comment that was created', 'wp-graphql' ),
-				'resolve'     => function ( $payload ) {
-					return get_comment( $payload['id'] );
-				},
-			]
-		];
-	}
+    /**
+     * Defines the mutation output field configuration.
+     *
+     * @return array
+     */
+    public static function get_output_fields() {
+        return [
+            'comment' => [
+                'type'        => 'Comment',
+                'description' => __( 'The comment that was created', 'wp-graphql' ),
+                'resolve'     => function ( $payload ) {
+                    return get_comment( $payload['id'] );
+                },
+            ]
+        ];
+    }
 
-	public static function mutate_and_get_payload() {
-		return function ( $input, AppContext $context, ResolveInfo $info ) {
-			/**
-			 * Throw an exception if there's no input
-			 */
-			if ( ( empty( $input ) || ! is_array( $input ) ) ) {
-				throw new UserError( __( 'Mutation not processed. There was no input for the mutation or the comment_object was invalid', 'wp-graphql' ) );
-			}
+    /**
+     * Defines the mutation data modification closure.
+     *
+     * @return callable
+     */
+    public static function mutate_and_get_payload() {
+        return function ( $input, AppContext $context, ResolveInfo $info ) {
+            /**
+             * Throw an exception if there's no input
+             */
+            if ( ( empty( $input ) || ! is_array( $input ) ) ) {
+                throw new UserError( __( 'Mutation not processed. There was no input for the mutation or the comment_object was invalid', 'wp-graphql' ) );
+            }
 
-			/**
-			 * Stop if post not open to comments
-			 */
-			if ( get_post( $input['postId'] )->post_status === 'closed' ) {
-				throw new UserError( __( 'Sorry, this post is closed to comments at the moment', 'wp-graphql' ) );
-			}
+            /**
+             * Stop if post not open to comments
+             */
+            if ( get_post( $input['postId'] )->post_status === 'closed' ) {
+                throw new UserError( __( 'Sorry, this post is closed to comments at the moment', 'wp-graphql' ) );
+            }
 
-			/**
-			 * Map all of the args from GraphQL to WordPress friendly args array
-			 */
-			$comment_args = [
-				'comment_author_url' => '',
-				'comment_type'       => '',
-				'comment_parent'     => 0,
-				'user_id'            => 0,
-				'comment_author_IP'  => ':1',
-				'comment_agent'      => '',
-				'comment_date'       => date( 'Y-m-d H:i:s' ),
-			];
+            /**
+             * Map all of the args from GraphQL to WordPress friendly args array
+             */
+            $comment_args = [
+                'comment_author_url' => '',
+                'comment_type'       => '',
+                'comment_parent'     => 0,
+                'user_id'            => 0,
+                'comment_author_IP'  => ':1',
+                'comment_agent'      => '',
+                'comment_date'       => date( 'Y-m-d H:i:s' ),
+            ];
 
-			CommentMutation::prepare_comment_object( $input, $comment_args, 'createComment' );
+            CommentMutation::prepare_comment_object( $input, $comment_args, 'createComment' );
 
-			/**
-			 * Insert the comment and retrieve the ID
-			 */
-			$comment_id = wp_new_comment( $comment_args, true );
+            /**
+             * Insert the comment and retrieve the ID
+             */
+            $comment_id = wp_new_comment( $comment_args, true );
 
-			/**
-			 * Throw an exception if the comment failed to be created
-			 */
-			if ( is_wp_error( $comment_id ) ) {
-				$error_message = $comment_id->get_error_message();
-				if ( ! empty( $error_message ) ) {
-					throw new UserError( esc_html( $error_message ) );
-				} else {
-					throw new UserError( __( 'The object failed to create but no error was provided', 'wp-graphql' ) );
-				}
-			}
+            /**
+             * Throw an exception if the comment failed to be created
+             */
+            if ( is_wp_error( $comment_id ) ) {
+                $error_message = $comment_id->get_error_message();
+                if ( ! empty( $error_message ) ) {
+                    throw new UserError( esc_html( $error_message ) );
+                } else {
+                    throw new UserError( __( 'The object failed to create but no error was provided', 'wp-graphql' ) );
+                }
+            }
 
-			/**
-			 * If the $comment_id is empty, we should throw an exception
-			 */
-			if ( empty( $comment_id ) ) {
-				throw new UserError( __( 'The object failed to create', 'wp-graphql' ) );
-			}
+            /**
+             * If the $comment_id is empty, we should throw an exception
+             */
+            if ( empty( $comment_id ) ) {
+                throw new UserError( __( 'The object failed to create', 'wp-graphql' ) );
+            }
 
-			/**
-			 * This updates additional data not part of the comments table ( commentmeta, other relations, etc )
-			 *
-			 * The input for the commentMutation will be passed, along with the $new_comment_id for the
-			 * comment that was created so that relations can be set, meta can be updated, etc.
-			 */
-			CommentMutation::update_additional_comment_data( $comment_id, $input, 'createComment', $context, $info );
+            /**
+             * This updates additional data not part of the comments table ( commentmeta, other relations, etc )
+             *
+             * The input for the commentMutation will be passed, along with the $new_comment_id for the
+             * comment that was created so that relations can be set, meta can be updated, etc.
+             */
+            CommentMutation::update_additional_comment_data( $comment_id, $input, 'createComment', $context, $info );
 
-			/**
-			 * Return the comment object
-			 */
-			return [
-				'id' => $comment_id,
-			];
-		};
-	}
+            /**
+             * Return the comment object
+             */
+            return [
+                'id' => $comment_id,
+            ];
+        };
+    }
 }

--- a/src/Mutation/CommentDelete.php
+++ b/src/Mutation/CommentDelete.php
@@ -8,75 +8,87 @@ use GraphQLRelay\Relay;
 class CommentDelete {
 	public static function register_mutation() {
 		register_graphql_mutation( 'deleteComment', [
-			'inputFields'         => [
-				'id'          => [
-					'type'        => [
-						'non_null' => 'ID',
-					],
-					'description' => __( 'The ID of the comment to be deleted', 'wp-graphql' ),
-				],
-				'forceDelete' => [
-					'type'        => 'Boolean',
-					'description' => __( 'Whether the comment should be force deleted instead of being moved to the trash', 'wp-graphql' ),
-				],
-			],
-			'outputFields'        => [
-				'deletedId' => [
-					'type'        => 'Id',
-					'description' => __( 'The ID of the deleted comment', 'wp-graphql' ),
-					'resolve'     => function ( $payload ) {
-						$deleted = ( object ) $payload['commentObject'];
-
-						return ! empty( $deleted->comment_ID ) ? Relay::toGlobalId( 'comment', absint( $deleted->comment_ID ) ) : null;
-					},
-				],
-				'comment'   => [
-					'type'        => 'Comment',
-					'description' => __( 'The comment before it was deleted', 'wp-graphql' ),
-					'resolve'     => function ( $payload ) {
-						$deleted = ( object ) $payload['commentObject'];
-
-						return ! empty( $deleted ) ? $deleted : null;
-					},
-				],
-			],
-			'mutateAndGetPayload' => function ( $input ) {
-				/**
-				 * Get the ID from the global ID
-				 */
-				$id_parts = Relay::fromGlobalId( $input['id'] );
-
-				/**
-				 * Get the post object before deleting it
-				 */
-				$comment_id            = absint( $id_parts['id'] );
-				$comment_before_delete = get_comment( $comment_id );
-
-				/**
-				 * Stop now if a user isn't allowed to delete the comment
-				 */
-				$user_id = $comment_before_delete->user_id;
-				if (
-					! current_user_can( 'moderate_comments' ) &&
-					absint( get_current_user_id() ) !== absint( $user_id )
-				) {
-					throw new UserError( __( 'Sorry, you are not allowed to delete this comment.', 'wp-graphql' ) );
-				}
-
-				/**
-				 * Check if we should force delete or not
-				 */
-				$force_delete = ( ! empty( $input['forceDelete'] ) && true === $input['forceDelete'] ) ? true : false;
-
-				/**
-				 * Delete the comment
-				 */
-				$deleted = wp_delete_comment( $id_parts['id'], $force_delete );
-
-				return [
-					'commentObject' => $comment_before_delete,
-				];
-			},
+			'inputFields'         => self::get_input_fields(),
+			'outputFields'        => self::get_output_fields(),
+			'mutateAndGetPayload' => self::mutate_and_get_payload(),
 		] );
+	}
+	
+	public static function get_input_fields() {
+		return [
+			'id'          => [
+				'type'        => [
+					'non_null' => 'ID',
+				],
+				'description' => __( 'The deleted comment ID', 'wp-graphql' ),
+			],
+			'forceDelete' => [
+				'type'        => 'Boolean',
+				'description' => __( 'Whether the comment should be force deleted instead of being moved to the trash', 'wp-graphql' ),
+			],
+		];
+	}
+
+	public static function get_output_fields() {
+		return [
+			'deletedId' => [
+				'type'        => 'Id',
+				'description' => __( 'The deleted comment ID', 'wp-graphql' ),
+				'resolve'     => function ( $payload ) {
+					$deleted = ( object ) $payload['commentObject'];
+
+					return ! empty( $deleted->comment_ID ) ? Relay::toGlobalId( 'comment', absint( $deleted->comment_ID ) ) : null;
+				},
+			],
+			'comment'   => [
+				'type'        => 'Comment',
+				'description' => __( 'The deleted comment object', 'wp-graphql' ),
+				'resolve'     => function ( $payload ) {
+					$deleted = ( object ) $payload['commentObject'];
+
+					return ! empty( $deleted ) ? $deleted : null;
+				},
+			],
+		];
+	}
+
+	public static function mutate_and_get_payload() {
+		return function ( $input ) {
+			/**
+			 * Get the ID from the global ID
+			 */
+			$id_parts = Relay::fromGlobalId( $input['id'] );
+
+			/**
+			 * Get the post object before deleting it
+			 */
+			$comment_id            = absint( $id_parts['id'] );
+			$comment_before_delete = get_comment( $comment_id );
+
+			/**
+			 * Stop now if a user isn't allowed to delete the comment
+			 */
+			$user_id = $comment_before_delete->user_id;
+			if (
+				! current_user_can( 'moderate_comments' ) &&
+				absint( get_current_user_id() ) !== absint( $user_id )
+			) {
+				throw new UserError( __( 'Sorry, you are not allowed to delete this comment.', 'wp-graphql' ) );
+			}
+
+			/**
+			 * Check if we should force delete or not
+			 */
+			$force_delete = ( ! empty( $input['forceDelete'] ) && true === $input['forceDelete'] ) ? true : false;
+
+			/**
+			 * Delete the comment
+			 */
+			$deleted = wp_delete_comment( $id_parts['id'], $force_delete );
+
+			return [
+				'commentObject' => $comment_before_delete,
+			];
+		};
 	}
 }

--- a/src/Mutation/CommentDelete.php
+++ b/src/Mutation/CommentDelete.php
@@ -6,89 +6,101 @@ use GraphQL\Error\UserError;
 use GraphQLRelay\Relay;
 
 class CommentDelete {
-	public static function register_mutation() {
-		register_graphql_mutation( 'deleteComment', [
-			'inputFields'         => self::get_input_fields(),
-			'outputFields'        => self::get_output_fields(),
-			'mutateAndGetPayload' => self::mutate_and_get_payload(),
-		] );
-	}
-	
-	public static function get_input_fields() {
-		return [
-			'id'          => [
-				'type'        => [
-					'non_null' => 'ID',
-				],
-				'description' => __( 'The deleted comment ID', 'wp-graphql' ),
-			],
-			'forceDelete' => [
-				'type'        => 'Boolean',
-				'description' => __( 'Whether the comment should be force deleted instead of being moved to the trash', 'wp-graphql' ),
-			],
-		];
-	}
+    /**
+     * Registers the CommentDelete mutation.
+     */
+    public static function register_mutation() {
+        register_graphql_mutation( 'deleteComment', [
+            'inputFields'         => self::get_input_fields(),
+            'outputFields'        => self::get_output_fields(),
+            'mutateAndGetPayload' => self::mutate_and_get_payload(),
+        ] );
+    }
 
-	public static function get_output_fields() {
-		return [
-			'deletedId' => [
-				'type'        => 'Id',
-				'description' => __( 'The deleted comment ID', 'wp-graphql' ),
-				'resolve'     => function ( $payload ) {
-					$deleted = ( object ) $payload['commentObject'];
+    /**
+     * Defines the mutation input field configuration.
+     *
+     * @return array
+     */
+    public static function get_input_fields() {
+        return [
+            'id'          => [
+                'type'        => [
+                    'non_null' => 'ID',
+                ],
+                'description' => __( 'The deleted comment ID', 'wp-graphql' ),
+            ],
+            'forceDelete' => [
+                'type'        => 'Boolean',
+                'description' => __( 'Whether the comment should be force deleted instead of being moved to the trash', 'wp-graphql' ),
+            ],
+        ];
+    }
 
-					return ! empty( $deleted->comment_ID ) ? Relay::toGlobalId( 'comment', absint( $deleted->comment_ID ) ) : null;
-				},
-			],
-			'comment'   => [
-				'type'        => 'Comment',
-				'description' => __( 'The deleted comment object', 'wp-graphql' ),
-				'resolve'     => function ( $payload ) {
-					$deleted = ( object ) $payload['commentObject'];
+    /**
+     * Defines the mutation output field configuration.
+     *
+     * @return array
+     */
+    public static function get_output_fields() {
+        return array_merge(
+            CommentCreate::get_output_fields(),
+            [
+                'deletedId' => [
+                    'type'        => 'Id',
+                    'description' => __( 'The deleted comment ID', 'wp-graphql' ),
+                    'resolve'     => function ( $payload ) {
+                        $deleted = ( object ) $payload['commentObject'];
 
-					return ! empty( $deleted ) ? $deleted : null;
-				},
-			],
-		];
-	}
+                        return ! empty( $deleted->comment_ID ) ? Relay::toGlobalId( 'comment', absint( $deleted->comment_ID ) ) : null;
+                    },
+                ]
+            ]
+        );
+    }
 
-	public static function mutate_and_get_payload() {
-		return function ( $input ) {
-			/**
-			 * Get the ID from the global ID
-			 */
-			$id_parts = Relay::fromGlobalId( $input['id'] );
+    /**
+     * Defines the mutation data modification closure.
+     *
+     * @return callable
+     */
+    public static function mutate_and_get_payload() {
+        return function ( $input ) {
+            /**
+             * Get the ID from the global ID
+             */
+            $id_parts = Relay::fromGlobalId( $input['id'] );
 
-			/**
-			 * Get the post object before deleting it
-			 */
-			$comment_id            = absint( $id_parts['id'] );
-			$comment_before_delete = get_comment( $comment_id );
+            /**
+             * Get the post object before deleting it
+             */
+            $comment_id            = absint( $id_parts['id'] );
+            $comment_before_delete = get_comment( $comment_id );
 
-			/**
-			 * Stop now if a user isn't allowed to delete the comment
-			 */
-			$user_id = $comment_before_delete->user_id;
-			if (
-				! current_user_can( 'moderate_comments' ) &&
-				absint( get_current_user_id() ) !== absint( $user_id )
-			) {
-				throw new UserError( __( 'Sorry, you are not allowed to delete this comment.', 'wp-graphql' ) );
-			}
+            /**
+             * Stop now if a user isn't allowed to delete the comment
+             */
+            $user_id = $comment_before_delete->user_id;
+            if (
+                ! current_user_can( 'moderate_comments' ) &&
+                absint( get_current_user_id() ) !== absint( $user_id )
+            ) {
+                throw new UserError( __( 'Sorry, you are not allowed to delete this comment.', 'wp-graphql' ) );
+            }
 
-			/**
-			 * Check if we should force delete or not
-			 */
-			$force_delete = ( ! empty( $input['forceDelete'] ) && true === $input['forceDelete'] ) ? true : false;
+            /**
+             * Check if we should force delete or not
+             */
+            $force_delete = ( ! empty( $input['forceDelete'] ) && true === $input['forceDelete'] ) ? true : false;
 
-			/**
-			 * Delete the comment
-			 */
-			$deleted = wp_delete_comment( $id_parts['id'], $force_delete );
+            /**
+             * Delete the comment
+             */
+            wp_delete_comment( $id_parts['id'], $force_delete );
 
-			return [
-				'commentObject' => $comment_before_delete,
-			];
-		};
-	}
+            return [
+                'commentObject' => $comment_before_delete,
+            ];
+        };
+    }
 }

--- a/src/Mutation/CommentDelete.php
+++ b/src/Mutation/CommentDelete.php
@@ -43,20 +43,26 @@ class CommentDelete {
      * @return array
      */
     public static function get_output_fields() {
-        return array_merge(
-            CommentCreate::get_output_fields(),
-            [
-                'deletedId' => [
-                    'type'        => 'Id',
-                    'description' => __( 'The deleted comment ID', 'wp-graphql' ),
-                    'resolve'     => function ( $payload ) {
-                        $deleted = ( object ) $payload['commentObject'];
+        return [
+            'deletedId' => [
+                'type'        => 'Id',
+                'description' => __( 'The deleted comment ID', 'wp-graphql' ),
+                'resolve'     => function ( $payload ) {
+                    $deleted = ( object ) $payload['commentObject'];
 
-                        return ! empty( $deleted->comment_ID ) ? Relay::toGlobalId( 'comment', absint( $deleted->comment_ID ) ) : null;
-                    },
-                ]
-            ]
-        );
+                    return ! empty( $deleted->comment_ID ) ? Relay::toGlobalId( 'comment', absint( $deleted->comment_ID ) ) : null;
+                },
+            ],
+            'comment'   => [
+                'type'        => 'Comment',
+                'description' => __( 'The deleted comment object', 'wp-graphql' ),
+                'resolve'     => function ( $payload ) {
+                    $deleted = ( object ) $payload['commentObject'];
+
+                    return ! empty( $deleted ) ? $deleted : null;
+                },
+            ],
+        ];
     }
 
     /**

--- a/src/Mutation/CommentRestore.php
+++ b/src/Mutation/CommentRestore.php
@@ -39,20 +39,26 @@ class CommentRestore {
      * @return array
      */
     public static function get_output_fields() {
-        return array_merge(
-            CommentCreate::get_output_fields(),
-            [
-                'restoredId' => [
-                    'type'        => 'Id',
-                    'description' => __( 'The ID of the restored comment', 'wp-graphql' ),
-                    'resolve'     => function ( $payload ) {
-                        $restore = ( object ) $payload['commentObject'];
+        return [
+            'restoredId' => [
+                'type'        => 'Id',
+                'description' => __( 'The ID of the restored comment', 'wp-graphql' ),
+                'resolve'     => function ( $payload ) {
+                    $restore = ( object ) $payload['commentObject'];
 
-                        return ! empty( $restore->comment_ID ) ? Relay::toGlobalId( 'comment', absint( $restore->comment_ID ) ) : null;
-                    },
-                ],
-            ]
-        );
+                    return ! empty( $restore->comment_ID ) ? Relay::toGlobalId( 'comment', absint( $restore->comment_ID ) ) : null;
+                },
+            ],
+            'comment'    => [
+                'type'        => 'Comment',
+                'description' => __( 'The restored comment object', 'wp-graphql' ),
+                'resolve'     => function ( $payload ) {
+                    $restore = ( object ) $payload['commentObject'];
+
+                    return ! empty( $restore ) ? $restore : null;
+                },
+            ],
+        ];
     }
 
     /**

--- a/src/Mutation/CommentRestore.php
+++ b/src/Mutation/CommentRestore.php
@@ -6,77 +6,89 @@ use GraphQL\Error\UserError;
 use GraphQLRelay\Relay;
 
 class CommentRestore {
-	public static function register_mutation() {
-		register_graphql_mutation( 'restoreComment', [
-			'inputFields'         => self::get_input_fields(),
-			'outputFields'        => self::get_output_fields(),
-			'mutateAndGetPayload' => self::mutate_and_get_payload(),
-		] );
-	}
-	
-	public static function get_input_fields() {
-		return [
-			'id' => [
-				'type'        => [
-					'non_null' => 'ID',
-				],
-				'description' => __( 'The ID of the comment to be restored', 'wp-graphql' ),
-			],
-		];
-	}
+    /**
+     * Registers the CommentRestore mutation.
+     */
+    public static function register_mutation() {
+        register_graphql_mutation( 'restoreComment', [
+            'inputFields'         => self::get_input_fields(),
+            'outputFields'        => self::get_output_fields(),
+            'mutateAndGetPayload' => self::mutate_and_get_payload(),
+        ] );
+    }
 
-	public static function get_output_fields() {
-		return [
-			'restoredId' => [
-				'type'        => 'Id',
-				'description' => __( 'The ID of the restored comment', 'wp-graphql' ),
-				'resolve'     => function ( $payload ) {
-					$restore = ( object ) $payload['commentObject'];
+    /**
+     * Defines the mutation input field configuration.
+     *
+     * @return array
+     */
+    public static function get_input_fields() {
+        return [
+            'id' => [
+                'type'        => [
+                    'non_null' => 'ID',
+                ],
+                'description' => __( 'The ID of the comment to be restored', 'wp-graphql' ),
+            ],
+        ];
+    }
 
-					return ! empty( $restore->comment_ID ) ? Relay::toGlobalId( 'comment', absint( $restore->comment_ID ) ) : null;
-				},
-			],
-			'comment'    => [
-				'type'        => 'Comment',
-				'description' => __( 'The restored comment object', 'wp-graphql' ),
-				'resolve'     => function ( $payload ) {
-					$restore = ( object ) $payload['commentObject'];
+    /**
+     * Defines the mutation output field configuration.
+     *
+     * @return array
+     */
+    public static function get_output_fields() {
+        return array_merge(
+            CommentCreate::get_output_fields(),
+            [
+                'restoredId' => [
+                    'type'        => 'Id',
+                    'description' => __( 'The ID of the restored comment', 'wp-graphql' ),
+                    'resolve'     => function ( $payload ) {
+                        $restore = ( object ) $payload['commentObject'];
 
-					return ! empty( $restore ) ? $restore : null;
-				},
-			],
-		];
-	}
+                        return ! empty( $restore->comment_ID ) ? Relay::toGlobalId( 'comment', absint( $restore->comment_ID ) ) : null;
+                    },
+                ],
+            ]
+        );
+    }
 
-	public static function mutate_and_get_payload() {
-		return function ( $input ) {
-			/**
-				* Get the ID from the global ID
-				*/
-			$id_parts = Relay::fromGlobalId( $input['id'] );
+    /**
+     * Defines the mutation data modification closure.
+     *
+     * @return callable
+     */
+    public static function mutate_and_get_payload() {
+        return function ( $input ) {
+            /**
+             * Get the ID from the global ID
+             */
+            $id_parts = Relay::fromGlobalId( $input['id'] );
 
-			/**
-				* Get the post object before deleting it
-				*/
-			$comment_id = absint( $id_parts['id'] );
+            /**
+             * Get the post object before deleting it
+             */
+            $comment_id = absint( $id_parts['id'] );
 
-			/**
-				* Stop now if a user isn't allowed to delete the comment
-				*/
-			if ( ! current_user_can( 'moderate_comments' ) ) {
-				throw new UserError( __( 'Sorry, you are not allowed to delete this comment.', 'wp-graphql' ) );
-			}
+            /**
+             * Stop now if a user isn't allowed to delete the comment
+             */
+            if ( ! current_user_can( 'moderate_comments' ) ) {
+                throw new UserError( __( 'Sorry, you are not allowed to delete this comment.', 'wp-graphql' ) );
+            }
 
-			/**
-				* Delete the comment
-				*/
-			$restored = wp_untrash_comment( $id_parts['id'] );
+            /**
+             * Delete the comment
+             */
+            wp_untrash_comment( $id_parts['id'] );
 
-			$comment = get_comment( $comment_id );
+            $comment = get_comment( $comment_id );
 
-			return [
-				'commentObject' => $comment,
-			];
-		};
-	}
+            return [
+                'commentObject' => $comment,
+            ];
+        };
+    }
 }

--- a/src/Mutation/CommentRestore.php
+++ b/src/Mutation/CommentRestore.php
@@ -8,33 +8,32 @@ use GraphQLRelay\Relay;
 class CommentRestore {
 	public static function register_mutation() {
 		register_graphql_mutation( 'restoreComment', [
-			'inputFields'         => [
-				'id' => [
-					'type'        => [
-						'non_null' => 'ID',
-					],
-					'description' => __( 'The ID of the comment to be restored', 'wp-graphql' ),
+			'inputFields'         => self::get_input_fields(),
+			'outputFields'        => self::get_output_fields(),
+			'mutateAndGetPayload' => self::mutate_and_get_payload(),
+		] );
+	}
+	
+	public static function get_input_fields() {
+		return [
+			'id' => [
+				'type'        => [
+					'non_null' => 'ID',
 				],
 			],
-			'outputFields'        => [
-				'restoredId' => [
-					'type'        => 'Id',
-					'description' => __( 'The ID of the restored comment', 'wp-graphql' ),
-					'resolve'     => function ( $payload ) {
-						$restore = ( object ) $payload['commentObject'];
+		];
+	}
 
-						return ! empty( $restore->comment_ID ) ? Relay::toGlobalId( 'comment', absint( $restore->comment_ID ) ) : null;
-					},
-				],
-				'comment'    => [
-					'type'        => 'Comment',
-					'description' => __( 'The restored comment object', 'wp-graphql' ),
-					'resolve'     => function ( $payload ) {
-						$restore = ( object ) $payload['commentObject'];
+	public static function get_output_fields() {
+		return [
+			'restoredId' => [
+				'type'        => 'Id',
+				'description' => __( 'The ID of the restored comment', 'wp-graphql' ),
+				'resolve'     => function ( $payload ) {
+					$restore = ( object ) $payload['commentObject'];
 
-						return ! empty( $restore ) ? $restore : null;
-					},
-				],
+					return ! empty( $restore->comment_ID ) ? Relay::toGlobalId( 'comment', absint( $restore->comment_ID ) ) : null;
+				},
 			],
 			'mutateAndGetPayload' => function ( $input ) {
 				/**
@@ -42,29 +41,34 @@ class CommentRestore {
 				 */
 				$id_parts = Relay::fromGlobalId( $input['id'] );
 
-				/**
-				 * Get the post object before deleting it
-				 */
-				$comment_id = absint( $id_parts['id'] );
+					return ! empty( $restore ) ? $restore : null;
+				},
+			],
+		];
+	}
 
-				/**
-				 * Stop now if a user isn't allowed to delete the comment
-				 */
-				if ( ! current_user_can( 'moderate_comments' ) ) {
-					throw new UserError( __( 'Sorry, you are not allowed to delete this comment.', 'wp-graphql' ) );
-				}
-
-				/**
-				 * Delete the comment
-				 */
-				$restored = wp_untrash_comment( $id_parts['id'] );
-
-				$comment = get_comment( $comment_id );
+	public static function mutate_and_get_payload() {
+		return function ( $input ) {
+			/**
+				* Get the ID from the global ID
+				*/
+			$id_parts = Relay::fromGlobalId( $input['id'] );
 
 				return [
 					'commentObject' => $comment,
 				];
 			}
-		] );
+
+			/**
+				* Delete the comment
+				*/
+			$restored = wp_untrash_comment( $id_parts['id'] );
+
+			$comment = get_comment( $comment_id );
+
+			return [
+				'commentObject' => $comment,
+			];
+		};
 	}
 }

--- a/src/Mutation/CommentUpdate.php
+++ b/src/Mutation/CommentUpdate.php
@@ -23,14 +23,7 @@ class CommentUpdate {
 				'type'        => [
 					'non_null' => 'ID',
 				],
-			] ),
-			'outputFields'        => [
-				'comment' => [
-					'type'    => 'Comment',
-					'resolve' => function ( $payload ) {
-						return get_comment( $payload['id'] );
-					},
-				],
+				'description' => __( 'The ID of the comment being updated.', 'wp-graphql' ),
 			],
 		] );
 	}
@@ -55,13 +48,9 @@ class CommentUpdate {
 				throw new UserError( __( 'Mutation not processed. There was no input for the mutation or the comment_object was invalid', 'wp-graphql' ) );
 			}
 
-				/**
-				 * This updates additional data not part of the comments table ( commentmeta, other relations, etc )
-				 *
-				 * The input for the commentMutation will be passed, along with the $new_comment_id for the
-				 * comment that was created so that relations can be set, meta can be updated, etc.
-				 */
-				CommentMutation::update_additional_comment_data( $comment_id, $input, 'create', $context, $info );
+			$id_parts     = ! empty( $input['id'] ) ? Relay::fromGlobalId( $input['id'] ) : null;
+			$comment_id   = absint( $id_parts['id'] );
+			$comment_args = get_comment( $comment_id, ARRAY_A );
 
 
 			/**

--- a/src/Mutation/CommentUpdate.php
+++ b/src/Mutation/CommentUpdate.php
@@ -9,91 +9,106 @@ use WPGraphQL\AppContext;
 use WPGraphQL\Data\CommentMutation;
 
 class CommentUpdate {
-	public static function register_mutation() {
-		register_graphql_mutation( 'updateComment', [
-			'inputFields'         => self::get_input_fields(),
-			'outputFields'        => self::get_output_fields(),
-			'mutateAndGetPayload' => self::mutate_and_get_payload(),
-		] );
-	}
-	
-	public static function get_input_fields() {
-		return array_merge( CommentCreate::get_input_fields(), [
-			'id' => [
-				'type'        => [
-					'non_null' => 'ID',
-				],
-				'description' => __( 'The ID of the comment being updated.', 'wp-graphql' ),
-			],
-		] );
-	}
+    /**
+     * Registers the CommentUpdate mutation.
+     */
+    public static function register_mutation() {
+        register_graphql_mutation( 'updateComment', [
+            'inputFields'         => self::get_input_fields(),
+            'outputFields'        => self::get_output_fields(),
+            'mutateAndGetPayload' => self::mutate_and_get_payload(),
+        ] );
+    }
 
-	public static function get_output_fields() {
-		return [
-			'comment' => [
-				'type'    => 'Comment',
-				'resolve' => function ( $payload ) {
-					return get_comment( $payload['id'] );
-				},
-			],
-		];
-	}
+    /**
+     * Defines the mutation input field configuration.
+     *
+     * @return array
+     */
+    public static function get_input_fields() {
+        return array_merge(
+            CommentCreate::get_input_fields(),
+            [
+                'id' => [
+                    'type'        => [
+                        'non_null' => 'ID',
+                    ],
+                    'description' => __( 'The ID of the comment being updated.', 'wp-graphql' ),
+                ],
+            ] );
+    }
 
-	public static function mutate_and_get_payload() {
-		return function ( $input, AppContext $context, ResolveInfo $info ) {
-			/**
-			 * Throw an exception if there's no input
-			 */
-			if ( ( empty( $input ) || ! is_array( $input ) ) ) {
-				throw new UserError( __( 'Mutation not processed. There was no input for the mutation or the comment_object was invalid', 'wp-graphql' ) );
-			}
+    /**
+     * Defines the mutation output field configuration.
+     *
+     * @return array
+     */
+    public static function get_output_fields() {
+        return CommentCreate::get_output_fields();
+    }
 
-			$id_parts     = ! empty( $input['id'] ) ? Relay::fromGlobalId( $input['id'] ) : null;
-			$comment_id   = absint( $id_parts['id'] );
-			$comment_args = get_comment( $comment_id, ARRAY_A );
+    /**
+     * Defines the mutation data modification closure.
+     *
+     * @return callable
+     */
+    public static function mutate_and_get_payload() {
+        return function ( $input, AppContext $context, ResolveInfo $info ) {
+            /**
+             * Throw an exception if there's no input
+             */
+            if ( ( empty( $input ) || ! is_array( $input ) ) ) {
+                throw new UserError( __( 'Mutation not processed. There was no input for the mutation or the comment_object was invalid', 'wp-graphql' ) );
+            }
+
+            $id_parts     = ! empty( $input['id'] ) ? Relay::fromGlobalId( $input['id'] ) : null;
+            $comment_id   = absint( $id_parts['id'] );
+            $comment_args = get_comment( $comment_id, ARRAY_A );
 
 
-			/**
-			 * Map all of the args from GraphQL to WordPress friendly args array
-			 */
-			$user_id = $comment_args['user_id'];
-			CommentMutation::prepare_comment_object( $input, $comment_args, 'update', true );
+            /**
+             * Map all of the args from GraphQL to WordPress friendly args array
+             */
+            $user_id = $comment_args['user_id'];
+            CommentMutation::prepare_comment_object( $input, $comment_args, 'update', true );
 
-			/**
-			 * Check if use has required capabilities
-			 */
-			if (
-				! current_user_can( 'moderate_comments' ) &&
-				absint( get_current_user_id() ) !== absint( $user_id )
-			) {
-				throw new UserError( __( 'You do not have the appropriate capabilities to update this comment.', 'wp-graphql' ) );
-			}
+            /**
+             * Check if use has required capabilities
+             */
+            if (
+                ! current_user_can( 'moderate_comments' ) &&
+                absint( get_current_user_id() ) !== absint( $user_id )
+            ) {
+                throw new UserError( __( 'You do not have the appropriate capabilities to update this comment.', 'wp-graphql' ) );
+            }
 
-			/**
-			 * Update comment
-			 * $success   int   1 on success and 0 on fail
-			 */
-			$success = wp_update_comment( $comment_args );
+            /**
+             * Update comment
+             * $success   int   1 on success and 0 on fail
+             */
+            $success = wp_update_comment( $comment_args );
 
-			/**
-			 * Throw an exception if the comment failed to be created
-			 */
-			if ( ! $success ) {
-				throw new UserError( __( 'The comment failed to update', 'wp-graphql' ) );
-			}
+            /**
+             * Throw an exception if the comment failed to be created
+             */
+            if ( ! $success ) {
+                throw new UserError( __( 'The comment failed to update', 'wp-graphql' ) );
+            }
 
-			/**
-			 * This updates additional data not part of the comments table ( commentmeta, other relations, etc )
-			 *
-			 * The input for the commentMutation will be passed, along with the $new_comment_id for the
-			 * comment that was created so that relations can be set, meta can be updated, etc.
-			 */
-			CommentMutation::update_additional_comment_data( $comment_id, $input, 'create', $context, $info );
+            /**
+             * This updates additional data not part of the comments table ( commentmeta, other relations, etc )
+             *
+             * The input for the commentMutation will be passed, along with the $new_comment_id for the
+             * comment that was created so that relations can be set, meta can be updated, etc.
+             */
+            CommentMutation::update_additional_comment_data( $comment_id, $input, 'create', $context, $info );
 
-			/**
-			 * Return the comment object
-			 */
-			return [ 'id' => $comment_id ];
-		};
-	}
+            /**
+             * Return the comment object
+             */
+            return [
+                'id' => $comment_id
+            ];
+        };
+    }
 }

--- a/src/Mutation/CommentUpdate.php
+++ b/src/Mutation/CommentUpdate.php
@@ -11,12 +11,17 @@ use WPGraphQL\Data\CommentMutation;
 class CommentUpdate {
 	public static function register_mutation() {
 		register_graphql_mutation( 'updateComment', [
-			'inputFields'         => array_merge( CommentCreate::get_input_fields(), [
-				'id' => [
-					'type'        => [
-						'non_null' => 'ID',
-					],
-					'description' => __( 'The ID of the comment being updated.', 'wp-graphql' ),
+			'inputFields'         => self::get_input_fields(),
+			'outputFields'        => self::get_output_fields(),
+			'mutateAndGetPayload' => self::mutate_and_get_payload(),
+		] );
+	}
+	
+	public static function get_input_fields() {
+		return array_merge( CommentCreate::get_input_fields(), [
+			'id' => [
+				'type'        => [
+					'non_null' => 'ID',
 				],
 			] ),
 			'outputFields'        => [
@@ -27,47 +32,28 @@ class CommentUpdate {
 					},
 				],
 			],
-			'mutateAndGetPayload' => function ( $input, AppContext $context, ResolveInfo $info ) {
-				/**
-				 * Throw an exception if there's no input
-				 */
-				if ( ( empty( $input ) || ! is_array( $input ) ) ) {
-					throw new UserError( __( 'Mutation not processed. There was no input for the mutation or the comment_object was invalid', 'wp-graphql' ) );
-				}
+		] );
+	}
 
-				$id_parts     = ! empty( $input['id'] ) ? Relay::fromGlobalId( $input['id'] ) : null;
-				$comment_id   = absint( $id_parts['id'] );
-				$comment_args = get_comment( $comment_id, ARRAY_A );
+	public static function get_output_fields() {
+		return [
+			'comment' => [
+				'type'    => 'Comment',
+				'resolve' => function ( $payload ) {
+					return get_comment( $payload['id'] );
+				},
+			],
+		];
+	}
 
-
-				/**
-				 * Map all of the args from GraphQL to WordPress friendly args array
-				 */
-				$user_id = $comment_args['user_id'];
-				CommentMutation::prepare_comment_object( $input, $comment_args, 'update', true );
-
-				/**
-				 * Check if use has required capabilities
-				 */
-				if (
-					! current_user_can( 'moderate_comments' ) &&
-					absint( get_current_user_id() ) !== absint( $user_id )
-				) {
-					throw new UserError( __( 'You do not have the appropriate capabilities to update this comment.', 'wp-graphql' ) );
-				}
-
-				/**
-				 * Update comment
-				 * $success   int   1 on success and 0 on fail
-				 */
-				$success = wp_update_comment( $comment_args );
-
-				/**
-				 * Throw an exception if the comment failed to be created
-				 */
-				if ( ! $success ) {
-					throw new UserError( __( 'The comment failed to update', 'wp-graphql' ) );
-				}
+	public static function mutate_and_get_payload() {
+		return function ( $input, AppContext $context, ResolveInfo $info ) {
+			/**
+			 * Throw an exception if there's no input
+			 */
+			if ( ( empty( $input ) || ! is_array( $input ) ) ) {
+				throw new UserError( __( 'Mutation not processed. There was no input for the mutation or the comment_object was invalid', 'wp-graphql' ) );
+			}
 
 				/**
 				 * This updates additional data not part of the comments table ( commentmeta, other relations, etc )
@@ -77,11 +63,48 @@ class CommentUpdate {
 				 */
 				CommentMutation::update_additional_comment_data( $comment_id, $input, 'create', $context, $info );
 
-				/**
-				 * Return the comment object
-				 */
-				return [ 'id' => $comment_id ];
-			},
-		] );
+
+			/**
+			 * Map all of the args from GraphQL to WordPress friendly args array
+			 */
+			$user_id = $comment_args['user_id'];
+			CommentMutation::prepare_comment_object( $input, $comment_args, 'update', true );
+
+			/**
+			 * Check if use has required capabilities
+			 */
+			if (
+				! current_user_can( 'moderate_comments' ) &&
+				absint( get_current_user_id() ) !== absint( $user_id )
+			) {
+				throw new UserError( __( 'You do not have the appropriate capabilities to update this comment.', 'wp-graphql' ) );
+			}
+
+			/**
+			 * Update comment
+			 * $success   int   1 on success and 0 on fail
+			 */
+			$success = wp_update_comment( $comment_args );
+
+			/**
+			 * Throw an exception if the comment failed to be created
+			 */
+			if ( ! $success ) {
+				throw new UserError( __( 'The comment failed to update', 'wp-graphql' ) );
+			}
+
+			/**
+			 * This updates additional data not part of the comments table ( commentmeta, other relations, etc )
+			 *
+			 * The input for the commentMutation will be passed, along with the $new_comment_id for the
+			 * comment that was created so that relations can be set, meta can be updated, etc.
+			 */
+			CommentMutation::update_additional_comment_data( $comment_id, $input, 'create', $context, $info );
+
+			/**
+			 * Return the comment object
+			 */
+			return [ 'id' => $comment_id ];
+		};
 	}
 }

--- a/src/Mutation/MediaItemCreate.php
+++ b/src/Mutation/MediaItemCreate.php
@@ -9,225 +9,243 @@ use WPGraphQL\Data\DataSource;
 use WPGraphQL\Data\MediaItemMutation;
 
 class MediaItemCreate {
-	public static function register_mutation() {
-		register_graphql_mutation( 'createMediaItem', [
-			'inputFields'         => self::get_input_fields(),
-			'outputFields'        => self::get_output_fields(),
-			'mutateAndGetPayload' => self::mutate_and_get_payload(),
-		] );
-	}
+    /**
+     * Registers the MediaItemCreate mutation.
+     */
+    public static function register_mutation() {
+        register_graphql_mutation( 'createMediaItem', [
+            'inputFields'         => self::get_input_fields(),
+            'outputFields'        => self::get_output_fields(),
+            'mutateAndGetPayload' => self::mutate_and_get_payload(),
+        ] );
+    }
 
-	public static function get_input_fields() {
-		return [
-			'altText'       => [
-				'type'        => 'String',
-				'description' => __( 'Alternative text to display when mediaItem is not displayed', 'wp-graphql' ),
-			],
-			'authorId'      => [
-				'type'        => 'Id',
-				'description' => __( 'The userId to assign as the author of the mediaItem', 'wp-graphql' ),
-			],
-			'caption'       => [
-				'type'        => 'String',
-				'description' => __( 'The caption for the mediaItem', 'wp-graphql' ),
-			],
-			'commentStatus' => [
-				'type'        => 'String',
-				'description' => __( 'The comment status for the mediaItem', 'wp-graphql' ),
-			],
-			'date'          => [
-				'type'        => 'String',
-				'description' => __( 'The date of the mediaItem', 'wp-graphql' ),
-			],
-			'dateGmt'       => [
-				'type'        => 'String',
-				'description' => __( 'The date (in GMT zone) of the mediaItem', 'wp-graphql' ),
-			],
-			'description'   => [
-				'type'        => 'String',
-				'description' => __( 'Description of the mediaItem', 'wp-graphql' ),
-			],
-			'filePath'      => [
-				'type'        => 'String',
-				'description' => __( 'The file name of the mediaItem', 'wp-graphql' ),
-			],
-			'fileType'      => [
-				'type'        => 'MimeTypeEnum',
-				'description' => __( 'The file type of the mediaItem', 'wp-graphql' ),
-			],
-			'slug'          => [
-				'type'        => 'String',
-				'description' => __( 'The slug of the mediaItem', 'wp-graphql' ),
-			],
-			'status'        => [
-				'type'        => 'MediaItemStatusEnum',
-				'description' => __( 'The status of the mediaItem', 'wp-graphql' ),
-			],
-			'title'         => [
-				'type'        => 'String',
-				'description' => __( 'The title of the mediaItem', 'wp-graphql' ),
-			],
-			'pingStatus'    => [
-				'type'        => 'String',
-				'description' => __( 'The ping status for the mediaItem', 'wp-graphql' ),
-			],
-			'parentId'      => [
-				'type'        => 'Id',
-				'description' => __( 'The WordPress post ID or the graphQL postId of the parent object', 'wp-graphql' ),
-			],
-		];
-	}
+    /**
+     * Defines the mutation input field configuration.
+     *
+     * @return array
+     */
+    public static function get_input_fields() {
+        return [
+            'altText'       => [
+                'type'        => 'String',
+                'description' => __( 'Alternative text to display when mediaItem is not displayed', 'wp-graphql' ),
+            ],
+            'authorId'      => [
+                'type'        => 'Id',
+                'description' => __( 'The userId to assign as the author of the mediaItem', 'wp-graphql' ),
+            ],
+            'caption'       => [
+                'type'        => 'String',
+                'description' => __( 'The caption for the mediaItem', 'wp-graphql' ),
+            ],
+            'commentStatus' => [
+                'type'        => 'String',
+                'description' => __( 'The comment status for the mediaItem', 'wp-graphql' ),
+            ],
+            'date'          => [
+                'type'        => 'String',
+                'description' => __( 'The date of the mediaItem', 'wp-graphql' ),
+            ],
+            'dateGmt'       => [
+                'type'        => 'String',
+                'description' => __( 'The date (in GMT zone) of the mediaItem', 'wp-graphql' ),
+            ],
+            'description'   => [
+                'type'        => 'String',
+                'description' => __( 'Description of the mediaItem', 'wp-graphql' ),
+            ],
+            'filePath'      => [
+                'type'        => 'String',
+                'description' => __( 'The file name of the mediaItem', 'wp-graphql' ),
+            ],
+            'fileType'      => [
+                'type'        => 'MimeTypeEnum',
+                'description' => __( 'The file type of the mediaItem', 'wp-graphql' ),
+            ],
+            'slug'          => [
+                'type'        => 'String',
+                'description' => __( 'The slug of the mediaItem', 'wp-graphql' ),
+            ],
+            'status'        => [
+                'type'        => 'MediaItemStatusEnum',
+                'description' => __( 'The status of the mediaItem', 'wp-graphql' ),
+            ],
+            'title'         => [
+                'type'        => 'String',
+                'description' => __( 'The title of the mediaItem', 'wp-graphql' ),
+            ],
+            'pingStatus'    => [
+                'type'        => 'String',
+                'description' => __( 'The ping status for the mediaItem', 'wp-graphql' ),
+            ],
+            'parentId'      => [
+                'type'        => 'Id',
+                'description' => __( 'The WordPress post ID or the graphQL postId of the parent object', 'wp-graphql' ),
+            ],
+        ];
+    }
 
-	public static function get_output_fields() {
-		return [
-			'mediaItem' => [
-				'type'    => 'MediaItem',
-				'resolve' => function ( $payload ) {
-					return DataSource::resolve_post_object( $payload['id'], 'attachment' );
-				},
-			]
-		];
-	}
+    /**
+     * Defines the mutation output field configuration.
+     *
+     * @return array
+     */
+    public static function get_output_fields() {
+        return [
+            'mediaItem' => [
+                'type'    => 'MediaItem',
+                'resolve' => function ( $payload ) {
+                    return DataSource::resolve_post_object( $payload['postObjectId'], 'attachment' );
+                },
+            ]
+        ];
+    }
 
-	public static function mutate_and_get_payload() {
-		return function ( $input, AppContext $context, ResolveInfo $info ) {
-			/**
-			 * Stop now if a user isn't allowed to upload a mediaItem
-			 */
-			if ( ! current_user_can( 'upload_files' ) ) {
-				throw new UserError( __( 'Sorry, you are not allowed to upload mediaItems', 'wp-graphql' ) );
-			}
+    /**
+     * Defines the mutation data modification closure.
+     *
+     * @return callable
+     */
+    public static function mutate_and_get_payload() {
+        return function ( $input, AppContext $context, ResolveInfo $info ) {
+            /**
+             * Stop now if a user isn't allowed to upload a mediaItem
+             */
+            if ( ! current_user_can( 'upload_files' ) ) {
+                throw new UserError( __( 'Sorry, you are not allowed to upload mediaItems', 'wp-graphql' ) );
+            }
 
-			/**
-			 * Set the file name, whether it's a local file or from a URL.
-			 * Then set the url for the uploaded file
-			 */
-			$file_name         = basename( $input['filePath'] );
-			$uploaded_file_url = $input['filePath'];
+            /**
+             * Set the file name, whether it's a local file or from a URL.
+             * Then set the url for the uploaded file
+             */
+            $file_name         = basename( $input['filePath'] );
+            $uploaded_file_url = $input['filePath'];
 
-			/**
-			 * Require the file.php file from wp-admin. This file includes the
-			 * download_url and wp_handle_sideload methods
-			 */
-			require_once( ABSPATH . 'wp-admin/includes/file.php' );
+            /**
+             * Require the file.php file from wp-admin. This file includes the
+             * download_url and wp_handle_sideload methods
+             */
+            require_once( ABSPATH . 'wp-admin/includes/file.php' );
 
-			/**
-			 * If the mediaItem file is from a local server, use wp_upload_bits before saving it to the uploads folder
-			 */
-			if ( 'file' === parse_url( $input['filePath'], PHP_URL_SCHEME ) ) {
-				$uploaded_file     = wp_upload_bits( $file_name, null, file_get_contents( $input['filePath'] ) );
-				$uploaded_file_url = ( empty ( $uploaded_file['error'] ) ? $uploaded_file['url'] : null );
-			}
+            /**
+             * If the mediaItem file is from a local server, use wp_upload_bits before saving it to the uploads folder
+             */
+            if ( 'file' === parse_url( $input['filePath'], PHP_URL_SCHEME ) ) {
+                $uploaded_file     = wp_upload_bits( $file_name, null, file_get_contents( $input['filePath'] ) );
+                $uploaded_file_url = ( empty ( $uploaded_file['error'] ) ? $uploaded_file['url'] : null );
+            }
 
-			/**
-			 * URL data for the mediaItem, timeout value is the default, see:
-			 * https://developer.wordpress.org/reference/functions/download_url/
-			 */
-			$timeout_seconds = 300;
-			$temp_file       = download_url( $uploaded_file_url, $timeout_seconds );
+            /**
+             * URL data for the mediaItem, timeout value is the default, see:
+             * https://developer.wordpress.org/reference/functions/download_url/
+             */
+            $timeout_seconds = 300;
+            $temp_file       = download_url( $uploaded_file_url, $timeout_seconds );
 
-			/**
-			 * Handle the error from download_url if it occurs
-			 */
-			if ( is_wp_error( $temp_file ) ) {
-				throw new UserError( __( 'Sorry, the URL for this file is invalid, it must be a valid URL', 'wp-graphql' ) );
-			}
+            /**
+             * Handle the error from download_url if it occurs
+             */
+            if ( is_wp_error( $temp_file ) ) {
+                throw new UserError( __( 'Sorry, the URL for this file is invalid, it must be a valid URL', 'wp-graphql' ) );
+            }
 
-			/**
-			 * Build the file data for side loading
-			 */
-			$file_data = [
-				'name'     => $file_name,
-				'type'     => ! empty ( $input['fileType'] ) ? $input['fileType'] : wp_check_filetype( $temp_file ),
-				'tmp_name' => $temp_file,
-				'error'    => 0,
-				'size'     => filesize( $temp_file ),
-			];
+            /**
+             * Build the file data for side loading
+             */
+            $file_data = [
+                'name'     => $file_name,
+                'type'     => ! empty ( $input['fileType'] ) ? $input['fileType'] : wp_check_filetype( $temp_file ),
+                'tmp_name' => $temp_file,
+                'error'    => 0,
+                'size'     => filesize( $temp_file ),
+            ];
 
-			/**
-			 * Tells WordPress to not look for the POST form fields that would normally be present as
-			 * we downloaded the file from a remote server, so there will be no form fields
-			 * The default is true
-			 */
-			$overrides = [
-				'test_form' => false,
-			];
+            /**
+             * Tells WordPress to not look for the POST form fields that would normally be present as
+             * we downloaded the file from a remote server, so there will be no form fields
+             * The default is true
+             */
+            $overrides = [
+                'test_form' => false,
+            ];
 
-			/**
-			 * Insert the mediaItem and retrieve it's data
-			 */
-			$file = wp_handle_sideload( $file_data, $overrides );
+            /**
+             * Insert the mediaItem and retrieve it's data
+             */
+            $file = wp_handle_sideload( $file_data, $overrides );
 
-			/**
-			 * Handle the error from wp_handle_sideload if it occurs
-			 */
-			if ( ! empty( $file['error'] ) ) {
-				throw new UserError( __( 'Sorry, the URL for this file is invalid, it must be a path to the mediaItem file', 'wp-graphql' ) );
-			}
+            /**
+             * Handle the error from wp_handle_sideload if it occurs
+             */
+            if ( ! empty( $file['error'] ) ) {
+                throw new UserError( __( 'Sorry, the URL for this file is invalid, it must be a path to the mediaItem file', 'wp-graphql' ) );
+            }
 
-			/**
-			 * Insert the mediaItem object and get the ID
-			 */
-			$media_item_args = MediaItemMutation::prepare_media_item( $input, get_post_type_object( 'attachment' ), 'createMediaItem', $file );
+            /**
+             * Insert the mediaItem object and get the ID
+             */
+            $media_item_args = MediaItemMutation::prepare_media_item( $input, get_post_type_object( 'attachment' ), 'createMediaItem', $file );
 
-			/**
-			 * Get the post parent and if it's not set, set it to false
-			 */
-			$attachment_parent_id = ( ! empty( $media_item_args['post_parent'] ) ? $media_item_args['post_parent'] : false );
+            /**
+             * Get the post parent and if it's not set, set it to false
+             */
+            $attachment_parent_id = ( ! empty( $media_item_args['post_parent'] ) ? $media_item_args['post_parent'] : false );
 
-			/**
-			 * Stop now if a user isn't allowed to edit the parent post
-			 */
-			$parent = get_post( $attachment_parent_id );
+            /**
+             * Stop now if a user isn't allowed to edit the parent post
+             */
+            $parent = get_post( $attachment_parent_id );
 
-			if ( null !== get_post( $attachment_parent_id ) ) {
-				$post_parent_type = get_post_type_object( $parent->post_type );
-				if ( ! current_user_can( $post_parent_type->cap->edit_post, $attachment_parent_id ) ) {
-					throw new UserError( __( 'Sorry, you are not allowed to upload mediaItems to this post', 'wp-graphql' ) );
-				}
-			}
+            if ( null !== get_post( $attachment_parent_id ) ) {
+                $post_parent_type = get_post_type_object( $parent->post_type );
+                if ( ! current_user_can( $post_parent_type->cap->edit_post, $attachment_parent_id ) ) {
+                    throw new UserError( __( 'Sorry, you are not allowed to upload mediaItems to this post', 'wp-graphql' ) );
+                }
+            }
 
-			/**
-			 * If the mediaItem being created is being assigned to another user that's not the current user, make sure
-			 * the current user has permission to edit others mediaItems
-			 */
-			if ( ! empty( $input['authorId'] ) && get_current_user_id() !== $input['authorId'] && ! current_user_can( get_post_type_object( 'attachment' )->cap->edit_others_posts ) ) {
-				throw new UserError( __( 'Sorry, you are not allowed to create mediaItems as this user', 'wp-graphql' ) );
-			}
+            /**
+             * If the mediaItem being created is being assigned to another user that's not the current user, make sure
+             * the current user has permission to edit others mediaItems
+             */
+            if ( ! empty( $input['authorId'] ) && get_current_user_id() !== $input['authorId'] && ! current_user_can( get_post_type_object( 'attachment' )->cap->edit_others_posts ) ) {
+                throw new UserError( __( 'Sorry, you are not allowed to create mediaItems as this user', 'wp-graphql' ) );
+            }
 
-			/**
-			 * Insert the mediaItem
-			 *
-			 * Required Argument defaults are set in the main MediaItemMutation.php if they aren't set
-			 * by the user during input, they are:
-			 * post_title (pulled from file if not entered)
-			 * post_content (empty string if not entered)
-			 * post_status (inherit if not entered)
-			 * post_mime_type (pulled from the file if not entered in the mutation)
-			 */
-			$attachment_id = wp_insert_attachment( $media_item_args, $file['file'], $attachment_parent_id );
+            /**
+             * Insert the mediaItem
+             *
+             * Required Argument defaults are set in the main MediaItemMutation.php if they aren't set
+             * by the user during input, they are:
+             * post_title (pulled from file if not entered)
+             * post_content (empty string if not entered)
+             * post_status (inherit if not entered)
+             * post_mime_type (pulled from the file if not entered in the mutation)
+             */
+            $attachment_id = wp_insert_attachment( $media_item_args, $file['file'], $attachment_parent_id );
 
-			/**
-			 * Check if the wp_generate_attachment_metadata method exists and include it if not
-			 */
-			require_once( ABSPATH . 'wp-admin/includes/image.php' );
+            /**
+             * Check if the wp_generate_attachment_metadata method exists and include it if not
+             */
+            require_once( ABSPATH . 'wp-admin/includes/image.php' );
 
-			/**
-			 * Generate and update the mediaItem's metadata.
-			 * If we make it this far the file and attachment
-			 * have been validated and we will not receive any errors
-			 */
-			$attachment_data        = wp_generate_attachment_metadata( $attachment_id, $file['file'] );
-			wp_update_attachment_metadata( $attachment_id, $attachment_data );
+            /**
+             * Generate and update the mediaItem's metadata.
+             * If we make it this far the file and attachment
+             * have been validated and we will not receive any errors
+             */
+            $attachment_data        = wp_generate_attachment_metadata( $attachment_id, $file['file'] );
+            wp_update_attachment_metadata( $attachment_id, $attachment_data );
 
-			/**
-			 * Update alt text postmeta for mediaItem
-			 */
-			MediaItemMutation::update_additional_media_item_data( $attachment_id, $input, get_post_type_object( 'attachment' ), 'createMediaItem', $context, $info );
+            /**
+             * Update alt text postmeta for mediaItem
+             */
+            MediaItemMutation::update_additional_media_item_data( $attachment_id, $input, get_post_type_object( 'attachment' ), 'createMediaItem', $context, $info );
 
-			return [
-				'id' => $attachment_id,
-			];
-		};
-	}
+            return [
+                'postObjectId' => $attachment_id,
+            ];
+        };
+    }
 }

--- a/src/Mutation/MediaItemCreate.php
+++ b/src/Mutation/MediaItemCreate.php
@@ -12,155 +12,8 @@ class MediaItemCreate {
 	public static function register_mutation() {
 		register_graphql_mutation( 'createMediaItem', [
 			'inputFields'         => self::get_input_fields(),
-			'outputFields'        => [
-				'mediaItem' => [
-					'type'    => 'MediaItem',
-					'resolve' => function ( $payload ) {
-						return DataSource::resolve_post_object( $payload['id'], 'attachment' );
-					},
-				]
-			],
-			'mutateAndGetPayload' => function ( $input, AppContext $context, ResolveInfo $info ) {
-
-				/**
-				 * Stop now if a user isn't allowed to upload a mediaItem
-				 */
-				if ( ! current_user_can( 'upload_files' ) ) {
-					throw new UserError( __( 'Sorry, you are not allowed to upload mediaItems', 'wp-graphql' ) );
-				}
-
-				/**
-				 * Set the file name, whether it's a local file or from a URL.
-				 * Then set the url for the uploaded file
-				 */
-				$file_name         = basename( $input['filePath'] );
-				$uploaded_file_url = $input['filePath'];
-
-				/**
-				 * Require the file.php file from wp-admin. This file includes the
-				 * download_url and wp_handle_sideload methods
-				 */
-				require_once( ABSPATH . 'wp-admin/includes/file.php' );
-
-				/**
-				 * If the mediaItem file is from a local server, use wp_upload_bits before saving it to the uploads folder
-				 */
-				if ( 'file' === parse_url( $input['filePath'], PHP_URL_SCHEME ) ) {
-					$uploaded_file     = wp_upload_bits( $file_name, null, file_get_contents( $input['filePath'] ) );
-					$uploaded_file_url = ( empty ( $uploaded_file['error'] ) ? $uploaded_file['url'] : null );
-				}
-
-				/**
-				 * URL data for the mediaItem, timeout value is the default, see:
-				 * https://developer.wordpress.org/reference/functions/download_url/
-				 */
-				$timeout_seconds = 300;
-				$temp_file       = download_url( $uploaded_file_url, $timeout_seconds );
-
-				/**
-				 * Handle the error from download_url if it occurs
-				 */
-				if ( is_wp_error( $temp_file ) ) {
-					throw new UserError( __( 'Sorry, the URL for this file is invalid, it must be a valid URL', 'wp-graphql' ) );
-				}
-
-				/**
-				 * Build the file data for side loading
-				 */
-				$file_data = [
-					'name'     => $file_name,
-					'type'     => ! empty ( $input['fileType'] ) ? $input['fileType'] : wp_check_filetype( $temp_file ),
-					'tmp_name' => $temp_file,
-					'error'    => 0,
-					'size'     => filesize( $temp_file ),
-				];
-
-				/**
-				 * Tells WordPress to not look for the POST form fields that would normally be present as
-				 * we downloaded the file from a remote server, so there will be no form fields
-				 * The default is true
-				 */
-				$overrides = [
-					'test_form' => false,
-				];
-
-				/**
-				 * Insert the mediaItem and retrieve it's data
-				 */
-				$file = wp_handle_sideload( $file_data, $overrides );
-
-				/**
-				 * Handle the error from wp_handle_sideload if it occurs
-				 */
-				if ( ! empty( $file['error'] ) ) {
-					throw new UserError( __( 'Sorry, the URL for this file is invalid, it must be a path to the mediaItem file', 'wp-graphql' ) );
-				}
-
-				/**
-				 * Insert the mediaItem object and get the ID
-				 */
-				$media_item_args = MediaItemMutation::prepare_media_item( $input, get_post_type_object( 'attachment' ), 'createMediaItem', $file );
-
-				/**
-				 * Get the post parent and if it's not set, set it to false
-				 */
-				$attachment_parent_id = ( ! empty( $media_item_args['post_parent'] ) ? $media_item_args['post_parent'] : false );
-
-				/**
-				 * Stop now if a user isn't allowed to edit the parent post
-				 */
-				$parent = get_post( $attachment_parent_id );
-
-				if ( null !== get_post( $attachment_parent_id ) ) {
-					$post_parent_type = get_post_type_object( $parent->post_type );
-					if ( ! current_user_can( $post_parent_type->cap->edit_post, $attachment_parent_id ) ) {
-						throw new UserError( __( 'Sorry, you are not allowed to upload mediaItems to this post', 'wp-graphql' ) );
-					}
-				}
-
-				/**
-				 * If the mediaItem being created is being assigned to another user that's not the current user, make sure
-				 * the current user has permission to edit others mediaItems
-				 */
-				if ( ! empty( $input['authorId'] ) && get_current_user_id() !== $input['authorId'] && ! current_user_can( get_post_type_object( 'attachment' )->cap->edit_others_posts ) ) {
-					throw new UserError( __( 'Sorry, you are not allowed to create mediaItems as this user', 'wp-graphql' ) );
-				}
-
-				/**
-				 * Insert the mediaItem
-				 *
-				 * Required Argument defaults are set in the main MediaItemMutation.php if they aren't set
-				 * by the user during input, they are:
-				 * post_title (pulled from file if not entered)
-				 * post_content (empty string if not entered)
-				 * post_status (inherit if not entered)
-				 * post_mime_type (pulled from the file if not entered in the mutation)
-				 */
-				$attachment_id = wp_insert_attachment( $media_item_args, $file['file'], $attachment_parent_id );
-
-				/**
-				 * Check if the wp_generate_attachment_metadata method exists and include it if not
-				 */
-				require_once( ABSPATH . 'wp-admin/includes/image.php' );
-
-				/**
-				 * Generate and update the mediaItem's metadata.
-				 * If we make it this far the file and attachment
-				 * have been validated and we will not receive any errors
-				 */
-				$attachment_data        = wp_generate_attachment_metadata( $attachment_id, $file['file'] );
-				wp_update_attachment_metadata( $attachment_id, $attachment_data );
-
-				/**
-				 * Update alt text postmeta for mediaItem
-				 */
-				MediaItemMutation::update_additional_media_item_data( $attachment_id, $input, get_post_type_object( 'attachment' ), 'createMediaItem', $context, $info );
-
-				return [
-					'id' => $attachment_id,
-				];
-
-			},
+			'outputFields'        => self::get_output_fields(),
+			'mutateAndGetPayload' => self::mutate_and_get_payload(),
 		] );
 	}
 
@@ -223,5 +76,158 @@ class MediaItemCreate {
 				'description' => __( 'The WordPress post ID or the graphQL postId of the parent object', 'wp-graphql' ),
 			],
 		];
+	}
+
+	public static function get_output_fields() {
+		return [
+			'mediaItem' => [
+				'type'    => 'MediaItem',
+				'resolve' => function ( $payload ) {
+					return DataSource::resolve_post_object( $payload['id'], 'attachment' );
+				},
+			]
+		];
+	}
+
+	public static function mutate_and_get_payload() {
+		return function ( $input, AppContext $context, ResolveInfo $info ) {
+			/**
+			 * Stop now if a user isn't allowed to upload a mediaItem
+			 */
+			if ( ! current_user_can( 'upload_files' ) ) {
+				throw new UserError( __( 'Sorry, you are not allowed to upload mediaItems', 'wp-graphql' ) );
+			}
+
+			/**
+			 * Set the file name, whether it's a local file or from a URL.
+			 * Then set the url for the uploaded file
+			 */
+			$file_name         = basename( $input['filePath'] );
+			$uploaded_file_url = $input['filePath'];
+
+			/**
+			 * Require the file.php file from wp-admin. This file includes the
+			 * download_url and wp_handle_sideload methods
+			 */
+			require_once( ABSPATH . 'wp-admin/includes/file.php' );
+
+			/**
+			 * If the mediaItem file is from a local server, use wp_upload_bits before saving it to the uploads folder
+			 */
+			if ( 'file' === parse_url( $input['filePath'], PHP_URL_SCHEME ) ) {
+				$uploaded_file     = wp_upload_bits( $file_name, null, file_get_contents( $input['filePath'] ) );
+				$uploaded_file_url = ( empty ( $uploaded_file['error'] ) ? $uploaded_file['url'] : null );
+			}
+
+			/**
+			 * URL data for the mediaItem, timeout value is the default, see:
+			 * https://developer.wordpress.org/reference/functions/download_url/
+			 */
+			$timeout_seconds = 300;
+			$temp_file       = download_url( $uploaded_file_url, $timeout_seconds );
+
+			/**
+			 * Handle the error from download_url if it occurs
+			 */
+			if ( is_wp_error( $temp_file ) ) {
+				throw new UserError( __( 'Sorry, the URL for this file is invalid, it must be a valid URL', 'wp-graphql' ) );
+			}
+
+			/**
+			 * Build the file data for side loading
+			 */
+			$file_data = [
+				'name'     => $file_name,
+				'type'     => ! empty ( $input['fileType'] ) ? $input['fileType'] : wp_check_filetype( $temp_file ),
+				'tmp_name' => $temp_file,
+				'error'    => 0,
+				'size'     => filesize( $temp_file ),
+			];
+
+			/**
+			 * Tells WordPress to not look for the POST form fields that would normally be present as
+			 * we downloaded the file from a remote server, so there will be no form fields
+			 * The default is true
+			 */
+			$overrides = [
+				'test_form' => false,
+			];
+
+			/**
+			 * Insert the mediaItem and retrieve it's data
+			 */
+			$file = wp_handle_sideload( $file_data, $overrides );
+
+			/**
+			 * Handle the error from wp_handle_sideload if it occurs
+			 */
+			if ( ! empty( $file['error'] ) ) {
+				throw new UserError( __( 'Sorry, the URL for this file is invalid, it must be a path to the mediaItem file', 'wp-graphql' ) );
+			}
+
+			/**
+			 * Insert the mediaItem object and get the ID
+			 */
+			$media_item_args = MediaItemMutation::prepare_media_item( $input, get_post_type_object( 'attachment' ), 'createMediaItem', $file );
+
+			/**
+			 * Get the post parent and if it's not set, set it to false
+			 */
+			$attachment_parent_id = ( ! empty( $media_item_args['post_parent'] ) ? $media_item_args['post_parent'] : false );
+
+			/**
+			 * Stop now if a user isn't allowed to edit the parent post
+			 */
+			$parent = get_post( $attachment_parent_id );
+
+			if ( null !== get_post( $attachment_parent_id ) ) {
+				$post_parent_type = get_post_type_object( $parent->post_type );
+				if ( ! current_user_can( $post_parent_type->cap->edit_post, $attachment_parent_id ) ) {
+					throw new UserError( __( 'Sorry, you are not allowed to upload mediaItems to this post', 'wp-graphql' ) );
+				}
+			}
+
+			/**
+			 * If the mediaItem being created is being assigned to another user that's not the current user, make sure
+			 * the current user has permission to edit others mediaItems
+			 */
+			if ( ! empty( $input['authorId'] ) && get_current_user_id() !== $input['authorId'] && ! current_user_can( get_post_type_object( 'attachment' )->cap->edit_others_posts ) ) {
+				throw new UserError( __( 'Sorry, you are not allowed to create mediaItems as this user', 'wp-graphql' ) );
+			}
+
+			/**
+			 * Insert the mediaItem
+			 *
+			 * Required Argument defaults are set in the main MediaItemMutation.php if they aren't set
+			 * by the user during input, they are:
+			 * post_title (pulled from file if not entered)
+			 * post_content (empty string if not entered)
+			 * post_status (inherit if not entered)
+			 * post_mime_type (pulled from the file if not entered in the mutation)
+			 */
+			$attachment_id = wp_insert_attachment( $media_item_args, $file['file'], $attachment_parent_id );
+
+			/**
+			 * Check if the wp_generate_attachment_metadata method exists and include it if not
+			 */
+			require_once( ABSPATH . 'wp-admin/includes/image.php' );
+
+			/**
+			 * Generate and update the mediaItem's metadata.
+			 * If we make it this far the file and attachment
+			 * have been validated and we will not receive any errors
+			 */
+			$attachment_data        = wp_generate_attachment_metadata( $attachment_id, $file['file'] );
+			wp_update_attachment_metadata( $attachment_id, $attachment_data );
+
+			/**
+			 * Update alt text postmeta for mediaItem
+			 */
+			MediaItemMutation::update_additional_media_item_data( $attachment_id, $input, get_post_type_object( 'attachment' ), 'createMediaItem', $context, $info );
+
+			return [
+				'id' => $attachment_id,
+			];
+		};
 	}
 }

--- a/src/Mutation/MediaItemDelete.php
+++ b/src/Mutation/MediaItemDelete.php
@@ -20,10 +20,7 @@ class MediaItemDelete {
 				'type'        => [
 					'non_null' => 'ID',
 				],
-				'forceDelete' => [
-					'type'        => 'Boolean',
-					'description' => __( 'Whether the mediaItem should be force deleted instead of being moved to the trash', 'wp-graphql' ),
-				],
+				'description' => __( 'The ID of the mediaItem to delete', 'wp-graphql' ),
 			],
 			'forceDelete' => [
 				'type'        => 'Boolean',
@@ -43,7 +40,11 @@ class MediaItemDelete {
 					return ! empty( $deleted->ID ) ? Relay::toGlobalId( 'attachment', absint( $deleted->ID ) ) : null;
 				},
 			],
-			'mutateAndGetPayload' => function ( $input ) {
+			'mediaItem' => [
+				'type'        => 'MediaItem',
+				'description' => __( 'The mediaItem before it was deleted', 'wp-graphql' ),
+				'resolve'     => function ( $payload ) {
+					$deleted = (object) $payload['mediaItemObject'];
 
 					return ! empty( $deleted ) ? $deleted : null;
 				},
@@ -56,48 +57,73 @@ class MediaItemDelete {
 			$post_type_object = get_post_type_object( 'attachment' );
 			$mutation_name = 'deleteMediaItem';
 
-				/**
-				 * Get the mediaItem object before deleting it
-				 */
-				$media_item_before_delete = get_post( absint( $id_parts['id'] ) );
-				$media_item_before_delete = isset( $media_item_before_delete->ID ) && isset( $media_item_before_delete->ID ) ? DataSource::resolve_post_object( $media_item_before_delete->ID, $post_type_object->name ) : $media_item_before_delete;
+			/**
+			 * Get the ID from the global ID
+			 */
+			$id_parts            = Relay::fromGlobalId( $input['id'] );
+			$existing_media_item = get_post( absint( $id_parts['id'] ) );
+
+			/**
+			 * If there's no existing mediaItem, throw an exception
+			 */
+			if ( empty( $existing_media_item ) ) {
+				throw new UserError( __( 'No mediaItem could be found to delete', 'wp-graphql' ) );
+			}
+
+			/**
+			 * Stop now if a user isn't allowed to delete a mediaItem
+			 */
+			if ( ! current_user_can( $post_type_object->cap->delete_post, absint( $id_parts['id'] ) ) ) {
+				throw new UserError( __( 'Sorry, you are not allowed to delete mediaItems', 'wp-graphql' ) );
+			}
+
+			/**
+			 * Check if we should force delete or not
+			 */
+			$force_delete = ( ! empty( $input['forceDelete'] ) && true === $input['forceDelete'] ) ? true : false;
+
+			/**
+			 * Get the mediaItem object before deleting it
+			 */
+			$media_item_before_delete = get_post( absint( $id_parts['id'] ) );
+			$media_item_before_delete = isset( $media_item_before_delete->ID ) && isset( $media_item_before_delete->ID ) ? DataSource::resolve_post_object( $media_item_before_delete->ID, $post_type_object->name ) : $media_item_before_delete;
 
 
-				/**
-				 * If the mediaItem isn't of the attachment post type, throw an error
-				 */
-				if ( 'attachment' !== $media_item_before_delete->post_type ) {
-					throw new UserError( sprintf( __( 'Sorry, the item you are trying to delete is a %1%s, not a mediaItem', 'wp-graphql' ), $media_item_before_delete->post_type ) );
+			/**
+			 * If the mediaItem isn't of the attachment post type, throw an error
+			 */
+			if ( 'attachment' !== $media_item_before_delete->post_type ) {
+				throw new UserError( sprintf( __( 'Sorry, the item you are trying to delete is a %1%s, not a mediaItem', 'wp-graphql' ), $media_item_before_delete->post_type ) );
+			}
+
+			/**
+			 * If the mediaItem is already in the trash, and the forceDelete input was not passed,
+			 * don't remove from the trash
+			 */
+			if ( 'trash' === $media_item_before_delete->post_status ) {
+				if ( true !== $force_delete ) {
+					// Translators: the first placeholder is the post_type of the object being deleted and the second placeholder is the unique ID of that object
+					throw new UserError( sprintf( __( 'The mediaItem with id %1$s is already in the trash. To remove from the trash, use the forceDelete input', 'wp-graphql' ), $input['id'] ) );
 				}
+			}
 
-				/**
-				 * If the mediaItem is already in the trash, and the forceDelete input was not passed,
-				 * don't remove from the trash
-				 */
-				if ( 'trash' === $media_item_before_delete->post_status ) {
-					if ( true !== $force_delete ) {
-						// Translators: the first placeholder is the post_type of the object being deleted and the second placeholder is the unique ID of that object
-						throw new UserError( sprintf( __( 'The mediaItem with id %1$s is already in the trash. To remove from the trash, use the forceDelete input', 'wp-graphql' ), $input['id'] ) );
-					}
-				}
+			/**
+			 * Delete the mediaItem. This will not throw false thanks to
+			 * all of the above validation
+			 */
+			$deleted = wp_delete_attachment( $id_parts['id'], $force_delete );
 
-				/**
-				 * Delete the mediaItem. This will not throw false thanks to
-				 * all of the above validation
-				 */
-				$deleted = wp_delete_attachment( $id_parts['id'], $force_delete );
+			/**
+			 * If the post was moved to the trash, spoof the object's status before returning it
+			 */
+			$media_item_before_delete->post_status = ( false !== $deleted && true !== $force_delete ) ? 'trash' : $media_item_before_delete->post_status;
 
-				/**
-				 * If the post was moved to the trash, spoof the object's status before returning it
-				 */
-				$media_item_before_delete->post_status = ( false !== $deleted && true !== $force_delete ) ? 'trash' : $media_item_before_delete->post_status;
-
-				/**
-				 * Return the deletedId and the mediaItem before it was deleted
-				 */
-				return [
-					'mediaItemObject' => $media_item_before_delete,
-				];
+			/**
+			 * Return the deletedId and the mediaItem before it was deleted
+			 */
+			return [
+				'mediaItemObject' => $media_item_before_delete,
+			];
 
 		};
 	}

--- a/src/Mutation/MediaItemDelete.php
+++ b/src/Mutation/MediaItemDelete.php
@@ -6,30 +6,43 @@ use GraphQLRelay\Relay;
 use WPGraphQL\Data\DataSource;
 
 class MediaItemDelete {
-	public static function register_mutation() {
-		register_graphql_mutation( 'deleteMediaItem', [
-			'inputFields'         => self::get_input_fields(),
-			'outputFields'        => self::get_output_fields(),
-			'mutateAndGetPayload' => self::mutate_and_get_payload(),
-		]);
-	}
+    /**
+     * Registers the MediaItemDelete mutation.
+     */
+    public static function register_mutation() {
+        register_graphql_mutation( 'deleteMediaItem', [
+            'inputFields'         => self::get_input_fields(),
+            'outputFields'        => self::get_output_fields(),
+            'mutateAndGetPayload' => self::mutate_and_get_payload(),
+        ] );
+    }
 
-	public static function get_input_fields() {
-		return [
-			'id'          => [
-				'type'        => [
-					'non_null' => 'ID',
-				],
-				'description' => __( 'The ID of the mediaItem to delete', 'wp-graphql' ),
-			],
-			'forceDelete' => [
-				'type'        => 'Boolean',
-				'description' => __( 'Whether the mediaItem should be force deleted instead of being moved to the trash', 'wp-graphql' ),
-			],
-		];
-	}
+    /**
+     * Defines the mutation input field configuration.
+     *
+     * @return array
+     */
+    public static function get_input_fields() {
+        return [
+            'id'          => [
+                'type'        => [
+                    'non_null' => 'ID',
+                ],
+                'description' => __( 'The ID of the mediaItem to delete', 'wp-graphql' ),
+            ],
+            'forceDelete' => [
+                'type'        => 'Boolean',
+                'description' => __( 'Whether the mediaItem should be force deleted instead of being moved to the trash', 'wp-graphql' ),
+            ],
+        ];
+    }
 
-	public static function get_output_fields() {
+    /**
+     * Defines the mutation output field configuration.
+     *
+     * @return array
+     */
+    public static function get_output_fields() {
 		return [
 			'deletedId' => [
 				'type'        => 'ID',
@@ -50,81 +63,85 @@ class MediaItemDelete {
 				},
 			],
 		];
-	}
+    }
 
-	public static function mutate_and_get_payload() {
-		return function ( $input ) {
-			$post_type_object = get_post_type_object( 'attachment' );
-			$mutation_name = 'deleteMediaItem';
+    /**
+     * Defines the mutation data modification closure.
+     *
+     * @return callable
+     */
+    public static function mutate_and_get_payload() {
+        return function ( $input ) {
+            $post_type_object = get_post_type_object( 'attachment' );
 
-			/**
-			 * Get the ID from the global ID
-			 */
-			$id_parts            = Relay::fromGlobalId( $input['id'] );
-			$existing_media_item = get_post( absint( $id_parts['id'] ) );
+            /**
+             * Get the ID from the global ID
+             */
+            $id_parts            = Relay::fromGlobalId( $input['id'] );
+            $existing_media_item = get_post( absint( $id_parts['id'] ) );
 
-			/**
-			 * If there's no existing mediaItem, throw an exception
-			 */
-			if ( empty( $existing_media_item ) ) {
-				throw new UserError( __( 'No mediaItem could be found to delete', 'wp-graphql' ) );
-			}
+            /**
+             * If there's no existing mediaItem, throw an exception
+             */
+            if ( empty( $existing_media_item ) ) {
+                throw new UserError( __( 'No mediaItem could be found to delete', 'wp-graphql' ) );
+            }
 
-			/**
-			 * Stop now if a user isn't allowed to delete a mediaItem
-			 */
-			if ( ! current_user_can( $post_type_object->cap->delete_post, absint( $id_parts['id'] ) ) ) {
-				throw new UserError( __( 'Sorry, you are not allowed to delete mediaItems', 'wp-graphql' ) );
-			}
+            /**
+             * Stop now if a user isn't allowed to delete a mediaItem
+             */
+            if ( ! current_user_can( $post_type_object->cap->delete_post, absint( $id_parts['id'] ) ) ) {
+                throw new UserError( __( 'Sorry, you are not allowed to delete mediaItems', 'wp-graphql' ) );
+            }
 
-			/**
-			 * Check if we should force delete or not
-			 */
-			$force_delete = ( ! empty( $input['forceDelete'] ) && true === $input['forceDelete'] ) ? true : false;
+            /**
+             * Check if we should force delete or not
+             */
+            $force_delete = ( ! empty( $input['forceDelete'] ) && true === $input['forceDelete'] ) ? true : false;
 
-			/**
-			 * Get the mediaItem object before deleting it
-			 */
-			$media_item_before_delete = get_post( absint( $id_parts['id'] ) );
-			$media_item_before_delete = isset( $media_item_before_delete->ID ) && isset( $media_item_before_delete->ID ) ? DataSource::resolve_post_object( $media_item_before_delete->ID, $post_type_object->name ) : $media_item_before_delete;
+            /**
+             * Get the mediaItem object before deleting it
+             */
+            $media_item_before_delete = get_post( absint( $id_parts['id'] ) );
+            $media_item_before_delete = isset( $media_item_before_delete->ID ) && isset( $media_item_before_delete->ID ) ? DataSource::resolve_post_object( $media_item_before_delete->ID, $post_type_object->name ) : $media_item_before_delete;
 
 
-			/**
-			 * If the mediaItem isn't of the attachment post type, throw an error
-			 */
-			if ( 'attachment' !== $media_item_before_delete->post_type ) {
-				throw new UserError( sprintf( __( 'Sorry, the item you are trying to delete is a %1%s, not a mediaItem', 'wp-graphql' ), $media_item_before_delete->post_type ) );
-			}
+            /**
+             * If the mediaItem isn't of the attachment post type, throw an error
+             */
+            if ( 'attachment' !== $media_item_before_delete->post_type ) {
+                throw new UserError( sprintf( __( 'Sorry, the item you are trying to delete is a %1%s, not a mediaItem', 'wp-graphql' ), $media_item_before_delete->post_type ) );
+            }
 
-			/**
-			 * If the mediaItem is already in the trash, and the forceDelete input was not passed,
-			 * don't remove from the trash
-			 */
-			if ( 'trash' === $media_item_before_delete->post_status ) {
-				if ( true !== $force_delete ) {
-					// Translators: the first placeholder is the post_type of the object being deleted and the second placeholder is the unique ID of that object
-					throw new UserError( sprintf( __( 'The mediaItem with id %1$s is already in the trash. To remove from the trash, use the forceDelete input', 'wp-graphql' ), $input['id'] ) );
-				}
-			}
+            /**
+             * If the mediaItem is already in the trash, and the forceDelete input was not passed,
+             * don't remove from the trash
+             */
+            if ( 'trash' === $media_item_before_delete->post_status ) {
+                if ( true !== $force_delete ) {
+                    // Translators: the first placeholder is the post_type of the object being deleted and the second placeholder is the unique ID of that object
+                    throw new UserError( sprintf( __( 'The mediaItem with id %1$s is already in the trash. To remove from the trash, use the forceDelete input', 'wp-graphql' ), $input['id'] ) );
+                }
+            }
 
-			/**
-			 * Delete the mediaItem. This will not throw false thanks to
-			 * all of the above validation
-			 */
-			$deleted = wp_delete_attachment( $id_parts['id'], $force_delete );
+            /**
+             * Delete the mediaItem. This will not throw false thanks to
+             * all of the above validation
+             */
+            $deleted = wp_delete_attachment( $id_parts['id'], $force_delete );
 
-			/**
-			 * If the post was moved to the trash, spoof the object's status before returning it
-			 */
-			$media_item_before_delete->post_status = ( false !== $deleted && true !== $force_delete ) ? 'trash' : $media_item_before_delete->post_status;
+            /**
+             * If the post was moved to the trash, spoof the object's status before returning it
+             */
+            $media_item_before_delete->post_status = ( false !== $deleted && true !== $force_delete ) ? 'trash' : $media_item_before_delete->post_status;
 
-			/**
-			 * Return the deletedId and the mediaItem before it was deleted
-			 */
-			return [
-				'mediaItemObject' => $media_item_before_delete,
-			];
+            /**
+             * Return the deletedId and the mediaItem before it was deleted
+             */
+            return [
+                'mediaItemObject' => $media_item_before_delete,
+            ];
 
-		};
-	}
+        };
+    }
 }

--- a/src/Mutation/MediaItemUpdate.php
+++ b/src/Mutation/MediaItemUpdate.php
@@ -10,118 +10,128 @@ use WPGraphQL\Data\DataSource;
 use WPGraphQL\Data\MediaItemMutation;
 
 class MediaItemUpdate {
-	public static function register_mutation() {
-		register_graphql_mutation( 'updateMediaItem', [
-			'inputFields'         => self::get_input_fields(),
-			'outputFields'        => self::get_output_fields(),
-			'mutateAndGetPayload' => self::mutate_and_get_payload(),
-		] );
-	}
+    /**
+     * Registers the MediaItemUpdate mutation.
+     */
+    public static function register_mutation() {
+        register_graphql_mutation( 'updateMediaItem', [
+            'inputFields'         => self::get_input_fields(),
+            'outputFields'        => self::get_output_fields(),
+            'mutateAndGetPayload' => self::mutate_and_get_payload(),
+        ] );
+    }
 
-	public static function get_input_fields() {
-		return array_merge(
-			MediaItemCreate::get_input_fields(),
-			[
-				'id' => [
-					'type'        => [
-						'non_null' => 'ID',
-					],
-					// translators: the placeholder is the name of the type of post object being updated
-					'description' => sprintf( __( 'The ID of the %1$s object', 'wp-graphql' ), get_post_type_object( 'attachment' )->graphql_single_name ),
-				],
-			]
-		);
-	}
+    /**
+     * Defines the mutation input field configuration.
+     *
+     * @return array
+     */
+    public static function get_input_fields() {
+        return array_merge(
+            MediaItemCreate::get_input_fields(),
+            [
+                'id' => [
+                    'type'        => [
+                        'non_null' => 'ID',
+                    ],
+                    // translators: the placeholder is the name of the type of post object being updated
+                    'description' => sprintf( __( 'The ID of the %1$s object', 'wp-graphql' ), get_post_type_object( 'attachment' )->graphql_single_name ),
+                ],
+            ] );
+    }
 
-	public static function get_output_fields() {
-		return [
-			'mediaItem' => [
-				'type'    => 'MediaItem',
-				'resolve' => function ( $payload ) {
-					return DataSource::resolve_post_object( $payload['postObjectId'], 'attachment' );
-				},
-			],
-		];
-	}
+    /**
+     * Defines the mutation output field configuration.
+     *
+     * @return array
+     */
+    public static function get_output_fields() {
+        return MediaItemCreate::get_output_fields();
+    }
 
-	public static function mutate_and_get_payload() {
-		return function ( $input, AppContext $context, ResolveInfo $info ) {
-			$post_type_object = get_post_type_object( 'attachment' );
-			$mutation_name    = 'updateMediaItem';
+    /**
+     * Defines the mutation data modification closure.
+     *
+     * @return callable
+     */
+    public static function mutate_and_get_payload() {
+        return function ( $input, AppContext $context, ResolveInfo $info ) {
+            $post_type_object = get_post_type_object( 'attachment' );
+            $mutation_name    = 'updateMediaItem';
 
-			$id_parts            = ! empty( $input['id'] ) ? Relay::fromGlobalId( $input['id'] ) : null;
-			$existing_media_item = get_post( absint( $id_parts['id'] ) );
+            $id_parts            = ! empty( $input['id'] ) ? Relay::fromGlobalId( $input['id'] ) : null;
+            $existing_media_item = get_post( absint( $id_parts['id'] ) );
 
-			/**
-			 * If there's no existing mediaItem, throw an exception
-			 */
-			if ( null === $existing_media_item ) {
-				throw new UserError( __( 'No mediaItem with that ID could be found to update', 'wp-graphql' ) );
-			} else {
-				$author_id = $existing_media_item->post_author;
-			}
+            /**
+             * If there's no existing mediaItem, throw an exception
+             */
+            if ( null === $existing_media_item ) {
+                throw new UserError( __( 'No mediaItem with that ID could be found to update', 'wp-graphql' ) );
+            } else {
+                $author_id = $existing_media_item->post_author;
+            }
 
-			/**
-			 * Stop now if the post isn't a mediaItem
-			 */
-			if ( $post_type_object->name !== $existing_media_item->post_type ) {
-				// translators: The placeholder is the ID of the mediaItem being edited
-				throw new UserError( sprintf( __( 'The id %1$d is not of the type mediaItem', 'wp-graphql' ), $id_parts['id'] ) );
-			}
+            /**
+             * Stop now if the post isn't a mediaItem
+             */
+            if ( $post_type_object->name !== $existing_media_item->post_type ) {
+                // translators: The placeholder is the ID of the mediaItem being edited
+                throw new UserError( sprintf( __( 'The id %1$d is not of the type mediaItem', 'wp-graphql' ), $id_parts['id'] ) );
+            }
 
-			/**
-			 * Stop now if a user isn't allowed to edit mediaItems
-			 */
-			if ( ! current_user_can( $post_type_object->cap->edit_posts ) ) {
-				throw new UserError( __( 'Sorry, you are not allowed to update mediaItems', 'wp-graphql' ) );
-			}
+            /**
+             * Stop now if a user isn't allowed to edit mediaItems
+             */
+            if ( ! current_user_can( $post_type_object->cap->edit_posts ) ) {
+                throw new UserError( __( 'Sorry, you are not allowed to update mediaItems', 'wp-graphql' ) );
+            }
 
-			/**
-			 * If the mutation is setting the author to be someone other than the user making the request
-			 * make sure they have permission to edit others posts
-			 **/
-			if ( ! empty( $input['authorId'] ) ) {
-				$author_id_parts = Relay::fromGlobalId( $input['authorId'] );
-				$author_id       = $author_id_parts['id'];
-			}
+            /**
+             * If the mutation is setting the author to be someone other than the user making the request
+             * make sure they have permission to edit others posts
+             **/
+            if ( ! empty( $input['authorId'] ) ) {
+                $author_id_parts = Relay::fromGlobalId( $input['authorId'] );
+                $author_id       = $author_id_parts['id'];
+            }
 
-			/**
-			 * Check to see if the existing_media_item author matches the current user,
-			 * if not they need to be able to edit others posts to proceed
-			 */
-			if ( get_current_user_id() !== $author_id && ! current_user_can( $post_type_object->cap->edit_others_posts ) ) {
-				throw new UserError( __( 'Sorry, you are not allowed to update mediaItems as this user.', 'wp-graphql' ) );
-			}
+            /**
+             * Check to see if the existing_media_item author matches the current user,
+             * if not they need to be able to edit others posts to proceed
+             */
+            if ( get_current_user_id() !== $author_id && ! current_user_can( $post_type_object->cap->edit_others_posts ) ) {
+                throw new UserError( __( 'Sorry, you are not allowed to update mediaItems as this user.', 'wp-graphql' ) );
+            }
 
-			/**
-			 * insert the post object and get the ID
-			 */
-			$post_args                = MediaItemMutation::prepare_media_item( $input, $post_type_object, $mutation_name, false );
-			$post_args['ID']          = absint( $id_parts['id'] );
-			$post_args['post_author'] = $author_id;
+            /**
+             * insert the post object and get the ID
+             */
+            $post_args                = MediaItemMutation::prepare_media_item( $input, $post_type_object, $mutation_name, false );
+            $post_args['ID']          = absint( $id_parts['id'] );
+            $post_args['post_author'] = $author_id;
 
-			/**
-			 * Insert the post and retrieve the ID
-			 *
-			 * This will not fail as long as we have an ID in $post_args
-			 * Thanks to the validation above we will always have the ID
-			 */
-			$post_id = wp_update_post( wp_slash( (array) $post_args ), true );
+            /**
+             * Insert the post and retrieve the ID
+             *
+             * This will not fail as long as we have an ID in $post_args
+             * Thanks to the validation above we will always have the ID
+             */
+            $post_id = wp_update_post( wp_slash( (array) $post_args ), true );
 
-			/**
-			 * This updates additional data not part of the posts table (postmeta, terms, other relations, etc)
-			 *
-			 * The input for the postObjectMutation will be passed, along with the $new_post_id for the
-			 * postObject that was updated so that relations can be set, meta can be updated, etc.
-			 */
-			MediaItemMutation::update_additional_media_item_data( $post_id, $input, $post_type_object, $mutation_name, $context, $info );
+            /**
+             * This updates additional data not part of the posts table (postmeta, terms, other relations, etc)
+             *
+             * The input for the postObjectMutation will be passed, along with the $new_post_id for the
+             * postObject that was updated so that relations can be set, meta can be updated, etc.
+             */
+            MediaItemMutation::update_additional_media_item_data( $post_id, $input, $post_type_object, $mutation_name, $context, $info );
 
-			/**
-			 * Return the payload
-			 */
-			return [
-				'postObjectId' => $post_id,
-			];
-		};
-	}
+            /**
+             * Return the payload
+             */
+            return [
+                'postObjectId' => $post_id,
+            ];
+        };
+    }
 }

--- a/src/Mutation/MediaItemUpdate.php
+++ b/src/Mutation/MediaItemUpdate.php
@@ -26,14 +26,8 @@ class MediaItemUpdate {
 					'type'        => [
 						'non_null' => 'ID',
 					],
-				]
-			),
-			'outputFields'        => [
-				'mediaItem' => [
-					'type'    => 'MediaItem',
-					'resolve' => function ( $payload ) {
-						return DataSource::resolve_post_object( $payload['postObjectId'], 'attachment' );
-					},
+					// translators: the placeholder is the name of the type of post object being updated
+					'description' => sprintf( __( 'The ID of the %1$s object', 'wp-graphql' ), get_post_type_object( 'attachment' )->graphql_single_name ),
 				],
 			]
 		);
@@ -55,59 +49,56 @@ class MediaItemUpdate {
 			$post_type_object = get_post_type_object( 'attachment' );
 			$mutation_name    = 'updateMediaItem';
 
-				/**
-				 * Stop now if a user isn't allowed to edit mediaItems
-				 */
-				if ( ! current_user_can( $post_type_object->cap->edit_posts ) ) {
-					throw new UserError( __( 'Sorry, you are not allowed to update mediaItems', 'wp-graphql' ) );
-				}
+			$id_parts            = ! empty( $input['id'] ) ? Relay::fromGlobalId( $input['id'] ) : null;
+			$existing_media_item = get_post( absint( $id_parts['id'] ) );
 
-				/**
-				 * If the mutation is setting the author to be someone other than the user making the request
-				 * make sure they have permission to edit others posts
-				 **/
-				if ( ! empty( $input['authorId'] ) ) {
-					$author_id_parts = Relay::fromGlobalId( $input['authorId'] );
-					$author_id       = $author_id_parts['id'];
-				}
+			/**
+			 * If there's no existing mediaItem, throw an exception
+			 */
+			if ( null === $existing_media_item ) {
+				throw new UserError( __( 'No mediaItem with that ID could be found to update', 'wp-graphql' ) );
+			} else {
+				$author_id = $existing_media_item->post_author;
+			}
 
-				/**
-				 * Check to see if the existing_media_item author matches the current user,
-				 * if not they need to be able to edit others posts to proceed
-				 */
-				if ( get_current_user_id() !== $author_id && ! current_user_can( $post_type_object->cap->edit_others_posts ) ) {
-					throw new UserError( __( 'Sorry, you are not allowed to update mediaItems as this user.', 'wp-graphql' ) );
-				}
+			/**
+			 * Stop now if the post isn't a mediaItem
+			 */
+			if ( $post_type_object->name !== $existing_media_item->post_type ) {
+				// translators: The placeholder is the ID of the mediaItem being edited
+				throw new UserError( sprintf( __( 'The id %1$d is not of the type mediaItem', 'wp-graphql' ), $id_parts['id'] ) );
+			}
 
-				/**
-				 * insert the post object and get the ID
-				 */
-				$post_args                = MediaItemMutation::prepare_media_item( $input, $post_type_object, $mutation_name, false );
-				$post_args['ID']          = absint( $id_parts['id'] );
-				$post_args['post_author'] = $author_id;
+			/**
+			 * Stop now if a user isn't allowed to edit mediaItems
+			 */
+			if ( ! current_user_can( $post_type_object->cap->edit_posts ) ) {
+				throw new UserError( __( 'Sorry, you are not allowed to update mediaItems', 'wp-graphql' ) );
+			}
 
-				/**
-				 * Insert the post and retrieve the ID
-				 *
-				 * This will not fail as long as we have an ID in $post_args
-				 * Thanks to the validation above we will always have the ID
-				 */
-				$post_id = wp_update_post( wp_slash( (array) $post_args ), true );
+			/**
+			 * If the mutation is setting the author to be someone other than the user making the request
+			 * make sure they have permission to edit others posts
+			 **/
+			if ( ! empty( $input['authorId'] ) ) {
+				$author_id_parts = Relay::fromGlobalId( $input['authorId'] );
+				$author_id       = $author_id_parts['id'];
+			}
 
-				/**
-				 * This updates additional data not part of the posts table (postmeta, terms, other relations, etc)
-				 *
-				 * The input for the postObjectMutation will be passed, along with the $new_post_id for the
-				 * postObject that was updated so that relations can be set, meta can be updated, etc.
-				 */
-				MediaItemMutation::update_additional_media_item_data( $post_id, $input, $post_type_object, $mutation_name, $context, $info );
+			/**
+			 * Check to see if the existing_media_item author matches the current user,
+			 * if not they need to be able to edit others posts to proceed
+			 */
+			if ( get_current_user_id() !== $author_id && ! current_user_can( $post_type_object->cap->edit_others_posts ) ) {
+				throw new UserError( __( 'Sorry, you are not allowed to update mediaItems as this user.', 'wp-graphql' ) );
+			}
 
-				/**
-				 * Return the payload
-				 */
-				return [
-					'postObjectId' => $post_id,
-				];
+			/**
+			 * insert the post object and get the ID
+			 */
+			$post_args                = MediaItemMutation::prepare_media_item( $input, $post_type_object, $mutation_name, false );
+			$post_args['ID']          = absint( $id_parts['id'] );
+			$post_args['post_author'] = $author_id;
 
 			/**
 			 * Insert the post and retrieve the ID

--- a/src/Mutation/MediaItemUpdate.php
+++ b/src/Mutation/MediaItemUpdate.php
@@ -45,7 +45,7 @@ class MediaItemUpdate {
 	}
 
 	public static function mutate_and_get_payload() {
-		function ( $input, AppContext $context, ResolveInfo $info ) {
+		return function ( $input, AppContext $context, ResolveInfo $info ) {
 			$post_type_object = get_post_type_object( 'attachment' );
 			$mutation_name    = 'updateMediaItem';
 

--- a/src/Mutation/MediaItemUpdate.php
+++ b/src/Mutation/MediaItemUpdate.php
@@ -12,15 +12,19 @@ use WPGraphQL\Data\MediaItemMutation;
 class MediaItemUpdate {
 	public static function register_mutation() {
 		register_graphql_mutation( 'updateMediaItem', [
-			'inputFields'         => array_merge(
-				MediaItemCreate::get_input_fields(),
-				[
-					'id' => [
-						'type'        => [
-							'non_null' => 'ID',
-						],
-						// translators: the placeholder is the name of the type of post object being updated
-						'description' => sprintf( __( 'The ID of the %1$s object', 'wp-graphql' ), get_post_type_object( 'attachment' )->graphql_single_name ),
+			'inputFields'         => self::get_input_fields(),
+			'outputFields'        => self::get_output_fields(),
+			'mutateAndGetPayload' => self::mutate_and_get_payload(),
+		] );
+	}
+
+	public static function get_input_fields() {
+		return array_merge(
+			MediaItemCreate::get_input_fields(),
+			[
+				'id' => [
+					'type'        => [
+						'non_null' => 'ID',
 					],
 				]
 			),
@@ -31,31 +35,25 @@ class MediaItemUpdate {
 						return DataSource::resolve_post_object( $payload['postObjectId'], 'attachment' );
 					},
 				],
+			]
+		);
+	}
+
+	public static function get_output_fields() {
+		return [
+			'mediaItem' => [
+				'type'    => 'MediaItem',
+				'resolve' => function ( $payload ) {
+					return DataSource::resolve_post_object( $payload['postObjectId'], 'attachment' );
+				},
 			],
-			'mutateAndGetPayload' => function ( $input, AppContext $context, ResolveInfo $info ) {
+		];
+	}
 
-				$post_type_object = get_post_type_object( 'attachment' );
-				$mutation_name    = 'updateMediaItem';
-
-				$id_parts            = ! empty( $input['id'] ) ? Relay::fromGlobalId( $input['id'] ) : null;
-				$existing_media_item = get_post( absint( $id_parts['id'] ) );
-
-				/**
-				 * If there's no existing mediaItem, throw an exception
-				 */
-				if ( null === $existing_media_item ) {
-					throw new UserError( __( 'No mediaItem with that ID could be found to update', 'wp-graphql' ) );
-				} else {
-					$author_id = $existing_media_item->post_author;
-				}
-
-				/**
-				 * Stop now if the post isn't a mediaItem
-				 */
-				if ( $post_type_object->name !== $existing_media_item->post_type ) {
-					// translators: The placeholder is the ID of the mediaItem being edited
-					throw new UserError( sprintf( __( 'The id %1$d is not of the type mediaItem', 'wp-graphql' ), $id_parts['id'] ) );
-				}
+	public static function mutate_and_get_payload() {
+		function ( $input, AppContext $context, ResolveInfo $info ) {
+			$post_type_object = get_post_type_object( 'attachment' );
+			$mutation_name    = 'updateMediaItem';
 
 				/**
 				 * Stop now if a user isn't allowed to edit mediaItems
@@ -111,7 +109,28 @@ class MediaItemUpdate {
 					'postObjectId' => $post_id,
 				];
 
-			},
-		] );
+			/**
+			 * Insert the post and retrieve the ID
+			 *
+			 * This will not fail as long as we have an ID in $post_args
+			 * Thanks to the validation above we will always have the ID
+			 */
+			$post_id = wp_update_post( wp_slash( (array) $post_args ), true );
+
+			/**
+			 * This updates additional data not part of the posts table (postmeta, terms, other relations, etc)
+			 *
+			 * The input for the postObjectMutation will be passed, along with the $new_post_id for the
+			 * postObject that was updated so that relations can be set, meta can be updated, etc.
+			 */
+			MediaItemMutation::update_additional_media_item_data( $post_id, $input, $post_type_object, $mutation_name, $context, $info );
+
+			/**
+			 * Return the payload
+			 */
+			return [
+				'postObjectId' => $post_id,
+			];
+		};
 	}
 }

--- a/src/Mutation/PostObjectCreate.php
+++ b/src/Mutation/PostObjectCreate.php
@@ -18,7 +18,7 @@ class PostObjectCreate {
 			'mutateAndGetPayload' => self::mutate_and_get_payload( $post_type_object, $mutation_name ),
 		] );
 	}
-
+	
 	public static function get_input_fields( $post_type_object ) {
 		$fields = [
 			'authorId'      => [
@@ -90,14 +90,14 @@ class PostObjectCreate {
 				'description' => __( 'URLs queued to be pinged.', 'wp-graphql' ),
 			],
 		];
-
+		
 		$allowed_taxonomies = \WPGraphQL::$allowed_taxonomies;
 		if ( ! empty( $allowed_taxonomies ) && is_array( $allowed_taxonomies ) ) {
 			foreach ( $allowed_taxonomies as $taxonomy ) {
 				// If the taxonomy is in the array of taxonomies registered to the post_type
 				if ( in_array( $taxonomy, get_object_taxonomies( $post_type_object->name ), true ) ) {
 					$tax_object = get_taxonomy( $taxonomy );
-
+					
 					register_graphql_input_type( $post_type_object->graphql_single_name . ucfirst( $tax_object->graphql_plural_name ) . 'NodeInput', [
 						'description' => sprintf( __( 'List of %1$s to connect the %2$s to. If an ID is set, it will be used to create the connection. If not, it will look for a slug. If neither are valid existing terms, and the site is configured to allow terms to be created during post mutations, a term will be created using the Name if it exists in the input, then fallback to the slug if it exists.', 'wp-graphql' ), $tax_object->graphql_plural_name, $post_type_object->graphql_single_name ),
 						'fields'      => [
@@ -118,7 +118,7 @@ class PostObjectCreate {
 								'description' => sprintf( __( 'The name of the %1$s. This field is used to create a new term, if term creation is enabled in nested mutations, and if one does not already exist with the provided slug or ID or if a slug or ID is not provided. If no name is included and a term is created, the creation will fallback to the slug field.', 'wp-graphql' ), $tax_object->graphql_single_name ),
 							],
 						],
-					] );
+						] );
 
 					register_graphql_input_type( ucfirst( $post_type_object->graphql_single_name ) . ucfirst( $tax_object->graphql_plural_name ) . 'Input', [
 						'description' => sprintf( __( 'Set relationships between the %1$s to %2$s', 'wp-graphql' ), $post_type_object->graphql_single_name, $tax_object->graphql_plural_name ),

--- a/src/Mutation/PostObjectCreate.php
+++ b/src/Mutation/PostObjectCreate.php
@@ -10,177 +10,16 @@ use WPGraphQL\Data\PostObjectMutation;
 
 class PostObjectCreate {
 	public static function register_mutation( \WP_Post_Type $post_type_object ) {
-		register_graphql_mutation( 'create' . ucfirst( $post_type_object->graphql_single_name ), [
+		$mutation_name = 'create' . ucwords( $post_type_object->graphql_single_name );
+
+		register_graphql_mutation( $mutation_name, [
 			'inputFields'         => self::get_input_fields( $post_type_object ),
-			'outputFields'        => [
-				$post_type_object->graphql_single_name => [
-					'type'    => $post_type_object->graphql_single_name,
-					'resolve' => function ( $payload ) use ( $post_type_object ) {
-						return DataSource::resolve_post_object( $payload['id'], $post_type_object->name );
-					},
-				],
-			],
-			'mutateAndGetPayload' => function ( $input, AppContext $context, ResolveInfo $info ) use ( $post_type_object ) {
-
-				$mutation_name = 'create' . $post_type_object->graphql_single_name;
-
-				/**
-				 * Throw an exception if there's no input
-				 */
-				if ( ( empty( $post_type_object->name ) ) || ( empty( $input ) || ! is_array( $input ) ) ) {
-					throw new UserError( __( 'Mutation not processed. There was no input for the mutation or the post_type_object was invalid', 'wp-graphql' ) );
-				}
-
-				/**
-				 * Stop now if a user isn't allowed to create a post
-				 */
-				if ( ! current_user_can( $post_type_object->cap->create_posts ) ) {
-					// translators: the $post_type_object->graphql_plural_name placeholder is the name of the object being mutated
-					throw new UserError( sprintf( __( 'Sorry, you are not allowed to create %1$s', 'wp-graphql' ), $post_type_object->graphql_plural_name ) );
-				}
-
-				/**
-				 * If the post being created is being assigned to another user that's not the current user, make sure
-				 * the current user has permission to edit others posts for this post_type
-				 */
-				if ( ! empty( $input['authorId'] ) && get_current_user_id() !== $input['authorId'] && ! current_user_can( $post_type_object->cap->edit_others_posts ) ) {
-					// translators: the $post_type_object->graphql_plural_name placeholder is the name of the object being mutated
-					throw new UserError( sprintf( __( 'Sorry, you are not allowed to create %1$s as this user', 'wp-graphql' ), $post_type_object->graphql_plural_name ) );
-				}
-
-				/**
-				 * @todo: When we support assigning terms and setting posts as "sticky" we need to check permissions
-				 * @see :https://github.com/WordPress/WordPress/blob/e357195ce303017d517aff944644a7a1232926f7/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L504-L506
-				 * @see : https://github.com/WordPress/WordPress/blob/e357195ce303017d517aff944644a7a1232926f7/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L496-L498
-				 */
-
-				/**
-				 * insert the post object and get the ID
-				 */
-				$post_args = PostObjectMutation::prepare_post_object( $input, $post_type_object, $mutation_name );
-
-				/**
-				 * Filter the default post status to use when the post is initially created. Pass through a filter to
-				 * allow other plugins to override the default (for example, Edit Flow, which provides control over
-				 * customizing stati or various E-commerce plugins that make heavy use of custom stati)
-				 *
-				 * @param string        $default_status   The default status to be used when the post is initially inserted
-				 * @param \WP_Post_Type $post_type_object The Post Type that is being inserted
-				 * @param string        $mutation_name    The name of the mutation currently in progress
-				 */
-				$default_post_status = apply_filters( 'graphql_post_object_create_default_post_status', 'draft', $post_type_object, $mutation_name );
-
-				/**
-				 * We want to cache the "post_status" and set the status later. We will set the initial status
-				 * of the inserted post as the default status for the site, allow side effects to process with the
-				 * inserted post (set term object connections, set meta input, sideload images if necessary, etc)
-				 * Then will follow up with setting the status as what it was declared to be later
-				 */
-				$intended_post_status = ! empty( $post_args['post_status'] ) ? $post_args['post_status'] : $default_post_status;
-
-				/**
-				 * Set the post_status as the default for the initial insert. The intended $post_status will be set after
-				 * side effects are complete.
-				 */
-				$post_args['post_status'] = $default_post_status;
-
-				/**
-				 * Insert the post and retrieve the ID
-				 */
-				$post_id = wp_insert_post( wp_slash( (array) $post_args ), true );
-
-				/**
-				 * Throw an exception if the post failed to create
-				 */
-				if ( is_wp_error( $post_id ) ) {
-					$error_message = $post_id->get_error_message();
-					if ( ! empty( $error_message ) ) {
-						throw new UserError( esc_html( $error_message ) );
-					} else {
-						throw new UserError( __( 'The object failed to create but no error was provided', 'wp-graphql' ) );
-					}
-				}
-
-				/**
-				 * If the $post_id is empty, we should throw an exception
-				 */
-				if ( empty( $post_id ) ) {
-					throw new UserError( __( 'The object failed to create', 'wp-graphql' ) );
-				}
-
-				/**
-				 * This updates additional data not part of the posts table (postmeta, terms, other relations, etc)
-				 *
-				 * The input for the postObjectMutation will be passed, along with the $new_post_id for the
-				 * postObject that was created so that relations can be set, meta can be updated, etc.
-				 */
-				PostObjectMutation::update_additional_post_object_data( $post_id, $input, $post_type_object, $mutation_name, $context, $info, $default_post_status, $intended_post_status );
-
-				/**
-				 * Determine whether the intended status should be set or not.
-				 *
-				 * By filtering to false, the $intended_post_status will not be set at the completion of the mutation.
-				 *
-				 * This allows for side-effect actions to set the status later. For example, if a post
-				 * was being created via a GraphQL Mutation, the post had additional required assets, such as images
-				 * that needed to be sideloaded or some other semi-time-consuming side effect, those actions could
-				 * be deferred (cron or whatever), and when those actions complete they could come back and set
-				 * the $intended_status.
-				 *
-				 * @param boolean       $should_set_intended_status Whether to set the intended post_status or not. Default true.
-				 * @param \WP_Post_Type $post_type_object           The Post Type Object for the post being mutated
-				 * @param string        $mutation_name              The name of the mutation currently in progress
-				 * @param AppContext    $context                    The AppContext passed down to all resolvers
-				 * @param ResolveInfo   $info                       The ResolveInfo passed down to all resolvers
-				 * @param string        $intended_post_status       The intended post_status the post should have according to the mutation input
-				 * @param string        $default_post_status        The default status posts should use if an intended status wasn't set
-				 */
-				$should_set_intended_status = apply_filters( 'graphql_post_object_create_should_set_intended_post_status', true, $post_type_object, $mutation_name, $context, $info, $intended_post_status, $default_post_status );
-
-				/**
-				 * If the intended post status and the default post status are not the same,
-				 * update the post with the intended status now that side effects are complete.
-				 */
-				if ( $intended_post_status !== $default_post_status && true === $should_set_intended_status ) {
-
-					/**
-					 * If the post was deleted by a side effect action before getting here,
-					 * don't proceed.
-					 */
-					if ( ! $new_post = get_post( $post_id ) ) {
-						throw new UserError( sprintf( __( 'The status of the post could not be set', 'wp-graphql' ) ) );
-					}
-
-					/**
-					 * If the $intended_post_status is different than the current status of the post
-					 * proceed and update the status.
-					 */
-					if ( $intended_post_status !== $new_post->post_status ) {
-						$update_args = [
-							'ID'          => $post_id,
-							'post_status' => $intended_post_status,
-							// Prevent the post_date from being reset if the date was included in the create post $args
-							// see: https://core.trac.wordpress.org/browser/tags/4.9/src/wp-includes/post.php#L3637
-							'edit_date'   => ! empty( $post_args['post_date'] ) ? $post_args['post_date'] : false,
-						];
-
-						wp_update_post( $update_args );
-					}
-
-				}
-
-				/**
-				 * Return the post object
-				 */
-				return [
-					'id' => $post_id,
-				];
-			},
+			'outputFields'        => self::get_output_fields( $post_type_object ),
+			'mutateAndGetPayload' => self::mutate_and_get_payload( $post_type_object, $mutation_name ),
 		] );
 	}
 
 	public static function get_input_fields( $post_type_object ) {
-
 		$fields = [
 			'authorId'      => [
 				'type'        => 'ID',
@@ -305,5 +144,173 @@ class PostObjectCreate {
 		}
 
 		return $fields;
+	}
+		
+	public static function get_output_fields( $post_type_object ) {
+		return [
+			$post_type_object->graphql_single_name => [
+				'type'    => $post_type_object->graphql_single_name,
+				'resolve' => function ( $payload ) use ( $post_type_object ) {
+					return DataSource::resolve_post_object( $payload['postObjectId'], $post_type_object->name );
+				},
+			],
+		];
+	}
+
+	public static function mutate_and_get_payload( $post_type_object, $mutation_name ) {
+		return function ( $input, AppContext $context, ResolveInfo $info ) use ( $post_type_object, $mutation_name ) {
+
+			/**
+			 * Throw an exception if there's no input
+			 */
+			if ( ( empty( $post_type_object->name ) ) || ( empty( $input ) || ! is_array( $input ) ) ) {
+				throw new UserError( __( 'Mutation not processed. There was no input for the mutation or the post_type_object was invalid', 'wp-graphql' ) );
+			}
+
+			/**
+			 * Stop now if a user isn't allowed to create a post
+			 */
+			if ( ! current_user_can( $post_type_object->cap->create_posts ) ) {
+				// translators: the $post_type_object->graphql_plural_name placeholder is the name of the object being mutated
+				throw new UserError( sprintf( __( 'Sorry, you are not allowed to create %1$s', 'wp-graphql' ), $post_type_object->graphql_plural_name ) );
+			}
+
+			/**
+			 * If the post being created is being assigned to another user that's not the current user, make sure
+			 * the current user has permission to edit others posts for this post_type
+			 */
+			if ( ! empty( $input['authorId'] ) && get_current_user_id() !== $input['authorId'] && ! current_user_can( $post_type_object->cap->edit_others_posts ) ) {
+				// translators: the $post_type_object->graphql_plural_name placeholder is the name of the object being mutated
+				throw new UserError( sprintf( __( 'Sorry, you are not allowed to create %1$s as this user', 'wp-graphql' ), $post_type_object->graphql_plural_name ) );
+			}
+
+			/**
+			 * @todo: When we support assigning terms and setting posts as "sticky" we need to check permissions
+			 * @see :https://github.com/WordPress/WordPress/blob/e357195ce303017d517aff944644a7a1232926f7/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L504-L506
+			 * @see : https://github.com/WordPress/WordPress/blob/e357195ce303017d517aff944644a7a1232926f7/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L496-L498
+			 */
+
+			/**
+			 * insert the post object and get the ID
+			 */
+			$post_args = PostObjectMutation::prepare_post_object( $input, $post_type_object, $mutation_name );
+
+			/**
+			 * Filter the default post status to use when the post is initially created. Pass through a filter to
+			 * allow other plugins to override the default (for example, Edit Flow, which provides control over
+			 * customizing stati or various E-commerce plugins that make heavy use of custom stati)
+			 *
+			 * @param string        $default_status   The default status to be used when the post is initially inserted
+			 * @param \WP_Post_Type $post_type_object The Post Type that is being inserted
+			 * @param string        $mutation_name    The name of the mutation currently in progress
+			 */
+			$default_post_status = apply_filters( 'graphql_post_object_create_default_post_status', 'draft', $post_type_object, $mutation_name );
+
+			/**
+			 * We want to cache the "post_status" and set the status later. We will set the initial status
+			 * of the inserted post as the default status for the site, allow side effects to process with the
+			 * inserted post (set term object connections, set meta input, sideload images if necessary, etc)
+			 * Then will follow up with setting the status as what it was declared to be later
+			 */
+			$intended_post_status = ! empty( $post_args['post_status'] ) ? $post_args['post_status'] : $default_post_status;
+
+			/**
+			 * Set the post_status as the default for the initial insert. The intended $post_status will be set after
+			 * side effects are complete.
+			 */
+			$post_args['post_status'] = $default_post_status;
+
+			/**
+			 * Insert the post and retrieve the ID
+			 */
+			$post_id = wp_insert_post( wp_slash( (array) $post_args ), true );
+
+			/**
+			 * Throw an exception if the post failed to create
+			 */
+			if ( is_wp_error( $post_id ) ) {
+				$error_message = $post_id->get_error_message();
+				if ( ! empty( $error_message ) ) {
+					throw new UserError( esc_html( $error_message ) );
+				} else {
+					throw new UserError( __( 'The object failed to create but no error was provided', 'wp-graphql' ) );
+				}
+			}
+
+			/**
+			 * If the $post_id is empty, we should throw an exception
+			 */
+			if ( empty( $post_id ) ) {
+				throw new UserError( __( 'The object failed to create', 'wp-graphql' ) );
+			}
+
+			/**
+			 * This updates additional data not part of the posts table (postmeta, terms, other relations, etc)
+			 *
+			 * The input for the postObjectMutation will be passed, along with the $new_post_id for the
+			 * postObject that was created so that relations can be set, meta can be updated, etc.
+			 */
+			PostObjectMutation::update_additional_post_object_data( $post_id, $input, $post_type_object, $mutation_name, $context, $info, $default_post_status, $intended_post_status );
+
+			/**
+			 * Determine whether the intended status should be set or not.
+			 *
+			 * By filtering to false, the $intended_post_status will not be set at the completion of the mutation.
+			 *
+			 * This allows for side-effect actions to set the status later. For example, if a post
+			 * was being created via a GraphQL Mutation, the post had additional required assets, such as images
+			 * that needed to be sideloaded or some other semi-time-consuming side effect, those actions could
+			 * be deferred (cron or whatever), and when those actions complete they could come back and set
+			 * the $intended_status.
+			 *
+			 * @param boolean       $should_set_intended_status Whether to set the intended post_status or not. Default true.
+			 * @param \WP_Post_Type $post_type_object           The Post Type Object for the post being mutated
+			 * @param string        $mutation_name              The name of the mutation currently in progress
+			 * @param AppContext    $context                    The AppContext passed down to all resolvers
+			 * @param ResolveInfo   $info                       The ResolveInfo passed down to all resolvers
+			 * @param string        $intended_post_status       The intended post_status the post should have according to the mutation input
+			 * @param string        $default_post_status        The default status posts should use if an intended status wasn't set
+			 */
+			$should_set_intended_status = apply_filters( 'graphql_post_object_create_should_set_intended_post_status', true, $post_type_object, $mutation_name, $context, $info, $intended_post_status, $default_post_status );
+
+			/**
+			 * If the intended post status and the default post status are not the same,
+			 * update the post with the intended status now that side effects are complete.
+			 */
+			if ( $intended_post_status !== $default_post_status && true === $should_set_intended_status ) {
+
+				/**
+				 * If the post was deleted by a side effect action before getting here,
+				 * don't proceed.
+				 */
+				if ( ! $new_post = get_post( $post_id ) ) {
+					throw new UserError( sprintf( __( 'The status of the post could not be set', 'wp-graphql' ) ) );
+				}
+
+				/**
+				 * If the $intended_post_status is different than the current status of the post
+				 * proceed and update the status.
+				 */
+				if ( $intended_post_status !== $new_post->post_status ) {
+					$update_args = [
+						'ID'          => $post_id,
+						'post_status' => $intended_post_status,
+						// Prevent the post_date from being reset if the date was included in the create post $args
+						// see: https://core.trac.wordpress.org/browser/tags/4.9/src/wp-includes/post.php#L3637
+						'edit_date'   => ! empty( $post_args['post_date'] ) ? $post_args['post_date'] : false,
+					];
+
+					wp_update_post( $update_args );
+				}
+
+			}
+
+			/**
+			 * Return the post object
+			 */
+			return [
+				'postObjectId' => $post_id,
+			];
+		};
 	}
 }

--- a/src/Mutation/PostObjectCreate.php
+++ b/src/Mutation/PostObjectCreate.php
@@ -9,308 +9,335 @@ use WPGraphQL\Data\DataSource;
 use WPGraphQL\Data\PostObjectMutation;
 
 class PostObjectCreate {
-	public static function register_mutation( \WP_Post_Type $post_type_object ) {
-		$mutation_name = 'create' . ucwords( $post_type_object->graphql_single_name );
+    /**
+     * Registers the PostObjectCreate mutation.
+     *
+     * @param \WP_Post_Type $post_type_object   The post type of the mutation.
+     */
+    public static function register_mutation( \WP_Post_Type $post_type_object ) {
+        $mutation_name = 'create' . ucwords( $post_type_object->graphql_single_name );
 
-		register_graphql_mutation( $mutation_name, [
-			'inputFields'         => self::get_input_fields( $post_type_object ),
-			'outputFields'        => self::get_output_fields( $post_type_object ),
-			'mutateAndGetPayload' => self::mutate_and_get_payload( $post_type_object, $mutation_name ),
-		] );
-	}
-	
-	public static function get_input_fields( $post_type_object ) {
-		$fields = [
-			'authorId'      => [
-				'type'        => 'ID',
-				'description' => __( 'The userId to assign as the author of the post', 'wp-graphql' ),
-			],
-			'commentCount'  => [
-				'type'        => 'INT',
-				'description' => __( 'The number of comments. Even though WPGraphQL denotes this field as an integer, in WordPress this field should be saved as a numeric string for compatibility.', 'wp-graphql' ),
-			],
-			'commentStatus' => [
-				'type'        => 'String',
-				'description' => __( 'The comment status for the object', 'wp-graphql' ),
-			],
-			'content'       => [
-				'type'        => 'String',
-				'description' => __( 'The content of the object', 'wp-graphql' ),
-			],
-			'date'          => [
-				'type'        => 'String',
-				'description' => __( 'The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 ', 'wp-graphql' ),
-			],
-			'excerpt'       => [
-				'type'        => 'String',
-				'description' => __( 'The excerpt of the object', 'wp-graphql' ),
-			],
-			'menuOrder'     => [
-				'type'        => 'Int',
-				'description' => __( 'A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types.', 'wp-graphql' ),
-			],
-			'mimeType'      => [
-				'type'        => 'MimeTypeEnum',
-				'description' => __( 'If the post is an attachment or a media file, this field will carry the corresponding MIME type. This field is equivalent to the value of WP_Post->post_mime_type and the post_mime_type column in the "post_objects" database table.', 'wp-graphql' ),
-			],
-			'parentId'      => [
-				'type'        => 'Id',
-				'description' => __( 'The ID of the parent object', 'wp-graphql' ),
-			],
-			'password'      => [
-				'type'        => 'String',
-				'description' => __( 'The password used to protect the content of the object', 'wp-graphql' ),
-			],
-			'pinged'        => [
-				'type'        => [
-					'list_of' => 'String',
-				],
-				'description' => __( 'URLs that have been pinged.', 'wp-graphql' ),
-			],
-			'pingStatus'    => [
-				'type'        => 'String',
-				'description' => __( 'The ping status for the object', 'wp-graphql' ),
-			],
-			'slug'          => [
-				'type'        => 'String',
-				'description' => __( 'The slug of the object', 'wp-graphql' ),
-			],
-			'status'        => [
-				'type'        => 'PostStatusEnum',
-				'description' => __( 'The status of the object', 'wp-graphql' ),
-			],
-			'title'         => [
-				'type'        => 'String',
-				'description' => __( 'The title of the post', 'wp-graphql' ),
-			],
-			'toPing'        => [
-				'type'        => [
-					'list_of' => 'String',
-				],
-				'description' => __( 'URLs queued to be pinged.', 'wp-graphql' ),
-			],
-		];
-		
-		$allowed_taxonomies = \WPGraphQL::$allowed_taxonomies;
-		if ( ! empty( $allowed_taxonomies ) && is_array( $allowed_taxonomies ) ) {
-			foreach ( $allowed_taxonomies as $taxonomy ) {
-				// If the taxonomy is in the array of taxonomies registered to the post_type
-				if ( in_array( $taxonomy, get_object_taxonomies( $post_type_object->name ), true ) ) {
-					$tax_object = get_taxonomy( $taxonomy );
-					
-					register_graphql_input_type( $post_type_object->graphql_single_name . ucfirst( $tax_object->graphql_plural_name ) . 'NodeInput', [
-						'description' => sprintf( __( 'List of %1$s to connect the %2$s to. If an ID is set, it will be used to create the connection. If not, it will look for a slug. If neither are valid existing terms, and the site is configured to allow terms to be created during post mutations, a term will be created using the Name if it exists in the input, then fallback to the slug if it exists.', 'wp-graphql' ), $tax_object->graphql_plural_name, $post_type_object->graphql_single_name ),
-						'fields'      => [
-							'id'          => [
-								'type'        => 'Id',
-								'description' => sprintf( __( 'The ID of the %1$s. If present, this will be used to connect to the %2$s. If no existing %1$s exists with this ID, no connection will be made.', 'wp-graphql' ), $tax_object->graphql_single_name, $post_type_object->graphql_single_name ),
-							],
-							'slug'        => [
-								'type'        => 'String',
-								'description' => sprintf( __( 'The slug of the %1$s. If no ID is present, this field will be used to make a connection. If no existing term exists with this slug, this field will be used as a fallback to the Name field when creating a new term to connect to, if term creation is enabled as a nested mutation.', 'wp-graphql' ), $tax_object->graphql_single_name ),
-							],
-							'description' => [
-								'type'        => 'String',
-								'description' => sprintf( __( 'The description of the %1$s. This field is used to set a description of the %1$s if a new one is created during the mutation.', 'wp-graphql' ), $tax_object->graphql_single_name ),
-							],
-							'name'        => [
-								'type'        => 'String',
-								'description' => sprintf( __( 'The name of the %1$s. This field is used to create a new term, if term creation is enabled in nested mutations, and if one does not already exist with the provided slug or ID or if a slug or ID is not provided. If no name is included and a term is created, the creation will fallback to the slug field.', 'wp-graphql' ), $tax_object->graphql_single_name ),
-							],
-						],
-						] );
+        register_graphql_mutation( $mutation_name, [
+            'inputFields'         => self::get_input_fields( $post_type_object ),
+            'outputFields'        => self::get_output_fields( $post_type_object ),
+            'mutateAndGetPayload' => self::mutate_and_get_payload( $post_type_object, $mutation_name ),
+        ] );
+    }
 
-					register_graphql_input_type( ucfirst( $post_type_object->graphql_single_name ) . ucfirst( $tax_object->graphql_plural_name ) . 'Input', [
-						'description' => sprintf( __( 'Set relationships between the %1$s to %2$s', 'wp-graphql' ), $post_type_object->graphql_single_name, $tax_object->graphql_plural_name ),
-						'fields'      => [
-							'append' => [
-								'type'        => 'Boolean',
-								'description' => sprintf( __( 'If true, this will append the %1$s to existing related %2$s. If false, this will replace existing relationships. Default true.', 'wp-graphql' ), $tax_object->graphql_single_name, $tax_object->graphql_plural_name ),
-							],
-							'nodes'  => [
-								'type' => [
-									'list_of' => $post_type_object->graphql_single_name . ucfirst( $tax_object->graphql_plural_name ) . 'NodeInput',
-								],
-							],
-						],
-					] );
+    /**
+     * Defines the mutation input field configuration.
+     *
+     * @param \WP_Post_Type $post_type_object   The post type of the mutation.
+     *
+     * @return array
+     */
+    public static function get_input_fields( $post_type_object ) {
+        $fields = [
+            'authorId'      => [
+                'type'        => 'ID',
+                'description' => __( 'The userId to assign as the author of the post', 'wp-graphql' ),
+            ],
+            'commentCount'  => [
+                'type'        => 'INT',
+                'description' => __( 'The number of comments. Even though WPGraphQL denotes this field as an integer, in WordPress this field should be saved as a numeric string for compatibility.', 'wp-graphql' ),
+            ],
+            'commentStatus' => [
+                'type'        => 'String',
+                'description' => __( 'The comment status for the object', 'wp-graphql' ),
+            ],
+            'content'       => [
+                'type'        => 'String',
+                'description' => __( 'The content of the object', 'wp-graphql' ),
+            ],
+            'date'          => [
+                'type'        => 'String',
+                'description' => __( 'The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 ', 'wp-graphql' ),
+            ],
+            'excerpt'       => [
+                'type'        => 'String',
+                'description' => __( 'The excerpt of the object', 'wp-graphql' ),
+            ],
+            'menuOrder'     => [
+                'type'        => 'Int',
+                'description' => __( 'A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types.', 'wp-graphql' ),
+            ],
+            'mimeType'      => [
+                'type'        => 'MimeTypeEnum',
+                'description' => __( 'If the post is an attachment or a media file, this field will carry the corresponding MIME type. This field is equivalent to the value of WP_Post->post_mime_type and the post_mime_type column in the "post_objects" database table.', 'wp-graphql' ),
+            ],
+            'parentId'      => [
+                'type'        => 'Id',
+                'description' => __( 'The ID of the parent object', 'wp-graphql' ),
+            ],
+            'password'      => [
+                'type'        => 'String',
+                'description' => __( 'The password used to protect the content of the object', 'wp-graphql' ),
+            ],
+            'pinged'        => [
+                'type'        => [
+                    'list_of' => 'String',
+                ],
+                'description' => __( 'URLs that have been pinged.', 'wp-graphql' ),
+            ],
+            'pingStatus'    => [
+                'type'        => 'String',
+                'description' => __( 'The ping status for the object', 'wp-graphql' ),
+            ],
+            'slug'          => [
+                'type'        => 'String',
+                'description' => __( 'The slug of the object', 'wp-graphql' ),
+            ],
+            'status'        => [
+                'type'        => 'PostStatusEnum',
+                'description' => __( 'The status of the object', 'wp-graphql' ),
+            ],
+            'title'         => [
+                'type'        => 'String',
+                'description' => __( 'The title of the post', 'wp-graphql' ),
+            ],
+            'toPing'        => [
+                'type'        => [
+                    'list_of' => 'String',
+                ],
+                'description' => __( 'URLs queued to be pinged.', 'wp-graphql' ),
+            ],
+        ];
 
-					$fields[ $tax_object->graphql_plural_name ] = [
-						'description' => sprintf( __( 'Set connections between the %1$s and %2$s', 'wp-graphql' ), $post_type_object->graphql_single_name, $tax_object->graphql_plural_name ),
-						'type'        => ucfirst( $post_type_object->graphql_single_name ) . ucfirst( $tax_object->graphql_plural_name ) . 'Input',
-					];
-				}
-			}
-		}
+        $allowed_taxonomies = \WPGraphQL::$allowed_taxonomies;
+        if ( ! empty( $allowed_taxonomies ) && is_array( $allowed_taxonomies ) ) {
+            foreach ( $allowed_taxonomies as $taxonomy ) {
+                // If the taxonomy is in the array of taxonomies registered to the post_type
+                if ( in_array( $taxonomy, get_object_taxonomies( $post_type_object->name ), true ) ) {
+                    $tax_object = get_taxonomy( $taxonomy );
 
-		return $fields;
-	}
-		
-	public static function get_output_fields( $post_type_object ) {
-		return [
-			$post_type_object->graphql_single_name => [
-				'type'    => $post_type_object->graphql_single_name,
-				'resolve' => function ( $payload ) use ( $post_type_object ) {
-					return DataSource::resolve_post_object( $payload['postObjectId'], $post_type_object->name );
-				},
-			],
-		];
-	}
+                    register_graphql_input_type( $post_type_object->graphql_single_name . ucfirst( $tax_object->graphql_plural_name ) . 'NodeInput', [
+                        'description' => sprintf( __( 'List of %1$s to connect the %2$s to. If an ID is set, it will be used to create the connection. If not, it will look for a slug. If neither are valid existing terms, and the site is configured to allow terms to be created during post mutations, a term will be created using the Name if it exists in the input, then fallback to the slug if it exists.', 'wp-graphql' ), $tax_object->graphql_plural_name, $post_type_object->graphql_single_name ),
+                        'fields'      => [
+                            'id'          => [
+                                'type'        => 'Id',
+                                'description' => sprintf( __( 'The ID of the %1$s. If present, this will be used to connect to the %2$s. If no existing %1$s exists with this ID, no connection will be made.', 'wp-graphql' ), $tax_object->graphql_single_name, $post_type_object->graphql_single_name ),
+                            ],
+                            'slug'        => [
+                                'type'        => 'String',
+                                'description' => sprintf( __( 'The slug of the %1$s. If no ID is present, this field will be used to make a connection. If no existing term exists with this slug, this field will be used as a fallback to the Name field when creating a new term to connect to, if term creation is enabled as a nested mutation.', 'wp-graphql' ), $tax_object->graphql_single_name ),
+                            ],
+                            'description' => [
+                                'type'        => 'String',
+                                'description' => sprintf( __( 'The description of the %1$s. This field is used to set a description of the %1$s if a new one is created during the mutation.', 'wp-graphql' ), $tax_object->graphql_single_name ),
+                            ],
+                            'name'        => [
+                                'type'        => 'String',
+                                'description' => sprintf( __( 'The name of the %1$s. This field is used to create a new term, if term creation is enabled in nested mutations, and if one does not already exist with the provided slug or ID or if a slug or ID is not provided. If no name is included and a term is created, the creation will fallback to the slug field.', 'wp-graphql' ), $tax_object->graphql_single_name ),
+                            ],
+                        ],
+                    ] );
 
-	public static function mutate_and_get_payload( $post_type_object, $mutation_name ) {
-		return function ( $input, AppContext $context, ResolveInfo $info ) use ( $post_type_object, $mutation_name ) {
+                    register_graphql_input_type( ucfirst( $post_type_object->graphql_single_name ) . ucfirst( $tax_object->graphql_plural_name ) . 'Input', [
+                        'description' => sprintf( __( 'Set relationships between the %1$s to %2$s', 'wp-graphql' ), $post_type_object->graphql_single_name, $tax_object->graphql_plural_name ),
+                        'fields'      => [
+                            'append' => [
+                                'type'        => 'Boolean',
+                                'description' => sprintf( __( 'If true, this will append the %1$s to existing related %2$s. If false, this will replace existing relationships. Default true.', 'wp-graphql' ), $tax_object->graphql_single_name, $tax_object->graphql_plural_name ),
+                            ],
+                            'nodes'  => [
+                                'type' => [
+                                    'list_of' => $post_type_object->graphql_single_name . ucfirst( $tax_object->graphql_plural_name ) . 'NodeInput',
+                                ],
+                            ],
+                        ],
+                    ] );
 
-			/**
-			 * Throw an exception if there's no input
-			 */
-			if ( ( empty( $post_type_object->name ) ) || ( empty( $input ) || ! is_array( $input ) ) ) {
-				throw new UserError( __( 'Mutation not processed. There was no input for the mutation or the post_type_object was invalid', 'wp-graphql' ) );
-			}
+                    $fields[ $tax_object->graphql_plural_name ] = [
+                        'description' => sprintf( __( 'Set connections between the %1$s and %2$s', 'wp-graphql' ), $post_type_object->graphql_single_name, $tax_object->graphql_plural_name ),
+                        'type'        => ucfirst( $post_type_object->graphql_single_name ) . ucfirst( $tax_object->graphql_plural_name ) . 'Input',
+                    ];
+                }
+            }
+        }
 
-			/**
-			 * Stop now if a user isn't allowed to create a post
-			 */
-			if ( ! current_user_can( $post_type_object->cap->create_posts ) ) {
-				// translators: the $post_type_object->graphql_plural_name placeholder is the name of the object being mutated
-				throw new UserError( sprintf( __( 'Sorry, you are not allowed to create %1$s', 'wp-graphql' ), $post_type_object->graphql_plural_name ) );
-			}
+        return $fields;
+    }
 
-			/**
-			 * If the post being created is being assigned to another user that's not the current user, make sure
-			 * the current user has permission to edit others posts for this post_type
-			 */
-			if ( ! empty( $input['authorId'] ) && get_current_user_id() !== $input['authorId'] && ! current_user_can( $post_type_object->cap->edit_others_posts ) ) {
-				// translators: the $post_type_object->graphql_plural_name placeholder is the name of the object being mutated
-				throw new UserError( sprintf( __( 'Sorry, you are not allowed to create %1$s as this user', 'wp-graphql' ), $post_type_object->graphql_plural_name ) );
-			}
+    /**
+     * Defines the mutation output field configuration.
+     *
+     * @param \WP_Post_Type $post_type_object   The post type of the mutation.
+     *
+     * @return array
+     */
+    public static function get_output_fields( $post_type_object ) {
+        return [
+            $post_type_object->graphql_single_name => [
+                'type'    => $post_type_object->graphql_single_name,
+                'resolve' => function ( $payload ) use ( $post_type_object ) {
+                    return DataSource::resolve_post_object( $payload['postObjectId'], $post_type_object->name );
+                },
+            ],
+        ];
+    }
 
-			/**
-			 * @todo: When we support assigning terms and setting posts as "sticky" we need to check permissions
-			 * @see :https://github.com/WordPress/WordPress/blob/e357195ce303017d517aff944644a7a1232926f7/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L504-L506
-			 * @see : https://github.com/WordPress/WordPress/blob/e357195ce303017d517aff944644a7a1232926f7/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L496-L498
-			 */
+    /**
+     * Defines the mutation data modification closure.
+     *
+     * @param \WP_Post_Type $post_type_object   The post type of the mutation.
+     * @param string        $mutation_name      The mutation name.
+     *
+     * @return callable
+     */
+    public static function mutate_and_get_payload( $post_type_object, $mutation_name ) {
+        return function ( $input, AppContext $context, ResolveInfo $info ) use ( $post_type_object, $mutation_name ) {
 
-			/**
-			 * insert the post object and get the ID
-			 */
-			$post_args = PostObjectMutation::prepare_post_object( $input, $post_type_object, $mutation_name );
+            /**
+             * Throw an exception if there's no input
+             */
+            if ( ( empty( $post_type_object->name ) ) || ( empty( $input ) || ! is_array( $input ) ) ) {
+                throw new UserError( __( 'Mutation not processed. There was no input for the mutation or the post_type_object was invalid', 'wp-graphql' ) );
+            }
 
-			/**
-			 * Filter the default post status to use when the post is initially created. Pass through a filter to
-			 * allow other plugins to override the default (for example, Edit Flow, which provides control over
-			 * customizing stati or various E-commerce plugins that make heavy use of custom stati)
-			 *
-			 * @param string        $default_status   The default status to be used when the post is initially inserted
-			 * @param \WP_Post_Type $post_type_object The Post Type that is being inserted
-			 * @param string        $mutation_name    The name of the mutation currently in progress
-			 */
-			$default_post_status = apply_filters( 'graphql_post_object_create_default_post_status', 'draft', $post_type_object, $mutation_name );
+            /**
+             * Stop now if a user isn't allowed to create a post
+             */
+            if ( ! current_user_can( $post_type_object->cap->create_posts ) ) {
+                // translators: the $post_type_object->graphql_plural_name placeholder is the name of the object being mutated
+                throw new UserError( sprintf( __( 'Sorry, you are not allowed to create %1$s', 'wp-graphql' ), $post_type_object->graphql_plural_name ) );
+            }
 
-			/**
-			 * We want to cache the "post_status" and set the status later. We will set the initial status
-			 * of the inserted post as the default status for the site, allow side effects to process with the
-			 * inserted post (set term object connections, set meta input, sideload images if necessary, etc)
-			 * Then will follow up with setting the status as what it was declared to be later
-			 */
-			$intended_post_status = ! empty( $post_args['post_status'] ) ? $post_args['post_status'] : $default_post_status;
+            /**
+             * If the post being created is being assigned to another user that's not the current user, make sure
+             * the current user has permission to edit others posts for this post_type
+             */
+            if ( ! empty( $input['authorId'] ) && get_current_user_id() !== $input['authorId'] && ! current_user_can( $post_type_object->cap->edit_others_posts ) ) {
+                // translators: the $post_type_object->graphql_plural_name placeholder is the name of the object being mutated
+                throw new UserError( sprintf( __( 'Sorry, you are not allowed to create %1$s as this user', 'wp-graphql' ), $post_type_object->graphql_plural_name ) );
+            }
 
-			/**
-			 * Set the post_status as the default for the initial insert. The intended $post_status will be set after
-			 * side effects are complete.
-			 */
-			$post_args['post_status'] = $default_post_status;
+            /**
+             * @todo: When we support assigning terms and setting posts as "sticky" we need to check permissions
+             * @see :https://github.com/WordPress/WordPress/blob/e357195ce303017d517aff944644a7a1232926f7/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L504-L506
+             * @see : https://github.com/WordPress/WordPress/blob/e357195ce303017d517aff944644a7a1232926f7/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L496-L498
+             */
 
-			/**
-			 * Insert the post and retrieve the ID
-			 */
-			$post_id = wp_insert_post( wp_slash( (array) $post_args ), true );
+            /**
+             * insert the post object and get the ID
+             */
+            $post_args = PostObjectMutation::prepare_post_object( $input, $post_type_object, $mutation_name );
 
-			/**
-			 * Throw an exception if the post failed to create
-			 */
-			if ( is_wp_error( $post_id ) ) {
-				$error_message = $post_id->get_error_message();
-				if ( ! empty( $error_message ) ) {
-					throw new UserError( esc_html( $error_message ) );
-				} else {
-					throw new UserError( __( 'The object failed to create but no error was provided', 'wp-graphql' ) );
-				}
-			}
+            /**
+             * Filter the default post status to use when the post is initially created. Pass through a filter to
+             * allow other plugins to override the default (for example, Edit Flow, which provides control over
+             * customizing stati or various E-commerce plugins that make heavy use of custom stati)
+             *
+             * @param string        $default_status   The default status to be used when the post is initially inserted
+             * @param \WP_Post_Type $post_type_object The Post Type that is being inserted
+             * @param string        $mutation_name    The name of the mutation currently in progress
+             */
+            $default_post_status = apply_filters( 'graphql_post_object_create_default_post_status', 'draft', $post_type_object, $mutation_name );
 
-			/**
-			 * If the $post_id is empty, we should throw an exception
-			 */
-			if ( empty( $post_id ) ) {
-				throw new UserError( __( 'The object failed to create', 'wp-graphql' ) );
-			}
+            /**
+             * We want to cache the "post_status" and set the status later. We will set the initial status
+             * of the inserted post as the default status for the site, allow side effects to process with the
+             * inserted post (set term object connections, set meta input, sideload images if necessary, etc)
+             * Then will follow up with setting the status as what it was declared to be later
+             */
+            $intended_post_status = ! empty( $post_args['post_status'] ) ? $post_args['post_status'] : $default_post_status;
 
-			/**
-			 * This updates additional data not part of the posts table (postmeta, terms, other relations, etc)
-			 *
-			 * The input for the postObjectMutation will be passed, along with the $new_post_id for the
-			 * postObject that was created so that relations can be set, meta can be updated, etc.
-			 */
-			PostObjectMutation::update_additional_post_object_data( $post_id, $input, $post_type_object, $mutation_name, $context, $info, $default_post_status, $intended_post_status );
+            /**
+             * Set the post_status as the default for the initial insert. The intended $post_status will be set after
+             * side effects are complete.
+             */
+            $post_args['post_status'] = $default_post_status;
 
-			/**
-			 * Determine whether the intended status should be set or not.
-			 *
-			 * By filtering to false, the $intended_post_status will not be set at the completion of the mutation.
-			 *
-			 * This allows for side-effect actions to set the status later. For example, if a post
-			 * was being created via a GraphQL Mutation, the post had additional required assets, such as images
-			 * that needed to be sideloaded or some other semi-time-consuming side effect, those actions could
-			 * be deferred (cron or whatever), and when those actions complete they could come back and set
-			 * the $intended_status.
-			 *
-			 * @param boolean       $should_set_intended_status Whether to set the intended post_status or not. Default true.
-			 * @param \WP_Post_Type $post_type_object           The Post Type Object for the post being mutated
-			 * @param string        $mutation_name              The name of the mutation currently in progress
-			 * @param AppContext    $context                    The AppContext passed down to all resolvers
-			 * @param ResolveInfo   $info                       The ResolveInfo passed down to all resolvers
-			 * @param string        $intended_post_status       The intended post_status the post should have according to the mutation input
-			 * @param string        $default_post_status        The default status posts should use if an intended status wasn't set
-			 */
-			$should_set_intended_status = apply_filters( 'graphql_post_object_create_should_set_intended_post_status', true, $post_type_object, $mutation_name, $context, $info, $intended_post_status, $default_post_status );
+            /**
+             * Insert the post and retrieve the ID
+             */
+            $post_id = wp_insert_post( wp_slash( (array) $post_args ), true );
 
-			/**
-			 * If the intended post status and the default post status are not the same,
-			 * update the post with the intended status now that side effects are complete.
-			 */
-			if ( $intended_post_status !== $default_post_status && true === $should_set_intended_status ) {
+            /**
+             * Throw an exception if the post failed to create
+             */
+            if ( is_wp_error( $post_id ) ) {
+                $error_message = $post_id->get_error_message();
+                if ( ! empty( $error_message ) ) {
+                    throw new UserError( esc_html( $error_message ) );
+                } else {
+                    throw new UserError( __( 'The object failed to create but no error was provided', 'wp-graphql' ) );
+                }
+            }
 
-				/**
-				 * If the post was deleted by a side effect action before getting here,
-				 * don't proceed.
-				 */
-				if ( ! $new_post = get_post( $post_id ) ) {
-					throw new UserError( sprintf( __( 'The status of the post could not be set', 'wp-graphql' ) ) );
-				}
+            /**
+             * If the $post_id is empty, we should throw an exception
+             */
+            if ( empty( $post_id ) ) {
+                throw new UserError( __( 'The object failed to create', 'wp-graphql' ) );
+            }
 
-				/**
-				 * If the $intended_post_status is different than the current status of the post
-				 * proceed and update the status.
-				 */
-				if ( $intended_post_status !== $new_post->post_status ) {
-					$update_args = [
-						'ID'          => $post_id,
-						'post_status' => $intended_post_status,
-						// Prevent the post_date from being reset if the date was included in the create post $args
-						// see: https://core.trac.wordpress.org/browser/tags/4.9/src/wp-includes/post.php#L3637
-						'edit_date'   => ! empty( $post_args['post_date'] ) ? $post_args['post_date'] : false,
-					];
+            /**
+             * This updates additional data not part of the posts table (postmeta, terms, other relations, etc)
+             *
+             * The input for the postObjectMutation will be passed, along with the $new_post_id for the
+             * postObject that was created so that relations can be set, meta can be updated, etc.
+             */
+            PostObjectMutation::update_additional_post_object_data( $post_id, $input, $post_type_object, $mutation_name, $context, $info, $default_post_status, $intended_post_status );
 
-					wp_update_post( $update_args );
-				}
+            /**
+             * Determine whether the intended status should be set or not.
+             *
+             * By filtering to false, the $intended_post_status will not be set at the completion of the mutation.
+             *
+             * This allows for side-effect actions to set the status later. For example, if a post
+             * was being created via a GraphQL Mutation, the post had additional required assets, such as images
+             * that needed to be sideloaded or some other semi-time-consuming side effect, those actions could
+             * be deferred (cron or whatever), and when those actions complete they could come back and set
+             * the $intended_status.
+             *
+             * @param boolean       $should_set_intended_status Whether to set the intended post_status or not. Default true.
+             * @param \WP_Post_Type $post_type_object           The Post Type Object for the post being mutated
+             * @param string        $mutation_name              The name of the mutation currently in progress
+             * @param AppContext    $context                    The AppContext passed down to all resolvers
+             * @param ResolveInfo   $info                       The ResolveInfo passed down to all resolvers
+             * @param string        $intended_post_status       The intended post_status the post should have according to the mutation input
+             * @param string        $default_post_status        The default status posts should use if an intended status wasn't set
+             */
+            $should_set_intended_status = apply_filters( 'graphql_post_object_create_should_set_intended_post_status', true, $post_type_object, $mutation_name, $context, $info, $intended_post_status, $default_post_status );
 
-			}
+            /**
+             * If the intended post status and the default post status are not the same,
+             * update the post with the intended status now that side effects are complete.
+             */
+            if ( $intended_post_status !== $default_post_status && true === $should_set_intended_status ) {
 
-			/**
-			 * Return the post object
-			 */
-			return [
-				'postObjectId' => $post_id,
-			];
-		};
-	}
+                /**
+                 * If the post was deleted by a side effect action before getting here,
+                 * don't proceed.
+                 */
+                if ( ! $new_post = get_post( $post_id ) ) {
+                    throw new UserError( sprintf( __( 'The status of the post could not be set', 'wp-graphql' ) ) );
+                }
+
+                /**
+                 * If the $intended_post_status is different than the current status of the post
+                 * proceed and update the status.
+                 */
+                if ( $intended_post_status !== $new_post->post_status ) {
+                    $update_args = [
+                        'ID'          => $post_id,
+                        'post_status' => $intended_post_status,
+                        // Prevent the post_date from being reset if the date was included in the create post $args
+                        // see: https://core.trac.wordpress.org/browser/tags/4.9/src/wp-includes/post.php#L3637
+                        'edit_date'   => ! empty( $post_args['post_date'] ) ? $post_args['post_date'] : false,
+                    ];
+
+                    wp_update_post( $update_args );
+                }
+
+            }
+
+            /**
+             * Return the post object
+             */
+            return [
+                'postObjectId' => $post_id,
+            ];
+        };
+    }
 }

--- a/src/Mutation/PostObjectDelete.php
+++ b/src/Mutation/PostObjectDelete.php
@@ -23,10 +23,8 @@ class PostObjectDelete {
 				'type'        => [
 					'non_null' => 'ID',
 				],
-				'forceDelete' => [
-					'type'        => 'Boolean',
-					'description' => __( 'Whether the object should be force deleted instead of being moved to the trash', 'wp-graphql' ),
-				],
+				// translators: The placeholder is the name of the post's post_type being deleted
+				'description' => sprintf( __( 'The ID of the %1$s to delete', 'wp-graphql' ), $post_type_object->graphql_single_name ),
 			],
 			'forceDelete' => [
 				'type'        => 'Boolean',
@@ -46,7 +44,11 @@ class PostObjectDelete {
 					return ! empty( $deleted->ID ) ? Relay::toGlobalId( $post_type_object->name, absint( $deleted->ID ) ) : null;
 				},
 			],
-			'mutateAndGetPayload' => function ( $input ) use ( $post_type_object, $mutation_name ) {
+			$post_type_object->graphql_single_name => [
+				'type'        => $post_type_object->graphql_single_name,
+				'description' => __( 'The object before it was deleted', 'wp-graphql' ),
+				'resolve'     => function ( $payload ) use ( $post_type_object ) {
+					$deleted = (object) $payload['postObject'];
 
 					return ! empty( $deleted ) ? $deleted : null;
 				},
@@ -57,33 +59,51 @@ class PostObjectDelete {
 	public static function mutate_and_get_payload( $post_type_object, $mutation_name ) {
 		return function ( $input ) use ( $post_type_object, $mutation_name ) {
 
-				/**
-				 * Get the post object before deleting it
-				 */
-				$post_before_delete = get_post( absint( $id_parts['id'] ) );
-				$post_before_delete = isset( $post_before_delete->ID ) && isset( $post_before_delete->post_type ) ? DataSource::resolve_post_object( $post_before_delete->ID, $post_before_delete->post_type ) : $post_before_delete;
+			/**
+			* Get the ID from the global ID
+			*/
+			$id_parts = Relay::fromGlobalId( $input['id'] );
+
+			/**
+			* Stop now if a user isn't allowed to delete a post
+			*/
+			if ( ! current_user_can( $post_type_object->cap->delete_post, absint( $id_parts['id'] ) ) ) {
+				// translators: the $post_type_object->graphql_plural_name placeholder is the name of the object being mutated
+				throw new UserError( sprintf( __( 'Sorry, you are not allowed to delete %1$s', 'wp-graphql' ), $post_type_object->graphql_plural_name ) );
+			}
+
+			/**
+			* Check if we should force delete or not
+			*/
+			$force_delete = ( ! empty( $input['forceDelete'] ) && true === $input['forceDelete'] ) ? true : false;
+
+			/**
+			* Get the post object before deleting it
+			*/
+			$post_before_delete = get_post( absint( $id_parts['id'] ) );
+			$post_before_delete = isset( $post_before_delete->ID ) && isset( $post_before_delete->post_type ) ? DataSource::resolve_post_object( $post_before_delete->ID, $post_before_delete->post_type ) : $post_before_delete;
 
 
-				/**
-				 * If the post is already in the trash, and the forceDelete input was not passed,
-				 * don't remove from the trash
-				 */
-				if ( 'trash' === $post_before_delete->post_status ) {
-					if ( true !== $force_delete ) {
-						// Translators: the first placeholder is the post_type of the object being deleted and the second placeholder is the unique ID of that object
-						throw new UserError( sprintf( __( 'The %1$s with id %2$s is already in the trash. To remove from the trash, use the forceDelete input', 'wp-graphql' ), $post_type_object->graphql_single_name, $input['id'] ) );
-					}
+			/**
+			* If the post is already in the trash, and the forceDelete input was not passed,
+			* don't remove from the trash
+			*/
+			if ( 'trash' === $post_before_delete->post_status ) {
+				if ( true !== $force_delete ) {
+					// Translators: the first placeholder is the post_type of the object being deleted and the second placeholder is the unique ID of that object
+					throw new UserError( sprintf( __( 'The %1$s with id %2$s is already in the trash. To remove from the trash, use the forceDelete input', 'wp-graphql' ), $post_type_object->graphql_single_name, $input['id'] ) );
 				}
+			}
 
-				/**
-				 * Delete the post
-				 */
-				$deleted = wp_delete_post( $id_parts['id'], $force_delete );
+			/**
+			* Delete the post
+			*/
+			$deleted = wp_delete_post( $id_parts['id'], $force_delete );
 
-				/**
-				 * If the post was moved to the trash, spoof the object's status before returning it
-				 */
-				$post_before_delete->post_status = ( false !== $deleted && true !== $force_delete ) ? 'trash' : $post_before_delete->post_status;
+			/**
+			* If the post was moved to the trash, spoof the object's status before returning it
+			*/
+			$post_before_delete->post_status = ( false !== $deleted && true !== $force_delete ) ? 'trash' : $post_before_delete->post_status;
 
 			/**
 			* Return the deletedId and the object before it was deleted

--- a/src/Mutation/PostObjectDelete.php
+++ b/src/Mutation/PostObjectDelete.php
@@ -7,110 +7,137 @@ use GraphQLRelay\Relay;
 use WPGraphQL\Data\DataSource;
 
 class PostObjectDelete {
-	public static function register_mutation( \WP_Post_Type $post_type_object ) {
-		$mutation_name = 'delete' . ucwords( $post_type_object->graphql_single_name );
+    /**
+     * Registers the PostObjectDelete mutation.
+     *
+     * @param \WP_Post_Type $post_type_object   The post type of the mutation.
+     */
+    public static function register_mutation( \WP_Post_Type $post_type_object ) {
+        $mutation_name = 'delete' . ucwords( $post_type_object->graphql_single_name );
 
-		register_graphql_mutation( $mutation_name, [
-			'inputFields'         => self::get_input_fields( $post_type_object ),
-			'outputFields'        => self::get_output_fields( $post_type_object ),
-			'mutateAndGetPayload' => self::mutate_and_get_payload( $post_type_object, $mutation_name ),
-		] );
-	}
+        register_graphql_mutation( $mutation_name, [
+            'inputFields'         => self::get_input_fields( $post_type_object ),
+            'outputFields'        => self::get_output_fields( $post_type_object ),
+            'mutateAndGetPayload' => self::mutate_and_get_payload( $post_type_object, $mutation_name ),
+        ] );
+    }
 
-	public static function get_input_fields( $post_type_object ) {
-		return [
-			'id'          => [
-				'type'        => [
-					'non_null' => 'ID',
-				],
-				// translators: The placeholder is the name of the post's post_type being deleted
-				'description' => sprintf( __( 'The ID of the %1$s to delete', 'wp-graphql' ), $post_type_object->graphql_single_name ),
-			],
-			'forceDelete' => [
-				'type'        => 'Boolean',
-				'description' => __( 'Whether the object should be force deleted instead of being moved to the trash', 'wp-graphql' ),
-			],
-		];
-	}
+    /**
+     * Defines the mutation input field configuration.
+     *
+     * @param \WP_Post_Type $post_type_object   The post type of the mutation.
+     *
+     * @return array
+     */
+    public static function get_input_fields( $post_type_object ) {
+        return [
+            'id'          => [
+                'type'        => [
+                    'non_null' => 'ID',
+                ],
+                // translators: The placeholder is the name of the post's post_type being deleted
+                'description' => sprintf( __( 'The ID of the %1$s to delete', 'wp-graphql' ), $post_type_object->graphql_single_name ),
+            ],
+            'forceDelete' => [
+                'type'        => 'Boolean',
+                'description' => __( 'Whether the object should be force deleted instead of being moved to the trash', 'wp-graphql' ),
+            ],
+        ];
+    }
 
-	public static function get_output_fields( $post_type_object ) {
-		return [
-			'deletedId'                            => [
-				'type'        => 'Id',
-				'description' => __( 'The ID of the deleted object', 'wp-graphql' ),
-				'resolve'     => function ( $payload ) use ( $post_type_object ) {
-					$deleted = (object) $payload['postObject'];
+    /**
+     * Defines the mutation output field configuration.
+     *
+     * @param \WP_Post_Type $post_type_object   The post type of the mutation.
+     *
+     * @return array
+     */
+    public static function get_output_fields( $post_type_object ) {
+        return [
+            'deletedId'                            => [
+                'type'        => 'Id',
+                'description' => __( 'The ID of the deleted object', 'wp-graphql' ),
+                'resolve'     => function ( $payload ) use ( $post_type_object ) {
+                    $deleted = (object) $payload['postObject'];
 
-					return ! empty( $deleted->ID ) ? Relay::toGlobalId( $post_type_object->name, absint( $deleted->ID ) ) : null;
-				},
-			],
-			$post_type_object->graphql_single_name => [
-				'type'        => $post_type_object->graphql_single_name,
-				'description' => __( 'The object before it was deleted', 'wp-graphql' ),
-				'resolve'     => function ( $payload ) use ( $post_type_object ) {
-					$deleted = (object) $payload['postObject'];
+                    return ! empty( $deleted->ID ) ? Relay::toGlobalId( $post_type_object->name, absint( $deleted->ID ) ) : null;
+                },
+            ],
+            $post_type_object->graphql_single_name => [
+                'type'        => $post_type_object->graphql_single_name,
+                'description' => __( 'The object before it was deleted', 'wp-graphql' ),
+                'resolve'     => function ( $payload ) use ( $post_type_object ) {
+                    $deleted = (object) $payload['postObject'];
 
-					return ! empty( $deleted ) ? $deleted : null;
-				},
-			],
-		];
-	}
+                    return ! empty( $deleted ) ? $deleted : null;
+                },
+            ],
+        ];
+    }
 
-	public static function mutate_and_get_payload( $post_type_object, $mutation_name ) {
-		return function ( $input ) use ( $post_type_object, $mutation_name ) {
+    /**
+     * Defines the mutation data modification closure.
+     *
+     * @param \WP_Post_Type $post_type_object   The post type of the mutation.
+     * @param string        $mutation_name      The mutation name.
+     *
+     * @return callable
+     */
+    public static function mutate_and_get_payload( $post_type_object, $mutation_name ) {
+        return function ( $input ) use ( $post_type_object, $mutation_name ) {
 
-			/**
-			* Get the ID from the global ID
-			*/
-			$id_parts = Relay::fromGlobalId( $input['id'] );
+            /**
+             * Get the ID from the global ID
+             */
+            $id_parts = Relay::fromGlobalId( $input['id'] );
 
-			/**
-			* Stop now if a user isn't allowed to delete a post
-			*/
-			if ( ! current_user_can( $post_type_object->cap->delete_post, absint( $id_parts['id'] ) ) ) {
-				// translators: the $post_type_object->graphql_plural_name placeholder is the name of the object being mutated
-				throw new UserError( sprintf( __( 'Sorry, you are not allowed to delete %1$s', 'wp-graphql' ), $post_type_object->graphql_plural_name ) );
-			}
+            /**
+             * Stop now if a user isn't allowed to delete a post
+             */
+            if ( ! current_user_can( $post_type_object->cap->delete_post, absint( $id_parts['id'] ) ) ) {
+                // translators: the $post_type_object->graphql_plural_name placeholder is the name of the object being mutated
+                throw new UserError( sprintf( __( 'Sorry, you are not allowed to delete %1$s', 'wp-graphql' ), $post_type_object->graphql_plural_name ) );
+            }
 
-			/**
-			* Check if we should force delete or not
-			*/
-			$force_delete = ( ! empty( $input['forceDelete'] ) && true === $input['forceDelete'] ) ? true : false;
+            /**
+             * Check if we should force delete or not
+             */
+            $force_delete = ( ! empty( $input['forceDelete'] ) && true === $input['forceDelete'] ) ? true : false;
 
-			/**
-			* Get the post object before deleting it
-			*/
-			$post_before_delete = get_post( absint( $id_parts['id'] ) );
-			$post_before_delete = isset( $post_before_delete->ID ) && isset( $post_before_delete->post_type ) ? DataSource::resolve_post_object( $post_before_delete->ID, $post_before_delete->post_type ) : $post_before_delete;
+            /**
+             * Get the post object before deleting it
+             */
+            $post_before_delete = get_post( absint( $id_parts['id'] ) );
+            $post_before_delete = isset( $post_before_delete->ID ) && isset( $post_before_delete->post_type ) ? DataSource::resolve_post_object( $post_before_delete->ID, $post_before_delete->post_type ) : $post_before_delete;
 
 
-			/**
-			* If the post is already in the trash, and the forceDelete input was not passed,
-			* don't remove from the trash
-			*/
-			if ( 'trash' === $post_before_delete->post_status ) {
-				if ( true !== $force_delete ) {
-					// Translators: the first placeholder is the post_type of the object being deleted and the second placeholder is the unique ID of that object
-					throw new UserError( sprintf( __( 'The %1$s with id %2$s is already in the trash. To remove from the trash, use the forceDelete input', 'wp-graphql' ), $post_type_object->graphql_single_name, $input['id'] ) );
-				}
-			}
+            /**
+             * If the post is already in the trash, and the forceDelete input was not passed,
+             * don't remove from the trash
+             */
+            if ( 'trash' === $post_before_delete->post_status ) {
+                if ( true !== $force_delete ) {
+                    // Translators: the first placeholder is the post_type of the object being deleted and the second placeholder is the unique ID of that object
+                    throw new UserError( sprintf( __( 'The %1$s with id %2$s is already in the trash. To remove from the trash, use the forceDelete input', 'wp-graphql' ), $post_type_object->graphql_single_name, $input['id'] ) );
+                }
+            }
 
-			/**
-			* Delete the post
-			*/
-			$deleted = wp_delete_post( $id_parts['id'], $force_delete );
+            /**
+             * Delete the post
+             */
+            $deleted = wp_delete_post( $id_parts['id'], $force_delete );
 
-			/**
-			* If the post was moved to the trash, spoof the object's status before returning it
-			*/
-			$post_before_delete->post_status = ( false !== $deleted && true !== $force_delete ) ? 'trash' : $post_before_delete->post_status;
+            /**
+             * If the post was moved to the trash, spoof the object's status before returning it
+             */
+            $post_before_delete->post_status = ( false !== $deleted && true !== $force_delete ) ? 'trash' : $post_before_delete->post_status;
 
-			/**
-			* Return the deletedId and the object before it was deleted
-			*/
-			return [
-				'postObject' => $post_before_delete,
-			];
-		};
-	}
+            /**
+             * Return the deletedId and the object before it was deleted
+             */
+            return [
+                'postObject' => $post_before_delete,
+            ];
+        };
+    }
 }

--- a/src/Mutation/PostObjectUpdate.php
+++ b/src/Mutation/PostObjectUpdate.php
@@ -27,14 +27,8 @@ class PostObjectUpdate {
 					'type'        => [
 						'non_null' => 'ID',
 					],
-				]
-			),
-			'outputFields'        => [
-				$post_type_object->graphql_single_name => [
-					'type'    => $post_type_object->graphql_single_name,
-					'resolve' => function ( $payload ) use ( $post_type_object ) {
-						return DataSource::resolve_post_object( $payload['postObjectId'], $post_type_object->name );
-					},
+					// translators: the placeholder is the name of the type of post object being updated
+					'description' => sprintf( __( 'The ID of the %1$s object', 'wp-graphql' ), $post_type_object->graphql_single_name ),
 				],
 			]
 			);
@@ -47,54 +41,49 @@ class PostObjectUpdate {
 	public static function mutate_and_get_payload( $post_type_object, $mutation_name ) {
 		return function ( $input, AppContext $context, ResolveInfo $info ) use ( $post_type_object, $mutation_name ) {
 
-				/**
-				 * @todo: when we add support for assigning terms to posts, we should check permissions to make sure they can assign terms
-				 * @see : https://github.com/WordPress/WordPress/blob/e357195ce303017d517aff944644a7a1232926f7/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L644-L646
-				 */
+			$id_parts      = ! empty( $input['id'] ) ? Relay::fromGlobalId( $input['id'] ) : null;
+			$existing_post = get_post( absint( $id_parts['id'] ) );
 
-				/**
-				 * insert the post object and get the ID
-				 */
-				$post_args       = PostObjectMutation::prepare_post_object( $input, $post_type_object, $mutation_name );
-				$post_args['ID'] = absint( $id_parts['id'] );
+			/**
+			 * If there's no existing post, throw an exception
+			 */
+			if ( empty( $id_parts['id'] ) || false === $existing_post || $id_parts['type'] !== $post_type_object->name ) {
+				// translators: the placeholder is the name of the type of post being updated
+				throw new UserError( sprintf( __( 'No %1$s could be found to update', 'wp-graphql' ), $post_type_object->graphql_single_name ) );
+			}
 
-				/**
-				 * Insert the post and retrieve the ID
-				 */
-				$post_id = wp_update_post( wp_slash( (array) $post_args ), true );
+			if ( $post_type_object->name !== $existing_post->post_type ) {
+				// translators: The first placeholder is an ID and the second placeholder is the name of the post type being edited
+				throw new UserError( sprintf( __( 'The id %1$d is not of the type "%2$s"', 'wp-graphql' ), $id_parts['id'], $post_type_object->name ) );
+			}
 
-				/**
-				 * Throw an exception if the post failed to update
-				 */
-				if ( is_wp_error( $post_id ) ) {
-					throw new UserError( __( 'The object failed to update but no error was provided', 'wp-graphql' ) );
-				}
+			/**
+			 * Stop now if a user isn't allowed to edit posts
+			 */
+			if ( ! current_user_can( $post_type_object->cap->edit_posts ) ) {
+				// translators: the $post_type_object->graphql_single_name placeholder is the name of the object being mutated
+				throw new UserError( sprintf( __( 'Sorry, you are not allowed to update a %1$s', 'wp-graphql' ), $post_type_object->graphql_single_name ) );
+			}
 
-				/**
-				 * Fires after a single term is created or updated via a GraphQL mutation
-				 *
-				 * The dynamic portion of the hook name, `$taxonomy->name` refers to the taxonomy of the term being mutated
-				 *
-				 * @param int    $post_id       Inserted post ID
-				 * @param array  $args          The args used to insert the term
-				 * @param string $mutation_name The name of the mutation being performed
-				 */
-				do_action( "graphql_insert_{$post_type_object->name}", $post_id, $post_args, $mutation_name );
+			/**
+			 * If the mutation is setting the author to be someone other than the user making the request
+			 * make sure they have permission to edit others posts
+			 */
+			$author_id_parts = ! empty( $input['authorId'] ) ? Relay::fromGlobalId( $input['authorId'] ) : null;
+			if ( ! empty( $author_id_parts['id'] ) && get_current_user_id() !== $author_id_parts['id'] && ! current_user_can( $post_type_object->cap->edit_others_posts ) ) {
+				// translators: the $post_type_object->graphql_single_name placeholder is the name of the object being mutated
+				throw new UserError( sprintf( __( 'Sorry, you are not allowed to update %1$s as this user.', 'wp-graphql' ), $post_type_object->graphql_plural_name ) );
+			}
 
-				/**
-				 * This updates additional data not part of the posts table (postmeta, terms, other relations, etc)
-				 *
-				 * The input for the postObjectMutation will be passed, along with the $new_post_id for the
-				 * postObject that was updated so that relations can be set, meta can be updated, etc.
-				 */
-				PostObjectMutation::update_additional_post_object_data( $post_id, $input, $post_type_object, $mutation_name, $context, $info );
+			/**
+			 * @todo: when we add support for making posts sticky, we should check permissions to make sure users can make posts sticky
+			 * @see : https://github.com/WordPress/WordPress/blob/e357195ce303017d517aff944644a7a1232926f7/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L640-L642
+			 */
 
-				/**
-				 * Return the payload
-				 */
-				return [
-					'postObjectId' => $post_id,
-				];
+			/**
+			 * @todo: when we add support for assigning terms to posts, we should check permissions to make sure they can assign terms
+			 * @see : https://github.com/WordPress/WordPress/blob/e357195ce303017d517aff944644a7a1232926f7/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L644-L646
+			 */
 
 			/**
 			 * insert the post object and get the ID

--- a/src/Mutation/PostObjectUpdate.php
+++ b/src/Mutation/PostObjectUpdate.php
@@ -9,125 +9,152 @@ use WPGraphQL\Data\DataSource;
 use WPGraphQL\Data\PostObjectMutation;
 
 class PostObjectUpdate {
-	public static function register_mutation( \WP_Post_Type $post_type_object ) {
-		$mutation_name = 'update' . ucwords( $post_type_object->graphql_single_name );
+    /**
+     * Registers the PostObjectUpdate mutation.
+     *
+     * @param \WP_Post_Type $post_type_object   The post type of the mutation.
+     */
+    public static function register_mutation( \WP_Post_Type $post_type_object ) {
+        $mutation_name = 'update' . ucwords( $post_type_object->graphql_single_name );
 
-		register_graphql_mutation( $mutation_name, [
-			'inputFields'         => self::get_input_fields( $post_type_object ),
-			'outputFields'        => self::get_output_fields( $post_type_object ),
-			'mutateAndGetPayload' => self::mutate_and_get_payload( $post_type_object, $mutation_name ),
-		] );
-	}
+        register_graphql_mutation( $mutation_name, [
+            'inputFields'         => self::get_input_fields( $post_type_object ),
+            'outputFields'        => self::get_output_fields( $post_type_object ),
+            'mutateAndGetPayload' => self::mutate_and_get_payload( $post_type_object, $mutation_name ),
+        ] );
+    }
 
-	public static function get_input_fields( $post_type_object ) {
-		return array_merge(
-			PostObjectCreate::get_input_fields( $post_type_object ),
-			[
-				'id' => [
-					'type'        => [
-						'non_null' => 'ID',
-					],
-					// translators: the placeholder is the name of the type of post object being updated
-					'description' => sprintf( __( 'The ID of the %1$s object', 'wp-graphql' ), $post_type_object->graphql_single_name ),
-				],
-			]
-		);
-	}
+    /**
+     * Defines the mutation input field configuration.
+     *
+     * @param \WP_Post_Type $post_type_object   The post type of the mutation.
+     *
+     * @return array
+     */
+    public static function get_input_fields( $post_type_object ) {
+        return array_merge(
+            PostObjectCreate::get_input_fields( $post_type_object ),
+            [
+                'id' => [
+                    'type'        => [
+                        'non_null' => 'ID',
+                    ],
+                    // translators: the placeholder is the name of the type of post object being updated
+                    'description' => sprintf( __( 'The ID of the %1$s object', 'wp-graphql' ), $post_type_object->graphql_single_name ),
+                ],
+            ]
+        );
+    }
 
-	public static function get_output_fields( $post_type_object ) {
-		return PostObjectCreate::get_output_fields( $post_type_object );
-	}
+    /**
+     * Defines the mutation output field configuration.
+     *
+     * @param \WP_Post_Type $post_type_object   The post type of the mutation.
+     *
+     * @return array
+     */
+    public static function get_output_fields( $post_type_object ) {
+        return PostObjectCreate::get_output_fields( $post_type_object );
+    }
 
-	public static function mutate_and_get_payload( $post_type_object, $mutation_name ) {
-		return function ( $input, AppContext $context, ResolveInfo $info ) use ( $post_type_object, $mutation_name ) {
+    /**
+     * Defines the mutation data modification closure.
+     *
+     * @param \WP_Post_Type $post_type_object   The post type of the mutation.
+     * @param string        $mutation_name      The mutation name.
+     *
+     * @return callable
+     */
+    public static function mutate_and_get_payload( $post_type_object, $mutation_name ) {
+        return function ( $input, AppContext $context, ResolveInfo $info ) use ( $post_type_object, $mutation_name ) {
 
-			$id_parts      = ! empty( $input['id'] ) ? Relay::fromGlobalId( $input['id'] ) : null;
-			$existing_post = get_post( absint( $id_parts['id'] ) );
+            $id_parts      = ! empty( $input['id'] ) ? Relay::fromGlobalId( $input['id'] ) : null;
+            $existing_post = get_post( absint( $id_parts['id'] ) );
 
-			/**
-			 * If there's no existing post, throw an exception
-			 */
-			if ( empty( $id_parts['id'] ) || false === $existing_post || $id_parts['type'] !== $post_type_object->name ) {
-				// translators: the placeholder is the name of the type of post being updated
-				throw new UserError( sprintf( __( 'No %1$s could be found to update', 'wp-graphql' ), $post_type_object->graphql_single_name ) );
-			}
+            /**
+             * If there's no existing post, throw an exception
+             */
+            if ( empty( $id_parts['id'] ) || false === $existing_post || $id_parts['type'] !== $post_type_object->name ) {
+                // translators: the placeholder is the name of the type of post being updated
+                throw new UserError( sprintf( __( 'No %1$s could be found to update', 'wp-graphql' ), $post_type_object->graphql_single_name ) );
+            }
 
-			if ( $post_type_object->name !== $existing_post->post_type ) {
-				// translators: The first placeholder is an ID and the second placeholder is the name of the post type being edited
-				throw new UserError( sprintf( __( 'The id %1$d is not of the type "%2$s"', 'wp-graphql' ), $id_parts['id'], $post_type_object->name ) );
-			}
+            if ( $post_type_object->name !== $existing_post->post_type ) {
+                // translators: The first placeholder is an ID and the second placeholder is the name of the post type being edited
+                throw new UserError( sprintf( __( 'The id %1$d is not of the type "%2$s"', 'wp-graphql' ), $id_parts['id'], $post_type_object->name ) );
+            }
 
-			/**
-			 * Stop now if a user isn't allowed to edit posts
-			 */
-			if ( ! current_user_can( $post_type_object->cap->edit_posts ) ) {
-				// translators: the $post_type_object->graphql_single_name placeholder is the name of the object being mutated
-				throw new UserError( sprintf( __( 'Sorry, you are not allowed to update a %1$s', 'wp-graphql' ), $post_type_object->graphql_single_name ) );
-			}
+            /**
+             * Stop now if a user isn't allowed to edit posts
+             */
+            if ( ! current_user_can( $post_type_object->cap->edit_posts ) ) {
+                // translators: the $post_type_object->graphql_single_name placeholder is the name of the object being mutated
+                throw new UserError( sprintf( __( 'Sorry, you are not allowed to update a %1$s', 'wp-graphql' ), $post_type_object->graphql_single_name ) );
+            }
 
-			/**
-			 * If the mutation is setting the author to be someone other than the user making the request
-			 * make sure they have permission to edit others posts
-			 */
-			$author_id_parts = ! empty( $input['authorId'] ) ? Relay::fromGlobalId( $input['authorId'] ) : null;
-			if ( ! empty( $author_id_parts['id'] ) && get_current_user_id() !== $author_id_parts['id'] && ! current_user_can( $post_type_object->cap->edit_others_posts ) ) {
-				// translators: the $post_type_object->graphql_single_name placeholder is the name of the object being mutated
-				throw new UserError( sprintf( __( 'Sorry, you are not allowed to update %1$s as this user.', 'wp-graphql' ), $post_type_object->graphql_plural_name ) );
-			}
+            /**
+             * If the mutation is setting the author to be someone other than the user making the request
+             * make sure they have permission to edit others posts
+             */
+            $author_id_parts = ! empty( $input['authorId'] ) ? Relay::fromGlobalId( $input['authorId'] ) : null;
+            if ( ! empty( $author_id_parts['id'] ) && get_current_user_id() !== $author_id_parts['id'] && ! current_user_can( $post_type_object->cap->edit_others_posts ) ) {
+                // translators: the $post_type_object->graphql_single_name placeholder is the name of the object being mutated
+                throw new UserError( sprintf( __( 'Sorry, you are not allowed to update %1$s as this user.', 'wp-graphql' ), $post_type_object->graphql_plural_name ) );
+            }
 
-			/**
-			 * @todo: when we add support for making posts sticky, we should check permissions to make sure users can make posts sticky
-			 * @see : https://github.com/WordPress/WordPress/blob/e357195ce303017d517aff944644a7a1232926f7/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L640-L642
-			 */
+            /**
+             * @todo: when we add support for making posts sticky, we should check permissions to make sure users can make posts sticky
+             * @see : https://github.com/WordPress/WordPress/blob/e357195ce303017d517aff944644a7a1232926f7/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L640-L642
+             */
 
-			/**
-			 * @todo: when we add support for assigning terms to posts, we should check permissions to make sure they can assign terms
-			 * @see : https://github.com/WordPress/WordPress/blob/e357195ce303017d517aff944644a7a1232926f7/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L644-L646
-			 */
+            /**
+             * @todo: when we add support for assigning terms to posts, we should check permissions to make sure they can assign terms
+             * @see : https://github.com/WordPress/WordPress/blob/e357195ce303017d517aff944644a7a1232926f7/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L644-L646
+             */
 
-			/**
-			 * insert the post object and get the ID
-			 */
-			$post_args       = PostObjectMutation::prepare_post_object( $input, $post_type_object, $mutation_name );
-			$post_args['ID'] = absint( $id_parts['id'] );
+            /**
+             * insert the post object and get the ID
+             */
+            $post_args       = PostObjectMutation::prepare_post_object( $input, $post_type_object, $mutation_name );
+            $post_args['ID'] = absint( $id_parts['id'] );
 
-			/**
-			 * Insert the post and retrieve the ID
-			 */
-			$post_id = wp_update_post( wp_slash( (array) $post_args ), true );
+            /**
+             * Insert the post and retrieve the ID
+             */
+            $post_id = wp_update_post( wp_slash( (array) $post_args ), true );
 
-			/**
-			 * Throw an exception if the post failed to update
-			 */
-			if ( is_wp_error( $post_id ) ) {
-				throw new UserError( __( 'The object failed to update but no error was provided', 'wp-graphql' ) );
-			}
+            /**
+             * Throw an exception if the post failed to update
+             */
+            if ( is_wp_error( $post_id ) ) {
+                throw new UserError( __( 'The object failed to update but no error was provided', 'wp-graphql' ) );
+            }
 
-			/**
-			 * Fires after a single term is created or updated via a GraphQL mutation
-			 *
-			 * The dynamic portion of the hook name, `$taxonomy->name` refers to the taxonomy of the term being mutated
-			 *
-			 * @param int    $post_id       Inserted post ID
-			 * @param array  $args          The args used to insert the term
-			 * @param string $mutation_name The name of the mutation being performed
-			 */
-			do_action( "graphql_insert_{$post_type_object->name}", $post_id, $post_args, $mutation_name );
+            /**
+             * Fires after a single term is created or updated via a GraphQL mutation
+             *
+             * The dynamic portion of the hook name, `$taxonomy->name` refers to the taxonomy of the term being mutated
+             *
+             * @param int    $post_id       Inserted post ID
+             * @param array  $args          The args used to insert the term
+             * @param string $mutation_name The name of the mutation being performed
+             */
+            do_action( "graphql_insert_{$post_type_object->name}", $post_id, $post_args, $mutation_name );
 
-			/**
-			 * This updates additional data not part of the posts table (postmeta, terms, other relations, etc)
-			 *
-			 * The input for the postObjectMutation will be passed, along with the $new_post_id for the
-			 * postObject that was updated so that relations can be set, meta can be updated, etc.
-			 */
-			PostObjectMutation::update_additional_post_object_data( $post_id, $input, $post_type_object, $mutation_name, $context, $info );
+            /**
+             * This updates additional data not part of the posts table (postmeta, terms, other relations, etc)
+             *
+             * The input for the postObjectMutation will be passed, along with the $new_post_id for the
+             * postObject that was updated so that relations can be set, meta can be updated, etc.
+             */
+            PostObjectMutation::update_additional_post_object_data( $post_id, $input, $post_type_object, $mutation_name, $context, $info );
 
-			/**
-			 * Return the payload
-			 */
-			return [
-				'postObjectId' => $post_id,
-			];
-		};
-	}
+            /**
+             * Return the payload
+             */
+            return [
+                'postObjectId' => $post_id,
+            ];
+        };
+    }
 }

--- a/src/Mutation/PostObjectUpdate.php
+++ b/src/Mutation/PostObjectUpdate.php
@@ -10,19 +10,22 @@ use WPGraphQL\Data\PostObjectMutation;
 
 class PostObjectUpdate {
 	public static function register_mutation( \WP_Post_Type $post_type_object ) {
-
-		$mutation_name = 'Update' . ucwords( $post_type_object->graphql_single_name );
+		$mutation_name = 'update' . ucwords( $post_type_object->graphql_single_name );
 
 		register_graphql_mutation( $mutation_name, [
-			'inputFields'         => array_merge(
-				PostObjectCreate::get_input_fields( $post_type_object ),
-				[
-					'id' => [
-						'type'        => [
-							'non_null' => 'ID',
-						],
-						// translators: the placeholder is the name of the type of post object being updated
-						'description' => sprintf( __( 'The ID of the %1$s object', 'wp-graphql' ), $post_type_object->graphql_single_name ),
+			'inputFields'         => self::get_input_fields( $post_type_object ),
+			'outputFields'        => self::get_output_fields( $post_type_object ),
+			'mutateAndGetPayload' => self::mutate_and_get_payload( $post_type_object, $mutation_name ),
+		] );
+	}
+
+	public static function get_input_fields( $post_type_object ) {
+		return array_merge(
+			PostObjectCreate::get_input_fields( $post_type_object ),
+			[
+				'id' => [
+					'type'        => [
+						'non_null' => 'ID',
 					],
 				]
 			),
@@ -33,47 +36,16 @@ class PostObjectUpdate {
 						return DataSource::resolve_post_object( $payload['postObjectId'], $post_type_object->name );
 					},
 				],
-			],
-			'mutateAndGetPayload' => function ( $input, AppContext $context, ResolveInfo $info ) use ( $post_type_object, $mutation_name ) {
+			]
+			);
+	}
 
-				$id_parts      = ! empty( $input['id'] ) ? Relay::fromGlobalId( $input['id'] ) : null;
-				$existing_post = get_post( absint( $id_parts['id'] ) );
+	public static function get_output_fields( $post_type_object ) {
+		return PostObjectCreate::get_output_fields( $post_type_object );
+	}
 
-				/**
-				 * If there's no existing post, throw an exception
-				 */
-				if ( empty( $id_parts['id'] ) || false === $existing_post || $id_parts['type'] !== $post_type_object->name ) {
-					// translators: the placeholder is the name of the type of post being updated
-					throw new UserError( sprintf( __( 'No %1$s could be found to update', 'wp-graphql' ), $post_type_object->graphql_single_name ) );
-				}
-
-				if ( $post_type_object->name !== $existing_post->post_type ) {
-					// translators: The first placeholder is an ID and the second placeholder is the name of the post type being edited
-					throw new UserError( sprintf( __( 'The id %1$d is not of the type "%2$s"', 'wp-graphql' ), $id_parts['id'], $post_type_object->name ) );
-				}
-
-				/**
-				 * Stop now if a user isn't allowed to edit posts
-				 */
-				if ( ! current_user_can( $post_type_object->cap->edit_posts ) ) {
-					// translators: the $post_type_object->graphql_single_name placeholder is the name of the object being mutated
-					throw new UserError( sprintf( __( 'Sorry, you are not allowed to update a %1$s', 'wp-graphql' ), $post_type_object->graphql_single_name ) );
-				}
-
-				/**
-				 * If the mutation is setting the author to be someone other than the user making the request
-				 * make sure they have permission to edit others posts
-				 */
-				$author_id_parts = ! empty( $input['authorId'] ) ? Relay::fromGlobalId( $input['authorId'] ) : null;
-				if ( ! empty( $author_id_parts['id'] ) && get_current_user_id() !== $author_id_parts['id'] && ! current_user_can( $post_type_object->cap->edit_others_posts ) ) {
-					// translators: the $post_type_object->graphql_single_name placeholder is the name of the object being mutated
-					throw new UserError( sprintf( __( 'Sorry, you are not allowed to update %1$s as this user.', 'wp-graphql' ), $post_type_object->graphql_plural_name ) );
-				}
-
-				/**
-				 * @todo: when we add support for making posts sticky, we should check permissions to make sure users can make posts sticky
-				 * @see : https://github.com/WordPress/WordPress/blob/e357195ce303017d517aff944644a7a1232926f7/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L640-L642
-				 */
+	public static function mutate_and_get_payload( $post_type_object, $mutation_name ) {
+		return function ( $input, AppContext $context, ResolveInfo $info ) use ( $post_type_object, $mutation_name ) {
 
 				/**
 				 * @todo: when we add support for assigning terms to posts, we should check permissions to make sure they can assign terms
@@ -124,7 +96,49 @@ class PostObjectUpdate {
 					'postObjectId' => $post_id,
 				];
 
-			},
-		] );
+			/**
+			 * insert the post object and get the ID
+			 */
+			$post_args       = PostObjectMutation::prepare_post_object( $input, $post_type_object, $mutation_name );
+			$post_args['ID'] = absint( $id_parts['id'] );
+
+			/**
+			 * Insert the post and retrieve the ID
+			 */
+			$post_id = wp_update_post( wp_slash( (array) $post_args ), true );
+
+			/**
+			 * Throw an exception if the post failed to update
+			 */
+			if ( is_wp_error( $post_id ) ) {
+				throw new UserError( __( 'The object failed to update but no error was provided', 'wp-graphql' ) );
+			}
+
+			/**
+			 * Fires after a single term is created or updated via a GraphQL mutation
+			 *
+			 * The dynamic portion of the hook name, `$taxonomy->name` refers to the taxonomy of the term being mutated
+			 *
+			 * @param int    $post_id       Inserted post ID
+			 * @param array  $args          The args used to insert the term
+			 * @param string $mutation_name The name of the mutation being performed
+			 */
+			do_action( "graphql_insert_{$post_type_object->name}", $post_id, $post_args, $mutation_name );
+
+			/**
+			 * This updates additional data not part of the posts table (postmeta, terms, other relations, etc)
+			 *
+			 * The input for the postObjectMutation will be passed, along with the $new_post_id for the
+			 * postObject that was updated so that relations can be set, meta can be updated, etc.
+			 */
+			PostObjectMutation::update_additional_post_object_data( $post_id, $input, $post_type_object, $mutation_name, $context, $info );
+
+			/**
+			 * Return the payload
+			 */
+			return [
+				'postObjectId' => $post_id,
+			];
+		};
 	}
 }

--- a/src/Mutation/PostObjectUpdate.php
+++ b/src/Mutation/PostObjectUpdate.php
@@ -31,7 +31,7 @@ class PostObjectUpdate {
 					'description' => sprintf( __( 'The ID of the %1$s object', 'wp-graphql' ), $post_type_object->graphql_single_name ),
 				],
 			]
-			);
+		);
 	}
 
 	public static function get_output_fields( $post_type_object ) {

--- a/src/Mutation/ResetUserPassword.php
+++ b/src/Mutation/ResetUserPassword.php
@@ -21,17 +21,9 @@ class ResetUserPassword {
 				'type'        => 'String',
 				'description' => __( 'Password reset key', 'wp-graphql' ),
 			],
-			'outputFields' => [
-				'user' => [
-					'type' => 'User',
-					'resolve' => function( $payload ) {
-						$user = null;
-						if ( ! empty( $payload['id'] ) ) {
-							$user = get_user_by( 'ID', absint( $payload['id'] ) );
-						}
-						return $user;
-					},
-				],
+			'login'    => [
+				'type'        => 'String',
+				'description' => __( 'The user\'s login (username).', 'wp-graphql' ),
 			],
 			'password' => [
 				'type'        => 'String',
@@ -47,23 +39,39 @@ class ResetUserPassword {
 	public static function mutate_and_get_payload() {
 		return function( $input, AppContext $context, ResolveInfo $info ) {
 
-					/**
-					 * Throw an error with the message
-					 */
-					throw new UserError( $message );
+			if ( empty( $input[ 'key' ] ) ) {
+				throw new UserError( __( 'A password reset key is required.', 'wp-graphql' ) );
+			}
+
+			if ( empty( $input[ 'login' ] ) ) {
+				throw new UserError( __( 'A user login is required.', 'wp-graphql' ) );
+			}
+
+			if ( empty( $input[ 'password' ] ) ) {
+				throw new UserError( __( 'A new password is required.', 'wp-graphql' ) );
+			}
+
+			$user = check_password_reset_key( $input['key'], $input['login'] );
+
+			/**
+			 * If the password reset key check returns an error
+			 */
+			if ( is_wp_error( $user ) ) {
+
+				/**
+				 * Determine the message to return
+				 */
+				if ( 'expired_key' === $user->get_error_code() ) {
+					$message = __( 'Password reset link has expired.', 'wp-graphql' );
+				} else {
+					$message = __( 'Password reset link is invalid.', 'wp-graphql' );
 				}
 
 				/**
-				 * Reset the password
+				 * Throw an error with the message
 				 */
-				reset_password( $user, $input['password'] );
-
-				/**
-				 * Return the user ID
-				 */
-				return [
-					'id' => $user->ID,
-				];
+				throw new UserError( $message );
+			}
 
 			/**
 			 * Reset the password

--- a/src/Mutation/ResetUserPassword.php
+++ b/src/Mutation/ResetUserPassword.php
@@ -7,83 +7,101 @@ use function Patchwork\Utils\args;
 use WPGraphQL\AppContext;
 
 class ResetUserPassword {
-	public static function register_mutation() {
-		register_graphql_mutation( 'resetUserPassword', [
-			'inputFields' => self::get_input_fields(),
-			'outputFields' => self::get_output_fields(),
-			'mutateAndGetPayload' => self::mutate_and_get_payload(),
-		] );
-	}
+    /**
+     * Registers the ResetUserPassword mutation.
+     */
+    public static function register_mutation() {
+        register_graphql_mutation( 'resetUserPassword', [
+            'inputFields' => self::get_input_fields(),
+            'outputFields' => self::get_output_fields(),
+            'mutateAndGetPayload' => self::mutate_and_get_payload(),
+        ] );
+    }
 
-	public static function get_input_fields() {
-		return [
-			'key'      => [
-				'type'        => 'String',
-				'description' => __( 'Password reset key', 'wp-graphql' ),
-			],
-			'login'    => [
-				'type'        => 'String',
-				'description' => __( 'The user\'s login (username).', 'wp-graphql' ),
-			],
-			'password' => [
-				'type'        => 'String',
-				'description' => __( 'The new password.', 'wp-graphql' ),
-			],
-		];
-	}
+    /**
+     * Defines the mutation input field configuration.
+     *
+     * @return array
+     */
+    public static function get_input_fields() {
+        return [
+            'key'      => [
+                'type'        => 'String',
+                'description' => __( 'Password reset key', 'wp-graphql' ),
+            ],
+            'login'    => [
+                'type'        => 'String',
+                'description' => __( 'The user\'s login (username).', 'wp-graphql' ),
+            ],
+            'password' => [
+                'type'        => 'String',
+                'description' => __( 'The new password.', 'wp-graphql' ),
+            ],
+        ];
+    }
 
-	public static function get_output_fields() {
-		return UserCreate::get_output_fields();
-	}
+    /**
+     * Defines the mutation output field configuration.
+     *
+     * @return array
+     */
+    public static function get_output_fields() {
+        return UserCreate::get_output_fields();
+    }
 
-	public static function mutate_and_get_payload() {
-		return function( $input, AppContext $context, ResolveInfo $info ) {
+    /**
+     * Defines the mutation data modification closure.
+     *
+     * @return callable
+     */
+    public static function mutate_and_get_payload() {
+        return function( $input, AppContext $context, ResolveInfo $info ) {
 
-			if ( empty( $input[ 'key' ] ) ) {
-				throw new UserError( __( 'A password reset key is required.', 'wp-graphql' ) );
-			}
+            if ( empty( $input[ 'key' ] ) ) {
+                throw new UserError( __( 'A password reset key is required.', 'wp-graphql' ) );
+            }
 
-			if ( empty( $input[ 'login' ] ) ) {
-				throw new UserError( __( 'A user login is required.', 'wp-graphql' ) );
-			}
+            if ( empty( $input[ 'login' ] ) ) {
+                throw new UserError( __( 'A user login is required.', 'wp-graphql' ) );
+            }
 
-			if ( empty( $input[ 'password' ] ) ) {
-				throw new UserError( __( 'A new password is required.', 'wp-graphql' ) );
-			}
+            if ( empty( $input[ 'password' ] ) ) {
+                throw new UserError( __( 'A new password is required.', 'wp-graphql' ) );
+            }
 
-			$user = check_password_reset_key( $input['key'], $input['login'] );
+            $user = check_password_reset_key( $input['key'], $input['login'] );
 
-			/**
-			 * If the password reset key check returns an error
-			 */
-			if ( is_wp_error( $user ) ) {
+            /**
+             * If the password reset key check returns an error
+             */
+            if ( is_wp_error( $user ) ) {
 
-				/**
-				 * Determine the message to return
-				 */
-				if ( 'expired_key' === $user->get_error_code() ) {
-					$message = __( 'Password reset link has expired.', 'wp-graphql' );
-				} else {
-					$message = __( 'Password reset link is invalid.', 'wp-graphql' );
-				}
+                /**
+                 * Determine the message to return
+                 */
+                if ( 'expired_key' === $user->get_error_code() ) {
+                    $message = __( 'Password reset link has expired.', 'wp-graphql' );
+                } else {
+                    $message = __( 'Password reset link is invalid.', 'wp-graphql' );
+                }
 
-				/**
-				 * Throw an error with the message
-				 */
-				throw new UserError( $message );
-			}
+                /**
+                 * Throw an error with the message
+                 */
+                throw new UserError( $message );
+            }
 
-			/**
-			 * Reset the password
-			 */
-			reset_password( $user, $input['password'] );
+            /**
+             * Reset the password
+             */
+            reset_password( $user, $input['password'] );
 
-			/**
-			 * Return the user ID
-			 */
-			return [
-				'id' => $user->ID,
-			];
-		};
-	}
+            /**
+             * Return the user ID
+             */
+            return [
+                'id' => $user->ID,
+            ];
+        };
+    }
 }

--- a/src/Mutation/ResetUserPassword.php
+++ b/src/Mutation/ResetUserPassword.php
@@ -9,19 +9,17 @@ use WPGraphQL\AppContext;
 class ResetUserPassword {
 	public static function register_mutation() {
 		register_graphql_mutation( 'resetUserPassword', [
-			'inputFields' => [
-				'key'      => [
-					'type'        => 'String',
-					'description' => __( 'Password reset key', 'wp-graphql' ),
-				],
-				'login'    => [
-					'type'        => 'String',
-					'description' => __( 'The user\'s login (username).', 'wp-graphql' ),
-				],
-				'password' => [
-					'type'        => 'String',
-					'description' => __( 'The new password.', 'wp-graphql' ),
-				],
+			'inputFields' => self::get_input_fields(),
+			'outputFields' => self::get_output_fields(),
+			'mutateAndGetPayload' => self::mutate_and_get_payload(),
+		] );
+	}
+
+	public static function get_input_fields() {
+		return [
+			'key'      => [
+				'type'        => 'String',
+				'description' => __( 'Password reset key', 'wp-graphql' ),
 			],
 			'outputFields' => [
 				'user' => [
@@ -35,35 +33,19 @@ class ResetUserPassword {
 					},
 				],
 			],
-			'mutateAndGetPayload' => function( $input, AppContext $context, ResolveInfo $info ) {
+			'password' => [
+				'type'        => 'String',
+				'description' => __( 'The new password.', 'wp-graphql' ),
+			],
+		];
+	}
 
-				if ( empty( $input[ 'key' ] ) ) {
-					throw new UserError( __( 'A password reset key is required.', 'wp-graphql' ) );
-				}
+	public static function get_output_fields() {
+		return UserCreate::get_output_fields();
+	}
 
-				if ( empty( $input[ 'login' ] ) ) {
-					throw new UserError( __( 'A user login is required.', 'wp-graphql' ) );
-				}
-
-				if ( empty( $input[ 'password' ] ) ) {
-					throw new UserError( __( 'A new password is required.', 'wp-graphql' ) );
-				}
-
-				$user = check_password_reset_key( $input['key'], $input['login'] );
-
-				/**
-				 * If the password reset key check returns an error
-				 */
-				if ( is_wp_error( $user ) ) {
-
-					/**
-					 * Determine the message to return
-					 */
-					if ( 'expired_key' === $user->get_error_code() ) {
-						$message = __( 'Password reset link has expired.', 'wp-graphql' );
-					} else {
-						$message = __( 'Password reset link is invalid.', 'wp-graphql' );
-					}
+	public static function mutate_and_get_payload() {
+		return function( $input, AppContext $context, ResolveInfo $info ) {
 
 					/**
 					 * Throw an error with the message
@@ -83,7 +65,17 @@ class ResetUserPassword {
 					'id' => $user->ID,
 				];
 
-			},
-		] );
+			/**
+			 * Reset the password
+			 */
+			reset_password( $user, $input['password'] );
+
+			/**
+			 * Return the user ID
+			 */
+			return [
+				'id' => $user->ID,
+			];
+		};
 	}
 }

--- a/src/Mutation/TermObjectCreate.php
+++ b/src/Mutation/TermObjectCreate.php
@@ -8,7 +8,6 @@ use WPGraphQL\Data\TermObjectMutation;
 
 class TermObjectCreate {
 	public static function register_mutation( \WP_Taxonomy $taxonomy ) {
-
 		$mutation_name = 'create' . ucwords( $taxonomy->graphql_single_name );
 
 		register_graphql_mutation( $mutation_name, [
@@ -20,83 +19,10 @@ class TermObjectCreate {
 					// Translators: The placeholder is the name of the taxonomy for the object being mutated
 					'description' => sprintf( __( 'The name of the %1$s object to mutate', 'wp-graphql' ), $taxonomy->name ),
 				]
-			]),
-			'outputFields'        => [
-					$taxonomy->graphql_single_name => [
-						'type'        => $taxonomy->graphql_single_name,
-						// translators: Placeholder is the name of the taxonomy
-						'description' => sprintf( __( 'The created %s', 'wp-graphql' ), $taxonomy->name ),
-						'resolve'     => function ( $payload ) use ( $taxonomy ) {
-							return get_term( $payload['id'], $taxonomy->name );
-						},
-					],
-				],
-			'mutateAndGetPayload' => function( $input, AppContext $context, ResolveInfo $info ) use ( $taxonomy, $mutation_name ) {
-
-				/**
-				 * Ensure the user can edit_terms
-				 */
-				if ( ! current_user_can( $taxonomy->cap->edit_terms ) ) {
-					// translators: the $taxonomy->graphql_plural_name placeholder is the name of the object being mutated
-					throw new UserError( sprintf( __( 'Sorry, you are not allowed to create %1$s', 'wp-graphql' ), $taxonomy->graphql_plural_name ) );
-				}
-
-				/**
-				 * Prepare the object for insertion
-				 */
-				$args = TermObjectMutation::prepare_object( $input, $taxonomy, $mutation_name );
-
-				/**
-				 * Ensure a name was provided
-				 */
-				if ( empty( $args['name'] ) ) {
-					// Translators: The placeholder is the name of the taxonomy of the term being mutated
-					throw new UserError( sprintf( __( 'A name is required to create a %1$s' ), $taxonomy->name ) );
-				}
-
-				/**
-				 * Insert the term
-				 */
-				$term = wp_insert_term( wp_slash( $args['name'] ), $taxonomy->name, wp_slash( (array) $args ) );
-
-				/**
-				 * If it was an error, return the message as an exception
-				 */
-				if ( is_wp_error( $term ) ) {
-					$error_message = $term->get_error_message();
-					if ( ! empty( $error_message ) ) {
-						throw new UserError( esc_html( $error_message ) );
-					} else {
-						throw new UserError( __( 'The object failed to update but no error was provided', 'wp-graphql' ) );
-					}
-				}
-
-				/**
-				 * If the response to creating the term didn't respond with a term_id, throw an exception
-				 */
-				if ( empty( $term['term_id'] ) ) {
-					throw new UserError( __( 'The object failed to create', 'wp-graphql' ) );
-				}
-
-				/**
-				 * Fires after a single term is created or updated via a GraphQL mutation
-				 *
-				 * The dynamic portion of the hook name, `$taxonomy->name` refers to the taxonomy of the term being mutated
-				 *
-				 * @param int         $term_id       Inserted term object
-				 * @param array       $args          The args used to insert the term
-				 * @param string      $mutation_name The name of the mutation being performed
-				 * @param AppContext  $context       The AppContext passed down the resolve tree
-				 * @param ResolveInfo $info          The ResolveInfo passed down the resolve tree
-				 */
-				do_action( "graphql_insert_{$taxonomy->name}", $term['term_id'], $args, $mutation_name, $context, $info );
-
-				return [
-					'id' => $term['term_id'],
-				];
-
-			},
-		]);
+			] ),
+			'outputFields'        => self::get_output_fields( $taxonomy ),
+			'mutateAndGetPayload' => self::mutate_and_get_payload( $taxonomy, $mutation_name ),
+		] );
 	}
 
 	public static function get_input_fields( \WP_Taxonomy $taxonomy ) {
@@ -129,5 +55,85 @@ class TermObjectCreate {
 		}
 
 		return $fields;
+	}
+
+	public static function get_output_fields( \WP_Taxonomy $taxonomy ) {
+		return [
+			$taxonomy->graphql_single_name => [
+				'type'        => $taxonomy->graphql_single_name,
+				// translators: Placeholder is the name of the taxonomy
+				'description' => sprintf( __( 'The created %s', 'wp-graphql' ), $taxonomy->name ),
+				'resolve'     => function ( $payload ) use ( $taxonomy ) {
+					return get_term( $payload['id'], $taxonomy->name );
+				},
+			],
+		];
+	}
+
+	public static function mutate_and_get_payload( \WP_Taxonomy $taxonomy, $mutation_name ) {
+		return function( $input, AppContext $context, ResolveInfo $info ) use ( $taxonomy, $mutation_name ) {
+
+			/**
+			 * Ensure the user can edit_terms
+			 */
+			if ( ! current_user_can( $taxonomy->cap->edit_terms ) ) {
+				// translators: the $taxonomy->graphql_plural_name placeholder is the name of the object being mutated
+				throw new UserError( sprintf( __( 'Sorry, you are not allowed to create %1$s', 'wp-graphql' ), $taxonomy->graphql_plural_name ) );
+			}
+
+			/**
+			 * Prepare the object for insertion
+			 */
+			$args = TermObjectMutation::prepare_object( $input, $taxonomy, $mutation_name );
+
+			/**
+			 * Ensure a name was provided
+			 */
+			if ( empty( $args['name'] ) ) {
+				// Translators: The placeholder is the name of the taxonomy of the term being mutated
+				throw new UserError( sprintf( __( 'A name is required to create a %1$s' ), $taxonomy->name ) );
+			}
+
+			/**
+			 * Insert the term
+			 */
+			$term = wp_insert_term( wp_slash( $args['name'] ), $taxonomy->name, wp_slash( (array) $args ) );
+
+			/**
+			 * If it was an error, return the message as an exception
+			 */
+			if ( is_wp_error( $term ) ) {
+				$error_message = $term->get_error_message();
+				if ( ! empty( $error_message ) ) {
+					throw new UserError( esc_html( $error_message ) );
+				} else {
+					throw new UserError( __( 'The object failed to update but no error was provided', 'wp-graphql' ) );
+				}
+			}
+
+			/**
+			 * If the response to creating the term didn't respond with a term_id, throw an exception
+			 */
+			if ( empty( $term['term_id'] ) ) {
+				throw new UserError( __( 'The object failed to create', 'wp-graphql' ) );
+			}
+
+			/**
+			 * Fires after a single term is created or updated via a GraphQL mutation
+			 *
+			 * The dynamic portion of the hook name, `$taxonomy->name` refers to the taxonomy of the term being mutated
+			 *
+			 * @param int         $term_id       Inserted term object
+			 * @param array       $args          The args used to insert the term
+			 * @param string      $mutation_name The name of the mutation being performed
+			 * @param AppContext  $context       The AppContext passed down the resolve tree
+			 * @param ResolveInfo $info          The ResolveInfo passed down the resolve tree
+			 */
+			do_action( "graphql_insert_{$taxonomy->name}", $term['term_id'], $args, $mutation_name, $context, $info );
+
+			return [
+				'id' => $term['term_id'],
+			];
+		};
 	}
 }

--- a/src/Mutation/TermObjectCreate.php
+++ b/src/Mutation/TermObjectCreate.php
@@ -7,133 +7,160 @@ use WPGraphQL\AppContext;
 use WPGraphQL\Data\TermObjectMutation;
 
 class TermObjectCreate {
-	public static function register_mutation( \WP_Taxonomy $taxonomy ) {
-		$mutation_name = 'create' . ucwords( $taxonomy->graphql_single_name );
+    /**
+     * Registers the TermObjectCreate mutation.
+     *
+     * @param \WP_Taxonomy  $taxonomy    The taxonomy type of the mutation.
+     */
+    public static function register_mutation( \WP_Taxonomy $taxonomy ) {
+        $mutation_name = 'create' . ucwords( $taxonomy->graphql_single_name );
 
-		register_graphql_mutation( $mutation_name, [
-			'inputFields'         => array_merge( self::get_input_fields( $taxonomy ), [
-				'name' => [
-					'type'        => [
-						'non_null' => 'String',
-					],
-					// Translators: The placeholder is the name of the taxonomy for the object being mutated
-					'description' => sprintf( __( 'The name of the %1$s object to mutate', 'wp-graphql' ), $taxonomy->name ),
-				]
-			] ),
-			'outputFields'        => self::get_output_fields( $taxonomy ),
-			'mutateAndGetPayload' => self::mutate_and_get_payload( $taxonomy, $mutation_name ),
-		] );
-	}
+        register_graphql_mutation( $mutation_name, [
+            'inputFields'         => array_merge( self::get_input_fields( $taxonomy ), [
+                'name' => [
+                    'type'        => [
+                        'non_null' => 'String',
+                    ],
+                    // Translators: The placeholder is the name of the taxonomy for the object being mutated
+                    'description' => sprintf( __( 'The name of the %1$s object to mutate', 'wp-graphql' ), $taxonomy->name ),
+                ]
+            ] ),
+            'outputFields'        => self::get_output_fields( $taxonomy ),
+            'mutateAndGetPayload' => self::mutate_and_get_payload( $taxonomy, $mutation_name ),
+        ] );
+    }
 
-	public static function get_input_fields( \WP_Taxonomy $taxonomy ) {
-		$fields = [
-			'aliasOf'     => [
-				'type'        => 'String',
-				// Translators: The placeholder is the name of the taxonomy for the object being mutated
-				'description' => sprintf( __( 'The slug that the %1$s will be an alias of', 'wp-graphql' ), $taxonomy->name ),
-			],
-			'description' => [
-				'type'        => 'String',
-				// Translators: The placeholder is the name of the taxonomy for the object being mutated
-				'description' => sprintf( __( 'The description of the %1$s object', 'wp-graphql' ), $taxonomy->name ),
-			],
-			'slug'        => [
-				'type'        => 'String',
-				'description' => __( 'If this argument exists then the slug will be checked to see if it is not an existing valid term. If that check succeeds (it is not a valid term), then it is added and the term id is given. If it fails, then a check is made to whether the taxonomy is hierarchical and the parent argument is not empty. If the second check succeeds, the term will be inserted and the term id will be given. If the slug argument is empty, then it will be calculated from the term name.' ),
-			],
-		];
+    /**
+     * Defines the mutation input field configuration.
+     *
+     * @param \WP_Taxonomy  $taxonomy    The taxonomy type of the mutation.
+     *
+     * @return array
+     */
+    public static function get_input_fields( \WP_Taxonomy $taxonomy ) {
+        $fields = [
+            'aliasOf'     => [
+                'type'        => 'String',
+                // Translators: The placeholder is the name of the taxonomy for the object being mutated
+                'description' => sprintf( __( 'The slug that the %1$s will be an alias of', 'wp-graphql' ), $taxonomy->name ),
+            ],
+            'description' => [
+                'type'        => 'String',
+                // Translators: The placeholder is the name of the taxonomy for the object being mutated
+                'description' => sprintf( __( 'The description of the %1$s object', 'wp-graphql' ), $taxonomy->name ),
+            ],
+            'slug'        => [
+                'type'        => 'String',
+                'description' => __( 'If this argument exists then the slug will be checked to see if it is not an existing valid term. If that check succeeds (it is not a valid term), then it is added and the term id is given. If it fails, then a check is made to whether the taxonomy is hierarchical and the parent argument is not empty. If the second check succeeds, the term will be inserted and the term id will be given. If the slug argument is empty, then it will be calculated from the term name.' ),
+            ],
+        ];
 
-		/**
-		 * Add a parentId field to hierarchical taxonomies to allow parents to be set
-		 */
-		if ( true === $taxonomy->hierarchical ) {
-			$fields['parentId'] = [
-				'type'        => 'Id',
-				// Translators: The placeholder is the name of the taxonomy for the object being mutated
-				'description' => sprintf( __( 'The ID of the %1$s that should be set as the parent', 'wp-graphql' ), $taxonomy->name ),
-			];
-		}
+        /**
+         * Add a parentId field to hierarchical taxonomies to allow parents to be set
+         */
+        if ( true === $taxonomy->hierarchical ) {
+            $fields['parentId'] = [
+                'type'        => 'Id',
+                // Translators: The placeholder is the name of the taxonomy for the object being mutated
+                'description' => sprintf( __( 'The ID of the %1$s that should be set as the parent', 'wp-graphql' ), $taxonomy->name ),
+            ];
+        }
 
-		return $fields;
-	}
+        return $fields;
+    }
 
-	public static function get_output_fields( \WP_Taxonomy $taxonomy ) {
-		return [
-			$taxonomy->graphql_single_name => [
-				'type'        => $taxonomy->graphql_single_name,
-				// translators: Placeholder is the name of the taxonomy
-				'description' => sprintf( __( 'The created %s', 'wp-graphql' ), $taxonomy->name ),
-				'resolve'     => function ( $payload ) use ( $taxonomy ) {
-					return get_term( $payload['id'], $taxonomy->name );
-				},
-			],
-		];
-	}
+    /**
+     * Defines the mutation output field configuration.
+     *
+     * @param \WP_Taxonomy  $taxonomy    The taxonomy type of the mutation.
+     *
+     * @return array
+     */
+    public static function get_output_fields( \WP_Taxonomy $taxonomy ) {
+        return [
+            $taxonomy->graphql_single_name => [
+                'type'        => $taxonomy->graphql_single_name,
+                // translators: Placeholder is the name of the taxonomy
+                'description' => sprintf( __( 'The created %s', 'wp-graphql' ), $taxonomy->name ),
+                'resolve'     => function ( $payload ) use ( $taxonomy ) {
+                    return get_term( $payload['termId'], $taxonomy->name );
+                },
+            ],
+        ];
+    }
 
-	public static function mutate_and_get_payload( \WP_Taxonomy $taxonomy, $mutation_name ) {
-		return function( $input, AppContext $context, ResolveInfo $info ) use ( $taxonomy, $mutation_name ) {
+    /**
+     * Defines the mutation data modification closure.
+     *
+     * @param \WP_Taxonomy  $taxonomy       The taxonomy type of the mutation.
+     * @param string        $mutation_name  The name of the mutation.
+     *
+     * @return callable
+     */
+    public static function mutate_and_get_payload( \WP_Taxonomy $taxonomy, $mutation_name ) {
+        return function( $input, AppContext $context, ResolveInfo $info ) use ( $taxonomy, $mutation_name ) {
 
-			/**
-			 * Ensure the user can edit_terms
-			 */
-			if ( ! current_user_can( $taxonomy->cap->edit_terms ) ) {
-				// translators: the $taxonomy->graphql_plural_name placeholder is the name of the object being mutated
-				throw new UserError( sprintf( __( 'Sorry, you are not allowed to create %1$s', 'wp-graphql' ), $taxonomy->graphql_plural_name ) );
-			}
+            /**
+             * Ensure the user can edit_terms
+             */
+            if ( ! current_user_can( $taxonomy->cap->edit_terms ) ) {
+                // translators: the $taxonomy->graphql_plural_name placeholder is the name of the object being mutated
+                throw new UserError( sprintf( __( 'Sorry, you are not allowed to create %1$s', 'wp-graphql' ), $taxonomy->graphql_plural_name ) );
+            }
 
-			/**
-			 * Prepare the object for insertion
-			 */
-			$args = TermObjectMutation::prepare_object( $input, $taxonomy, $mutation_name );
+            /**
+             * Prepare the object for insertion
+             */
+            $args = TermObjectMutation::prepare_object( $input, $taxonomy, $mutation_name );
 
-			/**
-			 * Ensure a name was provided
-			 */
-			if ( empty( $args['name'] ) ) {
-				// Translators: The placeholder is the name of the taxonomy of the term being mutated
-				throw new UserError( sprintf( __( 'A name is required to create a %1$s' ), $taxonomy->name ) );
-			}
+            /**
+             * Ensure a name was provided
+             */
+            if ( empty( $args['name'] ) ) {
+                // Translators: The placeholder is the name of the taxonomy of the term being mutated
+                throw new UserError( sprintf( __( 'A name is required to create a %1$s' ), $taxonomy->name ) );
+            }
 
-			/**
-			 * Insert the term
-			 */
-			$term = wp_insert_term( wp_slash( $args['name'] ), $taxonomy->name, wp_slash( (array) $args ) );
+            /**
+             * Insert the term
+             */
+            $term = wp_insert_term( wp_slash( $args['name'] ), $taxonomy->name, wp_slash( (array) $args ) );
 
-			/**
-			 * If it was an error, return the message as an exception
-			 */
-			if ( is_wp_error( $term ) ) {
-				$error_message = $term->get_error_message();
-				if ( ! empty( $error_message ) ) {
-					throw new UserError( esc_html( $error_message ) );
-				} else {
-					throw new UserError( __( 'The object failed to update but no error was provided', 'wp-graphql' ) );
-				}
-			}
+            /**
+             * If it was an error, return the message as an exception
+             */
+            if ( is_wp_error( $term ) ) {
+                $error_message = $term->get_error_message();
+                if ( ! empty( $error_message ) ) {
+                    throw new UserError( esc_html( $error_message ) );
+                } else {
+                    throw new UserError( __( 'The object failed to update but no error was provided', 'wp-graphql' ) );
+                }
+            }
 
-			/**
-			 * If the response to creating the term didn't respond with a term_id, throw an exception
-			 */
-			if ( empty( $term['term_id'] ) ) {
-				throw new UserError( __( 'The object failed to create', 'wp-graphql' ) );
-			}
+            /**
+             * If the response to creating the term didn't respond with a term_id, throw an exception
+             */
+            if ( empty( $term['term_id'] ) ) {
+                throw new UserError( __( 'The object failed to create', 'wp-graphql' ) );
+            }
 
-			/**
-			 * Fires after a single term is created or updated via a GraphQL mutation
-			 *
-			 * The dynamic portion of the hook name, `$taxonomy->name` refers to the taxonomy of the term being mutated
-			 *
-			 * @param int         $term_id       Inserted term object
-			 * @param array       $args          The args used to insert the term
-			 * @param string      $mutation_name The name of the mutation being performed
-			 * @param AppContext  $context       The AppContext passed down the resolve tree
-			 * @param ResolveInfo $info          The ResolveInfo passed down the resolve tree
-			 */
-			do_action( "graphql_insert_{$taxonomy->name}", $term['term_id'], $args, $mutation_name, $context, $info );
+            /**
+             * Fires after a single term is created or updated via a GraphQL mutation
+             *
+             * The dynamic portion of the hook name, `$taxonomy->name` refers to the taxonomy of the term being mutated
+             *
+             * @param int         $term_id       Inserted term object
+             * @param array       $args          The args used to insert the term
+             * @param string      $mutation_name The name of the mutation being performed
+             * @param AppContext  $context       The AppContext passed down the resolve tree
+             * @param ResolveInfo $info          The ResolveInfo passed down the resolve tree
+             */
+            do_action( "graphql_insert_{$taxonomy->name}", $term['term_id'], $args, $mutation_name, $context, $info );
 
-			return [
-				'id' => $term['term_id'],
-			];
-		};
-	}
+            return [
+                'termId' => $term['term_id'],
+            ];
+        };
+    }
 }

--- a/src/Mutation/TermObjectDelete.php
+++ b/src/Mutation/TermObjectDelete.php
@@ -6,98 +6,107 @@ use GraphQLRelay\Relay;
 
 class TermObjectDelete {
 	public static function register_mutation( \WP_Taxonomy $taxonomy ) {
-
 		$mutation_name = 'delete' . ucfirst( $taxonomy->graphql_single_name );
 
 		register_graphql_mutation( $mutation_name, [
-			'inputFields'         => [
-				'id' => [
-					'type'        => [
-						'non_null' => 'ID',
-					],
-					// translators: The placeholder is the name of the taxonomy for the term being deleted
-					'description' => sprintf( __( 'The ID of the %1$s to delete', 'wp-graphql' ), $taxonomy->graphql_single_name ),
+			'inputFields'         => self::get_input_fields( $taxonomy ),
+			'outputFields'        => self::get_output_fields( $taxonomy ),
+			'mutateAndGetPayload' => self::mutate_and_get_payload( $taxonomy, $mutation_name ),
+		] );
+	}
+
+	public static function get_input_fields( \WP_Taxonomy $taxonomy ) {
+		return [
+			'id' => [
+				'type'        => [
+					'non_null' => 'ID',
 				],
+				// translators: The placeholder is the name of the taxonomy for the term being deleted
+				'description' => sprintf( __( 'The ID of the %1$s to delete', 'wp-graphql' ), $taxonomy->graphql_single_name ),
 			],
-			'outputFields'        => [
-				'deletedId'                    => [
-					'type'        => 'ID',
-					'description' => __( 'The ID of the deleted object', 'wp-graphql' ),
-					'resolve'     => function( $payload ) use ( $taxonomy ) {
-						$deleted = (object) $payload['termObject'];
+		];
+	}
 
-						return ! empty( $deleted->term_id ) ? Relay::toGlobalId( $taxonomy->name, $deleted->term_id ) : null;
-					},
-				],
-				$taxonomy->graphql_single_name => [
-					'type'        => $taxonomy->graphql_single_name,
-					'description' => __( 'The object before it was deleted', 'wp-graphql' ),
-					'resolve'     => function( $payload ) use ( $taxonomy ) {
-						$deleted = (object) $payload['termObject'];
+	public static function get_output_fields( \WP_Taxonomy $taxonomy ) {
+		return [
+			'deletedId'                    => [
+				'type'        => 'ID',
+				'description' => __( 'The ID of the deleted object', 'wp-graphql' ),
+				'resolve'     => function( $payload ) use ( $taxonomy ) {
+					$deleted = (object) $payload['termObject'];
 
-						return ! empty( $deleted ) ? $deleted : null;
-					},
-				],
+					return ! empty( $deleted->term_id ) ? Relay::toGlobalId( $taxonomy->name, $deleted->term_id ) : null;
+				},
 			],
-			'mutateAndGetPayload' => function( $input ) use ( $taxonomy, $mutation_name ) {
+			$taxonomy->graphql_single_name => [
+				'type'        => $taxonomy->graphql_single_name,
+				'description' => __( 'The deteted term object', 'wp-graphql' ),
+				'resolve'     => function( $payload ) use ( $taxonomy ) {
+					$deleted = (object) $payload['termObject'];
 
-				$id_parts = Relay::fromGlobalId( $input['id'] );
+					return ! empty( $deleted ) ? $deleted : null;
+				},
+			],
+		];
+	}
 
-				if ( ! empty( $id_parts['id'] ) && absint( $id_parts['id'] ) ) {
-					$term_id = absint( $id_parts['id'] );
+	public static function mutate_and_get_payload( \WP_Taxonomy $taxonomy, $mutation_name ) {
+		return function( $input ) use ( $taxonomy, $mutation_name ) {
+
+			$id_parts = Relay::fromGlobalId( $input['id'] );
+
+			if ( ! empty( $id_parts['id'] ) && absint( $id_parts['id'] ) ) {
+				$term_id = absint( $id_parts['id'] );
+			} else {
+				// Translators: The placeholder is the name of the taxonomy for the term being deleted
+				throw new UserError( sprintf( __( 'The ID for the %1$s was not valid', 'wp-graphql' ), $taxonomy->graphql_single_name ) );
+			}
+
+			/**
+			 * Ensure the type for the Global ID matches the type being mutated
+			 */
+			if ( empty( $id_parts['type'] ) || $taxonomy->name !== $id_parts['type'] ) {
+				// Translators: The placeholder is the name of the taxonomy for the term being edited
+				throw new UserError( sprintf( __( 'The ID passed is not for a %1$s object', 'wp-graphql' ), $taxonomy->graphql_single_name ) );
+			}
+
+			/**
+			 * Get the term before deleting it
+			 */
+			$term_object = get_term( $term_id, $taxonomy->name );
+
+			/**
+			 * Ensure the user can delete terms of this taxonomy
+			 */
+			if ( ! current_user_can( 'delete_term', $term_object->term_id ) ) {
+				// Translators: The placeholder is the name of the taxonomy for the term being deleted
+				throw new UserError( sprintf( __( 'You do not have permission to delete %1$s', 'wp-graphql' ), $taxonomy->graphql_plural_name ) );
+			}
+
+			/**
+			 * Delete the term and get the response
+			 */
+			$deleted = wp_delete_term( $term_id, $taxonomy->name );
+
+			/**
+			 * If there was an error deleting the term, get the error message and return it
+			 */
+			if ( is_wp_error( $deleted ) ) {
+				$error_message = $deleted->get_error_message();
+				if ( ! empty( $error_message ) ) {
+					throw new UserError( esc_html( $error_message ) );
 				} else {
 					// Translators: The placeholder is the name of the taxonomy for the term being deleted
-					throw new UserError( sprintf( __( 'The ID for the %1$s was not valid', 'wp-graphql' ), $taxonomy->graphql_single_name ) );
+					throw new UserError( sprintf( __( 'The %1$s failed to delete but no error was provided', 'wp-graphql' ), $taxonomy->name ) );
 				}
+			}
 
-				/**
-				 * Ensure the type for the Global ID matches the type being mutated
-				 */
-				if ( empty( $id_parts['type'] ) || $taxonomy->name !== $id_parts['type'] ) {
-					// Translators: The placeholder is the name of the taxonomy for the term being edited
-					throw new UserError( sprintf( __( 'The ID passed is not for a %1$s object', 'wp-graphql' ), $taxonomy->graphql_single_name ) );
-				}
-
-				/**
-				 * Get the term before deleting it
-				 */
-				$term_object = get_term( $term_id, $taxonomy->name );
-
-				/**
-				 * Ensure the user can delete terms of this taxonomy
-				 */
-				if ( ! current_user_can( 'delete_term', $term_object->term_id ) ) {
-					// Translators: The placeholder is the name of the taxonomy for the term being deleted
-					throw new UserError( sprintf( __( 'You do not have permission to delete %1$s', 'wp-graphql' ), $taxonomy->graphql_plural_name ) );
-				}
-
-				/**
-				 * Delete the term and get the response
-				 */
-				$deleted = wp_delete_term( $term_id, $taxonomy->name );
-
-				/**
-				 * If there was an error deleting the term, get the error message and return it
-				 */
-				if ( is_wp_error( $deleted ) ) {
-					$error_message = $deleted->get_error_message();
-					if ( ! empty( $error_message ) ) {
-						throw new UserError( esc_html( $error_message ) );
-					} else {
-						// Translators: The placeholder is the name of the taxonomy for the term being deleted
-						throw new UserError( sprintf( __( 'The %1$s failed to delete but no error was provided', 'wp-graphql' ), $taxonomy->name ) );
-					}
-				}
-
-				/**
-				 * Return the term object that was retrieved prior to deletion
-				 */
-				return [
-					'termObject' => $term_object,
-				];
-
-			},
-		]);
-
+			/**
+			 * Return the term object that was retrieved prior to deletion
+			 */
+			return [
+				'termObject' => $term_object,
+			];
+		};
 	}
 }

--- a/src/Mutation/TermObjectDelete.php
+++ b/src/Mutation/TermObjectDelete.php
@@ -5,29 +5,48 @@ use GraphQL\Error\UserError;
 use GraphQLRelay\Relay;
 
 class TermObjectDelete {
-	public static function register_mutation( \WP_Taxonomy $taxonomy ) {
-		$mutation_name = 'delete' . ucfirst( $taxonomy->graphql_single_name );
+    /**
+     * Registers the TermObjectDelete mutation.
+     *
+     * @param \WP_Taxonomy  $taxonomy    The taxonomy type of the mutation.
+     */
+    public static function register_mutation( \WP_Taxonomy $taxonomy ) {
+        $mutation_name = 'delete' . ucfirst( $taxonomy->graphql_single_name );
 
-		register_graphql_mutation( $mutation_name, [
-			'inputFields'         => self::get_input_fields( $taxonomy ),
-			'outputFields'        => self::get_output_fields( $taxonomy ),
-			'mutateAndGetPayload' => self::mutate_and_get_payload( $taxonomy, $mutation_name ),
-		] );
-	}
+        register_graphql_mutation( $mutation_name, [
+            'inputFields'         => self::get_input_fields( $taxonomy ),
+            'outputFields'        => self::get_output_fields( $taxonomy ),
+            'mutateAndGetPayload' => self::mutate_and_get_payload( $taxonomy, $mutation_name ),
+        ] );
+    }
 
-	public static function get_input_fields( \WP_Taxonomy $taxonomy ) {
-		return [
-			'id' => [
-				'type'        => [
-					'non_null' => 'ID',
-				],
-				// translators: The placeholder is the name of the taxonomy for the term being deleted
-				'description' => sprintf( __( 'The ID of the %1$s to delete', 'wp-graphql' ), $taxonomy->graphql_single_name ),
-			],
-		];
-	}
+    /**
+     * Defines the mutation input field configuration.
+     *
+     * @param \WP_Taxonomy  $taxonomy    The taxonomy type of the mutation.
+     *
+     * @return array
+     */
+    public static function get_input_fields( \WP_Taxonomy $taxonomy ) {
+        return [
+            'id' => [
+                'type'        => [
+                    'non_null' => 'ID',
+                ],
+                // translators: The placeholder is the name of the taxonomy for the term being deleted
+                'description' => sprintf( __( 'The ID of the %1$s to delete', 'wp-graphql' ), $taxonomy->graphql_single_name ),
+            ],
+        ];
+    }
 
-	public static function get_output_fields( \WP_Taxonomy $taxonomy ) {
+    /**
+     * Defines the mutation output field configuration.
+     *
+     * @param \WP_Taxonomy  $taxonomy    The taxonomy type of the mutation.
+     *
+     * @return array
+     */
+     public static function get_output_fields( \WP_Taxonomy $taxonomy ) {
 		return [
 			'deletedId'                    => [
 				'type'        => 'ID',
@@ -50,63 +69,71 @@ class TermObjectDelete {
 		];
 	}
 
-	public static function mutate_and_get_payload( \WP_Taxonomy $taxonomy, $mutation_name ) {
-		return function( $input ) use ( $taxonomy, $mutation_name ) {
+    /**
+     * Defines the mutation data modification closure.
+     *
+     * @param \WP_Taxonomy  $taxonomy       The taxonomy type of the mutation.
+     * @param string        $mutation_name  The name of the mutation.
+     *
+     * @return callable
+     */
+    public static function mutate_and_get_payload( \WP_Taxonomy $taxonomy, $mutation_name ) {
+        return function( $input ) use ( $taxonomy, $mutation_name ) {
 
-			$id_parts = Relay::fromGlobalId( $input['id'] );
+            $id_parts = Relay::fromGlobalId( $input['id'] );
 
-			if ( ! empty( $id_parts['id'] ) && absint( $id_parts['id'] ) ) {
-				$term_id = absint( $id_parts['id'] );
-			} else {
-				// Translators: The placeholder is the name of the taxonomy for the term being deleted
-				throw new UserError( sprintf( __( 'The ID for the %1$s was not valid', 'wp-graphql' ), $taxonomy->graphql_single_name ) );
-			}
+            if ( ! empty( $id_parts['id'] ) && absint( $id_parts['id'] ) ) {
+                $term_id = absint( $id_parts['id'] );
+            } else {
+                // Translators: The placeholder is the name of the taxonomy for the term being deleted
+                throw new UserError( sprintf( __( 'The ID for the %1$s was not valid', 'wp-graphql' ), $taxonomy->graphql_single_name ) );
+            }
 
-			/**
-			 * Ensure the type for the Global ID matches the type being mutated
-			 */
-			if ( empty( $id_parts['type'] ) || $taxonomy->name !== $id_parts['type'] ) {
-				// Translators: The placeholder is the name of the taxonomy for the term being edited
-				throw new UserError( sprintf( __( 'The ID passed is not for a %1$s object', 'wp-graphql' ), $taxonomy->graphql_single_name ) );
-			}
+            /**
+             * Ensure the type for the Global ID matches the type being mutated
+             */
+            if ( empty( $id_parts['type'] ) || $taxonomy->name !== $id_parts['type'] ) {
+                // Translators: The placeholder is the name of the taxonomy for the term being edited
+                throw new UserError( sprintf( __( 'The ID passed is not for a %1$s object', 'wp-graphql' ), $taxonomy->graphql_single_name ) );
+            }
 
-			/**
-			 * Get the term before deleting it
-			 */
-			$term_object = get_term( $term_id, $taxonomy->name );
+            /**
+             * Get the term before deleting it
+             */
+            $term_object = get_term( $term_id, $taxonomy->name );
 
-			/**
-			 * Ensure the user can delete terms of this taxonomy
-			 */
-			if ( ! current_user_can( 'delete_term', $term_object->term_id ) ) {
-				// Translators: The placeholder is the name of the taxonomy for the term being deleted
-				throw new UserError( sprintf( __( 'You do not have permission to delete %1$s', 'wp-graphql' ), $taxonomy->graphql_plural_name ) );
-			}
+            /**
+             * Ensure the user can delete terms of this taxonomy
+             */
+            if ( ! current_user_can( 'delete_term', $term_object->term_id ) ) {
+                // Translators: The placeholder is the name of the taxonomy for the term being deleted
+                throw new UserError( sprintf( __( 'You do not have permission to delete %1$s', 'wp-graphql' ), $taxonomy->graphql_plural_name ) );
+            }
 
-			/**
-			 * Delete the term and get the response
-			 */
-			$deleted = wp_delete_term( $term_id, $taxonomy->name );
+            /**
+             * Delete the term and get the response
+             */
+            $deleted = wp_delete_term( $term_id, $taxonomy->name );
 
-			/**
-			 * If there was an error deleting the term, get the error message and return it
-			 */
-			if ( is_wp_error( $deleted ) ) {
-				$error_message = $deleted->get_error_message();
-				if ( ! empty( $error_message ) ) {
-					throw new UserError( esc_html( $error_message ) );
-				} else {
-					// Translators: The placeholder is the name of the taxonomy for the term being deleted
-					throw new UserError( sprintf( __( 'The %1$s failed to delete but no error was provided', 'wp-graphql' ), $taxonomy->name ) );
-				}
-			}
+            /**
+             * If there was an error deleting the term, get the error message and return it
+             */
+            if ( is_wp_error( $deleted ) ) {
+                $error_message = $deleted->get_error_message();
+                if ( ! empty( $error_message ) ) {
+                    throw new UserError( esc_html( $error_message ) );
+                } else {
+                    // Translators: The placeholder is the name of the taxonomy for the term being deleted
+                    throw new UserError( sprintf( __( 'The %1$s failed to delete but no error was provided', 'wp-graphql' ), $taxonomy->name ) );
+                }
+            }
 
-			/**
-			 * Return the term object that was retrieved prior to deletion
-			 */
-			return [
-				'termObject' => $term_object,
-			];
-		};
-	}
+            /**
+             * Return the term object that was retrieved prior to deletion
+             */
+            return [
+                'termObject' => $term_object,
+            ];
+        };
+    }
 }

--- a/src/Mutation/TermObjectUpdate.php
+++ b/src/Mutation/TermObjectUpdate.php
@@ -9,115 +9,124 @@ use WPGraphQL\Data\TermObjectMutation;
 
 class TermObjectUpdate {
 	public static function register_mutation( \WP_Taxonomy $taxonomy ) {
-
 		$mutation_name = 'Update' . ucwords( $taxonomy->graphql_single_name );
 		register_graphql_mutation( $mutation_name, [
-			'inputFields'         => array_merge(
-				TermObjectCreate::get_input_fields( $taxonomy ),
-				[
-					'name' => [
-						'type'        => 'String',
-						// Translators: The placeholder is the name of the taxonomy for the object being mutated
-						'description' => sprintf( __( 'The name of the %1$s object to mutate', 'wp-graphql' ), $taxonomy->name ),
-					],
-					'id'   => [
-						'type'        => [
-							'non_null' => 'ID',
-						],
-						// Translators: The placeholder is the taxonomy of the term being updated
-						'description' => sprintf( __( 'The ID of the %1$s object to update', 'wp-graphql' ), $taxonomy->graphql_single_name ),
-					],
-				]
-			),
-			'outputFields'        => [
-				$taxonomy->graphql_single_name => [
-					'type'    => $taxonomy->graphql_single_name,
-					'resolve' => function( $payload ) use ( $taxonomy ) {
-						return get_term( $payload['term_id'], $taxonomy->name );
-					},
+			'inputFields'         => self::get_input_fields( $taxonomy ),
+			'outputFields'        => self::get_output_fields( $taxonomy ),
+			'mutateAndGetPayload' => self::mutate_and_get_payload( $taxonomy, $mutation_name ),
+		] );
+	}
+
+	public static function get_input_fields( \WP_Taxonomy $taxonomy ) {
+		return array_merge(
+			TermObjectCreate::get_input_fields( $taxonomy ),
+			[
+				'name' => [
+					'type'        => 'String',
+					// Translators: The placeholder is the name of the taxonomy for the object being mutated
+					'description' => sprintf( __( 'The name of the %1$s object to mutate', 'wp-graphql' ), $taxonomy->name ),
 				],
+				'id'   => [
+					'type'        => [
+						'non_null' => 'ID',
+					],
+					// Translators: The placeholder is the taxonomy of the term being updated
+					'description' => sprintf( __( 'The ID of the %1$s object to update', 'wp-graphql' ), $taxonomy->graphql_single_name ),
+				],
+			]
+		);
+	}
+
+	public static function get_output_fields( \WP_Taxonomy $taxonomy ) {
+		return [
+			$taxonomy->graphql_single_name => [
+				'type'    => $taxonomy->graphql_single_name,
+				'resolve' => function( $payload ) use ( $taxonomy ) {
+					return get_term( $payload['term_id'], $taxonomy->name );
+				},
 			],
-			'mutateAndGetPayload' => function( $input, AppContext $context, ResolveInfo $info ) use ( $taxonomy, $mutation_name ) {
+		];
+	}
 
-				/**
-				 * Get the ID parts
-				 */
-				$id_parts = ! empty( $input['id'] ) ? Relay::fromGlobalId( $input['id'] ) : null;
+	public static function mutate_and_get_payload( \WP_Taxonomy $taxonomy, $mutation_name ) {
+		return function( $input, AppContext $context, ResolveInfo $info ) use ( $taxonomy, $mutation_name ) {
+			/**
+			 * Get the ID parts
+			 */
+			$id_parts = ! empty( $input['id'] ) ? Relay::fromGlobalId( $input['id'] ) : null;
 
-				/**
-				 * Ensure the type for the Global ID matches the type being mutated
-				 */
-				if ( empty( $id_parts['type'] ) || $taxonomy->name !== $id_parts['type'] ) {
-					// Translators: The placeholder is the name of the taxonomy for the term being edited
-					throw new UserError( sprintf( __( 'The ID passed is not for a %1$s object', 'wp-graphql' ), $taxonomy->graphql_single_name ) );
-				}
+			/**
+			 * Ensure the type for the Global ID matches the type being mutated
+			 */
+			if ( empty( $id_parts['type'] ) || $taxonomy->name !== $id_parts['type'] ) {
+				// Translators: The placeholder is the name of the taxonomy for the term being edited
+				throw new UserError( sprintf( __( 'The ID passed is not for a %1$s object', 'wp-graphql' ), $taxonomy->graphql_single_name ) );
+			}
 
-				/**
-				 * Get the existing term
-				 */
-				$existing_term = get_term( absint( $id_parts['id'] ), $taxonomy->name );
+			/**
+			 * Get the existing term
+			 */
+			$existing_term = get_term( absint( $id_parts['id'] ), $taxonomy->name );
 
-				/**
-				 * If there was an error getting the existing term, return the error message
-				 */
-				if ( is_wp_error( $existing_term ) ) {
-					$error_message = $existing_term->get_error_message();
-					if ( ! empty( $error_message ) ) {
-						throw new UserError( esc_html( $error_message ) );
-					} else {
-						// Translators: The placeholder is the name of the taxonomy for the term being deleted
-						throw new UserError( sprintf( __( 'The %1$s failed to update', 'wp-graphql' ), $taxonomy->name ) );
-					}
-				}
-
-				/**
-				 * Ensure the user has permission to edit terms
-				 */
-				if ( ! current_user_can( 'edit_term', $existing_term->term_id ) ) {
+			/**
+			 * If there was an error getting the existing term, return the error message
+			 */
+			if ( is_wp_error( $existing_term ) ) {
+				$error_message = $existing_term->get_error_message();
+				if ( ! empty( $error_message ) ) {
+					throw new UserError( esc_html( $error_message ) );
+				} else {
 					// Translators: The placeholder is the name of the taxonomy for the term being deleted
-					throw new UserError( sprintf( __( 'You do not have permission to update %1$s', 'wp-graphql' ), $taxonomy->graphql_plural_name ) );
+					throw new UserError( sprintf( __( 'The %1$s failed to update', 'wp-graphql' ), $taxonomy->name ) );
 				}
+			}
+
+			/**
+			 * Ensure the user has permission to edit terms
+			 */
+			if ( ! current_user_can( 'edit_term', $existing_term->term_id ) ) {
+				// Translators: The placeholder is the name of the taxonomy for the term being deleted
+				throw new UserError( sprintf( __( 'You do not have permission to update %1$s', 'wp-graphql' ), $taxonomy->graphql_plural_name ) );
+			}
+
+			/**
+			 * Prepare the $args for mutation
+			 */
+			$args = TermObjectMutation::prepare_object( $input, $taxonomy, $mutation_name );
+
+			if ( ! empty( $args ) ) {
 
 				/**
-				 * Prepare the $args for mutation
+				 * Update the term
 				 */
-				$args = TermObjectMutation::prepare_object( $input, $taxonomy, $mutation_name );
+				$update = wp_update_term( $existing_term->term_id, $taxonomy->name, wp_slash( (array) $args ) );
 
-				if ( ! empty( $args ) ) {
-
-					/**
-					 * Update the term
-					 */
-					$update = wp_update_term( $existing_term->term_id, $taxonomy->name, wp_slash( (array) $args ) );
-
-					/**
-					 * Respond with any errors
-					 */
-					if ( is_wp_error( $update ) ) {
-						// Translators: the placeholder is the name of the taxonomy
-						throw new UserError( sprintf( __( 'The %1$s failed to update', 'wp-graphql' ), $taxonomy->name ) );
-					}
+				/**
+				 * Respond with any errors
+				 */
+				if ( is_wp_error( $update ) ) {
+					// Translators: the placeholder is the name of the taxonomy
+					throw new UserError( sprintf( __( 'The %1$s failed to update', 'wp-graphql' ), $taxonomy->name ) );
 				}
+			}
 
-				/**
-				 * Fires an action when a term is updated via a GraphQL Mutation
-				 *
-				 * @param int         $term_id       The ID of the term object that was mutated
-				 * @param array       $args          The args used to update the term
-				 * @param string      $mutation_name The name of the mutation being performed (create, update, delete, etc)
-				 * @param AppContext  $context       The AppContext passed down the resolve tree
-				 * @param ResolveInfo $info          The ResolveInfo passed down the resolve tree
-				 */
-				do_action( "graphql_update_{$taxonomy->name}", $existing_term->term_id, $args, $mutation_name, $context, $info );
+			/**
+			 * Fires an action when a term is updated via a GraphQL Mutation
+			 *
+			 * @param int         $term_id       The ID of the term object that was mutated
+			 * @param array       $args          The args used to update the term
+			 * @param string      $mutation_name The name of the mutation being performed (create, update, delete, etc)
+			 * @param AppContext  $context       The AppContext passed down the resolve tree
+			 * @param ResolveInfo $info          The ResolveInfo passed down the resolve tree
+			 */
+			do_action( "graphql_update_{$taxonomy->name}", $existing_term->term_id, $args, $mutation_name, $context, $info );
 
-				/**
-				 * Return the payload
-				 */
-				return [
-					'term_id' => $existing_term->term_id,
-				];
-
-			},
-		]);
+			/**
+			 * Return the payload
+			 */
+			return [
+				'term_id' => $existing_term->term_id,
+			];
+		};
 	}
 }

--- a/src/Mutation/TermObjectUpdate.php
+++ b/src/Mutation/TermObjectUpdate.php
@@ -8,125 +8,143 @@ use WPGraphQL\AppContext;
 use WPGraphQL\Data\TermObjectMutation;
 
 class TermObjectUpdate {
-	public static function register_mutation( \WP_Taxonomy $taxonomy ) {
-		$mutation_name = 'Update' . ucwords( $taxonomy->graphql_single_name );
-		register_graphql_mutation( $mutation_name, [
-			'inputFields'         => self::get_input_fields( $taxonomy ),
-			'outputFields'        => self::get_output_fields( $taxonomy ),
-			'mutateAndGetPayload' => self::mutate_and_get_payload( $taxonomy, $mutation_name ),
-		] );
-	}
+    /**
+     * Registers the TermObjectUpdate mutation.
+     */
+    public static function register_mutation( \WP_Taxonomy $taxonomy ) {
+        $mutation_name = 'Update' . ucwords( $taxonomy->graphql_single_name );
+        register_graphql_mutation( $mutation_name, [
+            'inputFields'         => self::get_input_fields( $taxonomy ),
+            'outputFields'        => self::get_output_fields( $taxonomy ),
+            'mutateAndGetPayload' => self::mutate_and_get_payload( $taxonomy, $mutation_name ),
+        ] );
+    }
 
-	public static function get_input_fields( \WP_Taxonomy $taxonomy ) {
-		return array_merge(
-			TermObjectCreate::get_input_fields( $taxonomy ),
-			[
-				'name' => [
-					'type'        => 'String',
-					// Translators: The placeholder is the name of the taxonomy for the object being mutated
-					'description' => sprintf( __( 'The name of the %1$s object to mutate', 'wp-graphql' ), $taxonomy->name ),
-				],
-				'id'   => [
-					'type'        => [
-						'non_null' => 'ID',
-					],
-					// Translators: The placeholder is the taxonomy of the term being updated
-					'description' => sprintf( __( 'The ID of the %1$s object to update', 'wp-graphql' ), $taxonomy->graphql_single_name ),
-				],
-			]
-		);
-	}
+    /**
+     * Defines the mutation input field configuration.
+     *
+     * @param \WP_Taxonomy  $taxonomy    The taxonomy type of the mutation.
+     *
+     * @return array
+     */
+    public static function get_input_fields( \WP_Taxonomy $taxonomy ) {
+        return array_merge(
+            TermObjectCreate::get_input_fields( $taxonomy ),
+            [
+                'name' => [
+                    'type'        => 'String',
+                    // Translators: The placeholder is the name of the taxonomy for the object being mutated
+                    'description' => sprintf( __( 'The name of the %1$s object to mutate', 'wp-graphql' ), $taxonomy->name ),
+                ],
+                'id'   => [
+                    'type'        => [
+                        'non_null' => 'ID',
+                    ],
+                    // Translators: The placeholder is the taxonomy of the term being updated
+                    'description' => sprintf( __( 'The ID of the %1$s object to update', 'wp-graphql' ), $taxonomy->graphql_single_name ),
+                ],
+            ]
+        );
+    }
 
-	public static function get_output_fields( \WP_Taxonomy $taxonomy ) {
-		return [
-			$taxonomy->graphql_single_name => [
-				'type'    => $taxonomy->graphql_single_name,
-				'resolve' => function( $payload ) use ( $taxonomy ) {
-					return get_term( $payload['term_id'], $taxonomy->name );
-				},
-			],
-		];
-	}
+    /**
+     * Defines the mutation output field configuration.
+     *
+     * @param \WP_Taxonomy  $taxonomy    The taxonomy type of the mutation.
+     *
+     * @return array
+     */
+     public static function get_output_fields( \WP_Taxonomy $taxonomy ) {
+        return TermObjectCreate::get_output_fields( $taxonomy );
+    }
 
-	public static function mutate_and_get_payload( \WP_Taxonomy $taxonomy, $mutation_name ) {
-		return function( $input, AppContext $context, ResolveInfo $info ) use ( $taxonomy, $mutation_name ) {
-			/**
-			 * Get the ID parts
-			 */
-			$id_parts = ! empty( $input['id'] ) ? Relay::fromGlobalId( $input['id'] ) : null;
+    /**
+     * Defines the mutation data modification closure.
+     *
+     * @param \WP_Taxonomy  $taxonomy       The taxonomy type of the mutation.
+     * @param string        $mutation_name  The name of the mutation.
+     *
+     * @return callable
+     */
+    public static function mutate_and_get_payload( \WP_Taxonomy $taxonomy, $mutation_name ) {
+        return function( $input, AppContext $context, ResolveInfo $info ) use ( $taxonomy, $mutation_name ) {
+            /**
+             * Get the ID parts
+             */
+            $id_parts = ! empty( $input['id'] ) ? Relay::fromGlobalId( $input['id'] ) : null;
 
-			/**
-			 * Ensure the type for the Global ID matches the type being mutated
-			 */
-			if ( empty( $id_parts['type'] ) || $taxonomy->name !== $id_parts['type'] ) {
-				// Translators: The placeholder is the name of the taxonomy for the term being edited
-				throw new UserError( sprintf( __( 'The ID passed is not for a %1$s object', 'wp-graphql' ), $taxonomy->graphql_single_name ) );
-			}
+            /**
+             * Ensure the type for the Global ID matches the type being mutated
+             */
+            if ( empty( $id_parts['type'] ) || $taxonomy->name !== $id_parts['type'] ) {
+                // Translators: The placeholder is the name of the taxonomy for the term being edited
+                throw new UserError( sprintf( __( 'The ID passed is not for a %1$s object', 'wp-graphql' ), $taxonomy->graphql_single_name ) );
+            }
 
-			/**
-			 * Get the existing term
-			 */
-			$existing_term = get_term( absint( $id_parts['id'] ), $taxonomy->name );
+            /**
+             * Get the existing term
+             */
+            $existing_term = get_term( absint( $id_parts['id'] ), $taxonomy->name );
 
-			/**
-			 * If there was an error getting the existing term, return the error message
-			 */
-			if ( is_wp_error( $existing_term ) ) {
-				$error_message = $existing_term->get_error_message();
-				if ( ! empty( $error_message ) ) {
-					throw new UserError( esc_html( $error_message ) );
-				} else {
-					// Translators: The placeholder is the name of the taxonomy for the term being deleted
-					throw new UserError( sprintf( __( 'The %1$s failed to update', 'wp-graphql' ), $taxonomy->name ) );
-				}
-			}
+            /**
+             * If there was an error getting the existing term, return the error message
+             */
+            if ( is_wp_error( $existing_term ) ) {
+                $error_message = $existing_term->get_error_message();
+                if ( ! empty( $error_message ) ) {
+                    throw new UserError( esc_html( $error_message ) );
+                } else {
+                    // Translators: The placeholder is the name of the taxonomy for the term being deleted
+                    throw new UserError( sprintf( __( 'The %1$s failed to update', 'wp-graphql' ), $taxonomy->name ) );
+                }
+            }
 
-			/**
-			 * Ensure the user has permission to edit terms
-			 */
-			if ( ! current_user_can( 'edit_term', $existing_term->term_id ) ) {
-				// Translators: The placeholder is the name of the taxonomy for the term being deleted
-				throw new UserError( sprintf( __( 'You do not have permission to update %1$s', 'wp-graphql' ), $taxonomy->graphql_plural_name ) );
-			}
+            /**
+             * Ensure the user has permission to edit terms
+             */
+            if ( ! current_user_can( 'edit_term', $existing_term->term_id ) ) {
+                // Translators: The placeholder is the name of the taxonomy for the term being deleted
+                throw new UserError( sprintf( __( 'You do not have permission to update %1$s', 'wp-graphql' ), $taxonomy->graphql_plural_name ) );
+            }
 
-			/**
-			 * Prepare the $args for mutation
-			 */
-			$args = TermObjectMutation::prepare_object( $input, $taxonomy, $mutation_name );
+            /**
+             * Prepare the $args for mutation
+             */
+            $args = TermObjectMutation::prepare_object( $input, $taxonomy, $mutation_name );
 
-			if ( ! empty( $args ) ) {
+            if ( ! empty( $args ) ) {
 
-				/**
-				 * Update the term
-				 */
-				$update = wp_update_term( $existing_term->term_id, $taxonomy->name, wp_slash( (array) $args ) );
+                /**
+                 * Update the term
+                 */
+                $update = wp_update_term( $existing_term->term_id, $taxonomy->name, wp_slash( (array) $args ) );
 
-				/**
-				 * Respond with any errors
-				 */
-				if ( is_wp_error( $update ) ) {
-					// Translators: the placeholder is the name of the taxonomy
-					throw new UserError( sprintf( __( 'The %1$s failed to update', 'wp-graphql' ), $taxonomy->name ) );
-				}
-			}
+                /**
+                 * Respond with any errors
+                 */
+                if ( is_wp_error( $update ) ) {
+                    // Translators: the placeholder is the name of the taxonomy
+                    throw new UserError( sprintf( __( 'The %1$s failed to update', 'wp-graphql' ), $taxonomy->name ) );
+                }
+            }
 
-			/**
-			 * Fires an action when a term is updated via a GraphQL Mutation
-			 *
-			 * @param int         $term_id       The ID of the term object that was mutated
-			 * @param array       $args          The args used to update the term
-			 * @param string      $mutation_name The name of the mutation being performed (create, update, delete, etc)
-			 * @param AppContext  $context       The AppContext passed down the resolve tree
-			 * @param ResolveInfo $info          The ResolveInfo passed down the resolve tree
-			 */
-			do_action( "graphql_update_{$taxonomy->name}", $existing_term->term_id, $args, $mutation_name, $context, $info );
+            /**
+             * Fires an action when a term is updated via a GraphQL Mutation
+             *
+             * @param int         $term_id       The ID of the term object that was mutated
+             * @param array       $args          The args used to update the term
+             * @param string      $mutation_name The name of the mutation being performed (create, update, delete, etc)
+             * @param AppContext  $context       The AppContext passed down the resolve tree
+             * @param ResolveInfo $info          The ResolveInfo passed down the resolve tree
+             */
+            do_action( "graphql_update_{$taxonomy->name}", $existing_term->term_id, $args, $mutation_name, $context, $info );
 
-			/**
-			 * Return the payload
-			 */
-			return [
-				'term_id' => $existing_term->term_id,
-			];
-		};
-	}
+            /**
+             * Return the payload
+             */
+            return [
+                'termId' => $existing_term->term_id,
+            ];
+        };
+    }
 }

--- a/src/Mutation/UpdateSettings.php
+++ b/src/Mutation/UpdateSettings.php
@@ -6,151 +6,168 @@ use GraphQL\Error\UserError;
 use WPGraphQL\Data\DataSource;
 
 class UpdateSettings {
-	public static function register_mutation() {
-		register_graphql_mutation( 'updateSettings', [
-			'inputFields'         => self::get_input_fields(),
-			'outputFields'        => self::get_output_fields(),
-			'mutateAndGetPayload' => self::mutate_and_get_payload(),
-		] );
-	}
+    /**
+     * Registers the CommentCreate mutation.
+     */
+    public static function register_mutation() {
+        register_graphql_mutation( 'updateSettings', [
+            'inputFields'         => self::get_input_fields(),
+            'outputFields'        => self::get_output_fields(),
+            'mutateAndGetPayload' => self::mutate_and_get_payload(),
+        ] );
+    }
 
-	public static function get_input_fields() {
-		$allowed_settings = DataSource::get_allowed_settings();
+    /**
+     * Defines the mutation input field configuration.
+     *
+     * @return array
+     */
+    public static function get_input_fields() {
+        $allowed_settings = DataSource::get_allowed_settings();
 
-		$input_fields = [];
+        $input_fields = [];
 
-		if ( ! empty( $allowed_settings ) && empty( self::$input_fields ) ) {
+        if ( ! empty( $allowed_settings ) && empty( self::$input_fields ) ) {
 
-			/**
-			 * Loop through the $allowed_settings and build fields
-			 * for the individual settings
-			 */
-			foreach ( $allowed_settings as $key => $setting ) {
+            /**
+             * Loop through the $allowed_settings and build fields
+             * for the individual settings
+             */
+            foreach ( $allowed_settings as $key => $setting ) {
 
-				/**
-				 * Determine if the individual setting already has a
-				 * REST API name, if not use the option name.
-				 * Sanitize the field name to be camelcase
-				 */
-				if ( ! empty( $setting['show_in_rest']['name'] ) ) {
-					$individual_setting_key = lcfirst( $setting['group'] . 'Settings' . str_replace( '_', '', ucwords( $setting['show_in_rest']['name'], '_' ) ) );
-				} else {
-					$individual_setting_key = lcfirst( $setting['group'] . 'Settings' . str_replace( '_', '', ucwords( $key, '_' ) ) );
-				}
+                /**
+                 * Determine if the individual setting already has a
+                 * REST API name, if not use the option name.
+                 * Sanitize the field name to be camelcase
+                 */
+                if ( ! empty( $setting['show_in_rest']['name'] ) ) {
+                    $individual_setting_key = lcfirst( $setting['group'] . 'Settings' . str_replace( '_', '', ucwords( $setting['show_in_rest']['name'], '_' ) ) );
+                } else {
+                    $individual_setting_key = lcfirst( $setting['group'] . 'Settings' . str_replace( '_', '', ucwords( $key, '_' ) ) );
+                }
 
-				/**
-				 * Dynamically build the individual setting,
-				 * then add it to the $input_fields
-				 */
-				$input_fields[ $individual_setting_key ] = [
-					'type'        => $setting['type'],
-					'description' => $setting['description'],
-				];
+                /**
+                 * Dynamically build the individual setting,
+                 * then add it to the $input_fields
+                 */
+                $input_fields[ $individual_setting_key ] = [
+                    'type'        => $setting['type'],
+                    'description' => $setting['description'],
+                ];
 
-			}
+            }
 
-		}
+        }
 
-		return $input_fields;
-	}
+        return $input_fields;
+    }
 
-	public static function get_output_fields() {
-		$output_fields = [];
+    /**
+     * Defines the mutation output field configuration.
+     *
+     * @return array
+     */
+    public static function get_output_fields() {
+        $output_fields = [];
 
-		/**
-		 * Get the allowed setting groups and their fields
-		 */
-		$allowed_setting_groups = DataSource::get_allowed_settings_by_group();
-		if ( ! empty( $allowed_setting_groups ) && is_array( $allowed_setting_groups ) ) {
-			foreach ( $allowed_setting_groups as $group => $setting_type ) {
-				$setting_type = str_replace( '_', '', strtolower( $group ) );
-				// $output_fields[ $setting_type . 'Settings' ] = SettingQuery::root_query( $group, $setting_type );
+        /**
+         * Get the allowed setting groups and their fields
+         */
+        $allowed_setting_groups = DataSource::get_allowed_settings_by_group();
+        if ( ! empty( $allowed_setting_groups ) && is_array( $allowed_setting_groups ) ) {
+            foreach ( $allowed_setting_groups as $group => $setting_type ) {
+                $setting_type = str_replace( '_', '', strtolower( $group ) );
 
-				$output_fields[ $setting_type . 'Settings' ] = [
-					'type'    => $setting_type . 'Settings',
-					'resolve' => function () use ( $setting_type ) {
-						return $setting_type;
-					},
-				];
+                $output_fields[ $setting_type . 'Settings' ] = [
+                    'type'    => $setting_type . 'Settings',
+                    'resolve' => function () use ( $setting_type ) {
+                        return $setting_type;
+                    },
+                ];
 
-			}
-		}
+            }
+        }
 
-		/**
-		 * Get all of the settings, regardless of group
-		 */
-		$output_fields['allSettings'] = [
-			'type'    => 'Settings',
-			'resolve' => function () {
-				return true;
-			},
-		];
+        /**
+         * Get all of the settings, regardless of group
+         */
+        $output_fields['allSettings'] = [
+            'type'    => 'Settings',
+            'resolve' => function () {
+                return true;
+            },
+        ];
 
-		return $output_fields;
-	}
+        return $output_fields;
+    }
 
-	public static function mutate_and_get_payload() {
-		return function ( $input ) {
-			/**
-			 * Check that the user can manage setting options
-			 */
-			if ( ! current_user_can( 'manage_options' ) ) {
-				throw new UserError( __( 'Sorry, you are not allowed to edit settings as this user.', 'wp-graphql' ) );
-			}
+    /**
+     * Defines the mutation data modification closure.
+     *
+     * @return callable
+     */
+    public static function mutate_and_get_payload() {
+        return function ( $input ) {
+            /**
+             * Check that the user can manage setting options
+             */
+            if ( ! current_user_can( 'manage_options' ) ) {
+                throw new UserError( __( 'Sorry, you are not allowed to edit settings as this user.', 'wp-graphql' ) );
+            }
 
-			/**
-			 * The $updatable_settings_options will store all of the allowed
-			 * settings in a WP ready format
-			 */
-			$updatable_settings_options = [];
+            /**
+             * The $updatable_settings_options will store all of the allowed
+             * settings in a WP ready format
+             */
+            $updatable_settings_options = [];
 
-			$allowed_settings = DataSource::get_allowed_settings();
+            $allowed_settings = DataSource::get_allowed_settings();
 
-			/**
-			 * Loop through the $allowed_settings and build the insert options array
-			 */
-			foreach ( $allowed_settings as $key => $setting ) {
+            /**
+             * Loop through the $allowed_settings and build the insert options array
+             */
+            foreach ( $allowed_settings as $key => $setting ) {
 
-				/**
-				 * Determine if the individual setting already has a
-				 * REST API name, if not use the option name.
-				 * Sanitize the field name to be camelcase
-				 */
-				if ( ! empty( $setting['show_in_rest']['name'] ) ) {
-					$individual_setting_key = lcfirst( $setting['group'] . 'Settings' . str_replace( '_', '', ucwords( $setting['show_in_rest']['name'], '_' ) ) );
-				} else {
-					$individual_setting_key = lcfirst( $setting['group'] . 'Settings' . str_replace( '_', '', ucwords( $key, '_' ) ) );
-				}
+                /**
+                 * Determine if the individual setting already has a
+                 * REST API name, if not use the option name.
+                 * Sanitize the field name to be camelcase
+                 */
+                if ( ! empty( $setting['show_in_rest']['name'] ) ) {
+                    $individual_setting_key = lcfirst( $setting['group'] . 'Settings' . str_replace( '_', '', ucwords( $setting['show_in_rest']['name'], '_' ) ) );
+                } else {
+                    $individual_setting_key = lcfirst( $setting['group'] . 'Settings' . str_replace( '_', '', ucwords( $key, '_' ) ) );
+                }
 
-				/**
-				 * Dynamically build the individual setting,
-				 * then add it to $updatable_settings_options
-				 */
-				$updatable_settings_options[ $individual_setting_key ] = [
-					'option' => $key,
-					'group'  => $setting['group'],
-				];
+                /**
+                 * Dynamically build the individual setting,
+                 * then add it to $updatable_settings_options
+                 */
+                $updatable_settings_options[ $individual_setting_key ] = [
+                    'option' => $key,
+                    'group'  => $setting['group'],
+                ];
 
-			}
+            }
 
-			foreach ( $input as $key => $value ) {
-				/**
-				 * Throw an error if the input field is the site url,
-				 * as we do not want users changing it and breaking all
-				 * the things
-				 */
-				if ( 'generalSettingsUrl' === $key ) {
-					throw new UserError( __( 'Sorry, that is not allowed, speak with your site administrator to change the site URL.', 'wp-graphql' ) );
-				}
+            foreach ( $input as $key => $value ) {
+                /**
+                 * Throw an error if the input field is the site url,
+                 * as we do not want users changing it and breaking all
+                 * the things
+                 */
+                if ( 'generalSettingsUrl' === $key ) {
+                    throw new UserError( __( 'Sorry, that is not allowed, speak with your site administrator to change the site URL.', 'wp-graphql' ) );
+                }
 
-				/**
-				 * Check to see that the input field exists in settings, if so grab the option
-				 * name and update the option
-				 */
-				if ( array_key_exists( $key, $updatable_settings_options ) ) {
-					update_option( $updatable_settings_options[ $key ]['option'], $value );
-				}
-			}
-		};
-	}
+                /**
+                 * Check to see that the input field exists in settings, if so grab the option
+                 * name and update the option
+                 */
+                if ( array_key_exists( $key, $updatable_settings_options ) ) {
+                    update_option( $updatable_settings_options[ $key ]['option'], $value );
+                }
+            }
+        };
+    }
 }

--- a/src/Mutation/UserCreate.php
+++ b/src/Mutation/UserCreate.php
@@ -7,150 +7,168 @@ use WPGraphQL\AppContext;
 use WPGraphQL\Data\UserMutation;
 
 class UserCreate {
-	public static function register_mutation() {
-		register_graphql_mutation( 'createUser', [
-			'inputFields' => array_merge( [
-				'username' => [
-					'type'        => [
-						'non_null' => 'String',
-					],
-					// translators: the placeholder is the name of the type of post object being updated
-					'description' => __( 'A string that contains the user\'s username for logging in.', 'wp-graphql' ),
-				],
-			], self::get_input_fields() ),
-			'outputFields'        => self::get_output_fields(),
-			'mutateAndGetPayload' => self::mutate_and_get_payload(),
-		] );
-	}
+    /**
+     * Registers the CommentCreate mutation.
+     */
+    public static function register_mutation() {
+        register_graphql_mutation( 'createUser', [
+            'inputFields' => array_merge( [
+                'username' => [
+                    'type'        => [
+                        'non_null' => 'String',
+                    ],
+                    // translators: the placeholder is the name of the type of post object being updated
+                    'description' => __( 'A string that contains the user\'s username for logging in.', 'wp-graphql' ),
+                ],
+            ], self::get_input_fields() ),
+            'outputFields'        => self::get_output_fields(),
+            'mutateAndGetPayload' => self::mutate_and_get_payload(),
+        ] );
+    }
 
-	public static function get_input_fields() {
-		return [
-			'password'    => [
-				'type'        => 'String',
-				'description' => __( 'A string that contains the plain text password for the user.', 'wp-graphql' ),
-			],
-			'nicename'    => [
-				'type'        => 'String',
-				'description' => __( 'A string that contains a URL-friendly name for the user. The default is the user\'s username.', 'wp-graphql' ),
-			],
-			'websiteUrl'  => [
-				'type'        => 'String',
-				'description' => __( 'A string containing the user\'s URL for the user\'s web site.', 'wp-grapql' ),
-			],
-			'email'       => [
-				'type'        => 'String',
-				'description' => __( 'A string containing the user\'s email address.', 'wp-graphql' ),
-			],
-			'displayName' => [
-				'type'        => 'String',
-				'description' => __( 'A string that will be shown on the site. Defaults to user\'s username. It is likely that you will want to change this, for both appearance and security through obscurity (that is if you dont use and delete the default admin user).', 'wp-graphql' ),
-			],
-			'nickname'    => [
-				'type'        => 'String',
-				'description' => __( 'The user\'s nickname, defaults to the user\'s username.', 'wp-graphql' ),
-			],
-			'firstName'   => [
-				'type'        => 'String',
-				'description' => __( '	The user\'s first name.', 'wp-graphql' ),
-			],
-			'lastName'    => [
-				'type'        => 'String',
-				'description' => __( 'The user\'s last name.', 'wp-graphql' ),
-			],
-			'description' => [
-				'type'        => 'String',
-				'description' => __( 'A string containing content about the user.', 'wp-graphql' ),
-			],
-			'richEditing' => [
-				'type'        => 'String',
-				'description' => __( 'A string for whether to enable the rich editor or not. False if not empty.', 'wp-graphql' ),
-			],
-			'registered'  => [
-				'type'        => 'String',
-				'description' => __( 'The date the user registered. Format is Y-m-d H:i:s.', 'wp-graphql' ),
-			],
-			'roles'       => [
-				'type'        => [
-					'list_of' => 'String',
-				],
-				'description' => __( 'An array of roles to be assigned to the user.', 'wp-graphql' ),
-			],
-			'jabber'      => [
-				'type'        => 'String',
-				'description' => __( 'User\'s Jabber account.', 'wp-graphql' ),
-			],
-			'aim'         => [
-				'type'        => 'String',
-				'description' => __( 'User\'s AOL IM account.', 'wp-graphql' ),
-			],
-			'yim'         => [
-				'type'        => 'String',
-				'description' => __( 'User\'s Yahoo IM account.', 'wp-graphql' ),
-			],
-			'locale'      => [
-				'type'        => 'String',
-				'description' => __( 'User\'s locale.', 'wp-graphql' ),
-			],
-		];
-	}
-	
-	public static function get_output_fields() {
-		return [
-			'user' => [
-				'type'    => 'User',
-				'resolve' => function ( $payload ) {
-					return get_user_by( 'ID', $payload['id'] );
-				},
-			],
-		];
-	}
+    /**
+     * Defines the mutation input field configuration.
+     *
+     * @return array
+     */
+    public static function get_input_fields() {
+        return [
+            'password'    => [
+                'type'        => 'String',
+                'description' => __( 'A string that contains the plain text password for the user.', 'wp-graphql' ),
+            ],
+            'nicename'    => [
+                'type'        => 'String',
+                'description' => __( 'A string that contains a URL-friendly name for the user. The default is the user\'s username.', 'wp-graphql' ),
+            ],
+            'websiteUrl'  => [
+                'type'        => 'String',
+                'description' => __( 'A string containing the user\'s URL for the user\'s web site.', 'wp-grapql' ),
+            ],
+            'email'       => [
+                'type'        => 'String',
+                'description' => __( 'A string containing the user\'s email address.', 'wp-graphql' ),
+            ],
+            'displayName' => [
+                'type'        => 'String',
+                'description' => __( 'A string that will be shown on the site. Defaults to user\'s username. It is likely that you will want to change this, for both appearance and security through obscurity (that is if you dont use and delete the default admin user).', 'wp-graphql' ),
+            ],
+            'nickname'    => [
+                'type'        => 'String',
+                'description' => __( 'The user\'s nickname, defaults to the user\'s username.', 'wp-graphql' ),
+            ],
+            'firstName'   => [
+                'type'        => 'String',
+                'description' => __( '	The user\'s first name.', 'wp-graphql' ),
+            ],
+            'lastName'    => [
+                'type'        => 'String',
+                'description' => __( 'The user\'s last name.', 'wp-graphql' ),
+            ],
+            'description' => [
+                'type'        => 'String',
+                'description' => __( 'A string containing content about the user.', 'wp-graphql' ),
+            ],
+            'richEditing' => [
+                'type'        => 'String',
+                'description' => __( 'A string for whether to enable the rich editor or not. False if not empty.', 'wp-graphql' ),
+            ],
+            'registered'  => [
+                'type'        => 'String',
+                'description' => __( 'The date the user registered. Format is Y-m-d H:i:s.', 'wp-graphql' ),
+            ],
+            'roles'       => [
+                'type'        => [
+                    'list_of' => 'String',
+                ],
+                'description' => __( 'An array of roles to be assigned to the user.', 'wp-graphql' ),
+            ],
+            'jabber'      => [
+                'type'        => 'String',
+                'description' => __( 'User\'s Jabber account.', 'wp-graphql' ),
+            ],
+            'aim'         => [
+                'type'        => 'String',
+                'description' => __( 'User\'s AOL IM account.', 'wp-graphql' ),
+            ],
+            'yim'         => [
+                'type'        => 'String',
+                'description' => __( 'User\'s Yahoo IM account.', 'wp-graphql' ),
+            ],
+            'locale'      => [
+                'type'        => 'String',
+                'description' => __( 'User\'s locale.', 'wp-graphql' ),
+            ],
+        ];
+    }
 
-	public static function mutate_and_get_payload() {
-		return function ( $input, AppContext $context, ResolveInfo $info ) {
-			if ( ! current_user_can( 'create_users' ) ) {
-				throw new UserError( __( 'Sorry, you are not allowed to create a new user.', 'wp-graphql' ) );
-			}
+    /**
+     * Defines the mutation output field configuration.
+     *
+     * @return array
+     */
+    public static function get_output_fields() {
+        return [
+            'user' => [
+                'type'    => 'User',
+                'resolve' => function ( $payload ) {
+                    return get_user_by( 'ID', $payload['id'] );
+                },
+            ],
+        ];
+    }
 
-			/**
-			 * Map all of the args from GQL to WP friendly
-			 */
-			$user_args = UserMutation::prepare_user_object( $input, 'createUser' );
+    /**
+     * Defines the mutation data modification closure.
+     *
+     * @return callable
+     */
+    public static function mutate_and_get_payload() {
+        return function ( $input, AppContext $context, ResolveInfo $info ) {
+            if ( ! current_user_can( 'create_users' ) ) {
+                throw new UserError( __( 'Sorry, you are not allowed to create a new user.', 'wp-graphql' ) );
+            }
 
-			/**
-			 * Create the new user
-			 */
-			$user_id = wp_insert_user( $user_args );
+            /**
+             * Map all of the args from GQL to WP friendly
+             */
+            $user_args = UserMutation::prepare_user_object( $input, 'createUser' );
 
-			/**
-			 * Throw an exception if the post failed to create
-			 */
-			if ( is_wp_error( $user_id ) ) {
-				$error_message = $user_id->get_error_message();
-				if ( ! empty( $error_message ) ) {
-					throw new UserError( esc_html( $error_message ) );
-				} else {
-					throw new UserError( __( 'The object failed to create but no error was provided', 'wp-graphql' ) );
-				}
-			}
+            /**
+             * Create the new user
+             */
+            $user_id = wp_insert_user( $user_args );
 
-			/**
-			 * If the $post_id is empty, we should throw an exception
-			 */
-			if ( empty( $user_id ) ) {
-				throw new UserError( __( 'The object failed to create', 'wp-graphql' ) );
-			}
+            /**
+             * Throw an exception if the post failed to create
+             */
+            if ( is_wp_error( $user_id ) ) {
+                $error_message = $user_id->get_error_message();
+                if ( ! empty( $error_message ) ) {
+                    throw new UserError( esc_html( $error_message ) );
+                } else {
+                    throw new UserError( __( 'The object failed to create but no error was provided', 'wp-graphql' ) );
+                }
+            }
 
-			/**
-			 * Update additional user data
-			 */
-			UserMutation::update_additional_user_object_data( $user_id, $input, 'createUser', $context, $info );
+            /**
+             * If the $post_id is empty, we should throw an exception
+             */
+            if ( empty( $user_id ) ) {
+                throw new UserError( __( 'The object failed to create', 'wp-graphql' ) );
+            }
 
-			/**
-			 * Return the new user ID
-			 */
-			return [
-				'id' => $user_id,
-			];
-		};
-	}
+            /**
+             * Update additional user data
+             */
+            UserMutation::update_additional_user_object_data( $user_id, $input, 'createUser', $context, $info );
+
+            /**
+             * Return the new user ID
+             */
+            return [
+                'id' => $user_id,
+            ];
+        };
+    }
 }

--- a/src/Mutation/UserCreate.php
+++ b/src/Mutation/UserCreate.php
@@ -94,7 +94,7 @@ class UserCreate {
 		];
 	}
 	
-	public static function get_output_fields( $post_type_object ) {
+	public static function get_output_fields() {
 		return [
 			'user' => [
 				'type'    => 'User',

--- a/src/Mutation/UserDelete.php
+++ b/src/Mutation/UserDelete.php
@@ -7,91 +7,102 @@ use GraphQLRelay\Relay;
 class UserDelete {
 	public static function register_mutation() {
 		register_graphql_mutation( 'deleteUser', [
-			'inputFields' => [
-				'id'         => [
-					'type'        => [
-						'non_null' => 'ID',
-					],
-					'description' => __( 'The ID of the user you want to delete', 'wp-graphql' ),
+			'inputFields'         => self::get_input_fields(),
+			'outputFields'        => self::get_output_fields(),
+			'mutateAndGetPayload' => self::mutate_and_get_payload(),
+		] );
+	}
+
+	public static function get_input_fields() {
+		return [
+			'id'         => [
+				'type'        => [
+					'non_null' => 'ID',
 				],
-				'reassignId' => [
-					'type'        => 'ID',
-					'description' => __( 'Reassign posts and links to new User ID.', 'wp-graphql' ),
-				],
+				'description' => __( 'The ID of the user you want to delete', 'wp-graphql' ),
 			],
-			'outputFields' => [
-				'deletedId' => [
-					'type'        => 'ID',
-					'description' => __( 'The ID of the user that you just deleted', 'wp-graphql' ),
-					'resolve'     => function ( $payload ) {
-						$deleted = (object) $payload['userObject'];
-
-						return ( ! empty( $deleted->ID ) ) ? Relay::toGlobalId( 'user', $deleted->ID ) : null;
-					},
-				],
-				'user'      => [
-					'type'        => 'User',
-					'description' => __( 'The user object for the user you are trying to delete', 'wp-graphql' ),
-					'resolve'     => function ( $payload ) {
-						$deleted = (object) $payload['userObject'];
-
-						return ( ! empty( $deleted ) ) ? $deleted : null;
-					},
-				],
+			'reassignId' => [
+				'type'        => 'ID',
+				'description' => __( 'Reassign posts and links to new User ID.', 'wp-graphql' ),
 			],
-			'mutateAndGetPayload' => function ( $input ) {
+		];
+	}
+		
+	public static function get_output_fields() {
+		return [
+			'deletedId' => [
+				'type'        => 'ID',
+				'description' => __( 'The ID of the user that you just deleted', 'wp-graphql' ),
+				'resolve'     => function ( $payload ) {
+					$deleted = (object) $payload['userObject'];
 
-				/**
-				 * Get the ID from the global ID
-				 */
-				$id_parts = Relay::fromGlobalId( $input['id'] );
+					return ( ! empty( $deleted->ID ) ) ? Relay::toGlobalId( 'user', $deleted->ID ) : null;
+				},
+			],
+			'user'      => [
+				'type'        => 'User',
+				'description' => __( 'The deleted user object', 'wp-graphql' ),
+				'resolve'     => function ( $payload ) {
+					$deleted = (object) $payload['userObject'];
 
-				if ( ! current_user_can( 'delete_users' ) ) {
-					throw new UserError( __( 'Sorry, you are not allowed to delete users.', 'wp-graphql' ) );
-				}
+					return ( ! empty( $deleted ) ) ? $deleted : null;
+				},
+			],
+		];
+	}
 
-				/**
-				 * Retrieve the user object before it's deleted
-				 */
-				$user_before_delete = get_user_by( 'id', absint( $id_parts['id'] ) );
+	public static function mutate_and_get_payload() {
+		return function ( $input ) {
+			/**
+			 * Get the ID from the global ID
+			 */
+			$id_parts = Relay::fromGlobalId( $input['id'] );
 
-				/**
-				 * Throw an error if the user we are trying to delete doesn't exist
-				 */
-				if ( false === $user_before_delete ) {
-					throw new UserError( __( 'Could not find an existing user to delete', 'wp-graphql' ) );
-				}
-
-				/**
-				 * Get the DB id for the user to reassign posts to from the relay ID.
-				 */
-				$reassign_id_parts = ( ! empty( $input['reassignId'] ) ) ? Relay::fromGlobalId( $input['reassignId'] ) : null;
-				$reassign_id       = ( ! empty( $reassign_id_parts ) ) ? absint( $reassign_id_parts['id'] ) : null;
-
-				/**
-				 * If the wp_delete_user doesn't exist yet, load the file in which it is
-				 * registered so it is available in this context. I think we need to
-				 * load this manually here because WordPress only uses this
-				 * function on the user edit screen normally.
-				 */
-				if ( ! function_exists( 'wp_delete_user' ) ) {
-					require_once( ABSPATH . 'wp-admin/includes/user.php' );
-				}
-
-				if ( is_multisite() ) {
-					$deleted_user = wpmu_delete_user( absint( $id_parts['id'] ) );
-				} else {
-					$deleted_user = wp_delete_user( absint( $id_parts['id'] ), $reassign_id );
-				}
-
-				if ( true !== $deleted_user ) {
-					throw new UserError( __( 'Could not delete the user.', 'wp-grapgql' ) );
-				}
-
-				return [
-					'userObject' => $user_before_delete,
-				];
+			if ( ! current_user_can( 'delete_users' ) ) {
+				throw new UserError( __( 'Sorry, you are not allowed to delete users.', 'wp-graphql' ) );
 			}
-		]);
+
+			/**
+			 * Retrieve the user object before it's deleted
+			 */
+			$user_before_delete = get_user_by( 'id', absint( $id_parts['id'] ) );
+
+			/**
+			 * Throw an error if the user we are trying to delete doesn't exist
+			 */
+			if ( false === $user_before_delete ) {
+				throw new UserError( __( 'Could not find an existing user to delete', 'wp-graphql' ) );
+			}
+
+			/**
+			 * Get the DB id for the user to reassign posts to from the relay ID.
+			 */
+			$reassign_id_parts = ( ! empty( $input['reassignId'] ) ) ? Relay::fromGlobalId( $input['reassignId'] ) : null;
+			$reassign_id       = ( ! empty( $reassign_id_parts ) ) ? absint( $reassign_id_parts['id'] ) : null;
+
+			/**
+			 * If the wp_delete_user doesn't exist yet, load the file in which it is
+			 * registered so it is available in this context. I think we need to
+			 * load this manually here because WordPress only uses this
+			 * function on the user edit screen normally.
+			 */
+			if ( ! function_exists( 'wp_delete_user' ) ) {
+				require_once( ABSPATH . 'wp-admin/includes/user.php' );
+			}
+
+			if ( is_multisite() ) {
+				$deleted_user = wpmu_delete_user( absint( $id_parts['id'] ) );
+			} else {
+				$deleted_user = wp_delete_user( absint( $id_parts['id'] ), $reassign_id );
+			}
+
+			if ( true !== $deleted_user ) {
+				throw new UserError( __( 'Could not delete the user.', 'wp-grapgql' ) );
+			}
+
+			return [
+				'userObject' => $user_before_delete,
+			];
+		};
 	}
 }

--- a/src/Mutation/UserDelete.php
+++ b/src/Mutation/UserDelete.php
@@ -5,104 +5,122 @@ use GraphQL\Error\UserError;
 use GraphQLRelay\Relay;
 
 class UserDelete {
-	public static function register_mutation() {
-		register_graphql_mutation( 'deleteUser', [
-			'inputFields'         => self::get_input_fields(),
-			'outputFields'        => self::get_output_fields(),
-			'mutateAndGetPayload' => self::mutate_and_get_payload(),
-		] );
-	}
+    /**
+     * Registers the CommentCreate mutation.
+     */
+    public static function register_mutation() {
+        register_graphql_mutation( 'deleteUser', [
+            'inputFields'         => self::get_input_fields(),
+            'outputFields'        => self::get_output_fields(),
+            'mutateAndGetPayload' => self::mutate_and_get_payload(),
+        ] );
+    }
 
-	public static function get_input_fields() {
-		return [
-			'id'         => [
-				'type'        => [
-					'non_null' => 'ID',
-				],
-				'description' => __( 'The ID of the user you want to delete', 'wp-graphql' ),
-			],
-			'reassignId' => [
-				'type'        => 'ID',
-				'description' => __( 'Reassign posts and links to new User ID.', 'wp-graphql' ),
-			],
-		];
-	}
-		
-	public static function get_output_fields() {
-		return [
-			'deletedId' => [
-				'type'        => 'ID',
-				'description' => __( 'The ID of the user that you just deleted', 'wp-graphql' ),
-				'resolve'     => function ( $payload ) {
-					$deleted = (object) $payload['userObject'];
+    /**
+     * Defines the mutation input field configuration.
+     *
+     * @return array
+     */
+    public static function get_input_fields() {
+        return [
+            'id'         => [
+                'type'        => [
+                    'non_null' => 'ID',
+                ],
+                'description' => __( 'The ID of the user you want to delete', 'wp-graphql' ),
+            ],
+            'reassignId' => [
+                'type'        => 'ID',
+                'description' => __( 'Reassign posts and links to new User ID.', 'wp-graphql' ),
+            ],
+        ];
+    }
 
-					return ( ! empty( $deleted->ID ) ) ? Relay::toGlobalId( 'user', $deleted->ID ) : null;
-				},
-			],
-			'user'      => [
-				'type'        => 'User',
-				'description' => __( 'The deleted user object', 'wp-graphql' ),
-				'resolve'     => function ( $payload ) {
-					$deleted = (object) $payload['userObject'];
+    /**
+     * Defines the mutation output field configuration.
+     *
+     * @return array
+     */
+    public static function get_output_fields() {
+        return [
+            'deletedId' => [
+                'type'        => 'ID',
+                'description' => __( 'The ID of the user that you just deleted', 'wp-graphql' ),
+                'resolve'     => function ( $payload ) {
+                    $deleted = (object) $payload['userObject'];
 
-					return ( ! empty( $deleted ) ) ? $deleted : null;
-				},
-			],
-		];
-	}
+                    return ( ! empty( $deleted->ID ) ) ? Relay::toGlobalId( 'user', $deleted->ID ) : null;
+                },
+            ],
+            'user'      => [
+                'type'        => 'User',
+                'description' => __( 'The deleted user object', 'wp-graphql' ),
+                'resolve'     => function ( $payload ) {
+                    $deleted = (object) $payload['userObject'];
 
-	public static function mutate_and_get_payload() {
-		return function ( $input ) {
-			/**
-			 * Get the ID from the global ID
-			 */
-			$id_parts = Relay::fromGlobalId( $input['id'] );
+                    return ( ! empty( $deleted ) ) ? $deleted : null;
+                },
+            ],
+        ];
+    }
 
-			if ( ! current_user_can( 'delete_users' ) ) {
-				throw new UserError( __( 'Sorry, you are not allowed to delete users.', 'wp-graphql' ) );
-			}
+    /**
+     * Defines the mutation data modification closure.
+     *
+     * @return callable
+     */
+    public static function mutate_and_get_payload() {
+        return function ( $input ) {
+            /**
+             * Get the ID from the global ID
+             */
+            $id_parts = Relay::fromGlobalId( $input['id'] );
 
-			/**
-			 * Retrieve the user object before it's deleted
-			 */
-			$user_before_delete = get_user_by( 'id', absint( $id_parts['id'] ) );
+            if ( ! current_user_can( 'delete_users' ) ) {
+                throw new UserError( __( 'Sorry, you are not allowed to delete users.', 'wp-graphql' ) );
+            }
 
-			/**
-			 * Throw an error if the user we are trying to delete doesn't exist
-			 */
-			if ( false === $user_before_delete ) {
-				throw new UserError( __( 'Could not find an existing user to delete', 'wp-graphql' ) );
-			}
+            /**
+             * Retrieve the user object before it's deleted
+             */
+            $user_before_delete = get_user_by( 'id', absint( $id_parts['id'] ) );
 
-			/**
-			 * Get the DB id for the user to reassign posts to from the relay ID.
-			 */
-			$reassign_id_parts = ( ! empty( $input['reassignId'] ) ) ? Relay::fromGlobalId( $input['reassignId'] ) : null;
-			$reassign_id       = ( ! empty( $reassign_id_parts ) ) ? absint( $reassign_id_parts['id'] ) : null;
+            /**
+             * Throw an error if the user we are trying to delete doesn't exist
+             */
+            if ( false === $user_before_delete ) {
+                throw new UserError( __( 'Could not find an existing user to delete', 'wp-graphql' ) );
+            }
 
-			/**
-			 * If the wp_delete_user doesn't exist yet, load the file in which it is
-			 * registered so it is available in this context. I think we need to
-			 * load this manually here because WordPress only uses this
-			 * function on the user edit screen normally.
-			 */
-			if ( ! function_exists( 'wp_delete_user' ) ) {
-				require_once( ABSPATH . 'wp-admin/includes/user.php' );
-			}
+            /**
+             * Get the DB id for the user to reassign posts to from the relay ID.
+             */
+            $reassign_id_parts = ( ! empty( $input['reassignId'] ) ) ? Relay::fromGlobalId( $input['reassignId'] ) : null;
+            $reassign_id       = ( ! empty( $reassign_id_parts ) ) ? absint( $reassign_id_parts['id'] ) : null;
 
-			if ( is_multisite() ) {
-				$deleted_user = wpmu_delete_user( absint( $id_parts['id'] ) );
-			} else {
-				$deleted_user = wp_delete_user( absint( $id_parts['id'] ), $reassign_id );
-			}
+            /**
+             * If the wp_delete_user doesn't exist yet, load the file in which it is
+             * registered so it is available in this context. I think we need to
+             * load this manually here because WordPress only uses this
+             * function on the user edit screen normally.
+             */
+            if ( ! function_exists( 'wp_delete_user' ) ) {
+                require_once( ABSPATH . 'wp-admin/includes/user.php' );
+            }
 
-			if ( true !== $deleted_user ) {
-				throw new UserError( __( 'Could not delete the user.', 'wp-grapgql' ) );
-			}
+            if ( is_multisite() ) {
+                $deleted_user = wpmu_delete_user( absint( $id_parts['id'] ) );
+            } else {
+                $deleted_user = wp_delete_user( absint( $id_parts['id'] ), $reassign_id );
+            }
 
-			return [
-				'userObject' => $user_before_delete,
-			];
-		};
-	}
+            if ( true !== $deleted_user ) {
+                throw new UserError( __( 'Could not delete the user.', 'wp-grapgql' ) );
+            }
+
+            return [
+                'userObject' => $user_before_delete,
+            ];
+        };
+    }
 }

--- a/src/Mutation/UserRegister.php
+++ b/src/Mutation/UserRegister.php
@@ -9,93 +9,98 @@ use WPGraphQL\Data\UserMutation;
 class UserRegister {
 	public static function register_mutation() {
 		register_graphql_mutation( 'registerUser', [
-			'inputFields'         => array_merge( UserCreate::get_input_fields(), [
-				'username' => [
-					'type'        => [
-						'non_null' => 'String'
-					],
-					// translators: the placeholder is the name of the type of object being updated
-					'description' => __( 'A string that contains the user\'s username.', 'wp-graphql' ),
+			'inputFields'         => self::get_input_fields(),
+			'outputFields'        => self::get_output_fields(),
+			'mutateAndGetPayload' => self::mutate_and_get_payload(),
+		] );
+	}
+
+	public static function get_input_fields() {
+		return array_merge( UserCreate::get_input_fields(), [
+			'username' => [
+				'type'        => [
+					'non_null' => 'String'
 				],
-				'email'    => [
-					'type'        => 'String',
-					'description' => __( 'A string containing the user\'s email address.', 'wp-graphql' ),
-				],
-			] ),
-			'outputFields'        => [
-				'user' => [
-					'type'    => 'User',
-					'resolve' => function ( $payload ) {
-						return get_user_by( 'ID', $payload['id'] );
-					},
-				],
+				// translators: the placeholder is the name of the type of object being updated
+				'description' => __( 'A string that contains the user\'s username.', 'wp-graphql' ),
 			],
-			'mutateAndGetPayload' => function ( $input, AppContext $context, ResolveInfo $info ) {
+			'email'    => [
+				'type'        => 'String',
+				'description' => __( 'A string containing the user\'s email address.', 'wp-graphql' ),
+			],
+		] );
+	}
+		
+	public static function get_output_fields() {
+		return UserCreate::get_output_fields();
+	}
 
-				if ( ! get_option( 'users_can_register' ) ) {
-					throw new UserError( __( 'User registration is currently not allowed.', 'wp-graphql' ) );
-				}
+	public static function mutate_and_get_payload() {
+		return function ( $input, AppContext $context, ResolveInfo $info ) {
 
-				if ( empty( $input['username'] ) ) {
-					throw new UserError( __( 'A username was not provided.', 'wp-graphql' ) );
-				}
-
-				if ( empty( $input['email'] ) ) {
-					throw new UserError( __( 'An email address was not provided.', 'wp-graphql' ) );
-				}
-
-				/**
-				 * Map all of the args from GQL to WP friendly
-				 */
-				$user_args = UserMutation::prepare_user_object( $input, 'registerUser' );
-
-				/**
-				 * Register the new user
-				 */
-				$user_id = register_new_user( $user_args['user_login'], $user_args['user_email'] );
-
-				/**
-				 * Throw an exception if the user failed to register
-				 */
-				if ( is_wp_error( $user_id ) ) {
-					$error_message = $user_id->get_error_message();
-					if ( ! empty( $error_message ) ) {
-						throw new UserError( esc_html( $error_message ) );
-					} else {
-						throw new UserError( __( 'The user failed to register but no error was provided', 'wp-graphql' ) );
-					}
-				}
-
-				/**
-				 * If the $user_id is empty, we should throw an exception
-				 */
-				if ( empty( $user_id ) ) {
-					throw new UserError( __( 'The user failed to create', 'wp-graphql' ) );
-				}
-
-				/**
-				 * Set the ID of the user to be used in the update
-				 */
-				$user_args['ID'] = absint( $user_id );
-
-				/**
-				 * Update the registered user with the additional input (firstName, lastName, etc) from the mutation
-				 */
-				wp_update_user( $user_args );
-
-				/**
-				 * Update additional user data
-				 */
-				UserMutation::update_additional_user_object_data( $user_id, $input, 'registerUser', $context, $info );
-
-				/**
-				 * Return the new user ID
-				 */
-				return [
-					'id' => $user_id,
-				];
-
+			if ( ! get_option( 'users_can_register' ) ) {
+				throw new UserError( __( 'User registration is currently not allowed.', 'wp-graphql' ) );
 			}
-		]);
+
+			if ( empty( $input['username'] ) ) {
+				throw new UserError( __( 'A username was not provided.', 'wp-graphql' ) );
+			}
+
+			if ( empty( $input['email'] ) ) {
+				throw new UserError( __( 'An email address was not provided.', 'wp-graphql' ) );
+			}
+
+			/**
+			 * Map all of the args from GQL to WP friendly
+			 */
+			$user_args = UserMutation::prepare_user_object( $input, 'registerUser' );
+
+			/**
+			 * Register the new user
+			 */
+			$user_id = register_new_user( $user_args['user_login'], $user_args['user_email'] );
+
+			/**
+			 * Throw an exception if the user failed to register
+			 */
+			if ( is_wp_error( $user_id ) ) {
+				$error_message = $user_id->get_error_message();
+				if ( ! empty( $error_message ) ) {
+					throw new UserError( esc_html( $error_message ) );
+				} else {
+					throw new UserError( __( 'The user failed to register but no error was provided', 'wp-graphql' ) );
+				}
+			}
+
+			/**
+			 * If the $user_id is empty, we should throw an exception
+			 */
+			if ( empty( $user_id ) ) {
+				throw new UserError( __( 'The user failed to create', 'wp-graphql' ) );
+			}
+
+			/**
+			 * Set the ID of the user to be used in the update
+			 */
+			$user_args['ID'] = absint( $user_id );
+
+			/**
+			 * Update the registered user with the additional input (firstName, lastName, etc) from the mutation
+			 */
+			wp_update_user( $user_args );
+
+			/**
+			 * Update additional user data
+			 */
+			UserMutation::update_additional_user_object_data( $user_id, $input, 'registerUser', $context, $info );
+
+			/**
+			 * Return the new user ID
+			 */
+			return [
+				'id' => $user_id,
+			];
+
+		};
 	}
 }

--- a/src/Mutation/UserRegister.php
+++ b/src/Mutation/UserRegister.php
@@ -7,100 +7,118 @@ use WPGraphQL\AppContext;
 use WPGraphQL\Data\UserMutation;
 
 class UserRegister {
-	public static function register_mutation() {
-		register_graphql_mutation( 'registerUser', [
-			'inputFields'         => self::get_input_fields(),
-			'outputFields'        => self::get_output_fields(),
-			'mutateAndGetPayload' => self::mutate_and_get_payload(),
-		] );
-	}
+    /**
+     * Registers the CommentCreate mutation.
+     */
+    public static function register_mutation() {
+        register_graphql_mutation( 'registerUser', [
+            'inputFields'         => self::get_input_fields(),
+            'outputFields'        => self::get_output_fields(),
+            'mutateAndGetPayload' => self::mutate_and_get_payload(),
+        ] );
+    }
 
-	public static function get_input_fields() {
-		return array_merge( UserCreate::get_input_fields(), [
-			'username' => [
-				'type'        => [
-					'non_null' => 'String'
-				],
-				// translators: the placeholder is the name of the type of object being updated
-				'description' => __( 'A string that contains the user\'s username.', 'wp-graphql' ),
-			],
-			'email'    => [
-				'type'        => 'String',
-				'description' => __( 'A string containing the user\'s email address.', 'wp-graphql' ),
-			],
-		] );
-	}
-		
-	public static function get_output_fields() {
-		return UserCreate::get_output_fields();
-	}
+    /**
+     * Defines the mutation input field configuration.
+     *
+     * @return array
+     */
+    public static function get_input_fields() {
+        return array_merge( UserCreate::get_input_fields(), [
+            'username' => [
+                'type'        => [
+                    'non_null' => 'String'
+                ],
+                // translators: the placeholder is the name of the type of object being updated
+                'description' => __( 'A string that contains the user\'s username.', 'wp-graphql' ),
+            ],
+            'email'    => [
+                'type'        => 'String',
+                'description' => __( 'A string containing the user\'s email address.', 'wp-graphql' ),
+            ],
+        ] );
+    }
 
-	public static function mutate_and_get_payload() {
-		return function ( $input, AppContext $context, ResolveInfo $info ) {
+    /**
+     * Defines the mutation output field configuration.
+     *
+     * @return array
+     */
+    public static function get_output_fields() {
+        return UserCreate::get_output_fields();
+    }
 
-			if ( ! get_option( 'users_can_register' ) ) {
-				throw new UserError( __( 'User registration is currently not allowed.', 'wp-graphql' ) );
-			}
+    /**
+     * Defines the mutation data modification closure.
+     *
+     * @return callable
+     */
+    public static function mutate_and_get_payload() {
+        return function ( $input, AppContext $context, ResolveInfo $info ) {
 
-			if ( empty( $input['username'] ) ) {
-				throw new UserError( __( 'A username was not provided.', 'wp-graphql' ) );
-			}
+            if ( ! get_option( 'users_can_register' ) ) {
+                throw new UserError( __( 'User registration is currently not allowed.', 'wp-graphql' ) );
+            }
 
-			if ( empty( $input['email'] ) ) {
-				throw new UserError( __( 'An email address was not provided.', 'wp-graphql' ) );
-			}
+            if ( empty( $input['username'] ) ) {
+                throw new UserError( __( 'A username was not provided.', 'wp-graphql' ) );
+            }
 
-			/**
-			 * Map all of the args from GQL to WP friendly
-			 */
-			$user_args = UserMutation::prepare_user_object( $input, 'registerUser' );
+            if ( empty( $input['email'] ) ) {
+                throw new UserError( __( 'An email address was not provided.', 'wp-graphql' ) );
+            }
 
-			/**
-			 * Register the new user
-			 */
-			$user_id = register_new_user( $user_args['user_login'], $user_args['user_email'] );
+            /**
+             * Map all of the args from GQL to WP friendly
+             */
+            $user_args = UserMutation::prepare_user_object( $input, 'registerUser' );
 
-			/**
-			 * Throw an exception if the user failed to register
-			 */
-			if ( is_wp_error( $user_id ) ) {
-				$error_message = $user_id->get_error_message();
-				if ( ! empty( $error_message ) ) {
-					throw new UserError( esc_html( $error_message ) );
-				} else {
-					throw new UserError( __( 'The user failed to register but no error was provided', 'wp-graphql' ) );
-				}
-			}
+            /**
+             * Register the new user
+             */
+            $user_id = register_new_user( $user_args['user_login'], $user_args['user_email'] );
 
-			/**
-			 * If the $user_id is empty, we should throw an exception
-			 */
-			if ( empty( $user_id ) ) {
-				throw new UserError( __( 'The user failed to create', 'wp-graphql' ) );
-			}
+            /**
+             * Throw an exception if the user failed to register
+             */
+            if ( is_wp_error( $user_id ) ) {
+                $error_message = $user_id->get_error_message();
+                if ( ! empty( $error_message ) ) {
+                    throw new UserError( esc_html( $error_message ) );
+                } else {
+                    throw new UserError( __( 'The user failed to register but no error was provided', 'wp-graphql' ) );
+                }
+            }
 
-			/**
-			 * Set the ID of the user to be used in the update
-			 */
-			$user_args['ID'] = absint( $user_id );
+            /**
+             * If the $user_id is empty, we should throw an exception
+             */
+            if ( empty( $user_id ) ) {
+                throw new UserError( __( 'The user failed to create', 'wp-graphql' ) );
+            }
 
-			/**
-			 * Update the registered user with the additional input (firstName, lastName, etc) from the mutation
-			 */
-			wp_update_user( $user_args );
+            /**
+             * Set the ID of the user to be used in the update
+             */
+            $user_args['ID'] = absint( $user_id );
 
-			/**
-			 * Update additional user data
-			 */
-			UserMutation::update_additional_user_object_data( $user_id, $input, 'registerUser', $context, $info );
+            /**
+             * Update the registered user with the additional input (firstName, lastName, etc) from the mutation
+             */
+            wp_update_user( $user_args );
 
-			/**
-			 * Return the new user ID
-			 */
-			return [
-				'id' => $user_id,
-			];
+            /**
+             * Update additional user data
+             */
+            UserMutation::update_additional_user_object_data( $user_id, $input, 'registerUser', $context, $info );
 
-		};
-	}
+            /**
+             * Return the new user ID
+             */
+            return [
+                'id' => $user_id,
+            ];
+
+        };
+    }
 }

--- a/src/Mutation/UserUpdate.php
+++ b/src/Mutation/UserUpdate.php
@@ -27,7 +27,7 @@ class UserUpdate {
 			],
 		], UserCreate::get_input_fields() );
 	}
-		
+
 	public static function get_output_fields() {
 		return UserCreate::get_output_fields();
 	}
@@ -91,7 +91,7 @@ class UserUpdate {
 			 * Return the new user ID
 			 */
 			return [
-				'userId' => $user_id,
+				'id' => $user_id,
 			];
 		};
 	}

--- a/src/Mutation/UserUpdate.php
+++ b/src/Mutation/UserUpdate.php
@@ -8,91 +8,108 @@ use WPGraphQL\AppContext;
 use WPGraphQL\Data\UserMutation;
 
 class UserUpdate {
-	public static function register_mutation() {
-		register_graphql_mutation( 'updateUser', [
-			'inputFields'         => self::get_input_fields(),
-			'outputFields'        => self::get_output_fields(),
-			'mutateAndGetPayload' => self::mutate_and_get_payload(),
-		] );
-	}
+    /**
+     * Registers the CommentCreate mutation.
+     */
+    public static function register_mutation() {
+        register_graphql_mutation( 'updateUser', [
+            'inputFields'         => self::get_input_fields(),
+            'outputFields'        => self::get_output_fields(),
+            'mutateAndGetPayload' => self::mutate_and_get_payload(),
+        ] );
+    }
 
-	public static function get_input_fields() {
-		return array_merge( [
-			'id' => [
-				'type'        => [
-					'non_null' => 'ID',
-				],
-				// translators: the placeholder is the name of the type of post object being updated
-				'description' => __( 'The ID of the user', 'wp-graphql' ),
-			],
-		], UserCreate::get_input_fields() );
-	}
+    /**
+     * Defines the mutation input field configuration.
+     *
+     * @return array
+     */
+    public static function get_input_fields() {
+        return array_merge( [
+            'id' => [
+                'type'        => [
+                    'non_null' => 'ID',
+                ],
+                // translators: the placeholder is the name of the type of post object being updated
+                'description' => __( 'The ID of the user', 'wp-graphql' ),
+            ],
+        ], UserCreate::get_input_fields() );
+    }
 
-	public static function get_output_fields() {
-		return UserCreate::get_output_fields();
-	}
+    /**
+     * Defines the mutation output field configuration.
+     *
+     * @return array
+     */
+    public static function get_output_fields() {
+        return UserCreate::get_output_fields();
+    }
 
-	public static function mutate_and_get_payload() {
+    /**
+     * Defines the mutation data modification closure.
+     *
+     * @return callable
+     */
+    public static function mutate_and_get_payload() {
+        return function ( $input, AppContext $context, ResolveInfo $info ) {
 
-		return function ( $input, AppContext $context, ResolveInfo $info ) {
+            $id_parts      = ! empty( $input['id'] ) ? Relay::fromGlobalId( $input['id'] ) : null;
+            $existing_user = get_user_by( 'ID', $id_parts['id'] );
 
-			$id_parts      = ! empty( $input['id'] ) ? Relay::fromGlobalId( $input['id'] ) : null;
-			$existing_user = get_user_by( 'ID', $id_parts['id'] );
+            /**
+             * If there's no existing user, throw an exception
+             */
+            if ( empty( $id_parts['id'] ) || false === $existing_user ) {
+                throw new UserError( $id_parts['id'] );
+            }
 
-			/**
-			 * If there's no existing user, throw an exception
-			 */
-			if ( empty( $id_parts['id'] ) || false === $existing_user ) {
-				throw new UserError( $id_parts['id'] );
-			}
+            if ( ! current_user_can( 'edit_user', $existing_user->ID ) ) {
+                throw new UserError( __( 'You do not have the appropriate capabilities to perform this action', 'wp-graphql' ) );
+            }
 
-			if ( ! current_user_can( 'edit_user', $existing_user->ID ) ) {
-				throw new UserError( __( 'You do not have the appropriate capabilities to perform this action', 'wp-graphql' ) );
-			}
+            if ( isset( $input['roles'] ) && ! current_user_can( 'edit_users' ) ) {
+                unset( $input['roles'] );
+                throw new UserError( __( 'You do not have the appropriate capabilities to perform this action', 'wp-graphql' ) );
+            }
 
-			if ( isset( $input['roles'] ) && ! current_user_can( 'edit_users' ) ) {
-				unset( $input['roles'] );
-				throw new UserError( __( 'You do not have the appropriate capabilities to perform this action', 'wp-graphql' ) );
-			}
+            $user_args       = UserMutation::prepare_user_object( $input, 'updateUser' );
+            $user_args['ID'] = absint( $id_parts['id'] );
 
-			$user_args       = UserMutation::prepare_user_object( $input, 'updateUser' );
-			$user_args['ID'] = absint( $id_parts['id'] );
+            /**
+             * Update the user
+             */
+            $user_id = wp_update_user( $user_args );
 
-			/**
-			 * Update the user
-			 */
-			$user_id = wp_update_user( $user_args );
+            /**
+             * Throw an exception if the post failed to create
+             */
+            if ( is_wp_error( $user_id ) ) {
+                $error_message = $user_id->get_error_message();
+                if ( ! empty( $error_message ) ) {
+                    throw new UserError( esc_html( $error_message ) );
+                } else {
+                    throw new UserError( __( 'The user failed to update but no error was provided', 'wp-graphql' ) );
+                }
+            }
 
-			/**
-			 * Throw an exception if the post failed to create
-			 */
-			if ( is_wp_error( $user_id ) ) {
-				$error_message = $user_id->get_error_message();
-				if ( ! empty( $error_message ) ) {
-					throw new UserError( esc_html( $error_message ) );
-				} else {
-					throw new UserError( __( 'The user failed to update but no error was provided', 'wp-graphql' ) );
-				}
-			}
+            /**
+             * If the $user_id is empty, we should throw an exception
+             */
+            if ( empty( $user_id ) ) {
+                throw new UserError( __( 'The user failed to update', 'wp-graphql' ) );
+            }
 
-			/**
-			 * If the $user_id is empty, we should throw an exception
-			 */
-			if ( empty( $user_id ) ) {
-				throw new UserError( __( 'The user failed to update', 'wp-graphql' ) );
-			}
+            /**
+             * Update additional user data
+             */
+            UserMutation::update_additional_user_object_data( $user_id, $input, 'updateUser', $context, $info );
 
-			/**
-			 * Update additional user data
-			 */
-			UserMutation::update_additional_user_object_data( $user_id, $input, 'updateUser', $context, $info );
-
-			/**
-			 * Return the new user ID
-			 */
-			return [
-				'id' => $user_id,
-			];
-		};
-	}
+            /**
+             * Return the new user ID
+             */
+            return [
+                'id' => $user_id,
+            ];
+        };
+    }
 }


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
Creates public functions for each mutation class's configuration of input, output and mutation. I wanted to mutate a CPT with custom fields while retaining all the base fields from `PostTypeCreate`. I went through and refactored all mutations (except password recovery email, seemed superfluous) to be consistent.


Does this close any currently open issues?
------------------------------------------
#611 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
I haven't rigorously tested this. It works in de facto use in my app (I have been using my fork in production for several weeks). I would hope the team could run the automated tests in the project - I have no idea how to do that!


Where has this been tested?
---------------------------
**Operating System:** Windows 10, Red Hat

**WordPress Version:** 5.0.2, latest 4.x (prior to 5 release).
