### PR TITLE
#869 - Fixes bugs when registering multi-word option_group name with …

### DIFF
--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -513,6 +513,11 @@ class DataSource {
 	public static function get_setting_group_fields( $group ) {
 
 		/**
+		* Convert camelCase $group to snake_case to match $settings_groups keys retrieved from WordPress
+		*/
+		$group = strtolower( preg_replace( '/(?<=[a-z])(?=[A-Z])/', '_', $group ) );
+
+		/**
 		 * Get all of the settings, sorted by group
 		 */
 		$settings_groups = self::get_allowed_settings_by_group();

--- a/src/Type/Object/Settings.php
+++ b/src/Type/Object/Settings.php
@@ -27,7 +27,7 @@ if ( ! empty( $registered_settings ) && is_array( $registered_settings ) ) {
 		} else {
 			$field_key = $key;
 		}
-		$field_key = lcfirst( $setting_field['group'] . 'Settings' . str_replace( '_', '', ucwords( $field_key, '_' ) ) );
+		$field_key = lcfirst( str_replace( '_', '', ucwords( $setting_field['group'], '_' ) ) . 'Settings' . str_replace( '_', '', ucwords( $field_key, '_' ) ) );
 
 		if ( ! empty( $key ) && ! empty( $field_key ) ) {
 

--- a/src/TypeRegistry.php
+++ b/src/TypeRegistry.php
@@ -135,7 +135,7 @@ class TypeRegistry {
 		if ( ! empty( $allowed_setting_types ) && is_array( $allowed_setting_types ) ) {
 			foreach ( $allowed_setting_types as $group => $setting_type ) {
 
-				$group_name = str_replace( '_', '', strtolower( $group ) );
+				$group_name = lcfirst( str_replace( '_', '', ucwords( $group, '_' ) ) );
 				register_settings_group( $group_name );
 
 				register_graphql_field( 'RootQuery', $group_name . 'Settings', [


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Currently unable to provide multi-word WordPress `$option_group` names in `snake_case` as demonstrated in the WordPress & WPGraphQL docs without a few bugs.

1) Unable to query setting fields in a custom settings group unless the `$option_group` name was registered as a single word.
2) Querying setting fields with `allSettings` works, however the naming convention is mixed. For example, if the registered `$option_group` is `my_options_group` and `$option_name` is `my_option_name`, the resulting setting name to query with would be `my_options_groupSettingsMyOptionName`. I'm not sure if this is intended but it doesn't feel right. One would expect it to be all camel case `myOptionsGroupSettingsMyOptionName`.

Properly converting the `$option_group` name to `camelCase` in `TypeRegistry` and `Settings` and back to `snake_case` in `DataSource` fixes the bugs.  

Does this close any currently open issues?
------------------------------------------
Issue #869


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
This is the first PR I've ever submitted. I apologize in advance if I did anything wrong.


Where has this been tested?
---------------------------
**Operating System:** MacOS Mojave 10.14.4

**WordPress Version:** 5.1