### PR TITLE
🐛 #805 - BUGFIX for `menuItems{ nodes { ... } }` breaking

### DIFF
--- a/src/Connection/Menus.php
+++ b/src/Connection/Menus.php
@@ -42,17 +42,6 @@ class Menus {
 					'description' => __( 'The slug of the menu to query items for', 'wp-graphql' ),
 				],
 			],
-			'connectionFields' => [
-				'nodes' => [
-					'type'        => [
-						'list_of' => 'Menu',
-					],
-					'description' => __( 'The nodes of the connection, without the edges', 'wp-graphql' ),
-					'resolve'     => function ( $source, $args, $context, $info ) {
-						return ! empty( $source['nodes'] ) ? $source['nodes'] : [];
-					},
-				],
-			],
 			'resolveNode'      => function ( $id, $args, $context, $info ) {
 				return DataSource::resolve_term_object( $id, $context );
 			},

--- a/tests/wpunit/MenuItemConnectionQueriesTest.php
+++ b/tests/wpunit/MenuItemConnectionQueriesTest.php
@@ -97,6 +97,9 @@ class MenuItemConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 						}
 					}
 				}
+				nodes {
+				  menuItemId
+				}
 			}
 		}
 		';
@@ -105,6 +108,35 @@ class MenuItemConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 		// The query should return no menu items since no where args were specified.
 		$this->assertEquals( 0, count( $actual['data']['menuItems']['edges'] ) );
+		$this->assertEquals( 0, count( $actual['data']['menuItems']['edges'] ) );
+	}
+
+	public function testMenuItemsQueryNodes() {
+
+		$count = 10;
+		$created = $this->createMenuItems( 'my-test-menu-id', $count );
+
+		$menu_item_id = intval( $created['menu_item_ids'][2] );
+		$post_id = intval( $created['post_ids'][2] );
+
+		$query = '
+		{
+			menuItems( where: { id: ' . $menu_item_id . ' } ) {
+				nodes {
+				   menuItemId
+				}
+			}
+		}
+		';
+
+		$actual = do_graphql_request( $query );
+
+		foreach ( $actual['data']['menuItems']['nodes'] as $node ) {
+			$this->assertTrue( in_array( $node['menuItemId'], [ $menu_item_id ], true ) );
+		}
+
+		$this->assertEquals( 1, count( $actual['data']['menuItems']['nodes'] ) );
+
 	}
 
 	public function testMenuItemsQueryById() {
@@ -132,7 +164,6 @@ class MenuItemConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		';
 
 		$actual = do_graphql_request( $query );
-
 
 		// Perform some common assertions.
 		$this->compareResults( [ $menu_item_id ], [ $post_id ], $actual );


### PR DESCRIPTION
🐛  BUGFIX: 

#805 - Fix {menuItems{ nodes { ... } } queries and include a test to reduce future regressions

----

In v0.3.0 some changes were made to connections causing resolution of nodes to happen a bit differently. The `menuItems` connection wasn't appropriately adjusted to compensate for said changes. 

This updates the menuItem connections and includes a test to reduce risk of future regressions. 

---

Closes #805 