### PR TITLE
Fix issue with model layer returning connected items on private posts

### DIFF
--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -6,6 +6,7 @@ use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Connection\ArrayConnection;
 use WPGraphQL\AppContext;
+use WPGraphQL\Model\Post;
 
 /**
  * Class AbstractConnectionResolver
@@ -106,6 +107,11 @@ abstract class AbstractConnectionResolver {
 	 * @throws \Exception
 	 */
 	public function __construct( $source, $args, $context, $info ) {
+
+		// Bail if the Post->ID is empty, as that indicates a private post.
+		if ( $source instanceof Post && empty( $source->ID ) ) {
+			return null;
+		}
 
 		/**
 		 * Set the source (the root object) for the resolver

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -110,7 +110,7 @@ abstract class AbstractConnectionResolver {
 
 		// Bail if the Post->ID is empty, as that indicates a private post.
 		if ( $source instanceof Post && empty( $source->ID ) ) {
-			return null;
+			$this->should_execute = false;
 		}
 
 		/**

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -110,7 +110,7 @@ abstract class AbstractConnectionResolver {
 
 		// Bail if the Post->ID is empty, as that indicates a private post.
 		if ( $source instanceof Post && empty( $source->ID ) ) {
-			$this->should_execute = false;
+			return null;
 		}
 
 		/**

--- a/tests/wpunit/PostObjectQueriesTest.php
+++ b/tests/wpunit/PostObjectQueriesTest.php
@@ -1535,6 +1535,51 @@ class PostObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 	}
 
+	public function testPrivatePosts() {
+
+		$post_id = $this->factory()->post->create( [
+			'post_status' => 'private',
+			'post_content' => 'Test',
+		] );
+
+		/**
+		 * Create the global ID based on the post_type and the created $id
+		 */
+		$global_id = \GraphQLRelay\Relay::toGlobalId( 'post', $post_id );
+
+		$query = "
+		query {
+			postBy(id: \"{$global_id}\") {
+			    status
+			    title
+			    categories {
+			      nodes {
+			        id
+			        name
+			        slug
+			      }
+			    }
+		    }
+	    }";
+
+		$expected = [
+			'data' => [
+				'postBy' => [
+					'status' => null,
+					'title' => null,
+					'categories' => [
+						'nodes' => [],
+					],
+				]
+			]
+		];
+
+		$actual = do_graphql_request( $query );
+		var_dump( $actual );
+		$this->assertEquals( $expected, $actual );
+
+	}
+
 	/**
 	 * Test restricted posts returned on certain statuses
 	 * @dataProvider dataProviderRestrictedPosts

--- a/tests/wpunit/PostObjectQueriesTest.php
+++ b/tests/wpunit/PostObjectQueriesTest.php
@@ -1535,6 +1535,9 @@ class PostObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 	}
 
+	/**
+	 * Assert that no data is being leaked on private posts that are directly queried without auth.
+	 */
 	public function testPrivatePosts() {
 
 		$post_id = $this->factory()->post->create( [
@@ -1575,7 +1578,6 @@ class PostObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 		];
 
 		$actual = do_graphql_request( $query );
-		var_dump( $actual );
 		$this->assertEquals( $expected, $actual );
 
 	}


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
Makes sure we don't return all terms on taxonomy connections to private posts.


Does this close any currently open issues?
------------------------------------------
closes #992 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
It's definitely debatable that this short circuit code is in the correct place. Having the test here is useful though, and we can have a conversation around this now.


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
