### PR TITLE
CI-6732 | updating php composer and mariadb Docker versions

### DIFF
--- a/Dockerfile.test-base
+++ b/Dockerfile.test-base
@@ -26,7 +26,7 @@ RUN echo 'date.timezone = "UTC"' > /usr/local/etc/php/conf.d/timezone.ini \
         docker-php-ext-enable xdebug; \
      fi \
   && docker-php-ext-install pdo_mysql \
-  && curl -Ls 'https://raw.githubusercontent.com/composer/getcomposer.org/3c21a2c1affd88dd3fec6251e91a53e440bc2198/web/installer' | php -- --quiet \
+  && curl -Ls 'https://raw.githubusercontent.com/composer/getcomposer.org/ba13e3fc70f1c66250d1ea7ea4911d593aa1dba5/web/installer' | php -- --quiet \
   && chmod +x composer.phar \
   && mv composer.phar /usr/local/bin/composer \
   && curl -O 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar' \

--- a/docker/docker-compose.local-app.yml
+++ b/docker/docker-compose.local-app.yml
@@ -19,7 +19,7 @@ services:
       - './uploads.txt:/usr/local/etc/php/conf.d/uploads.ini:ro'
 
   mysql_test:
-    image: 'mariadb:10.2.25-bionic'
+    image: 'mariadb:10.2.26-bionic'
     ports:
       # Have Docker forward a randomly assigned host port to this site's MySQL container port
       - '3306'

--- a/docker/docker-compose.tests.yml
+++ b/docker/docker-compose.tests.yml
@@ -43,7 +43,7 @@ services:
     entrypoint: [ "docker-entrypoint.sut.sh" ]
 
   mysql_test:
-    image: 'mariadb:10.2.25-bionic'
+    image: 'mariadb:10.2.26-bionic'
     environment:
       MYSQL_DATABASE: 'wpgraphql_test'
       MYSQL_ROOT_PASSWORD: 'testing'


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- updating PHP composer version used in Docker image
- updating MariaDB version used by Docker Compose

Does this close any currently open issues?
------------------------------------------
N/A


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
N/A


Any other comments?
-------------------
N/A


Where has this been tested?
---------------------------
**Operating System:** OS X Mojave

**WordPress Version:** 5.2.2
