### PR TITLE
HTTP request detection fixes

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -120,15 +120,6 @@ class Router {
 	 * @return boolean
 	 */
 	public static function is_graphql_http_request() {
-		// If 'init' fired, check query vars.
-		if ( did_action( 'init' ) || doing_action( 'init' ) ) {
-			if ( empty( $GLOBALS['wp']->query_vars ) || ! is_array( $GLOBALS['wp']->query_vars ) || ! array_key_exists( self::$route, $GLOBALS['wp']->query_vars ) ) {
-				return false;
-			}
-
-			return true;
-		}
-
 		// Support wp-graphiql style request to /index.php?graphql
 		if ( isset( $_GET[ self::$route ] ) ) {
 			return true;

--- a/src/Router.php
+++ b/src/Router.php
@@ -136,9 +136,9 @@ class Router {
 
 		// If before 'init' check $_SERVER.
 		if ( isset( $_SERVER['HTTP_HOST'] ) && isset( $_SERVER['REQUEST_URI'] ) ) {
-			$haystack = esc_url_raw( wp_unslash( $_SERVER['HTTP_HOST'] ) )
-				. esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) );
-			$needle   = \home_url( \WPGraphQL\Router::$route );
+			$haystack = wp_unslash( $_SERVER['HTTP_HOST'] )
+				. wp_unslash( $_SERVER['REQUEST_URI'] );
+			$needle   = \home_url( self::$route );
 
 			// Strip protocol.
 			$haystack = preg_replace( '#^(http(s)?://)#', '', $haystack );

--- a/src/Router.php
+++ b/src/Router.php
@@ -129,6 +129,11 @@ class Router {
 			return true;
 		}
 
+		// Support wp-graphiql style request to /index.php?graphql
+		if ( isset( $_GET[ self::$route ] ) ) {
+			return true;
+		}
+
 		// If before 'init' check $_SERVER.
 		if ( isset( $_SERVER['HTTP_HOST'] ) && isset( $_SERVER['REQUEST_URI'] ) ) {
 			$haystack = esc_url_raw( wp_unslash( $_SERVER['HTTP_HOST'] ) )


### PR DESCRIPTION

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR fixes two issues with `is_graphql_http_request()`:

1. It did not work if the hostname had port in it because `esc_url_raw()` does not work with ports:

```
esc_url_raw("localhost/graphql")
"http://localhost/graphql"

esc_url_raw("localhost:8080/graphql")
""
```

`esc_url_raw()` is used for sanitization for db usage but here we only use it in PHP code to detect whether the URL ends with a given string. No need to use it here so it can be safely omitted.

2. Usage with wp-graphiql. wp-graphql sends graphql requests to `/index.php?graphql`. I guess that is so it can work without proper url permastructure setup. Anyway `is_graphql_http_request()` should support that too. The "after init" version checks for `query_vars` which is basically the same as the direct `$_GET` check (actually even more broad).


Does this close any currently open issues?
------------------------------------------
AFAIK not.


Any other comments?
-------------------
I removed the after init implementation completely. It makes no sense to maintain two implementations as they can get out of sync. The pre init version can handle all scenarios.

We should figure out how to write tests for this. For wp-graphql-polylang I now have some: https://github.com/valu-digital/wp-graphql-polylang/blob/master/tests/functional/BasicCest.php

But there it is easier because it is completely broken if `is_graphql_http_request()` does not work properly :)


Where has this been tested?
---------------------------
**Operating System:** Ubuntu Bionic

**WordPress Version:**  5.3


ping @kidunot89 you might be interested in these changes.