### PR TITLE
🐛 BUGFIX

### DIFF
--- a/src/Data/Connection/MenuConnectionResolver.php
+++ b/src/Data/Connection/MenuConnectionResolver.php
@@ -22,21 +22,21 @@ class MenuConnectionResolver extends TermObjectConnectionResolver {
 			'fields'     => 'ids',
 		];
 
-		if ( ! empty( $args['where']['slug'] ) ) {
-			$term_args['slug']    = $args['where']['slug'];
+		if ( ! empty( $this->args['where']['slug'] ) ) {
+			$term_args['slug']    = $this->args['where']['slug'];
 			$term_args['include'] = null;
 		}
 
-		if ( ! empty( $args['where']['location'] ) ) {
+		if ( ! empty( $this->args['where']['location'] ) ) {
 			$theme_locations = get_nav_menu_locations();
 
-			if ( isset( $theme_locations[ $args['where']['location'] ] ) ) {
-				$term_args['include'] = $theme_locations[ $args['where']['location'] ];
+			if ( isset( $theme_locations[ $this->args['where']['location'] ] ) ) {
+				$term_args['include'] = $theme_locations[ $this->args['where']['location'] ];
 			}
 		}
 
-		if ( ! empty( $args['where']['id'] ) ) {
-			$term_args['include'] = $args['where']['id'];
+		if ( ! empty( $this->args['where']['id'] ) ) {
+			$term_args['include'] = $this->args['where']['id'];
 		}
 
 		return $term_args;

--- a/tests/wpunit/MenuConnectionQueriesTest.php
+++ b/tests/wpunit/MenuConnectionQueriesTest.php
@@ -35,11 +35,19 @@ class MenuConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	public function testMenusQueryByLocation() {
+
+		/**
+		 * Create multiple menus so that we can test querying for 1 and ensure
+		 * we get it back properly.
+		 */
 		$menu_slug = 'my-test-menu-by-location';
-		$menu_id = wp_create_nav_menu( $menu_slug );
+		wp_create_nav_menu( $menu_slug );
+		wp_create_nav_menu( $menu_slug . '-2' );
+		$id_3 = wp_create_nav_menu( $menu_slug . '-3' );
+		wp_create_nav_menu( $menu_slug . '-4'  );
 
 		// Assign menu to location.
-		set_theme_mod( 'nav_menu_locations', [ 'my-menu-location' => $menu_id ] );
+		set_theme_mod( 'nav_menu_locations', [ 'my-menu-location' => $id_3 ] );
 
 		$query = '
 		{
@@ -56,9 +64,11 @@ class MenuConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 		$actual = do_graphql_request( $query );
 
+		codecept_debug( $actual );
+
 		$this->assertEquals( 1, count( $actual['data']['menus']['edges'] ) );
-		$this->assertEquals( $menu_id, $actual['data']['menus']['edges'][0]['node']['menuId'] );
-		$this->assertEquals( $menu_slug, $actual['data']['menus']['edges'][0]['node']['name'] );
+		$this->assertEquals( $id_3, $actual['data']['menus']['edges'][0]['node']['menuId'] );
+		$this->assertEquals( $menu_slug . '-3', $actual['data']['menus']['edges'][0]['node']['name'] );
 	}
 
 	public function testMenusQueryBySlug() {


### PR DESCRIPTION
This fixes a bug with menu connection args not properly being respected. This also updates the test that was making a poor assertion. Now we create many menus and query a specific one to ensure the args work properly. Before, the test created one menu, tried to query for it and it was passing because it was the only menu so it was being returned regardless, not because it matched the args.

Closes #811 