### PR TITLE
Update PostObjectCursor.php

### DIFF
--- a/src/Data/Cursor/PostObjectCursor.php
+++ b/src/Data/Cursor/PostObjectCursor.php
@@ -238,7 +238,7 @@ class PostObjectCursor {
 	 */
 	private function get_meta_key( $by ) {
 
-		if ( 'meta_value' === $by ) {
+		if ( 'meta_value' === $by || 'meta_value_num' === $by ) {
 			return $this->get_query_var( 'meta_key' );
 		}
 


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
Checks for `meta_value_num`  when processing `meta_key` query var.

1. Install WooCommerce
2. Import WooCommerce sample products
3. Install and activate WPGraphQL + WPGraphiQL + WooGraphQL.
4. Run the following query in WPGraphiQL.
```
{
  products(first: 5, where: {typeIn: [VARIABLE, SIMPLE], orderby: [{field: PRICE, order: DESC}]}) {
    edges {
      cursor
      node {
        id
        productId
        name
        ... on SimpleProduct {
          price
        }
        ... on VariableProduct {
          price
        }
      }
    }
  }
}
```
And you should get a result like this.
![query results](https://i.imgur.com/4EQ0RPE.png?1)
Which is the correct respond, however if when you attempt to retrieve the next group by cursor.
```
{
  products(first: 5, after: "YXJyYXljb25uZWN0aW9uOjk=" where: {typeIn: [VARIABLE, SIMPLE], orderby: [{field: PRICE, order: DESC}]}) {
    edges {
      cursor
      node {
        id
        productId
        name
        ... on SimpleProduct {
          price
        }
        ... on VariableProduct {
          price
        }
      }
    }
  }
}
```
You get these results
![query results 2](https://i.imgur.com/Kubx8MR.png?1)
Which is not the desired results. This is do to the fact that `PostObjectCursor` which modifies the WP_Query's final SQL statement doesn't check for query var `orderby` for `meta_value_num` which is used for many sorting field in the product connections and only checks for `meta_value`.

This PR implements that needed check and allowing for the SQL statement to be properly created for product connections ordered by numeric meta keys.
![query results 3](https://i.imgur.com/xawmbeA.png?1)

Does this close any currently open issues?
------------------------------------------
[WooGraphQL #153](https://github.com/wp-graphql/wp-graphql-woocommerce/issues/153)


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Linux Mint 19.2

**WordPress Version:** 5.2.4
