### PR TITLE
Allow filtering of User connection query args

### DIFF
--- a/src/Data/Connection/UserConnectionResolver.php
+++ b/src/Data/Connection/UserConnectionResolver.php
@@ -77,6 +77,20 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 			$query_args['has_published_posts'] = true;
 		}
 
+		/**
+		 * Filter the query_args that should be applied to the query. This filter is applied AFTER the input args from
+		 * the GraphQL Query have been applied and has the potential to override the GraphQL Query Input Args.
+		 *
+		 * @param array       $query_args array of query_args being passed to the
+		 * @param mixed       $source     source passed down from the resolve tree
+		 * @param array       $args       array of arguments input in the field as part of the GraphQL query
+		 * @param AppContext  $context    object passed down the resolve tree
+		 * @param ResolveInfo $info       info about fields passed down the resolve tree
+		 *
+		 * @since 0.3.6
+		 */
+		$query_args = apply_filters( 'graphql_user_connection_query_args', $query_args, $this->source, $this->args, $this->context, $this->info );
+
 		return $query_args;
 	}
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR adds the ability to filter query args for the User connection. E.G. this is useful if someone wants to set `count_total` to `true` within their user queries.


Does this close any currently open issues?
------------------------------------------
This will close #945 


Where has this been tested?
---------------------------
**Operating System:** macOS

**WordPress Version:** 5.2.2

Have also ran the test suite locally which passed.
