### PR TITLE
fix: url in wpgraphql-insights doc

### DIFF
--- a/docs/source/extensions/wpgraphql-insights.mdx
+++ b/docs/source/extensions/wpgraphql-insights.mdx
@@ -9,4 +9,4 @@ This plugin adds additional data to the response of your GraphQL queries which c
 
 ## Trace Data
 
-This plugin adds Trace data, in accordance with the [https://github.com/apollographql/apollo-tracing](Apollo Tracing) spec.
+This plugin adds Trace data, in accordance with the [Apollo Tracing](https://github.com/apollographql/apollo-tracing) spec.


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
The link in the `wpgraphql-insights.mdx` docs had a link that was not formatted correctly thus not showing up correctly.


Does this close any currently open issues?
------------------------------------------
No


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

Any other comments?
-------------------

Where has this been tested?
---------------------------
Viewed in Github

Original:
![Screen Shot 2020-04-07 at 1 52 30 PM](https://user-images.githubusercontent.com/996560/78702773-1d1d9080-78d7-11ea-9e36-ff71059dd88f.png)

Fixed:
![Screen Shot 2020-04-07 at 1 51 58 PM](https://user-images.githubusercontent.com/996560/78702783-2149ae00-78d7-11ea-8df4-93c898f2812d.png)

