### PR TITLE
#1120 - undefined index when not setting the order field for orderby

### DIFF
--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -267,7 +267,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 					$query_args['orderby'] = esc_sql( $orderby_input['field'] );
 				} elseif ( ! empty( $orderby_input['field'] ) ) {
 					$query_args['orderby'] = [
-						esc_sql( $orderby_input['field'] ) => esc_sql( $orderby_input['order'] ),
+						esc_sql( $orderby_input['field'] ) => isset( $orderby_input['order'] ) ? esc_sql( $orderby_input['order'] ) : 'DESC',
 					];
 				}
 			}

--- a/src/Type/Input/PostObjectsConnectionOrderbyInput.php
+++ b/src/Type/Input/PostObjectsConnectionOrderbyInput.php
@@ -13,9 +13,13 @@ class PostObjectsConnectionOrderbyInput {
 						'type' => [
 							'non_null' => 'PostObjectsConnectionOrderbyEnum',
 						],
+						'description' => __( 'The field to order by', 'wp-graphql' )
 					],
 					'order' => [
-						'type' => 'OrderEnum',
+						'type' => [
+							'non_null' => 'OrderEnum'
+						],
+						'description' => __( 'The direction to order by', 'wp-graphql' ),
 					],
 				],
 			]


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
When submitting a query for PostObjectConnection and using `orderby.field` input, but not `orderby.order` input, there is an undefined index warning causing issues. This sets the `order` field to be a `nonNull` input, so users _must_ submit a value. This also sets a default in the resolver should resolution somehow get to this point without an order being set. (the nonNull should prevent this in _most_ cases).

Breaking Change
------------------------------------------
This is a breaking change because it changes a previously nullable input to a nonNull input. 

Does this close any currently open issues?
------------------------------------------
closes #1120 

@drewbaker would you mind confirming that this PR resolves your issue? Thanks!

