### PR TITLE
(bug) Support back compat interface implementations

### DIFF
--- a/src/Type/WPObjectType.php
+++ b/src/Type/WPObjectType.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace WPGraphQL\Type;
 
 use GraphQL\Error\UserError;
@@ -29,6 +30,7 @@ class WPObjectType extends ObjectType {
 
 	/**
 	 * Instance of the Type Registry
+	 *
 	 * @var TypeRegistry
 	 */
 	private $type_registry;
@@ -55,6 +57,7 @@ class WPObjectType extends ObjectType {
 
 		/**
 		 * Setup the fields
+		 *
 		 * @return array|mixed
 		 */
 		$config['fields'] = function() use ( $config ) {
@@ -71,7 +74,7 @@ class WPObjectType extends ObjectType {
 				if ( ! is_array( $config['interfaces'] ) ) {
 					throw new UserError(
 						sprintf(
-							/* translators: %s: type name */
+						/* translators: %s: type name */
 							__( 'Invalid value provided as "interfaces" on %s.', 'wp-graphql' ),
 							$config['name']
 						)
@@ -99,6 +102,7 @@ class WPObjectType extends ObjectType {
 
 			$fields = $this->prepare_fields( $fields, $config['name'], $config );
 			$fields = $this->type_registry->prepare_fields( $fields, $config['name'] );
+
 			return $fields;
 		};
 
@@ -121,22 +125,23 @@ class WPObjectType extends ObjectType {
 					}
 				}
 			}
+
 			return $interfaces;
 		};
 
 		/**
 		 * Filter the config of WPObjectType
 		 *
-		 * @param array $config Array of configuration options passed to the WPObjectType when instantiating a new type
-		 * @param Object $this The instance of the WPObjectType class
+		 * @param array  $config Array of configuration options passed to the WPObjectType when instantiating a new type
+		 * @param Object $this   The instance of the WPObjectType class
 		 */
 		$config = apply_filters( 'graphql_wp_object_type_config', $config, $this );
 
 		/**
 		 * Run an action when the WPObjectType is instantiating
 		 *
-		 * @param array $config Array of configuration options passed to the WPObjectType when instantiating a new type
-		 * @param Object $this The instance of the WPObjectType class
+		 * @param array  $config Array of configuration options passed to the WPObjectType when instantiating a new type
+		 * @param Object $this   The instance of the WPObjectType class
 		 */
 		do_action( 'graphql_wp_object_type', $config, $this );
 
@@ -218,6 +223,7 @@ class WPObjectType extends ObjectType {
 		 * as it ensures it's not output in just random order
 		 */
 		ksort( $fields );
+
 		return $fields;
 	}
 

--- a/src/Type/WPObjectType.php
+++ b/src/Type/WPObjectType.php
@@ -73,15 +73,20 @@ class WPObjectType extends ObjectType {
 						sprintf(
 							/* translators: %s: type name */
 							__( 'Invalid value provided as "interfaces" on %s.', 'wp-graphql' ),
-							$type_name
+							$config['name']
 						)
 					);
 				}
 
 				foreach ( $config['interfaces'] as $interface_name ) {
-					$interface_type = $this->type_registry->get_type( $interface_name );
+					$interface_type = null;
+					if ( is_string( $interface_name ) ) {
+						$interface_type = $this->type_registry->get_type( $interface_name );
+					} else if ( $interface_name instanceof WPInterfaceType ) {
+						$interface_type = $interface_name;
+					}
 					$interface_fields = [];
-					if ( $interface_type instanceof WPInterfaceType ) {
+					if ( ! empty( $interface_type ) && $interface_type instanceof WPInterfaceType ) {
 						$interface_config_fields = $interface_type->getFields();
 						foreach ( $interface_config_fields as $interface_field ) {
 							$interface_fields[ $interface_field->name ] = $interface_field->config;
@@ -104,8 +109,14 @@ class WPObjectType extends ObjectType {
 			$interfaces = [];
 			if ( ! empty( $config['interfaces'] ) && is_array( $config['interfaces'] ) ) {
 				foreach ( $config['interfaces'] as $interface_name ) {
-					$interface_type = $this->type_registry->get_type( $interface_name );
-					if ( $interface_type instanceof WPInterfaceType ) {
+					$interface_type = null;
+					if ( is_string( $interface_name ) ) {
+						$interface_type = $this->type_registry->get_type( $interface_name );
+					} else if ( $interface_name instanceof WPInterfaceType ) {
+						$interface_type = $interface_name;
+					}
+
+					if ( ! empty( $interface_type ) && $interface_type instanceof WPInterfaceType ) {
 						$interfaces[ $interface_name ] = $interface_type;
 					}
 				}
@@ -175,7 +186,7 @@ class WPObjectType extends ObjectType {
 		 * @param string $type_name The name of the object type
 		 */
 		$fields = apply_filters( 'graphql_object_fields', $fields, $type_name );
-    
+
 		/**
 		 * Filter once with lowercase, once with uppercase for Back Compat.
 		 */


### PR DESCRIPTION
#1032 - Support backward compatible Interface registration for extensions that may have registered and used interfaces before interface inheritance was added

Closes #1032 