### PR TITLE
#827 - Add "success" field to comment mutations, so that unauthentica…

### DIFF
--- a/access-functions.php
+++ b/access-functions.php
@@ -30,6 +30,7 @@ function graphql_format_field_name( $field_name ) {
  * @access public
  * @return array
  * @since  0.2.0
+ * @throws Exception
  */
 function graphql( $request_data = [] ) {
 	$request = new \WPGraphQL\Request( $request_data );
@@ -47,6 +48,7 @@ function graphql( $request_data = [] ) {
  * @access public
  * @return array
  * @since  0.0.2
+ * @throws \Exception
  */
 function do_graphql_request( $query, $operation_name = '', $variables = [] ) {
 	return graphql( [

--- a/src/Mutation/CommentCreate.php
+++ b/src/Mutation/CommentCreate.php
@@ -95,6 +95,23 @@ class CommentCreate {
 
 					return DataSource::resolve_comment( absint( $payload['id'] ), $context );
 				},
+			],
+			/**
+			 * Comments can be created by non-authenticated users, but if the comment is not approved
+			 * the user will not have access to the comment in response to the mutation.
+			 *
+			 * This field allows for the mutation to respond with a success message that the
+			 * comment was indeed created, even if it cannot be returned in the response to respect
+			 * server privacy.
+			 *
+			 * If the success comes back as true, the client can then use that response to
+			 * dictate if they should use the input values as an optimistic response to the mutation
+			 * and store in the cache, localStorage, cookie or whatever else so that the
+			 * client can see their comment while it's still pending approval.
+			 */
+			'success' => [
+				'type' => 'Boolean',
+				'description' => __( 'Whether the mutation succeeded. If the comment is not approved, the server will not return the comment to a non authenticated user, but a success message can be returned if the create succeeded, and the client can optimistically add the comment to the client cache', 'wp-graphql' ),
 			]
 		];
 	}
@@ -178,6 +195,7 @@ class CommentCreate {
 			 */
 			return [
 				'id' => $comment_id,
+				'success' => true,
 			];
 		};
 	}


### PR DESCRIPTION
This adds a `success` field to the `createComment` mutation. Also includes a test to ensure this feature doesn't see future regressions. 

Closes #827 (@paulisloud)