### PR TITLE
Fix for hasNextPage/hasPreviousPage not fully respecting Relay spec

### DIFF
--- a/src/Data/Connection/CommentConnectionResolver.php
+++ b/src/Data/Connection/CommentConnectionResolver.php
@@ -253,7 +253,13 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 	 * @return bool
 	 */
 	public function is_valid_offset( $offset ) {
-		return ! empty( get_comment( $offset ) );
+		global $wpdb;
+
+		if ( ! empty( wp_cache_get( $offset, 'comment' ) ) ) {
+			return true;
+		}
+
+		return $wpdb->get_var( $wpdb->prepare( "SELECT EXISTS (SELECT 1 FROM $wpdb->comments WHERE comment_ID = %d)", $offset ) );
 	}
 
 }

--- a/src/Data/Connection/CommentConnectionResolver.php
+++ b/src/Data/Connection/CommentConnectionResolver.php
@@ -245,4 +245,15 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 
 	}
 
+	/**
+	 * Determine whether or not the the offset is valid, i.e the comment corresponding to the offset exists.
+	 * Offset is equivalent to comment_id. So this function is equivalent
+	 * to checking if the comment with the given ID exists.
+	 *
+	 * @return bool
+	 */
+	public function is_valid_offset( $offset ) {
+		return ! empty( get_comment( $offset ) );
+	}
+
 }

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -498,7 +498,13 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	 * @return bool
 	 */
 	public function is_valid_offset( $offset ) {
-		return ! empty( get_post( $offset ) );
+		global $wpdb;
+
+		if ( ! empty( wp_cache_get( $offset, 'posts' ) ) ) {
+			return true;
+		}
+
+		return $wpdb->get_var( $wpdb->prepare( "SELECT EXISTS (SELECT 1 FROM $wpdb->posts WHERE ID = %d)", $offset ) );
 	}
 
 }

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -438,11 +438,9 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 			foreach ( $this->post_type as $post_type ) {
 				$post_type_objects[] = get_post_type_object( $post_type );
 			}
-
 		} else {
 			$post_type_objects[] = get_post_type_object( $this->post_type );
 		}
-
 
 		/**
 		 * Make sure the statuses are allowed to be queried by the current user. If so, allow it,
@@ -452,7 +450,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		$allowed_statuses = array_filter(
 			array_map(
 				function( $status ) use ( $post_type_objects ) {
-					foreach( $post_type_objects as $post_type_object ) {
+					foreach ( $post_type_objects as $post_type_object ) {
 						if ( 'publish' === $status ) {
 							return $status;
 						}
@@ -490,6 +488,17 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		 * Return the $allowed_statuses to the query args
 		 */
 		return $allowed_statuses;
+	}
+
+	/**
+	 * Determine whether or not the the offset is valid, i.e the post corresponding to the offset exists.
+	 * Offset is equivalent to post_id. So this function is equivalent
+	 * to checking if the post with the given ID exists.
+	 *
+	 * @return bool
+	 */
+	public function is_valid_offset( $offset ) {
+		return ! empty( get_post( $offset ) );
 	}
 
 }

--- a/src/Data/Connection/TermObjectConnectionResolver.php
+++ b/src/Data/Connection/TermObjectConnectionResolver.php
@@ -276,4 +276,15 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 
 	}
 
+	/**
+	 * Determine whether or not the the offset is valid, i.e the term corresponding to the offset exists.
+	 * Offset is equivalent to term_id. So this function is equivalent
+	 * to checking if the term with the given ID exists.
+	 *
+	 * @return bool
+	 */
+	public function is_valid_offset( $offset ) {
+		return ! empty( get_term( $offset ) );
+	}
+
 }

--- a/src/Data/Connection/TermObjectConnectionResolver.php
+++ b/src/Data/Connection/TermObjectConnectionResolver.php
@@ -284,7 +284,11 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 	 * @return bool
 	 */
 	public function is_valid_offset( $offset ) {
-		return ! empty( get_term( $offset ) );
+		if ( ! empty( wp_cache_get( $offset, 'terms' ) ) ) {
+			return true;
+		}
+
+		return ! empty( term_exists( $offset ) );
 	}
 
 }

--- a/src/Data/Connection/UserConnectionResolver.php
+++ b/src/Data/Connection/UserConnectionResolver.php
@@ -226,4 +226,15 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 		return ! empty( $query_args ) && is_array( $query_args ) ? $query_args : [];
 
 	}
+
+	/**
+	 * Determine whether or not the the offset is valid, i.e the user corresponding to the offset exists.
+	 * Offset is equivalent to user_id. So this function is equivalent
+	 * to checking if the user with the given ID exists.
+	 *
+	 * @return bool
+	 */
+	public function is_valid_offset( $offset ) {
+		return ! empty( get_user_by( 'ID', $offset ) );
+	}
 }

--- a/src/Data/Connection/UserConnectionResolver.php
+++ b/src/Data/Connection/UserConnectionResolver.php
@@ -180,11 +180,11 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 		 * Only users with the "list_users" capability can filter users by roles
 		 */
 		if ( (
-				 ! empty( $args['roleIn'] ) ||
-				 ! empty( $args['roleNotIn'] ) ||
-				 ! empty( $args['role'] )
-			 ) &&
-			 ! current_user_can( 'list_users' )
+			 ! empty( $args['roleIn'] ) ||
+			 ! empty( $args['roleNotIn'] ) ||
+			 ! empty( $args['role'] )
+		 ) &&
+		 ! current_user_can( 'list_users' )
 		) {
 			throw new UserError( __( 'Sorry, you are not allowed to filter users by role.', 'wp-graphql' ) );
 		}
@@ -235,6 +235,12 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 	 * @return bool
 	 */
 	public function is_valid_offset( $offset ) {
-		return ! empty( get_user_by( 'ID', $offset ) );
+		global $wpdb;
+
+		if ( ! empty( wp_cache_get( $offset, 'users' ) ) ) {
+			return true;
+		}
+
+		return $wpdb->get_var( $wpdb->prepare( "SELECT EXISTS (SELECT 1 FROM $wpdb->users WHERE ID = %d)", $offset ) );
 	}
 }

--- a/src/Data/Connection/UserRoleConnectionResolver.php
+++ b/src/Data/Connection/UserRoleConnectionResolver.php
@@ -39,7 +39,6 @@ class UserRoleConnectionResolver extends AbstractConnectionResolver {
 			$roles = ! empty( $this->query->get_names() ) ? array_keys( $this->query->get_names() ) : [];
 		}
 
-
 		$roles = ! empty( $roles ) ? array_filter(
 			array_map(
 				function( $role ) use ( $current_user_roles ) {
@@ -54,7 +53,8 @@ class UserRoleConnectionResolver extends AbstractConnectionResolver {
 					return null;
 				},
 				$roles
-			) ) : $roles;
+			)
+		) : $roles;
 
 		return $roles;
 	}
@@ -72,6 +72,17 @@ class UserRoleConnectionResolver extends AbstractConnectionResolver {
 		}
 
 		return true;
+	}
+
+	/**
+	 * TODO: Temporarily return false for all offsets, as pagination
+	 * does not work for user roles. Will need to be updated when
+	 * proper pagination is implemented for user roles.
+	 *
+	 * @return bool
+	 */
+	public function is_valid_offset( $offset ) {
+		return false;
 	}
 
 }

--- a/tests/wpunit/CommentConnectionQueriesTest.php
+++ b/tests/wpunit/CommentConnectionQueriesTest.php
@@ -18,9 +18,11 @@ class CommentConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$this->current_time        = strtotime( '- 1 day' );
 		$this->current_date        = date( 'Y-m-d H:i:s', $this->current_time );
 		$this->current_date_gmt    = gmdate( 'Y-m-d H:i:s', $this->current_time );
-		$this->admin               = $this->factory()->user->create( [
-			'role' => 'administrator',
-		] );
+		$this->admin               = $this->factory()->user->create(
+			[
+				'role' => 'administrator',
+			]
+		);
 		$this->created_comment_ids = $this->create_comments();
 	}
 
