### PR TITLE
Add 'link' root query

### DIFF
--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -759,11 +759,30 @@ class DataSource {
 
 	}
 
-		/**
+	/**
      * Returns array of nav menu location names
      */
     public static function get_registered_nav_menu_locations() {
 			global $_wp_registered_nav_menus;
 			return array_keys( $_wp_registered_nav_menus );
+	}
+
+	/**
+	 * Get post object by its link.
+	 *
+	 * @param string $link from get_permalink() for example
+	 * @param string $post_type Optional. Post type; default is 'post'.
+	 *
+	 * @return \WP_Post|null WP_Post on success or null on failure
+	 * @see  https://codex.wordpress.org/Function_Reference/url_to_postid
+	 */
+	public static function get_post_object_by_link( $link, $post_type = 'post' ) {
+		$post_id = url_to_postid( $link );
+
+		if ( $post_id ) {
+			return self::resolve_post_object( $post_id, $post_type );
 		}
+
+		return null;
+	}
 }

--- a/src/Type/Object/RootQuery.php
+++ b/src/Type/Object/RootQuery.php
@@ -182,6 +182,10 @@ if ( ! empty( $allowed_post_types ) && is_array( $allowed_post_types ) ) {
 			'uri'                                         => [
 				'type'        => 'String',
 				'description' => sprintf( __( 'Get the %s by its uri', 'wp-graphql' ), $post_type_object->graphql_single_name ),
+			],
+			'link'                                         => [
+				'type'        => 'String',
+				'description' => sprintf( __( 'Get the %s by its link. Uses url_to_postid() to resolve the link.', 'wp-graphql' ), $post_type_object->graphql_single_name ),
 			]
 		];
 
@@ -215,6 +219,9 @@ if ( ! empty( $allowed_post_types ) && is_array( $allowed_post_types ) ) {
 				} elseif ( ! empty( $args['slug'] ) ) {
 					$slug        = esc_html( $args['slug'] );
 					$post_object = DataSource::get_post_object_by_uri( $slug, 'OBJECT', $post_type_object->name );
+				} elseif ( ! empty( $args['link'] ) ) {
+					$link   = esc_html( $args['link'] );
+					$post_object = DataSource::get_post_object_by_link( $link, $post_type_object->name );
 				}
 
 				if ( empty( $post_object ) || is_wp_error( $post_object ) ) {

--- a/tests/wpunit/PostObjectQueriesTest.php
+++ b/tests/wpunit/PostObjectQueriesTest.php
@@ -1538,4 +1538,74 @@ class PostObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 	}
 
+	/**
+	 * Test post can be queried its permalink
+	 */
+	public function testPostByPermalinkQuery() {
+		$post_id = $this->createPostObject( [
+			'post_type' => 'post',
+			'post_title' => 'Post title',
+		] );
+
+		$permalink = get_permalink($post_id);
+
+		$query = "
+		{
+			postBy(link: \"$permalink\") {
+				title
+			}
+		}
+		";
+
+
+		$expected = [
+			'data' => [
+				'postBy' => [
+					'title' => 'Post title',
+				]
+			]
+		];
+
+		/**
+		 * Run the GraphQL query
+		 */
+		$actual = do_graphql_request( $query );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Test wrong post type cannot be queried its permalink
+	 */
+	public function testPostByPermalinkQueryBadType() {
+
+		/** Create post of page type */
+		$post_id = $this->createPostObject( [
+			'post_type' => 'page',
+			'post_title' => 'Page title',
+		] );
+
+		$permalink = get_permalink($post_id);
+
+		/**
+		 * Try to query it as a post
+		 */
+		$query = "
+		{
+				postBy(link: \"$permalink\") {
+					title
+				}
+		}
+		";
+
+		/**
+		 * Run the GraphQL query
+		 */
+		$actual = do_graphql_request( $query );
+
+		$this->assertArrayHasKey( 'errors', $actual );
+		$this->assertEquals( 'The queried resource is not the correct type', $actual['errors'][0]['message'] );
+	}
+
 }


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------

It adds an ability to query all post types by their permalinks.


Does this close any currently open issues?
------------------------------------------

No.



Any other comments?
-------------------

This makes it easier to implement clients for headless WordPress installations. Without this the client implementor must be aware of the rewrite setup WordPress is using.

This was discussed in the Slack earlier https://wp-graphql.slack.com/archives/C3NM1M291/p1551470085101500


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …

5.0.5, Ubuntu Bionic.