### PR TITLE
#375 - Return visibility (isRestricted) on nodes

### DIFF
--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -53,6 +53,13 @@ abstract class AbstractConnectionResolver {
 	protected $query_args;
 
 	/**
+	 * Whether the connection resolver should execute
+	 *
+	 * @var bool
+	 */
+	protected $should_execute = true;
+
+	/**
 	 * The Query class/array/object used to fetch the data.
 	 *
 	 * Examples:
@@ -153,8 +160,8 @@ abstract class AbstractConnectionResolver {
 		 * @param bool                       $should_execute Whether the connection should execute
 		 * @param AbstractConnectionResolver $this           Instance of the Connection Resolver
 		 */
-		$should_execute = apply_filters( 'graphql_connection_should_execute', $this->should_execute(), $this );
-		if ( ! $should_execute ) {
+		$this->should_execute = apply_filters( 'graphql_connection_should_execute', $this->should_execute(), $this );
+		if ( false === $this->should_execute ) {
 			return [];
 		}
 

--- a/src/Type/Object/Avatar.php
+++ b/src/Type/Object/Avatar.php
@@ -46,5 +46,9 @@ register_graphql_type( 'Avatar', [
 			'type'        => 'String',
 			'description' => __( 'URL for the gravatar image source.', 'wp-graphql' ),
 		],
+		'isRestricted' => [
+			'type' => 'Boolean',
+			'description' => __( 'Whether the object is restricted from the current viewer', 'wp-graphql' ),
+		],
 	]
 ] );

--- a/src/Type/Object/Comment.php
+++ b/src/Type/Object/Comment.php
@@ -103,16 +103,12 @@ register_graphql_object_type( 'Comment', [
 			'type'        => 'Comment',
 			'description' => __( 'Parent comment of current comment. This field is equivalent to the WP_Comment instance matching the WP_Comment->comment_parent ID.', 'wp-graphql' ),
 			'resolve'     => function ( Comment $comment, $args, AppContext $context, ResolveInfo $info ) {
-				$parent = null;
-				if ( ! empty( $comment->comment_parent_id ) ) {
-					$parent_obj = \WP_Comment::get_instance( $comment->comment_parent_id );
-					if ( is_a( $parent_obj, 'WP_Comment' ) ) {
-						$parent = new Comment( $parent_obj );
-					}
-				}
-
-				return $parent;
+				return ! empty( $comment->comment_parent_id ) ? DataSource::resolve_comment( $comment->comment_parent_id, $context ) : null;
 			}
+		],
+		'isRestricted' => [
+			'type' => 'Boolean',
+			'description' => __( 'Whether the object is restricted from the current viewer', 'wp-graphql' ),
 		],
 	]
 ] );

--- a/src/Type/Object/CommentAuthor.php
+++ b/src/Type/Object/CommentAuthor.php
@@ -24,5 +24,9 @@ register_graphql_object_type( 'CommentAuthor', [
 			'type'        => 'String',
 			'description' => __( 'The url the comment author.', 'wp-graphql' ),
 		],
+		'isRestricted' => [
+			'type' => 'Boolean',
+			'description' => __( 'Whether the object is restricted from the current viewer', 'wp-graphql' ),
+		],
 	],
 ] );

--- a/src/Type/Object/Menu.php
+++ b/src/Type/Object/Menu.php
@@ -29,5 +29,9 @@ register_graphql_object_type( 'Menu', [
 			'type'        => 'String',
 			'description' => esc_html__( 'The url friendly name of the menu. Equivalent to WP_Term->slug', 'wp-graphql' ),
 		],
+		'isRestricted' => [
+			'type' => 'Boolean',
+			'description' => __( 'Whether the object is restricted from the current viewer', 'wp-graphql' ),
+		],
 	]
 ] );

--- a/src/Type/Object/MenuItem.php
+++ b/src/Type/Object/MenuItem.php
@@ -53,6 +53,10 @@ register_graphql_object_type( 'MenuItem', [
 			'type'        => 'String',
 			'description' => __( 'URL or destination of the menu item.', 'wp-graphql' ),
 		],
+		'isRestricted' => [
+			'type' => 'Boolean',
+			'description' => __( 'Whether the object is restricted from the current viewer', 'wp-graphql' ),
+		],
 		'connectedObject'  => [
 			'type'        => 'MenuItemObjectUnion',
 			'description' => __( 'The object connected to this menu item.', 'wp-graphql' ),

--- a/src/Type/Object/Plugin.php
+++ b/src/Type/Object/Plugin.php
@@ -34,6 +34,10 @@ register_graphql_object_type( 'Plugin', [
 			'type'        => 'String',
 			'description' => __( 'Current version of the plugin.', 'wp-graphql' ),
 		],
+		'isRestricted' => [
+			'type' => 'Boolean',
+			'description' => __( 'Whether the object is restricted from the current viewer', 'wp-graphql' ),
+		],
 	],
 	'interfaces'  => [ WPObjectType::node_interface() ],
 ] );

