### PR TITLE
Expose Router::is_graphql_request()

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -111,6 +111,19 @@ class Router {
 	}
 
 	/**
+	 * Returns true when the current request is a graphql request
+	 *
+	 * @return boolean
+	 */
+	public static function is_graphql_request() {
+		if ( empty( $GLOBALS['wp']->query_vars ) || ! is_array( $GLOBALS['wp']->query_vars ) || ! array_key_exists( self::$route, $GLOBALS['wp']->query_vars ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
 	 * This resolves the http request and ensures that WordPress can respond with the appropriate
 	 * JSON response instead of responding with a template from the standard WordPress Template
 	 * Loading process
@@ -131,7 +144,7 @@ class Router {
 		/**
 		 * Ensure we're on the registered route for graphql route
 		 */
-		if ( empty( $GLOBALS['wp']->query_vars ) || ! is_array( $GLOBALS['wp']->query_vars ) || ! array_key_exists( self::$route, $GLOBALS['wp']->query_vars ) ) {
+		if ( ! self::is_graphql_request() ) {
 			return;
 		}
 


### PR DESCRIPTION
For wp-graphql-polylang I need to detect whether the current http request is a graphql request really early. Right when Polylang initializes. `GRAPHQL_HTTP_REQUEST` constant it not yet defined at this point.

Here's what I currently do

https://github.com/valu-digital/wp-graphql-polylang/blob/bfddbc2d63aaf9e89ac7a254344faa8850609dbc/wp-graphql-polylang.php#L112-L120

but that's very brittle.

`Router::is_graphql_request()` would help a lot.