### PR TITLE
Feature/#636 pass connection args through context

### DIFF
--- a/src/AppContext.php
+++ b/src/AppContext.php
@@ -4,7 +4,11 @@ namespace WPGraphQL;
 /**
  * Class AppContext
  * Creates an object that contains all of the context for the GraphQL query
- * This class gets instantiated and populated in the main WPGraphQL class
+ * This class gets instantiated and populated in the main WPGraphQL class.
+ *
+ * The context is passed to each resolver during execution.
+ * 
+ * Resolvers have the ability to read and write to context to pass info to nested resolvers.
  *
  * @package WPGraphQL
  */
@@ -42,12 +46,38 @@ class AppContext {
 	public $config;
 
 	/**
+	 * Passes context about the current connection being resolved
+	 * @var mixed| String | null
+	 */
+	public $currentConnection = null;
+
+	/**
+	 * Passes context about the current connection
+	 * @var array
+	 */
+	public $connectionArgs = [];
+
+	/**
 	 * AppContext constructor.
 	 */
 	public function __construct() {
-
 		$this->config = apply_filters( 'graphql_app_context_config', $this->config );
+	}
 
+	/**
+	 * Returns the $args for the connection the field is a part of
+	 * @return array|mixed
+	 */
+	public function getConnectionArgs() {
+		return isset( $this->currentConnection ) && isset( $this->connectionArgs[ $this->currentConnection ] ) ? $this->connectionArgs[ $this->currentConnection ] : [];
+	}
+
+	/**
+	 * Returns the current connection
+	 * @return mixed|null|String
+	 */
+	public function getCurrentConnection() {
+		return isset( $this->currentConnection ) ? $this->currentConnection : null;
 	}
 
 }

--- a/src/TypeRegistry.php
+++ b/src/TypeRegistry.php
@@ -565,9 +565,9 @@ class TypeRegistry {
 		$connection_fields  = ! empty( $config['connectionFields'] ) && is_array( $config['connectionFields'] ) ? $config['connectionFields'] : [];
 		$connection_args    = ! empty( $config['connectionArgs'] ) && is_array( $config['connectionArgs'] ) ? $config['connectionArgs'] : [];
 		$edge_fields        = ! empty( $config['edgeFields'] ) && is_array( $config['edgeFields'] ) ? $config['edgeFields'] : [];
-		$resolve_node       = array_key_exists( 'resolveNode', $config ) ? $config['resolveNode'] : null;
-		$resolve_cursor     = array_key_exists( 'resolveCursor', $config ) ? $config['resolveCursor'] : null;
-		$resolve_connection = array_key_exists( 'resolve', $config ) ? $config['resolve'] : null;
+		$resolve_node       = array_key_exists( 'resolveNode', $config ) && is_callable( $config['resolve'] ) ? $config['resolveNode'] : null;
+		$resolve_cursor     = array_key_exists( 'resolveCursor', $config ) && is_callable( $config['resolve'] ) ? $config['resolveCursor'] : null;
+		$resolve_connection = array_key_exists( 'resolve', $config ) && is_callable( $config['resolve'] ) ? $config['resolve'] : function() { return null; };
 		$connection_name    = self::get_connection_name( $from_type, $to_type );
 		$where_args         = [];
 
@@ -658,7 +658,38 @@ class TypeRegistry {
 				],
 			], $where_args ),
 			'description' => sprintf( __( 'Connection between the %1$s type and the %2s type', 'wp-graphql' ), $from_type, $to_type ),
-			'resolve'     => $resolve_connection,
+			'resolve'     => function( $root, $args, $context, $info ) use ( $resolve_connection, $connection_name ) {
+
+				/**
+				 * Set the connection args context. Use base64_encode( wp_json_encode( $args ) ) to prevent conflicts as there can be
+				 * numerous instances of the same connection within any given query. If the connection
+				 * has the same args, we can use the existing cached args instead of storing new context
+				 */
+				$connection_id = $connection_name . ':' . base64_encode( wp_json_encode( $args ) );
+
+				/**
+				 * Set the previous connection by getting the currentConnection
+				 */
+				$context->prevConnection = isset( $context->currentConnection ) ? $context->currentConnection : null;
+
+				/**
+				 * Set the currentConnection using the $connectionId
+				 */
+				$context->currentConnection = $connection_id;
+
+				/**
+				 * Set the connectionArgs if they haven't already been set
+				 * (it's possible, although rare, to have multiple connections in a single query with the same args)
+				 */
+				if ( ! isset( $context->connectionArgs[ $connection_id ] ) ) {
+					$context->connectionArgs[ $connection_id ] = $args;
+				}
+
+				/**
+				 * Return the results
+				 */
+				return call_user_func( $resolve_connection, $root, $args, $context, $info );
+			},
 		] );
 
 	}

