### PR TITLE
Fix Typo in Custom Field Docs

### DIFF
--- a/docs/source/getting-started/custom-fields-and-meta.mdx
+++ b/docs/source/getting-started/custom-fields-and-meta.mdx
@@ -101,7 +101,7 @@ Now, we can query the color field on ANY exposed Custom Post Type in our Schema.
 }
 ```
 
-## Register multiple fields, speficying type
+## Register multiple fields, specifying type
 
 If instead we want to register multiple fields (in this case blurb and price), but control which Post Types they are exposed to, we could do the following:
 


### PR DESCRIPTION
In a piece of documentation markdown:
"speficying" -> "specifying"