### PR TITLE
#799 - hook "setup_types" to init

### DIFF
--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -265,7 +265,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 			 * Determine what to show in graphql
 			 */
 			add_action( 'init_graphql_request', 'register_initial_settings', 10 );
-			add_action( 'init_graphql_request', [ $this, 'setup_types' ], 10 );
+			add_action( 'init', [ $this, 'setup_types' ], 10 );
 		}
 
 		/**


### PR DESCRIPTION
This configures post_types and taxonomies to "show_in_graphql" so that even outside of GraphQL Requests that knowledge can be used.

For example, a plugin author may want to do something like: 

```
get_post_types([ 'show_in_graphql' => true ]);
```

Currently that would be null, because we only register types at init_graphql_request, and _most_ plugins will be executing code outside the context of a GraphQL request. 

This allows plugins and themes to get a list of Post Types and Taxonomies that are configured to Show in GraphQL, even outside the context of a GraphQL request

closes #799 