### PR TITLE
Bug/#985 register field on input type not working

### DIFF
--- a/src/Type/WPInputObjectType.php
+++ b/src/Type/WPInputObjectType.php
@@ -40,6 +40,32 @@ class WPInputObjectType extends InputObjectType {
 		$fields = apply_filters( 'graphql_input_fields', $fields, $type_name, $config );
 
 		/**
+		 * Filter once with lowercase, once with uppercase for Back Compat.
+		 */
+		$lc_type_name = lcfirst( $type_name );
+		$uc_type_name = ucfirst( $type_name );
+
+		/**
+		 * Filter the fields with the typename explicitly in the filter name
+		 *
+		 * This is useful for more targeted filtering, and is applied after the general filter, to allow for
+		 * more specific overrides
+		 *
+		 * @param array $fields The array of fields for the object config
+		 */
+		$fields = apply_filters( "graphql_{$lc_type_name}_fields", $fields );
+
+		/**
+		 * Filter the fields with the typename explicitly in the filter name
+		 *
+		 * This is useful for more targeted filtering, and is applied after the general filter, to allow for
+		 * more specific overrides
+		 *
+		 * @param array $fields The array of fields for the object config
+		 */
+		$fields = apply_filters( "graphql_{$uc_type_name}_fields", $fields );
+
+		/**
 		 * Sort the fields alphabetically by key. This makes reading through docs much easier
 		 *
 		 * @since 0.0.2

--- a/tests/wpunit/AccessFunctionsTest.php
+++ b/tests/wpunit/AccessFunctionsTest.php
@@ -56,13 +56,13 @@ class AccessFunctionsTest extends \Codeception\TestCase\WPTestCase {
 		/**
 		 * Introspection query to query the names of fields on the Type
 		 */
-		$query = '{ 
-	        __type( name: "RootQueryToTestCptConnectionWhereArgs" ) { 
-	            inputFields {
-	              name
-	            }
-	        } 
-        }';
+		$query = '{
+			__type( name: "RootQueryToTestCptConnectionWhereArgs" ) { 
+				inputFields {
+					name
+				}
+			} 
+		}';
 
 		$actual = graphql( [
 			'query' => $query,

--- a/tests/wpunit/AccessFunctionsTest.php
+++ b/tests/wpunit/AccessFunctionsTest.php
@@ -1,30 +1,90 @@
 <?php
 
-class AccessFunctionsTest extends \Codeception\TestCase\WPTestCase
-{
+class AccessFunctionsTest extends \Codeception\TestCase\WPTestCase {
 
-    public function setUp()
-    {
-        // before
-        parent::setUp();
+	public function setUp() {
+		// before
+		parent::setUp();
 
-        // your set up methods here
-    }
+		// your set up methods here
+	}
 
-    public function tearDown()
-    {
-        // your tear down methods here
+	public function tearDown() {
+		// your tear down methods here
 
-        // then
-        parent::tearDown();
-    }
+		// then
+		parent::tearDown();
+	}
 
-    // tests
-    public function testMe()
-    {
-	    $actual = graphql_format_field_name( 'This is some field name' );
-	    $expected = 'thisIsSomeFieldName';
-	    self::assertEquals( $expected, $actual );
-    }
+	// tests
+	public function testMe() {
+		$actual   = graphql_format_field_name( 'This is some field name' );
+		$expected = 'thisIsSomeFieldName';
+		self::assertEquals( $expected, $actual );
+	}
+
+	public function testRegisterInputField() {
+
+		/**
+		 * Register Test CPT
+		 */
+		register_post_type( 'test_cpt', [
+			"label"               => __( 'Test CPT', 'wp-graphql' ),
+			"labels"              => [
+				"name"          => __( 'Test CPT', 'wp-graphql' ),
+				"singular_name" => __( 'Test CPT', 'wp-graphql' ),
+			],
+			"description"         => __( 'test-post-type', 'wp-graphql' ),
+			"supports"            => [ 'title' ],
+			"show_in_graphql"     => true,
+			"graphql_single_name" => 'TestCpt',
+			"graphql_plural_name" => 'TestCpts',
+		] );
+
+		/**
+		 * Register a GraphQL Input Field to the connection where args
+		 */
+		register_graphql_field(
+			'RootQueryToTestCptConnectionWhereArgs',
+			'testTest',
+			[
+				'type'        => 'String',
+				'description' => 'just testing here'
+			]
+		);
+
+		/**
+		 * Introspection query to query the names of fields on the Type
+		 */
+		$query = '{ 
+	        __type( name: "RootQueryToTestCptConnectionWhereArgs" ) { 
+	            inputFields {
+	              name
+	            }
+	        } 
+        }';
+
+		$actual = graphql( [
+			'query' => $query,
+		] );
+
+		/**
+		 * Get an array of names from the inputFields
+		 */
+		$names = array_column( $actual['data']['__type']['inputFields'], 'name' );
+
+		/**
+		 * Assert that `testTest` exists in the $names (the field was properly registered)
+		 */
+		$this->assertTrue( in_array( 'testTest', $names ) );
+
+		/**
+		 * Cleanup
+		 */
+		deregister_graphql_field( 'RootQueryToTestCptConnectionWhereArgs', 'testTest' );
+		unregister_post_type( 'action_monitor' );
+		WPGraphQL::__clear_schema();
+
+	}
 
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
--------------------------------------------------
This adds filters to the WPInputType to ensure that `register_graphql_field` can work properly for Input types as well as Object types.


Does this close any currently open issues?
-----------------------------------------
closes #985 