### PR TITLE
Remove @access from docblocks - https://github.com/wp-graphql/wp-grap…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,6 @@ When contributing please ensure you follow the guidelines below so that we can k
 
 * We strive for full doc coverage and follow the standards set by phpDoc
 * Please make sure that every function is documented so that when we update our API Documentation things don't go awry!
-	* If you're adding/editing a function in a class, make sure to add `@access {private|public|protected}`
 * Finally, please use tabs and not spaces.
 
 At this point you're waiting on us to merge your pull request. We'll review all pull requests, and make suggestions and changes if necessary.

--- a/access-functions.php
+++ b/access-functions.php
@@ -10,7 +10,6 @@
  *
  * @param string $field_name Name of the field
  *
- * @access public
  * @return string Name of the field
  * @since  0.0.2
  */
@@ -27,7 +26,6 @@ function graphql_format_field_name( $field_name ) {
  *
  * @param array $request_data The GraphQL request data (query, variables, operation_name).
  *
- * @access public
  * @return array
  * @since  0.2.0
  * @throws Exception
@@ -45,7 +43,6 @@ function graphql( $request_data = [] ) {
  * @param string $operation_name The name of the operation
  * @param array  $variables      Variables to be passed to your GraphQL request
  *
- * @access public
  * @return array
  * @since  0.0.2
  * @throws \Exception

--- a/src/AppContext.php
+++ b/src/AppContext.php
@@ -26,7 +26,6 @@ class AppContext {
 	 * Stores the url string for the current site
 	 *
 	 * @var string $root_url
-	 * @access public
 	 */
 	public $root_url;
 
@@ -34,7 +33,6 @@ class AppContext {
 	 * Stores the WP_User object of the current user
 	 *
 	 * @var \WP_User $viewer
-	 * @access public
 	 */
 	public $viewer;
 
@@ -42,7 +40,6 @@ class AppContext {
 	 * Stores everything from the $_REQUEST global
 	 *
 	 * @var \mixed $request
-	 * @access public
 	 */
 	public $request;
 
@@ -50,7 +47,6 @@ class AppContext {
 	 * Stores additional $config properties
 	 *
 	 * @var \mixed $config
-	 * @access public
 	 */
 	public $config;
 

--- a/src/Connection/Comments.php
+++ b/src/Connection/Comments.php
@@ -16,7 +16,6 @@ class Comments {
 	/**
 	 * Register connections to Comments
 	 *
-	 * @access public
 	 */
 	public static function register_connections() {
 
@@ -68,7 +67,6 @@ class Comments {
 	 * Given an array of $args, this returns the connection config, merging the provided args
 	 * with the defaults
 	 *
-	 * @access public
 	 *
 	 * @param array $args
 	 *
@@ -91,7 +89,6 @@ class Comments {
 	/**
 	 * This returns the connection args for the Comment connection
 	 *
-	 * @access public
 	 * @return array
 	 */
 	public static function get_connection_args() {

--- a/src/Connection/MenuItems.php
+++ b/src/Connection/MenuItems.php
@@ -17,7 +17,6 @@ class MenuItems {
 	/**
 	 * Register connections to MenuItems
 	 *
-	 * @access public
 	 */
 	public static function register_connections() {
 
@@ -55,7 +54,6 @@ class MenuItems {
 	/**
 	 * Given an array of $args, returns the args for the connection with the provided args merged
 	 *
-	 * @access public
 	 * @param array $args
 	 *
 	 * @return array

--- a/src/Connection/Menus.php
+++ b/src/Connection/Menus.php
@@ -17,7 +17,6 @@ class Menus {
 	/**
 	 * Registers connections to Menus
 	 *
-	 * @access public
 	 */
 	public static function register_connections() {
 

--- a/src/Connection/Plugins.php
+++ b/src/Connection/Plugins.php
@@ -16,7 +16,6 @@ class Plugins {
 	/**
 	 * Register connections to Plugins
 	 *
-	 * @access public
 	 */
 	public static function register_connections() {
 		register_graphql_connection(

--- a/src/Connection/PostObjects.php
+++ b/src/Connection/PostObjects.php
@@ -167,7 +167,6 @@ class PostObjects {
 	/**
 	 * Given an optional array of args, this returns the args to be used in the connection
 	 *
-	 * @access public
 	 *
 	 * @param array         $args             The args to modify the defaults
 	 * @param \WP_Post_Type $post_type_object The post type the connection is going to

--- a/src/Connection/TermObjects.php
+++ b/src/Connection/TermObjects.php
@@ -17,7 +17,6 @@ class TermObjects {
 	/**
 	 * Register connections to TermObjects
 	 *
-	 * @access public
 	 */
 	public static function register_connections() {
 
@@ -100,7 +99,6 @@ class TermObjects {
 	 * Given the Taxonomy Object and an array of args, this returns an array of args for use in
 	 * registering a connection.
 	 *
-	 * @access public
 	 * @param \WP_Taxonomy $tax_object        The taxonomy object for the taxonomy having a
 	 *                                        connection registered to it
 	 * @param array        $args              The custom args to modify the connection registration
@@ -126,7 +124,6 @@ class TermObjects {
 	/**
 	 * Given an optional array of args, this returns the args to be used in the connection
 	 *
-	 * @access public
 	 * @param array $args The args to modify the defaults
 	 *
 	 * @return array

--- a/src/Connection/Themes.php
+++ b/src/Connection/Themes.php
@@ -16,7 +16,6 @@ class Themes {
 	/**
 	 * Register the connections
 	 *
-	 * @access public
 	 */
 	public static function register_connections() {
 

--- a/src/Connection/UserRoles.php
+++ b/src/Connection/UserRoles.php
@@ -16,7 +16,6 @@ class UserRoles {
 	/**
 	 * Register the connections
 	 *
-	 * @access public
 	 */
 	public static function register_connections() {
 

--- a/src/Connection/Users.php
+++ b/src/Connection/Users.php
@@ -16,7 +16,6 @@ class Users {
 	/**
 	 * Register connections to Users
 	 *
-	 * @access public
 	 */
 	public static function register_connections() {
 
@@ -41,7 +40,6 @@ class Users {
 	 * Returns the connection args for use in the connection
 	 *
 	 * @return array
-	 * @access public
 	 */
 	public static function get_connection_args() {
 		return [

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -175,7 +175,6 @@ abstract class AbstractConnectionResolver {
 	/**
 	 * Returns the source of the connection
 	 *
-	 * @access public
 	 * @return mixed
 	 */
 	public function getSource() {
@@ -185,7 +184,6 @@ abstract class AbstractConnectionResolver {
 	/**
 	 * Get the loader name
 	 *
-	 * @access protected
 	 * @throws \Exception
 	 * @return AbstractDataLoader
 	 */
@@ -210,7 +208,6 @@ abstract class AbstractConnectionResolver {
 	/**
 	 * Returns the AppContext of the connection
 	 *
-	 * @access public
 	 * @return AppContext
 	 */
 	public function getContext(): AppContext {
@@ -220,7 +217,6 @@ abstract class AbstractConnectionResolver {
 	/**
 	 * Returns the ResolveInfo of the connection
 	 *
-	 * @access public
 	 * @return ResolveInfo
 	 */
 	public function getInfo(): ResolveInfo {
@@ -230,8 +226,6 @@ abstract class AbstractConnectionResolver {
 	/**
 	 * Returns whether the connection should execute
 	 *
-	 * @access protected
-	 * @access public
 	 * @return bool
 	 */
 	protected function getShouldExecute(): bool {
@@ -340,7 +334,6 @@ abstract class AbstractConnectionResolver {
 	 * Returns the max between what was requested and what is defined as the $max_query_amount to
 	 * ensure that queries don't exceed unwanted limits when querying data.
 	 *
-	 * @access protected
 	 * @return int
 	 * @throws \Exception
 	 */
@@ -371,7 +364,6 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * This checks the $args to determine the amount requested, and if
 	 *
-	 * @access protected
 	 * @return int|null
 	 * @throws \Exception
 	 */
@@ -424,7 +416,6 @@ abstract class AbstractConnectionResolver {
 	 * This returns the offset to be used in the $query_args based on the $args passed to the
 	 * GraphQL query.
 	 *
-	 * @access protected
 	 * @return int|mixed
 	 */
 	protected function get_offset() {
@@ -459,7 +450,6 @@ abstract class AbstractConnectionResolver {
 	 * ore if there are more "items" after the "before" argument, has_next_page()
 	 * will be set to true
 	 *
-	 * @access protected
 	 * @return boolean
 	 */
 	protected function has_next_page() {
@@ -483,7 +473,6 @@ abstract class AbstractConnectionResolver {
 	 * or if there are more "items" before the "after" argument, has_previous_page()
 	 * will be set to true.
 	 *
-	 * @access protected
 	 * @return boolean
 	 */
 	protected function has_previous_page() {
@@ -503,7 +492,6 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * Determine the start cursor from the connection
 	 *
-	 * @access protected
 	 * @return mixed string|null
 	 */
 	protected function get_start_cursor() {
@@ -517,7 +505,6 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * Determine the end cursor from the connection
 	 *
-	 * @access protected
 	 * @return mixed string|null
 	 */
 	protected function get_end_cursor() {
@@ -536,7 +523,6 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * For backward pagination, we reverse the order of nodes.
 	 *
-	 * @access protected
 	 * @return array
 	 */
 	protected function get_nodes() {
@@ -561,7 +547,6 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * @param int $id
 	 *
-	 * @access protected
 	 * @return string
 	 */
 	protected function get_cursor_for_node( $id ) {
@@ -573,7 +558,6 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * This iterates over the nodes and returns edges
 	 *
-	 * @access protected
 	 * @return array
 	 */
 	protected function get_edges() {
@@ -617,7 +601,6 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * Returns pageInfo for the connection
 	 *
-	 * @access protected
 	 * @return array
 	 */
 	protected function get_page_info() {

--- a/src/Data/Connection/CommentConnectionResolver.php
+++ b/src/Data/Connection/CommentConnectionResolver.php
@@ -222,7 +222,6 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 	 * @param array $args The array of query arguments
 	 *
 	 * @since  0.0.5
-	 * @access private
 	 * @return array
 	 */
 	public function sanitize_input_fields( array $args ) {
@@ -274,7 +273,6 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 	 * offset exists. Offset is equivalent to comment_id. So this function is equivalent to
 	 * checking if the comment with the given ID exists.
 	 *
-	 * @access public
 	 *
 	 * @param int $offset The ID of the node used for the cursor offset
 	 *

--- a/src/Data/Connection/ContentTypeConnectionResolver.php
+++ b/src/Data/Connection/ContentTypeConnectionResolver.php
@@ -19,7 +19,6 @@ class ContentTypeConnectionResolver {
 	 *
 	 * @since  0.8.0
 	 * @return array
-	 * @access public
 	 * @throws \Exception
 	 */
 	public static function resolve( $source, array $args, AppContext $context, ResolveInfo $info ) {

--- a/src/Data/Connection/PluginConnectionResolver.php
+++ b/src/Data/Connection/PluginConnectionResolver.php
@@ -24,7 +24,6 @@ class PluginConnectionResolver {
 	 *
 	 * @since  0.5.0
 	 * @return array
-	 * @access public
 	 * @throws \Exception
 	 */
 	public static function resolve( $source, array $args, AppContext $context, ResolveInfo $info ) {

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -369,7 +369,6 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	 * now this gets the job done.
 	 *
 	 * @since  0.0.5
-	 * @access public
 	 * @return array
 	 */
 	public function sanitize_input_fields( $where_args ) {
@@ -530,7 +529,6 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	 * exists. Offset is equivalent to post_id. So this function is equivalent to checking if the
 	 * post with the given ID exists.
 	 *
-	 * @access public
 	 *
 	 * @param int $offset The ID of the node used in the cursor offset
 	 *

--- a/src/Data/Connection/TaxonomyConnectionResolver.php
+++ b/src/Data/Connection/TaxonomyConnectionResolver.php
@@ -19,7 +19,6 @@ class TaxonomyConnectionResolver {
 	 *
 	 * @since  0.8.0
 	 * @return array
-	 * @access public
 	 * @throws \Exception
 	 */
 	public static function resolve( $source, array $args, AppContext $context, ResolveInfo $info ) {

--- a/src/Data/Connection/TermObjectConnectionResolver.php
+++ b/src/Data/Connection/TermObjectConnectionResolver.php
@@ -248,7 +248,6 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 	 *
 	 * @since  0.0.5
 	 * @return array
-	 * @access public
 	 */
 	public function sanitize_input_fields() {
 
@@ -299,7 +298,6 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 	 * exists. Offset is equivalent to term_id. So this function is equivalent to checking if the
 	 * term with the given ID exists.
 	 *
-	 * @access public
 	 *
 	 * @param int $offset The ID of the node used in the cursor for offset
 	 *

--- a/src/Data/Connection/ThemeConnectionResolver.php
+++ b/src/Data/Connection/ThemeConnectionResolver.php
@@ -24,7 +24,6 @@ class ThemeConnectionResolver {
 	 *
 	 * @since  0.5.0
 	 * @return array
-	 * @access public
 	 * @throws \Exception
 	 */
 	public static function resolve( $source, array $args, AppContext $context, ResolveInfo $info ) {

--- a/src/Data/Connection/UserConnectionResolver.php
+++ b/src/Data/Connection/UserConnectionResolver.php
@@ -188,7 +188,6 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 	 *
 	 * @since  0.0.5
 	 * @return array
-	 * @access protected
 	 */
 	protected function sanitize_input_fields( array $args ) {
 
@@ -248,7 +247,6 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 	 * exists. Offset is equivalent to user_id. So this function is equivalent to checking if the
 	 * user with the given ID exists.
 	 *
-	 * @access public
 	 *
 	 * @param int $offset The ID of the node used as the offset in the cursor
 	 *

--- a/src/Data/Connection/UserRoleConnectionResolver.php
+++ b/src/Data/Connection/UserRoleConnectionResolver.php
@@ -25,7 +25,6 @@ class UserRoleConnectionResolver {
 	 *
 	 * @since  0.5.0
 	 * @return array
-	 * @access public
 	 * @throws \Exception
 	 */
 	public static function resolve( $source, array $args, AppContext $context, ResolveInfo $info ) {

--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -46,7 +46,6 @@ class DataSource {
 	 *
 	 * @var array $node_definition
 	 * @since  0.0.4
-	 * @access protected
 	 */
 	protected static $node_definition;
 
@@ -59,7 +58,6 @@ class DataSource {
 	 * @return Deferred object
 	 * @throws UserError
 	 * @since  0.0.5
-	 * @access public
 	 * @throws \Exception
 	 */
 	public static function resolve_comment( $id, $context ) {
@@ -123,7 +121,6 @@ class DataSource {
 	 * @return Plugin
 	 * @throws \Exception
 	 * @since  0.0.5
-	 * @access public
 	 */
 	public static function resolve_plugin( $info ) {
 
@@ -177,7 +174,6 @@ class DataSource {
 	 *
 	 * @return array
 	 * @since  0.0.5
-	 * @access public
 	 *
 	 * @throws \Exception
 	 */
@@ -194,7 +190,6 @@ class DataSource {
 	 * @throws UserError
 	 * @since  0.0.5
 	 * @return Deferred
-	 * @access public
 	 *
 	 * @throws \Exception
 	 */
@@ -246,7 +241,6 @@ class DataSource {
 	 *
 	 * @return mixed
 	 * @since  0.0.5
-	 * @access public
 	 * @throws \Exception
 	 */
 	public static function resolve_post_objects_connection( $source, array $args, AppContext $context, ResolveInfo $info, $post_type ) {
@@ -262,7 +256,6 @@ class DataSource {
 	 * @return PostType object
 	 * @throws UserError
 	 * @since  0.0.5
-	 * @access public
 	 * @throws \Exception
 	 */
 	public static function resolve_post_type( $post_type ) {
@@ -291,7 +284,6 @@ class DataSource {
 	 * @return Taxonomy object
 	 * @throws UserError | \Exception
 	 * @since  0.0.5
-	 * @access public
 	 */
 	public static function resolve_taxonomy( $taxonomy ) {
 
@@ -320,7 +312,6 @@ class DataSource {
 	 * @return mixed
 	 * @throws \Exception
 	 * @since  0.0.5
-	 * @access public
 	 */
 	public static function resolve_term_object( $id, AppContext $context ) {
 
@@ -350,7 +341,6 @@ class DataSource {
 	 *
 	 * @return array
 	 * @since  0.0.5
-	 * @access public
 	 * @throws \Exception
 	 */
 	public static function resolve_term_objects_connection( $source, array $args, $context, ResolveInfo $info, $taxonomy ) {
@@ -368,7 +358,6 @@ class DataSource {
 	 * @return Theme object
 	 * @throws UserError
 	 * @since  0.0.5
-	 * @access public
 	 *
 	 * @throws \Exception
 	 */
@@ -391,7 +380,6 @@ class DataSource {
 	 *
 	 * @return array
 	 * @since  0.0.5
-	 * @access public
 	 * @throws \Exception
 	 */
 	public static function resolve_themes_connection( $source, array $args, $context, ResolveInfo $info ) {
@@ -406,7 +394,6 @@ class DataSource {
 	 *
 	 * @return Deferred
 	 * @since  0.0.5
-	 * @access public
 	 * @throws \Exception
 	 */
 	public static function resolve_user( $id, AppContext $context ) {
@@ -434,7 +421,6 @@ class DataSource {
 	 *
 	 * @return array
 	 * @since  0.0.5
-	 * @access public
 	 * @throws \Exception
 	 */
 	public static function resolve_users_connection( $source, array $args, $context, ResolveInfo $info ) {
@@ -452,7 +438,6 @@ class DataSource {
 	 * @return UserRole
 	 * @throws \Exception
 	 * @since  0.0.30
-	 * @access public
 	 */
 	public static function resolve_user_role( $name ) {
 
@@ -513,7 +498,6 @@ class DataSource {
 	 * Get all of the allowed settings by group and return the
 	 * settings group that matches the group param
 	 *
-	 * @access public
 	 *
 	 * @param string $group
 	 *
@@ -533,7 +517,6 @@ class DataSource {
 	/**
 	 * Get all of the allowed settings by group
 	 *
-	 * @access public
 	 * @return array $allowed_settings_by_group
 	 */
 	public static function get_allowed_settings_by_group() {
@@ -579,7 +562,6 @@ class DataSource {
 	/**
 	 * Get all of the $allowed_settings
 	 *
-	 * @access public
 	 * @return array $allowed_settings
 	 */
 	public static function get_allowed_settings() {
@@ -632,7 +614,6 @@ class DataSource {
 	 *
 	 * @return array
 	 * @throws UserError
-	 * @access public
 	 */
 	public static function get_node_definition() {
 
@@ -845,7 +826,6 @@ class DataSource {
 	 * @param string $output    Optional. Output type; OBJECT*, ARRAY_N, or ARRAY_A.
 	 * @param string $post_type Optional. Post type; default is 'post'.
 	 *
-	 * @access public
 	 * @return \WP_Post|null WP_Post on success or null on failure
 	 * @see    https://github.com/Automattic/vip-go-mu-plugins/blob/52549ae9a392fc1343b7ac9dba4ebcdca46e7d55/vip-helpers/vip-caching.php#L186
 	 * @link   http://vip.wordpress.com/documentation/uncached-functions/ Uncached Functions
@@ -879,7 +859,6 @@ class DataSource {
 	/**
 	 * Returns array of nav menu location names
 	 *
-	 * @access public
 	 * @return array
 	 */
 	public static function get_registered_nav_menu_locations() {

--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -14,7 +14,6 @@ class NodeResolver {
 	/**
 	 * NodeResolver constructor.
 	 *
-	 * @access public
 	 */
 	public function __construct() {
 		global $wp;
@@ -25,7 +24,6 @@ class NodeResolver {
 	 * Given the URI of a resource, this method attempts to resolve it and return the
 	 * appropriate related object
 	 *
-	 * @access public
 	 *
 	 * @param array|string $uri              The path to be used as an identifier for the resource.
 	 * @param string       $extra_query_vars Any extra query vars to consider

--- a/src/Data/UserMutation.php
+++ b/src/Data/UserMutation.php
@@ -18,7 +18,6 @@ class UserMutation {
 	 * Stores the input fields static definition
 	 *
 	 * @var array $input_fields
-	 * @access private
 	 */
 	private static $input_fields = [];
 
@@ -26,7 +25,6 @@ class UserMutation {
 	 * Defines the accepted input arguments
 	 *
 	 * @return array|null
-	 * @access public
 	 */
 	public static function input_fields() {
 
@@ -118,7 +116,6 @@ class UserMutation {
 	 * @param array  $input         Data coming from the GraphQL mutation query input
 	 * @param string $mutation_name Name of the mutation being performed
 	 *
-	 * @access public
 	 * @return array
 	 */
 	public static function prepare_user_object( $input, $mutation_name ) {
@@ -242,7 +239,6 @@ class UserMutation {
 	 * @param int   $user_id The ID of the user
 	 * @param array $roles   List of roles that need to get added to the user
 	 *
-	 * @access private
 	 * @throws \Exception
 	 */
 	private static function add_user_roles( $user_id, $roles ) {
@@ -281,7 +277,6 @@ class UserMutation {
 	 * @param int    $user_id The ID of the user being mutated
 	 *
 	 * @return mixed|bool|\WP_Error
-	 * @access private
 	 */
 	private static function verify_user_role( $role, $user_id ) {
 

--- a/src/Model/Avatar.php
+++ b/src/Model/Avatar.php
@@ -24,7 +24,6 @@ class Avatar extends Model {
 	 * Stores the incoming avatar to be modeled
 	 *
 	 * @var array $data
-	 * @access protected
 	 */
 	protected $data;
 
@@ -34,7 +33,6 @@ class Avatar extends Model {
 	 * @param array $avatar The incoming avatar to be modeled
 	 *
 	 * @throws \Exception
-	 * @access public
 	 */
 	public function __construct( $avatar ) {
 		$this->data = $avatar;
@@ -44,7 +42,6 @@ class Avatar extends Model {
 	/**
 	 * Initializes the object
 	 *
-	 * @access protected
 	 * @return void
 	 */
 	protected function init() {

--- a/src/Model/Comment.php
+++ b/src/Model/Comment.php
@@ -31,7 +31,6 @@ class Comment extends Model {
 	 * Stores the incoming WP_Comment object to be modeled
 	 *
 	 * @var \WP_Comment $data
-	 * @access protected
 	 */
 	protected $data;
 
@@ -68,7 +67,6 @@ class Comment extends Model {
 	/**
 	 * Method for determining if the data should be considered private or not
 	 *
-	 * @access protected
 	 * @return bool
 	 */
 	protected function is_private() {
@@ -85,7 +83,6 @@ class Comment extends Model {
 	/**
 	 * Initializes the object
 	 *
-	 * @access protected
 	 * @return void
 	 */
 	protected function init() {

--- a/src/Model/CommentAuthor.php
+++ b/src/Model/CommentAuthor.php
@@ -20,7 +20,6 @@ class CommentAuthor extends Model {
 	 * Stores the comment author to be modeled
 	 *
 	 * @var array $data
-	 * @access protected
 	 */
 	protected $data;
 
@@ -30,7 +29,6 @@ class CommentAuthor extends Model {
 	 * @param array $comment_author The incoming comment author array to be modeled
 	 *
 	 * @throws \Exception
-	 * @access public
 	 */
 	public function __construct( $comment_author ) {
 		$this->data = $comment_author;
@@ -40,7 +38,6 @@ class CommentAuthor extends Model {
 	/**
 	 * Initializes the object
 	 *
-	 * @access protected
 	 * @return void
 	 */
 	protected function init() {

--- a/src/Model/Menu.php
+++ b/src/Model/Menu.php
@@ -21,7 +21,6 @@ class Menu extends Model {
 	 * Stores the incoming WP_Term object
 	 *
 	 * @var \WP_Term $data
-	 * @access protected
 	 */
 	protected $data;
 
@@ -30,7 +29,6 @@ class Menu extends Model {
 	 *
 	 * @param \WP_Term $term The incoming WP_Term object that needs modeling
 	 *
-	 * @access public
 	 * @return void
 	 * @throws \Exception
 	 */
@@ -42,7 +40,6 @@ class Menu extends Model {
 	/**
 	 * Initializes the Menu object
 	 *
-	 * @access protected
 	 * @return void
 	 */
 	protected function init() {

--- a/src/Model/MenuItem.php
+++ b/src/Model/MenuItem.php
@@ -26,7 +26,6 @@ class MenuItem extends Model {
 	 * Stores the incoming post data
 	 *
 	 * @var \WP_Post $data
-	 * @access protected
 	 */
 	protected $data;
 
@@ -35,7 +34,6 @@ class MenuItem extends Model {
 	 *
 	 * @param \WP_Post $post The incoming WP_Post object that needs modeling
 	 *
-	 * @access public
 	 * @return void
 	 * @throws \Exception
 	 */
@@ -47,7 +45,6 @@ class MenuItem extends Model {
 	/**
 	 * Initialize the Post object
 	 *
-	 * @access protected
 	 * @return void
 	 */
 	protected function init() {

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -13,7 +13,6 @@ abstract class Model {
 	 * Stores the name of the type the child class extending this one represents
 	 *
 	 * @var string $model_name
-	 * @access protected
 	 */
 	protected $model_name;
 
@@ -21,7 +20,6 @@ abstract class Model {
 	 * Stores the raw data passed to the child class when it's instantiated before it's transformed
 	 *
 	 * @var array $data
-	 * @access protected
 	 */
 	protected $data;
 
@@ -29,7 +27,6 @@ abstract class Model {
 	 * Stores the capability name for what to check on the user if the data should be considered "Restricted"
 	 *
 	 * @var string $restricted_cap
-	 * @access protected
 	 */
 	protected $restricted_cap;
 
@@ -37,7 +34,6 @@ abstract class Model {
 	 * Stores the array of allowed fields to show if the data is restricted
 	 *
 	 * @var array $allowed_restricted_fields
-	 * @access protected
 	 */
 	protected $allowed_restricted_fields;
 
@@ -45,7 +41,6 @@ abstract class Model {
 	 * Stores the DB ID of the user that owns this piece of data, or null if there is no owner
 	 *
 	 * @var int|null $owner
-	 * @access protected
 	 */
 	protected $owner;
 
@@ -53,7 +48,6 @@ abstract class Model {
 	 * Stores the WP_User object for the current user in the session
 	 *
 	 * @var \WP_User $current_user
-	 * @access protected
 	 */
 	protected $current_user;
 
@@ -61,7 +55,6 @@ abstract class Model {
 	 * Stores the visibility value for the current piece of data
 	 *
 	 * @var string
-	 * @access protected
 	 */
 	protected $visibility;
 
@@ -69,7 +62,6 @@ abstract class Model {
 	 * The fields for the modeled object. This will be populated in the child class
 	 *
 	 * @var array $fields
-	 * @access public
 	 */
 	public $fields;
 
@@ -82,7 +74,6 @@ abstract class Model {
 	 * @param null|int $owner                     Database ID of the user that owns this piece of
 	 *                                            data to compare with the current user ID
 	 *
-	 * @access protected
 	 * @return void
 	 * @throws \Exception
 	 */
@@ -112,7 +103,6 @@ abstract class Model {
 	 *
 	 * @param string $key The name of the field you are trying to retrieve
 	 *
-	 * @access public
 	 * @return bool
 	 */
 	public function __isset( $key ) {
@@ -126,7 +116,6 @@ abstract class Model {
 	 * @param string                    $key   Name of the key to set the data to
 	 * @param callable|int|string|mixed $value The value to set to the key
 	 *
-	 * @access public
 	 * @return void
 	 */
 	public function __set( $key, $value ) {
@@ -140,7 +129,6 @@ abstract class Model {
 	 *
 	 * @param string $key Name of the property that is trying to be accessed
 	 *
-	 * @access public
 	 * @return mixed|null
 	 */
 	public function __get( $key ) {
@@ -174,7 +162,6 @@ abstract class Model {
 	/**
 	 * Returns the name of the model, built from the child className
 	 *
-	 * @access protected
 	 * @return string
 	 */
 	protected function get_model_name() {
@@ -196,7 +183,6 @@ abstract class Model {
 	 * Return the visibility state for the current piece of data
 	 *
 	 * @return string
-	 * @access public
 	 */
 	public function get_visibility() {
 
@@ -259,7 +245,6 @@ abstract class Model {
 	 * Method to return the private state of the object. Can be overwritten in classes extending
 	 * this one.
 	 *
-	 * @access protected
 	 * @return bool
 	 */
 	protected function is_private() {
@@ -270,7 +255,6 @@ abstract class Model {
 	 * Whether or not the owner of the data matches the current user
 	 *
 	 * @return bool
-	 * @access protected
 	 */
 	protected function owner_matches_current_user() {
 		if ( empty( $this->current_user->ID ) || empty( $this->owner ) ) {
@@ -282,7 +266,6 @@ abstract class Model {
 	/**
 	 * Restricts fields for the data to only return the allowed fields if the data is restricted
 	 *
-	 * @access protected
 	 * @return void
 	 */
 	protected function restrict_fields() {
@@ -310,7 +293,6 @@ abstract class Model {
 	/**
 	 * Wraps all fields with another callback layer so we can inject hooks & filters into them
 	 *
-	 * @access protected
 	 * @return void
 	 */
 	protected function wrap_fields() {
@@ -439,7 +421,6 @@ abstract class Model {
 	/**
 	 * Returns instance of the data fully modeled
 	 *
-	 * @access protected
 	 * @return void
 	 */
 	protected function prepare_fields() {
@@ -474,7 +455,6 @@ abstract class Model {
 	 *                                  to build an object with those keys and their respective
 	 *                                  values.
 	 *
-	 * @access public
 	 * @return void
 	 */
 	public function filter( $fields ) {

--- a/src/Model/Plugin.php
+++ b/src/Model/Plugin.php
@@ -23,7 +23,6 @@ class Plugin extends Model {
 	 * Stores the incoming plugin data to be modeled
 	 *
 	 * @var array $data
-	 * @access protected
 	 */
 	protected $data;
 
@@ -32,7 +31,6 @@ class Plugin extends Model {
 	 *
 	 * @param array $plugin The incoming Plugin data to be modeled
 	 *
-	 * @access public
 	 * @throws \Exception
 	 */
 	public function __construct( $plugin ) {
@@ -43,7 +41,6 @@ class Plugin extends Model {
 	/**
 	 * Method for determining if the data should be considered private or not
 	 *
-	 * @access protected
 	 * @return bool
 	 */
 	protected function is_private() {
@@ -59,7 +56,6 @@ class Plugin extends Model {
 	/**
 	 * Initializes the object
 	 *
-	 * @access protected
 	 * @return void
 	 */
 	protected function init() {

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -66,7 +66,6 @@ class Post extends Model {
 	 * Stores the incoming post data
 	 *
 	 * @var \WP_Post $data
-	 * @access protected
 	 */
 	protected $data;
 
@@ -74,7 +73,6 @@ class Post extends Model {
 	 * Stores the incoming post type object for the post being modeled
 	 *
 	 * @var null|\WP_Post_Type $post_type_object
-	 * @access protected
 	 */
 	protected $post_type_object;
 
@@ -83,7 +81,6 @@ class Post extends Model {
 	 *
 	 * @param \WP_Post $post The incoming WP_Post object that needs modeling.
 	 *
-	 * @access public
 	 * @throws \Exception
 	 * @return void
 	 */
@@ -148,7 +145,6 @@ class Post extends Model {
 	/**
 	 * Retrieve the cap to check if the data should be restricted for the post
 	 *
-	 * @access protected
 	 * @return string
 	 */
 	protected function get_restricted_cap() {
@@ -233,7 +229,6 @@ class Post extends Model {
 	 *
 	 * @param \WP_Post $post_object The object of the post we need to verify permissions for
 	 *
-	 * @access protected
 	 * @return bool
 	 */
 	protected function is_post_private( $post_object = null ) {
@@ -298,7 +293,6 @@ class Post extends Model {
 	/**
 	 * Initialize the Post object
 	 *
-	 * @access protected
 	 * @return void
 	 */
 	protected function init() {

--- a/src/Model/PostType.php
+++ b/src/Model/PostType.php
@@ -41,7 +41,6 @@ class PostType extends Model {
 	 * Stores the incoming WP_Post_Type to be modeled
 	 *
 	 * @var \WP_Post_Type $data
-	 * @access protected
 	 */
 	protected $data;
 
@@ -50,7 +49,6 @@ class PostType extends Model {
 	 *
 	 * @param \WP_Post_Type $post_type The incoming post type to model
 	 *
-	 * @access public
 	 * @throws \Exception
 	 */
 	public function __construct( \WP_Post_Type $post_type ) {
@@ -79,7 +77,6 @@ class PostType extends Model {
 	/**
 	 * Method for determining if the data should be considered private or not
 	 *
-	 * @access protected
 	 * @return bool
 	 */
 	protected function is_private() {
@@ -95,7 +92,6 @@ class PostType extends Model {
 	/**
 	 * Initializes the object
 	 *
-	 * @access protected
 	 * @return void
 	 */
 	protected function init() {

--- a/src/Model/Taxonomy.php
+++ b/src/Model/Taxonomy.php
@@ -37,7 +37,6 @@ class Taxonomy extends Model {
 	 * Stores the incoming WP_Taxonomy object to be modeled
 	 *
 	 * @var \WP_Taxonomy $data
-	 * @access protected
 	 */
 	protected $data;
 
@@ -46,7 +45,6 @@ class Taxonomy extends Model {
 	 *
 	 * @param \WP_Taxonomy $taxonomy The incoming Taxonomy to model
 	 *
-	 * @access public
 	 * @throws \Exception
 	 */
 	public function __construct( \WP_Taxonomy $taxonomy ) {
@@ -75,7 +73,6 @@ class Taxonomy extends Model {
 	/**
 	 * Method for determining if the data should be considered private or not
 	 *
-	 * @access protected
 	 * @return bool
 	 */
 	protected function is_private() {
@@ -91,7 +88,6 @@ class Taxonomy extends Model {
 	/**
 	 * Initializes the object
 	 *
-	 * @access protected
 	 * @return void
 	 */
 	protected function init() {

--- a/src/Model/Term.php
+++ b/src/Model/Term.php
@@ -28,7 +28,6 @@ class Term extends Model {
 	 * Stores the incoming WP_Term object
 	 *
 	 * @var \WP_Term $data
-	 * @access protected
 	 */
 	protected $data;
 
@@ -36,7 +35,6 @@ class Term extends Model {
 	 * Stores the taxonomy object for the term being modeled
 	 *
 	 * @var null|\WP_Taxonomy $taxonomy_object
-	 * @access protected
 	 */
 	protected $taxonomy_object;
 
@@ -45,7 +43,6 @@ class Term extends Model {
 	 *
 	 * @param \WP_Term $term The incoming WP_Term object that needs modeling
 	 *
-	 * @access public
 	 * @return void
 	 * @throws \Exception
 	 */
@@ -58,7 +55,6 @@ class Term extends Model {
 	/**
 	 * Initializes the Term object
 	 *
-	 * @access protected
 	 * @return void
 	 */
 	protected function init() {

--- a/src/Model/Theme.php
+++ b/src/Model/Theme.php
@@ -26,7 +26,6 @@ class Theme extends Model {
 	 * Stores the incoming WP_Theme to be modeled
 	 *
 	 * @var \WP_Theme $data
-	 * @access protected
 	 */
 	protected $data;
 
@@ -36,7 +35,6 @@ class Theme extends Model {
 	 * @param \WP_Theme $theme The incoming WP_Theme to be modeled
 	 *
 	 * @return void
-	 * @access public
 	 * @throws \Exception
 	 */
 	public function __construct( \WP_Theme $theme ) {
@@ -47,7 +45,6 @@ class Theme extends Model {
 	/**
 	 * Method for determining if the data should be considered private or not
 	 *
-	 * @access protected
 	 * @return bool
 	 */
 	protected function is_private() {
@@ -67,7 +64,6 @@ class Theme extends Model {
 	/**
 	 * Initialize the object
 	 *
-	 * @access protected
 	 * @return void
 	 */
 	protected function init() {

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -35,7 +35,6 @@ class User extends Model {
 	 * Stores the WP_User object for the incoming data
 	 *
 	 * @var \WP_User $data
-	 * @access protected
 	 */
 	protected $data;
 
@@ -44,7 +43,6 @@ class User extends Model {
 	 *
 	 * @param \WP_User $user The incoming WP_User object that needs modeling
 	 *
-	 * @access public
 	 * @return void
 	 * @throws \Exception
 	 */
@@ -73,7 +71,6 @@ class User extends Model {
 	/**
 	 * Method for determining if the data should be considered private or not
 	 *
-	 * @access protected
 	 * @return bool
 	 */
 	protected function is_private() {
@@ -99,7 +96,6 @@ class User extends Model {
 	/**
 	 * Initialize the User object
 	 *
-	 * @access protected
 	 * @return void
 	 */
 	protected function init() {

--- a/src/Model/UserRole.php
+++ b/src/Model/UserRole.php
@@ -20,7 +20,6 @@ class UserRole extends Model {
 	 * Stores the incoming user role to be modeled
 	 *
 	 * @var array $data
-	 * @access protected
 	 */
 	protected $data;
 
@@ -29,7 +28,6 @@ class UserRole extends Model {
 	 *
 	 * @param array $user_role The incoming user role to be modeled
 	 *
-	 * @access public
 	 * @return void
 	 * @throws \Exception
 	 */
@@ -41,7 +39,6 @@ class UserRole extends Model {
 	/**
 	 * Method for determining if the data should be considered private or not
 	 *
-	 * @access protected
 	 * @return bool
 	 */
 	protected function is_private() {
@@ -61,7 +58,6 @@ class UserRole extends Model {
 	/**
 	 * Initializes the object
 	 *
-	 * @access protected
 	 * @return void
 	 */
 	protected function init() {

--- a/src/Registry/SchemaRegistry.php
+++ b/src/Registry/SchemaRegistry.php
@@ -13,7 +13,6 @@ class SchemaRegistry {
 
 	/**
 	 * @var TypeRegistry
-	 * @access protected
 	 */
 	protected $type_registry;
 

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -132,14 +132,12 @@ class TypeRegistry {
 	 * The registered Types
 	 *
 	 * @var array
-	 * @access protected
 	 */
 	protected $types;
 
 	/**
 	 * TypeRegistry constructor.
 	 *
-	 * @access public
 	 */
 	public function __construct() {
 		$this->types = [];
@@ -151,7 +149,6 @@ class TypeRegistry {
 	 * @param string $key Name of the array key to format
 	 *
 	 * @return string
-	 * @access protected
 	 */
 	protected function format_key( $key ) {
 		return strtolower( $key );
@@ -550,7 +547,6 @@ class TypeRegistry {
 	 * @param array  $fields    Array of fields and their settings to register on a Type
 	 * @param string $type_name Name of the Type to register the fields to
 	 *
-	 * @access protected
 	 * @return array
 	 * @throws \Exception
 	 */
@@ -580,7 +576,6 @@ class TypeRegistry {
 	 * @param array  $field_config Config data about the field to prepare
 	 * @param string $type_name    Name of the type to prepare the field for
 	 *
-	 * @access protected
 	 * @return array|null
 	 * @throws \Exception
 	 */
@@ -663,7 +658,6 @@ class TypeRegistry {
 	 * @param string $type_name Name of the type in the Type Registry to add the fields to
 	 * @param array  $fields    Fields to register
 	 *
-	 * @access public
 	 * @return void
 	 */
 	public function register_fields( $type_name, $fields ) {
@@ -683,7 +677,6 @@ class TypeRegistry {
 	 * @param string $field_name Name of the field to add to the type
 	 * @param array  $config     Info about the field to register to the type
 	 *
-	 * @access public
 	 * @return void
 	 */
 	public function register_field( $type_name, $field_name, $config ) {
@@ -724,7 +717,6 @@ class TypeRegistry {
 	 * @param string $type_name  Name of the Type the field is registered to
 	 * @param string $field_name Name of the field you would like to remove from the type
 	 *
-	 * @access public
 	 * @return void
 	 */
 	public function deregister_field( $type_name, $field_name ) {
@@ -755,7 +747,6 @@ class TypeRegistry {
 	 * @param string $from_type Name of the Type the connection is coming from
 	 * @param string $to_type   Name of the Type the connection is going to
 	 *
-	 * @access protected
 	 * @return string
 	 */
 	protected function get_connection_name( $from_type, $to_type ) {
@@ -767,7 +758,6 @@ class TypeRegistry {
 	 *
 	 * @param array $config The info about the connection being registered
 	 *
-	 * @access public
 	 * @return void
 	 * @throws \InvalidArgumentException
 	 * @throws \Exception
@@ -1009,7 +999,6 @@ class TypeRegistry {
 	 * @param string $mutation_name Name of the mutation being registered
 	 * @param array  $config        Info about the mutation being registered
 	 *
-	 * @access public
 	 * @return void
 	 * @throws \Exception
 	 */

--- a/src/Request.php
+++ b/src/Request.php
@@ -21,7 +21,6 @@ class Request {
 	 * App context for this request.
 	 *
 	 * @var \WPGraphQL\AppContext
-	 * @access private
 	 */
 	private $app_context;
 
@@ -29,7 +28,6 @@ class Request {
 	 * Request data.
 	 *
 	 * @var array
-	 * @access private
 	 */
 	private $data;
 
@@ -37,7 +35,6 @@ class Request {
 	 * Cached global post.
 	 *
 	 * @var \WP_Post
-	 * @access private
 	 */
 	private $global_post;
 
@@ -46,7 +43,6 @@ class Request {
 	 * OperationParams.
 	 *
 	 * @var OperationParams|OperationParams[]
-	 * @access private
 	 */
 	private $params;
 
@@ -54,7 +50,6 @@ class Request {
 	 * Schema for this request.
 	 *
 	 * @var \WPGraphQL\WPSchema
-	 * @access public
 	 */
 	public $schema;
 
@@ -65,7 +60,6 @@ class Request {
 	 *
 	 * @return void
 	 *
-	 * @access public
 	 *
 	 * @throws \Exception
 	 */
@@ -112,7 +106,6 @@ class Request {
 	/**
 	 * Apply filters and do actions before GraphQL execution
 	 *
-	 * @access private
 	 *
 	 * @return void
 	 */
@@ -153,7 +146,6 @@ class Request {
 	 * Anything else (true, WP_Error, thrown exception, etc) will prevent execution of the GraphQL
 	 * request.
 	 *
-	 * @access protected
 	 * @throws \Exception
 	 *
 	 * @return boolean
@@ -233,7 +225,6 @@ class Request {
 	 *
 	 * @param boolean $authentication_errors Whether there are authentication errors with the request
 	 *
-	 * @access protected
 	 * @return boolean
 	 */
 	protected function filtered_authentication_errors( $authentication_errors = false ) {
@@ -254,7 +245,6 @@ class Request {
 	 * @param mixed|array|object $response The response from execution. Array for batch requests,
 	 *                                     single object for individual requests
 	 * @return array
-	 * @access private
 	 *
 	 * @throws \Exception
 	 */
@@ -307,7 +297,6 @@ class Request {
 	 * @param array          $response The response for your GraphQL request
 	 * @param mixed|Int|null $key      The array key of the params for batch requests
 	 *
-	 *                                 @access private
 	 *
 	 * @return array
 	 */
@@ -391,7 +380,6 @@ class Request {
 	 *
 	 * @param  OperationParams $params OperationParams for the request.
 	 *
-	 *                                 @access private
 	 *
 	 * @return void
 	 */
@@ -410,7 +398,6 @@ class Request {
 	/**
 	 * Execute an internal request (graphql() function call).
 	 *
-	 * @access public
 	 * @return array
 	 * @throws \Exception
 	 */
@@ -456,7 +443,6 @@ class Request {
 	/**
 	 * Execute an HTTP request.
 	 *
-	 * @access public
 	 * @return array
 	 * @throws \Exception
 	 */
@@ -485,7 +471,6 @@ class Request {
 	/**
 	 * Get the operation params for the request.
 	 *
-	 * @access public
 	 * @return OperationParams
 	 */
 	public function get_params() {

--- a/src/Router.php
+++ b/src/Router.php
@@ -17,7 +17,6 @@ class Router {
 	 * Sets the route to use as the endpoint
 	 *
 	 * @var string $route
-	 * @access public
 	 */
 	public static $route = 'graphql';
 
@@ -39,7 +38,6 @@ class Router {
 	 * Router constructor.
 	 *
 	 * @since  0.0.1
-	 * @access public
 	 */
 	public function __construct() {
 
@@ -79,7 +77,6 @@ class Router {
 	 *
 	 * @uses   add_rewrite_rule()
 	 * @since  0.0.1
-	 * @access public
 	 * @return void
 	 */
 	public static function add_rewrite_rule() {
@@ -97,7 +94,6 @@ class Router {
 	 *
 	 * @param array $query_vars The array of whitelisted query variables
 	 *
-	 * @access public
 	 * @since  0.0.1
 	 * @return array
 	 */
@@ -160,7 +156,6 @@ class Router {
 	 * Loading process
 	 *
 	 * @since  0.0.1
-	 * @access public
 	 * @return void
 	 * @throws \Exception
 	 * @throws \Throwable
@@ -203,7 +198,6 @@ class Router {
 	 * Sends an HTTP header.
 	 *
 	 * @since  0.0.5
-	 * @access public
 	 *
 	 * @param string $key   Header key.
 	 * @param string $value Header value.
@@ -225,7 +219,6 @@ class Router {
 	 * Sends an HTTP status code.
 	 *
 	 * @since  0.0.5
-	 * @access protected
 	 */
 	protected static function set_status() {
 		status_header( self::$http_status_code );
@@ -286,7 +279,6 @@ class Router {
 	 * Set the response headers
 	 *
 	 * @since  0.0.1
-	 * @access public
 	 * @return void
 	 */
 	public static function set_headers() {
@@ -327,7 +319,6 @@ class Router {
 	 * Retrieves the raw request entity (body).
 	 *
 	 * @since  0.0.5
-	 * @access public
 	 * @global string $HTTP_RAW_POST_DATA Raw post data.
 	 * @return string Raw request data.
 	 */
@@ -352,7 +343,6 @@ class Router {
 	 * This processes the graphql requests that come into the /graphql endpoint via an HTTP request
 	 *
 	 * @since  0.0.1
-	 * @access public
 	 * @return mixed
 	 * @throws \Throwable
 	 */

--- a/src/Type/Enum/ContentNodeIdTypeEnum.php
+++ b/src/Type/Enum/ContentNodeIdTypeEnum.php
@@ -7,7 +7,6 @@ class ContentNodeIdTypeEnum {
 	/**
 	 * Register the Enum used for setting the field to identify content nodes by
 	 *
-	 * @access public
 	 * @return void
 	 */
 	public static function register_type() {

--- a/src/Type/Enum/TermNodeIdTypeEnum.php
+++ b/src/Type/Enum/TermNodeIdTypeEnum.php
@@ -7,7 +7,6 @@ class TermNodeIdTypeEnum {
 	/**
 	 * Register the Enum used for setting the field to identify term nodes by
 	 *
-	 * @access public
 	 * @return void
 	 */
 	public static function register_type() {

--- a/src/Type/Enum/UserNodeIdTypeEnum.php
+++ b/src/Type/Enum/UserNodeIdTypeEnum.php
@@ -6,7 +6,6 @@ class UserNodeIdTypeEnum {
 	/**
 	 * Register the Enum used for setting the field to identify User nodes by
 	 *
-	 * @access public
 	 * @return void
 	 */
 	public static function register_type() {

--- a/src/Type/Object/RootQuery.php
+++ b/src/Type/Object/RootQuery.php
@@ -415,7 +415,6 @@ class RootQuery {
 	/**
 	 * Register RootQuery fields for Post Objects of supported post types
 	 *
-	 * @access public
 	 */
 	public static function register_post_object_fields() {
 
@@ -542,7 +541,6 @@ class RootQuery {
 	/**
 	 * Register RootQuery fields for Term Objects of supported taxonomies
 	 *
-	 * @access public
 	 */
 	public static function register_term_object_fields() {
 

--- a/src/Type/Object/SettingGroup.php
+++ b/src/Type/Object/SettingGroup.php
@@ -26,7 +26,6 @@ class SettingGroup {
 	 * @param string $group_name Name  of the settings group to retrieve fields for
 	 *
 	 * @return array
-	 * @access public
 	 */
 	public static function get_settings_group_fields( $group_name, $group ) {
 

--- a/src/Type/Object/Settings.php
+++ b/src/Type/Object/Settings.php
@@ -16,7 +16,6 @@ class Settings {
 	 * Registers a Settings Type with fields for all settings based on settings
 	 * registered using the core register_setting API
 	 *
-	 * @access public
 	 *
 	 * @return void
 	 */

--- a/src/Type/Union/CommentAuthorUnion.php
+++ b/src/Type/Union/CommentAuthorUnion.php
@@ -11,7 +11,6 @@ class CommentAuthorUnion {
 	 *
 	 * @param TypeRegistry $type_registry
 	 *
-	 * @access public
 	 * @return void
 	 */
 	public static function register_type( TypeRegistry $type_registry ) {

--- a/src/Type/Union/MenuItemObjectUnion.php
+++ b/src/Type/Union/MenuItemObjectUnion.php
@@ -14,7 +14,6 @@ class MenuItemObjectUnion {
 	 *
 	 * @param TypeRegistry $type_registry
 	 *
-	 * @access public
 	 * @return void
 	 */
 	public static function register_type( TypeRegistry $type_registry ) {
@@ -53,7 +52,6 @@ class MenuItemObjectUnion {
 	/**
 	 * Returns a list of possible types for the union
 	 *
-	 * @access public
 	 * @return array
 	 */
 	public static function get_possible_types() {

--- a/src/Type/Union/PostObjectUnion.php
+++ b/src/Type/Union/PostObjectUnion.php
@@ -11,7 +11,6 @@ class PostObjectUnion {
 	 *
 	 * @param TypeRegistry $type_registry
 	 *
-	 * @access public
 	 * @return void
 	 */
 	public static function register_type( TypeRegistry $type_registry ) {
@@ -39,7 +38,6 @@ class PostObjectUnion {
 	/**
 	 * Returns a list of possible types for the union
 	 *
-	 * @access public
 	 * @return array
 	 */
 	public static function get_possible_types() {

--- a/src/Type/Union/TermObjectUnion.php
+++ b/src/Type/Union/TermObjectUnion.php
@@ -10,7 +10,6 @@ class TermObjectUnion {
 	 *
 	 * @param TypeRegistry $type_registry
 	 *
-	 * @access public
 	 * @return void
 	 */
 	public static function register_type( TypeRegistry $type_registry ) {
@@ -39,7 +38,6 @@ class TermObjectUnion {
 	/**
 	 * Returns a list of possible types for the union
 	 *
-	 * @access public
 	 * @return array
 	 */
 	public static function get_possible_types() {

--- a/src/Type/WPInterfaceType.php
+++ b/src/Type/WPInterfaceType.php
@@ -20,7 +20,6 @@ class WPInterfaceType extends InterfaceType {
 	 * @param array        $config
 	 * @param TypeRegistry $type_registry
 	 *
-	 * @access public
 	 */
 	public function __construct( array $config, TypeRegistry $type_registry ) {
 

--- a/src/Types.php
+++ b/src/Types.php
@@ -19,7 +19,6 @@ class Types {
 	 * @param array $args The raw query args from the GraphQL query
 	 * @param array $map  The mapping of where each of the args should go
 	 * @return array
-	 * @access public
 	 */
 	public static function map_input( $args, $map ) {
 		return Utils::map_input( $args, $map );

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -11,7 +11,6 @@ class Utils {
 	 *
 	 * @since  0.5.0
 	 * @return array
-	 * @access public
 	 */
 	public static function map_input( $args, $map ) {
 

--- a/tests/wpunit/MediaItemMutationsTest.php
+++ b/tests/wpunit/MediaItemMutationsTest.php
@@ -175,7 +175,6 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	 * and is reused throughout the createMediaItem tests
 	 *
 	 * @source wp-content/plugins/wp-graphql/src/Type/MediaItem/Mutation/MediaItemCreate.php
-	 * @access public
 	 * @return array $actual
 	 */
 	public function createMediaItemMutation() {
@@ -248,7 +247,6 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	 * and test whether they can create posts
 	 *
 	 * @source wp-content/plugins/wp-graphql/src/Type/MediaItem/MediaItemCreate.php:54
-	 * @access public
 	 * @return void
 	 */
 	public function testCreateMediaItemAsSubscriber() {
@@ -262,7 +260,6 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	 * does not exist on the test server.
 	 *
 	 * @source wp-content/plugins/wp-graphql/src/Type/MediaItem/Mutation/MediaItemCreate.php:89
-	 * @access public
 	 * @return void
 	 */
 	public function testCreateMediaItemFilePath() {
@@ -279,7 +276,6 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	 * get an error back from the source because they are required.
 	 *
 	 * @source wp-content/plugins/wp-graphql/src/Type/MediaItem/Mutation/MediaItemCreate.php:211
-	 * @access public
 	 * @return void
 	 */
 	public function testCreateMediaItemNoInput() {
@@ -308,7 +304,6 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	 * and test whether they can create posts with someone else's id
 	 *
 	 * @source wp-content/plugins/wp-graphql/src/Type/MediaItem/MediaItemCreate.php:61
-	 * @access public
 	 * @return void
 	 */
 	public function testCreateMediaItemOtherAuthor() {
@@ -359,7 +354,6 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	 * still get created
 	 *
 	 * @source wp-content/plugins/wp-graphql/src/Type/MediaItem/MediaItemCreate.php:89
-	 * @access public
 	 * @return void
 	 */
 	public function testCreateMediaItemWithInvalidUrl() {
@@ -375,7 +369,6 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	 * still get created
 	 *
 	 * @source wp-content/plugins/wp-graphql/src/Type/MediaItem/MediaItemCreate.php:121
-	 * @access public
 	 * @return void
 	 */
 	public function testCreateMediaItemWithNoFile() {
@@ -392,7 +385,6 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	 * succeed as an admin
 	 *
 	 * @source wp-content/plugins/wp-graphql/src/Type/MediaItem/Mutation/MediaItemCreate.php:142
-	 * @access public
 	 * @return void
 	 */
 	public function testCreateMediaItemAttachToParentAsAuthor() {
@@ -499,7 +491,6 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	 * edit other users posts.
 	 *
 	 * @source wp-content/plugins/wp-graphql/src/Type/MediaItem/MediaItemCreate.php:151
-	 * @access public
 	 * @return void
 	 */
 	public function testCreateMediaItemEditOthersPosts() {
@@ -531,7 +522,6 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	 * post_mime_type
 	 * @source wp-content/plugins/wp-graphql/src/Type/MediaItem/Mutation/MediaItemMutation.php:171
 	 *
-	 * @access public
 	 * @returnn void
 	 */
 	public function testCreateMediaItemDefaultValues() {
@@ -674,7 +664,6 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	 * This function tests the createMediaItem mutation
 	 *
 	 * @source wp-content/plugins/wp-graphql/src/Type/MediaItem/Mutation/MediaItemCreate.php
-	 * @access public
 	 * @return void
 	 */
 	public function testCreateMediaItemMutation() {
@@ -756,7 +745,6 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	 * This function tests the updateMediaItem mutation
 	 * and is reused throughout the updateMediaItem tests
 	 *
-	 * @access public
 	 * @return array $actual
 	 */
 	public function updateMediaItemMutation() {
@@ -800,7 +788,6 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	 * wanted to update.
 	 *
 	 * @source wp-content/plugins/wp-graphql/src/Type/MediaItem/MediaItemUpdate.php:57
-	 * @access public
 	 * @return void
 	 */
 	public function testUpdateMediaItemInvalidId() {
@@ -814,7 +801,6 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	 * Test whether the mediaItem we're updating is actually a mediaItem
 	 *
 	 * @souce wp-content/plugins/wp-graphql/src/Type/MediaItem/Mutation/MediaItemUpdate.php:67
-	 * @access public
 	 * @return void
 	 */
 	public function testUpdateMediaItemUpdatePost() {
@@ -830,7 +816,6 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	 * and test whether they can create posts
 	 *
 	 * @source wp-content/plugins/wp-graphql/src/Type/MediaItem/MediaItemUpdate.php:74
-	 * @access public
 	 * @return void
 	 */
 	public function testUpdateMediaItemAsSubscriber() {
@@ -845,7 +830,6 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	 * edit other users posts.
 	 *
 	 * @source wp-content/plugins/wp-graphql/src/Type/MediaItem/MediaItemUpdate.php:91
-	 * @access public
 	 * @return void
 	 */
 	public function testUpdateMediaItemEditOthersPosts() {
@@ -865,7 +849,6 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	 * edit other users posts.
 	 *
 	 * @source wp-content/plugins/wp-graphql/src/Type/MediaItem/MediaItemUpdate.php:91
-	 * @access public
 	 * @return void
 	 */
 	public function testUpdateMediaItemAddOtherAuthorsAsAuthor() {
@@ -881,7 +864,6 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	 * to that post as an admin. It should be created.
 	 *
 	 * @source wp-content/plugins/wp-graphql/src/Type/MediaItem/MediaItemUpdate.php:91
-	 * @access public
 	 * @return void
 	 */
 	public function testUpdateMediaItemAddOtherAuthorsAsAdmin() {
@@ -898,7 +880,6 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	 * This function tests the updateMediaItem mutation
 	 *
 	 * @source wp-content/plugins/wp-graphql/src/Type/MediaItem/Mutation/MediaItemUpdate.php
-	 * @access public
 	 * @return void
 	 */
 	public function testUpdateMediaItemMutation() {
@@ -953,7 +934,6 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	 * This function tests the deletMediaItem mutation
 	 * and is reused throughout the deleteMediaItem tests
 	 *
-	 * @access public
 	 * @return array $actual
 	 */
 	public function deleteMediaItemMutation() {
@@ -983,7 +963,6 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	 * Set the mediaItem id to a fake id and the mutation should fail
 	 *
 	 * @source wp-content/plugins/wp-graphql/src/Type/MediaItem/MediaItemDelete.php:79
-	 * @access public
 	 * @return void
 	 */
 	public function testDeleteMediaItemInvalidId() {
@@ -998,7 +977,6 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	 * the deletion should fail because we're a subscriber.
 	 *
 	 * @source wp-content/plugins/wp-graphql/src/Type/MediaItem/MediaItemDelete.php:86
-	 * @access public
 	 * @return void
 	 */
 	public function testDeleteMediaItemAsSubscriber() {
@@ -1011,7 +989,6 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	 * Set the force delete input to false and the
 	 *
 	 * @source wp-content/plugins/wp-graphql/src/Type/MediaItem/Mutation/MediaItemDelete.php:92
-	 * @access public
 	 * @return array $actual
 	 */
 	public function testDeleteMediaItemAlreadyInTrash() {
@@ -1057,7 +1034,6 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	 * Set the force delete input to false and the
 	 *
 	 * @source wp-content/plugins/wp-graphql/src/Type/MediaItem/Mutation/MediaItemDelete.php:92
-	 * @access public
 	 * @return array $actual
 	 */
 	public function testForceDeleteMediaItemAlreadyInTrash() {
@@ -1106,7 +1082,6 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	 * instead of an attachment
 	 *
 	 * @source wp-content/plugins/wp-graphql/src/Type/MediaItem/Mutation/MediaItemDelete.php:103
-	 * @access public
 	 * @return void
 	 */
 	public function testDeleteMediaItemAsPost() {
@@ -1149,7 +1124,6 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	 * This function tests the deleteMediaItem mutation
 	 *
 	 * @source wp-content/plugins/wp-graphql/src/Type/MediaItem/Mutation/MediaItemDelete.php
-	 * @access public
 	 * @return void
 	 */
 	public function testDeleteMediaItemMutation() {

--- a/tests/wpunit/SettingQueriesTest.php
+++ b/tests/wpunit/SettingQueriesTest.php
@@ -26,7 +26,6 @@ class SettingQueriesTest extends \Codeception\TestCase\WPTestCase {
 	 * Method for testing whether a user can query settings
 	 * if they don't have the 'manage_options' capability
 	 *
-	 * @access public
 	 * @return void
 	 */
 	public function testSettingQueryAsEditor() {
@@ -53,7 +52,6 @@ class SettingQueriesTest extends \Codeception\TestCase\WPTestCase {
 	/**
 	 * Method for testing the generalSettings
 	 *
-	 * @access public
 	 * @return void
 	 */
 	public function testGeneralSettingQuery() {
@@ -140,7 +138,6 @@ class SettingQueriesTest extends \Codeception\TestCase\WPTestCase {
 	/**
 	 * Method for testing the writingSettings
 	 *
-	 * @access public
 	 * @return void
 	 */
 	public function testWritingSettingQuery() {
@@ -176,7 +173,6 @@ class SettingQueriesTest extends \Codeception\TestCase\WPTestCase {
 	/**
 	 * Method for testing the readingSettings
 	 *
-	 * @access public
 	 * @return array $actual
 	 */
 	public function testReadingSettingQuery() {
@@ -209,7 +205,6 @@ class SettingQueriesTest extends \Codeception\TestCase\WPTestCase {
 	/**
 	 * Method for testing the discussionSettings
 	 *
-	 * @access public
 	 * @return array $actual
 	 */
 	public function testDiscussionSettingQuery() {
@@ -246,7 +241,6 @@ class SettingQueriesTest extends \Codeception\TestCase\WPTestCase {
 	 * Method for testing the testGetAllowedSettingsByGroup
 	 * and then checking that zoolSettings gets added and removed
 	 *
-	 * @access public
 	 * @return void
 	 */
 	public function testGetAllowedSettingsByGroup() {
@@ -287,7 +281,6 @@ class SettingQueriesTest extends \Codeception\TestCase\WPTestCase {
 	 * Method for testing the testGetAllowedSettings
 	 * and then checking that zoolSettings gets added and removed
 	 *
-	 * @access public
 	 * @return void
 	 */
 	public function testGetAllowedSettings() {

--- a/tests/wpunit/SettingsMutationsTest.php
+++ b/tests/wpunit/SettingsMutationsTest.php
@@ -138,7 +138,6 @@ class SettingsMutationsTest extends \Codeception\TestCase\WPTestCase  {
 	 * This function tests the updateSettings mutation
 	 * and is reused throughout the updateSettings tests
 	 *
-	 * @access public
 	 * @return array $actual
 	 */
 	public function updateSettingsMutation() {
@@ -254,7 +253,6 @@ class SettingsMutationsTest extends \Codeception\TestCase\WPTestCase  {
 	 * This function tests whether a user can update settings if they don't have the right credentials
 	 *
 	 * @source wp-content/plugins/wp-graphql/src/Type/Settings/Mutation/SettingsUpdate.php:51
-	 * @access public
 	 * @return void
 	 */
 	public function testUpdateSettingsAsAuthor() {
@@ -277,7 +275,6 @@ class SettingsMutationsTest extends \Codeception\TestCase\WPTestCase  {
 	 * They should not be able to query for the admin email
 	 * so we should receive an error back
 	 *
-	 * @access public
 	 * @return void
 	 */
 	public function testSettingsQueryAsEditor() {
@@ -306,7 +303,6 @@ class SettingsMutationsTest extends \Codeception\TestCase\WPTestCase  {
 	 * when trying to update the site's URL
 	 *
 	 * @source wp-content/plugins/wp-graphql/src/Type/Settings/Mutation/SettingsUpdate.php:63
-	 * @access public
 	 * @return void
 	 */
 	public function testUpdateSettingsSiteURLMutation() {
@@ -328,7 +324,6 @@ class SettingsMutationsTest extends \Codeception\TestCase\WPTestCase  {
 	 * This function tests the updateSettings mutation
 	 *
 	 * @source wp-content/plugins/wp-graphql/src/Type/Settings/Mutation/SettingsUpdate.php
-	 * @access public
 	 * @return void
 	 */
 	public function testUpdateSettingsMutation() {
@@ -451,7 +446,6 @@ class SettingsMutationsTest extends \Codeception\TestCase\WPTestCase  {
 	 * StartOfWeek = 0 (Sunday)
 	 *
 	 * @source wp-content/plugins/wp-graphql/src/Type/Settings/Mutation/SettingsUpdate.php:63
-	 * @access public
 	 * @return void
 	 */
 	public function testUpdateSettingsStartOfWeekMutation() {

--- a/tests/wpunit/SettingsQueriesTest.php
+++ b/tests/wpunit/SettingsQueriesTest.php
@@ -40,7 +40,6 @@ class WP_GraphQL_Test_Settings_Queries extends \Codeception\TestCase\WPTestCase 
 	 * They should not be able to query for the admin email
 	 * so we should receive an error back
 	 *
-	 * @access public
 	 * @return void
 	 */
 	public function testAllSettingsQueryAsEditor() {
@@ -67,7 +66,6 @@ class WP_GraphQL_Test_Settings_Queries extends \Codeception\TestCase\WPTestCase 
 	/**
 	 * Method for testing the generalSettings
 	 *
-	 * @access public
 	 * @return void
 	 */
 	public function testAllSettingsQuery() {

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -75,7 +75,6 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 		 *
 		 * @var WPGraphQL The one true WPGraphQL
 		 * @since  0.0.1
-		 * @access private
 		 */
 		private static $instance;
 
@@ -91,7 +90,6 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 		 *
 		 * @var array allowed_post_types
 		 * @since  0.0.5
-		 * @access public
 		 */
 		public static $allowed_post_types;
 
@@ -100,7 +98,6 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 		 *
 		 * @var array allowed_taxonomies
 		 * @since  0.0.5
-		 * @access public
 		 */
 		public static $allowed_taxonomies;
 
@@ -114,7 +111,6 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 		 *
 		 * @return object|WPGraphQL - The one true WPGraphQL
 		 * @since  0.0.1
-		 * @access public
 		 */
 		public static function instance() {
 
@@ -138,7 +134,6 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 		 * therefore, we don't want the object to be cloned.
 		 *
 		 * @since  0.0.1
-		 * @access public
 		 * @return void
 		 */
 		public function __clone() {
@@ -152,7 +147,6 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 		 * Disable unserializing of the class.
 		 *
 		 * @since  0.0.1
-		 * @access protected
 		 * @return void
 		 */
 		public function __wakeup() {
@@ -165,7 +159,6 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 		/**
 		 * Setup plugin constants.
 		 *
-		 * @access private
 		 * @since  0.0.1
 		 * @return void
 		 */
@@ -212,7 +205,6 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 		 * Include required files.
 		 * Uses composer's autoload
 		 *
-		 * @access private
 		 * @since  0.0.1
 		 * @return void
 		 */
@@ -390,7 +382,6 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 		 * This sets up built-in post_types and taxonomies to show in the GraphQL Schema
 		 *
 		 * @since  0.0.2
-		 * @access public
 		 * @return void
 		 */
 		public static function show_in_graphql() {
@@ -449,7 +440,6 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 		 *
 		 * @return array
 		 * @since  0.0.4
-		 * @access public
 		 */
 		public static function get_allowed_post_types( $args = [] ) {
 
@@ -498,7 +488,6 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 		 * the list of allowed_taxonomies to add/remove additional taxonomies
 		 *
 		 * @since  0.0.4
-		 * @access public
 		 * @return array
 		 */
 		public static function get_allowed_taxonomies() {
@@ -549,7 +538,6 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 		 * Returns the Schema as defined by static registrations throughout
 		 * the WP Load.
 		 *
-		 * @access protected
 		 * @return \WPGraphQL\WPSchema
 		 *
 		 * @throws Exception
@@ -589,7 +577,6 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 		 * Return the static schema if there is one
 		 *
 		 * @return null|string
-		 * @access public
 		 */
 		public static function get_static_schema() {
 			$schema = null;
@@ -604,7 +591,6 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 		 * Get the AppContext for use in passing down the Resolve Tree
 		 *
 		 * @return \WPGraphQL\AppContext
-		 * @access public
 		 */
 		public static function get_app_context() {
 


### PR DESCRIPTION
…hql/issues/1192

Remove @access from docblocks [#1192](https://github.com/wp-graphql/wp-graphql/issues/1192)

The @access tag in Doc blocks is unnecessary.

See: [#1163 ](https://github.com/wp-graphql/wp-graphql/pull/1163#discussion_r384151112)(comment)

🚀 We should remove all instances of @access from Doc blocks