### PR TITLE
#1144 - Prevent model layer from attempting to execute cached values

### DIFF
--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -145,7 +145,15 @@ abstract class Model {
 	 */
 	public function __get( $key ) {
 		if ( ! empty( $this->fields[ $key ] ) ) {
-			if ( is_callable( $this->fields[ $key ] ) ) {
+			/**
+			 * If the property has already been processed and cached to the model
+			 * return the processed value.
+			 *
+			 * Otherwise, if it's a callable, process it and cache the value.
+			 */
+			if ( is_scalar( $this->fields[ $key ] ) || ( is_object( $this->fields[ $key ] ) && ! is_callable( $this->fields[ $key ] ) ) || is_array( $this->fields[ $key ] ) ) {
+				return $this->fields[ $key ];
+			} else if ( is_callable( $this->fields[ $key ] ) ) {
 				$data       = call_user_func( $this->fields[ $key ] );
 				$this->$key = $data;
 				return $data;


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
If the Model has already processed a field, and it's a scalar, array or non-callable object, return it. Otherwise call the function to process and cache the field for next run.	

Does this close any currently open issues?
------------------------------------------
closes #1144 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

**Before**
![Screen Shot 2020-02-14 at 12 59 22 PM](https://user-images.githubusercontent.com/1260765/74563402-f6bc2400-4f29-11ea-993d-3bc48670d363.png)

**After**
![Screen Shot 2020-02-14 at 12 58 28 PM](https://user-images.githubusercontent.com/1260765/74563418-fde33200-4f29-11ea-93b8-b53803b90628.png)

**Before**
![Screen Shot 2020-02-14 at 12 59 35 PM](https://user-images.githubusercontent.com/1260765/74563437-089dc700-4f2a-11ea-8a83-c75f3f50b291.png)

**After**
![Screen Shot 2020-02-14 at 12 58 03 PM](https://user-images.githubusercontent.com/1260765/74563457-105d6b80-4f2a-11ea-9369-0b8db2bc1c5d.png)
