### PR TITLE
#1037 - Fixes conflict with WPGraphQL Tax Query

### DIFF
--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -437,7 +437,7 @@ class TypeRegistry {
 				case 'input':
 					if ( ! empty( $config['fields'] ) && is_array( $config['fields'] ) ) {
 						$config['fields'] = function() use ( $config ) {
-							$fields = WPInputObjectType::prepare_fields( $config['fields'], $config['name'] );
+							$fields = WPInputObjectType::prepare_fields( $config['fields'], $config['name'], $config, $this );
 							$fields = $this->prepare_fields( $fields, $config['name'] );
 
 							return $fields;

--- a/src/Type/WPInputObjectType.php
+++ b/src/Type/WPInputObjectType.php
@@ -2,6 +2,7 @@
 namespace WPGraphQL\Type;
 
 use GraphQL\Type\Definition\InputObjectType;
+use WPGraphQL\Registry\TypeRegistry;
 
 /**
  * Class WPInputObjectType
@@ -23,10 +24,11 @@ class WPInputObjectType extends InputObjectType {
 	 * @param array  $fields
 	 * @param string $type_name
 	 * @param array  $config
+	 * @param TypeRegistry $type_registry
 	 * @return mixed
 	 * @since 0.0.5
 	 */
-	public static function prepare_fields( array $fields, $type_name, $config = [] ) {
+	public static function prepare_fields( array $fields, $type_name, $config = [], TypeRegistry $type_registry ) {
 
 		/**
 		 * Filter all object fields, passing the $typename as a param
@@ -36,8 +38,9 @@ class WPInputObjectType extends InputObjectType {
 		 *
 		 * @param array  $fields    The array of fields for the object config
 		 * @param string $type_name The name of the object type
+		 * @param TypeRegistry $type_registry The TypeRegistry instance
 		 */
-		$fields = apply_filters( 'graphql_input_fields', $fields, $type_name, $config );
+		$fields = apply_filters( 'graphql_input_fields', $fields, $type_name, $config, $type_registry );
 
 		/**
 		 * Filter once with lowercase, once with uppercase for Back Compat.
@@ -52,8 +55,9 @@ class WPInputObjectType extends InputObjectType {
 		 * more specific overrides
 		 *
 		 * @param array $fields The array of fields for the object config
+		 * @param TypeRegistry $type_registry The TypeRegistry instance
 		 */
-		$fields = apply_filters( "graphql_{$lc_type_name}_fields", $fields );
+		$fields = apply_filters( "graphql_{$lc_type_name}_fields", $fields, $type_registry );
 
 		/**
 		 * Filter the fields with the typename explicitly in the filter name
@@ -62,8 +66,9 @@ class WPInputObjectType extends InputObjectType {
 		 * more specific overrides
 		 *
 		 * @param array $fields The array of fields for the object config
+		 * @param TypeRegistry $type_registry The TypeRegistry instance
 		 */
-		$fields = apply_filters( "graphql_{$uc_type_name}_fields", $fields );
+		$fields = apply_filters( "graphql_{$uc_type_name}_fields", $fields, $type_registry );
 
 		/**
 		 * Sort the fields alphabetically by key. This makes reading through docs much easier

--- a/src/Type/WPObjectType.php
+++ b/src/Type/WPObjectType.php
@@ -73,7 +73,7 @@ class WPObjectType extends ObjectType {
 						sprintf(
 							/* translators: %s: type name */
 							__( 'Invalid value provided as "interfaces" on %s.', 'wp-graphql' ),
-							$type_name
+							$config['name']
 						)
 					);
 				}
@@ -175,7 +175,7 @@ class WPObjectType extends ObjectType {
 		 * @param string $type_name The name of the object type
 		 */
 		$fields = apply_filters( 'graphql_object_fields', $fields, $type_name );
-    
+
 		/**
 		 * Filter once with lowercase, once with uppercase for Back Compat.
 		 */


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This passes the `$type_registry` to the `graphql_input_fields` filter, allowing for extensions using that filter to have access to the Type Registry


Does this close any currently open issues?
------------------------------------------
closes #1037 
closes https://github.com/wp-graphql/wp-graphql-meta-query/issues/8
