### PR TITLE
#1063 - Z-Index issue for GraphiQL in Docs

### DIFF
--- a/docs/src/components/GraphiQL/style.css
+++ b/docs/src/components/GraphiQL/style.css
@@ -61,4 +61,6 @@
 
 .graphiql-wrapper {
     margin: 20px auto;
+    z-index: 0;
+    position: relative;
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This updates the z-index for the GraphiQL component in the Docs to make sure it doesn't overlap the search header.

Does this close any currently open issues?
------------------------------------------
closes #1063 