### PR TITLE
Adds support for custom CPT schema definitions.

### DIFF
--- a/src/Type/Union/MenuItemObjectUnion.php
+++ b/src/Type/Union/MenuItemObjectUnion.php
@@ -52,7 +52,7 @@ register_graphql_union_type(
 				return Types::term_object( $object->taxonomyName );
 			}
 
-			return null;
+			return apply_filters( 'resolve_menu_item_type', null, $object );
 		},
 	]
 );

--- a/src/Type/Union/MenuItemObjectUnion.php
+++ b/src/Type/Union/MenuItemObjectUnion.php
@@ -52,7 +52,7 @@ register_graphql_union_type(
 				return Types::term_object( $object->taxonomyName );
 			}
 
-			return apply_filters( 'resolve_menu_item_type', null, $object );
+			return $object;
 		},
 	]
 );

--- a/src/Type/Union/PostObjectUnion.php
+++ b/src/Type/Union/PostObjectUnion.php
@@ -5,7 +5,7 @@ namespace WPGraphQL\Type;
 use WPGraphQL\Types;
 
 $possible_types     = [];
-$allowed_post_types = \WPGraphQL::get_allowed_post_types();
+$allowed_post_types = get_post_types( [ 'show_in_graphql' => true ] );
 if ( ! empty( $allowed_post_types ) && is_array( $allowed_post_types ) ) {
 	foreach ( $allowed_post_types as $allowed_post_type ) {
 		if ( empty( $possible_types[ $allowed_post_type ] ) ) {

--- a/src/Type/WPUnionType.php
+++ b/src/Type/WPUnionType.php
@@ -18,9 +18,11 @@ class WPUnionType extends UnionType {
 	/**
 	 * WPUnionType constructor.
 	 *
+	 * @param array $config The Config to setup a Union Type
+	 *
 	 * @since 0.0.30
 	 */
-	public function __construct( $config ) {
+	public function __construct( $config = [] ) {
 		/**
 		 * Set the Types to start with capitals
 		 */
@@ -37,6 +39,25 @@ class WPUnionType extends UnionType {
 		 * @return array
 		 */
 		$config['types'] = apply_filters( "graphql_{$config['name']}_possible_types", $config['types'] );
+
+		$config['resolveType'] = function( $object ) use ( $config ) {
+
+			$type = null;
+
+			if ( is_callable( $config['resolveType'] ) ) {
+				$type = call_user_func( $config['resolveType'], $object );
+			}
+
+			/**
+			 * Filter the resolve type method for all unions
+			 *
+			 * @param mixed $type The Type to resolve to, based on the object being resolved
+			 * @param mixed $object The Object being resolved
+			 * @param WPUnionType $this The WPUnionType instance
+			 */
+			return apply_filters( 'graphql_union_resolve_type', $type, $object, $this );
+
+		};
 
 		/**
 		 * Filter the config of WPUnionType

--- a/src/TypeRegistry.php
+++ b/src/TypeRegistry.php
@@ -198,15 +198,6 @@ class TypeRegistry {
 		}
 
 		/**
-		 * Register all Union Types
-		 * Unions need to be registered after other types as they reference other Types
-		 */
-		require_once WPGRAPHQL_PLUGIN_DIR . 'src/Type/Union/CommentAuthorUnion.php';
-		require_once WPGRAPHQL_PLUGIN_DIR . 'src/Type/Union/MenuItemObjectUnion.php';
-		require_once WPGRAPHQL_PLUGIN_DIR . 'src/Type/Union/PostObjectUnion.php';
-		require_once WPGRAPHQL_PLUGIN_DIR . 'src/Type/Union/TermObjectUnion.php';
-
-		/**
 		 * Register core connections
 		 */
 		Comments::register_connections();
@@ -243,6 +234,15 @@ class TypeRegistry {
 		if ( ! did_action( 'graphql_register_types' ) ) {
 			do_action( 'graphql_register_types' );
 		}
+
+		/**
+		 * Register all Union Types
+		 * Unions need to be registered after other types as they reference other Types
+		 */
+		require_once WPGRAPHQL_PLUGIN_DIR . 'src/Type/Union/CommentAuthorUnion.php';
+		require_once WPGRAPHQL_PLUGIN_DIR . 'src/Type/Union/MenuItemObjectUnion.php';
+		require_once WPGRAPHQL_PLUGIN_DIR . 'src/Type/Union/PostObjectUnion.php';
+		require_once WPGRAPHQL_PLUGIN_DIR . 'src/Type/Union/TermObjectUnion.php';
 
 	}
 


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
This implements a few changes related to opting-out of the Custom Post-Type schema design defined in `src/Type/Object/PostObject.php`  while still using some of the connected types like `MenuItemObjectUnion`.

#### Example Usage
This are the two filters being used in WooGraphQL to bypass the default post-type definition in `TypeRegistry`.

Register Product type.
```
/**
 * Registers WooCommerce post-types to be used in GraphQL schema
 *
 * @param array  $args      - allowed post-types.
 * @param string $post_type - name of taxonomy being checked.
 *
 * @return array
 */
public static function register_post_types( $args, $post_type ) {
	if ( 'product' === $post_type ) {
		$args['show_in_graphql']                = true;
		$args['graphql_single_name']         = 'Product';
		$args['graphql_plural_name']          = 'Products';
		$args['skip_graphql_type_registry'] = true;
	}
}
add_filter( 'register_post_type_args', 'register_post_types' , 10, 2 );
```

Opt-out of `WPGraphQL::get_allowed_post_types()`
```
/**
 * Filters "allowed_post_types" list if schema hasn't been defined.
 *
 * @param array $post_types  Post types registered in GraphQL schema.
 *
 * @return array
 */
public static function skip_type_registry( $post_types ) {
	return array_diff(
		$post_types,
		get_post_types(
			[
				'show_in_graphql'            => true,
				'skip_graphql_type_registry' => true,
			]
		)
	);
}
add_filter( 'graphql_post_entities_allowed_post_types', 'skip_type_registry', 10 );
```

In the example above the Product type is registered to the GraphQL schema but it's not defined by the with the rest of the CPTs in the [TypeRegistry](https://github.com/wp-graphql/wp-graphql/blob/develop/src/TypeRegistry.php#L159). However, the Product post-type can still be retrieve by direct calls to `get_post_types()` like in [MenuItemObjectUnion](https://github.com/wp-graphql/wp-graphql/blob/develop/src/Type/Union/MenuItemObjectUnion.php#L14).

Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 18.04

**WordPress Version:** 5.2
