### PR TITLE
Issue-859/CI-6320 | Fixing Docker tests; Updating Docker software versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,9 @@ env:
   matrix:
     # These apply to the latest WP version that is available as a Docker image: https://hub.docker.com/_/wordpress/
     - WP_VERSION=5.0.2 PHP_VERSION=5.6
-    - WP_VERSION=5.1.1 PHP_VERSION=7.1
-    - WP_VERSION=5.1.1 PHP_VERSION=7.2
-    - WP_VERSION=5.1.1 PHP_VERSION=7.3 COVERAGE=true LINT_SCHEMA=true
+    - WP_VERSION=5.2.0 PHP_VERSION=7.1
+    - WP_VERSION=5.2.0 PHP_VERSION=7.2
+    - WP_VERSION=5.2.0 PHP_VERSION=7.3 COVERAGE=true LINT_SCHEMA=true
     - PHPCS=true
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,9 @@ cache:
 env:
   matrix:
     # These apply to the latest WP version that is available as a Docker image: https://hub.docker.com/_/wordpress/
-    - WP_VERSION=5.0.2 PHP_VERSION=5.6
+
+    # Disabling PHP 5.6 tests until "composer.lock" is updated to work with PHP 7.X AND 5.6.
+    # - WP_VERSION=5.0.2 PHP_VERSION=5.6
     - WP_VERSION=5.2.0 PHP_VERSION=7.1
     - WP_VERSION=5.2.0 PHP_VERSION=7.2
     - WP_VERSION=5.2.0 PHP_VERSION=7.3 COVERAGE=true LINT_SCHEMA=true

--- a/Dockerfile.test-base
+++ b/Dockerfile.test-base
@@ -61,7 +61,7 @@ COPY --chown='www-data:www-data' vendor/ "${SUT_PLUGIN_DIR}/vendor/"
 # Run PHP Composer install so that Codeception dependencies are available
 USER www-data
 RUN cd "${SUT_PLUGIN_DIR}" \
-  && composer update --prefer-source --no-interaction --dev
+  && composer install --prefer-source --no-interaction --dev
 
 # Copy in all other files from repo, but preserve the files used by/modified by composer install.
 USER root

--- a/Dockerfile.test-base
+++ b/Dockerfile.test-base
@@ -26,7 +26,7 @@ RUN echo 'date.timezone = "UTC"' > /usr/local/etc/php/conf.d/timezone.ini \
         docker-php-ext-enable xdebug; \
      fi \
   && docker-php-ext-install pdo_mysql \
-  && curl -Ls 'https://raw.githubusercontent.com/composer/getcomposer.org/5eb0614d3fa7130b363698d3dca52c619b463615/web/installer' | php -- --quiet \
+  && curl -Ls 'https://raw.githubusercontent.com/composer/getcomposer.org/ffdc3c7fcb7c0f2a806508a868a35d13177a5a51/web/installer' | php -- --quiet \
   && chmod +x composer.phar \
   && mv composer.phar /usr/local/bin/composer \
   && curl -O 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar' \

--- a/README.md
+++ b/README.md
@@ -178,6 +178,32 @@ of the set up and configuration tasks performed by a developer.
    ![alt text](img/intellij-php-start-debug.png)
    
 1. Now when you visit http://127.0.0.1:8000 you can use the debugger.           
+
+
+#### Using MySQL clients to connect to MySQL containers
+1. Run the application with desired sites. Here's an example:
+   ```
+   ./run-docker-local-app.sh
+   ```
+
+1. List the MySQL containers that are running and their MySQL port mappings. These ports will change each time the app is run:  
+   ```
+   ./list-mysql-containers.sh
+   ```
+   
+   You should see output like the following:
+   ```
+   aa38d8d7eff1        mariadb:10.2.24-bionic          "docker-entrypoint.s…"   14 seconds ago      Up 13 seconds       0.0.0.0:32772->3306/tcp   docker_mysql_test_1
+   ```
+   
+1. Configure your MySQL client to connect to `localhost` and the appropriate ***host*** port. For example, to connect
+   to the MySQL container shown above, have the MySQL client connect with this configuration:
+   * IP/Hostname: `localhost`
+   * Port: `32772`
+   * Database: `wpgraphql_test`
+   * User: `root`
+   * Password: `testing`
+
    
 #### Running tests with Docker
 

