### PR TITLE
#1096 - Throw Exception when PHP version is lower than the required PHP version

### DIFF
--- a/docs/source/guides/debugging.mdx
+++ b/docs/source/guides/debugging.mdx
@@ -32,12 +32,15 @@ Below are some situations you may come across and some tips on how to debug them
 
 ### Internal Server Error / Schema Won’t Load in GraphiQL
 
-Sometimes you make a change to your Schema and you begin to get Internal server error responses and
-even refreshing WPGraphiQL won’t load your Schema.
+If you see an error that says "Internal Server Error" in the GraphQL response, this means something
+occurred during execution that caused an error. Not all errors are intended for public viewing as they
+can expose sensitive details about the system. To expose the errors, you can (https://docs.wpgraphql.com/guides/debugging/#graphql-debug)[enable GRAPHQL_DEBUG]:
 
-This typically occurs when a Field or Type has been registered incorrectly.
+One common reason for seeing the `Internal Server Error` response is when a Field or Type has been
+registered incorrectly.
 
-For example, when registering a Field, a Type is required as part of the config.
+For example, when registering a Field, a Type is required as part of the config. If a Type is not
+declared when registering a Field, an `Internal Server Error` will be thrown.
 
 #### Invalid Field
 

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -199,6 +199,12 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 			if ( ! defined( 'GRAPHQL_DEBUG' ) ) {
 				define( 'GRAPHQL_DEBUG', false );
 			}
+
+			// The minimum version of PHP this plugin requires to work properly
+			if ( ! defined( 'GRAPQHL_MIN_PHP_VERSION' ) ) {
+				define( 'GRAPQHL_MIN_PHP_VERSION', '7.0' );
+			}
+
 		}
 
 		/**
@@ -286,6 +292,25 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 			 */
 			add_action( 'init_graphql_request', 'register_initial_settings', 10 );
 			add_action( 'init', [ $this, 'setup_types' ], 10 );
+
+			// Throw an exception
+			add_action( 'do_graphql_request', [ $this, 'min_php_version_check' ] );
+
+		}
+
+		/**
+		 * Check if the minimum PHP version requirement is met before execution begins.
+		 *
+		 * If the server is running a lower version than required, throw an exception and prevent
+		 * further execution.
+		 *
+		 * @throws Exception
+		 */
+		public function min_php_version_check() {
+
+			if ( defined( 'GRAPQHL_MIN_PHP_VERSION' ) && version_compare( PHP_VERSION, GRAPQHL_MIN_PHP_VERSION, '<' ) ) {
+				throw new \Exception( sprintf( __( 'The server\'s current PHP version %1$s is lower than the WPGraphQL minimum required version: %2$s', 'wp-graphql' ), PHP_VERSION, GRAPQHL_MIN_PHP_VERSION ) );
+			}
 
 		}
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
If WPGraphQL is active on a server running a PHP version lower than required, currently it's difficult to understand why there are errors in the GraphQL resolution. 

This adds a check at the start of GraphQL execution to make sure the PHP version of the server meets the requirements for WPGraphQL, otherwise an Exception is thrown and further execution is prevented. 

### Changes
- Introduce a GRAPHQL_MIN_PHP_VERSION constant (7.0, default)
- add a check at the `do_graphql_request` hook to check the php version and throw an exception when the PHP version is lower than the required version
- update debugging docs about `Internal Server Error` messages and enabling `GRAPHQL_DEBUG`

Does this close any currently open issues?
------------------------------------------
closes #1096 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

With `GRAPHQL_DEBUG` enabled: 

![Screen Shot 2019-12-30 at 10 14 38 AM](https://user-images.githubusercontent.com/1260765/71592801-dad1ff80-2aee-11ea-9ca6-b953d07ba05a.png)

With `GRAPHQL_DEBUG` not enabled:

![Screen Shot 2019-12-30 at 10 29 40 AM](https://user-images.githubusercontent.com/1260765/71592982-664b9080-2aef-11ea-9465-d09cd35d02d1.png)

