### PR TITLE
Release/v0.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,14 +326,10 @@ Your changed files will now be linted via phpcs and your commit will fail with a
 ## Shout Outs
 This plugin brings the power of GraphQL (http://graphql.org/) to WordPress.
 
-This plugin is based on the hard work of Jason Bahl, Ryan Kanner, Hughie Devore and Peter Pak of Digital First Media (https://github.com/dfmedia),
-and Edwin Cromley of BE-Webdesign (https://github.com/BE-Webdesign).
-
 The plugin is built on top of the graphql-php library by Webonyx (https://github.com/webonyx/graphql-php) and makes use 
 of the graphql-relay-php library by Ivome (https://github.com/ivome/graphql-relay-php/)
 
-Special thanks to Digital First Media (http://digitalfirstmedia.com) for allocating development resources to push the 
-project forward.
+Special thanks to Gatsby (http://gatsbyjs.com) for allocating development resources to push the project forward.
 
 Some of the concepts and code are based on the WordPress Rest API. Much love to the folks (https://github.com/orgs/WP-API/people) 
 that put their blood, sweat and tears into the WP-API project, as it's been huge in moving WordPress forward as a 

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -145,7 +145,15 @@ abstract class Model {
 	 */
 	public function __get( $key ) {
 		if ( ! empty( $this->fields[ $key ] ) ) {
-			if ( is_callable( $this->fields[ $key ] ) ) {
+			/**
+			 * If the property has already been processed and cached to the model
+			 * return the processed value.
+			 *
+			 * Otherwise, if it's a callable, process it and cache the value.
+			 */
+			if ( is_scalar( $this->fields[ $key ] ) || ( is_object( $this->fields[ $key ] ) && ! is_callable( $this->fields[ $key ] ) ) || is_array( $this->fields[ $key ] ) ) {
+				return $this->fields[ $key ];
+			} else if ( is_callable( $this->fields[ $key ] ) ) {
 				$data       = call_user_func( $this->fields[ $key ] );
 				$this->$key = $data;
 				return $data;

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 0.6.1
+ * Version: 0.6.2
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 4.7.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  0.6.1
+ * @version  0.6.2
  */
 
 // Exit if accessed directly.
@@ -173,7 +173,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 
 			// Plugin version.
 			if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-				define( 'WPGRAPHQL_VERSION', '0.6.1' );
+				define( 'WPGRAPHQL_VERSION', '0.6.2' );
 			}
 
 			// Plugin Folder Path.


### PR DESCRIPTION
# Release Notes

## Bugfix
This fixes #1144, a bug in the Model Layer that was causing cached values of a Model to attempt to execute if the string name was a function. For example, if a field's value was the string `count` the Model would attempt to execute the `count()` method instead of returning the string `count`. 