### PR TITLE
Add arg filters for menu items

### DIFF
--- a/src/Data/MenuItemConnectionResolver.php
+++ b/src/Data/MenuItemConnectionResolver.php
@@ -145,6 +145,17 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 		$pagination_increase          = ! empty( $args['first'] ) && ( empty( $args['after'] ) && empty( $args['before'] ) ) ? 0 : 1;
 		$query_args['posts_per_page'] = self::get_query_amount( $source, $args, $context, $info ) + absint( $pagination_increase );
 
+		/**
+		 * Filter the $query args to allow folks to customize queries programmatically
+		 *
+		 * @param array       $query_args The args that will be passed to the WP_Query
+		 * @param mixed       $source     The source that's passed down the GraphQL queries
+		 * @param array       $args       The inputArgs on the field
+		 * @param AppContext  $context    The AppContext passed down the GraphQL tree
+		 * @param ResolveInfo $info       The ResolveInfo passed down the GraphQL tree
+		 */
+		$query_args = apply_filters( 'graphql_menu_item_connection_query_args', $query_args, $source, $args, $context, $info );
+
 		return $query_args;
 	}
 

--- a/src/Data/MenuItemConnectionResolver.php
+++ b/src/Data/MenuItemConnectionResolver.php
@@ -83,6 +83,16 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 	 */
 	public static function get_query_args( $source, array $args, AppContext $context, ResolveInfo $info ) {
 
+		/**
+		 * Filter the $args to allow folks to customize query generation programmatically
+		 *
+		 * @param array       $args       The inputArgs on the field
+		 * @param mixed       $source     The source that's passed down the GraphQL queries
+		 * @param AppContext  $context    The AppContext passed down the GraphQL tree
+		 * @param ResolveInfo $info       The ResolveInfo passed down the GraphQL tree
+		 */
+		$args = apply_filters( 'graphql_menu_item_connection_args', $args, $source, $context, $info );
+
 		// Prevent the query from matching anything by default.
 		$query_args = [
 			'post_type' => 'nav_menu_item',


### PR DESCRIPTION
Adds two filters for menu items connection resolvers

A `graphql_menu_item_connection_args` which can be used to filter the args passed to the `menuItems` query before the `$query_args` is generated.

A `graphql_menu_item_connection_query_args` which can be used to modify the `$query_args` once the wpgraphql logic is executed.

### Rationale

In the [wp-graphql-polylang](https://github.com/valu-digital/wp-graphql-polylang) were aiming to add a `language` where arg to all translatable items and with menus I was not able to find any way to modify the menu query based on the input args.

Eg. we want to be able to write

```graphql
{
  menuItems(where: {language: EN, location: TOP_MENU}) {
    nodes {
      label
    }
  }
}
```

Polylang handles menu translations by dynamically generating translated versions of the menu locations. Ex. `TOP_MENU` to `TOP_MENU___en`, `TOP_MENU___fi` etc. so we need to convert the `location` where arg using the `language` field.

Here's how we would use `graphql_menu_item_connection_args` to implement this:

https://github.com/valu-digital/wp-graphql-polylang/blob/507f095a87d86177a7dc41d35a54ee4efd019540/src/MenuItem.php#L26-L56

----


Currently we don't have a use case for `graphql_menu_item_connection_query_args` but I added it just for consistency because equivalents exists for posts, terms.