### PR TITLE
Merge pull request #1117 from wp-graphql/bug/#1115-UniformResourceIdentifiable-defines-incorrect-field-types

### DIFF
--- a/src/Type/InterfaceType/ContentNode.php
+++ b/src/Type/InterfaceType/ContentNode.php
@@ -124,7 +124,7 @@ class ContentNode {
 						'description' => __( 'The permalink of the post', 'wp-graphql' ),
 					],
 					'uri'           => [
-						'type'        => 'String',
+						'type'        => [ 'non_null' => 'String' ],
 						'description' => __( 'URI path for the resource', 'wp-graphql' ),
 					],
 					'isRestricted'  => [

--- a/src/Type/InterfaceType/TermNode.php
+++ b/src/Type/InterfaceType/TermNode.php
@@ -93,7 +93,7 @@ class TermNode {
 						'description' => __( 'The link to the term', 'wp-graphql' ),
 					],
 					'uri'            => [
-						'type'        => 'String',
+						'type'        => [ 'non_null' => 'String' ],
 						'description' => __( 'The unique resource identifier path', 'wp-graphql' ),
 					],
 				],

--- a/src/Type/InterfaceType/TermNode.php
+++ b/src/Type/InterfaceType/TermNode.php
@@ -47,7 +47,7 @@ class TermNode {
 						'description' => __( 'Unique identifier for the term', 'wp-graphql' ),
 					],
 					'databaseId'     => [
-						'type'        => 'Int',
+						'type'        => [ 'non_null' => 'Int' ],
 						'description' => __( 'Identifies the primary key from the database.', 'wp-graphql' ),
 						'resolve'     => function( Term $term, $args, $context, $info ) {
 							return absint( $term->term_id );

--- a/src/Type/InterfaceType/UniformResourceIdentifiable.php
+++ b/src/Type/InterfaceType/UniformResourceIdentifiable.php
@@ -19,11 +19,11 @@ class UniformResourceIdentifiable {
 						'description' => __( 'The unique resource identifier path', 'wp-graphql' ),
 					],
 					'id' => [
-						'type'        => [ 'non_null' => 'String' ],
+						'type'        => [ 'non_null' => 'ID' ],
 						'description' => __( 'The unique resource identifier path', 'wp-graphql' ),
 					],
 					'databaseId' => [
-						'type'        => [ 'non_null' => 'String' ],
+						'type'        => [ 'non_null' => 'Int' ],
 						'description' => __( 'The unique resource identifier path', 'wp-graphql' ),
 					],
 				],

--- a/src/Type/Object/RootQuery.php
+++ b/src/Type/Object/RootQuery.php
@@ -413,7 +413,7 @@ class RootQuery {
 						'description' => sprintf( __( 'Get the %s by its database ID', 'wp-graphql' ), $post_type_object->graphql_single_name ),
 					],
 					'uri'                                         => [
-						'type'        => 'String',
+						'type'        => [ 'non_null' => 'String' ],
 						'description' => sprintf( __( 'Get the %s by its uri', 'wp-graphql' ), $post_type_object->graphql_single_name ),
 					],
 				];

--- a/src/Type/Object/User.php
+++ b/src/Type/Object/User.php
@@ -16,11 +16,18 @@ class User {
 					'id'                => [
 						'description' => __( 'The globally unique identifier for the user object.', 'wp-graphql' ),
 					],
+					'databaseId'        => [
+						'type'        => [ 'non_null' => 'Int' ],
+						'description' => __( 'Identifies the primary key from the database.', 'wp-graphql' ),
+						'resolve' => function( \WPGraphQL\Model\User $user ) {
+							return absint( $user->userId );
+						}
+					],
 					'capabilities'      => [
 						'type'        => [
 							'list_of' => 'String',
 						],
-						'description' => __( 'This field is the id of the user. The id of the user matches WP_User->ID field and the value in the ID column for the "users" table in SQL.', 'wp-graphql' ),
+						'description' => __( 'A list of capabilities (permissions) granted to the user', 'wp-graphql' ),
 					],
 					'capKey'            => [
 						'type'        => 'String',
@@ -28,7 +35,7 @@ class User {
 					],
 					'email'             => [
 						'type'        => 'String',
-						'description' => __( 'Email of the user. This is equivalent to the WP_User->user_email property.', 'wp-graphql' ),
+						'description' => __( 'Email address of the user. This is equivalent to the WP_User->user_email property.', 'wp-graphql' ),
 					],
 					'firstName'         => [
 						'type'        => 'String',


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Fix UniformResourceIdentifiable Interface to define field types the same as how they're implemented elsewhere


Does this close any currently open issues?
------------------------------------------
closes #1115 
