### PR TITLE
#1059 - postBy entry throws error if post can't be found

### DIFF
--- a/src/Type/Object/RootQuery.php
+++ b/src/Type/Object/RootQuery.php
@@ -250,8 +250,8 @@ class RootQuery {
 								$post_id     = isset( $post_object->ID ) ? absint( $post_object->ID ) : null;
 							}
 							$post = DataSource::resolve_post_object( $post_id, $context );
-							if ( get_post( $post_id )->post_type !== $post_type_object->name ) {
-								throw new UserError( sprintf( __( 'No %1$s exists with this id: %2$s' ), $post_type_object->graphql_single_name, $args['id'] ) );
+							if ( ! get_post( $post_id ) || get_post( $post_id )->post_type !== $post_type_object->name ) {
+								return null;
 							}
 
 							return $post;

--- a/tests/wpunit/PostObjectQueriesTest.php
+++ b/tests/wpunit/PostObjectQueriesTest.php
@@ -1174,7 +1174,8 @@ class PostObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 		/**
 		 * This should return an error as we tried to query for a post using a Page ID
 		 */
-		$this->assertArrayHasKey( 'errors', $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertNull( $actual['data']['postBy'] );
 
 	}
 

--- a/tests/wpunit/PostObjectQueriesTest.php
+++ b/tests/wpunit/PostObjectQueriesTest.php
@@ -1132,9 +1132,10 @@ class PostObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$actual = do_graphql_request( $query );
 
 		/**
-		 * This should return an error as we tried to query for a deleted post
+		 * This should not return errors, and postBy should be null
 		 */
-		$this->assertArrayHasKey( 'errors', $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertNull( $actual['data']['postBy'] );
 
 	}
 
@@ -1172,7 +1173,7 @@ class PostObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$actual = do_graphql_request( $query );
 
 		/**
-		 * This should return an error as we tried to query for a post using a Page ID
+		 * This should not return an error, but should return null for the postBy response
 		 */
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertNull( $actual['data']['postBy'] );


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This updates the `{$postType}By` entry points to return null instead of throwing an error when a Post cannot be found. 

This makes it more consistent with other singe entry points in the Schema. 

There might be future follow-up as it seems like many APIs do indeed throw errors when individual resources cannot be found. See #1059 for more context on the discussion.


Does this close any currently open issues?
------------------------------------------
closes #1059 
