### PR TITLE
#1053 - TypeRegistry->get_types() not available within the `graphql_register_types` action

### DIFF
--- a/access-functions.php
+++ b/access-functions.php
@@ -65,9 +65,9 @@ function do_graphql_request( $query, $operation_name = '', $variables = [] ) {
  * @param array  $config    The Type config
  */
 function register_graphql_type( $type_name, $config ) {
-	add_action( 'init_graphql_type_registry', function( \WPGraphQL\Registry\TypeRegistry $type_registry ) use ( $type_name, $config ) {
+	add_action( 'graphql_register_types', function( \WPGraphQL\Registry\TypeRegistry $type_registry ) use ( $type_name, $config ) {
 		$type_registry->register_type( $type_name, $config );
-	} );
+	}, 5 );
 
 }
 
@@ -78,9 +78,9 @@ function register_graphql_type( $type_name, $config ) {
  * @param array  $config    The Type config
  */
 function register_graphql_interface_type( $type_name, $config ) {
-	add_action( 'init_graphql_type_registry', function( \WPGraphQL\Registry\TypeRegistry $type_registry ) use ( $type_name, $config ) {
+	add_action( 'graphql_register_types', function( \WPGraphQL\Registry\TypeRegistry $type_registry ) use ( $type_name, $config ) {
 		$type_registry->register_interface_type( $type_name, $config );
-	} );
+	}, 5 );
 }
 
 /**
@@ -113,10 +113,10 @@ function register_graphql_input_type( $type_name, $config ) {
  */
 function register_graphql_union_type( $type_name, $config ) {
 
-	add_action( 'init_graphql_type_registry', function( \WPGraphQL\Registry\TypeRegistry $type_registry ) use ( $type_name, $config ) {
+	add_action( 'graphql_register_types', function( \WPGraphQL\Registry\TypeRegistry $type_registry ) use ( $type_name, $config ) {
 		$config['kind'] = 'union';
 		$type_registry->register_type( $type_name, $config  );
-	} );
+	}, 5 );
 }
 
 /**
@@ -139,9 +139,9 @@ function register_graphql_enum_type( $type_name, $config ) {
  * @param array  $config     The Type config
  */
 function register_graphql_field( $type_name, $field_name, $config ) {
-	add_action( 'init_graphql_type_registry', function( \WPGraphQL\Registry\TypeRegistry $type_registry ) use ( $type_name, $field_name, $config ) {
+	add_action( 'graphql_register_types', function( \WPGraphQL\Registry\TypeRegistry $type_registry ) use ( $type_name, $field_name, $config ) {
 		$type_registry->register_field( $type_name, $field_name, $config  );
-	} );
+	}, 5 );
 }
 
 /**
@@ -152,19 +152,9 @@ function register_graphql_field( $type_name, $field_name, $config ) {
  * @param array  $fields    An array of field configs
  */
 function register_graphql_fields( $type_name, array $fields ) {
-	add_action( 'init_graphql_type_registry', function( \WPGraphQL\Registry\TypeRegistry $type_registry ) use ( $type_name, $fields ) {
+	add_action( 'graphql_register_types', function( \WPGraphQL\Registry\TypeRegistry $type_registry ) use ( $type_name, $fields ) {
 		$type_registry->register_fields( $type_name, $fields  );
-	} );
-}
-
-/**
- * Given a Schema Name and a Schema Config, this adds the Schema to the SchemaRegistry
- *
- * @param string $schema_name The name of the Schema to register
- * @param array  $config      The config for the Schema
- */
-function register_graphql_schema( $schema_name, array $config ) {
-	\WPGraphQL\SchemaRegistry::register_schema( $schema_name, $config );
+	}, 5 );
 }
 
 /**
@@ -174,9 +164,9 @@ function register_graphql_schema( $schema_name, array $config ) {
  * @param array $config Array to configure the connection
  */
 function register_graphql_connection( array $config ) {
-	add_action( 'init_graphql_type_registry', function( \WPGraphQL\Registry\TypeRegistry $type_registry ) use ( $config ) {
+	add_action( 'graphql_register_types', function( \WPGraphQL\Registry\TypeRegistry $type_registry ) use ( $config ) {
 		$type_registry->register_connection( $config );
-	}, 55 );
+	}, 9 );
 }
 
 /**
@@ -186,9 +176,9 @@ function register_graphql_connection( array $config ) {
  * @param string $field_name The name of the field to remove
  */
 function deregister_graphql_field( $type_name, $field_name ) {
-	add_action( 'init_graphql_type_registry', function( \WPGraphQL\Registry\TypeRegistry $type_registry ) use ( $type_name, $field_name ) {
+	add_action( 'graphql_register_types', function( \WPGraphQL\Registry\TypeRegistry $type_registry ) use ( $type_name, $field_name ) {
 		$type_registry->deregister_field( $type_name, $field_name );
-	} );
+	}, 5 );
 }
 
 /**
@@ -198,9 +188,9 @@ function deregister_graphql_field( $type_name, $field_name ) {
  * @param array  $config        The config for the mutation
  */
 function register_graphql_mutation( $mutation_name, $config ) {
-	add_action( 'init_graphql_type_registry', function( \WPGraphQL\Registry\TypeRegistry $type_registry ) use ( $mutation_name, $config ) {
+	add_action( 'graphql_register_types', function( \WPGraphQL\Registry\TypeRegistry $type_registry ) use ( $mutation_name, $config ) {
 		$type_registry->register_mutation( $mutation_name, $config );
-	} );
+	}, 5 );
 }
 
 /**
@@ -218,7 +208,6 @@ function register_graphql_mutation( $mutation_name, $config ) {
 function is_graphql_request() {
 	return WPGraphQL::is_graphql_request();
 }
-
 /**
  * Whether a GraphQL HTTP request is in action or not. This is determined by
  * checking if the request is occurring on the route defined for the GraphQL endpoint.

--- a/tests/wpunit/TypesTest.php
+++ b/tests/wpunit/TypesTest.php
@@ -173,7 +173,7 @@ class TypesTest extends \Codeception\TestCase\WPTestCase
 		/**
 		 * Execute a GraphQL Request to instantiate the Schema
 		 */
-		$actual = graphql( [e 'query' => '{posts{nodes{id}}}'] );
+		$actual = graphql( ['query' => '{posts{nodes{id}}}'] );
 
 	}
 

--- a/tests/wpunit/TypesTest.php
+++ b/tests/wpunit/TypesTest.php
@@ -145,4 +145,36 @@ class TypesTest extends \Codeception\TestCase\WPTestCase
 
 	}
 
