### PR TITLE
Fix docker test env

### DIFF
--- a/Dockerfile.test-base
+++ b/Dockerfile.test-base
@@ -19,7 +19,7 @@ FROM ${OFFICIAL_WORDPRESS_DOCKER_IMAGE}
 # Set timezone, install XDebug, PHP Composer, WP-CLI
 RUN echo 'date.timezone = "UTC"' > /usr/local/etc/php/conf.d/timezone.ini \
   && apt-get update -y \
-  && apt-get install --no-install-recommends -y mysql-client subversion \
+  && apt-get install --no-install-recommends -y mariadb-client subversion \
   && rm -rf /var/lib/apt/lists/* \
   && if echo "${PHP_VERSION}" | grep '^7'; then \
         pecl install xdebug; \


### PR DESCRIPTION
mysql-client has been renamed to mariadb-client


What does this implement/fix? Explain your changes.
---------------------------------------------------
Fix the `run-docker-test-environment.sh` script error with

```
Package mysql-client is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
```




