### PR TITLE
Fix cursor stability

### DIFF
--- a/src/Data/Config.php
+++ b/src/Data/Config.php
@@ -37,7 +37,25 @@ class Config {
 		 * can be used as a point of comparison when slicing the results to return.
 		 */
 		add_filter( 'terms_clauses', [ $this, 'graphql_wp_term_query_cursor_pagination_support' ], 10, 3 );
-		
+
+		/**
+		 * Filter WP_Query order by add some stability to meta query ordering
+		 */
+		add_filter( 'posts_orderby', [ $this, 'graphql_wp_query_cursor_pagination_stability' ], 10, 2 );
+
+	}
+
+	/**
+	 * When posts are ordered by a meta query the order might be random when
+	 * the meta values have same values multiple times. This filter adds a
+	 * secondary ordering by the post ID which forces stable order in such cases.
+	 *
+	 * @param string    $where The ORDER BY clause of the query.
+	 *
+	 * @return string
+	 */
+	public function graphql_wp_query_cursor_pagination_stability( $orderby ) {
+		return $orderby . ', wp_posts.ID DESC ';
 	}
 
 	/**

--- a/src/Data/Config.php
+++ b/src/Data/Config.php
@@ -110,7 +110,7 @@ class Config {
 							}
 						}
 					} else {
-						$where .= $wpdb->prepare( " AND {$wpdb->posts}.post_date {$compare}= %s AND {$wpdb->posts}.ID != %d", esc_sql( $cursor_post->post_date ), absint( $cursor_offset ) );
+						$where .= $wpdb->prepare( " AND {$wpdb->posts}.post_date {$compare} %s AND {$wpdb->posts}.ID != %d", esc_sql( $cursor_post->post_date ), absint( $cursor_offset ) );
 					}
 				} else {
 					$where .= $wpdb->prepare( " AND {$wpdb->posts}.ID {$compare} %d", $cursor_offset );


### PR DESCRIPTION
Fixes #729

This is part of #721 but I isolated everything from that branch that is related to the order in which cursors return the posts without any custom ordering.

I don't want this to be merged because #721 implements this too and merging this will make #721 harder to merge because it rewrites the pagination support this PR touches. I'm opening this just for discussion and review.


So there's currently an ordering issue when you have multiple posts with the same `post_date` field. When the date string is exactly the same MySQL has no idea in which order to return the posts and it will appear as random.

The `graphql_wp_query_cursor_pagination_stability` filter makes sure that in these situations posts will have a secondary order by their IDs making those situations actually stable.

Also I removed `=` from the date comparison. It caused off by one error in pages when the dates where same for all paginated posts.
