### PR TITLE
Setup postdata on field levels

### DIFF
--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -179,14 +179,6 @@ class DataSource {
 			remove_filter( 'the_content', 'prepend_attachment' );
 		}
 
-		/**
-		 * Set the resolving post to the global $post. That way any filters that
-		 * might be applied when resolving fields can rely on global post and
-		 * post data being set up.
-		 */
-		$GLOBALS['post'] = $post_object;
-		setup_postdata( $post_object );
-
 		return $post_object;
 
 	}

--- a/src/Request.php
+++ b/src/Request.php
@@ -139,9 +139,14 @@ class Request {
 		 * This allows for a GraphQL query to be used in the middle of post content, such as in a Shortcode
 		 * without disrupting the flow of the post as the global POST before and after GraphQL execution will be
 		 * the same.
+		 *
+		 * We cannot use wp_reset_postdata here because it just resets the post from the global query which can
+		 * be anything the because the resolvers themself can set it to whatever. So we just manually reset the
+		 * post with setup_postdata we cached before this request.
 		 */
 		if ( ! empty( $this->global_post ) ) {
 			$GLOBALS['post'] = $this->global_post;
+			setup_postdata( $this->global_post );
 		}
 
 		/**

--- a/src/Utils/InstrumentSchema.php
+++ b/src/Utils/InstrumentSchema.php
@@ -18,6 +18,12 @@ use WPGraphQL\Type\WPObjectType;
 class InstrumentSchema {
 
 	/**
+	* Cache post for the resolvers so we can call the setup_postdata only when the actual
+	* source post changes
+	*/
+	private static $cached_post = null;
+
+	/**
 	 * @param \WPGraphQL\WPSchema $schema
 	 *
 	 * @return \WPGraphQL\WPSchema
@@ -115,7 +121,8 @@ class InstrumentSchema {
 						 * This ensures that functions like get_the_content() work correctly
 						 * so graphql queries can be used in the loop without issues.
 						 */
-						if ( is_a( $source, 'WP_Post' ) ) {
+						if ( is_a( $source, 'WP_Post' ) && self::$cached_post !== $source ) {
+							self::$cached_post = $source;
 							$GLOBALS['post'] = $source;
 							setup_postdata( $source );
 						}

--- a/src/Utils/InstrumentSchema.php
+++ b/src/Utils/InstrumentSchema.php
@@ -111,6 +111,16 @@ class InstrumentSchema {
 					$field->resolveFn = function( $source, array $args, AppContext $context, ResolveInfo $info ) use ( $field_resolver, $type_name, $field_key, $field ) {
 
 						/**
+						 * Setup the global post to the current post (if a post)
+						 * This ensures that functions like get_the_content() work correctly
+						 * so graphql queries can be used in the loop without issues.
+						 */
+						if ( is_a( $source, 'WP_Post' ) ) {
+							$GLOBALS['post'] = $source;
+							setup_postdata( $source );
+						}
+
+						/**
 						 * Fire an action BEFORE the field resolves
 						 *
 						 * @param mixed           $source    The source passed down the Resolve Tree

--- a/tests/wpunit/PostObjectConnectionQueriesTest.php
+++ b/tests/wpunit/PostObjectConnectionQueriesTest.php
@@ -732,12 +732,12 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 		$post_1_args = [
 			'post_content' => 'Post content 1',
-			'post_excerpt' => 'Post excerpt 1',
+			'post_excerpt' => '',
 		];
 
 		$post_2_args = [
 			'post_content' => 'Post content 2',
-			'post_excerpt' => 'Post excerpt 2',
+			'post_excerpt' => '',
 		];
 
 		$post_1_id = $this->createPostObject( $post_1_args );

--- a/tests/wpunit/PostObjectQueriesTest.php
+++ b/tests/wpunit/PostObjectQueriesTest.php
@@ -1355,9 +1355,15 @@ class PostObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 		do_graphql_request( $graphql_query );
 
 		/**
-		 * Asset that the query has been reset to the main query.
+		 * Assert that the query has been reset to the main query.
 		 */
 		$this->assertEquals( $main_query_post_id, $post->ID );
+
+		// setup_postdata sets the global $id too so assert it is reset back to
+		// original
+		// https://github.com/WordPress/WordPress/blob/b5542c6b1b41d69b4e5c26ef8280c6e85de67224/wp-includes/class-wp-query.php#L4158
+		$this->assertEquals( $main_query_post_id, $GLOBALS['id'] );
+
 	}
 
 	/**


### PR DESCRIPTION
We noticed that the "Excerpt is always of the first post" (#503) issue has regressed and it was not caught by tests because the test added in #625 does not properly test the usage of the global post.

It does not use it because the `get_the_excerpt` filter uses the `wp_trim_excerpt` function by default and if a pre-existing excerpt is passed it just returns it:

https://github.com/WordPress/WordPress/blob/cddee8b72e59c9968b1c786c01992dae6f71ee13/wp-includes/formatting.php#L3685-L3686


Setting the `post_excerpt` string to an empty string causes `wp_trim_excerpt` to call `get_the_content( '' );` and thus the test fails.


I don't know how this should be really fixed but adding this to the `excerpt` resolver makes it pass again:

https://github.com/epeli/wp-graphql/commit/d174a6c41f82dbdbee4fcaaa816fa71e0fbc8139

but I'm pretty sure it's not the right solution so I didn't include it in this PR.

**UPDATE: I have now added a proper fix to this PR**

Where has this been tested?
---------------------------

The latest dev branch.
