### PR TITLE
Bug/774 restrict users without published posts

### DIFF
--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -72,6 +72,22 @@ class User extends Model {
 	}
 
 	/**
+	 * Method for determining if the data should be considered private or not
+	 *
+	 * @access protected
+	 * @return bool
+	 */
+	protected function is_private() {
+
+		if ( ! current_user_can( 'list_users' ) && '0' === count_user_posts( absint( $this->data->ID ), [], true ) ) {
+			return true;
+		}
+
+		return false;
+
+	}
+
+	/**
 	 * Initialize the User object
 	 *
 	 * @access protected

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -79,7 +79,7 @@ class User extends Model {
 	 */
 	protected function is_private() {
 
-		if ( ! current_user_can( 'list_users' ) && '0' === count_user_posts( absint( $this->data->ID ), [], true ) ) {
+		if ( ! count_user_posts( absint( $this->data->ID ), \WPGraphQL::$allowed_post_types, true ) && ! current_user_can( 'list_users' ) && false === $this->owner_matches_current_user() ) {
 			return true;
 		}
 

--- a/src/Mutation/UserRegister.php
+++ b/src/Mutation/UserRegister.php
@@ -106,6 +106,16 @@ class UserRegister {
                 throw new UserError( __( 'The user failed to create', 'wp-graphql' ) );
             }
 
+	        /**
+	         * If the client isn't already authenticated, set the state in the current session to
+	         * the user they just registered. This is mostly so that they can get a response from
+	         * the mutation about the user they just registered after the user object passes
+	         * through the user model.
+	         */
+            if ( ! is_user_logged_in() ) {
+	            wp_set_current_user( $user_id );
+            }
+
             /**
              * Set the ID of the user to be used in the update
              */

--- a/src/Mutation/UserRegister.php
+++ b/src/Mutation/UserRegister.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace WPGraphQL\Mutation;
 
 use GraphQL\Error\UserError;
@@ -7,142 +8,142 @@ use WPGraphQL\AppContext;
 use WPGraphQL\Data\UserMutation;
 
 class UserRegister {
-    /**
-     * Registers the CommentCreate mutation.
-     */
-    public static function register_mutation() {
-        register_graphql_mutation( 'registerUser', [
-            'inputFields'         => self::get_input_fields(),
-            'outputFields'        => self::get_output_fields(),
-            'mutateAndGetPayload' => self::mutate_and_get_payload(),
-        ] );
-    }
+	/**
+	 * Registers the CommentCreate mutation.
+	 */
+	public static function register_mutation() {
+		register_graphql_mutation( 'registerUser', [
+			'inputFields'         => self::get_input_fields(),
+			'outputFields'        => self::get_output_fields(),
+			'mutateAndGetPayload' => self::mutate_and_get_payload(),
+		] );
+	}
 
-    /**
-     * Defines the mutation input field configuration.
-     *
-     * @return array
-     */
-    public static function get_input_fields() {
-        $input_fields = array_merge( UserCreate::get_input_fields(), [
-            'username' => [
-                'type'        => [
-                    'non_null' => 'String'
-                ],
-                // translators: the placeholder is the name of the type of object being updated
-                'description' => __( 'A string that contains the user\'s username.', 'wp-graphql' ),
-            ],
-            'email'    => [
-                'type'        => 'String',
-                'description' => __( 'A string containing the user\'s email address.', 'wp-graphql' ),
-            ],
-        ] );
+	/**
+	 * Defines the mutation input field configuration.
+	 *
+	 * @return array
+	 */
+	public static function get_input_fields() {
+		$input_fields = array_merge( UserCreate::get_input_fields(), [
+			'username' => [
+				'type'        => [
+					'non_null' => 'String'
+				],
+				// translators: the placeholder is the name of the type of object being updated
+				'description' => __( 'A string that contains the user\'s username.', 'wp-graphql' ),
+			],
+			'email'    => [
+				'type'        => 'String',
+				'description' => __( 'A string containing the user\'s email address.', 'wp-graphql' ),
+			],
+		] );
 
-	    /**
-	     * make sure we don't allow input for role or roles
-	     */
-        unset( $input_fields['role'] );
-	    unset( $input_fields['roles'] );
+		/**
+		 * make sure we don't allow input for role or roles
+		 */
+		unset( $input_fields['role'] );
+		unset( $input_fields['roles'] );
 
-        return $input_fields;
+		return $input_fields;
 
-    }
+	}
 
-    /**
-     * Defines the mutation output field configuration.
-     *
-     * @return array
-     */
-    public static function get_output_fields() {
-        return UserCreate::get_output_fields();
-    }
+	/**
+	 * Defines the mutation output field configuration.
+	 *
+	 * @return array
+	 */
+	public static function get_output_fields() {
+		return UserCreate::get_output_fields();
+	}
 
-    /**
-     * Defines the mutation data modification closure.
-     *
-     * @return callable
-     */
-    public static function mutate_and_get_payload() {
-        return function ( $input, AppContext $context, ResolveInfo $info ) {
+	/**
+	 * Defines the mutation data modification closure.
+	 *
+	 * @return callable
+	 */
+	public static function mutate_and_get_payload() {
+		return function( $input, AppContext $context, ResolveInfo $info ) {
 
-            if ( ! get_option( 'users_can_register' ) ) {
-                throw new UserError( __( 'User registration is currently not allowed.', 'wp-graphql' ) );
-            }
+			if ( ! get_option( 'users_can_register' ) ) {
+				throw new UserError( __( 'User registration is currently not allowed.', 'wp-graphql' ) );
+			}
 
-            if ( empty( $input['username'] ) ) {
-                throw new UserError( __( 'A username was not provided.', 'wp-graphql' ) );
-            }
+			if ( empty( $input['username'] ) ) {
+				throw new UserError( __( 'A username was not provided.', 'wp-graphql' ) );
+			}
 
-            if ( empty( $input['email'] ) ) {
-                throw new UserError( __( 'An email address was not provided.', 'wp-graphql' ) );
-            }
+			if ( empty( $input['email'] ) ) {
+				throw new UserError( __( 'An email address was not provided.', 'wp-graphql' ) );
+			}
 
-            /**
-             * Map all of the args from GQL to WP friendly
-             */
-            $user_args = UserMutation::prepare_user_object( $input, 'registerUser' );
+			/**
+			 * Map all of the args from GQL to WP friendly
+			 */
+			$user_args = UserMutation::prepare_user_object( $input, 'registerUser' );
 
-            /**
-             * Register the new user
-             */
-            $user_id = register_new_user( $user_args['user_login'], $user_args['user_email'] );
+			/**
+			 * Register the new user
+			 */
+			$user_id = register_new_user( $user_args['user_login'], $user_args['user_email'] );
 
-            /**
-             * Throw an exception if the user failed to register
-             */
-            if ( is_wp_error( $user_id ) ) {
-                $error_message = $user_id->get_error_message();
-                if ( ! empty( $error_message ) ) {
-                    throw new UserError( esc_html( $error_message ) );
-                } else {
-                    throw new UserError( __( 'The user failed to register but no error was provided', 'wp-graphql' ) );
-                }
-            }
+			/**
+			 * Throw an exception if the user failed to register
+			 */
+			if ( is_wp_error( $user_id ) ) {
+				$error_message = $user_id->get_error_message();
+				if ( ! empty( $error_message ) ) {
+					throw new UserError( esc_html( $error_message ) );
+				} else {
+					throw new UserError( __( 'The user failed to register but no error was provided', 'wp-graphql' ) );
+				}
+			}
 
-            /**
-             * If the $user_id is empty, we should throw an exception
-             */
-            if ( empty( $user_id ) ) {
-                throw new UserError( __( 'The user failed to create', 'wp-graphql' ) );
-            }
+			/**
+			 * If the $user_id is empty, we should throw an exception
+			 */
+			if ( empty( $user_id ) ) {
+				throw new UserError( __( 'The user failed to create', 'wp-graphql' ) );
+			}
 
-	        /**
-	         * If the client isn't already authenticated, set the state in the current session to
-	         * the user they just registered. This is mostly so that they can get a response from
-	         * the mutation about the user they just registered after the user object passes
-	         * through the user model.
-	         */
-            if ( ! is_user_logged_in() ) {
-	            wp_set_current_user( $user_id );
-            }
+			/**
+			 * If the client isn't already authenticated, set the state in the current session to
+			 * the user they just registered. This is mostly so that they can get a response from
+			 * the mutation about the user they just registered after the user object passes
+			 * through the user model.
+			 */
+			if ( ! is_user_logged_in() ) {
+				wp_set_current_user( $user_id );
+			}
 
-            /**
-             * Set the ID of the user to be used in the update
-             */
-            $user_args['ID'] = absint( $user_id );
+			/**
+			 * Set the ID of the user to be used in the update
+			 */
+			$user_args['ID'] = absint( $user_id );
 
-	        /**
-	         * Make sure we don't accept any role input during registration
-	         */
-	        unset( $user_args['role'] );
+			/**
+			 * Make sure we don't accept any role input during registration
+			 */
+			unset( $user_args['role'] );
 
-            /**
-             * Update the registered user with the additional input (firstName, lastName, etc) from the mutation
-             */
-            wp_update_user( $user_args );
+			/**
+			 * Update the registered user with the additional input (firstName, lastName, etc) from the mutation
+			 */
+			wp_update_user( $user_args );
 
-            /**
-             * Update additional user data
-             */
-            UserMutation::update_additional_user_object_data( $user_id, $input, 'registerUser', $context, $info );
+			/**
+			 * Update additional user data
+			 */
+			UserMutation::update_additional_user_object_data( $user_id, $input, 'registerUser', $context, $info );
 
-            /**
-             * Return the new user ID
-             */
-            return [
-                'id' => $user_id,
-            ];
+			/**
+			 * Return the new user ID
+			 */
+			return [
+				'id' => $user_id,
+			];
 
-        };
-    }
+		};
+	}
 }

--- a/tests/wpunit/AvatarObjectQueriesTest.php
+++ b/tests/wpunit/AvatarObjectQueriesTest.php
@@ -11,6 +11,11 @@ class AvatarObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 			'role'       => 'admin',
 			'user_email' => 'test@test.com'
 		] );