--- a/src/TypeRegistry.php
+++ b/src/TypeRegistry.php
@@ -578,8 +578,8 @@ class TypeRegistry {
 		 */
 		if ( ! empty( $connection_args ) ) {
 			register_graphql_input_type( $connection_name . 'WhereArgs', [
-				//@TODO: Wondering if this description should be dynamic to include the name of the connection these args are for?
-				'description' => __( 'Arguments for filtering the connection', 'wp-graphql' ),
+				// Translators: Placeholder is the name of the connection
+				'description' => sprintf( __( 'Arguments for filtering the %s connection', 'wp-graphql' ), $connection_name ),
 				'fields'      => $connection_args,
 				'queryClass' => ! empty( $config['queryClass'] ) ? $config['queryClass'] : null,
 			] );


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This passes "CurrentConnection" and "ConnectionArgs" through the AppContext, so any resolver nested within a connection can have knowledge of the $args that were passed to the connection. 

Does this close any currently open issues?
------------------------------------------
closes #636 

Usage:
-------------------

Any field within a connection can now access the connection args like so: 

```
'resolve' => function( $root, $args, $context, $info ) {
   $connectionArgs = $context->getConnectionArgs();
}
```

Any other comments?
-------------------
Given the following query: 

```
{
  posts(first: 1, where: {search: "hello"}) {
    nodes {
      id
      title
      categories(first: 11) {
        nodes {
          name
        }
      }
    }
  }
  categories(first: 2) {
    nodes {
      id
      posts(first: 22) {
        nodes {
          id
          categories(first: 222) {
            nodes {
              id
              categoryId
            }
          }
        }
      }
    }
  }
}
```

I can use the following snippet to output the currentConnection and connectionArgs for each field in the resolve tree: 

```
add_filter( 'graphql_resolve_field', function( $result, $source, $args, \WPGraphQL\AppContext $context, $info, $type_name, $field_key, $field, $field_resolver ) {

	if ( isset( $context->currentConnection ) ) {

		$output = [];

		$output[ $type_name . '.' .$field_key ] = [
			'currentConnection' => $context->getCurrentConnection(),
			'connectionArgs' => $context->getConnectionArgs(),
		];

		print_r( $output );
		
	}

	return $result;

}, 10, 9 );
```

And the output I see is the following: 

```
Array
(
    [RootQuery.posts] => Array
        (
            [currentConnection] => RootQueryToPostConnection:eyJmaXJzdCI6MSwid2hlcmUiOnsic2VhcmNoIjoiaGVsbG8ifX0=
            [connectionArgs] => Array
                (
                    [first] => 1
                    [where] => Array
                        (
                            [search] => hello
                        )

                )

        )

)
Array
(
    [RootQueryToPostConnection.nodes] => Array
        (
            [currentConnection] => RootQueryToPostConnection:eyJmaXJzdCI6MSwid2hlcmUiOnsic2VhcmNoIjoiaGVsbG8ifX0=
            [connectionArgs] => Array
                (
                    [first] => 1
                    [where] => Array
                        (
                            [search] => hello
                        )

                )

        )

)
Array
(
    [Post.id] => Array
        (
            [currentConnection] => RootQueryToPostConnection:eyJmaXJzdCI6MSwid2hlcmUiOnsic2VhcmNoIjoiaGVsbG8ifX0=
            [connectionArgs] => Array
                (
                    [first] => 1
                    [where] => Array
                        (
                            [search] => hello
                        )

                )

        )

)
Array
(
    [Post.title] => Array
        (
            [currentConnection] => RootQueryToPostConnection:eyJmaXJzdCI6MSwid2hlcmUiOnsic2VhcmNoIjoiaGVsbG8ifX0=
            [connectionArgs] => Array
                (
                    [first] => 1
                    [where] => Array
                        (
                            [search] => hello
                        )

                )

        )

)
Array
(
    [Post.categories] => Array
        (
            [currentConnection] => PostToCategoryConnection:eyJmaXJzdCI6MTF9
            [connectionArgs] => Array
                (
                    [first] => 11
                )

        )

)
Array
(
    [PostToCategoryConnection.nodes] => Array
        (
            [currentConnection] => PostToCategoryConnection:eyJmaXJzdCI6MTF9
            [connectionArgs] => Array
                (
                    [first] => 11
                )

        )

)
Array
(
    [Category.name] => Array
        (
            [currentConnection] => PostToCategoryConnection:eyJmaXJzdCI6MTF9
            [connectionArgs] => Array
                (
                    [first] => 11
                )

        )

)
Array
(
    [RootQuery.categories] => Array
        (
            [currentConnection] => RootQueryToCategoryConnection:eyJmaXJzdCI6Mn0=
            [connectionArgs] => Array
                (
                    [first] => 2
                )

        )

)
Array
(
    [RootQueryToCategoryConnection.nodes] => Array
        (
            [currentConnection] => RootQueryToCategoryConnection:eyJmaXJzdCI6Mn0=
            [connectionArgs] => Array
                (
                    [first] => 2
                )

        )

)
Array
(
    [Category.id] => Array
        (
            [currentConnection] => RootQueryToCategoryConnection:eyJmaXJzdCI6Mn0=
            [connectionArgs] => Array
                (
                    [first] => 2
                )

        )

)
Array
(
    [Category.posts] => Array
        (
            [currentConnection] => CategoryToPostConnection:eyJmaXJzdCI6MjJ9
            [connectionArgs] => Array
                (
                    [first] => 22
                )

        )

)
Array
(
    [CategoryToPostConnection.nodes] => Array
        (
            [currentConnection] => CategoryToPostConnection:eyJmaXJzdCI6MjJ9
            [connectionArgs] => Array
                (
                    [first] => 22
                )

        )

)
Array
(
    [Post.id] => Array
        (
            [currentConnection] => CategoryToPostConnection:eyJmaXJzdCI6MjJ9
            [connectionArgs] => Array
                (
                    [first] => 22
                )

        )

)
Array
(
    [Post.categories] => Array
        (
            [currentConnection] => PostToCategoryConnection:eyJmaXJzdCI6MjIyfQ==
            [connectionArgs] => Array
                (
                    [first] => 222
                )

        )

)
Array
(
    [PostToCategoryConnection.nodes] => Array
        (
            [currentConnection] => PostToCategoryConnection:eyJmaXJzdCI6MjIyfQ==
            [connectionArgs] => Array
                (
                    [first] => 222
                )

        )

)
Array
(
    [Category.id] => Array
        (
            [currentConnection] => PostToCategoryConnection:eyJmaXJzdCI6MjIyfQ==
            [connectionArgs] => Array
                (
                    [first] => 222
                )

        )

)
Array
(
    [Category.categoryId] => Array
        (
            [currentConnection] => PostToCategoryConnection:eyJmaXJzdCI6MjIyfQ==
            [connectionArgs] => Array
                (
                    [first] => 222
                )

        )

)
Array
(
    [Category.id] => Array
        (
            [currentConnection] => PostToCategoryConnection:eyJmaXJzdCI6MjIyfQ==
            [connectionArgs] => Array
                (
                    [first] => 222
                )

        )

)
Array
(
    [Category.categoryId] => Array
        (
            [currentConnection] => PostToCategoryConnection:eyJmaXJzdCI6MjIyfQ==
            [connectionArgs] => Array
                (
                    [first] => 222
                )

        )

)
Array
(
    [Category.id] => Array
        (
            [currentConnection] => PostToCategoryConnection:eyJmaXJzdCI6MjIyfQ==
            [connectionArgs] => Array
                (
                    [first] => 222
                )

        )

)
Array
(
    [Category.categoryId] => Array
        (
            [currentConnection] => PostToCategoryConnection:eyJmaXJzdCI6MjIyfQ==
            [connectionArgs] => Array
                (
                    [first] => 222
                )

        )

)
Array
(
    [Post.id] => Array
        (
            [currentConnection] => PostToCategoryConnection:eyJmaXJzdCI6MjIyfQ==
            [connectionArgs] => Array
                (
                    [first] => 222
                )

        )

)
Array
(
    [Post.categories] => Array
        (
            [currentConnection] => PostToCategoryConnection:eyJmaXJzdCI6MjIyfQ==
            [connectionArgs] => Array
                (
                    [first] => 222
                )

        )

)
Array
(
    [PostToCategoryConnection.nodes] => Array
        (
            [currentConnection] => PostToCategoryConnection:eyJmaXJzdCI6MjIyfQ==
            [connectionArgs] => Array
                (
                    [first] => 222
                )

        )

)
Array
(
    [Category.id] => Array
        (
            [currentConnection] => PostToCategoryConnection:eyJmaXJzdCI6MjIyfQ==
            [connectionArgs] => Array
                (
                    [first] => 222
                )

        )

)
Array
(
    [Category.categoryId] => Array
        (
            [currentConnection] => PostToCategoryConnection:eyJmaXJzdCI6MjIyfQ==
            [connectionArgs] => Array
                (
                    [first] => 222
                )

        )

)
Array
(
    [Category.id] => Array
        (
            [currentConnection] => PostToCategoryConnection:eyJmaXJzdCI6MjIyfQ==
            [connectionArgs] => Array
                (
                    [first] => 222
                )

        )

)
Array
(
    [Category.posts] => Array
        (
            [currentConnection] => CategoryToPostConnection:eyJmaXJzdCI6MjJ9
            [connectionArgs] => Array
                (
                    [first] => 22
                )

        )

)
Array
(
    [CategoryToPostConnection.nodes] => Array
        (
            [currentConnection] => CategoryToPostConnection:eyJmaXJzdCI6MjJ9
            [connectionArgs] => Array
                (
                    [first] => 22
                )

        )

)
Array
(
    [Post.id] => Array
        (
            [currentConnection] => CategoryToPostConnection:eyJmaXJzdCI6MjJ9
            [connectionArgs] => Array
                (
                    [first] => 22
                )

        )

)
Array
(
    [Post.categories] => Array
        (
            [currentConnection] => PostToCategoryConnection:eyJmaXJzdCI6MjIyfQ==
            [connectionArgs] => Array
                (
                    [first] => 222
                )

        )

)
Array
(
    [PostToCategoryConnection.nodes] => Array
        (
            [currentConnection] => PostToCategoryConnection:eyJmaXJzdCI6MjIyfQ==
            [connectionArgs] => Array
                (
                    [first] => 222
                )

        )

)
Array
(
    [Category.id] => Array
        (
            [currentConnection] => PostToCategoryConnection:eyJmaXJzdCI6MjIyfQ==
            [connectionArgs] => Array
                (
                    [first] => 222
                )

        )

)
Array
(
    [Category.categoryId] => Array
        (
            [currentConnection] => PostToCategoryConnection:eyJmaXJzdCI6MjIyfQ==
            [connectionArgs] => Array
                (
                    [first] => 222
                )

        )

)
Array
(
    [Category.id] => Array
        (
            [currentConnection] => PostToCategoryConnection:eyJmaXJzdCI6MjIyfQ==
            [connectionArgs] => Array
                (
                    [first] => 222
                )

        )

)
Array
(
    [Category.categoryId] => Array
        (
            [currentConnection] => PostToCategoryConnection:eyJmaXJzdCI6MjIyfQ==
            [connectionArgs] => Array
                (
                    [first] => 222
                )

        )

)
Array
(
    [Category.id] => Array
        (
            [currentConnection] => PostToCategoryConnection:eyJmaXJzdCI6MjIyfQ==
            [connectionArgs] => Array
                (
                    [first] => 222
                )

        )

)
Array
(
    [Category.categoryId] => Array
        (
            [currentConnection] => PostToCategoryConnection:eyJmaXJzdCI6MjIyfQ==
            [connectionArgs] => Array
                (
                    [first] => 222
                )

        )

)
Array
(
    [Post.id] => Array
        (
            [currentConnection] => PostToCategoryConnection:eyJmaXJzdCI6MjIyfQ==
            [connectionArgs] => Array
                (
                    [first] => 222
                )

        )

)
Array
(
    [Post.categories] => Array
        (
            [currentConnection] => PostToCategoryConnection:eyJmaXJzdCI6MjIyfQ==
            [connectionArgs] => Array
                (
                    [first] => 222
                )

        )

)
Array
(
    [PostToCategoryConnection.nodes] => Array
        (
            [currentConnection] => PostToCategoryConnection:eyJmaXJzdCI6MjIyfQ==
            [connectionArgs] => Array
                (
                    [first] => 222
                )

        )

)
Array
(
    [Category.id] => Array
        (
            [currentConnection] => PostToCategoryConnection:eyJmaXJzdCI6MjIyfQ==
            [connectionArgs] => Array
                (
                    [first] => 222
                )

        )

)
Array
(
    [Category.categoryId] => Array
        (
            [currentConnection] => PostToCategoryConnection:eyJmaXJzdCI6MjIyfQ==
            [connectionArgs] => Array
                (
                    [first] => 222
                )

        )

)
```

Here we can see that each field in the ResolveTree properly receives the context of the connection it belongs to. 

Where has this been tested?
---------------------------
**Operating System:** …
Mac OS X 10.14.2

**WordPress Version:** …
WordPress 5.2
