### PR TITLE
#260 - 

### DIFF
--- a/tests/functional/ApolloPreflightRequestCept.php
+++ b/tests/functional/ApolloPreflightRequestCept.php
@@ -4,7 +4,7 @@ $I->wantTo('Send a preflight Options request like Apollo and check the response'
 
 
 $I->haveHttpHeader( 'Content-Type', 'application/json' );
-$I->sendOPTIONS( 'http://dashboardwpgraphql.local/graphql' );
+$I->sendOPTIONS( 'http://wpgraphql.test/graphql' );
 
 $I->seeResponseCodeIs( 200 );
 

--- a/tests/functional/ApolloPreflightRequestCept.php
+++ b/tests/functional/ApolloPreflightRequestCept.php
@@ -1,6 +1,6 @@
 <?php
 $I = new FunctionalTester( $scenario );
-$I->wantTo('Send a preflight Options request like Apollo and check the response' );
+$I->wantTo( 'Send a preflight Options request like Apollo and check the response' );
 
 
 $I->haveHttpHeader( 'Content-Type', 'application/json' );
@@ -8,7 +8,7 @@ $I->sendOPTIONS( 'http://wpgraphql.test/graphql' );
 
 $I->seeResponseCodeIs( 200 );
 
-$response       = $I->canSeeHttpHeader( 'Access-Control-Allow-Origin' );
+$response = $I->canSeeHttpHeader( 'Access-Control-Allow-Origin' );
 
 $expected = $I->grabHttpHeader( 'Access-Control-Allow-Origin' );
 $I->assertEquals( '*', $expected );
@@ -17,7 +17,7 @@ $expected = $I->grabHttpHeader( 'Content-Type' );
 $I->assertEquals( 'application/json ; charset=UTF-8', $expected );
 
 $access_control_allow_headers = $I->grabHttpHeader( 'Access-Control-Allow-Headers' );
-$headers = explode( ', ', $access_control_allow_headers );
+$headers                      = explode( ', ', $access_control_allow_headers );
 
 codecept_debug( $headers );
 

--- a/tests/functional/ApolloPreflightRequestCept.php
+++ b/tests/functional/ApolloPreflightRequestCept.php
@@ -1,0 +1,28 @@
+<?php
+$I = new FunctionalTester( $scenario );
+$I->wantTo('Send a preflight Options request like Apollo and check the response' );
+
+
+$I->haveHttpHeader( 'Content-Type', 'application/json' );
+$I->sendOPTIONS( 'http://dashboardwpgraphql.local/graphql' );
+
+$I->seeResponseCodeIs( 200 );
+
+$response       = $I->canSeeHttpHeader( 'Access-Control-Allow-Origin' );
+
+$expected = $I->grabHttpHeader( 'Access-Control-Allow-Origin' );
+$I->assertEquals( '*', $expected );
+
+$expected = $I->grabHttpHeader( 'Content-Type' );
+$I->assertEquals( 'application/json ; charset=UTF-8', $expected );
+
+$access_control_allow_headers = $I->grabHttpHeader( 'Access-Control-Allow-Headers' );
+$headers = explode( ', ', $access_control_allow_headers );
+
+codecept_debug( $headers );
+
+$I->assertContains( 'Content-Type', $headers );
+$I->assertContains( 'Authorization', $headers );
+
+
+


### PR DESCRIPTION
Adds tests for Apollo Preflight request to make sure `Access-Control-Allow-Origin` and `Access-Control-Allow-Headers` headers are returned and a status code of 200 is returned.

closes #260 