### PR TITLE
#1050 - Add display name to the User Role type and update description of the "name" field

### DIFF
--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -459,13 +459,16 @@ class DataSource {
 	 */
 	public static function resolve_user_role( $name ) {
 
-		$role = get_role( $name );
+		$role = isset( wp_roles()->roles[ $name ] ) ? wp_roles()->roles[ $name ] : null;
 
 		if ( null === $role ) {
 			throw new UserError( sprintf( __( 'No user role was found with the name %s', 'wp-graphql' ), $name ) );
 		} else {
 			$role       = (array) $role;
 			$role['id'] = $name;
+			$role['displayName'] = $role['name'];
+			$role['name'] = $name;
+
 
 			return new UserRole( $role );
 		}

--- a/src/Model/UserRole.php
+++ b/src/Model/UserRole.php
@@ -10,6 +10,7 @@ use GraphQLRelay\Relay;
  * @property string $id
  * @property string name
  * @property array  $capabilities
+ * @property string displayName
  *
  * @package WPGraphQL\Model
  */

--- a/src/Model/UserRole.php
+++ b/src/Model/UserRole.php
@@ -74,6 +74,9 @@ class UserRole extends Model {
 				'name'         => function() {
 					return ! empty( $this->data['name'] ) ? esc_html( $this->data['name'] ) : null;
 				},
+				'displayName' => function() {
+					return ! empty( $this->data['displayName'] ) ? esc_html( $this->data['displayName'] ) : null;
+				},
 				'capabilities' => function() {
 					if ( empty( $this->data['capabilities'] ) || ! is_array( $this->data['capabilities'] ) ) {
 						return null;

--- a/src/Type/Object/UserRole.php
+++ b/src/Type/Object/UserRole.php
@@ -15,13 +15,17 @@ class UserRole {
 					],
 					'name'         => [
 						'type'        => 'String',
-						'description' => __( 'The UI friendly name of the role' ),
+						'description' => __( 'The registered name of the role', 'wp-graphql' ),
 					],
 					'capabilities' => [
 						'type'        => [
 							'list_of' => 'String',
 						],
 						'description' => __( 'The capabilities that belong to this role', 'wp-graphql' ),
+					],
+					'displayName' => [
+						'type' => 'String',
+						'description' => __( 'The display name of the role', 'wp-graphql' ),
 					],
 					'isRestricted' => [
 						'type'        => 'Boolean',

--- a/tests/wpunit/UserRoleConnectionQueriesTest.php
+++ b/tests/wpunit/UserRoleConnectionQueriesTest.php
@@ -28,6 +28,7 @@ class UserRoleConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 						name
 						capabilities
 						id
+						displayName
 					}
 				}
 			}
@@ -42,6 +43,7 @@ class UserRoleConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 			$node = \WPGraphQL\Data\DataSource::resolve_user_role( $role_name );
 			$clean_node['id'] = $node->id;
 			$clean_node['name'] = $node->name;
+			$clean_node['displayName'] = $node->displayName;
 			$clean_node['capabilities'] = $node->capabilities;
 
 			$nodes[]['node'] = $clean_node;


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This adds a new `displayName` field to the `UserRole` type and updates the `name` field description to say that the `name` is the registered name, and `displayName` is the UI friendly name.

Does this close any currently open issues?
------------------------------------------
closes #1050 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
![Screen Shot 2019-12-02 at 9 24 57 AM](https://user-images.githubusercontent.com/1260765/69976109-ad8d3400-14e5-11ea-9fba-2075b80e2d13.png)
![Screen Shot 2019-12-02 at 9 25 13 AM](https://user-images.githubusercontent.com/1260765/69976110-ad8d3400-14e5-11ea-8ad8-16cd6e99e3de.png)
