### PR TITLE
#982 - Remove error that's thrown in the PostObjectLoader

### DIFF
--- a/src/Data/Loader/PostObjectLoader.php
+++ b/src/Data/Loader/PostObjectLoader.php
@@ -92,9 +92,6 @@ class PostObjectLoader extends AbstractDataLoader {
 			 */
 			$post_object = get_post( (int) $key );
 
-			if ( empty( $post_object ) ) {
-				throw new UserError( sprintf( __( 'No item was found with ID %s', 'wp-graphql' ), $key ) );
-			}
 
 			/**
 			 * Return the instance through the Model to ensure we only


### PR DESCRIPTION
This removes the error that's thrown in the PostObjectLoader. There are valid cases for a Post to _not_ be returned from the loader when a key is provided

closes #982 