### PR TITLE
#818 - Cursor Pagination Broken with Custom Orderby

### DIFF
--- a/src/Data/Cursor/PostObjectCursor.php
+++ b/src/Data/Cursor/PostObjectCursor.php
@@ -163,15 +163,14 @@ class PostObjectCursor {
 	 */
 	private function compare_with( $by, $order ) {
 
-		$post_field = 'post_' . $by;
+		$post_field = $by;
 		$value      = $this->get_cursor_post()->{$post_field};
 
 		/**
 		 * Compare by the post field if the key matches an value
 		 */
 		if ( ! empty( $value ) ) {
-			$this->builder->add_field( "{$this->wpdb->posts}.post_{$by}", $value, null, $order );
-
+			$this->builder->add_field( "{$this->wpdb->posts}.{$by}", $value, null, $order );
 			return;
 		}
 

--- a/tests/wpunit/PostObjectCursorTest.php
+++ b/tests/wpunit/PostObjectCursorTest.php
@@ -199,7 +199,7 @@ class PostObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 	 */
 	public function testPostOrderingByPostTitle() {
 		$this->assertQueryInCursor( [
-			'orderby' => 'title',
+			'orderby' => 'post_title',
 		] );
 	}
 
@@ -208,7 +208,7 @@ class PostObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 	 */
 	public function testPostOrderingByPostTitleASC() {
 		$this->assertQueryInCursor( [
-			'orderby' => 'title',
+			'orderby' => 'post_title',
 			'order' => 'ASC',
 		] );
 	}
@@ -218,7 +218,7 @@ class PostObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 	 */
 	public function testPostOrderingByPostTitleDESC() {
 		$this->assertQueryInCursor( [
-			'orderby' => 'title',
+			'orderby' => 'post_title',
 			'order' => 'DESC',
 		] );
 	}


### PR DESCRIPTION
This removes the `post_` prefix from the `compare_with` method to avoid issues with cursor pagination.

Closes #818 

----

There's still an edge case bug causing orderby title to skip a post if 2 adjacent posts have the same title. 

Very edge case-y, so will follow up with another bug to address.