### PR TITLE
Typo in isset check for existing queryId.

### DIFF
--- a/src/Server/WPHelper.php
+++ b/src/Server/WPHelper.php
@@ -68,7 +68,7 @@ class WPHelper extends Helper {
 		}
 
 		// Apollo server/client compatibility: look for the query id in extensions
-		if ( isset( $params['extensions']['persistedQuery']['sha256Hash'] ) && ! isset( $params['query'] ) ) {
+		if ( isset( $params['extensions']['persistedQuery']['sha256Hash'] ) && ! isset( $params['queryId'] ) ) {
 			$params['queryId'] = $params['extensions']['persistedQuery']['sha256Hash'];
 			unset( $params['extensions']['persistedQuery'] );
 		}


### PR DESCRIPTION
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
This isset check exists to make sure we don't clobber an existing `queryId`. A typo was preventing it from checking properly.