### PR TITLE
#1270 - register graphql scalar

### DIFF
--- a/access-functions.php
+++ b/access-functions.php
@@ -182,6 +182,17 @@ function register_graphql_connection( array $config ) {
 }
 
 /**
+ * Given a config array for a custom Scalar, this registers a Scalar for use in the Schema
+ *
+ * @param array $config
+ */
+function register_graphql_scalar( array $config ) {
+	add_action( get_graphql_register_action(), function( \WPGraphQL\Registry\TypeRegistry $type_registry ) use ( $config ) {
+		$type_registry->register_scalar( $config );
+	}, 10 );
+}
+
+/**
  * Given a Type Name and Field Name, this removes the field from the TypeRegistry
  *
  * @param string $type_name  The name of the Type to remove the field from

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -117,6 +117,7 @@ use WPGraphQL\Type\WPEnumType;
 use WPGraphQL\Type\WPInputObjectType;
 use WPGraphQL\Type\WPInterfaceType;
 use WPGraphQL\Type\WPObjectType;
+use WPGraphQL\Type\WPScalar;
 use WPGraphQL\Type\WPUnionType;
 
 /**
@@ -403,6 +404,19 @@ class TypeRegistry {
 		 */
 		do_action( 'graphql_register_types_late', $type_registry );
 
+	}
+
+	/**
+	 * Given a config for a custom Scalar, this adds the Scalar for use in the Schema.
+	 *
+	 * @param $config
+	 *
+	 * @return WPScalar
+	 */
+	public function register_scalar( $config ) {
+		$type = new WPScalar( $config, $this );
+		$this->types[ $this->format_key( $type->name ) ] = $type;
+		return $type;
 	}
 
 	/**

--- a/src/Type/WPScalar.php
+++ b/src/Type/WPScalar.php
@@ -1,0 +1,26 @@
+<?php
+namespace WPGraphQL\Type;
+
+use GraphQL\Type\Definition\CustomScalarType;
+use WPGraphQL\Registry\TypeRegistry;
+
+/**
+ * Class WPScalar
+ *
+ * @package WPGraphQL\Type
+ */
+class WPScalar extends CustomScalarType {
+
+	/**
+	 * WPScalar constructor.
+	 *
+	 * @param array        $config
+	 * @param TypeRegistry $type_registry
+	 */
+	public function __construct( array $config, TypeRegistry $type_registry ) {
+		$config = apply_filters( 'graphql_custom_scalar_config', $config, $type_registry );
+		parent::__construct( $config );
+
+	}
+
+}


### PR DESCRIPTION
This allows for custom scalars to be registered and used with WPGraphQL

Below is example of this in action:

## Register the Scalar:

```
add_action( 'graphql_register_types', function() {
	register_graphql_scalar([
		'name' => 'Email',
		'description' => __( 'Email according to the email spec, yo', 'wp-graphql' ),
		'serialize' => function( $value ) {
			return $value;
		},
		'parseValue' => function( $value ) {
			if (!filter_var($value, FILTER_VALIDATE_EMAIL)) {
				throw new Error("Cannot represent following value as email: " . \GraphQL\Utils\Utils::printSafeJson($value));
			}
			return $value;
		},
		'parseLiteral' => function( $valueNode, array $variables = null ) {
			// Note: throwing GraphQL\Error\Error vs \UnexpectedValueException to benefit from GraphQL
			// error location in query:
			if (!$valueNode instanceof \GraphQL\Language\AST\StringValueNode) {
				throw new Error('Query error: Can only parse strings got: ' . $valueNode->kind, [$valueNode]);
			}
			if (!filter_var($valueNode->value, FILTER_VALIDATE_EMAIL)) {
				throw new Error("Not a valid email", [$valueNode]);
			}
			return $valueNode->value;
		}
	]);
});
```

## Register a field to use the Scalar:

```
add_action( 'graphql_register_types', function() {
    register_graphql_field( 'RootQuery', 'testEmail', [
		'type' => 'Email',
		'description' => __( 'Testing custom scalars', 'wp-graphql' ),
		'resolve' => function() {
			return 'jasonbahl@mac.com';
		},
	] );
});
```

## Shows in the Schema, like so:

![Screen Shot 2020-04-27 at 2 43 15 PM](https://user-images.githubusercontent.com/1260765/80420074-7144e080-8897-11ea-9fa9-a7a308ecd2ed.png)


Does this close any currently open issues?
------------------------------------------
closes #1270
