### PR TITLE
Add github workflow to run PHP Code Sniffer on PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,3 @@
-name: CI
-
 on: pull_request
 name: Inspections
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on: pull_request
+name: Inspections
+jobs:
+  runPHPCSInspection:
+    name: Run PHPCS inspection
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Run PHPCS inspection
+      uses: rtCamp/action-phpcs-code-review@master
+      env:
+        VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+        VAULT_TOKEN: ${{ secrets.VAULT_TOKEN }}
+      with:
+        args: WordPress,WordPress-Core,WordPress-Docs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,6 @@ jobs:
     - name: Run PHPCS inspection
       uses: rtCamp/action-phpcs-code-review@master
       env:
-        VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
         VAULT_TOKEN: ${{ secrets.VAULT_TOKEN }}
       with:
         args: WordPress,WordPress-Core,WordPress-Docs


### PR DESCRIPTION
This adds a Github Action to run PHP Code Sniffs. 

Based: rtCamps use here: https://github.com/rtCamp/amp-admanager/blob/master/.github/workflows/pull_request.yml