### PR TITLE
Revert "CI-6875 | updating Wordpress, MySQL, and PHP Composer Docker versions"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,9 @@ env:
 
     # Disabling PHP 5.6 tests until "composer.lock" is updated to work with PHP 7.X AND 5.6.
     # - WP_VERSION=5.0.2 PHP_VERSION=5.6
-    - WP_VERSION=5.2.3 PHP_VERSION=7.1
-    - WP_VERSION=5.2.3 PHP_VERSION=7.2
-    - WP_VERSION=5.2.3 PHP_VERSION=7.3 COVERAGE=true LINT_SCHEMA=true
+    - WP_VERSION=5.2.2 PHP_VERSION=7.1
+    - WP_VERSION=5.2.2 PHP_VERSION=7.2
+    - WP_VERSION=5.2.2 PHP_VERSION=7.3 COVERAGE=true LINT_SCHEMA=true
     - PHPCS=true
 
 matrix:

--- a/Dockerfile.test-base
+++ b/Dockerfile.test-base
@@ -6,7 +6,7 @@
 # entrypoints are different.
 
 # Updating Software used in this Dockerfile:
-# PHP Composer: https://github.com/composer/getcomposer.org/commits/master
+# PHP Composer: https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md
 # XDebug: https://pecl.php.net/package/xdebug
 
 # Using the 'DESIRED_' prefix to avoid confusion with environment variables of the same name.
@@ -26,7 +26,7 @@ RUN echo 'date.timezone = "UTC"' > /usr/local/etc/php/conf.d/timezone.ini \
         docker-php-ext-enable xdebug; \
      fi \
   && docker-php-ext-install pdo_mysql \
-  && curl -Ls 'https://raw.githubusercontent.com/composer/getcomposer.org/fc4099e0ac116a1c8f61fffaf6693594dda79d16/web/installer' | php -- --quiet \
+  && curl -Ls 'https://raw.githubusercontent.com/composer/getcomposer.org/ba13e3fc70f1c66250d1ea7ea4911d593aa1dba5/web/installer' | php -- --quiet \
   && chmod +x composer.phar \
   && mv composer.phar /usr/local/bin/composer \
   && curl -O 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar' \

--- a/docker/docker-compose.local-app-xdebug.yml
+++ b/docker/docker-compose.local-app-xdebug.yml
@@ -7,7 +7,7 @@ services:
       context: '../'
       dockerfile: 'Dockerfile.xdebug'
       args:
-        DESIRED_WP_VERSION: "${WP_VERSION:-5.2.3}"
+        DESIRED_WP_VERSION: "${WP_VERSION:-5.2.2}"
         DESIRED_PHP_VERSION: "${PHP_VERSION:-7.3}"
     image: 'wordpress-utc-xdebug-cache'
     environment:

--- a/docker/docker-compose.local-app.yml
+++ b/docker/docker-compose.local-app.yml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   wpgraphql.test:
-    image: "wordpress:${WP_VERSION:-5.2.3}-php${PHP_VERSION:-7.3}-apache"
+    image: "wordpress:${WP_VERSION:-5.2.2}-php${PHP_VERSION:-7.3}-apache"
     ports:
       - '8000:80'
     environment:
@@ -19,7 +19,7 @@ services:
       - './uploads.txt:/usr/local/etc/php/conf.d/uploads.ini:ro'
 
   mysql_test:
-    image: 'mariadb:10.2.27-bionic'
+    image: 'mariadb:10.2.26-bionic'
     ports:
       # Have Docker forward a randomly assigned host port to this site's MySQL container port
       - '3306'

--- a/docker/docker-compose.tests.yml
+++ b/docker/docker-compose.tests.yml
@@ -6,7 +6,7 @@ services:
       context: '../'
       dockerfile: 'Dockerfile.test-base'
       args:
-        DESIRED_WP_VERSION: "${WP_VERSION:-5.2.3}"
+        DESIRED_WP_VERSION: "${WP_VERSION:-5.2.2}"
         DESIRED_PHP_VERSION: "${PHP_VERSION:-7.3}"
     image: 'wordpress-wp-graphql-test-base'
     container_name: 'wpgraphql-tester'
@@ -28,7 +28,7 @@ services:
       context: '../'
       dockerfile: 'Dockerfile.test-base'
       args:
-        DESIRED_WP_VERSION: "${WP_VERSION:-5.2.3}"
+        DESIRED_WP_VERSION: "${WP_VERSION:-5.2.2}"
         DESIRED_PHP_VERSION: "${PHP_VERSION:-7.3}"
     image: 'wordpress-wp-graphql-test-base'
     environment:
@@ -43,7 +43,7 @@ services:
     entrypoint: [ "docker-entrypoint.sut.sh" ]
 
   mysql_test:
-    image: 'mariadb:10.2.27-bionic'
+    image: 'mariadb:10.2.26-bionic'
     environment:
       MYSQL_DATABASE: 'wpgraphql_test'
       MYSQL_ROOT_PASSWORD: 'testing'


### PR DESCRIPTION
Reverts wp-graphql/wp-graphql#963

Travis builds are failing. Seems like it _could_ be related to this?