### PR TITLE
Feature/#738 unapproved comments should not be queryable

### DIFF
--- a/src/Connection/Comments.php
+++ b/src/Connection/Comments.php
@@ -128,7 +128,7 @@ class Comments {
 				'type'        => [
 					'list_of' => 'ID',
 				],
-				'description' => __( 'Array of author IDs to include comments for.', 'wp-graphql' ),
+				'description' => __( 'Array of IDs or email addresses of users whose unapproved comments will be returned by the query regardless of $status. Default empty', 'wp-graphql' ),
 			],
 			'karma'              => [
 				'type'        => 'Int',

--- a/src/Data/Connection/CommentConnectionResolver.php
+++ b/src/Data/Connection/CommentConnectionResolver.php
@@ -34,9 +34,9 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 		$query_args['no_found_rows'] = true;
 
 		/**
-		 * Set the default comment_status for Comment Queries to be "approved"
+		 * Set the default comment_status for Comment Queries to be "comment_approved"
 		 */
-		$query_args['comment_status'] = 'approved';
+		$query_args['status'] = 'approve';
 
 		/**
 		 * Set the default comment_parent for Comment Queries to be "0" to only get top level comments
@@ -74,6 +74,17 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 		 */
 		if ( ! empty( $input_fields ) ) {
 			$query_args = array_merge( $query_args, $input_fields );
+		}
+
+		/**
+		 * If the current user cannot moderate comments, do not include unapproved comments
+		 */
+		if ( ! current_user_can('moderate_comments' ) ) {
+			$query_args['status'] = ['approve'];
+			$query_args['include_unapproved'] = get_current_user_id() ? [ get_current_user_id() ] : [];
+			if ( empty( $query_args['include_unapproved'] ) ) {
+				unset( $query_args['include_unapproved'] );
+			}
 		}
 
 		/**
@@ -209,7 +220,7 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 			'contentParent'      => 'post_parent',
 			'contentStatus'      => 'post_status',
 			'contentType'        => 'post_type',
-			'includeUnapproved'  => 'includeUnapproved',
+			'includeUnapproved'  => 'include_unapproved',
 			'parentIn'           => 'parent__in',
 			'parentNotIn'        => 'parent__not_in',
 			'userId'             => 'user_id',

--- a/src/Data/Connection/UserConnectionResolver.php
+++ b/src/Data/Connection/UserConnectionResolver.php
@@ -69,6 +69,14 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 		$query_args['fields'] = 'ID';
 
 		/**
+		 * If the request is not authenticated, limit the query to users that have
+		 * published posts, as they're considered publicly facing users.
+		 */
+		if ( ! is_user_logged_in() ) {
+			$query_args['has_published_posts'] = true;
+		}
+
+		/**
 		 * Filter the query_args that should be applied to the query. This filter is applied AFTER the input args from
 		 * the GraphQL Query have been applied and has the potential to override the GraphQL Query Input Args.
 		 *

--- a/src/Data/Loader/CommentLoader.php
+++ b/src/Data/Loader/CommentLoader.php
@@ -71,11 +71,16 @@ class CommentLoader extends AbstractDataLoader {
 			 * values the consumer has access to.
 			 */
 			$loaded[ $key ] = new Deferred( function() use ( $comment_object ) {
+
+				if ( ! $comment_object instanceof \WP_Comment ) {
+					return null;
+				}
+
 				return new Comment( $comment_object );
 			});
 		}
 
-		return $loaded;
+		return ! empty( $loaded ) ? $loaded : [];
 
 	}
 

--- a/src/Data/Loader/PostObjectLoader.php
+++ b/src/Data/Loader/PostObjectLoader.php
@@ -96,7 +96,7 @@ class PostObjectLoader extends AbstractDataLoader {
 			 * Return the instance through the Model to ensure we only
 			 * return fields the consumer has access to.
 			 */
-			$this->loaded_posts[ $key ] = new Deferred(function() use ( $post_object ) {
+			$this->loaded_posts[ $key ] = new Deferred( function () use ( $post_object ) {
 
 				if ( ! $post_object instanceof \WP_Post ) {
 					return null;
@@ -110,13 +110,14 @@ class PostObjectLoader extends AbstractDataLoader {
 				 */
 				if ( ! empty( $post_object->post_author ) && absint( $post_object->post_author ) ) {
 					$author = DataSource::resolve_user( $post_object->post_author, $this->context );
-					return $author->then(function() use ( $post_object ) {
+
+					return $author->then( function () use ( $post_object ) {
 						return new Post( $post_object );
-					});
+					} );
 				} else {
 					return new Post( $post_object );
 				}
-			});
+			} );
 
 		}
 

--- a/tests/wpunit/ModelUserTest.php
+++ b/tests/wpunit/ModelUserTest.php
@@ -103,6 +103,15 @@ class ModelUserTest extends \Codeception\TestCase\WPTestCase {
 				'role' => $user['role'],
 			]);
 
+			/**
+			 * Create a post published by the user
+			 */
+			$this->factory()->post->create([
+				'post_title' => 'Post by ' . $user['role'],
+				'post_status' => 'publish',
+				'post_author' => $id
+			]);
+
 			$this->userIds[] = $id;
 			$user['user_data']['ID'] = $id;
 


### PR DESCRIPTION
Unapproved comments should not be returned to users that do not have "moderate_comments" capability

closes #738 