@@ -66,10 +68,12 @@ class CommentConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$created_comments = [];
 		for ( $i = 1; $i <= 20; $i ++ ) {
 			$date                   = date( 'Y-m-d H:i:s', strtotime( "-1 day +{$i} minutes" ) );
-			$created_comments[ $i ] = $this->createCommentObject( [
-				'comment_content' => $i,
-				'comment_date'    => $date,
-			] );
+			$created_comments[ $i ] = $this->createCommentObject(
+				[
+					'comment_content' => $i,
+					'comment_date'    => $date,
+				]
+			);
 		}
 
 		return $created_comments;
@@ -108,16 +112,18 @@ class CommentConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 			'first' => 1,
 		];
 
-		$results        = $this->commentsQuery( $variables );
+		$results = $this->commentsQuery( $variables );
 
-		$comments_query = new WP_Comment_Query;
-		$comments       = $comments_query->query( [
-			'comment_status' => 'approved',
-			'number'         => 1,
-			'order'          => 'DESC',
-			'orderby'        => 'comment_date',
-			'comment_parent' => 0,
-		] );
+		$comments_query = new WP_Comment_Query();
+		$comments       = $comments_query->query(
+			[
+				'comment_status' => 'approved',
+				'number'         => 1,
+				'order'          => 'DESC',
+				'orderby'        => 'comment_date',
+				'comment_parent' => 0,
+			]
+		);
 		$first_comment  = $comments[0];
 
 		$expected_cursor = \GraphQLRelay\Connection\ArrayConnection::offsetToCursor( $first_comment->comment_ID );
@@ -128,6 +134,8 @@ class CommentConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertEquals( $expected_cursor, $results['data']['comments']['pageInfo']['startCursor'] );
 		$this->assertEquals( $expected_cursor, $results['data']['comments']['pageInfo']['endCursor'] );
 		$this->assertEquals( $first_comment->comment_ID, $results['data']['comments']['nodes'][0]['commentId'] );
+		$this->assertEquals( false, $results['data']['comments']['pageInfo']['hasPreviousPage'] );
+		$this->assertEquals( true, $results['data']['comments']['pageInfo']['hasNextPage'] );
 
 	}
 
@@ -151,15 +159,17 @@ class CommentConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		 */
 		$results = $this->commentsQuery( $variables );
 
-		$comments_query  = new WP_Comment_Query;
-		$comments        = $comments_query->query( [
-			'comment_status' => 'approved',
-			'number'         => 1,
-			'offset'         => 1,
-			'order'          => 'DESC',
-			'orderby'        => 'comment_date',
-			'comment_parent' => 0,
-		] );
+		$comments_query  = new WP_Comment_Query();
+		$comments        = $comments_query->query(
+			[
+				'comment_status' => 'approved',
+				'number'         => 1,
+				'offset'         => 1,
+				'order'          => 'DESC',
+				'orderby'        => 'comment_date',
+				'comment_parent' => 0,
+			]
+		);
 		$second_comment  = $comments[0];
 		$expected_cursor = \GraphQLRelay\Connection\ArrayConnection::offsetToCursor( $second_comment->comment_ID );
 		$this->assertNotEmpty( $results );
@@ -168,6 +178,7 @@ class CommentConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertEquals( $expected_cursor, $results['data']['comments']['edges'][0]['cursor'] );
 		$this->assertEquals( $expected_cursor, $results['data']['comments']['pageInfo']['startCursor'] );
 		$this->assertEquals( $expected_cursor, $results['data']['comments']['pageInfo']['endCursor'] );
+		$this->assertEquals( true, $results['data']['comments']['pageInfo']['hasPreviousPage'] );
 
 	}
 
@@ -179,14 +190,16 @@ class CommentConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 		$results = $this->commentsQuery( $variables );
 
-		$comments_query = new WP_Comment_Query;
-		$comments       = $comments_query->query( [
-			'comment_status' => 'approved',
-			'number'         => 1,
-			'order'          => 'ASC',
-			'orderby'        => 'comment_date',
-			'comment_parent' => 0,
-		] );
+		$comments_query = new WP_Comment_Query();
+		$comments       = $comments_query->query(
+			[
+				'comment_status' => 'approved',
+				'number'         => 1,
+				'order'          => 'ASC',
+				'orderby'        => 'comment_date',
+				'comment_parent' => 0,
+			]
+		);
 		$last_comment   = $comments[0];
 
 		$expected_cursor = \GraphQLRelay\Connection\ArrayConnection::offsetToCursor( $last_comment->comment_ID );
@@ -196,7 +209,8 @@ class CommentConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertEquals( $expected_cursor, $results['data']['comments']['edges'][0]['cursor'] );
 		$this->assertEquals( $expected_cursor, $results['data']['comments']['pageInfo']['startCursor'] );
 		$this->assertEquals( $expected_cursor, $results['data']['comments']['pageInfo']['endCursor'] );
-
+		$this->assertEquals( true, $results['data']['comments']['pageInfo']['hasPreviousPage'] );
+		$this->assertEquals( false, $results['data']['comments']['pageInfo']['hasNextPage'] );
 
 	}
 
@@ -214,15 +228,17 @@ class CommentConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 		$results = $this->commentsQuery( $variables );
 
-		$comments_query         = new WP_Comment_Query;
-		$comments               = $comments_query->query( [
-			'comment_status' => 'approved',
-			'number'         => 1,
-			'offset'         => 1,
-			'order'          => 'ASC',
-			'orderby'        => 'comment_date',
-			'comment_parent' => 0,
-		] );
+		$comments_query         = new WP_Comment_Query();
+		$comments               = $comments_query->query(
+			[
+				'comment_status' => 'approved',
+				'number'         => 1,
+				'offset'         => 1,
+				'order'          => 'ASC',
+				'orderby'        => 'comment_date',
+				'comment_parent' => 0,
+			]
+		);
 		$second_to_last_comment = $comments[0];
 
 		$expected_cursor = \GraphQLRelay\Connection\ArrayConnection::offsetToCursor( $second_to_last_comment->comment_ID );
@@ -233,6 +249,7 @@ class CommentConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertEquals( $expected_cursor, $results['data']['comments']['edges'][0]['cursor'] );
 		$this->assertEquals( $expected_cursor, $results['data']['comments']['pageInfo']['startCursor'] );
 		$this->assertEquals( $expected_cursor, $results['data']['comments']['pageInfo']['endCursor'] );
+		$this->assertEquals( true, $results['data']['comments']['pageInfo']['hasNextPage'] );
 
 	}
 

--- a/tests/wpunit/PostObjectConnectionQueriesTest.php
+++ b/tests/wpunit/PostObjectConnectionQueriesTest.php
@@ -14,12 +14,16 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$this->current_time     = strtotime( '- 1 day' );
 		$this->current_date     = date( 'Y-m-d H:i:s', $this->current_time );
 		$this->current_date_gmt = gmdate( 'Y-m-d H:i:s', $this->current_time );
-		$this->admin            = $this->factory()->user->create( [
-			'role' => 'administrator',
-		] );
-		$this->subscriber       = $this->factory()->user->create( [
-			'role' => 'subscriber'
-		] );
+		$this->admin            = $this->factory()->user->create(
+			[
+				'role' => 'administrator',
+			]
+		);
+		$this->subscriber       = $this->factory()->user->create(
+			[
+				'role' => 'subscriber',
+			]
+		);
 
 		$this->created_post_ids = $this->create_posts();
 
@@ -90,12 +94,14 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		for ( $i = 1; $i <= $count; $i ++ ) {
 			// Set the date 1 minute apart for each post
 			$date                = date( 'Y-m-d H:i:s', strtotime( "-1 day +{$i} minutes" ) );
-			$created_posts[ $i ] = $this->createPostObject( [
-				'post_type'   => 'post',
-				'post_date'   => $date,
-				'post_status' => 'publish',
-				'post_title'  => $i,
-			] );
+			$created_posts[ $i ] = $this->createPostObject(
+				[
+					'post_type'   => 'post',
+					'post_date'   => $date,
+					'post_status' => 'publish',
+					'post_title'  => $i,
+				]
+			);
 		}
 
 		return $created_posts;
@@ -140,7 +146,7 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 		if ( empty( $field ) ) {
 			return $data;
-		} else if ( ! empty( $data ) ) {
+		} elseif ( ! empty( $data ) ) {
 			$data = $data[ $field ];
 		}
 
@@ -163,9 +169,11 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		/**
 		 * Let's query the first post in our data set so we can test against it
 		 */
