### PR TITLE
Refactored Bug fix. failed if it was user id in string format

### DIFF
--- a/src/Mutation/PostObjectCreate.php
+++ b/src/Mutation/PostObjectCreate.php
@@ -8,6 +8,7 @@ use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
 use WPGraphQL\Data\DataSource;
 use WPGraphQL\Data\PostObjectMutation;
+use GraphQLRelay\Relay;
 
 class PostObjectCreate {
     /**
@@ -211,8 +212,16 @@ class PostObjectCreate {
             /**
              * If the post being created is being assigned to another user that's not the current user, make sure
              * the current user has permission to edit others posts for this post_type
-             */
-            if ( ! empty( $input['authorId'] ) && get_current_user_id() !== $input['authorId'] && ! current_user_can( $post_type_object->cap->edit_others_posts ) ) {
+             *
+	     *
+	     * Bug Fix: ID failed if it was user id in string format i.e. '120029. Need to account for Hash/Gloabl ID's as well as numeric.
+	     */
+	    $authorID = absint($input['authorId'])
+	    if ($id_components = Relay::fromGlobalId ( $input['authorId'] ) && is_array( $id_components ) && ! empty( $id_components['id'])) {
+	        $authorID = $id_components['id'];
+	    }
+
+            if ( ! empty( $authorID ) && get_current_user_id() !== $authorID && ! current_user_can( $post_type_object->cap->edit_others_posts ) ) {
                 // translators: the $post_type_object->graphql_plural_name placeholder is the name of the object being mutated
                 throw new UserError( sprintf( __( 'Sorry, you are not allowed to create %1$s as this user', 'wp-graphql' ), $post_type_object->graphql_plural_name ) );
             }

--- a/src/Mutation/PostObjectCreate.php
+++ b/src/Mutation/PostObjectCreate.php
@@ -209,17 +209,14 @@ class PostObjectCreate {
                 throw new UserError( sprintf( __( 'Sorry, you are not allowed to create %1$s', 'wp-graphql' ), $post_type_object->graphql_plural_name ) );
             }
 
-            /**
+           /**
              * If the post being created is being assigned to another user that's not the current user, make sure
              * the current user has permission to edit others posts for this post_type
-             *
-	     *
-	     * Bug Fix: ID failed if it was user id in string format i.e. '120029. Need to account for Hash/Gloabl ID's as well as numeric.
-	     */
-	    $authorID = absint($input['authorId'])
-	    if ($id_components = Relay::fromGlobalId ( $input['authorId'] ) && is_array( $id_components ) && ! empty( $id_components['id'])) {
-	        $authorID = $id_components['id'];
-	    }
+             */
+            $authorID = absint($input['authorId']);
+            if ($id_components = Relay::fromGlobalId ( $input['authorId'] ) && is_array( $id_components ) && ! empty( $id_components['id'])) {
+	            $authorID = $id_components['id'];
+	        }
 
             if ( ! empty( $authorID ) && get_current_user_id() !== $authorID && ! current_user_can( $post_type_object->cap->edit_others_posts ) ) {
                 // translators: the $post_type_object->graphql_plural_name placeholder is the name of the object being mutated


### PR DESCRIPTION
Bug Fix: ID failed if it was user id in string format i.e. '120029. Need to account for Hash/Gloabl ID's as well as numeric.

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
…


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
