### PR TITLE
🚀 Release/v0.3.2

### DIFF
--- a/src/Connection/Menus.php
+++ b/src/Connection/Menus.php
@@ -42,17 +42,6 @@ class Menus {
 					'description' => __( 'The slug of the menu to query items for', 'wp-graphql' ),
 				],
 			],
-			'connectionFields' => [
-				'nodes' => [
-					'type'        => [
-						'list_of' => 'Menu',
-					],
-					'description' => __( 'The nodes of the connection, without the edges', 'wp-graphql' ),
-					'resolve'     => function ( $source, $args, $context, $info ) {
-						return ! empty( $source['nodes'] ) ? $source['nodes'] : [];
-					},
-				],
-			],
 			'resolveNode'      => function ( $id, $args, $context, $info ) {
 				return DataSource::resolve_term_object( $id, $context );
 			},

--- a/src/TypeRegistry.php
+++ b/src/TypeRegistry.php
@@ -510,7 +510,7 @@ class TypeRegistry {
 	 * @return mixed|WPObjectType|WPUnionType|WPInputObjectType|WPEnumType
 	 */
 	public static function get_type( $type_name ) {
-		return ( null !== self::$types[ self::format_key( $type_name ) ] ) ? ( self::$types[ self::format_key( $type_name ) ] ) : null;
+		return isset( self::$types[ self::format_key( $type_name ) ] ) ? ( self::$types[ self::format_key( $type_name ) ] ) : null;
 	}
 
 	/**

--- a/tests/wpunit/MenuItemConnectionQueriesTest.php
+++ b/tests/wpunit/MenuItemConnectionQueriesTest.php
@@ -97,6 +97,9 @@ class MenuItemConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 						}
 					}
 				}
+				nodes {
+				  menuItemId
+				}
 			}
 		}
 		';
@@ -105,6 +108,35 @@ class MenuItemConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 		// The query should return no menu items since no where args were specified.
 		$this->assertEquals( 0, count( $actual['data']['menuItems']['edges'] ) );
+		$this->assertEquals( 0, count( $actual['data']['menuItems']['edges'] ) );
+	}
+
+	public function testMenuItemsQueryNodes() {
+
+		$count = 10;
+		$created = $this->createMenuItems( 'my-test-menu-id', $count );
+
+		$menu_item_id = intval( $created['menu_item_ids'][2] );
+		$post_id = intval( $created['post_ids'][2] );
+
+		$query = '
+		{
+			menuItems( where: { id: ' . $menu_item_id . ' } ) {
+				nodes {
+				   menuItemId
+				}
+			}
+		}
+		';
+
+		$actual = do_graphql_request( $query );
+
+		foreach ( $actual['data']['menuItems']['nodes'] as $node ) {
+			$this->assertTrue( in_array( $node['menuItemId'], [ $menu_item_id ], true ) );
+		}
+
+		$this->assertEquals( 1, count( $actual['data']['menuItems']['nodes'] ) );
+
 	}
 
 	public function testMenuItemsQueryById() {
@@ -132,7 +164,6 @@ class MenuItemConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		';
 
 		$actual = do_graphql_request( $query );
-
 
 		// Perform some common assertions.
 		$this->compareResults( [ $menu_item_id ], [ $post_id ], $actual );

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -265,7 +265,8 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 			 * Determine what to show in graphql
 			 */
 			add_action( 'init_graphql_request', 'register_initial_settings', 10 );
-			add_action( 'init_graphql_request', [ $this, 'setup_types' ], 10 );
+			add_action( 'init', [ $this, 'setup_types' ], 10 );
+			add_action( 'init', [ $this, 'get_allowed_types' ], 999 );
 		}
 
 		/**
@@ -277,6 +278,12 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 			 * Setup the settings, post_types and taxonomies to show_in_graphql
 			 */
 			self::show_in_graphql();
+		}
+
+		/**
+		 * This gets the allowed post types and taxonomies when a GraphQL request has started
+		 */
+		public function get_allowed_types() {
 			self::get_allowed_post_types();
 			self::get_allowed_taxonomies();
 		}

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -5,7 +5,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 0.3.01
+ * Version: 0.3.2
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 4.7.0
@@ -17,7 +17,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  0.3.01
+ * @version  0.3.2
  */
 
 // Exit if accessed directly.
@@ -167,7 +167,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 
 			// Plugin version.
 			if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-				define( 'WPGRAPHQL_VERSION', '0.3.01' );
+				define( 'WPGRAPHQL_VERSION', '0.3.2' );
 			}
 
 			// Plugin Folder Path.


### PR DESCRIPTION
# 🚀 Release Notes

## New Features
- #799 WPGraphQL sets core Post Types and Taxonomies to `show_in_graphql` during `init` instead of `init_graphql_request` now. This allows for `get_post_types( [ 'show_in_graphql' => true ])` to work even outside the context of a GraphQL request. This is especially helpful for tools that want to know what Post Types and Taxonomies are set to `show_in_graphql`.

## Bug Fixes

- #806 resolved. Querying "nodes" on `menuItems` was introduced as a regression during the v0.3.0 release. Thanks, @JosephCarrington for reporting and working through to confirm it's resolution.
- #797 resolved. The TypeRegistry was throwing some PHP warnings if `TypeRegistry::get_type()` was used for a not-yet registered Type.
- #803 Fixes a bug introduced by #799 🤦‍♂️. Thanks @benallfree for working through this with me to get it resolved. 