### PR TITLE
Update & Cleanup gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,25 +1,15 @@
+/.github export-ignore
+/.coveralls export-ignore
+/.dockerignore export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /bin export-ignore
-/CODE_OF_CONDUCT.md export-ignore
-/CONTRIBUTING.md export-ignore
-/ISSUE_TEMPLATE.md export-ignore
-/PULL_REQUEST_TEMPLATE.md export-ignore
-#/changelog.md export-ignore
-#/readme.md export-ignore
-#/vendor export-ignore
-/Dockerfile export-ignore
-/docker-entrypoints export-ignore
-/docker-tasks export-ignore
 /img export-ignore
-/phpcs.ruleset.xml  export-ignore
-/phpunit.xml.dist export-ignore
-/run-docker-local-app.sh export-ignore
-/run-docker-shell.sh export-ignore
-/run-docker-test-environment.sh export-ignore
-/run-docker-tests.sh export-ignore
 /tests export-ignore
-
-
-
-
+/docker export-ignore
+/docs export-ignore
+/phpcs.xml  export-ignore
+/phpunit.xml.dist export-ignore
+codeception.yml export-ignore
+coveralls.yml export-ignore
+netlify.toml export-ignore


### PR DESCRIPTION
This PR seeks to 
- Remove files that are zipped into the release plugin during the release process. However, they do not affect the use of the plugin by end user. (This consequentially reduces the zip size.)
- Remove the files in .gitattributes that have been restructured in PR #1249 

Where has this been tested?
---------------------------
**Operating System:** Windows 10 & Mac OS 10.15
**WordPress Version:** WP 5.4