### PR TITLE
apply lcfirst when generating custom post type id field

### DIFF
--- a/src/Type/Object/RootQuery.php
+++ b/src/Type/Object/RootQuery.php
@@ -206,8 +206,8 @@ if ( ! empty( $allowed_post_types ) && is_array( $allowed_post_types ) ) {
 						throw new UserError( __( 'The "id" is invalid', 'wp-graphql' ) );
 					}
 					$post_object = DataSource::resolve_post_object( absint( $id_components['id'] ), $post_type_object->name );
-				} elseif ( ! empty( $args[ $post_type_object->graphql_single_name . 'Id' ] ) ) {
-					$id          = $args[ $post_type_object->graphql_single_name . 'Id' ];
+				} elseif ( ! empty( $args[ lcfirst( $post_type_object->graphql_single_name . 'Id' ) ] ) ) {
+					$id          = $args[ lcfirst( $post_type_object->graphql_single_name . 'Id' ) ];
 					$post_object = DataSource::resolve_post_object( $id, $post_type_object->name );
 				} elseif ( ! empty( $args['uri'] ) ) {
 					$uri         = esc_html( $args['uri'] );


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes https://github.com/wp-graphql/wp-graphql/issues/691
The case in which `graphql_single_name` and `graphql_plural_name` are spelt is now consistent between the check in the `RootQuery` and the created field in the `TypeRegistry`'s `prepare_field` function


Does this close any currently open issues?
------------------------------------------
https://github.com/wp-graphql/wp-graphql/issues/691


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
Nothing more than what I posted in the issue

Any other comments?
-------------------
Awesome project, thank you for all the work you put into it!

Where has this been tested?
---------------------------
**Operating System:**: Docker test suite

**WordPress Version:** 5.03
