### PR TITLE
#1043 - Don't call for allowed_types at the init hook

### DIFF
--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -286,7 +286,6 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 			 */
 			add_action( 'init_graphql_request', 'register_initial_settings', 10 );
 			add_action( 'init', [ $this, 'setup_types' ], 10 );
-			add_action( 'init', [ $this, 'get_allowed_types' ], 999 );
 
 		}
 
@@ -303,6 +302,8 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 
 		/**
 		 * This gets the allowed post types and taxonomies when a GraphQL request has started
+		 *
+		 * @deprecated v0.4.3
 		 */
 		public function get_allowed_types() {
 			self::get_allowed_post_types();


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
WPGraphQL calls `WPGraphQL::get_allowed_types()` at `init`, and if a Post Type or Taxonomy registered to "show_in_graphql" doesn't contain a single or plural name, this throws an exception. 

WPGraphQL has no business throwing exceptions on the `init` hook if a Post Type or Taxonomy doesn't have a graphql single or plural name. 

Does this close any currently open issues?
------------------------------------------ 
closes: https://github.com/wp-graphql/wp-graphql-custom-post-type-ui/issues/9
closes: https://github.com/wp-graphql/wp-graphql/issues/1043
