### PR TITLE
#796 - Add srcSet field to media items

### DIFF
--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -380,6 +380,10 @@ class Post extends Model {
 						$caption = apply_filters( 'the_excerpt', apply_filters( 'get_the_excerpt', $this->data->post_excerpt, $this->data ) );
 						return ! empty( $caption ) ? $caption : null;
 					},
+					'srcSet' => function() {
+						$src_set = wp_get_attachment_image_srcset( $this->data->ID );
+						return ! empty( $src_set ) ? $src_set : null;
+					},
 					'captionRaw' => [
 						'callback' => function() {
 							return ! empty( $this->data->post_excerpt ) ? $this->data->post_excerpt : null;

--- a/src/Type/Object/PostObject.php
+++ b/src/Type/Object/PostObject.php
@@ -73,6 +73,10 @@ function register_post_object_types( $post_type_object ) {
 				'type'        => 'String',
 				'description' => __( 'Alternative text to display when resource is not displayed', 'wp-graphql' ),
 			],
+			'srcSet' => [
+				'type' => 'string',
+				'description' => __( 'The srcset attribute specifies the URL of the image to use in different situations. It is a comma separated string of urls and their widths.', 'wp-graphql' ),
+			],
 			'description'  => [
 				'type'        => 'String',
 				'description' => __( 'Description of the image (stored as post_content)', 'wp-graphql' ),

--- a/tests/wpunit/MediaItemQueriesTest.php
+++ b/tests/wpunit/MediaItemQueriesTest.php
@@ -240,6 +240,7 @@ class MediaItemQueriesTest extends \Codeception\TestCase\WPTestCase {
 				status
 				title
 				toPing
+				srcSet
 			}
 		}";
 
@@ -247,6 +248,8 @@ class MediaItemQueriesTest extends \Codeception\TestCase\WPTestCase {
 		 * Run the GraphQL query
 		 */
 		$actual = do_graphql_request( $query );
+
+		codecept_debug( $actual );
 
 		$mediaItem = $actual['data']['mediaItem'];
 
@@ -282,6 +285,9 @@ class MediaItemQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertTrue( ( null === $mediaItem['status'] || is_string( $mediaItem['status'] ) ) );
 		$this->assertTrue( ( null === $mediaItem['title'] || is_string( $mediaItem['title'] ) ) );
 		$this->assertTrue( ( empty( $mediaItem['toPing'] ) || is_array( $mediaItem['toPing'] ) ) );
+		$this->assertContains( 'http://wpgraphql.test/wp-content/uploads/example-full.jpg 1500w', $mediaItem['srcSet'] );
+		$this->assertContains( 'http://wpgraphql.test/wp-content/uploads/example-thumbnail.jpg 150w', $mediaItem['srcSet'] );
+		$this->assertContains( 'http://wpgraphql.test/wp-content/uploads/example.jpg 300w', $mediaItem['srcSet'] );
 
 		$this->assertEquals(
 			[


### PR DESCRIPTION
Closes #796  

This adds the ability to query `srcSet` on media items. 

For example, on my local environment I can run this query:

```
{
  mediaItem(id: "YXR0YWNobWVudDoxNTI4") {
    id
    title
    srcSet
  }
}
```

and get this response: 

```
{
  "data": {
    "mediaItem": {
      "id": "YXR0YWNobWVudDoxNTI4",
      "title": "download",
      "srcSet": "https://dashboardwpgraphql.local/wp-content/uploads/2019/04/download-239x300.jpeg 239w, https://dashboardwpgraphql.local/wp-content/uploads/2019/04/download.jpeg 430w"
    }
  }
}
```