### PR TITLE
Delete User Mutation

### DIFF
--- a/src/Mutation/UserDelete.php
+++ b/src/Mutation/UserDelete.php
@@ -78,7 +78,7 @@ class UserDelete {
 			 */
 			$id_parts = Relay::fromGlobalId( $input['id'] );
 
-			if ( ! current_user_can( 'delete_users' ) ) {
+			if ( ! current_user_can( 'delete_users', absint( $id_parts['id'] ) ) ) {
 				throw new UserError( __( 'Sorry, you are not allowed to delete users.', 'wp-graphql' ) );
 			}
 


### PR DESCRIPTION
Passing the user ID to the `current_user_can` function in the `deleteUser` mutation so that extensions and plugins can properly extend it.

More background information here: #143 