### PR TITLE
Bug/740 - don't allow non-logged in users to comment if flag is set

### DIFF
--- a/src/Data/CommentMutation.php
+++ b/src/Data/CommentMutation.php
@@ -70,8 +70,8 @@ class CommentMutation {
 			}
 		}
 
-		if ( ! empty( $input['postId'] ) ) {
-			$output_args['comment_post_ID'] = $input['postId'];
+		if ( ! empty( $input['commentOn'] ) ) {
+			$output_args['comment_post_ID'] = $input['commentOn'];
 		}
 
 		if ( ! empty( $input['date'] ) && false !== strtotime( $input['date'] ) ) {

--- a/src/Mutation/CommentCreate.php
+++ b/src/Mutation/CommentCreate.php
@@ -27,7 +27,7 @@ class CommentCreate {
      */
     public static function get_input_fields() {
         return [
-            'postId'      => [
+            'commentOn'      => [
                 'type'        => 'Int',
                 'description' => __( 'The ID of the post the comment belongs to.', 'wp-graphql' ),
             ],
@@ -116,8 +116,12 @@ class CommentCreate {
             /**
              * Stop if post not open to comments
              */
-            if ( empty( $input['postId'] ) || get_post( $input['postId'] )->post_status === 'closed' ) {
+            if ( empty( $input['commentOn'] ) || get_post( $input['commentOn'] )->post_status === 'closed' ) {
                 throw new UserError( __( 'Sorry, this post is closed to comments at the moment', 'wp-graphql' ) );
+            }
+
+            if ( '1' === get_option( 'comment_registration' ) && ! is_user_logged_in() ) {
+				throw new UserError( __( 'This site requires you to be logged in to leave a comment', 'wp-graphql' ) );
             }
 
             /**

--- a/src/Mutation/CommentCreate.php
+++ b/src/Mutation/CommentCreate.php
@@ -9,175 +9,176 @@ use WPGraphQL\Data\CommentMutation;
 use WPGraphQL\Data\DataSource;
 
 class CommentCreate {
-    /**
-     * Registers the CommentCreate mutation.
-     */
-    public static function register_mutation() {
-        register_graphql_mutation( 'createComment', [
-            'inputFields'         => self::get_input_fields(),
-            'outputFields'        => self::get_output_fields(),
-            'mutateAndGetPayload' => self::mutate_and_get_payload(),
-        ] );
-    }
+	/**
+	 * Registers the CommentCreate mutation.
+	 */
+	public static function register_mutation() {
+		register_graphql_mutation( 'createComment', [
+			'inputFields'         => self::get_input_fields(),
+			'outputFields'        => self::get_output_fields(),
+			'mutateAndGetPayload' => self::mutate_and_get_payload(),
+		] );
+	}
 
-    /**
-     * Defines the mutation input field configuration.
-     *
-     * @return array
-     */
-    public static function get_input_fields() {
-        return [
-            'commentOn'      => [
-                'type'        => 'Int',
-                'description' => __( 'The ID of the post object the comment belongs to.', 'wp-graphql' ),
-            ],
-            'userId'      => [
-                'type'        => 'Int',
-                'description' => __( 'The userID of the comment\'s author.', 'wp-graphql' ),
-            ],
-            'author'      => [
-                'type'        => 'String',
-                'description' => __( 'The name of the comment\'s author.', 'wp-graphql' ),
-            ],
-            'authorEmail' => [
-                'type'        => 'String',
-                'description' => __( 'The email of the comment\'s author.', 'wp-graphql' ),
-            ],
-            'authorUrl'   => [
-                'type'        => 'String',
-                'description' => __( 'The url of the comment\'s author.', 'wp-graphql' ),
-            ],
-            'authorIp'    => [
-                'type'        => 'String',
-                'description' => __( 'IP address for the comment\'s author.', 'wp-graphql' ),
-            ],
-            'content'     => [
-                'type'        => 'String',
-                'description' => __( 'Content of the comment.', 'wp-graphql' ),
-            ],
-            'type'        => [
-                'type'        => 'String',
-                'description' => __( 'Type of comment.', 'wp-graphql' ),
-            ],
-            'parent'      => [
-                'type'        => 'ID',
-                'description' => __( 'Parent comment of current comment.', 'wp-graphql' ),
-            ],
-            'agent'       => [
-                'type'        => 'String',
-                'description' => __( 'User agent used to post the comment.', 'wp-graphql' ),
-            ],
-            'date'        => [
-                'type'        => 'String',
-                'description' => __( 'The date of the object. Preferable to enter as year/month/day ( e.g. 01/31/2017 ) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 ', 'wp-graphql' ),
-            ],
-            'approved'    => [
-                'type'        => 'String',
-                'description' => __( 'The approval status of the comment.', 'wp-graphql' ),
-            ],
-        ];
-    }
+	/**
+	 * Defines the mutation input field configuration.
+	 *
+	 * @return array
+	 */
+	public static function get_input_fields() {
+		return [
+			'commentOn'   => [
+				'type'        => 'Int',
+				'description' => __( 'The ID of the post object the comment belongs to.', 'wp-graphql' ),
+			],
+			'userId'      => [
+				'type'        => 'Int',
+				'description' => __( 'The userID of the comment\'s author.', 'wp-graphql' ),
+			],
+			'author'      => [
+				'type'        => 'String',
+				'description' => __( 'The name of the comment\'s author.', 'wp-graphql' ),
+			],
+			'authorEmail' => [
+				'type'        => 'String',
+				'description' => __( 'The email of the comment\'s author.', 'wp-graphql' ),
+			],
+			'authorUrl'   => [
+				'type'        => 'String',
+				'description' => __( 'The url of the comment\'s author.', 'wp-graphql' ),
+			],
+			'authorIp'    => [
+				'type'        => 'String',
+				'description' => __( 'IP address for the comment\'s author.', 'wp-graphql' ),
+			],
+			'content'     => [
+				'type'        => 'String',
+				'description' => __( 'Content of the comment.', 'wp-graphql' ),
+			],
+			'type'        => [
+				'type'        => 'String',
+				'description' => __( 'Type of comment.', 'wp-graphql' ),
+			],
+			'parent'      => [
+				'type'        => 'ID',
+				'description' => __( 'Parent comment of current comment.', 'wp-graphql' ),
+			],
+			'agent'       => [
+				'type'        => 'String',
+				'description' => __( 'User agent used to post the comment.', 'wp-graphql' ),
+			],
+			'date'        => [
+				'type'        => 'String',
+				'description' => __( 'The date of the object. Preferable to enter as year/month/day ( e.g. 01/31/2017 ) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 ', 'wp-graphql' ),
+			],
+			'approved'    => [
+				'type'        => 'String',
+				'description' => __( 'The approval status of the comment.', 'wp-graphql' ),
+			],
+		];
+	}
 
-    /**
-     * Defines the mutation output field configuration.
-     *
-     * @return array
-     */
-    public static function get_output_fields() {
-        return [
-            'comment' => [
-                'type'        => 'Comment',
-                'description' => __( 'The comment that was created', 'wp-graphql' ),
-                'resolve'     => function ( $payload, $args, AppContext $context, ResolveInfo $info ) {
-        	        if ( ! isset( $payload['id'] ) || ! absint( $payload['id'] ) ) {
-		                return null;
-	                }
-        	        return DataSource::resolve_comment( absint( $payload['id'] ), $context );
-                },
-            ]
-        ];
-    }
+	/**
+	 * Defines the mutation output field configuration.
+	 *
+	 * @return array
+	 */
+	public static function get_output_fields() {
+		return [
+			'comment' => [
+				'type'        => 'Comment',
+				'description' => __( 'The comment that was created', 'wp-graphql' ),
+				'resolve'     => function( $payload, $args, AppContext $context, ResolveInfo $info ) {
+					if ( ! isset( $payload['id'] ) || ! absint( $payload['id'] ) ) {
+						return null;
+					}
 
-    /**
-     * Defines the mutation data modification closure.
-     *
-     * @return callable
-     */
-    public static function mutate_and_get_payload() {
-        return function ( $input, AppContext $context, ResolveInfo $info ) {
+					return DataSource::resolve_comment( absint( $payload['id'] ), $context );
+				},
+			]
+		];
+	}
 
-            /**
-             * Throw an exception if there's no input
-             */
-            if ( ( empty( $input ) || ! is_array( $input ) ) ) {
-                throw new UserError( __( 'Mutation not processed. There was no input for the mutation or the comment_object was invalid', 'wp-graphql' ) );
-            }
+	/**
+	 * Defines the mutation data modification closure.
+	 *
+	 * @return callable
+	 */
+	public static function mutate_and_get_payload() {
+		return function( $input, AppContext $context, ResolveInfo $info ) {
 
-            /**
-             * Stop if post not open to comments
-             */
-            if ( empty( $input['commentOn'] ) || get_post( $input['commentOn'] )->post_status === 'closed' ) {
-                throw new UserError( __( 'Sorry, this post is closed to comments at the moment', 'wp-graphql' ) );
-            }
+			/**
+			 * Throw an exception if there's no input
+			 */
+			if ( ( empty( $input ) || ! is_array( $input ) ) ) {
+				throw new UserError( __( 'Mutation not processed. There was no input for the mutation or the comment_object was invalid', 'wp-graphql' ) );
+			}
 
-            if ( '1' === get_option( 'comment_registration' ) && ! is_user_logged_in() ) {
+			/**
+			 * Stop if post not open to comments
+			 */
+			if ( empty( $input['commentOn'] ) || get_post( $input['commentOn'] )->post_status === 'closed' ) {
+				throw new UserError( __( 'Sorry, this post is closed to comments at the moment', 'wp-graphql' ) );
+			}
+
+			if ( '1' === get_option( 'comment_registration' ) && ! is_user_logged_in() ) {
 				throw new UserError( __( 'This site requires you to be logged in to leave a comment', 'wp-graphql' ) );
-            }
+			}
 
-            /**
-             * Map all of the args from GraphQL to WordPress friendly args array
-             */
-            $comment_args = [
-                'comment_author_url' => '',
-                'comment_type'       => '',
-                'comment_parent'     => 0,
-                'user_id'            => 0,
-                'comment_author_IP'  => ':1',
-                'comment_agent'      => '',
-                'comment_date'       => date( 'Y-m-d H:i:s' ),
-            ];
+			/**
+			 * Map all of the args from GraphQL to WordPress friendly args array
+			 */
+			$comment_args = [
+				'comment_author_url' => '',
+				'comment_type'       => '',
+				'comment_parent'     => 0,
+				'user_id'            => 0,
+				'comment_author_IP'  => ':1',
+				'comment_agent'      => '',
+				'comment_date'       => date( 'Y-m-d H:i:s' ),
+			];
 
-            CommentMutation::prepare_comment_object( $input, $comment_args, 'createComment' );
+			CommentMutation::prepare_comment_object( $input, $comment_args, 'createComment' );
 
-            /**
-             * Insert the comment and retrieve the ID
-             */
-            $comment_id = wp_new_comment( $comment_args, true );
+			/**
+			 * Insert the comment and retrieve the ID
+			 */
+			$comment_id = wp_new_comment( $comment_args, true );
 
-            /**
-             * Throw an exception if the comment failed to be created
-             */
-            if ( is_wp_error( $comment_id ) ) {
+			/**
+			 * Throw an exception if the comment failed to be created
+			 */
+			if ( is_wp_error( $comment_id ) ) {
 
-                $error_message = $comment_id->get_error_message();
-                if ( ! empty( $error_message ) ) {
-                    throw new UserError( esc_html( $error_message ) );
-                } else {
-                    throw new UserError( __( 'The object failed to create but no error was provided', 'wp-graphql' ) );
-                }
-            }
+				$error_message = $comment_id->get_error_message();
+				if ( ! empty( $error_message ) ) {
+					throw new UserError( esc_html( $error_message ) );
+				} else {
+					throw new UserError( __( 'The object failed to create but no error was provided', 'wp-graphql' ) );
+				}
+			}
 
-            /**
-             * If the $comment_id is empty, we should throw an exception
-             */
-            if ( empty( $comment_id ) ) {
-                throw new UserError( __( 'The object failed to create', 'wp-graphql' ) );
-            }
+			/**
+			 * If the $comment_id is empty, we should throw an exception
+			 */
+			if ( empty( $comment_id ) ) {
+				throw new UserError( __( 'The object failed to create', 'wp-graphql' ) );
+			}
 
-            /**
-             * This updates additional data not part of the comments table ( commentmeta, other relations, etc )
-             *
-             * The input for the commentMutation will be passed, along with the $new_comment_id for the
-             * comment that was created so that relations can be set, meta can be updated, etc.
-             */
-            CommentMutation::update_additional_comment_data( $comment_id, $input, 'createComment', $context, $info );
+			/**
+			 * This updates additional data not part of the comments table ( commentmeta, other relations, etc )
+			 *
+			 * The input for the commentMutation will be passed, along with the $new_comment_id for the
+			 * comment that was created so that relations can be set, meta can be updated, etc.
+			 */
+			CommentMutation::update_additional_comment_data( $comment_id, $input, 'createComment', $context, $info );
 
-            /**
-             * Return the comment object
-             */
-            return [
-                'id' => $comment_id,
-            ];
-        };
-    }
+			/**
+			 * Return the comment object
+			 */
+			return [
+				'id' => $comment_id,
+			];
+		};
+	}
 }

--- a/src/Mutation/CommentCreate.php
+++ b/src/Mutation/CommentCreate.php
@@ -29,7 +29,7 @@ class CommentCreate {
         return [
             'commentOn'      => [
                 'type'        => 'Int',
-                'description' => __( 'The ID of the post the comment belongs to.', 'wp-graphql' ),
+                'description' => __( 'The ID of the post object the comment belongs to.', 'wp-graphql' ),
             ],
             'userId'      => [
                 'type'        => 'Int',

--- a/tests/wpunit/CommentMutationsTest.php
+++ b/tests/wpunit/CommentMutationsTest.php
@@ -393,25 +393,26 @@ class CommentMutationsTest extends \Codeception\TestCase\WPTestCase {
 
 		$mutation  = '
 		mutation createCommentTest( $clientMutationId:String!, $commentOn:Int!, $author:String!, $email: String!, $content:String!, $ip:String ){
-		  createComment( 
+		  createComment(
 		    input: {
 		      clientMutationId: $clientMutationId
 		      commentOn: $commentOn
-              content: $content
-              author: $author
-              authorEmail: $email
-              authorIp: $ip
+		      content: $content
+		      author: $author
+		      authorEmail: $email
+		      authorIp: $ip
 		    }
-          )
-          {
+		  )
+		  {
 		    clientMutationId
 		    comment {
-              content
-              authorIp
+		      content
+		      authorIp
 		    }
-          }
-        }
+		  }
+		}
 		';
+
 		$variables = wp_json_encode( [
 			'clientMutationId' => $this->client_mutation_id,
 			'commentOn'        => $post_id,

--- a/tests/wpunit/CommentMutationsTest.php
+++ b/tests/wpunit/CommentMutationsTest.php
@@ -1,7 +1,6 @@
 <?php
 
-class CommentMutationsTest extends \Codeception\TestCase\WPTestCase
-{
+class CommentMutationsTest extends \Codeception\TestCase\WPTestCase {
 	public $title;
 	public $content;
 	public $client_mutation_id;
@@ -13,7 +12,7 @@ class CommentMutationsTest extends \Codeception\TestCase\WPTestCase
 		// before
 		parent::setUp();
 
-		$this->title             = 'some title';
+		$this->title              = 'some title';
 		$this->content            = 'some content';
 		$this->client_mutation_id = 'someUniqueId';
 
@@ -38,8 +37,7 @@ class CommentMutationsTest extends \Codeception\TestCase\WPTestCase
 		parent::tearDown();
 	}
 
-	public function createComment( &$post_id, &$comment_id, $postCreator, $commentCreator )
-	{
+	public function createComment( &$post_id, &$comment_id, $postCreator, $commentCreator ) {
 		wp_set_current_user( $postCreator );
 		$post_args = [
 			'post_type'    => 'post',
@@ -54,13 +52,13 @@ class CommentMutationsTest extends \Codeception\TestCase\WPTestCase
 		$post_id = $this->factory()->post->create( $post_args );
 
 		wp_set_current_user( $commentCreator );
-		$user = wp_get_current_user();
+		$user         = wp_get_current_user();
 		$comment_args = [
-			'user_id' => $user->ID,
-			'comment_author' => $user->display_name,
+			'user_id'            => $user->ID,
+			'comment_author'     => $user->display_name,
 			'comment_author_url' => $user->user_url,
-			'comment_post_ID' => $post_id,
-			'comment_content' => 'Comment Content',
+			'comment_post_ID'    => $post_id,
+			'comment_content'    => 'Comment Content',
 		];
 
 		/**
@@ -69,14 +67,12 @@ class CommentMutationsTest extends \Codeception\TestCase\WPTestCase
 		$comment_id = $this->factory()->comment->create( $comment_args );
 	}
 
-	public function trashComment( &$comment_id )
-	{
+	public function trashComment( &$comment_id ) {
 		wp_trash_comment( $comment_id );
 	}
 
 	// tests
-	public function testCreateComment()
-	{
+	public function testCreateComment() {
 		$args = [
 			'post_type'    => 'post',
 			'post_status'  => 'publish',
@@ -98,7 +94,7 @@ class CommentMutationsTest extends \Codeception\TestCase\WPTestCase
 
 		wp_set_current_user( $this->admin );
 
-		$mutation = '
+		$mutation  = '
 		mutation createCommentTest( $clientMutationId:String!, $commentOn:Int!, $author:String!, $email: String!, $content:String!, $ip:String ){
 		  createComment( 
 		    input: {
@@ -134,9 +130,9 @@ class CommentMutationsTest extends \Codeception\TestCase\WPTestCase
 			'data' => [
 				'createComment' => [
 					'clientMutationId' => $this->client_mutation_id,
-					'comment'             => [
-						'content' => apply_filters( 'comment_text', $this->content ),
-						'authorIp'=> ':1',
+					'comment'          => [
+						'content'  => apply_filters( 'comment_text', $this->content ),
+						'authorIp' => ':1',
 					],
 				],
 			],
@@ -155,8 +151,7 @@ class CommentMutationsTest extends \Codeception\TestCase\WPTestCase
 		$this->assertEquals( '1', $count->total_comments );
 	}
 
-	public function testUpdateCommentWithAuthorConnection()
-	{
+	public function testUpdateCommentWithAuthorConnection() {
 		$this->createComment( $post_id, $comment_id, $this->author, $this->subscriber );
 
 		$new_post = $this->factory()->post->get_object_by_id( $post_id );
@@ -172,8 +167,8 @@ class CommentMutationsTest extends \Codeception\TestCase\WPTestCase
 		$this->assertEquals( $new_comment->comment_post_ID, $post_id );
 		$this->assertEquals( $new_comment->comment_content, 'Comment Content' );
 
-		$content = 'Updated Content';
-		$mutation = '
+		$content   = 'Updated Content';
+		$mutation  = '
 		mutation updateCommentTest( $clientMutationId: String!, $id: ID!, $content: String!, $ip: String ) {
 		  updateComment( 
 		    input: {
@@ -196,7 +191,7 @@ class CommentMutationsTest extends \Codeception\TestCase\WPTestCase
 		';
 		$variables = wp_json_encode( [
 			'clientMutationId' => $this->client_mutation_id,
-			'id'        => \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_id ),
+			'id'               => \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_id ),
 			'content'          => $content,
 			'ip'               => ':2',
 		] );
@@ -207,11 +202,11 @@ class CommentMutationsTest extends \Codeception\TestCase\WPTestCase
 			'data' => [
 				'updateComment' => [
 					'clientMutationId' => $this->client_mutation_id,
-					'comment' => [
-						'id'          => \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_id ),
-						'commentId'   => $comment_id,
-						'content'     => apply_filters( 'comment_text', $content ),
-						'authorIp'    => ':2',
+					'comment'          => [
+						'id'        => \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_id ),
+						'commentId' => $comment_id,
+						'content'   => apply_filters( 'comment_text', $content ),
+						'authorIp'  => ':2',
 					],
 				],
 			],
@@ -228,8 +223,7 @@ class CommentMutationsTest extends \Codeception\TestCase\WPTestCase
 		$this->assertEquals( $expected, $actual );
 	}
 
-	public function testDeleteCommentWithPostConnection()
-	{
+	public function testDeleteCommentWithPostConnection() {
 		$this->createComment( $post_id, $comment_id, $this->author, $this->subscriber );
 		$new_post = $this->factory()->post->get_object_by_id( $post_id );
 
@@ -239,7 +233,7 @@ class CommentMutationsTest extends \Codeception\TestCase\WPTestCase
 		$this->assertEquals( $new_post->post_content, 'Post Content' );
 
 		$new_comment = $this->factory()->comment->get_object_by_id( $comment_id );
-		$content = 'Comment Content';
+		$content     = 'Comment Content';
 		$this->assertEquals( $new_comment->user_id, get_current_user_id() );
 		$this->assertEquals( $new_comment->comment_post_ID, $post_id );
 		$this->assertEquals( $new_comment->comment_content, $content );
@@ -266,7 +260,7 @@ class CommentMutationsTest extends \Codeception\TestCase\WPTestCase
 
 		$variables = [
 			'clientMutationId' => $this->client_mutation_id,
-			'id' => \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_id ),
+			'id'               => \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_id ),
 		];
 
 		$actual = do_graphql_request( $mutation, 'deleteCommentTest', $variables );
@@ -275,11 +269,11 @@ class CommentMutationsTest extends \Codeception\TestCase\WPTestCase
 			'data' => [
 				'deleteComment' => [
 					'clientMutationId' => $this->client_mutation_id,
-					'deletedId' => \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_id ),
-					'comment' => [
-						'id'          => \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_id ),
-						'commentId'   => $comment_id,
-						'content'     => apply_filters( 'comment_text', $content ),
+					'deletedId'        => \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_id ),
+					'comment'          => [
+						'id'        => \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_id ),
+						'commentId' => $comment_id,
+						'content'   => apply_filters( 'comment_text', $content ),
 					],
 				],
 			],
@@ -296,8 +290,7 @@ class CommentMutationsTest extends \Codeception\TestCase\WPTestCase
 		$this->assertEquals( $expected, $actual );
 	}
 
-	public function testRestoreComment()
-	{
+	public function testRestoreComment() {
 		$this->createComment( $post_id, $comment_id, $this->author, $this->subscriber );
 		$new_post = $this->factory()->post->get_object_by_id( $post_id );
 
@@ -307,7 +300,7 @@ class CommentMutationsTest extends \Codeception\TestCase\WPTestCase
 		$this->assertEquals( $new_post->post_content, 'Post Content' );
 
 		$new_comment = $this->factory()->comment->get_object_by_id( $comment_id );
-		$content = 'Comment Content';
+		$content     = 'Comment Content';
 		$this->assertEquals( $new_comment->user_id, get_current_user_id() );
 		$this->assertEquals( $new_comment->comment_post_ID, $post_id );
 		$this->assertEquals( $new_comment->comment_content, $content );
@@ -336,7 +329,7 @@ class CommentMutationsTest extends \Codeception\TestCase\WPTestCase
 
 		$variables = [
 			'clientMutationId' => $this->client_mutation_id,
-			'id' => \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_id ),
+			'id'               => \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_id ),
 		];
 
 		wp_set_current_user( $this->admin );
@@ -347,11 +340,11 @@ class CommentMutationsTest extends \Codeception\TestCase\WPTestCase
 			'data' => [
 				'restoreComment' => [
 					'clientMutationId' => $this->client_mutation_id,
-					'restoredId' => \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_id ),
-					'comment' => [
-						'id'          => \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_id ),
-						'commentId'   => $comment_id,
-						'content'     => apply_filters( 'comment_text', $content ),
+					'restoredId'       => \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_id ),
+					'comment'          => [
+						'id'        => \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_id ),
+						'commentId' => $comment_id,
+						'content'   => apply_filters( 'comment_text', $content ),
 					],
 				],
 			],
@@ -369,7 +362,8 @@ class CommentMutationsTest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
-	 * Make sure that we can't leave a comment if we are not logged in and the comment registration flag is set
+	 * Make sure that we can't leave a comment if we are not logged in and the comment registration
+	 * flag is set
 	 */
 	public function testCantCreateCommentNotLoggedIn() {
 
@@ -397,7 +391,7 @@ class CommentMutationsTest extends \Codeception\TestCase\WPTestCase
 		$this->assertEquals( $new_post->post_title, 'Original Title' );
 		$this->assertEquals( $new_post->post_content, 'Original Content' );
 
-		$mutation = '
+		$mutation  = '
 		mutation createCommentTest( $clientMutationId:String!, $commentOn:Int!, $author:String!, $email: String!, $content:String!, $ip:String ){
 		  createComment( 
 		    input: {

--- a/tests/wpunit/CommentMutationsTest.php
+++ b/tests/wpunit/CommentMutationsTest.php
@@ -99,11 +99,11 @@ class CommentMutationsTest extends \Codeception\TestCase\WPTestCase
 		wp_set_current_user( $this->admin );
 
 		$mutation = '
-		mutation createCommentTest( $clientMutationId:String!, $postId:Int!, $author:String!, $email: String!, $content:String!, $ip:String ){
+		mutation createCommentTest( $clientMutationId:String!, $commentOn:Int!, $author:String!, $email: String!, $content:String!, $ip:String ){
 		  createComment( 
 		    input: {
 		      clientMutationId: $clientMutationId
-		      postId: $postId
+		      commentOn: $commentOn
               content: $content
               author: $author
               authorEmail: $email
@@ -121,7 +121,7 @@ class CommentMutationsTest extends \Codeception\TestCase\WPTestCase
 		';
 		$variables = wp_json_encode( [
 			'clientMutationId' => $this->client_mutation_id,
-			'postId'           => $post_id,
+			'commentOn'        => $post_id,
 			'content'          => $this->content,
 			'author'           => 'Comment Author',
 			'email'            => 'subscriber@example.com',
@@ -366,5 +366,71 @@ class CommentMutationsTest extends \Codeception\TestCase\WPTestCase
 		 * Compare the actual output vs the expected output
 		 */
 		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Make sure that we can't leave a comment if we are not logged in and the comment registration flag is set
+	 */
+	public function testCantCreateCommentNotLoggedIn() {
+
+		$args = [
+			'post_type'    => 'post',
+			'post_status'  => 'publish',
+			'post_title'   => 'Original Title',
+			'post_content' => 'Original Content',
+		];
+
+		/**
+		 * Set the flag so that only registered users can create comments
+		 */
+		update_option( 'comment_registration', '1' );
+
+		/**
+		 * Create a page to test against
+		 */
+		$post_id = $this->factory()->post->create( $args );
+
+		$new_post = $this->factory()->post->get_object_by_id( $post_id );
+
+		$this->assertEquals( $new_post->comment_count, '0' );
+		$this->assertEquals( $new_post->post_type, 'post' );
+		$this->assertEquals( $new_post->post_title, 'Original Title' );
+		$this->assertEquals( $new_post->post_content, 'Original Content' );
+
+		$mutation = '
+		mutation createCommentTest( $clientMutationId:String!, $commentOn:Int!, $author:String!, $email: String!, $content:String!, $ip:String ){
+		  createComment( 
+		    input: {
+		      clientMutationId: $clientMutationId
+		      commentOn: $commentOn
+              content: $content
+              author: $author
+              authorEmail: $email
+              authorIp: $ip
+		    }
+          )
+          {
+		    clientMutationId
+		    comment {
+              content
+              authorIp
+		    }
+          }
+        }
+		';
+		$variables = wp_json_encode( [
+			'clientMutationId' => $this->client_mutation_id,
+			'commentOn'        => $post_id,
+			'content'          => $this->content,
+			'author'           => 'Comment Author',
+			'email'            => 'subscriber@example.com',
+			'ip'               => ':1',
+		] );
+
+		$actual = do_graphql_request( $mutation, 'createCommentTest', $variables );
+
+		$this->assertNotEmpty( $actual['errors'] );
+		$this->assertEmpty( $actual['data']['createComment'] );
+
 	}
 }


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
…


Does this close any currently open issues?
------------------------------------------
#740 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
I also changed the `postId` input to `commentOn` as was discussed in the issue.


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
