### PR TITLE
Adding isFrontPage field to Pages

### DIFF
--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -31,6 +31,7 @@ use WPGraphQL\Types;
  * @property string $commentStatus
  * @property string $pingStatus
  * @property string $slug
+ * @property boolean $isFrontPage
  * @property string $toPing
  * @property string $pinged
  * @property string $modified
@@ -320,6 +321,17 @@ class Post extends Model {
 				'slug'            => function () {
 					return ! empty( $this->data->post_name ) ? $this->data->post_name : null;
 				},
+				'isFrontPage'     => function () {
+					$showOnFront = get_option( 'show_on_front' );					
+					if ( 'page' !== $showOnFront ) {
+						return false;
+					}					
+					$pageOnFront = get_option( 'page_on_front' );
+					if ( ! empty( $pageOnFront ) && $this->data->ID === absint( $pageOnFront ) ) {
+						return true;
+					}
+					return false;					
+				},				
 				'toPing'          => function () {
 					return ! empty( $this->data->to_ping ) && is_array( $this->data->to_ping ) ? implode( ',', (array) $this->data->to_ping ) : null;
 				},

--- a/src/Type/Object/PostObject.php
+++ b/src/Type/Object/PostObject.php
@@ -570,6 +570,13 @@ class PostObject {
 			],
 		];
 
+		if ( 'page' === $post_type_object->name ) {
+			$fields['isFrontPage'] = [
+				'type'        => [ 'non_null' => 'Boolean'],
+				'description' => __( 'Whether this page is set to the static front page.', 'wp-graphql' )
+			];
+		}
+
 		if ( 'attachment' === $post_type_object->name ) {
 			$fields['excerpt']['isDeprecated']      = true;
 			$fields['excerpt']['deprecationReason'] = __( 'Use the caption field instead of excerpt', 'wp-graphql' );


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds the `isFrontPage` field to pages to tell if set to homepage on the site


Does this close any currently open issues?
------------------------------------------
#1028 - Adding `isFrontPage` boolean to Pages data #5


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
It is breaking with a query like this

```
query MyQuery {
  menus {
    nodes {
      menuItems {
        nodes {
          connectedObject {
            ... on Page {
              id
              title
              isFrontPage
            }
          }
        }
      }
    }
  }
  pages {
    nodes {
      id
      title
      isFrontPage
    }
  }
}
```