-		$first_post      = new WP_Query( [
-			'posts_per_page' => 1,
-		] );
+		$first_post      = new WP_Query(
+			[
+				'posts_per_page' => 1,
+			]
+		);
 		$first_post_id   = $first_post->posts[0]->ID;
 		$expected_cursor = \GraphQLRelay\Connection\ArrayConnection::offsetToCursor( $first_post_id );
 		$this->assertNotEmpty( $results );
@@ -175,6 +183,8 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertEquals( $expected_cursor, $results['data']['posts']['pageInfo']['startCursor'] );
 		$this->assertEquals( $expected_cursor, $results['data']['posts']['pageInfo']['endCursor'] );
 		$this->assertEquals( $first_post_id, $results['data']['posts']['nodes'][0]['postId'] );
+		$this->assertEquals( false, $results['data']['posts']['pageInfo']['hasPreviousPage'] );
+		$this->assertEquals( true, $results['data']['posts']['pageInfo']['hasNextPage'] );
 
 		$this->forwardPagination( $expected_cursor );
 
@@ -192,10 +202,12 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		/**
 		 * Let's query the last post in our data set so we can test against it
 		 */
-		$last_post    = new WP_Query( [
-			'posts_per_page' => 1,
-			'order'          => 'ASC',
-		] );
+		$last_post    = new WP_Query(
+			[
+				'posts_per_page' => 1,
+				'order'          => 'ASC',
+			]
+		);
 		$last_post_id = $last_post->posts[0]->ID;
 
 		$expected_cursor = \GraphQLRelay\Connection\ArrayConnection::offsetToCursor( $last_post_id );
@@ -206,6 +218,8 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertEquals( $expected_cursor, $results['data']['posts']['edges'][0]['cursor'] );
 		$this->assertEquals( $expected_cursor, $results['data']['posts']['pageInfo']['startCursor'] );
 		$this->assertEquals( $expected_cursor, $results['data']['posts']['pageInfo']['endCursor'] );
+		$this->assertEquals( true, $results['data']['posts']['pageInfo']['hasPreviousPage'] );
+		$this->assertEquals( false, $results['data']['posts']['pageInfo']['hasNextPage'] );
 
 		$this->backwardPagination( $expected_cursor );
 
@@ -222,10 +236,12 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 		codecept_debug( $results );
 
-		$second_post     = new WP_Query( [
-			'posts_per_page' => 1,
-			'paged'          => 2,
-		] );
+		$second_post     = new WP_Query(
+			[
+				'posts_per_page' => 1,
+				'paged'          => 2,
+			]
+		);
 		$second_post_id  = $second_post->posts[0]->ID;
 		$expected_cursor = \GraphQLRelay\Connection\ArrayConnection::offsetToCursor( $second_post_id );
 		$this->assertNotEmpty( $results );
@@ -234,6 +250,8 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertEquals( $expected_cursor, $results['data']['posts']['edges'][0]['cursor'] );
 		$this->assertEquals( $expected_cursor, $results['data']['posts']['pageInfo']['startCursor'] );
 		$this->assertEquals( $expected_cursor, $results['data']['posts']['pageInfo']['endCursor'] );
+		$this->assertEquals( true, $results['data']['posts']['pageInfo']['hasPreviousPage'] );
+
 	}
 
 	public function backwardPagination( $cursor ) {
@@ -245,11 +263,13 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 		$results = $this->postsQuery( $variables );
 
-		$second_to_last_post    = new WP_Query( [
-			'posts_per_page' => 1,
-			'paged'          => 2,
-			'order'          => 'ASC',
-		] );
+		$second_to_last_post    = new WP_Query(
+			[
+				'posts_per_page' => 1,
+				'paged'          => 2,
+				'order'          => 'ASC',
+			]
+		);
 		$second_to_last_post_id = $second_to_last_post->posts[0]->ID;
 		$expected_cursor        = \GraphQLRelay\Connection\ArrayConnection::offsetToCursor( $second_to_last_post_id );
 		$this->assertNotEmpty( $results );
@@ -258,6 +278,7 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertEquals( $expected_cursor, $results['data']['posts']['edges'][0]['cursor'] );
 		$this->assertEquals( $expected_cursor, $results['data']['posts']['pageInfo']['startCursor'] );
 		$this->assertEquals( $expected_cursor, $results['data']['posts']['pageInfo']['endCursor'] );
+		$this->assertEquals( true, $results['data']['posts']['pageInfo']['hasNextPage'] );
 
 	}
 
@@ -280,18 +301,24 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		/**
 		 * Test the filter to make sure it's capping the results properly
 		 */
-		add_filter( 'graphql_connection_max_query_amount', function() {
-			return 20;
-		} );
+		add_filter(
+			'graphql_connection_max_query_amount',
+			function() {
+				return 20;
+			}
+		);
 
 		$variables = [
 			'first' => 150,
 		];
 		$results   = $this->postsQuery( $variables );
 
-		add_filter( 'graphql_connection_max_query_amount', function() {
-			return 100;
-		} );
+		add_filter(
+			'graphql_connection_max_query_amount',
+			function() {
+				return 100;
+			}
+		);
 
 		$this->assertCount( 20, $results['data']['posts']['edges'] );
 		$this->assertTrue( $results['data']['posts']['pageInfo']['hasNextPage'] );
