### PR TITLE
Create WPSchema config variable

### DIFF
--- a/src/WPSchema.php
+++ b/src/WPSchema.php
@@ -3,6 +3,8 @@
 namespace WPGraphQL;
 
 use GraphQL\Type\Schema;
+use GraphQL\Type\SchemaConfig;
+
 
 /**
  * Class WPSchema
@@ -12,6 +14,11 @@ use GraphQL\Type\Schema;
  * @package WPGraphQL
  */
 class WPSchema extends Schema {
+
+	/**
+	 * @var SchemaConfig
+	 */
+	public $config;
 
 	/**
 	 * Holds the $filterable_config which allows WordPress access to modifying the
@@ -30,6 +37,8 @@ class WPSchema extends Schema {
 	 * @since 0.0.9
 	 */
 	public function __construct( $config ) {
+
+		$this->config = $config;
 
 		/**
 		 * Set the $filterable_config as the $config that was passed to the WPSchema when instantiated


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
_PHPStorm complains that the $schema->config[] variable is private at https://github.com/wp-graphql/wp-graphql/blob/develop/src/Utils/InstrumentSchema.php#L53_

_The warning is caused by the IDE assuming a connection to the webonyx/Type/Schema->config[] rather than the explicitly defined \WPGraphQL\WPSchema object_. 

_The misconnection was due to the config variable not being created in WPSchema._ 

_I added the definition and the constructor's instantiation of the variable in \WPGraphQL\WPSchema.php._


Does this close any currently open issues?
------------------------------------------
_NO_


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
_NOTE: It didn't seem to cause any runtime errors; it was just an IDE warning that I wanted to remove. Hopefully it will avoid confusion in the future (and, who knows, it may even avoid runtime errors)._


Where has this been tested?
---------------------------
**Operating System:** _MacOS Mojave using Docker; so...
Linux 4.9.125-linuxkit x86_64
PHP 7.3.5 
PHPStorm 2019.1.1_

**WordPress Version:** _5.2_
