### PR TITLE
AbstractDataLoader::get() added.

### DIFF
--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -332,7 +332,9 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * @return mixed|Model|null
 	 */
-	abstract public function get_node_by_id( $id );
+	public function get_node_by_id( $id ) {
+		return $this->loader->get( $id );
+	}
 
 	/**
 	 * get_query_amount

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -333,7 +333,7 @@ abstract class AbstractConnectionResolver {
 	 * @return mixed|Model|null
 	 */
 	public function get_node_by_id( $id ) {
-		return $this->loader->get( $id );
+		return $this->loader->load( $id );
 	}
 
 	/**

--- a/src/Data/Connection/CommentConnectionResolver.php
+++ b/src/Data/Connection/CommentConnectionResolver.php
@@ -177,20 +177,6 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * Given an ID, return the model for the entity or null
-	 *
-	 * @param int $id Comment ID
-	 *
-	 * @return Comment|null
-	 *
-	 * @throws \Exception
-	 */
-	public function get_node_by_id( $id ) {
-		$comment = \WP_Comment::get_instance( $id );
-		return ! empty( $comment ) ? new Comment( $comment ) : null;
-	}
-
-	/**
 	 * @return array
 	 * @throws \Exception
 	 */

--- a/src/Data/Connection/MenuConnectionResolver.php
+++ b/src/Data/Connection/MenuConnectionResolver.php
@@ -12,17 +12,6 @@ use WPGraphQL\Model\Menu;
 class MenuConnectionResolver extends TermObjectConnectionResolver {
 
 	/**
-	 * @param $id
-	 *
-	 * @return Menu|null
-	 * @throws \Exception
-	 */
-	public function get_node_by_id( $id ) {
-		$term = get_term( $id );
-		return ! empty( $term ) && ! is_wp_error( $term ) ? new Menu( $term ) : null;
-	}
-
-	/**
 	 * Get the connection args for use in WP_Term_Query to query the menus
 	 *
 	 * @return array

--- a/src/Data/Connection/TermObjectConnectionResolver.php
+++ b/src/Data/Connection/TermObjectConnectionResolver.php
@@ -220,17 +220,6 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * @param $id
-	 *
-	 * @return mixed|null|\WPGraphQL\Model\Model|Term
-	 * @throws \Exception
-	 */
-	public function get_node_by_id( $id ) {
-		$term = get_term( $id );
-		return ! empty( $term ) && ! is_wp_error( $term ) ? new Term( $term ) : null;
-	}
-
-	/**
 	 * Whether the connection query should execute. Certain contexts _may_ warrant
 	 * restricting the query to execute at all. Default is true, meaning any time
 	 * a TermObjectConnection resolver is asked for, it will execute.

--- a/src/Data/Connection/UserConnectionResolver.php
+++ b/src/Data/Connection/UserConnectionResolver.php
@@ -27,17 +27,6 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 		return true;
 	}
 
-	/**
-	 * @param $id
-	 *
-	 * @return mixed|null|\WPGraphQL\Model\Model|User
-	 * @throws \Exception
-	 */
-	public function get_node_by_id( $id ) {
-		$user = get_user_by( 'id', $id );
-		return ! empty( $user ) ? new User( $user ) : null;
-	}
-
 	public function get_loader_name() {
 		return 'user';
 	}

--- a/src/Data/Loader/AbstractDataLoader.php
+++ b/src/Data/Loader/AbstractDataLoader.php
@@ -285,22 +285,6 @@ abstract class AbstractDataLoader {
 	}
 
 	/**
-	 * Returns objects connected to the provided by checking if the object is cached,
-	 * if the object associated with the key is loaded in the spot.
-	 *
-	 * @param mixed $key Object key.
-	 *
-	 * @return mixed
-	 */
-	public function get( $key ) {
-		if ( ! empty( $this->cached[ $key ] ) ) {
-			return $this->cached[ $key ];
-		} else {
-			return $this->load( $key );
-		}
-	}
-
-	/**
 	 * Given array of keys, loads and returns a map consisting of keys from `keys` array and loaded
 	 * values
 	 *

--- a/src/Data/Loader/AbstractDataLoader.php
+++ b/src/Data/Loader/AbstractDataLoader.php
@@ -285,6 +285,22 @@ abstract class AbstractDataLoader {
 	}
 
 	/**
+	 * Returns objects connected to the provided by checking if the object is cached,
+	 * if the object associated with the key is loaded in the spot.
+	 *
+	 * @param mixed $key Object key.
+	 *
+	 * @return mixed
+	 */
+	public function get( $key ) {
+		if ( ! empty( $this->cached[ $key ] ) ) {
+			return $this->cached[ $key ];
+		} else {
+			return $this->load( $key );
+		}
+	}
+
+	/**
 	 * Given array of keys, loads and returns a map consisting of keys from `keys` array and loaded
 	 * values
 	 *


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds a `get` function to the `AbstractDataLoader` class. This function is for the purpose of retrieving object cached by the loader, but loads the object on spot if not found in the cache.
```
public function get( $key ) {
	if ( ! empty( $this->cached[ $key ] ) ) {
		return $this->cached[ $key ];
	} else {
		return $this->load( $key );
	}
}
```
`AbstractConnectionResolver::get_node_by_id()` is no longer abstract.
```
public function get_node_by_id( $id ) {
	return $this->loader->get( $id );
}
```
The following connection resolver classes have had the `get_node_by_id()` function removed.
- CommentConnectionResolver
- MenuConnectionResolver
- TermObjectConnectionResolver
- UserConnectionResolver

The **PostObjectConnectionResolver** and **MenuItemConnectionResolver** use the **PostObjectLoader** which doesn't seem to be compatible with the `AbstractDataLoader::get()` most like due to this **Deferred** [here](https://github.com/kidunot89/wp-graphql/blob/feature/abstract-loader-get-function/src/Data/Loader/PostObjectLoader.php#L128-L148). So `get_node_by_id()` has been left unchanged in those two classes.

Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Linux Mint 19.2

**WordPress Version:** 5.2.3
