### PR TITLE
#1129 - Register the NodeWithPageAttributes Interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,5 @@
   },
   "lint-staged": {
     "*.php": "composer run check-cs"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
   }
 }

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -27,11 +27,11 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * PostObjectConnectionResolver constructor.
 	 *
-	 * @param mixed       $source           The object passed down from the previous level in the
-	 *                                      Resolve tree
-	 * @param array       $args             The input arguments for the query
-	 * @param AppContext  $context          The context of the request
-	 * @param ResolveInfo $info             The resolve info passed down the Resolve tree
+	 * @param mixed              $source           The object passed down from the previous level in the
+	 *                                             Resolve tree
+	 * @param array              $args             The input arguments for the query
+	 * @param AppContext         $context          The context of the request
+	 * @param ResolveInfo        $info             The resolve info passed down the Resolve tree
 	 * @param mixed string|array $post_type The post type to resolve for
 	 *
 	 * @throws \Exception
@@ -120,7 +120,6 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 					$this->should_execute = false;
 				}
 			}
-
 		}
 
 		return $this->should_execute;

--- a/src/Data/Connection/UserConnectionResolver.php
+++ b/src/Data/Connection/UserConnectionResolver.php
@@ -180,11 +180,11 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 		 * Only users with the "list_users" capability can filter users by roles
 		 */
 		if ( (
-			     ! empty( $args['roleIn'] ) ||
-			     ! empty( $args['roleNotIn'] ) ||
-			     ! empty( $args['role'] )
-		     ) &&
-		     ! current_user_can( 'list_users' )
+				 ! empty( $args['roleIn'] ) ||
+				 ! empty( $args['roleNotIn'] ) ||
+				 ! empty( $args['role'] )
+			 ) &&
+			 ! current_user_can( 'list_users' )
 		) {
 			throw new UserError( __( 'Sorry, you are not allowed to filter users by role.', 'wp-graphql' ) );
 		}

--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -59,7 +59,6 @@ class NodeResolver {
 			$uri = $parsed_url['path'];
 		}
 
-
 		$this->wp->query_vars = array();
 		$post_type_query_vars = array();
 
