### PR TITLE
Removes the type-hinting from the Post model constructor

### DIFF
--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -79,13 +79,13 @@ class Post extends Model {
 	/**
 	 * Post constructor.
 	 *
-	 * @param \WP_Post $post      The incoming WP_Post object that needs modeling.
-	 * @param integer  $owner_id  Owner of incoming WP_Post object.
+	 * @param \WP_Post|mixed $post      The incoming WP_Post object that needs modeling.
+	 * @param integer        $owner_id  Owner of incoming WP_Post object.
 	 *
 	 * @throws \Exception
 	 * @return void
 	 */
-	public function __construct( \WP_Post $post, $owner_id = null ) {
+	public function __construct( $post, $owner_id = null ) {
 
 		/**
 		 * Set the data as the Post object


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
Removes the `\WP_Post` parameter type-hinting from the `Post` model constructor.

It seems like a simply change, but I don't know if this is here for a reason beyond aesthetics :man_shrugging: 


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
