### PR TITLE
Pass the operation params to the executeRequest call (fixes #643).

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -262,7 +262,7 @@ class Request {
 		 * Get the response.
 		 */
 		$server = $this->get_server();
-		$response = $server->executeRequest();
+		$response = $server->executeRequest( $this->params );
 
 		return $this->after_execute( $response );
 	}


### PR DESCRIPTION
If we don't pass them, the Server attempts to reparse them from the request body. This means that HTTP request data could not be filtered with `graphql_request_data`.