### PR TITLE
Add Access-Control-Max-Age header to cache preflight responses.

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -205,6 +205,7 @@ class Router {
 		$headers = [
 			'Access-Control-Allow-Origin'  => '*',
 			'Access-Control-Allow-Headers' => implode( ', ', $access_control_allow_headers ),
+			'Access-Control-Max-Age'       => 600, // cache the result of preflight requests (600 is the upper limit for Chromium)
 			'Content-Type'                 => 'application/json ; charset=' . get_option( 'blog_charset' ),
 			'X-Robots-Tag'                 => 'noindex',
 			'X-Content-Type-Options'       => 'nosniff',


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds a `Access-Control-Max-Age` header so that preflight (`OPTIONS`) responses can be cached by the browser. Currently, when the GraphQL server is on a different hostname, the browser must send a preflight request and wait for a response before every single request:

![screenshot from 2019-02-03 13-36-12](https://user-images.githubusercontent.com/739304/52180797-b1163880-27b8-11e9-9d36-b75fbdcae487.png)

While a user could implement this herself by filtering `graphql_response_headers_to_send`, this seems like a reasonable default (that the user can still override if they want).

The value of `600` was chosen since it is the maximum value that Chromium supports (anything higher is rounded down):

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age