--- a/docker/docker-compose.local-app-xdebug.yml
+++ b/docker/docker-compose.local-app-xdebug.yml
@@ -7,7 +7,7 @@ services:
       context: '../'
       dockerfile: 'Dockerfile.xdebug'
       args:
-        DESIRED_WP_VERSION: "${WP_VERSION:-5.1.1}"
+        DESIRED_WP_VERSION: "${WP_VERSION:-5.2.0}"
         DESIRED_PHP_VERSION: "${PHP_VERSION:-7.3}"
     image: 'wordpress-utc-xdebug-cache'
     environment:

--- a/docker/docker-compose.local-app.yml
+++ b/docker/docker-compose.local-app.yml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   wpgraphql.test:
-    image: "wordpress:${WP_VERSION:-5.1.1}-php${PHP_VERSION:-7.3}-apache"
+    image: "wordpress:${WP_VERSION:-5.2.0}-php${PHP_VERSION:-7.3}-apache"
     ports:
       - '8000:80'
     environment:
@@ -19,7 +19,10 @@ services:
       - './uploads.txt:/usr/local/etc/php/conf.d/uploads.ini:ro'
 
   mysql_test:
-    image: 'mariadb:10.2.23-bionic'
+    image: 'mariadb:10.2.24-bionic'
+    ports:
+      # Have Docker forward a randomly assigned host port to this site's MySQL container port
+      - '3306'
     environment:
       MYSQL_DATABASE: 'wpgraphql_test'
       MYSQL_ROOT_PASSWORD: 'testing'

--- a/docker/docker-compose.tests.yml
+++ b/docker/docker-compose.tests.yml
@@ -6,7 +6,7 @@ services:
       context: '../'
       dockerfile: 'Dockerfile.test-base'
       args:
-        DESIRED_WP_VERSION: "${WP_VERSION:-5.1.1}"
+        DESIRED_WP_VERSION: "${WP_VERSION:-5.2.0}"
         DESIRED_PHP_VERSION: "${PHP_VERSION:-7.3}"
     image: 'wordpress-wp-graphql-test-base'
     container_name: 'wpgraphql-tester'
@@ -28,7 +28,7 @@ services:
       context: '../'
       dockerfile: 'Dockerfile.test-base'
       args:
-        DESIRED_WP_VERSION: "${WP_VERSION:-5.1.1}"
+        DESIRED_WP_VERSION: "${WP_VERSION:-5.2.0}"
         DESIRED_PHP_VERSION: "${PHP_VERSION:-7.3}"
     image: 'wordpress-wp-graphql-test-base'
     environment:
@@ -43,7 +43,7 @@ services:
     entrypoint: [ "docker-entrypoint.sut.sh" ]
 
   mysql_test:
-    image: 'mariadb:10.2.23-bionic'
+    image: 'mariadb:10.2.24-bionic'
     environment:
       MYSQL_DATABASE: 'wpgraphql_test'
       MYSQL_ROOT_PASSWORD: 'testing'

--- a/list-mysql-containers.sh
+++ b/list-mysql-containers.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -eu
+
+main() {
+  docker ps | grep 3306
+}
+
+main


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
* This change ensures the Docker build installs PHP libraries according to `composer.lock`. This will fix https://github.com/wp-graphql/wp-graphql/issues/859
* Travis runs tests based on WordPress 5.2.0
* Docker
   * Updating PHP Composer
   * Updating MariaDB version
   * Setting default WordPress version to 5.2.0
   * Exposing MySQL port so devs can connect to Docker MySQL container with a MySQL client
 * Other
   * Added README instructions for using MySQL client on Docker setup



Does this close any currently open issues?
------------------------------------------
Yes, https://github.com/wp-graphql/wp-graphql/issues/859


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
N/A

Any other comments?
-------------------
N/A


Where has this been tested?
---------------------------
**Operating System:**
OS X: Mojave + Docker for Mac

**WordPress Version:**
5.2.0
