### PR TITLE
Fix orderby with post object cursors

### DIFF
--- a/src/Data/Cursor/PostObjectCursor.php
+++ b/src/Data/Cursor/PostObjectCursor.php
@@ -142,6 +142,8 @@ class PostObjectCursor {
 			$this->compare_with_date();
 		}
 
+		$this->builder->add_field( "{$this->wpdb->posts}.ID", $this->cursor_offset, 'ID' );
+
 		return $this->to_sql();
 	}
 
@@ -150,7 +152,6 @@ class PostObjectCursor {
 	 */
 	private function compare_with_date() {
 		$this->builder->add_field( "{$this->wpdb->posts}.post_date", $this->get_cursor_post()->post_date, 'DATETIME' );
-		$this->builder->add_field( "{$this->wpdb->posts}.ID", $this->cursor_offset, 'ID' );
 	}
 
 	/**
@@ -163,14 +164,13 @@ class PostObjectCursor {
 	 */
 	private function compare_with( $by, $order ) {
 
-		$post_field = 'post_' . $by;
-		$value      = $this->get_cursor_post()->{$post_field};
+		$value      = $this->get_cursor_post()->{$by};
 
 		/**
 		 * Compare by the post field if the key matches an value
 		 */
 		if ( ! empty( $value ) ) {
-			$this->builder->add_field( "{$this->wpdb->posts}.post_{$by}", $value, null, $order );
+			$this->builder->add_field( "{$this->wpdb->posts}.{$by}", $value, null, $order );
 
 			return;
 		}

--- a/tests/wpunit/PostObjectCursorTest.php
+++ b/tests/wpunit/PostObjectCursorTest.php
@@ -226,6 +226,21 @@ class PostObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 		] );
 	}
 
+	public function testPostOrderingByDuplicatePostTitles() {
+		foreach ($this->created_post_ids as $index => $post_id) {
+			wp_update_post( [
+				'ID' => $post_id,
+				'post_title' => 'duptitle',
+
+			] );
+		}
+
+		$this->assertQueryInCursor( [
+			'orderby' => 'post_title',
+			'order' => 'DESC',
+		] );
+	}
+
 	public function testPostOrderingByMetaString() {
 
 		// Add post meta to created posts

--- a/tests/wpunit/PostObjectCursorTest.php
+++ b/tests/wpunit/PostObjectCursorTest.php
@@ -74,6 +74,8 @@ class PostObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 	 * @return array
 	 */
 	public function create_posts( $count = 20 ) {
+		// Ensure that ordering by titles is different from ordering by ids
+		$titles = "qwertyuiopasdfghjklzxcvbnm";
 
 		// Create posts
 		$created_posts = [];
@@ -84,7 +86,7 @@ class PostObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 				'post_type'   => 'post',
 				'post_date'   => $date,
 				'post_status' => 'publish',
-				'post_title'  => $i,
+				'post_title'  => $titles[ $i % strlen( $titles ) ],
 			] );
 		}
 

--- a/tests/wpunit/PostObjectCursorTest.php
+++ b/tests/wpunit/PostObjectCursorTest.php
@@ -201,7 +201,7 @@ class PostObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 	 */
 	public function testPostOrderingByPostTitleDefault() {
 		$this->assertQueryInCursor( [
-			'orderby' => 'title',
+			'orderby' => 'post_title',
 		] );
 	}
 
@@ -210,7 +210,7 @@ class PostObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 	 */
 	public function testPostOrderingByPostTitleASC() {
 		$this->assertQueryInCursor( [
-			'orderby' => 'title',
+			'orderby' => 'post_title',
 			'order' => 'ASC',
 		] );
 	}
@@ -220,7 +220,7 @@ class PostObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 	 */
 	public function testPostOrderingByPostTitleDESC() {
 		$this->assertQueryInCursor( [
-			'orderby' => 'title',
+			'orderby' => 'post_title',
 			'order' => 'DESC',
 		] );
 	}

--- a/tests/wpunit/PostObjectCursorTest.php
+++ b/tests/wpunit/PostObjectCursorTest.php
@@ -140,6 +140,7 @@ class PostObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 			  edges {
 				node {
 				  title
+				  postId
 				}
 			  }
 			}
