### PR TITLE
Connection Resolver improvements to make custom connections …

### DIFF
--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -18,8 +18,8 @@ use WPGraphQL\Types;
 class PostObjectConnectionResolver extends AbstractConnectionResolver {
 
 	/**
-	 * The name of the post type the connection resolver is resolving for
-	 * @var string
+	 * The name of the post type, or array of post types the connection resolver is resolving for
+	 * @var mixed string|array
 	 */
 	protected $post_type;
 
@@ -357,7 +357,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		 * @param array       $all_args   All of the arguments for the query (not just the "where" args)
 		 * @param AppContext  $context    The AppContext object
 		 * @param ResolveInfo $info       The ResolveInfo object
-		 * @param string      $post_type  The post type for the query
+		 * @param mixed|string|array      $post_type  The post type for the query
 		 *
 		 * @since 0.0.5
 		 * @return array

--- a/src/TypeRegistry.php
+++ b/src/TypeRegistry.php
@@ -572,9 +572,8 @@ class TypeRegistry {
 		$resolve_connection      = array_key_exists( 'resolve', $config ) && is_callable( $config['resolve'] ) ? $config['resolve'] : function () {
 			return null;
 		};
-		$connection_name         = self::get_connection_name( $from_type, $to_type );
+		$connection_name         = ! empty( $config['connectionTypeName'] ) ? $config['connectionTypeName'] : self::get_connection_name( $from_type, $to_type );
 		$where_args              = [];
-		$connection_field_config = ! empty( $config['connectionFieldConfig'] ) && is_array( $config['connectionFieldConfig'] ) ? $config['connectionFieldConfig'] : [];
 
 		/**
 		 * If there are any $connectionArgs,

--- a/vendor/composer/autoload_framework_classmap.php
+++ b/vendor/composer/autoload_framework_classmap.php
@@ -228,6 +228,7 @@ return array(
     'WPGraphQL\\Model\\Plugin' => $baseDir . '/src/Model/Plugin.php', 
     'WPGraphQL\\Model\\Post' => $baseDir . '/src/Model/Post.php', 
     'WPGraphQL\\Model\\PostType' => $baseDir . '/src/Model/PostType.php', 
+    'WPGraphQL\\Model\\Taxonomy' => $baseDir . '/src/Model/Taxonomy.php', 
     'WPGraphQL\\Model\\Term' => $baseDir . '/src/Model/Term.php', 
     'WPGraphQL\\Model\\Theme' => $baseDir . '/src/Model/Theme.php', 
     'WPGraphQL\\Model\\User' => $baseDir . '/src/Model/User.php', 


### PR DESCRIPTION
- This moves some of the logic of the AbstractConnectionResolver from the __construct() down to the `get_connection()` method allowing for the Resolver to be customized between instantiating it and resolving it.

- Adds a `setQueryArg` method to the AbstractConnectionResolver to allow for individual connections to override query args as needed

- adjusts the `register_graphql_connection` to accept a `connectionTypeName` input