@@ -78,9 +77,9 @@ class NodeResolver {
 			$error                   = '404';
 			$this->wp->did_permalink = true;
 
-			$pathinfo = isset( $uri ) ? $uri : '';
+			$pathinfo         = isset( $uri ) ? $uri : '';
 			list( $pathinfo ) = explode( '?', $pathinfo );
-			$pathinfo = str_replace( '%', '%25', $pathinfo );
+			$pathinfo         = str_replace( '%', '%25', $pathinfo );
 
 			list( $req_uri ) = explode( '?', $pathinfo );
 			$home_path       = trim( parse_url( home_url(), PHP_URL_PATH ), '/' );
@@ -130,7 +129,7 @@ class NodeResolver {
 					}
 
 					if ( preg_match( "#^$match#", $request_match, $matches ) ||
-					     preg_match( "#^$match#", urldecode( $request_match ), $matches ) ) {
+						 preg_match( "#^$match#", urldecode( $request_match ), $matches ) ) {
 
 						if ( $wp_rewrite->use_verbose_page_rules && preg_match( '/pagename=\$matches\[([0-9]+)\]/', $query, $varmatch ) ) {
 							// This is a verbose page match, let's check to be sure about it.
@@ -141,7 +140,7 @@ class NodeResolver {
 
 							$post_status_obj = get_post_status_object( $page->post_status );
 							if ( ! $post_status_obj->public && ! $post_status_obj->protected
-							     && ! $post_status_obj->private && $post_status_obj->exclude_from_search ) {
+								 && ! $post_status_obj->private && $post_status_obj->exclude_from_search ) {
 								continue;
 							}
 						}
@@ -157,7 +156,6 @@ class NodeResolver {
 
 				// Trim the query of everything up to the '?'.
 				$query = preg_replace( '!^.+\?!', '', $query );
-
 
 				// Substitute the substring matches into the query.
 				$query = addslashes( \WP_MatchesMapRegex::apply( $query, $matches ) );
@@ -194,9 +192,7 @@ class NodeResolver {
 			}
 		}
 
-
 		foreach ( $this->wp->public_query_vars as $wpvar ) {
-
 
 			$parsed_query = [];
 			if ( isset( $parsed_url['query'] ) ) {
@@ -217,7 +213,6 @@ class NodeResolver {
 				$this->wp->query_vars[ $wpvar ] = $parsed_query[ $wpvar ];
 			}
 
-
 			if ( ! empty( $this->wp->query_vars[ $wpvar ] ) ) {
 
 				if ( ! is_array( $this->wp->query_vars[ $wpvar ] ) ) {
@@ -236,7 +231,6 @@ class NodeResolver {
 				}
 			}
 		}
-
 
 		// Convert urldecoded spaces back into +
 		foreach ( get_taxonomies( array(), 'objects' ) as $taxonomy => $t ) {
@@ -349,12 +343,12 @@ class NodeResolver {
 
 			return ! empty( $posts->posts[0] ) ? new Post( $posts->posts[0] ) : null;
 
-		} else if ( isset( $this->wp->query_vars['cat'] ) ) {
+		} elseif ( isset( $this->wp->query_vars['cat'] ) ) {
 			$node = get_term( absint( $this->wp->query_vars['cat'] ), 'category' );
 
 			return ! empty( $node ) ? new Term( $node ) : null;
 
-		} else if ( isset( $this->wp->query_vars['tag'] ) ) {
+		} elseif ( isset( $this->wp->query_vars['tag'] ) ) {
 			$node = get_term_by( 'slug', $this->wp->query_vars['tag'], 'post_tag' );
 
 			return ! empty( $node ) ? new Term( $node ) : null;

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -51,6 +51,7 @@ use WPGraphQL\Type\InterfaceType\NodeWithComments;
 use WPGraphQL\Type\InterfaceType\NodeWithContentEditor;
 use WPGraphQL\Type\InterfaceType\NodeWithExcerpt;
 use WPGraphQL\Type\InterfaceType\NodeWithFeaturedImage;
+use WPGraphQL\Type\InterfaceType\NodeWithPageAttributes;
 use WPGraphQL\Type\InterfaceType\NodeWithRevisions;
 use WPGraphQL\Type\InterfaceType\NodeWithTitle;
 use WPGraphQL\Type\InterfaceType\Node;
@@ -204,9 +205,9 @@ class TypeRegistry {
 		NodeWithRevisions::register_type( $type_registry );
 		NodeWithTitle::register_type( $type_registry );
 		NodeWithTrackbacks::register_type( $type_registry );
+		NodeWithPageAttributes::register_type( $type_registry );
 		TermNode::register_type( $type_registry );
 		UniformResourceIdentifiable::register_type( $type_registry );
-
 
 		/**
 		 * Register Types
@@ -329,8 +330,6 @@ class TypeRegistry {
 					PostObjectDelete::register_mutation( $post_type_object );
 
 				}
-
-
 			}
 		}
 
@@ -354,27 +353,27 @@ class TypeRegistry {
 		 */
 		$allowed_setting_types = DataSource::get_allowed_settings_by_group();
 
- 		if ( ! empty( $allowed_setting_types ) && is_array( $allowed_setting_types ) ) {
-		    foreach ( $allowed_setting_types as $group => $setting_type ) {
+		if ( ! empty( $allowed_setting_types ) && is_array( $allowed_setting_types ) ) {
+			foreach ( $allowed_setting_types as $group => $setting_type ) {
 
-			    $group_name = lcfirst( preg_replace( '[^a-zA-Z0-9 -]', '_', $group ) );
-			    $group_name = lcfirst( str_replace( '_', ' ', ucwords( $group_name, '_' ) ) );
-			    $group_name = lcfirst( str_replace( '-', ' ', ucwords( $group_name, '_' ) ) );
-			    $group_name = lcfirst( str_replace( ' ', '', ucwords( $group_name, ' ' ) ) );
-			    SettingGroup::register_settings_group( $group_name, $group );
+				$group_name = lcfirst( preg_replace( '[^a-zA-Z0-9 -]', '_', $group ) );
+				$group_name = lcfirst( str_replace( '_', ' ', ucwords( $group_name, '_' ) ) );
+				$group_name = lcfirst( str_replace( '-', ' ', ucwords( $group_name, '_' ) ) );
+				$group_name = lcfirst( str_replace( ' ', '', ucwords( $group_name, ' ' ) ) );
+				SettingGroup::register_settings_group( $group_name, $group );
 
-			    register_graphql_field(
-				    'RootQuery',
-				    $group_name . 'Settings',
-				    [
-					    'type'    => ucfirst( $group_name ) . 'Settings',
-					    'resolve' => function() use ( $setting_type ) {
-						    return $setting_type;
-					    },
-				    ]
-			    );
-		    }
-	    }
+				register_graphql_field(
+					'RootQuery',
+					$group_name . 'Settings',
+					[
+						'type'    => ucfirst( $group_name ) . 'Settings',
+						'resolve' => function() use ( $setting_type ) {
+							return $setting_type;
+						},
+					]
+				);
+			}
+		}
 
 		/**
 		 * Fire an action as the type registry is initialized. This executes

--- a/src/Type/Enum/ContentNodeIdTypeEnum.php
+++ b/src/Type/Enum/ContentNodeIdTypeEnum.php
@@ -35,8 +35,8 @@ class ContentNodeIdTypeEnum {
 
 				if ( $post_type_object->name === 'attachment' ) {
 					$values['source_url'] = [
-						'name' => 'SOURCE_URL',
-						'value' => 'source_url',
+						'name'        => 'SOURCE_URL',
+						'value'       => 'source_url',
 						'description' => __( 'Identify a media item by its source url', 'wp-graphql' ),
 					];
 				}

--- a/src/Type/Enum/UserNodeIdTypeEnum.php
+++ b/src/Type/Enum/UserNodeIdTypeEnum.php
@@ -8,13 +8,15 @@ class UserNodeIdTypeEnum {
 	 *
 	 * @access public
 	 * @return void
-	 *
 	 */
 	public static function register_type() {
-		register_graphql_enum_type( 'UserNodeIdTypeEnum', [
-			'description' => __( 'The Type of Identifier used to fetch a single User node. To be used along with the "id" field. Default is "ID".', 'wp-graphql' ),
-			'values' => self::get_values(),
-		]);
+		register_graphql_enum_type(
+			'UserNodeIdTypeEnum',
+			[
+				'description' => __( 'The Type of Identifier used to fetch a single User node. To be used along with the "id" field. Default is "ID".', 'wp-graphql' ),
+				'values'      => self::get_values(),
+			]
+		);
 	}
 
 	/**
@@ -24,8 +26,8 @@ class UserNodeIdTypeEnum {
 	 */
 	public static function get_values() {
 		return [
-			'ID' => [
-				'name' => 'ID',
+			'ID'          => [
+				'name'        => 'ID',
 				'value'       => 'global_id',
 				'description' => __( 'The hashed Global ID', 'wp-graphql' ),
 			],
@@ -39,17 +41,17 @@ class UserNodeIdTypeEnum {
 				'value'       => 'uri',
 				'description' => __( 'The URI for the node', 'wp-graphql' ),
 			],
-			'SLUG'         => [
+			'SLUG'        => [
 				'name'        => 'SLUG',
 				'value'       => 'slug',
 				'description' => __( 'The slug of the User', 'wp-graphql' ),
 			],
-			'EMAIL'         => [
+			'EMAIL'       => [
 				'name'        => 'EMAIL',
 				'value'       => 'email',
 				'description' => __( 'The Email of the User', 'wp-graphql' ),
 			],
-			'USERNAME'         => [
+			'USERNAME'    => [
 				'name'        => 'USERNAME',
 				'value'       => 'login',
 				'description' => __( 'The username the User uses to login with', 'wp-graphql' ),

--- a/src/Type/InterfaceType/ContentNode.php
+++ b/src/Type/InterfaceType/ContentNode.php
@@ -50,14 +50,14 @@ class ContentNode {
 
 				},
 				'fields'      => [
-					'id'            => [
+					'id'           => [
 						'type'        => [
 							'non_null' => 'ID',
 						],
 						'description' => __( 'The globally unique identifier of the node.', 'wp-graphql' ),
 					],
 
-					'databaseId'    => [
+					'databaseId'   => [
 						'type'        => [
 							'non_null' => 'Int',
 						],
@@ -66,35 +66,35 @@ class ContentNode {
 							return absint( $post->ID );
 						},
 					],
-					'date'          => [
+					'date'         => [
 						'type'        => 'String',
 						'description' => __( 'Post publishing date.', 'wp-graphql' ),
 					],
-					'dateGmt'       => [
+					'dateGmt'      => [
 						'type'        => 'String',
 						'description' => __( 'The publishing date set in GMT.', 'wp-graphql' ),
 					],
-					'enclosure'     => [
+					'enclosure'    => [
 						'type'        => 'String',
 						'description' => __( 'The RSS enclosure for the object', 'wp-graphql' ),
 					],
-					'status'        => [
+					'status'       => [
 						'type'        => 'String',
 						'description' => __( 'The current status of the object', 'wp-graphql' ),
 					],
-					'slug'          => [
+					'slug'         => [
 						'type'        => 'String',
 						'description' => __( 'The uri slug for the post. This is equivalent to the WP_Post->post_name field and the post_name column in the database for the "post_objects" table.', 'wp-graphql' ),
 					],
-					'modified'      => [
+					'modified'     => [
 						'type'        => 'String',
 						'description' => __( 'The local modified time for a post. If a post was recently updated the modified field will change to match the corresponding time.', 'wp-graphql' ),
 					],
-					'modifiedGmt'   => [
+					'modifiedGmt'  => [
 						'type'        => 'String',
 						'description' => __( 'The GMT modified time for a post. If a post was recently updated the modified field will change to match the corresponding time in GMT.', 'wp-graphql' ),
 					],
-					'editLast'      => [
+					'editLast'     => [
 						'type'        => 'User',
 						'description' => __( 'The user that most recently edited the object', 'wp-graphql' ),
 						'resolve'     => function( Post $post, $args, AppContext $context, ResolveInfo $info ) {
@@ -107,27 +107,27 @@ class ContentNode {
 							return DataSource::resolve_user( $post->editLastId, $context );
 						},
 					],
-					'editLock'      => [
+					'editLock'     => [
 						'type'        => 'EditLock',
 						'description' => __( 'If a user has edited the object within the past 15 seconds, this will return the user and the time they last edited. Null if the edit lock doesn\'t exist or is greater than 15 seconds', 'wp-graphql' ),
 					],
-					'guid'          => [
+					'guid'         => [
 						'type'        => 'String',
 						'description' => __( 'The global unique identifier for this post. This currently matches the value stored in WP_Post->guid and the guid column in the "post_objects" database table.', 'wp-graphql' ),
 					],
-					'desiredSlug'   => [
+					'desiredSlug'  => [
 						'type'        => 'String',
 						'description' => __( 'The desired slug of the post', 'wp-graphql' ),
 					],
-					'link'          => [
+					'link'         => [
 						'type'        => 'String',
 						'description' => __( 'The permalink of the post', 'wp-graphql' ),
 					],
-					'uri'           => [
+					'uri'          => [
 						'type'        => [ 'non_null' => 'String' ],
 						'description' => __( 'URI path for the resource', 'wp-graphql' ),
 					],
-					'isRestricted'  => [
+					'isRestricted' => [
 						'type'        => 'Boolean',
 						'description' => __( 'Whether the object is restricted from the current viewer', 'wp-graphql' ),
 					],

--- a/src/Type/InterfaceType/ContentTemplate.php
+++ b/src/Type/InterfaceType/ContentTemplate.php
@@ -4,17 +4,20 @@ namespace WPGraphQL\Type\InterfaceType;
 
 class ContentTemplate {
 	public static function register_type( $type_registry ) {
-		register_graphql_interface_type( 'ContentTemplate', [
-			'description' => __( 'The template assigned to a node of content', 'wp-graphql' ),
-			'fields' => [
-				'templateName' => [
-					'type' => 'String',
-					'description' => __( 'The name of the template', 'wp-graphql' ),
+		register_graphql_interface_type(
+			'ContentTemplate',
+			[
+				'description' => __( 'The template assigned to a node of content', 'wp-graphql' ),
+				'fields'      => [
+					'templateName' => [
+						'type'        => 'String',
+						'description' => __( 'The name of the template', 'wp-graphql' ),
+					],
 				],
-			],
-			'resolveType' => function( $value ) use ( $type_registry ) {
-				return isset( $value[ '__typename' ] ) ? $value[ '__typename' ] : 'DefaultTemplate';
-			}
-		]);
+				'resolveType' => function( $value ) use ( $type_registry ) {
+					return isset( $value['__typename'] ) ? $value['__typename'] : 'DefaultTemplate';
+				},
+			]
+		);
 	}
 }

--- a/src/Type/InterfaceType/HierarchicalContentNode.php
+++ b/src/Type/InterfaceType/HierarchicalContentNode.php
@@ -6,54 +6,58 @@ use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
 use WPGraphQL\Data\DataSource;
 use WPGraphQL\Model\Post;
+use WPGraphQL\Registry\TypeRegistry;
 
 class HierarchicalContentNode {
-	public static function register_type() {
-		register_graphql_interface_type('HierarchicalContentNode', [
-			'description' => __( 'Content node with hierarchical (parent/child) relationships', 'wp-graphql' ),
-			'fields' => [
-				'ancestors'     => [
-					'type'        => [
-						'list_of' => 'PostObjectUnion',
-					],
-					'description' => esc_html__( 'Ancestors of the object', 'wp-graphql' ),
-					'args'        => [
-						'types' => [
-							'type'        => [
-								'list_of' => 'PostTypeEnum',
-							],
-							'description' => __( 'The types of ancestors to check for. Defaults to the same type as the current object', 'wp-graphql' ),
+	public static function register_type( TypeRegistry $type_registry ) {
+		register_graphql_interface_type(
+			'HierarchicalContentNode',
+			[
+				'description' => __( 'Content node with hierarchical (parent/child) relationships', 'wp-graphql' ),
+				'fields'      => [
+					'ancestors' => [
+						'type'        => [
+							'list_of' => 'PostObjectUnion',
 						],
-					],
-					'resolve'     => function( $source, $args, AppContext $context, ResolveInfo $info ) {
-						$ancestor_ids = get_ancestors( $source->ID, $source->post_type );
-						if ( empty( $ancestor_ids ) || ! is_array( $ancestor_ids ) ) {
-							return null;
-						}
-						$context->getLoader( 'post_object' )->buffer( $ancestor_ids );
-
-						return new Deferred(
-							function() use ( $context, $ancestor_ids ) {
-								// @codingStandardsIgnoreLine.
-								return $context->getLoader( 'post_object' )->loadMany( $ancestor_ids );
+						'description' => esc_html__( 'Ancestors of the object', 'wp-graphql' ),
+						'args'        => [
+							'types' => [
+								'type'        => [
+									'list_of' => 'PostTypeEnum',
+								],
+								'description' => __( 'The types of ancestors to check for. Defaults to the same type as the current object', 'wp-graphql' ),
+							],
+						],
+						'resolve'     => function( $source, $args, AppContext $context, ResolveInfo $info ) {
+							$ancestor_ids = get_ancestors( $source->ID, $source->post_type );
+							if ( empty( $ancestor_ids ) || ! is_array( $ancestor_ids ) ) {
+								return null;
 							}
-						);
-					},
-				],
-				'parent'        => [
-					'type'        => 'PostObjectUnion',
-					'description' => __( 'The parent of the object. The parent object can be of various types', 'wp-graphql' ),
-					'resolve'     => function( Post $post, $args, AppContext $context, ResolveInfo $info ) {
-						// @codingStandardsIgnoreLine.
-						if ( ! isset( $post->parentId ) || ! absint( $post->parentId ) ) {
-							return null;
-						}
+							$context->getLoader( 'post_object' )->buffer( $ancestor_ids );
 
-						// @codingStandardsIgnoreLine.
-						return DataSource::resolve_post_object( $post->parentId, $context );
-					},
+							return new Deferred(
+								function() use ( $context, $ancestor_ids ) {
+									// @codingStandardsIgnoreLine.
+									return $context->getLoader( 'post_object' )->loadMany( $ancestor_ids );
+								}
+							);
+						},
+					],
+					'parent'    => [
+						'type'        => 'PostObjectUnion',
+						'description' => __( 'The parent of the object. The parent object can be of various types', 'wp-graphql' ),
+						'resolve'     => function( Post $post, $args, AppContext $context, ResolveInfo $info ) {
+							// @codingStandardsIgnoreLine.
+							if ( ! isset( $post->parentId ) || ! absint( $post->parentId ) ) {
+								return null;
+							}
+
+							// @codingStandardsIgnoreLine.
+							return DataSource::resolve_post_object( $post->parentId, $context );
+						},
+					],
 				],
-			],
-		]);
+			]
+		);
 	}
 }

--- a/src/Type/InterfaceType/NodeWithAuthor.php
+++ b/src/Type/InterfaceType/NodeWithAuthor.php
@@ -11,24 +11,27 @@ class NodeWithAuthor {
 	/**
 	 * @param TypeRegistry $type_registry Instance of the Type Registry
 	 */
-	public static function register_type(  $type_registry ) {
-		register_graphql_interface_type( 'NodeWithAuthor', [
-			'description' => __( 'A node that can have an author assigned to it', 'wp-graphql' ),
-			'fields' => [
-				'author'        => [
-					'type'        => 'User',
-					'description' => __( "The author field will return a queryable User type matching the post's author.", 'wp-graphql' ),
-					'resolve'     => function( Post $post, $args, AppContext $context, ResolveInfo $info ) {
-						// @codingStandardsIgnoreLine.
-						if ( ! isset( $post->authorId ) || ! absint( $post->authorId ) ) {
-							return null;
-						};
+	public static function register_type( $type_registry ) {
+		register_graphql_interface_type(
+			'NodeWithAuthor',
+			[
+				'description' => __( 'A node that can have an author assigned to it', 'wp-graphql' ),
+				'fields'      => [
+					'author' => [
+						'type'        => 'User',
+						'description' => __( "The author field will return a queryable User type matching the post's author.", 'wp-graphql' ),
+						'resolve'     => function( Post $post, $args, AppContext $context, ResolveInfo $info ) {
+							// @codingStandardsIgnoreLine.
+							if ( ! isset( $post->authorId ) || ! absint( $post->authorId ) ) {
+								return null;
+							};
 
-						// @codingStandardsIgnoreLine.
-						return DataSource::resolve_user( $post->authorId, $context );
-					},
+							// @codingStandardsIgnoreLine.
+							return DataSource::resolve_user( $post->authorId, $context );
+						},
+					],
 				],
 			]
-		]);
+		);
 	}
 }

--- a/src/Type/InterfaceType/NodeWithComments.php
+++ b/src/Type/InterfaceType/NodeWithComments.php
@@ -8,18 +8,21 @@ class NodeWithComments {
 	 * @param TypeRegistry $type_registry Instance of the Type Registry
 	 */
 	public static function register_type( $type_registry ) {
-		register_graphql_interface_type( 'NodeWithComments', [
-			'description' => __( 'A node that can have comments associated with it', 'wp-graphql' ),
-			'fields' => [
-				'commentCount'  => [
-					'type'        => 'Int',
-					'description' => __( 'The number of comments. Even though WPGraphQL denotes this field as an integer, in WordPress this field should be saved as a numeric string for compatibility.', 'wp-graphql' ),
+		register_graphql_interface_type(
+			'NodeWithComments',
+			[
+				'description' => __( 'A node that can have comments associated with it', 'wp-graphql' ),
+				'fields'      => [
+					'commentCount'  => [
+						'type'        => 'Int',
+						'description' => __( 'The number of comments. Even though WPGraphQL denotes this field as an integer, in WordPress this field should be saved as a numeric string for compatibility.', 'wp-graphql' ),
+					],
+					'commentStatus' => [
+						'type'        => 'String',
+						'description' => __( 'Whether the comments are open or closed for this particular post.', 'wp-graphql' ),
+					],
 				],
-				'commentStatus' => [
-					'type'        => 'String',
-					'description' => __( 'Whether the comments are open or closed for this particular post.', 'wp-graphql' ),
-				],
-			],
-		]);
+			]
+		);
 	}
 }

--- a/src/Type/InterfaceType/NodeWithContentEditor.php
+++ b/src/Type/InterfaceType/NodeWithContentEditor.php
@@ -8,29 +8,32 @@ class NodeWithContentEditor {
 	 * @param TypeRegistry $type_registry Instance of the Type Registry
 	 */
 	public static function register_type( $type_registry ) {
-		register_graphql_interface_type( 'NodeWithContentEditor', [
-			'description' => __( 'A node that supports the content editor', 'wp-graphql' ),
-			'fields' => [
-				'content'       => [
-					'type'        => 'String',
-					'description' => __( 'The content of the post.', 'wp-graphql' ),
-					'args'        => [
-						'format' => [
-							'type'        => 'PostObjectFieldFormatEnum',
-							'description' => __( 'Format of the field output', 'wp-graphql' ),
+		register_graphql_interface_type(
+			'NodeWithContentEditor',
+			[
+				'description' => __( 'A node that supports the content editor', 'wp-graphql' ),
+				'fields'      => [
+					'content' => [
+						'type'        => 'String',
+						'description' => __( 'The content of the post.', 'wp-graphql' ),
+						'args'        => [
+							'format' => [
+								'type'        => 'PostObjectFieldFormatEnum',
+								'description' => __( 'Format of the field output', 'wp-graphql' ),
+							],
 						],
-					],
-					'resolve'     => function( $source, $args ) {
-						if ( isset( $args['format'] ) && 'raw' === $args['format'] ) {
-							// @codingStandardsIgnoreLine.
-							return $source->contentRaw;
-						}
+						'resolve'     => function( $source, $args ) {
+							if ( isset( $args['format'] ) && 'raw' === $args['format'] ) {
+								// @codingStandardsIgnoreLine.
+								return $source->contentRaw;
+							}
 
-						// @codingStandardsIgnoreLine.
-						return $source->contentRendered;
-					},
+							// @codingStandardsIgnoreLine.
+							return $source->contentRendered;
+						},
+					],
 				],
-			],
-		]);
+			]
+		);
 	}
 }

--- a/src/Type/InterfaceType/NodeWithExcerpt.php
+++ b/src/Type/InterfaceType/NodeWithExcerpt.php
@@ -8,29 +8,32 @@ class NodeWithExcerpt {
 	 * @param TypeRegistry $type_registry Instance of the Type Registry
 	 */
 	public static function register_type( $type_registry ) {
-		register_graphql_interface_type( 'NodeWithExcerpt', [
-			'description' => __( 'A node that can have an excerpt', 'wp-graphql' ),
-			'fields' => [
-				'excerpt'       => [
-					'type'        => 'String',
-					'description' => __( 'The excerpt of the post.', 'wp-graphql' ),
-					'args'        => [
-						'format' => [
-							'type'        => 'PostObjectFieldFormatEnum',
-							'description' => __( 'Format of the field output', 'wp-graphql' ),
+		register_graphql_interface_type(
+			'NodeWithExcerpt',
+			[
+				'description' => __( 'A node that can have an excerpt', 'wp-graphql' ),
+				'fields'      => [
+					'excerpt' => [
+						'type'        => 'String',
+						'description' => __( 'The excerpt of the post.', 'wp-graphql' ),
+						'args'        => [
+							'format' => [
+								'type'        => 'PostObjectFieldFormatEnum',
+								'description' => __( 'Format of the field output', 'wp-graphql' ),
+							],
 						],
-					],
-					'resolve'     => function( $source, $args ) {
-						if ( isset( $args['format'] ) && 'raw' === $args['format'] ) {
-							// @codingStandardsIgnoreLine.
-							return $source->excerptRaw;
-						}
+						'resolve'     => function( $source, $args ) {
+							if ( isset( $args['format'] ) && 'raw' === $args['format'] ) {
+								// @codingStandardsIgnoreLine.
+								return $source->excerptRaw;
+							}
 
-						// @codingStandardsIgnoreLine.
-						return $source->excerptRendered;
-					},
+							// @codingStandardsIgnoreLine.
+							return $source->excerptRendered;
+						},
+					],
 				],
-			],
-		]);
+			]
+		);
 	}
 }

--- a/src/Type/InterfaceType/NodeWithFeaturedImage.php
+++ b/src/Type/InterfaceType/NodeWithFeaturedImage.php
@@ -13,23 +13,26 @@ class NodeWithFeaturedImage {
 	 */
 	public static function register_type( $type_registry ) {
 
-		register_graphql_interface_type( 'NodeWithFeaturedImage', [
-			'description' => __( 'A node that can have a featured image set', 'wp-graphql' ),
-			'fields' => [
-				'featuredImage' => [
-					'type'        => 'MediaItem',
-					'description' => __( 'The featured image for the object', 'wp-graphql' ),
-					'resolve'     => function( Post $post, $args, AppContext $context, ResolveInfo $info ) {
-						// @codingStandardsIgnoreLine.
-						if ( empty( $post->featuredImageId ) || ! absint( $post->featuredImageId ) ) {
-							return null;
-						}
+		register_graphql_interface_type(
+			'NodeWithFeaturedImage',
+			[
+				'description' => __( 'A node that can have a featured image set', 'wp-graphql' ),
+				'fields'      => [
+					'featuredImage' => [
+						'type'        => 'MediaItem',
+						'description' => __( 'The featured image for the object', 'wp-graphql' ),
+						'resolve'     => function( Post $post, $args, AppContext $context, ResolveInfo $info ) {
+							// @codingStandardsIgnoreLine.
+							if ( empty( $post->featuredImageId ) || ! absint( $post->featuredImageId ) ) {
+								return null;
+							}
 
-						// @codingStandardsIgnoreLine.
-						return DataSource::resolve_post_object( $post->featuredImageId, $context );
-					},
+							// @codingStandardsIgnoreLine.
+							return DataSource::resolve_post_object( $post->featuredImageId, $context );
+						},
+					],
 				],
-			],
-		]);
+			]
+		);
 	}
 }

--- a/src/Type/InterfaceType/NodeWithPageAttributes.php
+++ b/src/Type/InterfaceType/NodeWithPageAttributes.php
@@ -1,16 +1,21 @@
 <?php
 namespace WPGraphQL\Type\InterfaceType;
 
+use WPGraphQL\Registry\TypeRegistry;
+
 class NodeWithPageAttributes {
-	public static function register_type() {
-		register_graphql_interface_type( 'NodeWithPageAttributes', [
-			'description' => __( 'A node that can have page attributes', 'wp-graphql' ),
-			'fields' => [
-				'menuOrder'     => [
-					'type'        => 'Int',
-					'description' => __( 'A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types.', 'wp-graphql' ),
+	public static function register_type( TypeRegistry $type_registry ) {
+		register_graphql_interface_type(
+			'NodeWithPageAttributes',
+			[
+				'description' => __( 'A node that can have page attributes', 'wp-graphql' ),
+				'fields'      => [
+					'menuOrder' => [
+						'type'        => 'Int',
+						'description' => __( 'A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types.', 'wp-graphql' ),
+					],
 				],
-			],
-		]);
+			]
+		);
 	}
 }

--- a/src/Type/InterfaceType/NodeWithRevisions.php
+++ b/src/Type/InterfaceType/NodeWithRevisions.php
@@ -5,33 +5,37 @@ use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
 use WPGraphQL\Data\DataSource;
 use WPGraphQL\Model\Post;
+use WPGraphQL\Registry\TypeRegistry;
 
 class NodeWithRevisions {
-	public static function register_type() {
-		register_graphql_interface_type( 'NodeWithRevisions', [
-			'description' => __( 'A node that can have revisions', 'wp-graphql' ),
-			'fields' => [
-				'isRevision'    => [
-					'type'        => 'Boolean',
-					'description' => __( 'True if the node is a revision of another node', 'wp-graphql' ),
-					'resolve'     => function( Post $post, $args, $context, $info ) {
-						return 'revision' === $post->post_type ? true : false;
-					},
-				],
-				'revisionOf'        => [
-					'type'        => 'PostObjectUnion',
-					'description' => __( 'If the current node is a revision, this field exposes the node this is a revision of. Returns null if the node is not a revision of another node.', 'wp-graphql' ),
-					'resolve'     => function( Post $post, $args, AppContext $context, ResolveInfo $info ) {
-						// @codingStandardsIgnoreLine.
-						if ( 'revision' !== $post->post_type || ! isset( $post->parentId ) || ! absint( $post->parentId ) ) {
-							return null;
-						}
+	public static function register_type( TypeRegistry $type_registry ) {
+		register_graphql_interface_type(
+			'NodeWithRevisions',
+			[
+				'description' => __( 'A node that can have revisions', 'wp-graphql' ),
+				'fields'      => [
+					'isRevision' => [
+						'type'        => 'Boolean',
+						'description' => __( 'True if the node is a revision of another node', 'wp-graphql' ),
+						'resolve'     => function( Post $post, $args, $context, $info ) {
+							return 'revision' === $post->post_type ? true : false;
+						},
+					],
+					'revisionOf' => [
+						'type'        => 'PostObjectUnion',
+						'description' => __( 'If the current node is a revision, this field exposes the node this is a revision of. Returns null if the node is not a revision of another node.', 'wp-graphql' ),
+						'resolve'     => function( Post $post, $args, AppContext $context, ResolveInfo $info ) {
+							// @codingStandardsIgnoreLine.
+							if ( 'revision' !== $post->post_type || ! isset( $post->parentId ) || ! absint( $post->parentId ) ) {
+								return null;
+							}
 
-						// @codingStandardsIgnoreLine.
-						return DataSource::resolve_post_object( $post->parentId, $context );
-					},
+							// @codingStandardsIgnoreLine.
+							return DataSource::resolve_post_object( $post->parentId, $context );
+						},
+					],
 				],
-			],
-		]);
+			]
+		);
 	}
 }

--- a/src/Type/InterfaceType/NodeWithTitle.php
+++ b/src/Type/InterfaceType/NodeWithTitle.php
@@ -5,34 +5,38 @@ use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
 use WPGraphQL\Data\DataSource;
 use WPGraphQL\Model\Post;
+use WPGraphQL\Registry\TypeRegistry;
 
 class NodeWithTitle {
-	public static function register_type() {
+	public static function register_type( TypeRegistry $type_registry ) {
 
-		register_graphql_interface_type( 'NodeWithTitle', [
-			'description' => __( 'A node that NodeWith a title', 'wp-graphql' ),
-			'fields' => [
-				'title'         => [
-					'type'        => 'String',
-					'description' => __( 'The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made.', 'wp-graphql' ),
-					'args'        => [
-						'format' => [
-							'type'        => 'PostObjectFieldFormatEnum',
-							'description' => __( 'Format of the field output', 'wp-graphql' ),
+		register_graphql_interface_type(
+			'NodeWithTitle',
+			[
+				'description' => __( 'A node that NodeWith a title', 'wp-graphql' ),
+				'fields'      => [
+					'title' => [
+						'type'        => 'String',
+						'description' => __( 'The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made.', 'wp-graphql' ),
+						'args'        => [
+							'format' => [
+								'type'        => 'PostObjectFieldFormatEnum',
+								'description' => __( 'Format of the field output', 'wp-graphql' ),
+							],
 						],
-					],
-					'resolve'     => function( $source, $args ) {
-						if ( isset( $args['format'] ) && 'raw' === $args['format'] ) {
-							// @codingStandardsIgnoreLine.
-							return $source->titleRaw;
-						}
+						'resolve'     => function( $source, $args ) {
+							if ( isset( $args['format'] ) && 'raw' === $args['format'] ) {
+								// @codingStandardsIgnoreLine.
+								return $source->titleRaw;
+							}
 
-						// @codingStandardsIgnoreLine.
-						return $source->titleRendered;
-					},
+							// @codingStandardsIgnoreLine.
+							return $source->titleRendered;
+						},
+					],
 				],
-			],
-		]);
+			]
+		);
 
 	}
 }

--- a/src/Type/InterfaceType/NodeWithTrackbacks.php
+++ b/src/Type/InterfaceType/NodeWithTrackbacks.php
@@ -1,24 +1,29 @@
 <?php
 namespace WPGraphQL\Type\InterfaceType;
 
+use WPGraphQL\Registry\TypeRegistry;
+
 class NodeWithTrackbacks {
-	public static function register_type() {
-		register_graphql_interface_type( 'NodeWithTrackbacks', [
-			'description' => __( 'A node that can have trackbacks and pingbacks', 'wp-graphql' ),
-			'fields' => [
-				'toPing' => [
-					'type'        => [ 'list_of' => 'String' ],
-					'description' => __( 'URLs queued to be pinged.', 'wp-graphql' ),
-				],
-				'pinged'        => [
-					'type'        => [ 'list_of' => 'String' ],
-					'description' => __( 'URLs that have been pinged.', 'wp-graphql' ),
-				],
-				'pingStatus'    => [
-					'type'        => 'String',
-					'description' => __( 'Whether the pings are open or closed for this particular post.', 'wp-graphql' ),
+	public static function register_type( TypeRegistry $type_registry ) {
+		register_graphql_interface_type(
+			'NodeWithTrackbacks',
+			[
+				'description' => __( 'A node that can have trackbacks and pingbacks', 'wp-graphql' ),
+				'fields'      => [
+					'toPing'     => [
+						'type'        => [ 'list_of' => 'String' ],
+						'description' => __( 'URLs queued to be pinged.', 'wp-graphql' ),
+					],
+					'pinged'     => [
+						'type'        => [ 'list_of' => 'String' ],
+						'description' => __( 'URLs that have been pinged.', 'wp-graphql' ),
+					],
+					'pingStatus' => [
+						'type'        => 'String',
+						'description' => __( 'Whether the pings are open or closed for this particular post.', 'wp-graphql' ),
+					],
 				],
 			]
-		]);
+		);
 	}
 }

--- a/src/Type/InterfaceType/UniformResourceIdentifiable.php
+++ b/src/Type/InterfaceType/UniformResourceIdentifiable.php
@@ -14,11 +14,11 @@ class UniformResourceIdentifiable {
 			[
 				'description' => __( 'Any node that has a URI', 'wp-graphql' ),
 				'fields'      => [
-					'uri' => [
+					'uri'        => [
 						'type'        => [ 'non_null' => 'String' ],
 						'description' => __( 'The unique resource identifier path', 'wp-graphql' ),
 					],
-					'id' => [
+					'id'         => [
 						'type'        => [ 'non_null' => 'ID' ],
 						'description' => __( 'The unique resource identifier path', 'wp-graphql' ),
 					],

--- a/src/Type/Object/PostObject.php
+++ b/src/Type/Object/PostObject.php
@@ -62,13 +62,16 @@ class PostObject {
 			$interfaces[] = 'NodeWithPageAttributes';
 		}
 
-		if ( $post_type_object->hierarchical || in_array( $post_type_object->name, [
+		if ( $post_type_object->hierarchical || in_array(
+			$post_type_object->name,
+			[
 				'attachment',
-				'revision'
-			], true ) ) {
+				'revision',
+			],
+			true
+		) ) {
 			$interfaces[] = 'HierarchicalContentNode';
 		}
-
 
 		register_graphql_object_type(
 			$single_name,
@@ -231,7 +234,7 @@ class PostObject {
 		$fields      = [
 			'id'                => [
 				'description' => sprintf(
-				/* translators: %s: custom post-type name */
+					/* translators: %s: custom post-type name */
 					__( 'The globally unique identifier of the %s object.', 'wp-graphql' ),
 					$post_type_object->name
 				),
@@ -411,12 +414,12 @@ class PostObject {
 		}
 
 		if ( ! $post_type_object->hierarchical && ! in_array(
-				$post_type_object->name,
-				[
-					'attachment',
-					'revision',
-				]
-			) ) {
+			$post_type_object->name,
+			[
+				'attachment',
+				'revision',
+			]
+		) ) {
 			$fields['ancestors']['isDeprecated']      = true;
 			$fields['ancestors']['deprecationReason'] = __( 'This content type is not hierarchical and typcially will not have ancestors', 'wp-graphql' );
 

--- a/src/Type/Object/RootQuery.php
+++ b/src/Type/Object/RootQuery.php
@@ -191,10 +191,14 @@ class RootQuery {
 								case 'name':
 								case 'database_id':
 									$taxonomy = isset( $args['taxonomy'] ) ? $args['taxonomy'] : null;
-									if ( empty( $taxonomy ) && in_array( $idType, [
+									if ( empty( $taxonomy ) && in_array(
+										$idType,
+										[
 											'name',
-											'slug'
-										], true ) ) {
+											'slug',
+										],
+										true
+									) ) {
 										throw new UserError( __( 'When fetching a Term Node by "slug" or "name", the "taxonomy" also needs to be set as an input.', 'wp-graphql' ) );
 									}
 									if ( 'database_id' === $idType ) {
@@ -271,7 +275,6 @@ class RootQuery {
 									}
 									break;
 								case 'login':
-
 									$current_user = wp_get_current_user();
 									if ( $current_user->user_login !== $args['id'] ) {
 										if ( ! current_user_can( 'list_users' ) ) {
@@ -283,7 +286,6 @@ class RootQuery {
 									$id   = isset( $user->ID ) ? $user->ID : null;
 									break;
 								case 'email':
-
 									$current_user = wp_get_current_user();
 									if ( $current_user->user_email !== $args['id'] ) {
 										if ( ! current_user_can( 'list_users' ) ) {
@@ -304,7 +306,6 @@ class RootQuery {
 									$id            = absint( $id_components['id'] );
 									break;
 							}
-
 
 							return ! empty( $id ) ? DataSource::resolve_user( $id, $context ) : null;
 						},
@@ -386,7 +387,7 @@ class RootQuery {
 									$post_id = absint( $args['id'] );
 									break;
 								case 'source_url':
-									$url = $args['id'];
+									$url     = $args['id'];
 									$post_id = absint( attachment_url_to_postid( $url ) );
 									break;
 								case 'global_id':
@@ -404,7 +405,7 @@ class RootQuery {
 					]
 				);
 				$post_by_args = [
-					'id'                                          => [
+					'id'  => [
 						'type'        => 'ID',
 						'description' => sprintf( __( 'Get the object by its global ID', 'wp-graphql' ), $post_type_object->graphql_single_name ),
 					],
@@ -412,7 +413,7 @@ class RootQuery {
 						'type'        => 'Int',
 						'description' => sprintf( __( 'Get the %s by its database ID', 'wp-graphql' ), $post_type_object->graphql_single_name ),
 					],
-					'uri'                                         => [
+					'uri' => [
 						'type'        => 'String',
 						'description' => sprintf( __( 'Get the %s by its uri', 'wp-graphql' ), $post_type_object->graphql_single_name ),
 					],

--- a/src/Type/Object/SettingGroup.php
+++ b/src/Type/Object/SettingGroup.php
@@ -54,8 +54,6 @@ class SettingGroup {
 				$field_key = lcfirst( str_replace( '-', ' ', ucwords( $field_key, '_' ) ) );
 				$field_key = lcfirst( str_replace( ' ', '', ucwords( $field_key, ' ' ) ) );
 
-
-
 				if ( ! empty( $key ) && ! empty( $field_key ) ) {
 
 					/**
@@ -89,7 +87,7 @@ class SettingGroup {
 									break;
 								case 'boolean':
 								case 'bool':
-								return (bool) $option;
+									return (bool) $option;
 									break;
 								case 'number':
 								case 'float':

--- a/src/Type/Object/Settings.php
+++ b/src/Type/Object/Settings.php
@@ -73,7 +73,6 @@ class Settings {
 
 				$field_key = $group . 'Settings' . ucfirst( $field_key );
 
-
 				if ( ! empty( $key ) && ! empty( $field_key ) ) {
 
 					/**

--- a/src/Type/Object/User.php
+++ b/src/Type/Object/User.php
@@ -19,9 +19,9 @@ class User {
 					'databaseId'        => [
 						'type'        => [ 'non_null' => 'Int' ],
 						'description' => __( 'Identifies the primary key from the database.', 'wp-graphql' ),
-						'resolve' => function( \WPGraphQL\Model\User $user ) {
+						'resolve'     => function( \WPGraphQL\Model\User $user ) {
 							return absint( $user->userId );
-						}
+						},
 					],
 					'capabilities'      => [
 						'type'        => [

--- a/src/Type/Union/ContentTemplateUnion.php
+++ b/src/Type/Union/ContentTemplateUnion.php
@@ -8,7 +8,7 @@ class ContentTemplateUnion {
 
 		if ( ! empty( $registered_page_templates ) && is_array( $registered_page_templates ) ) {
 
-			$page_templates[ 'default' ] = 'Default';
+			$page_templates['default'] = 'Default';
 			foreach ( $registered_page_templates as $post_type_templates ) {
 				foreach ( $post_type_templates as $file => $name ) {
 					$page_templates[ $file ] = $name;
@@ -17,45 +17,50 @@ class ContentTemplateUnion {
 		}
 
 		if ( ! empty( $page_templates ) && is_array( $page_templates ) ) {
-			$type_names = [];
+			$type_names         = [];
 			$type_names_by_file = [];
 			foreach ( $page_templates as $file => $name ) {
 				$name               = ucwords( $name );
 				$name               = preg_replace( '/[^\w]/', '', $name );
 				$template_type_name = $name . 'Template';
-				register_graphql_object_type( $template_type_name, [
-					'interfaces'  => [ 'ContentTemplate' ],
-					// Translators: Placeholder is the name of the GraphQL Type in the Schema
-					'description' => __( 'The template assigned to the node', 'wp-graphql' ),
-					'fields' => [
-						'templateName' => [
-							'resolve' => function( $template ) use ( $page_templates ) {
-								return isset( $template['templateName'] ) ? $template['templateName'] : null;
-							}
+				register_graphql_object_type(
+					$template_type_name,
+					[
+						'interfaces'  => [ 'ContentTemplate' ],
+						// Translators: Placeholder is the name of the GraphQL Type in the Schema
+						'description' => __( 'The template assigned to the node', 'wp-graphql' ),
+						'fields'      => [
+							'templateName' => [
+								'resolve' => function( $template ) use ( $page_templates ) {
+									return isset( $template['templateName'] ) ? $template['templateName'] : null;
+								},
+							],
+							'templateFile' => [
+								'resolve' => function( $template ) use ( $page_templates ) {
+									return isset( $template['templateFile'] ) ? $template['templateFile'] : null;
+								},
+							],
 						],
-						'templateFile' => [
-							'resolve' => function( $template ) use ( $page_templates ) {
-								return isset( $template['templateFile'] ) ? $template['templateFile'] : null;
-							}
-						],
-					],
-				] );
-				$type_names[] = $template_type_name;
+					]
+				);
+				$type_names[]                = $template_type_name;
 				$type_names_by_file[ $file ] = $template_type_name;
 
 			}
 
 			if ( ! empty( $type_names ) ) {
 
-				register_graphql_union_type( 'ContentTemplateUnion', [
-					'typeNames'   => $type_names,
-					'resolveType' => function( $value ) use ( $type_names_by_file, $type_registry ) {
-						return isset( $value[ '__typename' ] ) ? $value[ '__typename' ] : 'DefaultTemplate';
-					}
-				] );
+				register_graphql_union_type(
+					'ContentTemplateUnion',
+					[
+						'typeNames'   => $type_names,
+						'resolveType' => function( $value ) use ( $type_names_by_file, $type_registry ) {
+							return isset( $value['__typename'] ) ? $value['__typename'] : 'DefaultTemplate';
+						},
+					]
+				);
 
 			}
-
 		}
 
 	}


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
The `menuOrder` field was missing after the v0.6.0 release. This is because the menuOrder field was moved to the `NodeWithPageAttributes` Interface and applied only to Post Types that support page attributes. However, the `NodeWithPageAttributes` Interface was never added to the TypeRegistry, so it was not getting applied. 

This adds the NodeWithPageAttributes Interface to the TypeRegistry. 

This also corrects some formatting issues missed in the v0.6.0 release

Does this close any currently open issues?
------------------------------------------
closes #1129 
