### PR TITLE
👌 IMPROVE: make connection methods public

### DIFF
--- a/src/Connection/Comments.php
+++ b/src/Connection/Comments.php
@@ -15,6 +15,8 @@ class Comments {
 
 	/**
 	 * Register connections to Comments
+	 *
+	 * @access public
 	 */
 	public static function register_connections() {
 
@@ -62,11 +64,12 @@ class Comments {
 	 * Given an array of $args, this returns the connection config, merging the provided args
 	 * with the defaults
 	 *
+	 * @access public
 	 * @param array $args
 	 *
 	 * @return array
 	 */
-	protected static function get_connection_config( $args = [] ) {
+	public static function get_connection_config( $args = [] ) {
 		$defaults = [
 			'fromType'       => 'RootQuery',
 			'toType'         => 'Comment',
@@ -83,9 +86,10 @@ class Comments {
 	/**
 	 * This returns the connection args for the Comment connection
 	 *
+	 * @access public
 	 * @return array
 	 */
-	protected static function get_connection_args() {
+	public static function get_connection_args() {
 		return [
 			'authorEmail'        => [
 				'type'        => 'String',

--- a/src/Connection/MenuItems.php
+++ b/src/Connection/MenuItems.php
@@ -15,6 +15,8 @@ class MenuItems {
 
 	/**
 	 * Register connections to MenuItems
+	 *
+	 * @access public
 	 */
 	public static function register_connections() {
 
@@ -44,11 +46,12 @@ class MenuItems {
 	/**
 	 * Given an array of $args, returns the args for the connection with the provided args merged
 	 *
+	 * @access public
 	 * @param array $args
 	 *
 	 * @return array
 	 */
-	protected static function get_connection_config( $args = [] ) {
+	public static function get_connection_config( $args = [] ) {
 		return array_merge( [
 			'fromType'       => 'RootQuery',
 			'fromFieldName'  => 'menuItems',

--- a/src/Connection/Menus.php
+++ b/src/Connection/Menus.php
@@ -15,6 +15,8 @@ class Menus {
 
 	/**
 	 * Registers connections to Menus
+	 *
+	 * @access public
 	 */
 	public static function register_connections() {
 

--- a/src/Connection/Plugins.php
+++ b/src/Connection/Plugins.php
@@ -12,6 +12,12 @@ use WPGraphQL\Data\DataSource;
  * @package WPGraphQL\Connection
  */
 class Plugins {
+
+	/**
+	 * Register connections to Plugins
+	 *
+	 * @access public
+	 */
 	public static function register_connections() {
 		register_graphql_connection( [
 			'fromType'      => 'RootQuery',

--- a/src/Connection/PostObjects.php
+++ b/src/Connection/PostObjects.php
@@ -81,7 +81,7 @@ class PostObjects {
 	 *
 	 * @return array
 	 */
-	protected static function get_connection_config( $post_type_object, $args = [] ) {
+	public static function get_connection_config( $post_type_object, $args = [] ) {
 
 		$connection_args = self::get_connection_args();
 
@@ -114,11 +114,12 @@ class PostObjects {
 	/**
 	 * Given an optional array of args, this returns the args to be used in the connection
 	 *
+	 * @access public
 	 * @param array $args The args to modify the defaults
 	 *
 	 * @return array
 	 */
-	protected static function get_connection_args( $args = [] ) {
+	public static function get_connection_args( $args = [] ) {
 
 		return array_merge( [
 

--- a/src/Connection/TermObjects.php
+++ b/src/Connection/TermObjects.php
@@ -15,6 +15,8 @@ class TermObjects {
 
 	/**
 	 * Register connections to TermObjects
+	 *
+	 * @access public
 	 */
 	public static function register_connections() {
 
@@ -65,13 +67,14 @@ class TermObjects {
 	 * Given the Taxonomy Object and an array of args, this returns an array of args for use in
 	 * registering a connection.
 	 *
+	 * @access public
 	 * @param \WP_Taxonomy $tax_object        The taxonomy object for the taxonomy having a
 	 *                                        connection registered to it
 	 * @param array        $args              The custom args to modify the connection registration
 	 *
 	 * @return array
 	 */
-	protected static function get_connection_config( $tax_object, $args = [] ) {
+	public static function get_connection_config( $tax_object, $args = [] ) {
 
 		$defaults = [
 			'fromType'         => 'RootQuery',
@@ -99,11 +102,12 @@ class TermObjects {
 	/**
 	 * Given an optional array of args, this returns the args to be used in the connection
 	 *
+	 * @access public
 	 * @param array $args The args to modify the defaults
 	 *
 	 * @return array
 	 */
-	protected static function get_connection_args( $args = [] ) {
+	public static function get_connection_args( $args = [] ) {
 		return array_merge( [
 			'objectIds'                       => [
 				'type'        => [

--- a/src/Connection/Themes.php
+++ b/src/Connection/Themes.php
@@ -15,6 +15,8 @@ class Themes {
 
 	/**
 	 * Register the connections
+	 *
+	 * @access public
 	 */
 	public static function register_connections() {
 

--- a/src/Connection/UserRoles.php
+++ b/src/Connection/UserRoles.php
@@ -15,6 +15,8 @@ class UserRoles {
 
 	/**
 	 * Register the connections
+	 *
+	 * @access public
 	 */
 	public static function register_connections() {
 

--- a/src/Connection/Users.php
+++ b/src/Connection/Users.php
@@ -13,6 +13,8 @@ class Users {
 
 	/**
 	 * Register connections to Users
+	 *
+	 * @access public
 	 */
 	public static function register_connections() {
 
@@ -46,8 +48,9 @@ class Users {
 	 * Returns the connection args for use in the connection
 	 *
 	 * @return array
+	 * @access public
 	 */
-	protected static function get_connection_args() {
+	public static function get_connection_args() {
 		return [
 			'role'              => [
 				'type'        => 'UserRoleEnum',


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This makes connection methods public for easier re-use when extending and creating custom connections

Does this close any currently open issues?
------------------------------------------
closes #668 

Any other comments?
-------------------
Now, when registering custom connections, one could do somethign like: 

```
register_graphql_connection([
		'fromType' => 'RootQuery',
		'toType' => 'AudioUnion',
		'fromFieldName' => 'audio',
                 'connectionArgs' => \WPGraphQL\Connection\PostObjects::get_connection_args(),
		'resolve' => function( $root, $args, $context, $info ) {
			return \WPGraphQL\Data\DataSource::resolve_post_objects_connection( $root, $args, $context, $info, null );
		}
	]);
```

Note the use of `\WPGraphQL\Connection\PostObjects::get_connection_args()`

This will allow for folks to create custom connections that make use of the connection args already defined for PostObjectConnections

All other protected methods re: Connection registration have been made public as well making it easier to access when extending the Schema. 