### PR TITLE
Fix incorrect enum for contentType field in Comments Connection schema

### DIFF
--- a/src/Connection/Comments.php
+++ b/src/Connection/Comments.php
@@ -231,7 +231,7 @@ class Comments {
 			],
 			'contentType'        => [
 				'type'        => [
-					'list_of' => 'PostStatusEnum',
+					'list_of' => 'PostTypeEnum',
 				],
 				'description' => __( 'Content object type or array of types to retrieve affiliated comments for. Pass \'any\' to match any value.', 'wp-graphql' ),
 			],


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
I was writing unit tests for CommentsQueryConnection and noticed an incorrect enum for contentType field in Comments Connection schema. This PR fixes it.


Does this close any currently open issues?
------------------------------------------
No issue opened


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** MacOS Mojave

**WordPress Version:** 5.2.2