@@ -299,19 +326,23 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 	public function testPostHasPassword() {
 		// Create a test post with a password
-		$this->createPostObject( [
-			'post_title'    => 'Password protected',
-			'post_type'     => 'post',
-			'post_status'   => 'publish',
-			'post_password' => 'password',
-		] );
+		$this->createPostObject(
+			[
+				'post_title'    => 'Password protected',
+				'post_type'     => 'post',
+				'post_status'   => 'publish',
+				'post_password' => 'password',
+			]
+		);
 
 		/**
 		 * WP_Query posts with a password
 		 */
-		$wp_query_posts_with_password = new WP_Query( [
-			'has_password' => true,
-		] );
+		$wp_query_posts_with_password = new WP_Query(
+			[
+				'has_password' => true,
+			]
+		);
 
 		/**
 		 * GraphQL query posts that have a password
@@ -349,14 +380,18 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 	public function testPageWithChildren() {
 
-		$parent_id = $this->factory->post->create( [
-			'post_type' => 'page'
-		] );
+		$parent_id = $this->factory->post->create(
+			[
+				'post_type' => 'page',
+			]
+		);
 
-		$child_id = $this->factory->post->create( [
-			'post_type'   => 'page',
-			'post_parent' => $parent_id
-		] );
+		$child_id = $this->factory->post->create(
+			[
+				'post_type'   => 'page',
+				'post_parent' => $parent_id,
+			]
+		);
 
 		$global_id       = \GraphQLRelay\Relay::toGlobalId( 'page', $parent_id );
 		$global_child_id = \GraphQLRelay\Relay::toGlobalId( 'page', $child_id );
@@ -396,7 +431,6 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertEquals( $global_child_id, $child['id'] );
 		$this->assertEquals( $child_id, $child['pageId'] );
 
-
 	}
 
 	/**
@@ -432,20 +466,26 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 	public function testPrivatePostsWithoutProperCaps() {
 
-		$private_post = $this->createPostObject( [
-			'post_status' => 'private',
-		] );
-		$public_post  = $this->createPostObject( [
-			'post_status' => 'publish',
-		] );
+		$private_post = $this->createPostObject(
+			[
+				'post_status' => 'private',
+			]
+		);
+		$public_post  = $this->createPostObject(
+			[
+				'post_status' => 'publish',
+			]
+		);
 
 		wp_set_current_user( $this->subscriber );
-		$actual = $this->postsQuery( [
-			'where' => [
-				'in'    => [ $private_post, $public_post ],
-				'stati' => [ 'PUBLISH', 'PRIVATE' ]
+		$actual = $this->postsQuery(
+			[
+				'where' => [
+					'in'    => [ $private_post, $public_post ],
+					'stati' => [ 'PUBLISH', 'PRIVATE' ],
+				],
 			]
-		] );
+		);
 
 		$this->assertCount( 1, $actual['data']['posts']['edges'] );
 		$this->assertNotEmpty( $this->getReturnField( $actual, 0, 'id' ) );
@@ -464,12 +504,14 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$post_id = $this->createPostObject( $post_args );
 
 		wp_set_current_user( $this->admin );
-		$actual = $this->postsQuery( [
-			'where' => [
-				'in'    => [ $post_id ],
-				'stati' => [ 'PUBLISH', 'PRIVATE' ]
+		$actual = $this->postsQuery(
+			[
+				'where' => [
+					'in'    => [ $post_id ],
+					'stati' => [ 'PUBLISH', 'PRIVATE' ],
+				],
 			]
-		] );
+		);
 
 		codecept_debug( $actual );
 
@@ -488,12 +530,14 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$post_id = $this->createPostObject( $post_args );
 
 		wp_set_current_user( $this->subscriber );
-		$actual = $this->postsQuery( [
-			'where' => [
-				'in'    => [ $post_id ],
-				'stati' => [ 'PUBLISH', 'PRIVATE' ]
+		$actual = $this->postsQuery(
+			[
+				'where' => [
+					'in'    => [ $post_id ],
+					'stati' => [ 'PUBLISH', 'PRIVATE' ],
+				],
 			]
-		] );
+		);
 
 		/**
 		 * Since we're querying for a private post, we want to make sure a subscriber, even if they
@@ -510,7 +554,6 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		 *
 		 * We're going in the direction of the REST API here. Where certain statuses can only be
 		 * queried by users with certain capabilities.
-		 *
 		 */
 		$this->assertEmpty( $actual['data']['posts']['edges'] );
 		$this->assertEmpty( $actual['data']['posts']['nodes'] );
@@ -523,11 +566,13 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 	public function testRevisionWithoutProperCaps( $role, $show_revisions ) {
 
 		$parent_post = $this->createPostObject( [] );
-		$revision    = $this->createPostObject( [
-			'post_type'   => 'revision',
-			'post_parent' => $parent_post,
-			'post_status' => 'inherit',
-		] );
+		$revision    = $this->createPostObject(
+			[
+				'post_type'   => 'revision',
+				'post_parent' => $parent_post,
+				'post_status' => 'inherit',
+			]
+		);
 
 		$query = "
 		{
@@ -584,12 +629,14 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 		wp_set_current_user( $this->{$role} );
 
-		$actual = $this->postsQuery( [
-			'where' => [
-				'in'    => [ $public_post, $draft_post ],
-				'stati' => [ 'PUBLISH', 'DRAFT' ]
+		$actual = $this->postsQuery(
+			[
+				'where' => [
+					'in'    => [ $public_post, $draft_post ],
+					'stati' => [ 'PUBLISH', 'DRAFT' ],
+				],
 			]
-		] );
+		);
 
 		if ( 'admin' === $role ) {
 
@@ -610,7 +657,7 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 				$this->assertNull( $content_field );
 				$this->assertNull( $excerpt_field );
 			}
-		} else if ( 'subscriber' === $role ) {
+		} elseif ( 'subscriber' === $role ) {
 
 			/**
 			 * The subscriber should only have access to 1 post, the public one.
@@ -636,12 +683,14 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 		wp_set_current_user( $this->{$role} );
 
-		$actual = $this->postsQuery( [
-			'where' => [
-				'in'    => [ $public_post, $draft_post ],
-				'stati' => [ 'PUBLISH', 'TRASH' ]
+		$actual = $this->postsQuery(
+			[
+				'where' => [
+					'in'    => [ $public_post, $draft_post ],
+					'stati' => [ 'PUBLISH', 'TRASH' ],
+				],
 			]
-		] );
+		);
 
 		if ( 'admin' === $role ) {
 			/**
@@ -660,7 +709,7 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 				$this->assertNull( $content_field );
 				$this->assertNull( $excerpt_field );
 			}
-		} else if ( 'subscriber' === $role ) {
+		} elseif ( 'subscriber' === $role ) {
 			/**
 			 * The subscriber should only be able to see 1 post, the public one, not the trashed post.
 			 */
@@ -679,7 +728,7 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 			[
 				'admin',
 				true,
-			]
+			],
 		];
 	}
 

--- a/tests/wpunit/TermObjectConnectionQueriesTest.php
+++ b/tests/wpunit/TermObjectConnectionQueriesTest.php
@@ -15,9 +15,11 @@ class TermObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$this->current_time     = strtotime( '- 1 day' );
 		$this->current_date     = date( 'Y-m-d H:i:s', $this->current_time );
 		$this->current_date_gmt = gmdate( 'Y-m-d H:i:s', $this->current_time );
-		$this->admin            = $this->factory()->user->create( [
-			'role' => 'administrator',
-		] );
+		$this->admin            = $this->factory()->user->create(
+			[
+				'role' => 'administrator',
+			]
+		);
 		$this->created_term_ids = $this->create_terms();
 	}
 
@@ -66,11 +68,13 @@ class TermObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		// Create 20 posts
 		$created_terms = [];
 		for ( $i = 1; $i <= 20; $i ++ ) {
-			$term_id             = $this->createTermObject( [
-				'taxonomy'    => 'category',
-				'description' => $i,
-				'name'        => $i,
-			] );
+			$term_id             = $this->createTermObject(
+				[
+					'taxonomy'    => 'category',
+					'description' => $i,
+					'name'        => $i,
+				]
+			);
 			$created_terms[ $i ] = $term_id;
 		}
 
@@ -120,14 +124,16 @@ class TermObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		/**
 		 * Let's query the first post in our data set so we can test against it
 		 */
-		$query = new WP_Term_Query( [
-			'taxonomy'   => 'category',
-			'number'     => 1,
-			'parent'     => 0,
-			'orderby'    => 'name',
-			'order'      => 'ASC',
-			'hide_empty' => false,
-		] );
+		$query = new WP_Term_Query(
+			[
+				'taxonomy'   => 'category',
+				'number'     => 1,
+				'parent'     => 0,
+				'orderby'    => 'name',
+				'order'      => 'ASC',
+				'hide_empty' => false,
+			]
+		);
 		$terms = $query->get_terms();
 
 		$first_term_id   = $terms[0]->term_id;
@@ -139,6 +145,8 @@ class TermObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertEquals( $expected_cursor, $results['data']['categories']['pageInfo']['startCursor'] );
 		$this->assertEquals( $expected_cursor, $results['data']['categories']['pageInfo']['endCursor'] );
 		$this->assertEquals( $first_term_id, $results['data']['categories']['nodes'][0]['categoryId'] );
+		$this->assertEquals( false, $results['data']['categories']['pageInfo']['hasPreviousPage'] );
+		$this->assertEquals( true, $results['data']['categories']['pageInfo']['hasNextPage'] );
 		$this->forwardPagination( $expected_cursor );
 
 	}
@@ -153,15 +161,17 @@ class TermObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$results = $this->categoriesQuery( $variables );
 
 		$offset = 1;
-		$query  = new WP_Term_Query( [
-			'taxonomy'   => 'category',
-			'number'     => 1,
-			'offset'     => $offset,
-			'parent'     => 0,
-			'orderby'    => 'name',
-			'order'      => 'ASC',
-			'hide_empty' => false,
-		] );
+		$query  = new WP_Term_Query(
+			[
+				'taxonomy'   => 'category',
+				'number'     => 1,
+				'offset'     => $offset,
+				'parent'     => 0,
+				'orderby'    => 'name',
+				'order'      => 'ASC',
+				'hide_empty' => false,
+			]
+		);
 		$terms  = $query->get_terms();
 
 		$second_term_id  = $terms[ $offset ]->term_id;
@@ -172,6 +182,7 @@ class TermObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertEquals( $expected_cursor, $results['data']['categories']['edges'][0]['cursor'] );
 		$this->assertEquals( $expected_cursor, $results['data']['categories']['pageInfo']['startCursor'] );
 		$this->assertEquals( $expected_cursor, $results['data']['categories']['pageInfo']['endCursor'] );
