### PR TITLE
Fix for Sticky posts being repeated on every page

### DIFF
--- a/src/Data/PostObjectConnectionResolver.php
+++ b/src/Data/PostObjectConnectionResolver.php
@@ -83,12 +83,22 @@ class PostObjectConnectionResolver extends ConnectionResolver {
 		 */
 		$query_args['post_parent'] = 0;
 
+
 		/**
 		 * Set the graphql_cursor_offset which is used by Config::graphql_wp_query_cursor_pagination_support
 		 * to filter the WP_Query to support cursor pagination
 		 */
-		$query_args['graphql_cursor_offset']  = self::get_offset( $args );
+		$cursor_offset                        = self::get_offset( $args );
+		$query_args['graphql_cursor_offset']  = $cursor_offset;
 		$query_args['graphql_cursor_compare'] = ( ! empty( $last ) ) ? '>' : '<';
+
+		/**
+		 * If the starting offset is not 0 sticky posts will not be queried as the automatic checks in wp-query don't
+		 * trigger due to the page parameter not being set in the query_vars, fixes #732
+		 */
+		if ( 0 !== $cursor_offset ) {
+			$query_args['ignore_sticky_posts'] = true;
+		}
 
 		/**
 		 * Pass the graphql $args to the WP_Query

--- a/src/Data/PostObjectConnectionResolver.php
+++ b/src/Data/PostObjectConnectionResolver.php
@@ -83,7 +83,6 @@ class PostObjectConnectionResolver extends ConnectionResolver {
 		 */
 		$query_args['post_parent'] = 0;
 
-
 		/**
 		 * Set the graphql_cursor_offset which is used by Config::graphql_wp_query_cursor_pagination_support
 		 * to filter the WP_Query to support cursor pagination


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
fixes #732 

Any other comments?
-------------------
for now the implementation is so that if the `graphql_cursor_offset` is not 0, the query_var `ignore_sticky_posts` is set. This should be pretty similar to what WordPress core does where the value of `page` is checked and if it is any different from 1, sticky posts are ignored. I thought that calculating the page and then injecting that into the query_vars could lead to strange pagination side effects.

Where has this been tested?
---------------------------
**Operating System:** Windows 10, Docker

**WordPress Version:** 5.1.1
