### PR TITLE
#1259 - Throw InvariantViolation if suppress_filters are applied to WP_Query in GraphQL

### DIFF
--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -85,11 +85,12 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	 */
 	public function get_query() {
 
-		if ( isset( $this->query_args['suppress_filters'] ) && true == $this->query_args['suppress_filters'] ) {
+		$query = new \WP_Query( $this->query_args );
+
+		if ( isset( $query->query_vars['suppress_filters'] ) && true == $query->query_vars['suppress_filters'] ) {
 			throw new InvariantViolation( __( 'WP_Query has been modified by a plugin or theme to suppress_filters, which will cause issues with WPGraphQL Execution. If you need to suppress filters for a specific reason within GraphQL, consider registering a custom field to the WPGraphQL Schema with a custom resolver.', 'wp-graphql' ) );
 		}
 
-		$query = new \WP_Query( $this->query_args );
 		return $query;
 	}
 

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -2,6 +2,7 @@
 
 namespace WPGraphQL\Data\Connection;
 
+use GraphQL\Error\InvariantViolation;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
 use WPGraphQL\Model\Post;
@@ -76,10 +77,20 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
+	 * Returns the query being executed
+	 *
 	 * @return \WP_Query
+	 *
+	 * @throws \Exception
 	 */
 	public function get_query() {
-		return new \WP_Query( $this->query_args );
+
+		if ( isset( $this->query_args['suppress_filters'] ) && true == $this->query_args['suppress_filters'] ) {
+			throw new InvariantViolation( __( 'WP_Query has been modified by a plugin or theme to suppress_filters, which will cause issues with WPGraphQL Execution. If you need to suppress filters for a specific reason within GraphQL, consider registering a custom field to the WPGraphQL Schema with a custom resolver.', 'wp-graphql' ) );
+		}
+
+		$query = new \WP_Query( $this->query_args );
+		return $query;
 	}
 
 	/**
@@ -344,6 +355,8 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		 * fetching the full objects, either from cache of from a follow-up query to the DB
 		 */
 		$query_args['fields'] = 'ids';
+
+
 
 		/**
 		 * Filter the $query args to allow folks to customize queries programmatically

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -357,8 +357,6 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		 */
 		$query_args['fields'] = 'ids';
 
-
-
 		/**
 		 * Filter the $query args to allow folks to customize queries programmatically
 		 *

--- a/src/Data/Loader/AbstractDataLoader.php
+++ b/src/Data/Loader/AbstractDataLoader.php
@@ -288,7 +288,7 @@ abstract class AbstractDataLoader {
 			}
 		}
 		// Re-include previously-cached entries to result:
-		$result       += array_intersect_key( $this->cached, $this->buffer );
+		$result      += array_intersect_key( $this->cached, $this->buffer );
 		$this->buffer = [];
 
 		return $result;

--- a/tests/wpunit/PostObjectConnectionQueriesTest.php
+++ b/tests/wpunit/PostObjectConnectionQueriesTest.php
@@ -10,6 +10,7 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 	public function setUp() {
 		parent::setUp();
+		WPGraphQL::clear_schema();
 
 		$this->current_time     = strtotime( '- 1 day' );
 		$this->current_date     = date( 'Y-m-d H:i:s', $this->current_time );
@@ -809,6 +810,34 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->assertArrayNotHasKey( $private_post_id, $ids );
 
+
+	}
+
+	public function testSuppressFiltersThrowsException() {
+
+		WPGraphQL::clear_schema();
+
+		add_filter( 'graphql_post_object_connection_query_args', function( $args ) {
+			$args['suppress_filters'] = true;
+			return $args;
+		} );
+
+		$actual = graphql([
+			'query' => '
+			{
+			  posts {
+			    nodes {
+			      id
+			      title
+			    }
+			  }
+			}
+			'
+		]);
+
+		codecept_debug( $actual );
+
+		$this->assertArrayHasKey( 'errors', $actual );
 
 	}
 

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -342,6 +342,7 @@ return array(
     'WPGraphQL\\Type\\WPInputObjectType' => $baseDir . '/src/Type/WPInputObjectType.php',
     'WPGraphQL\\Type\\WPInterfaceType' => $baseDir . '/src/Type/WPInterfaceType.php',
     'WPGraphQL\\Type\\WPObjectType' => $baseDir . '/src/Type/WPObjectType.php',
+    'WPGraphQL\\Type\\WPScalar' => $baseDir . '/src/Type/WPScalar.php',
     'WPGraphQL\\Type\\WPUnionType' => $baseDir . '/src/Type/WPUnionType.php',
     'WPGraphQL\\Types' => $baseDir . '/src/Types.php',
     'WPGraphQL\\Utils\\InstrumentSchema' => $baseDir . '/src/Utils/InstrumentSchema.php',

--- a/vendor/composer/autoload_framework_classmap.php
+++ b/vendor/composer/autoload_framework_classmap.php
@@ -2824,6 +2824,7 @@ return array(
     'WPGraphQL\\Type\\WPInputObjectType' => $baseDir . '/src/Type/WPInputObjectType.php', 
     'WPGraphQL\\Type\\WPInterfaceType' => $baseDir . '/src/Type/WPInterfaceType.php', 
     'WPGraphQL\\Type\\WPObjectType' => $baseDir . '/src/Type/WPObjectType.php', 
+    'WPGraphQL\\Type\\WPScalar' => $baseDir . '/src/Type/WPScalar.php', 
     'WPGraphQL\\Type\\WPUnionType' => $baseDir . '/src/Type/WPUnionType.php', 
     'WPGraphQL\\Types' => $baseDir . '/src/Types.php', 
     'WPGraphQL\\Utils\\InstrumentSchema' => $baseDir . '/src/Utils/InstrumentSchema.php', 

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -365,6 +365,7 @@ class ComposerStaticInitb5d297f2045c131f44c3ae5d053159fa
         'WPGraphQL\\Type\\WPInputObjectType' => __DIR__ . '/../..' . '/src/Type/WPInputObjectType.php',
         'WPGraphQL\\Type\\WPInterfaceType' => __DIR__ . '/../..' . '/src/Type/WPInterfaceType.php',
         'WPGraphQL\\Type\\WPObjectType' => __DIR__ . '/../..' . '/src/Type/WPObjectType.php',
+        'WPGraphQL\\Type\\WPScalar' => __DIR__ . '/../..' . '/src/Type/WPScalar.php',
         'WPGraphQL\\Type\\WPUnionType' => __DIR__ . '/../..' . '/src/Type/WPUnionType.php',
         'WPGraphQL\\Types' => __DIR__ . '/../..' . '/src/Types.php',
         'WPGraphQL\\Utils\\InstrumentSchema' => __DIR__ . '/../..' . '/src/Utils/InstrumentSchema.php',


### PR DESCRIPTION
WPGraphQL needs filters to properly handle pagination. If `suppress_filters` is applied to WP_Query by theme or plugin code, WPGraphQL can behave funky. 

This throws an InvariantViolation if `suppress_filters` is applied to `WP_Query` so developers can address appropriately.