+	/**
+	 * Ensure get_types returns types expected to be in the Schema
+	 * @throws Exception
+	 */
+	public function testTypeRegistryGetTypes() {
+
+		/**
+		 * Register a custom type to make sure new types registered
+		 * show in the get_types() method
+		 */
+		register_graphql_type( 'MyCustomType', [
+			'fields' => [
+				'test' => [
+					'type' => 'String'
+				]
+			]
+		] );
+
+		add_action( 'graphql_register_types', function( \WPGraphQL\Registry\TypeRegistry $type_registry ) {
+			$types = $type_registry->get_types();
+			$this->assertArrayHasKey( 'mycustomtype', $types );
+			$this->assertArrayHasKey( 'string', $types );
+			$this->assertArrayHasKey( 'post', $types );
+		} );
+
+		/**
+		 * Execute a GraphQL Request to instantiate the Schema
+		 */
+		$actual = graphql( [e 'query' => '{posts{nodes{id}}}'] );
+
+	}
+
 }

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -286,7 +286,6 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 			 */
 			add_action( 'init_graphql_request', 'register_initial_settings', 10 );
 			add_action( 'init', [ $this, 'setup_types' ], 10 );
-			add_action( 'init', [ $this, 'get_allowed_types' ], 999 );
 
 		}
 
@@ -303,6 +302,8 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 
 		/**
 		 * This gets the allowed post types and taxonomies when a GraphQL request has started
+		 *
+		 * @deprecated v0.4.3
 		 */
 		public function get_allowed_types() {
 			self::get_allowed_post_types();
@@ -433,7 +434,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 					if ( empty( $post_type_object->graphql_single_name ) || empty( $post_type_object->graphql_plural_name ) ) {
 						throw new \GraphQL\Error\UserError(
 							sprintf(
-								/* translators: %s will replaced with the registered type */
+							/* translators: %s will replaced with the registered type */
 								__( 'The %s post_type isn\'t configured properly to show in GraphQL. It needs a "graphql_single_name" and a "graphql_plural_name"', 'wp-graphql' ),
 								$post_type_object->name
 							)
@@ -487,7 +488,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 					if ( empty( $tax_object->graphql_single_name ) || empty( $tax_object->graphql_plural_name ) ) {
 						throw new \GraphQL\Error\UserError(
 							sprintf(
-								/* translators: %s will replaced with the registered taxonomty */
+							/* translators: %s will replaced with the registered taxonomty */
 								__( 'The %s taxonomy isn\'t configured properly to show in GraphQL. It needs a "graphql_single_name" and a "graphql_plural_name"', 'wp-graphql' ),
 								$tax_object->name
 							)


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This pull request updates the `access-functions.php` file to register types earlier in the Schema generation lifecycle, allowing for the TypeRegistry->get_types() method to properly return all registered Types

This adds tests to ensure get_types() method works properly.


Does this close any currently open issues?
------------------------------------------
closes #1052 reported by @kellenmace 
