### PR TITLE
MenuLocationEnum fix

### DIFF
--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -766,4 +766,12 @@ class DataSource {
 		return null;
 
 	}
+
+		/**
+     * Returns array of nav menu location names
+     */
+    public static function get_registered_nav_menu_locations() {
+			global $_wp_registered_nav_menus;
+			return array_keys( $_wp_registered_nav_menus );
+		}
 }

--- a/src/Type/Enum/MenuLocationEnum.php
+++ b/src/Type/Enum/MenuLocationEnum.php
@@ -1,12 +1,14 @@
 <?php
 namespace WPGraphQL\Type;
 
+use WPGraphQL\Data\DataSource;
+
 $values = [];
 
-$locations = array_keys( get_nav_menu_locations() );
+$locations = DataSource::get_registered_nav_menu_locations();
 
 if ( ! empty( $locations ) && is_array( $locations ) ) {
-	foreach ( array_keys( get_nav_menu_locations() ) as $location ) {
+	foreach ( $locations as $location ) {
 		$values[ WPEnumType::get_safe_name( $location ) ] = [
 			'value' => $location,
 		];


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
Makes menu locations without assigned menus visible to `MenuLocationEnum`. Relies on `$_wp_registered_nav_menus` global, instead of `get_nav_menu_locations()`.


Does this close any currently open issues?
------------------------------------------
No


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 18.04

**WordPress Version:** 5.0.2
