### PR TITLE
add leading slashes to uri field resolvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Download and install like any WordPress plugin.
 
 ## Documentation
 
-Documentation can be found [here](https://docs.wpgraphql.com). The repository where the Documentation content lives is [here](https://github.com/wp-graphql/docs.wpgraphql.com)
+Documentation can be found [here](https://docs.wpgraphql.com). The content for the documentation lives [here](https://github.com/wp-graphql/wp-graphql/tree/develop/docs/source)
 
 - Requires PHP 7.0+
 - Requires WordPress 5.0+

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Download and install like any WordPress plugin.
 
 Documentation can be found [here](https://docs.wpgraphql.com). The repository where the Documentation content lives is [here](https://github.com/wp-graphql/docs.wpgraphql.com)
 
-- Requires PHP 5.5+
-- Requires WordPress 4.7+
+- Requires PHP 7.0+
+- Requires WordPress 5.0+
 
 ## Overview
 This plugin brings the power of GraphQL to WordPress.

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -442,7 +442,7 @@ class Post extends Model {
 						return '/';
 					}
 
-					return ! empty( $uri ) ? ltrim( str_ireplace( home_url(), '', $uri ), '/' ) : null;
+					return ! empty( $uri ) ? str_ireplace( home_url(), '', $uri ) : null;
 				},
 				'commentCount'    => function() {
 					return ! empty( $this->data->comment_count ) ? absint( $this->data->comment_count ) : null;

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -177,7 +177,7 @@ class User extends Model {
 				'uri'               => function() {
 					$user_profile_url = get_author_posts_url( $this->data->ID );
 
-					return ! empty( $user_profile_url ) ? ltrim( str_ireplace( home_url(), '', $user_profile_url ), '/' ) : '';
+					return ! empty( $user_profile_url ) ? str_ireplace( home_url(), '', $user_profile_url ) : '';
 				},
 			];
 

--- a/src/Type/Object/TermObject.php
+++ b/src/Type/Object/TermObject.php
@@ -37,7 +37,7 @@ class TermObject {
 					],
 					'uri'               => [
 						'resolve' => function( $term, $args, $context, $info ) {
-							return ! empty( $term->link ) ? ltrim( str_ireplace( home_url(), '', $term->link ), '/' ) : '';
+							return ! empty( $term->link ) ? str_ireplace( home_url(), '', $term->link ) : '';
 						},
 					],
 				],

--- a/tests/wpunit/ContentNodeInterfaceTest.php
+++ b/tests/wpunit/ContentNodeInterfaceTest.php
@@ -245,9 +245,9 @@ class ContentNodeInterfaceTest extends \Codeception\TestCase\WPTestCase {
 
 		$variables = [
 			'postIdType' => 'URI',
-			'postId'     => ltrim( parse_url( get_permalink( $post_id ) )['path'], '/' ),
+			'postId'     => parse_url( get_permalink( $post_id ) )['path'],
 			'pageIdType' => 'URI',
-			'pageId'     => ltrim( parse_url( get_permalink( $page_id ) )['path'], '/' ),
+			'pageId'     => parse_url( get_permalink( $page_id ) )['path'],
 		];
 
 		codecept_debug( $variables );

--- a/tests/wpunit/PostObjectQueriesTest.php
+++ b/tests/wpunit/PostObjectQueriesTest.php
@@ -1001,7 +1001,7 @@ class PostObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 				'pageBy' => [
 					'id'    => $global_child_id,
 					'title' => 'Child Page',
-					'uri'   => ltrim( $uri, '/' ),
+					'uri'   => $uri,
 				],
 			],
 		];
@@ -1883,7 +1883,7 @@ class PostObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 			'id' => $global_id,
 			'postId' => $post_id,
 			'title' => $title,
-			'uri' => ltrim( str_ireplace( home_url(), '', $permalink ), '/' ),
+			'uri' => str_ireplace( home_url(), '', $permalink ),
 			'slug' => $slug,
 		];
 
@@ -1971,7 +1971,7 @@ class PostObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 			'id' => $global_id,
 			'pageId' => $page_id,
 			'title' => $title,
-			'uri' => ltrim( str_ireplace( home_url(), '', get_permalink( $page_id ) ), '/' ),
+			'uri' => str_ireplace( home_url(), '', get_permalink( $page_id ) ),
 			'slug' => $slug,
 		];
 

--- a/tests/wpunit/PostTypeObjectQueriesTest.php
+++ b/tests/wpunit/PostTypeObjectQueriesTest.php
@@ -96,7 +96,6 @@ class PostTypeObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 							itemsListNavigation
 							itemsList
 						}
-						menuIcon
 						menuPosition
 						name
 						public
@@ -184,7 +183,6 @@ class PostTypeObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 										'itemsListNavigation' => 'Posts list navigation',
 										'itemsList'           => 'Posts list',
 									],
-									'menuIcon'               => null,
 									'menuPosition'           => 5,
 									'name'                   => 'post',
 									'public'                 => true,
@@ -253,7 +251,6 @@ class PostTypeObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 						hierarchical
 						id
 						label
