### PR TITLE
Adding support for GitHub Updater

### DIFF
--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -2,6 +2,7 @@
 /**
  * Plugin Name: WP GraphQL
  * Plugin URI: https://github.com/wp-graphql/wp-graphql
+ * GitHub Plugin URI: https://github.com/wp-graphql/wp-graphql
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com


### PR DESCRIPTION
Adds support for [GitHub Updater](https://github.com/afragen/github-updater) by adding `GitHub Plugin URI` option. 

A lot of use GitHub Updater to update/manage plugins, I hope this would make it easier of anyone to keep the plugin up to date.


…


Where has this been tested?
---------------------------
**Operating System:** …
Ubuntu 18.04 

**WordPress Version:** …
5.3.2