### PR TITLE
#802 - Throw exception for invalid list_of / non_null Types

### DIFF
--- a/src/TypeRegistry.php
+++ b/src/TypeRegistry.php
@@ -504,7 +504,9 @@ class TypeRegistry {
 				} else if ( is_string( $type['non_null'] ) ) {
 					$non_null_type = TypeRegistry::get_type( $type['non_null'] );
 				}
-				if ( ! empty( $non_null_type ) ) {
+				if ( empty( $non_null_type ) ) {
+					throw new \Exception( sprintf( __( 'The non_null type %s is an invalid or non-existent type', 'wp-graphql' ), (string) $type['non_null'] ) );
+				} else {
 					$type = Types::non_null( $non_null_type );
 				}
 			} else if ( isset( $type['list_of'] ) ) {
@@ -514,7 +516,9 @@ class TypeRegistry {
 					$list_of_type = TypeRegistry::get_type( $type['list_of'] );
 				}
 
-				if ( ! empty( $list_of_type ) ) {
+				if ( empty( $list_of_type ) ) {
+					throw new \Exception( sprintf( __( 'The list_of type %s is an invalid or non-existent type', 'wp-graphql' ), (string) $type['list_of'] ) );
+				} else {
 					$type = Types::list_of( $list_of_type );
 				}
 			}


### PR DESCRIPTION
Closes #802 

If a field is configured with a `list_of` or `non_null` and the Type being wrapped is invalid, this will now throw an exception to better communicate why the Schema is not valid

For example:

```
add_action( 'graphql_register_types', function() {
	register_graphql_field( 'RootQuery', 'testField', [
		'type' => [ 'list_of' => 'NonExistentType' ]
	] );
} );
```

Will now return:

```
{
  "errors": [
    {
      "debugMessage": "The list_of type NonExistentType is an invalid or non-existent type",
      "message": "Internal server error",
      "category": "internal"
    }
  ]
}
```