### PR TITLE
#1297 - use deprecationReason instead of isDeprecated

### DIFF
--- a/src/Type/Object/PostObject.php
+++ b/src/Type/Object/PostObject.php
@@ -242,7 +242,6 @@ class PostObject {
 				'type'              => [
 					'non_null' => 'Int',
 				],
-				'isDeprecated'      => true,
 				'deprecationReason' => __( 'Deprecated in favor of the databaseId field', 'wp-graphql' ),
 				'description'       => __( 'The id field matches the WP_Post->ID field.', 'wp-graphql' ),
 				'resolve'           => function( Post $post, $args, $context, $info ) {
@@ -416,11 +415,8 @@ class PostObject {
 			! $post_type_object->hierarchical &&
 			! in_array( $post_type_object->name, [ 'attachment', 'revision' ], true )
 		) {
-			$fields['ancestors']['isDeprecated']      = true;
-			$fields['ancestors']['deprecationReason'] = __( 'This content type is not hierarchical and typcially will not have ancestors', 'wp-graphql' );
-
-			$fields['parent']['isDeprecated']      = true;
-			$fields['parent']['deprecationReason'] = __( 'This content type is not hierarchical and typcially will not have a parent', 'wp-graphql' );
+			$fields['ancestors']['deprecationReason'] = __( 'This content type is not hierarchical and typically will not have ancestors', 'wp-graphql' );
+			$fields['parent']['deprecationReason'] = __( 'This content type is not hierarchical and typically will not have a parent', 'wp-graphql' );
 		}
 
 		$fields['template'] = [

--- a/src/Type/Object/RootQuery.php
+++ b/src/Type/Object/RootQuery.php
@@ -504,7 +504,6 @@ class RootQuery {
 					$post_type_object->graphql_single_name . 'By',
 					[
 						'type'              => $post_type_object->graphql_single_name,
-						'isDeprecated'      => true,
 						'deprecationReason' => __( 'Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: "" ), use post(id: "" idType: "")', 'wp-graphql' ),
 						'description'       => sprintf( __( 'A %s object', 'wp-graphql' ), $post_type_object->graphql_single_name ),
 						'args'              => $post_by_args,

--- a/src/Type/Object/TermObject.php
+++ b/src/Type/Object/TermObject.php
@@ -28,7 +28,6 @@ class TermObject {
 				'fields'      => [
 					$single_name . 'Id' => [
 						'type'              => 'Int',
-						'isDeprecated'      => true,
 						'deprecationReason' => __( 'Deprecated in favor of databaseId', 'wp-graphql' ),
 						'description'       => __( 'The id field matches the WP_Post->ID field.', 'wp-graphql' ),
 						'resolve'           => function( Term $term, $args, $context, $info ) {

--- a/tests/wpunit/IntrospectionQueryTest.php
+++ b/tests/wpunit/IntrospectionQueryTest.php
@@ -1,0 +1,133 @@
+<?php
+
+class IntrospectionQueryTest extends \Codeception\TestCase\WPTestCase {
+
+	public function setUp() {
+		// before
+		parent::setUp();
+
+		// your set up methods here
+	}
+
+	public function tearDown() {
+		// your tear down methods here
+
+		// then
+		parent::tearDown();
+	}
+
+	// Validate schema.
+	public function testSchema() {
+		try {
+			$request = new \WPGraphQL\Request();
+			$request->schema->assertValid();
+
+			// Assert true upon success.
+			$this->assertTrue( true );
+		} catch ( \GraphQL\Error\InvariantViolation $e ) {
+			// use --debug flag to view.
+			codecept_debug( $e->getMessage() );
+
+			// Fail upon throwing
+			$this->assertTrue( false );
+		}
+	}
+
+	// Test introspection query.
+	public function testIntrospectionQuery() {
+		$query = '
+            query IntrospectionQuery {
+                __schema {
+                    queryType { name }
+                    mutationType { name }
+                    subscriptionType { name }
+                    types {
+                        ...FullType
+                    }
+                    directives {
+                        name
+                        description
+                        locations
+                        args {
+                            ...InputValue
+                        }
+                    }
+                }
+            }
+            fragment FullType on __Type {
+                kind
+                name
+                description
+                fields(includeDeprecated: true) {
+                    name
+                    description
+                    args {
+                        ...InputValue
+                    }
+                    type {
+                        ...TypeRef
+                    }
+                        isDeprecated
+                        deprecationReason
+                    }
+                    inputFields {
+                        ...InputValue
+                    }
+                    interfaces {
+                        ...TypeRef
+                    }
+                    enumValues(includeDeprecated: true) {
+                    name
+                    description
+                    isDeprecated
+                    deprecationReason
+                }
+                possibleTypes {
+                    ...TypeRef
+                }
+            }
+            fragment InputValue on __InputValue {
+                name
+                description
+                type { ...TypeRef }
+                defaultValue
+            }
+            fragment TypeRef on __Type {
+                kind
+                name
+                ofType {
+                    kind
+                    name
+                    ofType {
+                        kind
+                        name
+                        ofType {
+                            kind
+                            name
+                            ofType {
+                                kind
+                                name
+                                ofType {
+                                    kind
+                                    name
+                                    ofType {
+                                        kind
+                                        name
+                                        ofType {
+                                            kind
+                                            name
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ';
+
+		$results = graphql( array( 'query' => $query ) );
+
+		$this->assertArrayNotHasKey( 'errors', $results );
+	}
+}

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -342,6 +342,7 @@ return array(
     'WPGraphQL\\Type\\WPInputObjectType' => $baseDir . '/src/Type/WPInputObjectType.php',
     'WPGraphQL\\Type\\WPInterfaceType' => $baseDir . '/src/Type/WPInterfaceType.php',
     'WPGraphQL\\Type\\WPObjectType' => $baseDir . '/src/Type/WPObjectType.php',
+    'WPGraphQL\\Type\\WPScalar' => $baseDir . '/src/Type/WPScalar.php',
     'WPGraphQL\\Type\\WPUnionType' => $baseDir . '/src/Type/WPUnionType.php',
     'WPGraphQL\\Types' => $baseDir . '/src/Types.php',
     'WPGraphQL\\Utils\\InstrumentSchema' => $baseDir . '/src/Utils/InstrumentSchema.php',

--- a/vendor/composer/autoload_framework_classmap.php
+++ b/vendor/composer/autoload_framework_classmap.php
@@ -2824,6 +2824,7 @@ return array(
     'WPGraphQL\\Type\\WPInputObjectType' => $baseDir . '/src/Type/WPInputObjectType.php', 
     'WPGraphQL\\Type\\WPInterfaceType' => $baseDir . '/src/Type/WPInterfaceType.php', 
     'WPGraphQL\\Type\\WPObjectType' => $baseDir . '/src/Type/WPObjectType.php', 
+    'WPGraphQL\\Type\\WPScalar' => $baseDir . '/src/Type/WPScalar.php', 
     'WPGraphQL\\Type\\WPUnionType' => $baseDir . '/src/Type/WPUnionType.php', 
     'WPGraphQL\\Types' => $baseDir . '/src/Types.php', 
     'WPGraphQL\\Utils\\InstrumentSchema' => $baseDir . '/src/Utils/InstrumentSchema.php', 

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -365,6 +365,7 @@ class ComposerStaticInitb5d297f2045c131f44c3ae5d053159fa
         'WPGraphQL\\Type\\WPInputObjectType' => __DIR__ . '/../..' . '/src/Type/WPInputObjectType.php',
         'WPGraphQL\\Type\\WPInterfaceType' => __DIR__ . '/../..' . '/src/Type/WPInterfaceType.php',
         'WPGraphQL\\Type\\WPObjectType' => __DIR__ . '/../..' . '/src/Type/WPObjectType.php',
+        'WPGraphQL\\Type\\WPScalar' => __DIR__ . '/../..' . '/src/Type/WPScalar.php',
         'WPGraphQL\\Type\\WPUnionType' => __DIR__ . '/../..' . '/src/Type/WPUnionType.php',
         'WPGraphQL\\Types' => __DIR__ . '/../..' . '/src/Types.php',
         'WPGraphQL\\Utils\\InstrumentSchema' => __DIR__ . '/../..' . '/src/Utils/InstrumentSchema.php',


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This removes use of `isDeprecated` in favor of using `deprecationReason` to ensure deprecating fields _always_ include a reason. 

Does this close any currently open issues?
------------------------------------------
closes #1297 

Any other comments?
-------------------
I believe this might help with an issue @kidunot89 was running into with WPGraphQL for WooCommerce tests