--- a/src/Type/Object/PostType.php
+++ b/src/Type/Object/PostType.php
@@ -107,6 +107,10 @@ register_graphql_object_type( 'PostType', [
 			'type'        => 'String',
 			'description' => __( 'The plural name of the post type within the GraphQL Schema.', 'wp-graphql' ),
 		],
+		'isRestricted' => [
+			'type' => 'Boolean',
+			'description' => __( 'Whether the object is restricted from the current viewer', 'wp-graphql' ),
+		],
 		'connectedTaxonomyNames' => [
 			'type'        => [
 				'list_of' => 'String'

--- a/src/Type/Object/Taxonomy.php
+++ b/src/Type/Object/Taxonomy.php
@@ -32,6 +32,10 @@ register_graphql_object_type( 'Taxonomy', [
 			'type'        => 'Boolean',
 			'description' => __( 'Whether the taxonomy is publicly queryable', 'wp-graphql' ),
 		],
+		'isRestricted' => [
+			'type' => 'Boolean',
+			'description' => __( 'Whether the object is restricted from the current viewer', 'wp-graphql' ),
+		],
 		'hierarchical'           => [
 			'type'        => 'Boolean',
 			'description' => __( 'Whether the taxonomy is hierarchical', 'wp-graphql' ),

--- a/src/Type/Object/TermObject.php
+++ b/src/Type/Object/TermObject.php
@@ -55,6 +55,10 @@ function register_taxonomy_object_type( $taxonomy_object ) {
 					return DataSource::resolve_taxonomy( $source->taxonomyName );
 				}
 			],
+			'isRestricted' => [
+				'type' => 'Boolean',
+				'description' => __( 'Whether the object is restricted from the current viewer', 'wp-graphql' ),
+			],
 			'link'              => [
 				'type'        => 'String',
 				'description' => __( 'The link to the term', 'wp-graphql' ),

--- a/src/Type/Object/Theme.php
+++ b/src/Type/Object/Theme.php
@@ -49,6 +49,10 @@ register_graphql_object_type( 'Theme', [
 			'type'        => 'Float',
 			'description' => __( 'The current version of the theme. This field is equivalent to WP_Theme->get( "Version" ).', 'wp-graphql' ),
 		],
+		'isRestricted' => [
+			'type' => 'Boolean',
+			'description' => __( 'Whether the object is restricted from the current viewer', 'wp-graphql' ),
+		],
 	],
 
 ] );

--- a/src/Type/Object/User.php
+++ b/src/Type/Object/User.php
@@ -82,16 +82,8 @@ register_graphql_type( 'User', [
 			'description' => __( 'The Id of the user. Equivalent to WP_User->ID', 'wp-graphql' ),
 		],
 		'isRestricted' => [
-			'type' => 'Bool',
-			'description' => __( 'Whether or not the user is restricted', 'wp-graphql' ),
-		],
-		'isPublic' => [
-			'type' => 'Bool',
-			'description' => __( 'Whether or not the user is public', 'wp-graphql' ),
-		],
-		'isPrivate' => [
-			'type' => 'Bool',
-			'description' => __( 'Whether or not the user is private', 'wp-graphql' ),
+			'type' => 'Boolean',
+			'description' => __( 'Whether the object is restricted from the current viewer', 'wp-graphql' ),
 		],
 		'avatar'            => [
 			'type'        => 'Avatar',

--- a/src/Type/Object/UserRole.php
+++ b/src/Type/Object/UserRole.php
@@ -20,6 +20,10 @@ register_graphql_object_type( 'UserRole', [
 				'list_of' => 'String'
 			],
 			'description' => __( 'The capabilities that belong to this role', 'wp-graphql' ),
-		]
+		],
+		'isRestricted' => [
+			'type' => 'Boolean',
+			'description' => __( 'Whether the object is restricted from the current viewer', 'wp-graphql' ),
+		],
 	]
 ] );

--- a/tests/wpunit/UserObjectQueriesTest.php
+++ b/tests/wpunit/UserObjectQueriesTest.php
@@ -686,9 +686,7 @@ class UserObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 				    lastName
 				    url
 				    description
-				    isPublic
 				    isRestricted
-				    isPrivate
 				  }
 				}
 			}
@@ -709,9 +707,7 @@ class UserObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 								'lastName' => $user_2['last_name'],
 								'url' => $user_2['user_url'],
 								'description' => $user_2['description'],
-								'isPublic' => true,
 								'isRestricted' => false,
-								'isPrivate' => false,
 							],
 						],
 						[
@@ -723,9 +719,7 @@ class UserObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 								'lastName' => $user_2['last_name'],
 								'url' => null,
 								'description' => $user_1['description'],
-								'isPublic' => false,
 								'isRestricted' => true,
-								'isPrivate' => false,
 							],
 						],
 					],


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

- This adds `isRestricted: Boolean` fields to the various ObjectTypes that have an associated model. This allows for queries to know whether a node isRestricted or not. This gives client some insight into whether there is actually no data for a particular field, or whether there's no data returned because it's restricted.

I think there's room to expand this further down the road so the client can have even more info on what fields are public/restricted, etc. Could help build UIs properly if the consumer knows that x field is null because it's listed as a restricted field, vs it's null because there is simply no underlying data.

- This also fixes a bug with the PostObjectConnectionResolver to prevent querying a connection if the user specifies ONLY post_stati that they don't have permission to view.




Does this close any currently open issues?
------------------------------------------
closes #375 