@@ -150,7 +151,7 @@ class PostObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertArrayNotHasKey( 'errors', $first, print_r( $first, true ) );
 
 		$first_page_actual = array_map( function( $edge ) {
-			return $edge['node']['title'];
+			return $edge['node']['postId'];
 		}, $first['data']['posts']['edges']);
 
 
@@ -160,7 +161,7 @@ class PostObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertArrayNotHasKey( 'errors', $second, print_r( $second, true ) );
 
 		$second_page_actual = array_map( function( $edge ) {
-			return $edge['node']['title'];
+			return $edge['node']['postId'];
 		}, $second['data']['posts']['edges']);
 
 		// Make correspondig WP_Query
@@ -181,8 +182,8 @@ class PostObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 		] ) );
 
 
-		$first_page_expected = wp_list_pluck($first_page->posts, 'post_title');
-		$second_page_expected = wp_list_pluck($second_page->posts, 'post_title');
+		$first_page_expected = wp_list_pluck($first_page->posts, 'ID');
+		$second_page_expected = wp_list_pluck($second_page->posts, 'ID');
 
 		// Aserting like this we get more readable assertion fail message
 		$this->assertEquals( implode(',', $first_page_expected), implode(',', $first_page_actual), 'First page' );

--- a/tests/wpunit/PostObjectCursorTest.php
+++ b/tests/wpunit/PostObjectCursorTest.php
@@ -199,7 +199,7 @@ class PostObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 	/**
 	 * Simple title ordering test
 	 */
-	public function testPostOrderingByPostTitle() {
+	public function testPostOrderingByPostTitleDefault() {
 		$this->assertQueryInCursor( [
 			'orderby' => 'title',
 		] );


### PR DESCRIPTION
The docker test environment is broken for me so I'm sending this as a PR now to see how the tests execute.


What does this implement/fix? Explain your changes.
---------------------------------------------------

I have following posts

![image](https://user-images.githubusercontent.com/225712/58232199-9ce35080-7d41-11e9-9306-016613a24c98.png)



and I execute this query for the second page

```graphql
{
  posts(first: 5, after: "YXJyYXljb25uZWN0aW9uOjI4", where: {orderby: {field: TITLE, order: ASC}}) {
    pageInfo {
      endCursor
    }
    edges {
      node {
        title
        content
      }
    }
  }
}
```


Before this PR it returns this

![image](https://user-images.githubusercontent.com/225712/58232279-dddb6500-7d41-11e9-9eb4-bf4ec7f246a8.png)

which is wrong. The generated SQL query is 

```sql
SELECT wp_posts.ID
FROM wp_posts
WHERE 1 = 1
	AND wp_posts.post_parent = 0
	AND wp_posts.post_type = 'post'
	AND ((wp_posts.post_status = 'publish'))
	AND CAST(wp_posts.post_date AS DATETIME) <= CAST('2019-05-23 06:04:47' AS DATETIME)
	AND (
		CAST(wp_posts.post_date AS DATETIME) < CAST('2019-05-23 06:04:47' AS DATETIME)
		OR (wp_posts.ID < 28)
		)
ORDER BY wp_posts.post_title ASC
	,wp_posts.ID DESC LIMIT 0
	,6
```

Which is clearly wrong too. No `post_title`!

After this PR is applied the second page matches what is seen in the wp-admin and the SQL query is

```sql
SELECT wp_posts.ID
FROM wp_posts
WHERE 1 = 1
	AND wp_posts.post_parent = 0
	AND wp_posts.post_type = 'post'
	AND ((wp_posts.post_status = 'publish'))
	AND wp_posts.post_title >= 'foo'
	AND (
		wp_posts.post_title > 'foo'
		OR (wp_posts.ID < 28)
		)
ORDER BY wp_posts.post_title ASC
	,wp_posts.ID DESC LIMIT 0
	,6
```

and the result

![image](https://user-images.githubusercontent.com/225712/58232519-60642480-7d42-11e9-9839-9096ec5ec0d4.png)


Does this close any currently open issues?
------------------------------------------
Closes #818
Closes #861
Closes #862
