### PR TITLE
#897 - Cursor pagination does not preserve order with the "search" where arg

### DIFF
--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -266,6 +266,18 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		}
 
 		/**
+		 * If the query contains search default the results to
+		 */
+		if ( isset( $query_args['s'] ) && ! empty( $query_args['s'] ) ) {
+			/**
+			 * Don't order search results by title (causes funky issues with cursors)
+			 */
+			$query_args['search_orderby_title'] = false;
+			$query_args['orderby'] = 'date';
+			$query_args['order'] = isset( $last ) ? 'ASC' : 'DESC';
+		}
+
+		/**
 		 * If there's no orderby params in the inputArgs, set order based on the first/last argument
 		 */
 		if ( empty( $query_args['orderby'] ) ) {

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -19,6 +19,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 
 	/**
 	 * The name of the post type, or array of post types the connection resolver is resolving for
+	 *
 	 * @var mixed string|array
 	 */
 	protected $post_type;
@@ -273,8 +274,8 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 			 * Don't order search results by title (causes funky issues with cursors)
 			 */
 			$query_args['search_orderby_title'] = false;
-			$query_args['orderby'] = 'date';
-			$query_args['order'] = isset( $last ) ? 'ASC' : 'DESC';
+			$query_args['orderby']              = 'date';
+			$query_args['order']                = isset( $last ) ? 'ASC' : 'DESC';
 		}
 
 		/**
@@ -354,8 +355,8 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		$query_args = Types::map_input( $where_args, $arg_mapping );
 
 		if ( ! empty( $query_args['post_status'] ) ) {
-			$allowed_stati =  $this->sanitize_post_stati( $query_args['post_status'] );
-			$query_args['post_status'] = ! empty( $allowed_stati ) ? $allowed_stati : ['publish'];
+			$allowed_stati             = $this->sanitize_post_stati( $query_args['post_status'] );
+			$query_args['post_status'] = ! empty( $allowed_stati ) ? $allowed_stati : [ 'publish' ];
 		}
 
 		/**
@@ -363,13 +364,13 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		 * This allows plugins/themes to hook in and alter what $args should be allowed to be passed
 		 * from a GraphQL Query to the WP_Query
 		 *
-		 * @param array       $query_args The mapped query arguments
-		 * @param array       $args       Query "where" args
-		 * @param mixed       $source     The query results for a query calling this
-		 * @param array       $all_args   All of the arguments for the query (not just the "where" args)
-		 * @param AppContext  $context    The AppContext object
-		 * @param ResolveInfo $info       The ResolveInfo object
-		 * @param mixed|string|array      $post_type  The post type for the query
+		 * @param array              $query_args The mapped query arguments
+		 * @param array              $args       Query "where" args
+		 * @param mixed              $source     The query results for a query calling this
+		 * @param array              $all_args   All of the arguments for the query (not just the "where" args)
+		 * @param AppContext         $context    The AppContext object
+		 * @param ResolveInfo        $info       The ResolveInfo object
+		 * @param mixed|string|array $post_type  The post type for the query
 		 *
 		 * @since 0.0.5
 		 * @return array
@@ -408,12 +409,12 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		/**
 		 * Parse the list of stati
 		 */
-		$statuses         = wp_parse_slug_list( $stati );
+		$statuses = wp_parse_slug_list( $stati );
 
 		/**
 		 * Get the Post Type object
 		 */
-		$post_type_obj    = get_post_type_object( $this->post_type );
+		$post_type_obj = get_post_type_object( $this->post_type );
 
 		/**
 		 * Make sure the statuses are allowed to be queried by the current user. If so, allow it,

--- a/src/Data/Cursor/PostObjectCursor.php
+++ b/src/Data/Cursor/PostObjectCursor.php
@@ -121,20 +121,22 @@ class PostObjectCursor {
 		$orderby = $this->get_query_var( 'orderby' );
 		$order   = $this->get_query_var( 'order' );
 
-
 		if ( ! empty( $orderby ) && is_array( $orderby ) ) {
+
 			/**
 			 * Loop through all order keys if it is an array
 			 */
 			foreach ( $orderby as $by => $order ) {
 				$this->compare_with( $by, $order );
 			}
