### PR TITLE
Release/v0.8.3

### DIFF
--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -228,7 +228,7 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * @return bool
 	 */
-	protected function getShouldExecute(): bool {
+	public function getShouldExecute(): bool {
 		return $this->should_execute;
 	}
 
@@ -279,7 +279,7 @@ abstract class AbstractConnectionResolver {
 	abstract public function get_query();
 
 	/**
-	 * get_items
+	 * get_ids
 	 *
 	 * Return an array of ids from the query
 	 *
@@ -325,6 +325,7 @@ abstract class AbstractConnectionResolver {
 	 * @param $id
 	 *
 	 * @return mixed|Model|null
+	 * @throws \Exception
 	 */
 	public function get_node_by_id( $id ) {
 		return $this->loader->load( $id );
@@ -339,7 +340,7 @@ abstract class AbstractConnectionResolver {
 	 * @return int
 	 * @throws \Exception
 	 */
-	protected function get_query_amount() {
+	public function get_query_amount() {
 
 		/**
 		 * Filter the maximum number of posts per page that should be quried. The default is 100 to prevent queries from
@@ -369,7 +370,7 @@ abstract class AbstractConnectionResolver {
 	 * @return int|null
 	 * @throws \Exception
 	 */
-	protected function get_amount_requested() {
+	public function get_amount_requested() {
 
 		/**
 		 * Set the default amount
@@ -420,7 +421,7 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * @return int|mixed
 	 */
-	protected function get_offset() {
+	public function get_offset() {
 
 		/**
 		 * Defaults
@@ -454,7 +455,7 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * @return boolean
 	 */
-	protected function has_next_page() {
+	public function has_next_page() {
 		if ( ! empty( $this->args['first'] ) ) {
 			return count( $this->ids ) > $this->query_amount;
 		}
@@ -477,7 +478,7 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * @return boolean
 	 */
-	protected function has_previous_page() {
+	public function has_previous_page() {
 		if ( ! empty( $this->args['last'] ) ) {
 			return count( $this->ids ) > $this->query_amount;
 		}
@@ -496,7 +497,7 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * @return mixed string|null
 	 */
-	protected function get_start_cursor() {
+	public function get_start_cursor() {
 		$first_edge = $this->edges && ! empty( $this->edges ) ? $this->edges[0] : null;
 
 		return isset( $first_edge['cursor'] ) ? $first_edge['cursor'] : null;
@@ -509,7 +510,7 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * @return mixed string|null
 	 */
-	protected function get_end_cursor() {
+	public function get_end_cursor() {
 		$last_edge = $this->edges && ! empty( $this->edges ) ? $this->edges[ count( $this->edges ) - 1 ] : null;
 
 		return isset( $last_edge['cursor'] ) ? $last_edge['cursor'] : null;
@@ -526,8 +527,9 @@ abstract class AbstractConnectionResolver {
 	 * For backward pagination, we reverse the order of nodes.
 	 *
 	 * @return array
+	 * @throws \Exception
 	 */
-	protected function get_nodes() {
+	public function get_nodes() {
 		if ( empty( $this->ids ) ) {
 			return [];
 		}
@@ -576,7 +578,7 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * @return array
 	 */
-	protected function get_edges() {
+	public function get_edges() {
 		$edges = [];
 		if ( ! empty( $this->nodes ) ) {
 
@@ -620,7 +622,7 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * @return array
 	 */
-	protected function get_page_info() {
+	public function get_page_info() {
 
 		$page_info = [
 			'startCursor'     => $this->get_start_cursor(),
@@ -744,10 +746,7 @@ abstract class AbstractConnectionResolver {
 	 */
 	public function get_connection() {
 
-		$ids = $this->execute_and_get_ids();
-		if ( empty( $ids ) ) {
-			return $ids;
-		}
+		$this->execute_and_get_ids();
 
 		/**
 		 * Return a Deferred function to load all buffered nodes before
@@ -755,7 +754,10 @@ abstract class AbstractConnectionResolver {
 		 */
 		return new Deferred(
 			function() {
-				$this->loader->loadMany( $this->ids );
+
+				if ( ! empty( $this->ids ) ) {
+					$this->loader->loadMany( $this->ids );
+				}
 
 				/**
 				 * Set the items. These are the "nodes" that make up the connection.

--- a/src/Data/Connection/MenuConnectionResolver.php
+++ b/src/Data/Connection/MenuConnectionResolver.php
@@ -2,8 +2,6 @@
 
 namespace WPGraphQL\Data\Connection;
 
-use WPGraphQL\Model\Menu;
-
 /**
  * Class MenuConnectionResolver
  *

--- a/tests/wpunit/CommentObjectQueriesTest.php
+++ b/tests/wpunit/CommentObjectQueriesTest.php
@@ -152,7 +152,7 @@ class CommentObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 					],
 					'authorIp'    => null,
 					'children'    => [
-						'edges' => null,
+						'edges' => [],
 					],
 					'commentId'   => $comment_id,
 					'commentedOn' => null,

--- a/tests/wpunit/MenuItemConnectionQueriesTest.php
+++ b/tests/wpunit/MenuItemConnectionQueriesTest.php
@@ -109,8 +109,7 @@ class MenuItemConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		codecept_debug( $actual );
 
 		// The query should return no menu items since no where args were specified.
-		$this->assertEquals( null, $actual['data']['menuItems']['edges'] );
-		$this->assertEquals( null, $actual['data']['menuItems']['edges'] );
+		$this->assertEquals( [], $actual['data']['menuItems']['edges'] );
 	}
 
 	public function testMenuItemsQueryNodes() {

--- a/tests/wpunit/TermObjectQueriesTest.php
+++ b/tests/wpunit/TermObjectQueriesTest.php
@@ -216,7 +216,7 @@ class TermObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 					'link'           => get_term_link( $term_id ),
 					'name'           => 'A Category',
 					'posts'          => [
-						'edges' => null,
+						'edges' => [],
 					],
 					'slug'           => 'a-category',
 					'taxonomy'       => [

--- a/tests/wpunit/UserObjectQueriesTest.php
+++ b/tests/wpunit/UserObjectQueriesTest.php
@@ -170,7 +170,7 @@ class UserObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 					'capKey'            => 'wp_capabilities',
 					'capabilities'      => [ 'read', 'level_0', 'subscriber' ],
 					'comments'          => [
-						'edges' => null,
+						'edges' => [],
 					],
 					'description'       => null,
 					'email'             => 'test@test.com',
@@ -180,15 +180,15 @@ class UserObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 					'lastName'          => null,
 					'locale'            => 'en_US',
 					'mediaItems'        => [
-						'edges' => null,
+						'edges' => [],
 					],
 					'name'              => $user->data->display_name,
 					'nickname'          => $user->nickname,
 					'pages'             => [
-						'edges' => null,
+						'edges' => [],
 					],
 					'posts'             => [
-						'edges' => null,
+						'edges' => [],
 					],
 					'registeredDate'    => date( 'c', strtotime( $user->user_registered ) ),
 					'roles'             => [

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 0.8.2
+ * Version: 0.8.3
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 4.7.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  0.8.2
+ * @version  0.8.3
  */
 
 // Exit if accessed directly.
@@ -166,7 +166,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 
 			// Plugin version.
 			if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-				define( 'WPGRAPHQL_VERSION', '0.8.2' );
+				define( 'WPGRAPHQL_VERSION', '0.8.3' );
 			}
 
 			// Plugin Folder Path.


### PR DESCRIPTION
# Release Notes

## Bugfix

- The WPGraphQL v0.8.0 release changed some methods in the AbstractConnectionResolver from public to protected, breaking plugins that had been using filters that returned an instance of a ConnectionResolver and were using public methods from the Class. 
   - See: https://github.com/valu-digital/wp-graphql-offset-pagination/issues/3