-						menuIcon
 						menuPosition
 						name
 						public
@@ -300,7 +297,6 @@ class PostTypeObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 									'hierarchical'           => true,
 									'id'                     => $global_id,
 									'label'                  => 'Pages',
-									'menuIcon'               => null,
 									'menuPosition'           => 20,
 									'name'                   => 'page',
 									'public'                 => true,
@@ -374,7 +370,6 @@ class PostTypeObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 						hierarchical
 						id
 						label
-						menuIcon
 						menuPosition
 						name
 						public
@@ -421,7 +416,6 @@ class PostTypeObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 									'hierarchical'           => false,
 									'id'                     => $global_id,
 									'label'                  => 'Media',
-									'menuIcon'               => null,
 									'menuPosition'           => null,
 									'name'                   => 'attachment',
 									'public'                 => true,

--- a/tests/wpunit/PostTypeObjectQueriesTest.php
+++ b/tests/wpunit/PostTypeObjectQueriesTest.php
@@ -174,7 +174,7 @@ class PostTypeObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 										'attributes'          => 'Post Attributes',
 										'insertIntoItem'      => 'Insert into post',
 										'uploadedToThisItem'  => 'Uploaded to this post',
-										'featuredImage'       => 'Featured image',
+										'featuredImage'       => 'Featured Image',
 										'setFeaturedImage'    => 'Set featured image',
 										'removeFeaturedImage' => 'Remove featured image',
 										'useFeaturedImage'    => null,

--- a/tests/wpunit/PostTypeObjectQueriesTest.php
+++ b/tests/wpunit/PostTypeObjectQueriesTest.php
@@ -174,7 +174,7 @@ class PostTypeObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 										'attributes'          => 'Post Attributes',
 										'insertIntoItem'      => 'Insert into post',
 										'uploadedToThisItem'  => 'Uploaded to this post',
-										'featuredImage'       => 'Featured Image',
+										'featuredImage'       => 'Featured image',
 										'setFeaturedImage'    => 'Set featured image',
 										'removeFeaturedImage' => 'Remove featured image',
 										'useFeaturedImage'    => null,

--- a/tests/wpunit/UserObjectQueriesTest.php
+++ b/tests/wpunit/UserObjectQueriesTest.php
@@ -1266,7 +1266,7 @@ class UserObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 		wp_set_current_user( $admin->ID );
 
-		$uri = ltrim( str_ireplace( home_url(), '', get_author_posts_url( $admin->ID ) ), '/' );
+		$uri = str_ireplace( home_url(), '', get_author_posts_url( $admin->ID ) );
 		codecept_debug( $uri );
 
 		$query = '
@@ -1312,7 +1312,7 @@ class UserObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 			'userId' => $admin->ID,
 			'username' => $admin->user_login,
 			'slug' => $admin->user_nicename,
-			'uri' => ltrim( str_ireplace( home_url(), '', get_author_posts_url( $admin->ID ) ), '/' ),
+			'uri' => str_ireplace( home_url(), '', get_author_posts_url( $admin->ID ) ),
 			'email' => $admin->user_email,
 		];
 
@@ -1397,7 +1397,7 @@ class UserObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 			'post_status' => 'publish'
 		] );
 
-		$uri = ltrim( str_ireplace( home_url(), '', get_author_posts_url( $admin->ID ) ), '/' );
+		$uri = str_ireplace( home_url(), '', get_author_posts_url( $admin->ID ) );
 		codecept_debug( $uri );
 
 		$query = '
@@ -1443,7 +1443,7 @@ class UserObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 			'userId' => $admin->ID,
 			'username' => $admin->user_login,
 			'slug' => $admin->user_nicename,
-			'uri' => ltrim( str_ireplace( home_url(), '', get_author_posts_url( $admin->ID ) ), '/' ),
+			'uri' => str_ireplace( home_url(), '', get_author_posts_url( $admin->ID ) ),
 			'email' => $admin->user_email,
 		];
 
@@ -1508,7 +1508,7 @@ class UserObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 		wp_set_current_user( $subscriber->ID );
 
-		$uri = ltrim( str_ireplace( home_url(), '', get_author_posts_url( $subscriber->ID ) ), '/' );
+		$uri = str_ireplace( home_url(), '', get_author_posts_url( $subscriber->ID ) );
 		codecept_debug( $uri );
 
 		$query = '
@@ -1560,7 +1560,7 @@ class UserObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 			'userId' => $subscriber->ID,
 			'username' => $subscriber->user_login,
 			'slug' => $subscriber->user_nicename,
-			'uri' => ltrim( str_ireplace( home_url(), '', get_author_posts_url( $subscriber->ID ) ), '/' ),
+			'uri' => str_ireplace( home_url(), '', get_author_posts_url( $subscriber->ID ) ),
 			'email' => $subscriber->user_email,
 		];
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This adds a leading slash to the uri field to make uri fields absolute paths rather than relative.


Does this close any currently open issues?
------------------------------------------
https://github.com/wp-graphql/wp-graphql/issues/1206
