### PR TITLE
CI-6718 | updating software used by Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,9 @@ env:
 
     # Disabling PHP 5.6 tests until "composer.lock" is updated to work with PHP 7.X AND 5.6.
     # - WP_VERSION=5.0.2 PHP_VERSION=5.6
-    - WP_VERSION=5.2.0 PHP_VERSION=7.1
-    - WP_VERSION=5.2.0 PHP_VERSION=7.2
-    - WP_VERSION=5.2.0 PHP_VERSION=7.3 COVERAGE=true LINT_SCHEMA=true
+    - WP_VERSION=5.2.2 PHP_VERSION=7.1
+    - WP_VERSION=5.2.2 PHP_VERSION=7.2
+    - WP_VERSION=5.2.2 PHP_VERSION=7.3 COVERAGE=true LINT_SCHEMA=true
     - PHPCS=true
 
 matrix:
@@ -36,7 +36,7 @@ matrix:
 
 before_install:
   - sudo rm /usr/local/bin/docker-compose
-  - curl -L https://github.com/docker/compose/releases/download/1.24.0/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/1.24.1/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
   - |

--- a/Dockerfile.test-base
+++ b/Dockerfile.test-base
@@ -26,7 +26,7 @@ RUN echo 'date.timezone = "UTC"' > /usr/local/etc/php/conf.d/timezone.ini \
         docker-php-ext-enable xdebug; \
      fi \
   && docker-php-ext-install pdo_mysql \
-  && curl -Ls 'https://raw.githubusercontent.com/composer/getcomposer.org/ffdc3c7fcb7c0f2a806508a868a35d13177a5a51/web/installer' | php -- --quiet \
+  && curl -Ls 'https://raw.githubusercontent.com/composer/getcomposer.org/3c21a2c1affd88dd3fec6251e91a53e440bc2198/web/installer' | php -- --quiet \
   && chmod +x composer.phar \
   && mv composer.phar /usr/local/bin/composer \
   && curl -O 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar' \

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Notes:
   
 
 #### Updating WP Docker software versions
-Make sure the `docker-compose*.yml` files refer to the most recent and specific version of the official WordPress Docker and MySQL compatible images.
+Make sure the `docker/docker-compose*.yml` files refer to the most recent and specific version of the official WordPress Docker and MySQL compatible images.
 Please avoid using the `latest` Docker tag. Once Docker caches a Docker image for a given tag onto your machine, it won't automatically
 check for updates. Using an actual version number ensures Docker image caches are updated at the right time.
 

--- a/docker/docker-compose.local-app-xdebug.yml
+++ b/docker/docker-compose.local-app-xdebug.yml
@@ -7,7 +7,7 @@ services:
       context: '../'
       dockerfile: 'Dockerfile.xdebug'
       args:
-        DESIRED_WP_VERSION: "${WP_VERSION:-5.2.0}"
+        DESIRED_WP_VERSION: "${WP_VERSION:-5.2.2}"
         DESIRED_PHP_VERSION: "${PHP_VERSION:-7.3}"
     image: 'wordpress-utc-xdebug-cache'
     environment:

--- a/docker/docker-compose.local-app.yml
+++ b/docker/docker-compose.local-app.yml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   wpgraphql.test:
-    image: "wordpress:${WP_VERSION:-5.2.0}-php${PHP_VERSION:-7.3}-apache"
+    image: "wordpress:${WP_VERSION:-5.2.2}-php${PHP_VERSION:-7.3}-apache"
     ports:
       - '8000:80'
     environment:
@@ -19,7 +19,7 @@ services:
       - './uploads.txt:/usr/local/etc/php/conf.d/uploads.ini:ro'
 
   mysql_test:
-    image: 'mariadb:10.2.24-bionic'
+    image: 'mariadb:10.2.25-bionic'
     ports:
       # Have Docker forward a randomly assigned host port to this site's MySQL container port
       - '3306'

--- a/docker/docker-compose.tests.yml
+++ b/docker/docker-compose.tests.yml
@@ -6,7 +6,7 @@ services:
       context: '../'
       dockerfile: 'Dockerfile.test-base'
       args:
-        DESIRED_WP_VERSION: "${WP_VERSION:-5.2.0}"
+        DESIRED_WP_VERSION: "${WP_VERSION:-5.2.2}"
         DESIRED_PHP_VERSION: "${PHP_VERSION:-7.3}"
     image: 'wordpress-wp-graphql-test-base'
     container_name: 'wpgraphql-tester'
@@ -28,7 +28,7 @@ services:
       context: '../'
       dockerfile: 'Dockerfile.test-base'
       args:
-        DESIRED_WP_VERSION: "${WP_VERSION:-5.2.0}"
+        DESIRED_WP_VERSION: "${WP_VERSION:-5.2.2}"
         DESIRED_PHP_VERSION: "${PHP_VERSION:-7.3}"
     image: 'wordpress-wp-graphql-test-base'
     environment:
@@ -43,7 +43,7 @@ services:
     entrypoint: [ "docker-entrypoint.sut.sh" ]
 
   mysql_test:
-    image: 'mariadb:10.2.24-bionic'
+    image: 'mariadb:10.2.25-bionic'
     environment:
       MYSQL_DATABASE: 'wpgraphql_test'
       MYSQL_ROOT_PASSWORD: 'testing'


### PR DESCRIPTION

What does this implement/fix? Explain your changes.
---------------------------------------------------
* Updating Travis and Docker to run with WP 5.2.2 + MariaDB 10.2.25
* Updating PHP COmposer version used in Docker


Does this close any currently open issues?
------------------------------------------
N/A


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
N/A

Any other comments?
-------------------
N/A


Where has this been tested?
---------------------------
**Operating System:** 
OS X Mojave

**WordPress Version:**
5.2.2