+		$this->assertEquals( true, $results['data']['categories']['pageInfo']['hasPreviousPage'] );
 	}
 
 	public function testLastPost() {
@@ -186,14 +197,16 @@ class TermObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		/**
 		 * Let's query the last post in our data set so we can test against it
 		 */
-		$query = new WP_Term_Query( [
-			'taxonomy'   => 'category',
-			'number'     => 1,
-			'parent'     => 0,
-			'orderby'    => 'name',
-			'order'      => 'DESC',
-			'hide_empty' => false,
-		] );
+		$query = new WP_Term_Query(
+			[
+				'taxonomy'   => 'category',
+				'number'     => 1,
+				'parent'     => 0,
+				'orderby'    => 'name',
+				'order'      => 'DESC',
+				'hide_empty' => false,
+			]
+		);
 		$terms = $query->get_terms();
 
 		$last_term_id    = $terms[0]->term_id;
@@ -204,6 +217,8 @@ class TermObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertEquals( $expected_cursor, $results['data']['categories']['edges'][0]['cursor'] );
 		$this->assertEquals( $expected_cursor, $results['data']['categories']['pageInfo']['startCursor'] );
 		$this->assertEquals( $expected_cursor, $results['data']['categories']['pageInfo']['endCursor'] );
+		$this->assertEquals( true, $results['data']['categories']['pageInfo']['hasPreviousPage'] );
+		$this->assertEquals( false, $results['data']['categories']['pageInfo']['hasNextPage'] );
 
 		$this->backwardPagination( $expected_cursor );
 
@@ -219,15 +234,17 @@ class TermObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$results = $this->categoriesQuery( $variables );
 
 		$offset = 1;
-		$query  = new WP_Term_Query( [
-			'taxonomy'   => 'category',
-			'number'     => 1,
-			'parent'     => 0,
-			'offset'     => $offset,
-			'orderby'    => 'name',
-			'order'      => 'DESC',
-			'hide_empty' => false,
-		] );
+		$query  = new WP_Term_Query(
+			[
+				'taxonomy'   => 'category',
+				'number'     => 1,
+				'parent'     => 0,
+				'offset'     => $offset,
+				'orderby'    => 'name',
+				'order'      => 'DESC',
+				'hide_empty' => false,
+			]
+		);
 		$terms  = $query->get_terms();
 
 		$second_last_term_id = $terms[ $offset ]->term_id;
@@ -238,6 +255,7 @@ class TermObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertEquals( $expected_cursor, $results['data']['categories']['edges'][0]['cursor'] );
 		$this->assertEquals( $expected_cursor, $results['data']['categories']['pageInfo']['startCursor'] );
 		$this->assertEquals( $expected_cursor, $results['data']['categories']['pageInfo']['endCursor'] );
+		$this->assertEquals( true, $results['data']['categories']['pageInfo']['hasNextPage'] );
 
 	}
 

--- a/tests/wpunit/UserObjectCursorTest.php
+++ b/tests/wpunit/UserObjectCursorTest.php
@@ -21,18 +21,20 @@ class UserObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 		$this->current_time = strtotime( '- 1 day' );
 		$this->current_date = date( 'Y-m-d H:i:s', $this->current_time );
 		// Number of users to create. More created users will slow down the test.
-		$this->count	= 10;
+		$this->count = 10;
 		$this->create_users();
 
 		$this->query = '
-		query GET_POSTS($first: Int, $last: Int, $after: String, $before: String, $where: RootQueryToUserConnectionWhereArgs) {
+		query GET_USERS($first: Int, $last: Int, $after: String, $before: String, $where: RootQueryToUserConnectionWhereArgs) {
 			users(last: $last, before: $before, first: $first, after: $after, where: $where) {
 				pageInfo {
 					startCursor
 					endCursor
+					hasNextPage
+					hasPreviousPage
 				}
-			    	nodes {
-			      		userId
+			    nodes {
+			      	userId
 				}
 		  	}
 		}
@@ -51,8 +53,8 @@ class UserObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 		 * Set up the $defaults
 		 */
 		$defaults = [
-			'role'		=> 'subscriber',
-			'user_url' 	=> 'http://www.test.test',
+			'role'     => 'subscriber',
+			'user_url' => 'http://www.test.test',
 		];
 
 		/**
@@ -82,9 +84,11 @@ class UserObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 		$created_user_ids = [ 1 ];
 		// Create a few more users
 		for ( $i = 1; $i < $this->count; $i ++ ) {
-			$created_user_ids[ $i ]	= $this->createUserObject( [
-				'user_email' => 'test_user_' . $i . '@test.com',
-			] );
+			$created_user_ids[ $i ] = $this->createUserObject(
+				[
+					'user_email' => 'test_user_' . $i . '@test.com',
+				]
+			);
 		}
 
 		$this->created_user_ids = array_reverse( $created_user_ids );
@@ -96,10 +100,12 @@ class UserObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 	 */
 	public function delete_users() {
 		global $wpdb;
-		$wpdb->query( $wpdb->prepare(
-			"DELETE FROM {$wpdb->prefix}users WHERE ID <> %d",
-		    array( 1 )
-		) );
+		$wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM {$wpdb->prefix}users WHERE ID <> %d",
+				array( 1 )
+			)
+		);
 		$this->created_user_ids = [ 1 ];
 	}
 
