### PR TITLE
Remove cached method shim for get_page_by_uri

### DIFF
--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -818,45 +818,6 @@ class DataSource {
 	}
 
 	/**
-	 * Cached version of get_page_by_path so that we're not making unnecessary SQL all the time
-	 *
-	 * This is a modified version of the cached function from WordPress.com VIP MU Plugins here.
-	 *
-	 * @param string $uri
-	 * @param string $output    Optional. Output type; OBJECT*, ARRAY_N, or ARRAY_A.
-	 * @param string $post_type Optional. Post type; default is 'post'.
-	 *
-	 * @return \WP_Post|null WP_Post on success or null on failure
-	 * @see    https://github.com/Automattic/vip-go-mu-plugins/blob/52549ae9a392fc1343b7ac9dba4ebcdca46e7d55/vip-helpers/vip-caching.php#L186
-	 * @link   http://vip.wordpress.com/documentation/uncached-functions/ Uncached Functions
-	 */
-	public static function get_post_object_by_uri( $uri, $output = OBJECT, $post_type = 'post' ) {
-
-		if ( is_array( $post_type ) ) {
-			$cache_key = sanitize_key( $uri ) . '_' . md5( serialize( $post_type ) );
-		} else {
-			$cache_key = $post_type . '_' . sanitize_key( $uri );
-		}
-		$post_id = wp_cache_get( $cache_key, 'get_post_object_by_path' );
-
-		if ( false === $post_id ) {
-			$post    = get_page_by_path( $uri, $output, $post_type );
-			$post_id = $post ? $post->ID : 0;
-			if ( 0 === $post_id ) {
-				wp_cache_set( $cache_key, $post_id, 'get_post_object_by_path', ( 1 * HOUR_IN_SECONDS + mt_rand( 0, HOUR_IN_SECONDS ) ) ); // We only store the ID to keep our footprint small
-			} else {
-				wp_cache_set( $cache_key, $post_id, 'get_post_object_by_path', 0 ); // We only store the ID to keep our footprint small
-			}
-		}
-		if ( $post_id ) {
-			return get_post( absint( $post_id ) );
-		}
-
-		return null;
-
-	}
-
-	/**
 	 * Returns array of nav menu location names
 	 *
 	 * @return array

--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -818,6 +818,21 @@ class DataSource {
 	}
 
 	/**
+	 * This was used for caching the get_page_by_path function, which is now cached in core,
+	 * please use that function directly instead.
+	 *
+	 * @param string $uri
+	 * @param string $output    Optional. Output type; OBJECT*, ARRAY_N, or ARRAY_A.
+	 * @param string $post_type Optional. Post type; default is 'post'.
+	 *
+	 * @return \WP_Post|null WP_Post on success or null on failure
+	 * @deprecated since 0.8.4 Use the get_page_by_path function instead.
+	 */
+	public static function get_post_object_by_uri( $uri, $output = OBJECT, $post_type = 'post' ) {
+		return get_page_by_path( $uri, $output, $post_type );
+	}
+
+	/**
 	 * Returns array of nav menu location names
 	 *
 	 * @return array

--- a/src/Type/Object/RootQuery.php
+++ b/src/Type/Object/RootQuery.php
@@ -451,7 +451,7 @@ class RootQuery {
 								case 'uri':
 								case 'slug':
 									$slug        = esc_html( $args['id'] );
-									$post_object = DataSource::get_post_object_by_uri( $slug, 'OBJECT', $post_type_object->name );
+									$post_object = get_page_by_path( $slug, 'OBJECT', $post_type_object->name );
 									$post_id     = isset( $post_object->ID ) ? absint( $post_object->ID ) : null;
 									break;
 								case 'database_id':
@@ -522,11 +522,11 @@ class RootQuery {
 								$post_id = absint( $id );
 							} elseif ( ! empty( $args['uri'] ) ) {
 								$uri         = esc_html( $args['uri'] );
-								$post_object = DataSource::get_post_object_by_uri( $uri, 'OBJECT', $post_type_object->name );
+								$post_object = get_page_by_path( $uri, 'OBJECT', $post_type_object->name );
 								$post_id     = isset( $post_object->ID ) ? absint( $post_object->ID ) : null;
 							} elseif ( ! empty( $args['slug'] ) ) {
 								$slug        = esc_html( $args['slug'] );
-								$post_object = DataSource::get_post_object_by_uri( $slug, 'OBJECT', $post_type_object->name );
+								$post_object = get_page_by_path( $slug, 'OBJECT', $post_type_object->name );
 								$post_id     = isset( $post_object->ID ) ? absint( $post_object->ID ) : null;
 							}
 							$post = DataSource::resolve_post_object( $post_id, $context );


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
This cached shim is no longer needed since the core version of this function is now cached. I left the method in there since it was public and anyone could be using it. I just threw a deprecated tag on it and removed usage from within the plugin.


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
