### PR TITLE
#1101 - Updating Travis to test on PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,23 +19,11 @@ cache:
   apt: true
 
 ## Set the global environment variables
-#env:
-#  matrix:
-#    # These apply to the latest WP version that is available as a Docker image: https://hub.docker.com/_/wordpress/
-#
-#    # Disabling PHP 5.6 tests until "composer.lock" is updated to work with PHP 7.X AND 5.6.
-#    # - WP_VERSION=5.0.2 PHP_VERSION=5.6
-#    - WP_VERSION=5.3.2 PHP_VERSION=7.2
-#    - WP_VERSION=5.3.2 PHP_VERSION=7.3
-#    - WP_VERSION=5.3.2 PHP_VERSION=7.4 ALLOW_FAIL=true
-#    - WP_VERSION=5.3.2 PHP_VERSION=7.4 COVERAGE=true LINT_SCHEMA=true
-#    - PHPCS=true ALLOW_FAIL=true
-
 matrix:
   include:
-    - php: 7.0
+    - php: 7.2
       env: WP_VERSION=5.0 PHP_VERSION=7.0
-    - php: 7.1
+    - php: 7.2
       env: WP_VERSION=5.3.0 PHP_VERSION=7.1
     - php: 7.2
       env: WP_VERSION=5.3.2 PHP_VERSION=7.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,21 +18,34 @@ branches:
 cache:
   apt: true
 
-# Set the global environment variables
-env:
-  matrix:
-    # These apply to the latest WP version that is available as a Docker image: https://hub.docker.com/_/wordpress/
-
-    # Disabling PHP 5.6 tests until "composer.lock" is updated to work with PHP 7.X AND 5.6.
-    # - WP_VERSION=5.0.2 PHP_VERSION=5.6
-    - WP_VERSION=5.2.3 PHP_VERSION=7.1
-    - WP_VERSION=5.2.3 PHP_VERSION=7.2
-    - WP_VERSION=5.2.3 PHP_VERSION=7.3 COVERAGE=true LINT_SCHEMA=true
-    - PHPCS=true
+## Set the global environment variables
+#env:
+#  matrix:
+#    # These apply to the latest WP version that is available as a Docker image: https://hub.docker.com/_/wordpress/
+#
+#    # Disabling PHP 5.6 tests until "composer.lock" is updated to work with PHP 7.X AND 5.6.
+#    # - WP_VERSION=5.0.2 PHP_VERSION=5.6
+#    - WP_VERSION=5.3.2 PHP_VERSION=7.2
+#    - WP_VERSION=5.3.2 PHP_VERSION=7.3
+#    - WP_VERSION=5.3.2 PHP_VERSION=7.4 ALLOW_FAIL=true
+#    - WP_VERSION=5.3.2 PHP_VERSION=7.4 COVERAGE=true LINT_SCHEMA=true
+#    - PHPCS=true ALLOW_FAIL=true
 
 matrix:
+  include:
+    - php: 7.2
+      env: WP_VERSION=5.3.2 PHP_VERSION=7.2
+    - php: 7.3
+      env: WP_VERSION=5.3.2 PHP_VERSION=7.3
+    - php: 7.4
+      env: WP_VERSION=5.3.2 PHP_VERSION=7.4
+    - php: 7.4
+      env: WP_VERSION=5.3.2 PHP_VERSION=7.4 COVERAGE=true LINT_SCHEMA=true
+    - php: 7.4
+      env: WP_VERSION=5.3.2 PHP_VERSION=7.4 PHPCS=true
   allow_failures:
-    - env: PHPCS=true
+    - env: WP_VERSION=5.3.2 PHP_VERSION=7.4
+    - env: WP_VERSION=5.3.2 PHP_VERSION=7.4 PHPCS=true
 
 before_install:
   - sudo rm /usr/local/bin/docker-compose
