### PR TITLE
Specify post to revision connection name to prevent clashes with unnamed user connections

### DIFF
--- a/src/Connection/PostObjects.php
+++ b/src/Connection/PostObjects.php
@@ -117,10 +117,11 @@ class PostObjects {
 						self::get_connection_config(
 							$post_type_object,
 							[
-								'fromType'      => $post_type_object->graphql_single_name,
-								'toType'        => $post_type_object->graphql_single_name,
-								'fromFieldName' => 'revisions',
-								'resolve'       => function( $root, $args, $context, $info ) {
+								'connectionTypeName'	=> $post_type_object->graphql_single_name . 'ToRevisionConnection',
+								'fromType'      			=> $post_type_object->graphql_single_name,
+								'toType'        			=> $post_type_object->graphql_single_name,
+								'fromFieldName' 			=> 'revisions',
+								'resolve'       			=> function( $root, $args, $context, $info ) {
 									return DataSource::resolve_post_objects_connection( $root, $args, $context, $info, 'revision' );
 								},
 							]


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
**BREAKING:** This sets a name for the core Revision connections to Post Types. Otherwise users cannot add their own connection args to unnamed connections. Any connection args fail silently.


Does this close any currently open issues?
------------------------------------------
#1148 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
Hi


Where has this been tested?
---------------------------
**Operating System:** Rasbpian, RHEL

**WordPress Version:** latest only
