### PR TITLE
#935 - Check for authentication errors prior to execution.

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -175,6 +175,7 @@ class Request {
 	 * execution if Authentication errors exist.
 	 *
 	 * @param $authentication_errors
+	 * @access protected
 	 *
 	 * @return boolean
 	 */
@@ -194,6 +195,7 @@ class Request {
 	 *                                     single object for individual requests
 	 *
 	 * @return array
+	 * @access private
 	 *
 	 * @throws \Exception
 	 */


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This adds a check for authentication errors prior to execution of the request. 

If there are no authentication errors, execution proceeds as normal. If there are authentication errors, a 403 is returned and execution is prevented.

Does this close any currently open issues?
------------------------------------------
fixes #935 
also related: https://github.com/wp-graphql/wp-graphql-jwt-authentication/issues/38
