### PR TITLE
interface field hook implemented

### DIFF
--- a/src/Type/InterfaceType/Node.php
+++ b/src/Type/InterfaceType/Node.php
@@ -14,6 +14,7 @@ class Node {
 						'type' => [
 							'non_null' => 'ID',
 						],
+						'description' => __( 'The globally unique ID for the object', 'wp-graphql' ),
 					],
 				],
 				'resolveType' => function( $node ) {

--- a/src/Type/Object/Comment.php
+++ b/src/Type/Object/Comment.php
@@ -15,10 +15,7 @@ class Comment {
 				'interfaces'  => [ 'Node' ],
 				'fields'      => [
 					'id'           => [
-						'type'        => [
-							'non_null' => 'ID',
-						],
-						'description' => __( 'The globally unique identifier for the user', 'wp-graphql' ),
+						'description' => __( 'The globally unique identifier for the comment object', 'wp-graphql' ),
 					],
 					'commentId'    => [
 						'type'        => 'Int',

--- a/src/Type/Object/CommentAuthor.php
+++ b/src/Type/Object/CommentAuthor.php
@@ -11,10 +11,7 @@ class CommentAuthor {
 				'interfaces'  => [ 'Node' ],
 				'fields'      => [
 					'id'           => [
-						'type'        => [
-							'non_null' => 'ID',
-						],
-						'description' => __( 'The globally unique identifier for the Comment Author user', 'wp-graphql' ),
+						'description' => __( 'The globally unique identifier for the comment author object', 'wp-graphql' ),
 					],
 					'name'         => [
 						'type'        => 'String',

--- a/src/Type/Object/Menu.php
+++ b/src/Type/Object/Menu.php
@@ -8,6 +8,7 @@ class Menu {
 			'Menu',
 			[
 				'description' => __( 'Menus are the containers for navigation items. Menus can be assigned to menu locations, which are typically registered by the active theme.', 'wp-graphql' ),
+				'interfaces'  => [ 'Node' ],
 				'fields'      => [
 					'id'           => [
 						'description' => __( 'The globally unique identifier of the nav menu object.', 'wp-graphql' ),

--- a/src/Type/Object/Menu.php
+++ b/src/Type/Object/Menu.php
@@ -10,10 +10,7 @@ class Menu {
 				'description' => __( 'Menus are the containers for navigation items. Menus can be assigned to menu locations, which are typically registered by the active theme.', 'wp-graphql' ),
 				'fields'      => [
 					'id'           => [
-						'type'        => [
-							'non_null' => 'ID',
-						],
-						'description' => __( 'ID of the nav menu.', 'wp-graphql' ),
+						'description' => __( 'The globally unique identifier of the nav menu object.', 'wp-graphql' ),
 					],
 					'count'        => [
 						'type'        => 'Int',

--- a/src/Type/Object/MenuItem.php
+++ b/src/Type/Object/MenuItem.php
@@ -12,6 +12,7 @@ class MenuItem {
 			'MenuItem',
 			[
 				'description' => __( 'Navigation menu items are the individual items assigned to a menu. These are rendered as the links in a navigation menu.', 'wp-graphql' ),
+				'interfaces' => [ 'Node' ],
 				'fields'      => [
 					'id'               => [
 						'description' => __( 'The globally unique identifier of the nav menu item object.', 'wp-graphql' ),

--- a/src/Type/Object/MenuItem.php
+++ b/src/Type/Object/MenuItem.php
@@ -14,10 +14,7 @@ class MenuItem {
 				'description' => __( 'Navigation menu items are the individual items assigned to a menu. These are rendered as the links in a navigation menu.', 'wp-graphql' ),
 				'fields'      => [
 					'id'               => [
-						'type'        => [
-							'non_null' => 'ID',
-						],
-						'description' => __( 'Relay ID of the menu item.', 'wp-graphql' ),
+						'description' => __( 'The globally unique identifier of the nav menu item object.', 'wp-graphql' ),
 					],
 					'cssClasses'       => [
 						'type'        => [

--- a/src/Type/Object/Plugin.php
+++ b/src/Type/Object/Plugin.php
@@ -10,9 +10,7 @@ class Plugin {
 				'description' => __( 'An plugin object', 'wp-graphql' ),
 				'fields'      => [
 					'id'           => [
-						'type' => [
-							'non_null' => 'ID',
-						],
+						'description' => __( 'The globally unique identifier of the plugin object.', 'wp-graphql' ),
 					],
 					'name'         => [
 						'type'        => 'String',

--- a/src/Type/Object/PostObject.php
+++ b/src/Type/Object/PostObject.php
@@ -209,12 +209,6 @@ class PostObject {
 	public static function get_post_object_fields( $post_type_object ) {
 		$single_name = $post_type_object->graphql_single_name;
 		$fields      = [
-			'id'                => [
-				'type'        => [
-					'non_null' => 'ID',
-				],
-				'description' => __( 'The globally unique ID for the object', 'wp-graphql' ),
-			],
 			$single_name . 'Id' => [
 				'type'        => [
 					'non_null' => 'Int',

--- a/src/Type/Object/PostObject.php
+++ b/src/Type/Object/PostObject.php
@@ -209,6 +209,13 @@ class PostObject {
 	public static function get_post_object_fields( $post_type_object ) {
 		$single_name = $post_type_object->graphql_single_name;
 		$fields      = [
+			'id'                => [
+				'description' => sprintf(
+					/* translators: %s: custom post-type name */
+					__( 'The globally unique identifier of the %s object.', 'wp-graphql' ),
+					$post_type_object->name
+				),
+			],
 			$single_name . 'Id' => [
 				'type'        => [
 					'non_null' => 'Int',

--- a/src/Type/Object/PostType.php
+++ b/src/Type/Object/PostType.php
@@ -14,9 +14,7 @@ class PostType {
 				'interfaces'  => [ 'Node' ],
 				'fields'      => [
 					'id'                     => [
-						'type' => [
-							'non_null' => 'ID',
-						],
+						'description' => __( 'The globally unique identifier of the post-type object.', 'wp-graphql' ),
 					],
 					'name'                   => [
 						'type'        => 'String',

--- a/src/Type/Object/Taxonomy.php
+++ b/src/Type/Object/Taxonomy.php
@@ -16,9 +16,7 @@ class Taxonomy {
 				'interfaces'  => [ 'Node' ],
 				'fields'      => [
 					'id'                     => [
-						'type' => [
-							'non_null' => 'ID',
-						],
+						'description' => __( 'The globally unique identifier of the taxonomy object.', 'wp-graphql' ),
 					],
 					'name'                   => [
 						'type'        => 'String',

--- a/src/Type/Object/TermObject.php
+++ b/src/Type/Object/TermObject.php
@@ -20,8 +20,11 @@ class TermObject {
 						'type'        => [
 							'non_null' => 'ID',
 						],
-						// Placeholder is the name of the taxonomy
-						'description' => __( 'The global ID for the ' . $taxonomy_object->name, 'wp-graphql' ),
+						'description' => sprintf(
+							/* translators: %s: taxonomy name */
+							__( 'The global ID for the %s', 'wp-graphql' ),
+							$taxonomy_object->name
+						),
 					],
 					$single_name . 'Id' => [
 						'type'        => 'Int',

--- a/src/Type/Object/TermObject.php
+++ b/src/Type/Object/TermObject.php
@@ -17,12 +17,9 @@ class TermObject {
 				'interfaces'  => [ 'Node' ],
 				'fields'      => [
 					'id'                => [
-						'type'        => [
-							'non_null' => 'ID',
-						],
 						'description' => sprintf(
 							/* translators: %s: taxonomy name */
-							__( 'The global ID for the %s', 'wp-graphql' ),
+							__( 'The globally unique identifier for the %s term object.', 'wp-graphql' ),
 							$taxonomy_object->name
 						),
 					],

--- a/src/Type/Object/Theme.php
+++ b/src/Type/Object/Theme.php
@@ -11,9 +11,7 @@ class Theme {
 				'interfaces'  => [ 'Node' ],
 				'fields'      => [
 					'id'           => [
-						'type' => [
-							'non_null' => 'ID',
-						],
+						'description' => __( 'The globally unique identifier of the theme object.', 'wp-graphql' ),
 					],
 					'slug'         => [
 						'type'        => 'String',

--- a/src/Type/Object/User.php
+++ b/src/Type/Object/User.php
@@ -14,10 +14,7 @@ class User {
 				'interfaces'  => [ 'Node' ],
 				'fields'      => [
 					'id'                => [
-						'type'        => [
-							'non_null' => 'ID',
-						],
-						'description' => __( 'The globally unique identifier for the user', 'wp-graphql' ),
+						'description' => __( 'The globally unique identifier for the user object.', 'wp-graphql' ),
 					],
 					'capabilities'      => [
 						'type'        => [

--- a/src/Type/Object/UserRole.php
+++ b/src/Type/Object/UserRole.php
@@ -8,6 +8,7 @@ class UserRole {
 			'UserRole',
 			[
 				'description' => __( 'A user role object', 'wp-graphql' ),
+				'interfaces'  => [ 'Node' ],
 				'fields'      => [
 					'id'           => [
 						'description' => __( 'The globally unique identifier for the user role object.', 'wp-graphql' ),

--- a/src/Type/Object/UserRole.php
+++ b/src/Type/Object/UserRole.php
@@ -10,10 +10,7 @@ class UserRole {
 				'description' => __( 'A user role object', 'wp-graphql' ),
 				'fields'      => [
 					'id'           => [
-						'type'        => [
-							'non_null' => 'ID',
-						],
-						'description' => __( 'The globally unique identifier for the role', 'wp-graphql' ),
+						'description' => __( 'The globally unique identifier for the user role object.', 'wp-graphql' ),
 					],
 					'name'         => [
 						'type'        => 'String',

--- a/src/Type/WPInterfaceType.php
+++ b/src/Type/WPInterfaceType.php
@@ -98,6 +98,15 @@ class WPInterfaceType extends InterfaceType {
 		 * as it ensures it's not output in just random order
 		 */
 		ksort( $fields );
+
+		// Make field definitions available for inheriting objects.
+		add_filter(
+			"graphql_interface_{$type_name}_fields",
+			function( $other_interface_fields ) use ( $fields ) {
+				return array_merge( $other_interface_fields, $fields );
+			}
+		);
+
 		return $fields;
 	}
 

--- a/src/Type/WPObjectType.php
+++ b/src/Type/WPObjectType.php
@@ -1,6 +1,7 @@
 <?php
 namespace WPGraphQL\Type;
 
+use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ObjectType;
 use WPGraphQL\Data\DataSource;
 use WPGraphQL\Registry\TypeRegistry;
@@ -129,6 +130,16 @@ class WPObjectType extends ObjectType {
 		// Get any parent interface fields.
 		$parent_fields = [];
 		if ( ! empty( $config['interfaces'] ) ) {
+			if ( ! is_array( $config['interfaces'] ) ) {
+				throw new UserError(
+					sprintf(
+						/* translators: %s: type name */
+						__( 'Invalid value provided as "interfaces" on %s.', 'wp-graphql' ),
+						$type_name
+					)
+				);
+			}
+
 			foreach ( $config['interfaces'] as $name ) {
 				/**
 				 * Retrieves the field definitions for fields on any Interfaces being implemented.
@@ -140,7 +151,7 @@ class WPObjectType extends ObjectType {
 		}
 
 		// Include any parent field definition not already defined.
-		$fields = array_merge( $parent_fields, $fields );
+		$fields = array_replace_recursive( $parent_fields, $fields );
 
 		/**
 		 * Filter once with lowercase, once with uppercase for Back Compat.

--- a/src/Type/WPObjectType.php
+++ b/src/Type/WPObjectType.php
@@ -66,18 +66,18 @@ class WPObjectType extends ObjectType {
 			 *
 			 * Types are still responsible for ensuring the fields resolve properly.
 			 */
-			if ( ! empty( $config['interfaces'] ) ) ) {
-        // Throw if "interfaces" invalid.
-        if ( ! is_array( $config['interfaces'] ) ) {
-          throw new UserError(
-            sprintf(
-              /* translators: %s: type name */
-              __( 'Invalid value provided as "interfaces" on %s.', 'wp-graphql' ),
-              $type_name
-            )
-          );
-        }
-        
+			if ( ! empty( $config['interfaces'] ) ) {
+				// Throw if "interfaces" invalid.
+				if ( ! is_array( $config['interfaces'] ) ) {
+					throw new UserError(
+						sprintf(
+							/* translators: %s: type name */
+							__( 'Invalid value provided as "interfaces" on %s.', 'wp-graphql' ),
+							$type_name
+						)
+					);
+				}
+
 				foreach ( $config['interfaces'] as $interface_name ) {
 					$interface_type = $this->type_registry->get_type( $interface_name );
 					$interface_fields = [];

--- a/tests/wpunit/MenuItemQueriesTest.php
+++ b/tests/wpunit/MenuItemQueriesTest.php
@@ -39,6 +39,8 @@ class MenuItemQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 		$actual = do_graphql_request( $query );
 
+		codecept_debug( $actual );
+
 		$this->assertEquals( $menu_item_id, $actual['data']['menuItem']['menuItemId'] );
 		$this->assertEquals( $menu_item_relay_id, $actual['data']['menuItem']['id'] );
 		$this->assertEquals( $post_id, $actual['data']['menuItem']['connectedObject']['postId'] );

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -25,8 +25,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'GRAPHQL_DEBUG', true );
-
 /**
  * If the codeception remote coverage file exists, require it.
  *

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -25,6 +25,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+define( 'GRAPHQL_DEBUG', true );
+
 /**
  * If the codeception remote coverage file exists, require it.
  *


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
- Creates a `graphql_interface_{$type_name}_fields` filter that is provided the WPInterface fields after all field registration has be completed.
- The `graphql_interface_{$type_name}_fields` filter is hooked into by any inheriting types and the WPInterface's fields are retrieved and merge with the inheriting types fields.
- The WPInterface's fields configs are overwrite by any existing field configs on the inheriting type.
- This allow the forgoing of any field defined in the Parent Interface. For example the `id` field definition was removed from CPT definitions in `src/Type/Post.php` and it's description was played on the `id` definition in `Node`.  

Does this close any currently open issues?
------------------------------------------
#991 
[WooGraphQL #166](https://github.com/wp-graphql/wp-graphql-woocommerce/issues/166)


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Linux Mint 19.2

**WordPress Version:** 5.2.4
