### PR TITLE
Replaced HTTP_HOST with SERVER_NAME

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -121,8 +121,8 @@ class Router {
 		}
 
 		// If before 'init' check $_SERVER.
-		if ( isset( $_SERVER['HTTP_HOST'] ) && isset( $_SERVER['REQUEST_URI'] ) ) {
-			$haystack = wp_unslash( $_SERVER['HTTP_HOST'] )
+		if ( isset( $_SERVER['SERVER_NAME'] ) && isset( $_SERVER['REQUEST_URI'] ) ) {
+			$haystack = wp_unslash( $_SERVER['SERVER_NAME'] )
 				. wp_unslash( $_SERVER['REQUEST_URI'] );
 			$needle   = site_url( self::$route );
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Instead of checking for `$_SERVER['HTTP_HOST']`  we can check the `$_SERVER['SERVER_NAME']` variable. This way we do not rely on the client supplying the correct host but can rely on our own server configuration.

Does this close any currently open issues?
------------------------------------------
Not that I could find.


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
N/A


Any other comments?
-------------------
When you call `/wp/graphql` on a domain that is different than the one configured in `site_url` the router will return 404. This is an issue for me because I want to do call within a docker network (which uses the container names as host). For example  "http://wpcontainer/wp/grapql" instead of "http://www.example.com/wp/graphql". Right now I have to override the HTTP_HOST header and hardcode it to the one used in `site_url` to make sure that it works.

For the differences in these variables see https://www.geeksforgeeks.org/what-is-the-difference-between-http_host-and-server_name-in-php/

Alternatively it might also be possible to strip the host part all together and only compare the path?

Where has this been tested?
---------------------------
**Operating System:** Docker containers with alpine 3.11, NGINX 1.17,  FCGI PHP 7.4.

**WordPress Version:** 5.4.1





