### PR TITLE
Edit confusing and wrong args type

### DIFF
--- a/src/Connection/PostObjects.php
+++ b/src/Connection/PostObjects.php
@@ -158,13 +158,13 @@ class PostObjects {
 			],
 			'authorIn'     => [
 				'type'        => [
-					'list_of' => 'ID',
+					'list_of' => 'Int',
 				],
 				'description' => __( 'Find objects connected to author(s) in the array of author\'s userIds', 'wp-graphql' ),
 			],
 			'authorNotIn'  => [
 				'type'        => [
-					'list_of' => 'ID',
+					'list_of' => 'Int',
 				],
 				'description' => __( 'Find objects NOT connected to author(s) in the array of author\'s
 							userIds', 'wp-graphql' ),
@@ -178,7 +178,7 @@ class PostObjects {
 			 */
 			'categoryId'   => [
 				'type'        => 'Int',
-				'description' => __( 'Category ID', 'wp-graphql' ),
+				'description' => __( 'Use categoryId', 'wp-graphql' ),
 			],
 			'categoryName' => [
 				'type'        => 'String',
@@ -186,17 +186,17 @@ class PostObjects {
 			],
 			'categoryIn'   => [
 				'type'        => [
-					'list_of' => 'ID',
+					'list_of' => 'Int',
 				],
-				'description' => __( 'Array of category IDs, used to display objects from one
+				'description' => __( 'Array of categoryIds, used to display objects from one
 										category OR another', 'wp-graphql' ),
 			],
 			'categoryNotIn'   => [
 				'type'        => [
-					'list_of' => 'ID',
+					'list_of' => 'Int',
 				],
-				'description' => __( 'Array of category IDs, used to display objects from one
-										category OR another', 'wp-graphql' ),
+				'description' => __( 'Used to display objects that are excluded from array
+				 						of categoryIds', 'wp-graphql' ),
 			],
 
 			/**
@@ -210,22 +210,22 @@ class PostObjects {
 				'description' => __( 'Tag Slug', 'wp-graphql' ),
 			],
 			'tagId'        => [
-				'type'        => 'String',
-				'description' => __( 'Use Tag ID', 'wp-graphql' ),
+				'type'        => 'Int',
+				'description' => __( 'Use tagId', 'wp-graphql' ),
 			],
 			'tagIn'        => [
 				'type'        => [
-					'list_of' => 'ID',
+					'list_of' => 'Int',
 				],
-				'description' => __( 'Array of tag IDs, used to display objects from one tag OR
+				'description' => __( 'Array of tagIds, used to display objects from one tag OR
 							another', 'wp-graphql' ),
 			],
 			'tagNotIn'      => [
 				'type'         => [
-					'list_of' => 'ID'
+					'list_of' => 'Int'
 				],
-				'description' => __( 'Array of tag IDs, used to display objects from one tag OR
-							another', 'wp-graphql' ),
+				'description' => __( 'Used to display objects that are excluded from array of
+							tagIds, ', 'wp-graphql' ),
 			],
 			'tagSlugAnd'   => [
 				'type'        => [


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
The authorIds, authorNotIn, categoryIds, categoryNotIn, tagIds, tagNotIns are implemented with author's `userId`, not author's global `ID`, so does `categoryId` and `tagId`. So the type should be `Int`.
And tagIds should not be `String` especially


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
