### PR TITLE
#734 - Tightening User Access

### DIFF
--- a/src/Data/Connection/UserConnectionResolver.php
+++ b/src/Data/Connection/UserConnectionResolver.php
@@ -69,6 +69,14 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 		$query_args['fields'] = 'ID';
 
 		/**
+		 * If the request is not authenticated, limit the query to users that have
+		 * published posts, as they're considered publicly facing users.
+		 */
+		if ( ! is_user_logged_in() ) {
+			$query_args['has_published_posts'] = true;
+		}
+
+		/**
 		 * Filter the query_args that should be applied to the query. This filter is applied AFTER the input args from
 		 * the GraphQL Query have been applied and has the potential to override the GraphQL Query Input Args.
 		 *

--- a/src/Data/Loader/PostObjectLoader.php
+++ b/src/Data/Loader/PostObjectLoader.php
@@ -96,7 +96,7 @@ class PostObjectLoader extends AbstractDataLoader {
 			 * Return the instance through the Model to ensure we only
 			 * return fields the consumer has access to.
 			 */
-			$this->loaded_posts[ $key ] = new Deferred(function() use ( $post_object ) {
+			$this->loaded_posts[ $key ] = new Deferred( function () use ( $post_object ) {
 
 				if ( ! $post_object instanceof \WP_Post ) {
 					return null;
@@ -110,13 +110,14 @@ class PostObjectLoader extends AbstractDataLoader {
 				 */
 				if ( ! empty( $post_object->post_author ) && absint( $post_object->post_author ) ) {
 					$author = DataSource::resolve_user( $post_object->post_author, $this->context );
-					return $author->then(function() use ( $post_object ) {
+
+					return $author->then( function () use ( $post_object ) {
 						return new Post( $post_object );
-					});
+					} );
 				} else {
 					return new Post( $post_object );
 				}
-			});
+			} );
 
 		}
 

--- a/tests/wpunit/ModelUserTest.php
+++ b/tests/wpunit/ModelUserTest.php
@@ -103,6 +103,15 @@ class ModelUserTest extends \Codeception\TestCase\WPTestCase {
 				'role' => $user['role'],
 			]);
 
+			/**
+			 * Create a post published by the user
+			 */
+			$this->factory()->post->create([
+				'post_title' => 'Post by ' . $user['role'],
+				'post_status' => 'publish',
+				'post_author' => $id
+			]);
+
 			$this->userIds[] = $id;
 			$user['user_data']['ID'] = $id;
 


### PR DESCRIPTION
- This PR tightens access to users by limiting the UserConnectionResolver to querying for users where `"has_published_posts" => true` if the request is not authenticated.

closes #734 