@@ -67,6 +80,11 @@ after_success:
   - |
     if [[ "${COVERAGE}" == 'true' ]]; then
       bash <(curl -s https://codecov.io/bash)
+
+      composer self-update # This should not be required, but it is always a good practice to update composer
+      composer install
+      composer require php-coveralls/php-coveralls
+      travis_retry php vendor/bin/php-coveralls
     fi
   # Install GraphQL Schema Linter
   # Move to the WordPress Install

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,6 @@ cache:
 matrix:
   include:
     - php: 7.2
-      env: WP_VERSION=5.0 PHP_VERSION=7.0
-    - php: 7.2
       env: WP_VERSION=5.3.0 PHP_VERSION=7.1
     - php: 7.2
       env: WP_VERSION=5.3.2 PHP_VERSION=7.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,13 +28,10 @@ matrix:
     - php: 7.3
       env: WP_VERSION=5.3.2 PHP_VERSION=7.3
     - php: 7.4
-      env: WP_VERSION=5.3.2 PHP_VERSION=7.4
-    - php: 7.4
       env: WP_VERSION=5.3.2 PHP_VERSION=7.4 COVERAGE=true LINT_SCHEMA=true
     - php: 7.4
       env: WP_VERSION=5.3.2 PHP_VERSION=7.4 PHPCS=true
   allow_failures:
-    - env: WP_VERSION=5.3.2 PHP_VERSION=7.4
     - env: WP_VERSION=5.3.2 PHP_VERSION=7.4 PHPCS=true
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,10 @@ cache:
 
 matrix:
   include:
+    - php: 7.0
+      env: WP_VERSION=5.0 PHP_VERSION=7.0
+    - php: 7.1
+      env: WP_VERSION=5.3.0 PHP_VERSION=7.1
     - php: 7.2
       env: WP_VERSION=5.3.2 PHP_VERSION=7.2
     - php: 7.3

--- a/docker/docker-compose.local-app-xdebug.yml
+++ b/docker/docker-compose.local-app-xdebug.yml
@@ -7,8 +7,8 @@ services:
       context: '../'
       dockerfile: 'Dockerfile.xdebug'
       args:
-        DESIRED_WP_VERSION: "${WP_VERSION:-5.2.3}"
-        DESIRED_PHP_VERSION: "${PHP_VERSION:-7.3}"
+        DESIRED_WP_VERSION: "${WP_VERSION:-5.3.2}"
+        DESIRED_PHP_VERSION: "${PHP_VERSION:-7.4}"
     image: 'wordpress-utc-xdebug-cache'
     environment:
       # XDebug remote debugging: https://xdebug.org/docs/remote

--- a/docker/docker-compose.local-app.yml
+++ b/docker/docker-compose.local-app.yml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   wpgraphql.test:
-    image: "wordpress:${WP_VERSION:-5.2.3}-php${PHP_VERSION:-7.3}-apache"
+    image: "wordpress:${WP_VERSION:-5.3.2}-php${PHP_VERSION:-7.4}-apache"
     ports:
       - '8000:80'
     environment:

--- a/docker/docker-compose.tests.yml
+++ b/docker/docker-compose.tests.yml
@@ -6,8 +6,8 @@ services:
       context: '../'
       dockerfile: 'Dockerfile.test-base'
       args:
-        DESIRED_WP_VERSION: "${WP_VERSION:-5.2.3}"
-        DESIRED_PHP_VERSION: "${PHP_VERSION:-7.3}"
+        DESIRED_WP_VERSION: "${WP_VERSION:-5.3.2}"
+        DESIRED_PHP_VERSION: "${PHP_VERSION:-7.4}"
     image: 'wordpress-wp-graphql-test-base'
     container_name: 'wpgraphql-tester'
     environment:
@@ -28,8 +28,8 @@ services:
       context: '../'
       dockerfile: 'Dockerfile.test-base'
       args:
-        DESIRED_WP_VERSION: "${WP_VERSION:-5.2.3}"
-        DESIRED_PHP_VERSION: "${PHP_VERSION:-7.3}"
+        DESIRED_WP_VERSION: "${WP_VERSION:-5.3.2}"
+        DESIRED_PHP_VERSION: "${PHP_VERSION:-7.4}"
     image: 'wordpress-wp-graphql-test-base'
     environment:
       WORDPRESS_DB_HOST: 'mysql_test'

--- a/src/Data/Connection/UserRoleConnectionResolver.php
+++ b/src/Data/Connection/UserRoleConnectionResolver.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace WPGraphQL\Data\Connection;
 
 use WPGraphQL\Model\User;
@@ -33,12 +34,13 @@ class UserRoleConnectionResolver extends AbstractConnectionResolver {
 		$current_user_roles = wp_get_current_user()->roles;
 
 		if ( $this->source instanceof User ) {
-			$roles = $this->source->roles;
+			$roles = ! empty( $this->source->roles ) ? $this->source->roles : [];
 		} else {
 			$roles = ! empty( $this->query->get_names() ) ? array_keys( $this->query->get_names() ) : [];
 		}
 
-		$roles = array_filter(
+
+		$roles = ! empty( $roles ) ? array_filter(
 			array_map(
 				function( $role ) use ( $current_user_roles ) {
 					if ( current_user_can( 'list_users' ) ) {
@@ -48,11 +50,11 @@ class UserRoleConnectionResolver extends AbstractConnectionResolver {
 					if ( in_array( $role, $current_user_roles, true ) ) {
 						return $role;
 					}
+
 					return null;
 				},
 				$roles
-			)
-		);
+			) ) : $roles;
 
 		return $roles;
 	}
@@ -68,6 +70,7 @@ class UserRoleConnectionResolver extends AbstractConnectionResolver {
 		if ( ! is_user_logged_in() ) {
 			return false;
 		}
+
 		return true;
 	}
 

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -490,16 +490,9 @@ class Post extends Model {
 					'mediaItemUrl'        => function() {
 						return wp_get_attachment_url( $this->data->ID );
 					},
-					'sourceUrl'           => function( $size = 'full' ) {
-						if ( ! empty( $size ) ) {
-							$image_src = wp_get_attachment_image_src( $this->data->ID, $size );
-
-							if ( ! empty( $image_src ) ) {
-								return $image_src[0];
-							}
-						}
-
-						return wp_get_attachment_image_src( $this->data->ID, $size );
+					'sourceUrl'           => function() {
+						$source_url = wp_get_attachment_image_src( $this->data->ID, 'full' );
+						return isset( $source_url[0] ) ? $source_url[0] : null;
 					},
 					'sourceUrlsBySize'    => function() {
 						$sizes = get_intermediate_image_sizes();

--- a/src/Type/Object/PostObject.php
+++ b/src/Type/Object/PostObject.php
@@ -183,7 +183,11 @@ class PostObject {
 						],
 						'resolve'     => function( $image, $args, $context, $info ) {
 							// @codingStandardsIgnoreLine.
-							return ! empty( $args['size'] ) ? $image->sourceUrlsBySize[ $args['size'] ] : $image->sourceUrl;
+							$size = null;
+							if ( isset( $args['size'] ) ) {
+								$size = ( 'full' === $args['size'] ) ? 'large' : $args['size'];
+							}
+							return ! empty( $size ) ? $image->sourceUrlsBySize[ $size ] : $image->sourceUrl;
 						},
 					],
 					'mimeType'     => [

--- a/tests/wpunit/ModelUserTest.php
+++ b/tests/wpunit/ModelUserTest.php
@@ -187,14 +187,13 @@ class ModelUserTest extends \Codeception\TestCase\WPTestCase {
 		wp_set_current_user( $this->author );
 
 		$actual = $this->queryUsers();
-
 		$this->assertNotEmpty( $actual['data']['users']['nodes'] );
 		$this->assertNotEmpty( $actual['data']['users']['nodes'][0]['id'] );
 		$this->assertTrue( in_array( $actual['data']['users']['nodes'][0]['userId'], $this->userIds, true ) );
 		$this->assertNotEmpty( $actual['data']['users']['nodes'][0]['firstName'] );
 		$this->assertNotEmpty( $actual['data']['users']['nodes'][0]['lastName'] );
 		$this->assertNull( $actual['data']['users']['nodes'][0]['email'] );
-		$this->assertNull( $actual['data']['users']['nodes'][0]['roles']['nodes']  );
+		$this->assertEmpty( $actual['data']['users']['nodes'][0]['roles']['nodes']  );
 		$this->assertNull( $actual['data']['users']['nodes'][0]['username'] );
 
 		// They should still have access to their own email & role
@@ -218,7 +217,7 @@ class ModelUserTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertNotEmpty( $actual['data']['users']['nodes'][0]['firstName'] );
 		$this->assertNotEmpty( $actual['data']['users']['nodes'][0]['lastName'] );
 		$this->assertNull( $actual['data']['users']['nodes'][0]['email'] );
-		$this->assertNull( $actual['data']['users']['nodes'][0]['roles']['nodes']  );
+		$this->assertEmpty( $actual['data']['users']['nodes'][0]['roles']['nodes']  );
 		$this->assertNull( $actual['data']['users']['nodes'][0]['username'] );
 
 		// They should still have access to their own email & role
@@ -242,7 +241,7 @@ class ModelUserTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertNotEmpty( $actual['data']['users']['nodes'][0]['firstName'] );
 		$this->assertNotEmpty( $actual['data']['users']['nodes'][0]['lastName'] );
 		$this->assertNull( $actual['data']['users']['nodes'][0]['email'] );
-		$this->assertNull( $actual['data']['users']['nodes'][0]['roles']['nodes']  );
+		$this->assertEmpty( $actual['data']['users']['nodes'][0]['roles']['nodes']  );
 		$this->assertNull( $actual['data']['users']['nodes'][0]['username'] );
 
 		// They should still have access to their own email & role
@@ -266,7 +265,7 @@ class ModelUserTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertNotEmpty( $actual['data']['users']['nodes'][0]['firstName'] );
 		$this->assertNotEmpty( $actual['data']['users']['nodes'][0]['lastName'] );
 		$this->assertNull( $actual['data']['users']['nodes'][1]['email'] );
-		$this->assertNull( $actual['data']['users']['nodes'][1]['roles']['nodes'] );
+		$this->assertEmpty( $actual['data']['users']['nodes'][1]['roles']['nodes'] );
 		$this->assertNull( $actual['data']['users']['nodes'][1]['username'] );
 
 		// They should still have access to their own email & role

--- a/tests/wpunit/PostObjectQueriesTest.php
+++ b/tests/wpunit/PostObjectQueriesTest.php
@@ -124,6 +124,7 @@ class PostObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 	 * This tests creating a single post with data and retrieving said post via a GraphQL query
 	 *
 	 * @since 0.0.5
+	 * @throws Exception
 	 */
 	public function testPostQuery() {
 
@@ -248,7 +249,7 @@ class PostObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 						'mediaItemId' => $featured_image_id,
 						'thumbnail' => wp_get_attachment_image_src( $featured_image_id, 'thumbnail' )[0],
 						'medium' => wp_get_attachment_image_src( $featured_image_id, 'medium' )[0],
-						'full' => wp_get_attachment_image_src( $featured_image_id, 'full' )[0],
+						'full' => wp_get_attachment_image_src( $featured_image_id, 'large' )[0],
 						'sourceUrl' => wp_get_attachment_image_src( $featured_image_id, 'full' )[0]
 					],
 				],

--- a/tests/wpunit/UserObjectQueriesTest.php
+++ b/tests/wpunit/UserObjectQueriesTest.php
@@ -134,6 +134,8 @@ class UserObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 		 */
 		$actual = do_graphql_request( $query );
 
+		codecept_debug( $actual );
+
 
 		/**
 		 * Establish the expectation for the output of the query
@@ -798,13 +800,13 @@ class UserObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 		$actual = do_graphql_request( $query );
 
-
+		codecept_debug( $actual );
 		/**
 		 * Results should be empty for a non-authenticated request because the
 		 * users have no published posts and are not considered public
 		 */
-		$this->assertEmpty( $actual['data']['users']['pageInfo']['hasNextPage'] );
-		$this->assertEmpty( $actual['data']['users']['edges'] );
+		$this->assertArrayHasKey( 'errors', $actual );
+		$this->assertEmpty( $actual['data']['users'] );
 
 	}
 


### PR DESCRIPTION
This updates Travis to test on PHP 7.4 and updates the WordPress versions to the latest. 

This also addresses the issues that were surfaced by testing in PHP 7.4 and WP 5.3.2