### PR TITLE
 Apply wp_unslash to query (GET) variables to undo wp_magic_quotes

### DIFF
--- a/src/Server/WPHelper.php
+++ b/src/Server/WPHelper.php
@@ -23,8 +23,11 @@ class WPHelper extends Helper {
 	 * @throws RequestError
 	 */
 	public function parseRequestParams( $method, array $bodyParams, array $queryParams ) {
+		// Apply wp_unslash to query (GET) variables to undo wp_magic_quotes. We
+		// don't need to do this for POST variables because graphql-php reads the
+		// HTTP body directly.
 		$parsed_body_params = $this->parse_params( $bodyParams );
-		$parsed_query_params = $this->parse_extensions( $queryParams );
+		$parsed_query_params = $this->parse_extensions( wp_unslash( $queryParams ) );
 
 		/**
 		 * Allow the request data to be filtered. Previously this filter was only
@@ -67,7 +70,7 @@ class WPHelper extends Helper {
 	 */
 	private function parse_extensions( $params ) {
 		if ( isset( $params['extensions'] ) && is_string( $params['extensions'] ) ) {
-			$tmp = json_decode( stripslashes( $params['extensions'] ), true );
+			$tmp = json_decode( $params['extensions'], true );
 			if ( ! json_last_error() ) {
 				$params['extensions'] = $tmp;
 			}

--- a/tests/functional/BasicPostListCept.php
+++ b/tests/functional/BasicPostListCept.php
@@ -3,6 +3,45 @@
 $I = new FunctionalTester( $scenario );
 $I->wantTo('Get public data without passing authentication headers');
 
+$query = '
+{
+	posts {
+		edges {
+			node {
+				id
+				title
+				link
+				date
+			}
+		}
+	}
+}';
+
+function verifyResponse( $I ) {
+	$I->seeResponseCodeIs( 200 );
+	$I->seeResponseIsJson();
+	$response = $I->grabResponse();
+	$response_array = json_decode( $response, true );
+
+	/**
+	 * Make sure query is valid and has no errors
+	 */
+	$I->assertArrayNotHasKey( 'errors', $response_array  );
+
+	/**
+	 * Make sure response is properly returning data as expected
+	 */
+	$I->assertArrayHasKey( 'data', $response_array );
+
+	/**
+	 * Make sure there is a post returned with the data we requested
+	 */
+	$I->assertNotEmpty( $response_array['data']['posts']['edges'][0]['node']['id'] );
+	$I->assertNotEmpty( $response_array['data']['posts']['edges'][0]['node']['title'] );
+	$I->assertNotEmpty( $response_array['data']['posts']['edges'][0]['node']['link'] );
+	$I->assertNotEmpty( $response_array['data']['posts']['edges'][0]['node']['date'] );	
+}
+
 /**
  * Make sure there's a post in the database to query for. If there was no data,
  * we'd have some issues.
@@ -18,41 +57,34 @@ $I->havePostInDatabase([
  * Set the content-type so we get a proper response from the API
  */
 $I->haveHttpHeader( 'Content-Type', 'application/json' );
-$I->sendPOST( 'http://wpgraphql.test/graphql', json_encode([
-	'query' => '
-	{
-		posts {
-			edges {
-				node {
-					id
-					title
-					link
-					date
-				}
-			}
-		}
-	}'
-]) );
+$I->sendPOST( 'http://wpgraphql.test/graphql', json_encode( [ 'query' => $query ] ) );
 
-$I->seeResponseCodeIs( 200 );
-$I->seeResponseIsJson();
-$response = $I->grabResponse();
-$response_array = json_decode( $response, true );
+verifyResponse( $I );
 
 /**
- * Make sure query is valid and has no errors
+ * Now try the same request as GET.
  */
-$I->assertArrayNotHasKey( 'errors', $response_array  );
+$query_vars = http_build_query( [
+	'query' => $query,
+	'variables' => json_encode( [ 'foo' => 'bar ' ] ), // unused but help test variable encoding
+] );
+
+$I->haveHttpHeader( 'Content-Type', 'application/json' );
+$I->sendGET( "http://wpgraphql.test/graphql?{$query_vars}" );
+
+verifyResponse( $I );
 
 /**
- * Make sure response is properly returning data as expected
+ * If the query provides an operation name, the request must provide a matching
+ * operationName parameter.
  */
-$I->assertArrayHasKey( 'data', $response_array );
+$query_vars = http_build_query( [
+	'operationName' => 'TestQuery',
+	'query' => "query TestQuery {$query}",
+	'variables' => json_encode( [ 'foo' => 'bar ' ] ), // unused but help test variable encoding
+] );
 
-/**
- * Make sure there is a post returned with the data we requested
- */
-$I->assertNotEmpty( $response_array['data']['posts']['edges'][0]['node']['id'] );
-$I->assertNotEmpty( $response_array['data']['posts']['edges'][0]['node']['title'] );
-$I->assertNotEmpty( $response_array['data']['posts']['edges'][0]['node']['link'] );
-$I->assertNotEmpty( $response_array['data']['posts']['edges'][0]['node']['date'] );
+$I->haveHttpHeader( 'Content-Type', 'application/json' );
+$I->sendGET( "http://wpgraphql.test/graphql?{$query_vars}" );
+
+verifyResponse( $I );


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
Adding variables to a `GET` request results in an error from `graphql-php`, e.g.:

```
GraphQL Request parameter "variables" must be object or JSON string parse
d to object, but got "{\\"foo\\":\\"bar \\"}"
```

This is because WordPress adds slashes to superglobals for safety reasons (`wp_magic_quotes`):

https://github.com/WordPress/WordPress/blob/92c3c46abe9f3b9e27764cbd483204530e8c1c2a/wp-includes/load.php#L761-L763

I had accounted for this and was stripping slashes on the `extensions` parameter, but didn't realize the same issue existed for `variables` and all other `GET` parameters. This PR applies `wp_unslash` to all `GET` query variables.

Even though WordPress also escapes `$_POST`, the same problem does not exist there because `graphql-php` reads the request body directly from `php://input`:

https://github.com/webonyx/graphql-php/blob/master/src/Server/Helper.php#L463

Does this close any currently open issues?
------------------------------------------
I looked around but didn't find one. This is critical for persisted query support, which is how I turned it up.

Screenshot of existing issue
---------------------
![screenshot from 2019-02-02 20-53-11](https://user-images.githubusercontent.com/739304/52171563-c6de1c00-272c-11e9-889d-3a299a97c61f.png)



Any other comments?
-------------------
Added tests. They fail without this fix.

Where has this been tested?
---------------------------
**WordPress Version:** 5.0.3
