### PR TITLE
Do not execute graphql_request_data twice for GET requests

### DIFF
--- a/src/Server/WPHelper.php
+++ b/src/Server/WPHelper.php
@@ -29,6 +29,12 @@ class WPHelper extends Helper {
 		$parsed_body_params = $this->parse_params( $bodyParams );
 		$parsed_query_params = $this->parse_extensions( wp_unslash( $queryParams ) );
 
+		$request_context = [
+			'method' => $method,
+			'query_params' => ! empty( $parsed_query_params ) ? $parsed_query_params : null,
+			'body_params' => ! empty( $parsed_body_params ) ? $parsed_body_params : null
+		];
+
 		/**
 		 * Allow the request data to be filtered. Previously this filter was only
 		 * applied to non-HTTP requests. Since 0.2.0, we will apply it to all
@@ -39,13 +45,19 @@ class WPHelper extends Helper {
 		 * graphql-php's built-in persistentQueryLoader).
 		 *
 		 * @param array $data An array containing the pieces of the data of the GraphQL request
+		 * @param array $request_context An array containing the both body and query params
 		 */
-		$parsed_body_params = apply_filters( 'graphql_request_data', $parsed_body_params );
-		if ( ! empty( $parsed_query_params ) ) {
-			$parsed_query_params = apply_filters( 'graphql_request_data', $parsed_query_params );
+		if ( 'GET' === $method ) {
+			$parsed_query_params = apply_filters( 'graphql_request_data', $parsed_query_params, $request_context );
+			// In GET requests there cannot be any body params so it's empty.
+			return parent::parseRequestParams( $method, [], $parsed_query_params );
 		}
-
-		return parent::parseRequestParams( $method, $parsed_body_params, $parsed_query_params );
+		
+		// In POST requests the query params are ignored by default but users can
+		// merge them into the body params manually using the $request_context if
+		// needed.
+		$parsed_body_params = apply_filters( 'graphql_request_data', $parsed_body_params, $request_context );
+		return parent::parseRequestParams( $method, $parsed_body_params, [] );
 	}
 
 	/**

--- a/tests/wpunit/WPHelperTest.php
+++ b/tests/wpunit/WPHelperTest.php
@@ -143,6 +143,22 @@ class WPHelperTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	/**
+	 * Test that POST request can access query params
+	 */
+	public function testRequestContext() {
+		$body_params = $this->get_example_params();
+
+		add_filter( 'graphql_request_data', function( $params, $context ) {
+			return [ 'query' => $context['query_params']['querything'] ];
+		}, 10, 2 );
+
+		$helper = new WPHelper();
+		$params = $helper->parseRequestParams( 'POST', $body_params, [ 'querything' => 'queryvalue' ] );
+
+		$this->assertEquals( 'queryvalue', $params->query );
+	}
+
+	/**
 	 * Test that GET params can be filtered with graphql_request_data.
 	 */
 	public function testRequestGetDataFilter() {


### PR DESCRIPTION
Fixes #707


- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------

Avoids executing `graphql_request_data` filter twice on GET requests.

graphql-php uses only the query params on GET requets so executing the filter only for the query params on GET requests should be ok:

https://github.com/webonyx/graphql-php/blob/616fc10837c73f0a333c38f8aefa285cf70c5717/src/Server/Helper.php#L123

Added a second param to the filter so the users can access the query params on POST requests too if needed.


Does this close any currently open issues?
------------------------------------------

https://github.com/wp-graphql/wp-graphql/issues/707



Where has this been tested?
---------------------------
**Operating System:** …

Ubuntu Bionci, the Docker test env

**WordPress Version:** …

5.x