+
+		// Create a published post for the author so it is public in the API.
+		$this->factory()->post->create( [
+			'post_author' => $this->admin,
+		]);
 	}
 
 	public function tearDown() {

--- a/tests/wpunit/NodesTest.php
+++ b/tests/wpunit/NodesTest.php
@@ -295,9 +295,13 @@ class NodesTest extends \Codeception\TestCase\WPTestCase {
 	/**
 	 * testUserNodeQuery
 	 *
+	 * @dataProvider dataProviderUserNode
+	 *
+	 * @param bool $has_posts whether or not the user has published posts
+	 *
 	 * @since 0.0.5
 	 */
-	public function testUserNodeQuery() {
+	public function testUserNodeQuery( $has_posts, $user, $private ) {
 
 		$user_args = array(
 			'role'       => 'editor',
@@ -305,6 +309,30 @@ class NodesTest extends \Codeception\TestCase\WPTestCase {
 		);
 
 		$user_id = $this->factory->user->create( $user_args );
+
+		if ( true === $has_posts ) {
+			$this->factory()->post->create( [
+				'post_author' => $user_id,
+			] );
+		}
+
+		if ( ! empty( $user ) ) {
+
+			switch ( $user ) {
+				case 'admin':
+					$current_user = $this->admin;
+					break;
+				case 'owner':
+					$current_user = $user_id;
+					break;
+				default:
+					$current_user = 0;
+					break;
+			}
+
+			wp_set_current_user( $current_user );
+
+		}
 
 		$global_id = \GraphQLRelay\Relay::toGlobalId( 'user', $user_id );
 		$query     = "
@@ -328,7 +356,36 @@ class NodesTest extends \Codeception\TestCase\WPTestCase {
 			],
 		];
 
+		if ( true === $private ) {
+			$expected['data']['node']['userId'] = null;
+		}
+
 		$this->assertEquals( $expected, $actual );
+	}
+
+	public function dataProviderUserNode() {
+		return [
+			[
+				'has_posts' => true,
+				'user' => '',
+				'private' => false,
+			],
+			[
+				'has_posts' => false,
+				'user' => '',
+				'private' => true,
+			],
+			[
+				'has_posts' => false,
+				'user' => 'admin',
+				'private' => false,
+			],
+			[
+				'has_posts' => false,
+				'user' => 'owner',
+				'private' => false,
+			]
+		];
 	}
 
 	/**

--- a/tests/wpunit/UserObjectMutationsTest.php
+++ b/tests/wpunit/UserObjectMutationsTest.php
@@ -28,6 +28,10 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 			'role' => 'author',
 		] );
 
+		$this->factory()->post->create( [
+			'post_author' => $this->author,
+		] );
+
 		$this->admin = $this->factory->user->create( [
 			'role' => 'administrator',
 		] );
@@ -856,7 +860,7 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	public function testSendPasswordResetEmailResponseWithUsername() {
-		$user     = get_userdata( $this->subscriber );
+		$user     = get_userdata( $this->author );
 		$username = $user->user_login;
 		// Run the mutation, passing in a valid username.
 		$actual   = $this->sendPasswordResetEmailMutation( $username );
@@ -868,7 +872,7 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	public function testSendPasswordResetEmailResponseWithEmail() {
-		$user  = get_userdata( $this->subscriber );
+		$user  = get_userdata( $this->author );
 		$email = $user->user_email;
 		// Run the mutation, passing in a valid email address.
 		$actual   = $this->sendPasswordResetEmailMutation( $email );
@@ -880,7 +884,7 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	public function getSendPasswordResetEmailExpected() {
-		$user     = get_userdata( $this->subscriber );
+		$user     = get_userdata( $this->author );
 
 		return [
 			'data' => [

--- a/tests/wpunit/UserObjectQueriesTest.php
+++ b/tests/wpunit/UserObjectQueriesTest.php
@@ -672,6 +672,16 @@ class UserObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$user_1_id = $this->createUserObject( $user_1 );
 		$user_2_id = $this->createUserObject( $user_2 );
 
+		/**
+		 * Create posts for users so they are only restricted instead of private
+		 */
+		$this->factory()->post->create([
+			'post_author' => $user_1_id,
+		]);
+		$this->factory()->post->create([
+			'post_author' => $user_2_id,
+		]);
+
 		wp_set_current_user( $user_2_id );
 
 		$query = '
@@ -807,6 +817,17 @@ class UserObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertNotEmpty( $actual['data']['users']['edges'] );
 		$this->assertCount( 1, $actual['data']['users']['edges'] );
 
+	}
+
+	public function dataProviderUserHasPosts() {
+		return [
+			[
+				'has_posts' => true,
+			],
+			[
+				'has_posts' => false,
+			]
+		];
 	}
 
 }


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
Restricts users that don't have any public posts to users with the `list_users` cap, or if it matches the current user.


Does this close any currently open issues?
------------------------------------------
#774 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
I made a change to the registerUser mutation that sets the current user context to the user that was registered in the mutation, so the mutation could actually return the user. Otherwise the model thinks the user is private, and will return all null fields which feels a little unexpected. We should probably chat about it. I _think_ it's fine, since it's basically just exposing all of the data that you are entering in the mutation, not sure if it would have some unintended consequences though.


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
