### PR TITLE
#849 - This ensures that list_of and non_null can be used with each other

### DIFF
--- a/src/TypeRegistry.php
+++ b/src/TypeRegistry.php
@@ -474,19 +474,7 @@ class TypeRegistry {
 			}
 		}
 
-		if ( is_array( $field_config['type'] ) ) {
-			if ( isset( $field_config['type']['non_null'] ) && is_string( $field_config['type']['non_null'] ) ) {
-				$non_null_type = TypeRegistry::get_type( $field_config['type']['non_null'] );
-				if ( ! empty( $non_null_type ) ) {
-					$field_config['type'] = Types::non_null( $non_null_type );
-				}
-			} else if ( isset( $field_config['type']['list_of'] ) && is_string( $field_config['type']['list_of'] ) ) {
-				$list_of_type = TypeRegistry::get_type( $field_config['type']['list_of'] );
-				if ( ! empty( $list_of_type ) ) {
-					$field_config['type'] = Types::list_of( $list_of_type );
-				}
-			}
-		}
+		$field_config['type'] = self::setup_type_modifiers( $field_config['type'] );
 
 		if ( ! empty( $field_config['args'] ) && is_array( $field_config['args'] ) ) {
 			foreach ( $field_config['args'] as $arg_name => $arg_config ) {
@@ -497,6 +485,41 @@ class TypeRegistry {
 		}
 
 		return $field_config;
+	}
+
+	/**
+	 * @param mixed string|array $type
+	 *
+	 * @return mixed
+	 * @throws \Exception
+	 */
+	public static function setup_type_modifiers( $type ) {
+
+		if ( is_array( $type ) ) {
+			if ( isset( $type['non_null'] ) ) {
+				if ( is_array( $type['non_null'] ) ) {
+					$non_null_type = self::setup_type_modifiers( $type['non_null'] );
+				} else if ( is_string( $type['non_null'] ) ) {
+					$non_null_type = TypeRegistry::get_type( $type['non_null'] );
+				}
+				if ( ! empty( $non_null_type ) ) {
+					$type = Types::non_null( $non_null_type );
+				}
+			} else if ( isset( $type['list_of'] ) ) {
+				if ( is_array( $type['list_of'] ) ) {
+					$list_of_type = self::setup_type_modifiers( $type['list_of'] );
+				} else if ( is_string( $type['list_of'] ) ) {
+					$list_of_type = TypeRegistry::get_type( $type['list_of'] );
+				}
+
+				if ( ! empty( $list_of_type ) ) {
+					$type = Types::list_of( $list_of_type );
+				}
+			}
+		}
+
+		return $type;
+
 	}
 
 	/**


### PR DESCRIPTION
Previously this expected the value of the `list_of` and `non_null` fields to be a string of the name of the Type, like `non_null => ID` or `non_null => String` or whatever.

If an array was passed as the value, things got weird.

This now allows for a String of a Type name to be passed through _or_ an array, which will then circle back to setup non_null / list_of again.

----
closes #849 