### PR TITLE
"home_url" to "get_site_url"

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -129,7 +129,7 @@ class Router {
 		if ( isset( $_SERVER['HTTP_HOST'] ) && isset( $_SERVER['REQUEST_URI'] ) ) {
 			$haystack = wp_unslash( $_SERVER['HTTP_HOST'] )
 				. wp_unslash( $_SERVER['REQUEST_URI'] );
-			$needle   = \get_site_url( self::$route );
+			$needle   = site_url( self::$route );
 
 			// Strip protocol.
 			$haystack = preg_replace( '#^(http(s)?://)#', '', $haystack );

--- a/src/Router.php
+++ b/src/Router.php
@@ -129,7 +129,7 @@ class Router {
 		if ( isset( $_SERVER['HTTP_HOST'] ) && isset( $_SERVER['REQUEST_URI'] ) ) {
 			$haystack = wp_unslash( $_SERVER['HTTP_HOST'] )
 				. wp_unslash( $_SERVER['REQUEST_URI'] );
-			$needle   = \home_url( self::$route );
+			$needle   = \get_site_url( self::$route );
 
 			// Strip protocol.
 			$haystack = preg_replace( '#^(http(s)?://)#', '', $haystack );


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
I've started to see a common trend in headless WordPress site where the `Site Address` is changed to the located of the front-end application. `home_url()` retrieve `Site Address` causing `Router::is_graphql_http_request()`  to return false incorrectly. `get_site_url()` retrieve the `WordPress Address`, the url at which the WordPress installation lives.


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Linux Mint 19.2

**WordPress Version:** 5.3
