### PR TITLE
🐛 FIX: Fixes PHP warnings in the Request class

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -160,7 +160,7 @@ class Request {
 	 *
 	 * @return array
 	 */
-	private function after_execute_actions( $response, $key ) {
+	private function after_execute_actions( $response, $key = null ) {
 
 		/**
 		 * Determine which params (batch or single request) to use when passing through to the actions


### PR DESCRIPTION
This fixes a bug with `after_execute_actions` throwing PHP warnings that was causing problems when WP_DEBUG_DISPLAY is turned on.

Closes #657