### PR TITLE
Add description for Post Types and Taxonomies added to the Schema

### DIFF
--- a/src/Type/Object/RootQuery.php
+++ b/src/Type/Object/RootQuery.php
@@ -428,7 +428,7 @@ class RootQuery {
 					$post_type_object->graphql_single_name,
 					[
 						'type'        => $post_type_object->graphql_single_name,
-						'description' => sprintf( __( 'A % object', 'wp-graphql' ), $post_type_object->graphql_single_name ),
+						'description' => sprintf( __( '%1$s object. %2$s', 'wp-graphql' ), $post_type_object->graphql_single_name, $post_type_object->description ),
 						'args'        => [
 							'id'     => [
 								'type' => [

--- a/src/Type/Object/RootQuery.php
+++ b/src/Type/Object/RootQuery.php
@@ -428,7 +428,7 @@ class RootQuery {
 					$post_type_object->graphql_single_name,
 					[
 						'type'        => $post_type_object->graphql_single_name,
-						'description' => sprintf( __( '%1$s object. %2$s', 'wp-graphql' ), $post_type_object->graphql_single_name, $post_type_object->description ),
+						'description' => sprintf( __( 'An object of the %1$s Type. %2$s', 'wp-graphql' ), $post_type_object->graphql_single_name, $post_type_object->description ),
 						'args'        => [
 							'id'     => [
 								'type' => [


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
This PR adds Object Single name and description to the documents in GraphiQL IDE for exposed data. See the screenshots.

Closes: #1204 

**Before:**

![Screenshot 2020-04-09 at 19 01 42](https://user-images.githubusercontent.com/7713923/78917716-f0fd3d80-7a97-11ea-8434-a8bedc7980e8.png)

**After:**

![Screenshot 2020-04-09 at 19 18 49](https://user-images.githubusercontent.com/7713923/78917655-dfb43100-7a97-11ea-89c5-ee3127d15782.png)

Where has this been tested?
---------------------------
**Operating System:** … Linux

**WordPress Version:** … 5.3.2
