### PR TITLE
filter plugins by status

### DIFF
--- a/src/Connection/Plugins.php
+++ b/src/Connection/Plugins.php
@@ -19,13 +19,39 @@ class Plugins {
 	 * @access public
 	 */
 	public static function register_connections() {
+
+		$connection_args = self::get_connection_args();
+
 		register_graphql_connection( [
 			'fromType'      => 'RootQuery',
 			'toType'        => 'Plugin',
 			'fromFieldName' => 'plugins',
+			'connectionArgs'   => $connection_args,
 			'resolve'       => function ( $root, $args, $context, $info ) {
 				return DataSource::resolve_plugins_connection( $root, $args, $context, $info );
 			},
 		] );
+	}
+
+	/**
+	 * Given an optional array of args, this returns the args to be used in the connection
+	 *
+	 * @access public
+	 * @param array $args The args to modify the defaults
+	 *
+	 * @return array
+	 */
+	public static function get_connection_args( $args = [] ) {
+
+		return array_merge( [
+
+			/**
+			 * Status parameters
+			 */
+			'status'       => [
+				'type' => 'PluginStatusEnum',
+			],
+
+		], $args );
 	}
 }

--- a/src/Data/Connection/PluginConnectionResolver.php
+++ b/src/Data/Connection/PluginConnectionResolver.php
@@ -15,6 +15,78 @@ use WPGraphQL\Data\DataSource;
 class PluginConnectionResolver {
 
 	/**
+	 * Gets plugins filtered by args. 
+	 * 
+	 * @param array       $args    The query arguments
+	 * 
+	 * @return array
+	 * @access public
+	 */
+	public static function get_plugin_objects( array $args ) {
+
+		// File has not loaded.
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		// This is missing must use and drop in plugins.
+		$plugins = apply_filters( 'all_plugins', get_plugins() );
+		$mu_plugins = get_mu_plugins();
+		$dropins = get_dropins();
+		$all_plugins = array_merge( $plugins, $mu_plugins, $dropins );
+
+		if ( ! empty( $args['where']['status'] ) ) {
+			switch ( $args['where']['status'] ) {
+
+				case 'active':
+					$active_plugins = array();
+					foreach ( (array) $plugins as $plugin_file => $plugin_data ) {
+						if ( is_plugin_active( $plugin_file ) ) {
+							$active_plugins[ $plugin_file ] = $plugin_data;
+						}
+					}
+					return $active_plugins;
+
+				case 'drop_in':
+					return $dropins;
+
+				case 'inactive':
+					$inactive_plugins = array();
+					foreach ( (array) $plugins as $plugin_file => $plugin_data ) {
+						if ( ! is_plugin_active( $plugin_file ) ) {
+							$inactive_plugins[ $plugin_file ] = $plugin_data;
+						}
+					}
+					return $inactive_plugins;
+
+				case 'must_use':
+					return $mu_plugins;
+
+				case 'recently_active':
+					$recently_activated = get_site_option( 'recently_activated', array() );
+					$recently_active_plugins = array();
+					foreach ( (array) $plugins as $plugin_file => $plugin_data ) {
+						if ( isset( $recently_activated[ $plugin_file ] ) ) {
+							// Populate the recently activated list with plugins that have been recently activated
+							$recently_active_plugins[ $plugin_file ] = $plugin_data;
+						}
+					}
+					return $recently_active_plugins;
+
+				case 'upgrade':
+					$current = get_site_transient( 'update_plugins' );
+					$upgrade_plugins = array();
+					foreach ( (array) $plugins as $plugin_file => $plugin_data ) {
+						if ( isset( $current->response[ $plugin_file ] ) ) {
+							$upgrade_plugins[ $plugin_file ] = $plugin_data;
+						}
+					}
+					return $upgrade_plugins;
+
+			}
+		}
+		
+		return $all_plugins;
+	}
+
+	/**
 	 * Creates the connection for plugins
 	 *
 	 * @param mixed       $source  The query results
@@ -29,10 +101,7 @@ class PluginConnectionResolver {
 	 */
 	public static function resolve( $source, array $args, AppContext $context, ResolveInfo $info ) {
 
-		// File has not loaded.
-		require_once ABSPATH . 'wp-admin/includes/plugin.php';
-		// This is missing must use and drop in plugins.
-		$plugins = apply_filters( 'all_plugins', get_plugins() );
+		$plugins = self::get_plugin_objects( $args );
 		$plugins_array = [];
 		if ( ! empty( $plugins ) && is_array( $plugins ) ) {
 			foreach ( $plugins as $plugin ) {

--- a/src/Type/Enum/PluginStatusEnum.php
+++ b/src/Type/Enum/PluginStatusEnum.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace WPGraphQL\Type;
+
+register_graphql_enum_type( 'PluginStatusEnum', [
+	'description'  => __( 'The status of the plugin object', 'wp-graphql' ),
+	'values'       => [
+		'ACTIVE' => [
+			'value' => 'active',
+		],
+		'DROP_IN'  => [
+			'value' => 'drop_in',
+		],
+		'INACTIVE' => [
+			'value' => 'inactive',
+		],
+		'MUST_USE' => [
+			'value' => 'must_use',
+		],
+		'RECENTLY_ACTIVE' => [
+			'value' => 'recently_active',
+		],
+		'UPGRADE' => [
+			'value' => 'upgrade',
+		],
+	],
+] );

--- a/src/TypeRegistry.php
+++ b/src/TypeRegistry.php
@@ -102,6 +102,7 @@ class TypeRegistry {
 		require_once( WPGRAPHQL_PLUGIN_DIR . 'src/Type/Enum/OrderEnum.php' );
 		require_once( WPGRAPHQL_PLUGIN_DIR . 'src/Type/Object/PageInfo.php' );
 		require_once( WPGRAPHQL_PLUGIN_DIR . 'src/Type/Object/Plugin.php' );
+		require_once( WPGRAPHQL_PLUGIN_DIR . 'src/Type/Enum/PluginStatusEnum.php' );
 		require_once( WPGRAPHQL_PLUGIN_DIR . 'src/Type/Input/PostObjectsConnectionOrderbyInput.php' );
 		require_once( WPGRAPHQL_PLUGIN_DIR . 'src/Type/Enum/PostObjectsConnectionOrderbyEnum.php' );
 		require_once( WPGRAPHQL_PLUGIN_DIR . 'src/Type/Enum/PostObjectsConnectionDateColumnEnum.php' );


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
Allows plugins to be filtered by their status (active, recently active, inactive, must-use, drop-in and upgrade)


Does this close any currently open issues?
------------------------------------------
#178 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
N/A

Any other comments?
-------------------
I am a first time contributor at WPGraphQL. Would really appreciate any feedback.


Where has this been tested?
---------------------------
**Operating System:** Docker, MacOS Mojave

**WordPress Version:** 5.2.2