@@ -109,136 +115,154 @@ class UserObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 	public function testUsersForwardPagination() {
 
 		$paged_count = ceil( $this->count / 2 );
-		$expected = array_slice( $this->created_user_ids, 0, $paged_count );
+		$expected    = array_slice( $this->created_user_ids, 0, $paged_count );
 
 		codecept_debug( $expected );
 
-		$actual = graphql( [
-			'query' 		=> $this->query,
-			'variables' => [
-				'first' => $paged_count,
-				'where' => [
-					'search' => 'http://www.test.test',
+		$actual = graphql(
+			[
+				'query'     => $this->query,
+				'variables' => [
+					'first' => $paged_count,
+					'where' => [
+						'search' => 'http://www.test.test',
+					],
 				],
-			],
-		] );
+			]
+		);
 
 		codecept_debug( $actual );
 
 		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEquals( false, $actual['data']['users']['pageInfo']['hasPreviousPage'] );
+		$this->assertEquals( true, $actual['data']['users']['pageInfo']['hasNextPage'] );
 
 		// Compare actual results to ground truth
 		for ( $i = 0; $i < $paged_count; $i ++ ) {
-			$this->assertEquals( $expected[$i], $actual['data']['users']['nodes'][$i]['userId'] );
+			$this->assertEquals( $expected[ $i ], $actual['data']['users']['nodes'][ $i ]['userId'] );
 		}
 
 		$expected = array_slice( $this->created_user_ids, $paged_count, $paged_count );
 
 		codecept_debug( $expected );
 
-		$actual = graphql( [
-			'query' 		=> $this->query,
-			'variables' => [
-				'first' => $paged_count,
-				'after' => $actual['data']['users']['pageInfo']['endCursor'],
-				'where' => [
-					'search' => 'http://www.test.test',
+		$actual = graphql(
+			[
+				'query'     => $this->query,
+				'variables' => [
+					'first' => $paged_count,
+					'after' => $actual['data']['users']['pageInfo']['endCursor'],
+					'where' => [
+						'search' => 'http://www.test.test',
+					],
 				],
-			],
-		] );
+			]
+		);
 
 		codecept_debug( $actual );
 
 		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEquals( true, $actual['data']['users']['pageInfo']['hasPreviousPage'] );
+		$this->assertEquals( false, $actual['data']['users']['pageInfo']['hasNextPage'] );
 
 		for ( $i = 0; $i < $paged_count - 1; $i ++ ) {
-			$this->assertEquals( $expected[$i], $actual['data']['users']['nodes'][$i]['userId'] );
+			$this->assertEquals( $expected[ $i ], $actual['data']['users']['nodes'][ $i ]['userId'] );
 		}
 	}
 
 	/**
 	 * Tests the backward pagination of connections
+	 *
 	 * @throws Exception
 	 */
 	public function testUsersBackwardPagination() {
 
 		$paged_count = ceil( $this->count / 2 );
-		$expected = array_slice( $this->created_user_ids, $paged_count - 1, $paged_count );
+		$expected    = array_slice( $this->created_user_ids, $paged_count - 1, $paged_count );
 
 		codecept_debug( $expected );
 
-		$actual = graphql( [
-			'query' 		=> $this->query,
-			'variables' => [
-				'last' => $paged_count,
-				'where' => [
-					'search' => 'http://www.test.test',
+		$actual = graphql(
+			[
+				'query'     => $this->query,
+				'variables' => [
+					'last'  => $paged_count,
+					'where' => [
+						'search' => 'http://www.test.test',
+					],
 				],
-			],
-		] );
+			]
+		);
 
 		codecept_debug( $actual );
 
 		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEquals( true, $actual['data']['users']['pageInfo']['hasPreviousPage'] );
+		$this->assertEquals( false, $actual['data']['users']['pageInfo']['hasNextPage'] );
 
 		// Compare actual results to ground truth
 		for ( $i = 0; $i < $paged_count; $i ++ ) {
-			$this->assertEquals( $expected[$i], $actual['data']['users']['nodes'][$i]['userId'] );
+			$this->assertEquals( $expected[ $i ], $actual['data']['users']['nodes'][ $i ]['userId'] );
 		}
 
 		$paged_count = ceil( $this->count / 2 );
-		$expected = array_slice( $this->created_user_ids, 0, $paged_count - 1);
+		$expected    = array_slice( $this->created_user_ids, 0, $paged_count - 1 );
 
 		codecept_debug( $expected );
 
-		$actual = graphql( [
-			'query' 		=> $this->query,
-			'variables' => [
-				'last' => $paged_count,
-				'before' => $actual['data']['users']['pageInfo']['startCursor'],
-				'where' => [
-					'search' => 'http://www.test.test',
+		$actual = graphql(
+			[
+				'query'     => $this->query,
+				'variables' => [
+					'last'   => $paged_count,
+					'before' => $actual['data']['users']['pageInfo']['startCursor'],
+					'where'  => [
+						'search' => 'http://www.test.test',
+					],
 				],
-			],
-		] );
+			]
+		);
 
 		codecept_debug( $actual );
 
 		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEquals( false, $actual['data']['users']['pageInfo']['hasPreviousPage'] );
+		$this->assertEquals( true, $actual['data']['users']['pageInfo']['hasNextPage'] );
 
 		for ( $i = 0; $i < $paged_count - 1; $i ++ ) {
-			$this->assertEquals( $expected[$i], $actual['data']['users']['nodes'][$i]['userId'] );
+			$this->assertEquals( $expected[ $i ], $actual['data']['users']['nodes'][ $i ]['userId'] );
 		}
 	}
 
-	private function formatNumber($num) {
-		return sprintf('%08d', $num);
+	private function formatNumber( $num ) {
+		return sprintf( '%08d', $num );
 	}
 
-	private function numberToMysqlDate($num) {
-		return sprintf('2019-03-%02d', $num);
+	private function numberToMysqlDate( $num ) {
+		return sprintf( '2019-03-%02d', $num );
 	}
 
 	private function deleteByMetaKey( $key, $value ) {
 		$args = array(
 			'meta_query' => array(
 				array(
-					'key' => $key,
-					'value' => $value,
+					'key'     => $key,
+					'value'   => $value,
 					'compare' => '=',
-				)
-			)
-		 );
+				),
+			),
+		);
 
-		 $query = new WP_User_Query($args);
+		 $query = new WP_User_Query( $args );
 
-		 foreach ( $query->results as $user ) {
+		foreach ( $query->results as $user ) {
 			wp_delete_user( $user->ID, true );
-		 }
+		}
 	}
 
 	/**
 	 * Assert given 'orderby' field by comparing the GraphQL query against a plain WP_User_Query
+	 *
 	 * @throws Exception
 	 */
 	public function assertQueryInCursor( $graphql_args, $wp_user_query_args, $order_by_meta_field = false ) {
@@ -247,9 +271,14 @@ class UserObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 
 		// Meta field orderby is not supported in schema and needs to be passed in through hook
 		if ( $order_by_meta_field ) {
-			add_filter( 'graphql_map_input_fields_to_wp_user_query', function( $query_args ) use ( $wp_user_query_args ) {
-				return array_merge( $query_args, $wp_user_query_args );
-			}, 10, 1 );
+			add_filter(
+				'graphql_map_input_fields_to_wp_user_query',
+				function( $query_args ) use ( $wp_user_query_args ) {
+					return array_merge( $query_args, $wp_user_query_args );
+				},
+				10,
+				1
+			);
 		}
 
 		$users_per_page = ceil( $this->count / 2 );
@@ -278,51 +307,66 @@ class UserObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->assertArrayNotHasKey( 'errors', $first, print_r( $first, true ) );
 
-		$first_page_actual = array_map( function( $edge ) {
-			return $edge['node']['userId'];
-		}, $first['data']['users']['edges']);
-
+		$first_page_actual = array_map(
+			function( $edge ) {
+				return $edge['node']['userId'];
+			},
+			$first['data']['users']['edges']
+		);
 
 		$cursor = $first['data']['users']['pageInfo']['endCursor'];
 		$second = do_graphql_request( $query, 'getUsers', [ 'cursor' => $cursor ] );
 
 		$this->assertArrayNotHasKey( 'errors', $second, print_r( $second, true ) );
 
-		$second_page_actual = array_map( function( $edge ) {
-			return $edge['node']['userId'];
-		}, $second['data']['users']['edges']);
+		$second_page_actual = array_map(
+			function( $edge ) {
+				return $edge['node']['userId'];
+			},
+			$second['data']['users']['edges']
+		);
 
 		// Make corresponding WP_User_Query
 		WPGraphQL::__set_is_graphql_request( true );
-		$first_page = new WP_User_Query( array_merge( $wp_user_query_args, [
-			'number' => $users_per_page,
-			'paged' => 1,
-		] ) );
+		$first_page = new WP_User_Query(
+			array_merge(
+				$wp_user_query_args,
+				[
+					'number' => $users_per_page,
+					'paged'  => 1,
+				]
+			)
+		);
 
-		$second_page = new WP_User_Query( array_merge( $wp_user_query_args, [
-			'number' => $users_per_page,
-			'paged' => 2,
-		] ) );
+		$second_page = new WP_User_Query(
+			array_merge(
+				$wp_user_query_args,
+				[
+					'number' => $users_per_page,
+					'paged'  => 2,
+				]
+			)
+		);
 		WPGraphQL::__set_is_graphql_request( false );
-		$first_page_expected 	= wp_list_pluck($first_page->results, 'ID');
-		$second_page_expected = wp_list_pluck($second_page->results, 'ID');
+		$first_page_expected  = wp_list_pluck( $first_page->results, 'ID' );
+		$second_page_expected = wp_list_pluck( $second_page->results, 'ID' );
 
 		// WPGraphQL uses reverse ordering compared to WP_User_Query ordering	if orderby arg is not specified
 		if ( empty( $wp_user_query_args['orderby'] ) ) {
-			$first_page_expected 	= array_reverse( wp_list_pluck($second_page->results, 'ID') );
-			$second_page_expected = array_reverse( wp_list_pluck($first_page->results, 'ID') );
+			$first_page_expected  = array_reverse( wp_list_pluck( $second_page->results, 'ID' ) );
+			$second_page_expected = array_reverse( wp_list_pluck( $first_page->results, 'ID' ) );
 		}
 
 		// Aserting like this we get more readable assertion fail message
-		$this->assertEquals( implode(',', $first_page_expected), implode(',', $first_page_actual), 'First page' );
-		$this->assertEquals( implode(',', $second_page_expected), implode(',', $second_page_actual), 'Second page' );
+		$this->assertEquals( implode( ',', $first_page_expected ), implode( ',', $first_page_actual ), 'First page' );
+		$this->assertEquals( implode( ',', $second_page_expected ), implode( ',', $second_page_actual ), 'Second page' );
 	}
 
 	/**
 	 * Test default order
 	 */
 	public function testDefaultUserOrdering() {
-		$this->assertQueryInCursor( NULL, [ ] );
+		$this->assertQueryInCursor( null, [] );
 	}
 
 	/**
@@ -332,8 +376,8 @@ class UserObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertQueryInCursor(
 			[
 				'orderby' => [
-					'field' => 'LOGIN_IN'
-				]
+					'field' => 'LOGIN_IN',
+				],
 			],
 			[
 				'orderby' => 'login__in',
@@ -349,12 +393,12 @@ class UserObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 			[
 				'orderby' => [
 					'field' => 'LOGIN_IN',
-					'order' => 'ASC'
-				]
+					'order' => 'ASC',
+				],
 			],
 			[
 				'orderby' => 'login__in',
-				'order' 	=> 'ASC'
+				'order'   => 'ASC',
 			]
 		);
 	}
@@ -367,12 +411,12 @@ class UserObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 			[
 				'orderby' => [
 					'field' => 'LOGIN_IN',
-					'order' => 'DESC'
-				]
+					'order' => 'DESC',
+				],
 			],
 			[
 				'orderby' => 'login__in',
-				'order' 	=> 'DESC'
+				'order'   => 'DESC',
 			]
 		);
 	}
@@ -385,12 +429,12 @@ class UserObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 			[
 				'orderby' => [
 					'field' => 'NICE_NAME',
-					'order'	=> 'ASC'
-				]
+					'order' => 'ASC',
+				],
 			],
 			[
 				'orderby' => 'nicename',
-				'order'		=> 'ASC'
+				'order'   => 'ASC',
 			]
 		);
 	}
@@ -403,35 +447,37 @@ class UserObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 			[
 				'orderby' => [
 					'field' => 'NICE_NAME',
-					'order'	=> 'DESC'
-				]
+					'order' => 'DESC',
+				],
 			],
 			[
 				'orderby' => 'nicename',
-				'order'		=> 'DESC'
+				'order'   => 'DESC',
 			]
 		);
 	}
 
 	public function testUserOrderingByDuplicateUserNames() {
-		foreach ($this->created_user_ids as $index => $user_id) {
-			wp_update_user( [
-				'ID' => $user_id,
-				'user_nicename' => 'dupname',
+		foreach ( $this->created_user_ids as $index => $user_id ) {
+			wp_update_user(
+				[
+					'ID'            => $user_id,
+					'user_nicename' => 'dupname',
 
-			] );
+				]
+			);
 		}
 
 		$this->assertQueryInCursor(
 			[
 				'orderby' => [
 					'field' => 'NICE_NAME',
-					'order'	=> 'DESC'
-				]
+					'order' => 'DESC',
+				],
 			],
 			[
 				'orderby' => 'nicename',
-				'order'		=> 'DESC'
+				'order'   => 'DESC',
 			]
 		);
 	}
@@ -439,13 +485,13 @@ class UserObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 	public function testUserOrderingByMetaString() {
 
 		// Add user meta to created users
-		foreach ($this->created_user_ids as $index => $user_id) {
-			update_user_meta($user_id, 'test_meta', $this->formatNumber( $index ) );
+		foreach ( $this->created_user_ids as $index => $user_id ) {
+			update_user_meta( $user_id, 'test_meta', $this->formatNumber( $index ) );
 		}
 
 		// Move number 9 to the second page when ordering by test_meta
 		$this->deleteByMetaKey( 'test_meta', $this->formatNumber( 6 ) );
-		update_user_meta($this->created_user_ids[9], 'test_meta', $this->formatNumber( 6 ) );
+		update_user_meta( $this->created_user_ids[9], 'test_meta', $this->formatNumber( 6 ) );
 
 		// Must use dummy where args here to force
 		// graphql_map_input_fields_to_wp_query to be executed
@@ -453,12 +499,12 @@ class UserObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 			[
 				'roleIn' => [
 					'ADMINISTRATOR',
-					'SUBSCRIBER'
-				]
+					'SUBSCRIBER',
+				],
 			],
 			[
-				'orderby' 	=> [ 'meta_value' => 'ASC', ],
-				'meta_key' 	=> 'test_meta',
+				'orderby'  => [ 'meta_value' => 'ASC' ],
+				'meta_key' => 'test_meta',
 			],
 			true
 		);
@@ -468,7 +514,7 @@ class UserObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 	public function testUserOrderingByMetaDate() {
 
 		// Add user meta to created users
-		foreach ($this->created_user_ids as $index => $user_id) {
+		foreach ( $this->created_user_ids as $index => $user_id ) {
 			update_user_meta( $user_id, 'test_meta', $this->numberToMysqlDate( $index ) );
 		}
 
@@ -480,12 +526,12 @@ class UserObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 			[
 				'roleIn' => [
 					'ADMINISTRATOR',
-					'SUBSCRIBER'
-				]
+					'SUBSCRIBER',
+				],
 			],
 			[
-				'orderby' => [ 'meta_value' => 'ASC', ],
-				'meta_key' => 'test_meta',
+				'orderby'   => [ 'meta_value' => 'ASC' ],
+				'meta_key'  => 'test_meta',
 				'meta_type' => 'DATE',
 			],
 			true
@@ -495,7 +541,7 @@ class UserObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 	public function testUserOrderingByMetaDateDESC() {
 
 		// Add user meta to created users
-		foreach ($this->created_user_ids as $index => $user_id) {
+		foreach ( $this->created_user_ids as $index => $user_id ) {
 			update_user_meta( $user_id, 'test_meta', $this->numberToMysqlDate( $index ) );
 		}
 
@@ -506,12 +552,12 @@ class UserObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 			[
 				'roleIn' => [
 					'ADMINISTRATOR',
-					'SUBSCRIBER'
-				]
+					'SUBSCRIBER',
+				],
 			],
 			[
-				'orderby' => [ 'meta_value' => 'DESC', ],
-				'meta_key' => 'test_meta',
+				'orderby'   => [ 'meta_value' => 'DESC' ],
+				'meta_key'  => 'test_meta',
 				'meta_type' => 'DATE',
 			],
 			true
@@ -521,24 +567,24 @@ class UserObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 	public function testUserOrderingByMetaNumber() {
 
 		// Add user meta to created users
-		foreach ($this->created_user_ids as $index => $user_id) {
-			update_user_meta($user_id, 'test_meta', $index );
+		foreach ( $this->created_user_ids as $index => $user_id ) {
+			update_user_meta( $user_id, 'test_meta', $index );
 		}
 
 		// Move number 9 to the second page when ordering by test_meta
 		$this->deleteByMetaKey( 'test_meta', 6 );
-		update_user_meta($this->created_user_ids[9], 'test_meta', 6 );
+		update_user_meta( $this->created_user_ids[9], 'test_meta', 6 );
 
 		$this->assertQueryInCursor(
 			[
 				'roleIn' => [
 					'ADMINISTRATOR',
-					'SUBSCRIBER'
-				]
+					'SUBSCRIBER',
+				],
 			],
 			[
-				'orderby' => [ 'meta_value' => 'ASC', ],
-				'meta_key' => 'test_meta',
+				'orderby'   => [ 'meta_value' => 'ASC' ],
+				'meta_key'  => 'test_meta',
 				'meta_type' => 'UNSIGNED',
 			],
 			true
@@ -548,7 +594,7 @@ class UserObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 	public function testUserOrderingByMetaNumberDESC() {
 
 		// Add user meta to created users
-		foreach ($this->created_user_ids as $index => $user_id) {
+		foreach ( $this->created_user_ids as $index => $user_id ) {
 			update_user_meta( $user_id, 'test_meta', $index );
 		}
 
@@ -559,12 +605,12 @@ class UserObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 			[
 				'roleIn' => [
 					'ADMINISTRATOR',
-					'SUBSCRIBER'
-				]
+					'SUBSCRIBER',
+				],
 			],
 			[
-				'orderby' => [ 'meta_value' => 'DESC', ],
-				'meta_key' => 'test_meta',
+				'orderby'   => [ 'meta_value' => 'DESC' ],
+				'meta_key'  => 'test_meta',
 				'meta_type' => 'UNSIGNED',
 			],
 			true
@@ -573,25 +619,25 @@ class UserObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 
 	public function testUserOrderingWithMetaFiltering() {
 		// Add user meta to created users
-		foreach ($this->created_user_ids as $index => $user_id) {
-			update_user_meta($user_id, 'test_meta', $index );
+		foreach ( $this->created_user_ids as $index => $user_id ) {
+			update_user_meta( $user_id, 'test_meta', $index );
 		}
 
 		// Move number 2 to the second page when ordering by test_meta
 		$this->deleteByMetaKey( 'test_meta', 7 );
-		update_user_meta($this->created_user_ids[2], 'test_meta', 7 );
+		update_user_meta( $this->created_user_ids[2], 'test_meta', 7 );
 
 		$this->assertQueryInCursor(
 			[
 				'roleIn' => [
 					'ADMINISTRATOR',
-					'SUBSCRIBER'
-				]
+					'SUBSCRIBER',
+				],
 			],
 			[
-				'orderby' => [ 'meta_value' => 'ASC', ],
-				'meta_key' => 'test_meta',
-				'meta_type' => 'UNSIGNED',
+				'orderby'    => [ 'meta_value' => 'ASC' ],
+				'meta_key'   => 'test_meta',
+				'meta_type'  => 'UNSIGNED',
 				'meta_query' => [
 					[
 						'key'     => 'test_meta',
@@ -599,7 +645,7 @@ class UserObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 						'value'   => 10,
 						'type'    => 'UNSIGNED',
 					],
-				]
+				],
 			],
 			true
 		);
@@ -608,29 +654,29 @@ class UserObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 
 	public function testUserOrderingByMetaQueryClause() {
 
-		foreach ($this->created_user_ids as $index => $user_id) {
-			update_user_meta($user_id, 'test_meta', $this->formatNumber( $index ) );
+		foreach ( $this->created_user_ids as $index => $user_id ) {
+			update_user_meta( $user_id, 'test_meta', $this->formatNumber( $index ) );
 		}
 
 		// Move number 9 to the second page when ordering by test_meta
 		$this->deleteByMetaKey( 'test_meta', $this->formatNumber( 6 ) );
-		update_user_meta($this->created_user_ids[9], 'test_meta', $this->formatNumber( 6 ) );
+		update_user_meta( $this->created_user_ids[9], 'test_meta', $this->formatNumber( 6 ) );
 
 		$this->assertQueryInCursor(
 			[
 				'roleIn' => [
 					'ADMINISTRATOR',
-					'SUBSCRIBER'
-				]
+					'SUBSCRIBER',
+				],
 			],
 			[
-				'orderby' => [ 'test_clause' => 'ASC', ],
+				'orderby'    => [ 'test_clause' => 'ASC' ],
 				'meta_query' => [
 					'test_clause' => [
-						'key' => 'test_meta',
+						'key'     => 'test_meta',
 						'compare' => 'EXISTS',
-					]
-				]
+					],
+				],
 			],
 			true
 		);
@@ -638,30 +684,30 @@ class UserObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 
 	public function testUserOrderingByMetaQueryClauseString() {
 
-		foreach ($this->created_user_ids as $index => $user_id) {
-			update_user_meta($user_id, 'test_meta', $this->formatNumber( $index ) );
+		foreach ( $this->created_user_ids as $index => $user_id ) {
+			update_user_meta( $user_id, 'test_meta', $this->formatNumber( $index ) );
 		}
 
 		// Move number 9 to the second page when ordering by test_meta
 		$this->deleteByMetaKey( 'test_meta', $this->formatNumber( 6 ) );
-		update_user_meta($this->created_user_ids[9], 'test_meta', $this->formatNumber( 6 ) );
+		update_user_meta( $this->created_user_ids[9], 'test_meta', $this->formatNumber( 6 ) );
 
 		$this->assertQueryInCursor(
 			[
 				'roleIn' => [
 					'ADMINISTRATOR',
-					'SUBSCRIBER'
-				]
+					'SUBSCRIBER',
+				],
 			],
 			[
-				'orderby' => 'test_clause',
-				'order' => 'ASC',
+				'orderby'    => 'test_clause',
+				'order'      => 'ASC',
 				'meta_query' => [
 					'test_clause' => [
-						'key' => 'test_meta',
+						'key'     => 'test_meta',
 						'compare' => 'EXISTS',
-					]
-				]
+					],
+				],
 			],
 			true
 		);
@@ -669,13 +715,13 @@ class UserObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	/**
-	* When ordering users with the same meta value the returned order can vary if
-	* there isn't a second ordering field. This test does not fail every time
-	* so it tries to execute the assertion multiple times to make happen more often
-	*/
+	 * When ordering users with the same meta value the returned order can vary if
+	 * there isn't a second ordering field. This test does not fail every time
+	 * so it tries to execute the assertion multiple times to make happen more often
+	 */
 	public function testUserOrderingStability() {
 
-		foreach ($this->created_user_ids as $index => $user_id) {
+		foreach ( $this->created_user_ids as $index => $user_id ) {
 			update_user_meta( $user_id, 'test_meta', $this->numberToMysqlDate( $index ) );
 		}
 
@@ -685,12 +731,12 @@ class UserObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 			[
 				'roleIn' => [
 					'ADMINISTRATOR',
-					'SUBSCRIBER'
-				]
+					'SUBSCRIBER',
+				],
 			],
 			[
-				'orderby' => [ 'meta_value' => 'ASC', ],
-				'meta_key' => 'test_meta',
+				'orderby'   => [ 'meta_value' => 'ASC' ],
+				'meta_key'  => 'test_meta',
 				'meta_type' => 'DATE',
 			],
 			true
@@ -702,12 +748,12 @@ class UserObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 			[
 				'roleIn' => [
 					'ADMINISTRATOR',
-					'SUBSCRIBER'
-				]
+					'SUBSCRIBER',
+				],
 			],
 			[
-				'orderby' => [ 'meta_value' => 'ASC', ],
-				'meta_key' => 'test_meta',
+				'orderby'   => [ 'meta_value' => 'ASC' ],
+				'meta_key'  => 'test_meta',
 				'meta_type' => 'DATE',
 			],
 			true
@@ -719,12 +765,12 @@ class UserObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 			[
 				'roleIn' => [
 					'ADMINISTRATOR',
-					'SUBSCRIBER'
-				]
+					'SUBSCRIBER',
+				],
 			],
 			[
-				'orderby' => [ 'meta_value' => 'ASC', ],
-				'meta_key' => 'test_meta',
+				'orderby'   => [ 'meta_value' => 'ASC' ],
+				'meta_key'  => 'test_meta',
 				'meta_type' => 'DATE',
 			],
 			true
@@ -738,27 +784,27 @@ class UserObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 	public function testUserOrderingByMetaValueNum() {
 
 		// Add user meta to created users
-		foreach ($this->created_user_ids as $index => $user_id) {
-			update_user_meta($user_id, 'test_meta', $index );
+		foreach ( $this->created_user_ids as $index => $user_id ) {
+			update_user_meta( $user_id, 'test_meta', $index );
 		}
 
 		// Move number 8 to the second page when ordering by test_meta
 		$this->deleteByMetaKey( 'test_meta', 6 );
-		update_user_meta($this->created_user_ids[8], 'test_meta', 6 );
+		update_user_meta( $this->created_user_ids[8], 'test_meta', 6 );
 
 		$this->deleteByMetaKey( 'test_meta', 6 );
-		update_user_meta($this->created_user_ids[2], 'test_meta', 6 );
+		update_user_meta( $this->created_user_ids[2], 'test_meta', 6 );
 
 		$this->assertQueryInCursor(
 			[
 				'roleIn' => [
 					'ADMINISTRATOR',
-					'SUBSCRIBER'
-				]
+					'SUBSCRIBER',
+				],
 			],
 			[
-				'orderby' => 'meta_value_num',
-				'order' => 'ASC',
+				'orderby'  => 'meta_value_num',
+				'order'    => 'ASC',
 				'meta_key' => 'test_meta',
 			],
 			true
@@ -767,6 +813,7 @@ class UserObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 
 	/**
 	 * Test orderby nicename__in should work even with order parameter added by mistake
+	 *
 	 * @throws Exception
 	 */
 	public function testOrderbyNiceNameIn() {
@@ -774,12 +821,12 @@ class UserObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 			[
 				'orderby' => [
 					'field' => 'NICE_NAME_IN',
-					'order'	=> 'DESC'
-				]
+					'order' => 'DESC',
+				],
 			],
 			[
 				'orderby' => 'nicename__in',
-				'order' => 'DESC',
+				'order'   => 'DESC',
 			]
 		);
 	}


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
If you query with `after` arg, `hasPreviousPage` will always return `false`. Similarly, if you query with `before` arg, `hasNextPage` will always return false. This PR fixes this for all connections supporting pagination.


Does this close any currently open issues?
------------------------------------------
#594 


Any other comments?
-------------------
`hasNextPage`/`hasPreviousPage` will always return false if you query `userRoles` with `before`/`after` queries respectively. This PR leaves that behavior as is, as pagination is yet to be implement for `userRoles`. This will need to be fixed in the future.


Where has this been tested?
---------------------------
wpgraphql docker test script
