### PR TITLE
Issue 624, CI-6146 | Running tests with WP 5.0.3 + PHP 7.3; Updating PHP composer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ env:
   matrix:
     # These apply to the latest WP version that is available as a Docker image: https://hub.docker.com/_/wordpress/
     - WP_VERSION=5.0.2 PHP_VERSION=5.6
-    - WP_VERSION=5.0.2 PHP_VERSION=7.1
-    - WP_VERSION=5.0.2 PHP_VERSION=7.2
+    - WP_VERSION=5.0.3 PHP_VERSION=7.1
+    - WP_VERSION=5.0.3 PHP_VERSION=7.2
     - WP_VERSION=5.0.3 PHP_VERSION=7.3 COVERAGE=true LINT_SCHEMA=true
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,10 @@ cache:
 env:
   matrix:
     # These apply to the latest WP version that is available as a Docker image: https://hub.docker.com/_/wordpress/
-    - PHP_VERSION=5.6
-    - PHP_VERSION=7.1
-    - PHP_VERSION=7.2 COVERAGE=true LINT_SCHEMA=true
+    - WP_VERSION=5.0.2 PHP_VERSION=5.6
+    - WP_VERSION=5.0.2 PHP_VERSION=7.1
+    - WP_VERSION=5.0.2 PHP_VERSION=7.2
+    - WP_VERSION=5.0.3 PHP_VERSION=7.3 COVERAGE=true LINT_SCHEMA=true
 
 before_install:
 - sudo rm /usr/local/bin/docker-compose

--- a/Dockerfile.test-base
+++ b/Dockerfile.test-base
@@ -20,9 +20,16 @@ RUN echo 'date.timezone = "UTC"' > /usr/local/etc/php/conf.d/timezone.ini \
   && apt-get update -y \
   && apt-get install --no-install-recommends -y mysql-client subversion \
   && rm -rf /var/lib/apt/lists/* \
-  && if echo "${PHP_VERSION}" | grep '^7.'; then pecl install 'xdebug' && docker-php-ext-enable xdebug; fi \
+  && if echo "${PHP_VERSION}" | grep '^7'; then \
+        if echo "${PHP_VERSION}" | grep '^7.3'; then \
+          pecl install 'xdebug-2.7.0RC2'; \
+        else \
+          pecl install xdebug; \
+        fi; \
+        docker-php-ext-enable xdebug; \
+     fi \
   && docker-php-ext-install pdo_mysql \
-  && curl -Ls 'https://raw.githubusercontent.com/composer/getcomposer.org/d3e09029468023aa4e9dcd165e9b6f43df0a9999/web/installer' | php -- --quiet \
+  && curl -Ls 'https://raw.githubusercontent.com/composer/getcomposer.org/cb19f2aa3aeaa2006c0cd69a7ef011eb31463067/web/installer' | php -- --quiet \
   && chmod +x composer.phar \
   && mv composer.phar /usr/local/bin/composer \
   && curl -O 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar' \

--- a/Dockerfile.xdebug
+++ b/Dockerfile.xdebug
@@ -12,4 +12,11 @@ ARG OFFICIAL_WORDPRESS_DOCKER_IMAGE="wordpress:${DESIRED_WP_VERSION}-php${DESIRE
 FROM ${OFFICIAL_WORDPRESS_DOCKER_IMAGE}
 
 # Install XDebug for PHP 7.X.
-RUN if echo "${PHP_VERSION}" | grep '^7.'; then pecl install xdebug; docker-php-ext-enable xdebug; fi
+RUN if echo "${PHP_VERSION}" | grep '^7'; then \
+      if echo "${PHP_VERSION}" | grep '^7.3'; then \
+        pecl install 'xdebug-2.7.0RC2'; \
+      else \
+        pecl install xdebug; \
+      fi; \
+      docker-php-ext-enable xdebug; \
+    fi

--- a/README.md
+++ b/README.md
@@ -242,10 +242,21 @@ Notes:
 * Code coverage for `functional` and `acceptance` tests is only supported for PHP 7.X. 
   
 
-#### Updating WP Docker image
+#### Updating WP Docker software versions
 Make sure the `docker-compose*.yml` files refer to the most recent and specific version of the official WordPress Docker and MySQL compatible images.
 Please avoid using the `latest` Docker tag. Once Docker caches a Docker image for a given tag onto your machine, it won't automatically
 check for updates. Using an actual version number ensures Docker image caches are updated at the right time.
+
+List of software versions to check:
+* Travis config `.travis.yml`
+* Test base Dockerfile (`Dockerfile.test-base`)
+   * XDebug
+   * Official WordPress/PHP Docker image
+   * PHP Composer
+
+* XDebug Dockerfile (`Dockerfile.xdebug`)
+   * XDebug
+
   
 ### Generating Code Coverage
 You can generate code coverage for tests by passing `--coverage`, `--coverage-xml` or `--coverage-html` with the tests. 

--- a/docker/docker-compose.local-app.yml
+++ b/docker/docker-compose.local-app.yml
@@ -19,7 +19,7 @@ services:
       - './uploads.txt:/usr/local/etc/php/conf.d/uploads.ini:ro'
 
   mysql_test:
-    image: 'mariadb:10.2.21-bionic'
+    image: 'mariadb:10.2.22-bionic'
     environment:
       MYSQL_DATABASE: 'wpgraphql_test'
       MYSQL_ROOT_PASSWORD: 'testing'

--- a/docker/docker-compose.tests.yml
+++ b/docker/docker-compose.tests.yml
@@ -43,7 +43,7 @@ services:
     entrypoint: [ "docker-entrypoint.sut.sh" ]
 
   mysql_test:
-    image: 'mariadb:10.2.21-bionic'
+    image: 'mariadb:10.2.22-bionic'
     environment:
       MYSQL_DATABASE: 'wpgraphql_test'
       MYSQL_ROOT_PASSWORD: 'testing'


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
- Adding support for WP 5.0.3 + PHP 7.3  tests.
- Updating PHP Composer version

Please note: Use of PHP 7.3 requires use of `xdebug-2.7.0RC2` which seems to work for code coverage, but not for debugging. Because of this, I'm leaving the ***default*** Docker WP and PHP versions at 5.0.2 and 7.2, respectively. This ensures debugging doesn't break for current Xdebug users  while still allowing Travis to run WP 5.0.3 + PHP 7.X tests.

Does this close any currently open issues?
------------------------------------------
Yes: https://github.com/wp-graphql/wp-graphql/issues/624

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
N/A


Any other comments?
-------------------
N/A


Where has this been tested?
---------------------------
**Operating System:**
Ubuntu Linux

**WordPress Version:** 
- WP 5.0.2+PHP 5.6
- WP 5.0.3+PHP 7.1
- WP 5.0.3+PHP 7.2
- WP 5.0.3+PHP 7.3
