### PR TITLE
#964 - grapqhl() function breaks when used in page templates

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -161,6 +161,16 @@ class Request {
 	protected function has_authentication_errors() {
 
 		/**
+		 * Bail if this is not an HTTP request.
+		 *
+		 * Auth for internal requests will happen
+		 * via WordPress internals.
+		 */
+		if ( ! is_graphql_http_request() ) {
+			return false;
+		}
+
+		/**
 		 * Access the global $wp_rest_auth_cookie
 		 */
 		global $wp_rest_auth_cookie;


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
We only need to check for authentication errors for graphql http requests. We don't need to for regular internal requests using graphql() function in Page templates, etc.


Does this close any currently open issues?
-----------------------------------------
Closes #964 

Screenshots
-----------------------------------------

### BEFORE:
![Screen Shot 2019-12-11 at 3 25 20 PM](https://user-images.githubusercontent.com/1260765/70665766-8394e980-1c2a-11ea-860e-6e3a5b3faa58.png)


### AFTER: 
![Screen Shot 2019-12-11 at 3 24 19 PM](https://user-images.githubusercontent.com/1260765/70665712-6233fd80-1c2a-11ea-96ba-08c6c104ecd4.png)
