### PR TITLE
Feature/#738 unapproved comments should not be queryable

### DIFF
--- a/src/Connection/Comments.php
+++ b/src/Connection/Comments.php
@@ -128,7 +128,7 @@ class Comments {
 				'type'        => [
 					'list_of' => 'ID',
 				],
-				'description' => __( 'Array of author IDs to include comments for.', 'wp-graphql' ),
+				'description' => __( 'Array of IDs or email addresses of users whose unapproved comments will be returned by the query regardless of $status. Default empty', 'wp-graphql' ),
 			],
 			'karma'              => [
 				'type'        => 'Int',

--- a/src/Data/Connection/CommentConnectionResolver.php
+++ b/src/Data/Connection/CommentConnectionResolver.php
@@ -34,9 +34,9 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 		$query_args['no_found_rows'] = true;
 
 		/**
-		 * Set the default comment_status for Comment Queries to be "approved"
+		 * Set the default comment_status for Comment Queries to be "comment_approved"
 		 */
-		$query_args['comment_status'] = 'approved';
+		$query_args['status'] = 'approve';
 
 		/**
 		 * Set the default comment_parent for Comment Queries to be "0" to only get top level comments
@@ -74,6 +74,17 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 		 */
 		if ( ! empty( $input_fields ) ) {
 			$query_args = array_merge( $query_args, $input_fields );
+		}
+
+		/**
+		 * If the current user cannot moderate comments, do not include unapproved comments
+		 */
+		if ( ! current_user_can('moderate_comments' ) ) {
+			$query_args['status'] = ['approve'];
+			$query_args['include_unapproved'] = get_current_user_id() ? [ get_current_user_id() ] : [];
+			if ( empty( $query_args['include_unapproved'] ) ) {
+				unset( $query_args['include_unapproved'] );
+			}
 		}
 
 		/**
@@ -209,7 +220,7 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 			'contentParent'      => 'post_parent',
 			'contentStatus'      => 'post_status',
 			'contentType'        => 'post_type',
-			'includeUnapproved'  => 'includeUnapproved',
+			'includeUnapproved'  => 'include_unapproved',
 			'parentIn'           => 'parent__in',
 			'parentNotIn'        => 'parent__not_in',
 			'userId'             => 'user_id',

--- a/src/Data/Loader/CommentLoader.php
+++ b/src/Data/Loader/CommentLoader.php
@@ -71,11 +71,16 @@ class CommentLoader extends AbstractDataLoader {
 			 * values the consumer has access to.
 			 */
 			$loaded[ $key ] = new Deferred( function() use ( $comment_object ) {
+
+				if ( ! $comment_object instanceof \WP_Comment ) {
+					return null;
+				}
+
 				return new Comment( $comment_object );
 			});
 		}
 
-		return $loaded;
+		return ! empty( $loaded ) ? $loaded : [];
 
 	}
 

--- a/src/Type/Object/Comment.php
+++ b/src/Type/Object/Comment.php
@@ -90,7 +90,7 @@ register_graphql_object_type( 'Comment', [
 			'description' => __( 'Karma value for the comment. This field is equivalent to WP_Comment->comment_karma and the value matching the "comment_karma" column in SQL.', 'wp-graphql' ),
 		],
 		'approved'    => [
-			'type'        => 'String',
+			'type'        => 'Boolean',
 			'description' => __( 'The approval status of the comment. This field is equivalent to WP_Comment->comment_approved and the value matching the "comment_approved" column in SQL.', 'wp-graphql' ),
 		],
 		'agent'       => [


### PR DESCRIPTION
Unapproved comments should not be returned to users that do not have "moderate_comments" capability

Closes #738