+
 		} else if ( ! empty( $orderby ) && is_string( $orderby ) ) {
 
 			/**
 			 * If $orderby is just a string just compare with it directly as DESC
 			 */
 			$this->compare_with( $orderby, $order );
+
 		}
 
 		/**
@@ -166,7 +168,7 @@ class PostObjectCursor {
 	 */
 	private function compare_with( $by, $order ) {
 
-		switch( $by ) {
+		switch ( $by ) {
 			case 'author':
 			case 'title':
 			case 'type':
@@ -178,7 +180,7 @@ class PostObjectCursor {
 				break;
 		}
 
-		$value      = $this->get_cursor_post()->{$by};
+		$value = $this->get_cursor_post()->{$by};
 
 		/**
 		 * Compare by the post field if the key matches an value

--- a/src/Data/Cursor/PostObjectCursor.php
+++ b/src/Data/Cursor/PostObjectCursor.php
@@ -121,6 +121,7 @@ class PostObjectCursor {
 		$orderby = $this->get_query_var( 'orderby' );
 		$order   = $this->get_query_var( 'order' );
 
+
 		if ( ! empty( $orderby ) && is_array( $orderby ) ) {
 			/**
 			 * Loop through all order keys if it is an array
@@ -129,6 +130,7 @@ class PostObjectCursor {
 				$this->compare_with( $by, $order );
 			}
 		} else if ( ! empty( $orderby ) && is_string( $orderby ) ) {
+
 			/**
 			 * If $orderby is just a string just compare with it directly as DESC
 			 */
@@ -163,6 +165,18 @@ class PostObjectCursor {
 	 * @return string
 	 */
 	private function compare_with( $by, $order ) {
+
+		switch( $by ) {
+			case 'author':
+			case 'title':
+			case 'type':
+			case 'name':
+			case 'modified':
+			case 'date':
+			case 'parent':
+				$by = 'post_' . $by;
+				break;
+		}
 
 		$value      = $this->get_cursor_post()->{$by};
 

--- a/tests/wpunit/PostObjectConnectionQueriesTest.php
+++ b/tests/wpunit/PostObjectConnectionQueriesTest.php
@@ -17,9 +17,9 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$this->admin            = $this->factory()->user->create( [
 			'role' => 'administrator',
 		] );
-		$this->subscriber = $this->factory()->user->create( [
+		$this->subscriber       = $this->factory()->user->create( [
 			'role' => 'subscriber'
-		]);
+		] );
 
 		$this->created_post_ids = $this->create_posts();
 
@@ -38,15 +38,15 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		 * Set up the $defaults
 		 */
 		$defaults = [
-			'post_author'  => $this->admin,
-			'post_content' => 'Test page content',
-			'post_excerpt' => 'Test excerpt',
-			'post_status'  => 'publish',
-			'post_title'   => 'Test Title',
-			'post_type'    => 'post',
-			'post_date'    => $this->current_date,
-			'has_password' => false,
-			'post_password'=> null,
+			'post_author'   => $this->admin,
+			'post_content'  => 'Test page content',
+			'post_excerpt'  => 'Test excerpt',
+			'post_status'   => 'publish',
+			'post_title'    => 'Test Title',
+			'post_type'     => 'post',
+			'post_date'     => $this->current_date,
+			'has_password'  => false,
+			'post_password' => null,
 		];
 
 		/**
@@ -80,6 +80,7 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 	 * Creates several posts (with different timestamps) for use in cursor query tests
 	 *
 	 * @param  int $count Number of posts to create.
+	 *
 	 * @return array
 	 */
 	public function create_posts( $count = 20 ) {
@@ -139,7 +140,7 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 		if ( empty( $field ) ) {
 			return $data;
-		} else if ( ! empty( $data )) {
+		} else if ( ! empty( $data ) ) {
 			$data = $data[ $field ];
 		}
 
@@ -430,12 +431,17 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$private_post = $this->createPostObject( [
 			'post_status' => 'private',
 		] );
-		$public_post = $this->createPostObject( [
+		$public_post  = $this->createPostObject( [
 			'post_status' => 'publish',
 		] );
 
 		wp_set_current_user( $this->subscriber );
-		$actual = $this->postsQuery( [ 'where' => [ 'in' => [ $private_post, $public_post ], 'stati' => [ 'PUBLISH', 'PRIVATE' ] ] ] );
+		$actual = $this->postsQuery( [
+			'where' => [
+				'in'    => [ $private_post, $public_post ],
+				'stati' => [ 'PUBLISH', 'PRIVATE' ]
+			]
+		] );
 
 		$this->assertCount( 1, $actual['data']['posts']['edges'] );
 		$this->assertNotEmpty( $this->getReturnField( $actual, 0, 'id' ) );
@@ -446,7 +452,7 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 	public function testPrivatePostsWithProperCaps() {
 
 		$post_args = [
-			'post_title' => 'Private post WITH caps',
+			'post_title'  => 'Private post WITH caps',
 			'post_status' => 'private',
 			'post_author' => $this->subscriber,
 		];
@@ -454,7 +460,12 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$post_id = $this->createPostObject( $post_args );
 
 		wp_set_current_user( $this->admin );
-		$actual = $this->postsQuery( [ 'where' => [ 'in' => [ $post_id ], 'stati' => [ 'PUBLISH', 'PRIVATE' ] ] ] );
+		$actual = $this->postsQuery( [
+			'where' => [
+				'in'    => [ $post_id ],
+				'stati' => [ 'PUBLISH', 'PRIVATE' ]
+			]
+		] );
 		$this->assertEquals( $post_args['post_title'], $this->getReturnField( $actual, 0, 'title' ) );
 
 	}
@@ -462,7 +473,7 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 	public function testPrivatePostsForCurrentUser() {
 
 		$post_args = [
-			'post_title' => 'Private post WITH caps',
+			'post_title'  => 'Private post WITH caps',
 			'post_status' => 'private',
 			'post_author' => $this->subscriber,
 		];
@@ -470,7 +481,12 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$post_id = $this->createPostObject( $post_args );
 
 		wp_set_current_user( $this->subscriber );
-		$actual = $this->postsQuery( [ 'where' => [ 'in' => [ $post_id ], 'stati' => [ 'PUBLISH', 'PRIVATE' ] ] ] );
+		$actual = $this->postsQuery( [
+			'where' => [
+				'in'    => [ $post_id ],
+				'stati' => [ 'PUBLISH', 'PRIVATE' ]
+			]
+		] );
 
 		/**
 		 * Since we're querying for a private post, we want to make sure a subscriber, even if they
@@ -500,8 +516,8 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 	public function testRevisionWithoutProperCaps( $role, $show_revisions ) {
 
 		$parent_post = $this->createPostObject( [] );
-		$revision = $this->createPostObject( [
-			'post_type' => 'revision',
+		$revision    = $this->createPostObject( [
+			'post_type'   => 'revision',
 			'post_parent' => $parent_post,
 			'post_status' => 'inherit',
 		] );
@@ -550,16 +566,21 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 	public function testDraftPosts( $role, $show_draft ) {
 
 		$public_post = $this->createPostObject( [] );
-		$draft_args = [
-			'post_title' => 'Draft Title',
+		$draft_args  = [
+			'post_title'   => 'Draft Title',
 			'post_content' => 'Draft Post Content Here',
-			'post_status' => 'draft',
+			'post_status'  => 'draft',
 		];
-		$draft_post = $this->createPostObject( $draft_args );
+		$draft_post  = $this->createPostObject( $draft_args );
 
 		wp_set_current_user( $this->{$role} );
 
-		$actual = $this->postsQuery( [ 'where' => [ 'in' => [ $public_post, $draft_post ], 'stati' => [ 'PUBLISH', 'DRAFT' ] ] ] );
+		$actual = $this->postsQuery( [
+			'where' => [
+				'in'    => [ $public_post, $draft_post ],
+				'stati' => [ 'PUBLISH', 'DRAFT' ]
+			]
+		] );
 
 		if ( 'admin' === $role ) {
 
@@ -597,16 +618,21 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 	public function testTrashPosts( $role, $show_trash ) {
 
 		$public_post = $this->createPostObject( [] );
-		$draft_args = [
-			'post_title' => 'Trash Title',
+		$draft_args  = [
+			'post_title'   => 'Trash Title',
 			'post_content' => 'Trash Post Content Here',
-			'post_status' => 'trash',
+			'post_status'  => 'trash',
 		];
-		$draft_post = $this->createPostObject( $draft_args );
+		$draft_post  = $this->createPostObject( $draft_args );
 
 		wp_set_current_user( $this->{$role} );
 
-		$actual = $this->postsQuery( [ 'where' => [ 'in' => [ $public_post, $draft_post ], 'stati' => [ 'PUBLISH', 'TRASH' ] ] ] );
+		$actual = $this->postsQuery( [
+			'where' => [
+				'in'    => [ $public_post, $draft_post ],
+				'stati' => [ 'PUBLISH', 'TRASH' ]
+			]
+		] );
 
 		if ( 'admin' === $role ) {
 			/**
@@ -615,7 +641,7 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 			$this->assertNotEmpty( $actual['data']['posts']['edges'] );
 			$this->assertCount( 2, $actual['data']['posts']['edges'] );
 			$this->assertNotNull( $this->getReturnField( $actual, 1, 'id' ) );
-			$content_field =  $this->getReturnField( $actual, 1, 'content' );
+			$content_field = $this->getReturnField( $actual, 1, 'content' );
 			$excerpt_field = $this->getReturnField( $actual, 1, 'excerpt' );
 
 			if ( true === $show_trash ) {
@@ -647,6 +673,5 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 			]
 		];
 	}
-
 
 }

--- a/tests/wpunit/PostObjectSearchTest.php
+++ b/tests/wpunit/PostObjectSearchTest.php
@@ -1,0 +1,221 @@
+<?php
+
+class PostObjectSearchTest extends \Codeception\TestCase\WPTestCase {
+	public $current_time;
+	public $current_date;
+	public $current_date_gmt;
+	public $created_post_ids;
+	public $admin;
+	public $query;
+	public $app_context;
+	public $app_info;
+	public $subscriber;
+
+	public function setUp() {
+
+		parent::setUp();
+
+		global $wpdb;
+		$wpdb->delete( $wpdb->prefix . 'posts', array( 'post_type' => 'post' ) );
+
+		$this->current_time     = strtotime( '- 1 day' );
+		$this->current_date     = date( 'Y-m-d H:i:s', $this->current_time );
+		$this->current_date_gmt = gmdate( 'Y-m-d H:i:s', $this->current_time );
+		$this->admin            = $this->factory()->user->create( [
+			'role' => 'administrator',
+		] );
+		$this->subscriber = $this->factory()->user->create( [
+			'role' => 'subscriber'
+		]);
+
+		$this->created_post_ids = $this->create_posts();
+
+		$this->app_context = new \WPGraphQL\AppContext();
+
+		$this->app_info = new \GraphQL\Type\Definition\ResolveInfo( array() );
+
+		$this->query = '
+		query GET_POSTS($first: Int, $last: Int, $after: String, $before: String $where:RootQueryToPostConnectionWhereArgs) {
+		  posts(last: $last, before: $before, first: $first, after: $after, where:$where) {
+		    pageInfo {
+		      hasPreviousPage
+		      hasNextPage
+		      startCursor
+		      endCursor
+		    }
+		    edges {
+		      cursor
+		      node {
+		        id
+		        postId
+		        date
+		        title
+		      }
+		    }
+		  }
+		}
+		';
+
+
+	}
+
+	public function tearDown() {
+		global $wpdb;
+		$wpdb->delete( $wpdb->prefix . 'posts', array( 'post_type' => 'post' ) );
+		parent::tearDown();
+	}
+
+	public function createPostObject( $args ) {
+
+		/**
+		 * Set up the $defaults
+		 */
+		$defaults = [
+			'post_author'  => $this->admin,
+			'post_content' => 'test',
+			'post_excerpt' => 'Test excerpt',
+			'post_status'  => 'publish',
+			'post_title'   => 'Test Title',
+			'post_type'    => 'post',
+			'post_date'    => $this->current_date,
+			'has_password' => false,
+			'post_password'=> null,
+		];
+
+		/**
+		 * Combine the defaults with the $args that were
+		 * passed through
+		 */
+		$args = array_merge( $defaults, $args );
+
+		/**
+		 * Create the page
+		 */
+		$post_id = $this->factory->post->create( $args );
+
+		/**
+		 * Update the _edit_last and _edit_lock fields to simulate a user editing the page to
+		 * test retrieving the fields
+		 *
+		 * @since 0.0.5
+		 */
+		update_post_meta( $post_id, '_edit_lock', $this->current_time . ':' . $this->admin );
+		update_post_meta( $post_id, '_edit_last', $this->admin );
+
+		/**
+		 * Return the $id of the post_object that was created
+		 */
+		return $post_id;
+
+	}
+
+	/**
+	 * Creates several posts (with different timestamps) for use in cursor query tests
+	 *
+	 * @param  int $count Number of posts to create.
+	 * @return array
+	 */
+	public function create_posts( $count = 20 ) {
+
+		// Create posts
+		$created_posts = [];
+		for ( $i = 1; $i <= $count; $i ++ ) {
+			// Set the date 1 minute apart for each post
+			$date                = date( 'Y-m-d H:i:s', strtotime( "-1 day +{$i} minutes" ) );
+			$created_posts[ $i ] = $this->createPostObject( [
+				'post_type'   => 'post',
+				'post_date'   => $date,
+				'post_status' => 'publish',
+				'post_title'  => 'search | ' . $i,
+			] );
+		}
+
+		return $created_posts;
+
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function testSearchPostsForwardPagination() {
+
+		$actual = graphql([
+			'query' => $this->query,
+			'variables' => [
+				'first' => 2,
+				'where' => [
+					'search' => 'test'
+				]
+			]
+		]);
+
+		codecept_debug( $actual );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEquals( $this->created_post_ids[20], $actual['data']['posts']['edges'][0]['node']['postId'] );
+		$this->assertEquals( $this->created_post_ids[19], $actual['data']['posts']['edges'][1]['node']['postId'] );
+
+		$actual = graphql([
+			'query' => $this->query,
+			'variables' => [
+				'first' => 2,
+				'after' => $actual['data']['posts']['pageInfo']['endCursor'],
+				'where' => [
+					'search' => 'test'
+				]
+			]
+		]);
+
+		codecept_debug( $actual );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEquals( $this->created_post_ids[18], $actual['data']['posts']['edges'][0]['node']['postId'] );
+		$this->assertEquals( $this->created_post_ids[17], $actual['data']['posts']['edges'][1]['node']['postId'] );
+
+
+	}
+
+	/**
+	 * Tests the backward pagination of connections
+	 * @throws Exception
+	 */
+	public function testSearchPostsBackwardPagination() {
+
+		$actual = graphql([
+			'query' => $this->query,
+			'variables' => [
+				'last' => 2,
+				'where' => [
+					'search' => 'test'
+				]
+			]
+		]);
+
+		codecept_debug( $actual );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEquals( $this->created_post_ids[2], $actual['data']['posts']['edges'][0]['node']['postId'] );
+		$this->assertEquals( $this->created_post_ids[1], $actual['data']['posts']['edges'][1]['node']['postId'] );
+
+		$actual = graphql([
+			'query' => $this->query,
+			'variables' => [
+				'last' => 2,
+				'before' => $actual['data']['posts']['pageInfo']['startCursor'],
+				'where' => [
+					'search' => 'test'
+				]
+			]
+		]);
+
+		codecept_debug( $actual );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEquals( $this->created_post_ids[4], $actual['data']['posts']['edges'][0]['node']['postId'] );
+		$this->assertEquals( $this->created_post_ids[3], $actual['data']['posts']['edges'][1]['node']['postId'] );
+
+	}
+
+}
+
+


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
WP_Query applies default ordering by title when the "s" arg is passed to it, which was causing funky issues with WPGraphQL Cursor Pagination.

This sets the `search_orderby_title` to false, and defaults to orderby date. Custom orderby options can be passed to the connection as well.


Does this close any currently open issues?
------------------------------------------
#897 

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
To test, I created 4 posts with the word "floof" as the content. 

In the admin, you can see a search for "floof" shows posts: `Four, Three, Two, One"

![Screen Shot 2019-07-09 at 2 13 50 PM](https://user-images.githubusercontent.com/1260765/60919828-e9341280-a253-11e9-8dad-2c188c2e7fe5.png)

### Query the last 2

Here, I query for the `last: 2` items, and as expected, we get Posts `Two` and `One`.

#### Query
```graphql
query GET_POSTS($first: Int, $last: Int, $after: String, $before: String, $where: RootQueryToPostConnectionWhereArgs) {
  posts(last: $last, before: $before, first: $first, after: $after, where: $where) {
    pageInfo {
      hasPreviousPage
      hasNextPage
      startCursor
      endCursor
    }
    edges {
      cursor
      node {
        id
        date
        title
      }
    }
  }
}
```

#### Variables
```json
{
  "last": 2,
  "before": "YXJyYXljb25uZWN0aW9uOjEzOTc=",
  "where": {
    "search": "floof"
  }
}
```

#### Screenshot of results
![Screen Shot 2019-07-09 at 2 15 29 PM](https://user-images.githubusercontent.com/1260765/60919901-20a2bf00-a254-11e9-8abc-b835c4e749cf.png)

### Query with before cursor

Now, if we execute the same query, but use the `startCursor` from the previous query results as the value for the `before` input we get items `Four` and `Three`:

#### Variables
```json
{
  "last": 2,
  "before": "YXJyYXljb25uZWN0aW9uOjEzOTc=",
  "where": {
    "search": "floof"
  }
}
```

#### Screenshot of paginated query
![Screen Shot 2019-07-09 at 2 17 54 PM](https://user-images.githubusercontent.com/1260765/60919988-5ba4f280-a254-11e9-961f-595ec877fe9f.png)

Any other comments
---------------------------
Tests are included for forward and backward pagination using the `{where: { search: ""} }` argument

Where has this been tested?
---------------------------
**Operating System:** Mac OSX 10.14.5
**WordPress Version:** WordPress v5.2.2
