### PR TITLE
Provide graphql_server_config action to allow customization of ServerConfig.

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -296,7 +296,7 @@ class Request {
 		 * upon directly to override default values or implement new features, e.g.,
 		 * $config->setValidationRules().
 		 *
-		 * @since 0.2.1
+		 * @since 0.2.0
 		 *
 		 * @param ServerConfig    $config Server config
 		 * @param OperationParams $params Request operation params

--- a/src/Request.php
+++ b/src/Request.php
@@ -200,7 +200,7 @@ class Request {
 	}
 
 	/**
-	 * Returns all registered Schemas
+	 * Execute an internal request (graphql() function call).
 	 *
 	 * @return array
 	 */
@@ -241,7 +241,7 @@ class Request {
 	}
 
 	/**
-	 * Returns all registered Schemas
+	 * Execute an HTTP request.
 	 *
 	 * @return array
 	 */
@@ -290,6 +290,18 @@ class Request {
 			->setSchema( $this->schema )
 			->setContext( $this->app_context )
 			->setQueryBatching( true );
+
+		/**
+		 * Run an action when the server config is created. The config can be acted
+		 * upon directly to override default values or implement new features, e.g.,
+		 * $config->setValidationRules().
+		 *
+		 * @since 0.2.1
+		 *
+		 * @param ServerConfig    $config Server config
+		 * @param OperationParams $params Request operation params
+		 */
+		do_action( 'graphql_server_config', $config, $this->params );
 
 		$server = new StandardServer( $config );
 

--- a/src/Server/WPHelper.php
+++ b/src/Server/WPHelper.php
@@ -29,6 +29,10 @@ class WPHelper extends Helper {
 		 * applied to non-HTTP requests. Since 0.2.0, we will apply it to all
 		 * requests.
 		 *
+		 * This is a great place to hook if you are interested in implementing
+		 * persisted queries (and ends up being a bit more flexible than
+		 * graphql-php's built-in persistentQueryLoader).
+		 *
 		 * @param array $data An array containing the pieces of the data of the GraphQL request
 		 */
 		$parsed_body_params = apply_filters( 'graphql_request_data', $parsed_body_params );


### PR DESCRIPTION
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
This new action makes it possible to adjust the `ServerConfig` before the request is executed. So, for example, if I wanted to add some custom validation rules, I could call a method on the ServerConfig instance via this action, e.g.:

```
add_action( 'graphql_server_config', function( $config ) use ( $rules ) {
  $config->setValidationRules( $rules );
}, 10, 1 );
```

I don't strictly need this to implement persisted queries, but it is one avenue for implementation.

This also clean up some comments in the Request/WPHelper classes.