### PR TITLE
Add `graphql_ast` filters

### DIFF
--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -87,7 +87,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 
 		$query = new \WP_Query( $this->query_args );
 
-		if ( isset( $query->query_vars['suppress_filters'] ) && true == $query->query_vars['suppress_filters'] ) {
+		if ( isset( $query->query_vars['suppress_filters'] ) && false !== (bool) $query->query_vars['suppress_filters'] ) {
 			throw new InvariantViolation( __( 'WP_Query has been modified by a plugin or theme to suppress_filters, which will cause issues with WPGraphQL Execution. If you need to suppress filters for a specific reason within GraphQL, consider registering a custom field to the WPGraphQL Schema with a custom resolver.', 'wp-graphql' ) );
 		}
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -5,6 +5,8 @@ namespace WPGraphQL;
 use GraphQL\Server\OperationParams;
 use GraphQL\Server\ServerConfig;
 use GraphQL\Server\StandardServer;
+use GraphQL\Error\FormattedError;
+use GraphQL\Language\Parser;
 use WPGraphQL\Server\WPHelper;
 
 /**
@@ -45,6 +47,14 @@ class Request {
 	 * @var OperationParams|OperationParams[]
 	 */
 	private $params;
+
+
+	/**
+	 * Parsed Abstract Syntax Tree of the GraphQL Query
+	 *
+	 * @var GraphQL\Language\AST\DocumentNode
+	 */
+	private $doc;
 
 	/**
 	 * Schema for this request.
@@ -100,6 +110,77 @@ class Request {
 		$app_context->root_url = get_bloginfo( 'url' );
 		$app_context->request  = ! empty( $_REQUEST ) ? $_REQUEST : null; // phpcs:ignore
 		$this->app_context     = $app_context;
+	}
+
+	/**
+	 * Parse the graphql query to GraphQL\Language\AST\DocumentNode object
+	 *
+	 * Possibly returns GraphQL\Error\SyntaxError wrapped in a response array
+	 * if malformed graphql query was passed
+	 *
+	 * @return null|array
+	 */
+	private function parse_query() {
+
+		/**
+		 * Sort circuit GraphQL query parsing by returning a DocumentNode instance.
+		 * Can be used for AST caching for example.
+		 *
+		 * @param GraphQL\Language\AST\DocumentNode|false $query_ast Just a null value since the query is not parsed yet
+		 * @param string                                  $query     The GraphQL query as string
+		 * @param array                                   $variables GraphQL query variables
+		 * @param string                                  $operation The graphql operation name
+		 * @param \WPGraphQL\AppContex                    $context   The app context
+		 */
+		$this->doc = apply_filters(
+			'graphql_pre_ast',
+			false,
+			$this->params->query,
+			$this->params->variables,
+			$this->params->operation,
+			$this->app_context
+		);
+
+		/**
+		 * Parse the GraphQL query if we did not get preparsed query
+		 */
+		if ( false === $this->doc ) {
+			try {
+					$this->doc = Parser::parse( $this->params->query );
+			} catch ( \GraphQL\Error\SyntaxError $syntax_error ) {
+				/**
+				 * Wrap the error to GraphQL response
+				 */
+				return [
+					'errors' => [ FormattedError::createFromException( $syntax_error, GRAPHQL_DEBUG ) ],
+				];
+			}
+		}
+
+		/**
+		 * Filter the GraphQL query Abstract Syntax Tree before it is passed to
+		 * graphl-php for execution
+		 *
+		 * @param GraphQL\Language\AST\DocumentNode $query_ast The parsed GraphQL Query AST
+		 * @param string                            $query     The GraphQL query as string
+		 * @param array                             $variables GraphQL query variables
+		 * @param string                            $operation The graphql operation name
+		 * @param \WPGraphQL\AppContex              $context   The app context
+		 */
+		$this->doc = apply_filters(
+			'graphql_ast',
+			$this->doc,
+			$this->params->query,
+			$this->params->variables,
+			$this->params->operation,
+			$this->app_context
+		);
+
+		if ( ! $this->doc instanceof \GraphQL\Language\AST\DocumentNode ) {
+			return [
+				'errors' => [ 'Failed to get valid GraphQL\Language\AST\DocumentNode' ],
+			];
+		}
 	}
 
 	/**
@@ -407,9 +488,18 @@ class Request {
 		 */
 		$this->before_execute();
 
+		$syntax_error_response = $this->parse_query();
+
+		/**
+		 * Return early with the syntax error response if bad query was passed
+		 */
+		if ( $syntax_error_response ) {
+			return $this->after_execute( $syntax_error_response );
+		}
+
 		$result = \GraphQL\GraphQL::executeQuery(
 			$this->schema,
-			$this->params->query,
+			$this->doc,
 			null,
 			$this->app_context,
 			$this->params->variables,
@@ -455,11 +545,27 @@ class Request {
 		 */
 		$this->before_execute();
 
+		$syntax_error_response = $this->parse_query();
+
+		/**
+		 * Return early with the syntax error response if bad query was passed
+		 */
+		if ( $syntax_error_response ) {
+			return $this->after_execute( $syntax_error_response, $this->params );
+		}
+
 		/**
 		 * Get the response.
 		 */
-		$server   = $this->get_server();
-		$response = $server->executeRequest( $this->params );
+		$server = $this->get_server();
+
+		/**
+		 * Pass in the preparsed query instead of the the string to avoid
+		 * duplicate query parsing
+		 */
+		$this->params->query = $this->doc;
+
+		$response = $server->executeRequest( $params );
 
 		return $this->after_execute( $response, $this->params );
 	}

--- a/src/Type/Object/PostObject.php
+++ b/src/Type/Object/PostObject.php
@@ -416,7 +416,7 @@ class PostObject {
 			! in_array( $post_type_object->name, [ 'attachment', 'revision' ], true )
 		) {
 			$fields['ancestors']['deprecationReason'] = __( 'This content type is not hierarchical and typically will not have ancestors', 'wp-graphql' );
-			$fields['parent']['deprecationReason'] = __( 'This content type is not hierarchical and typically will not have a parent', 'wp-graphql' );
+			$fields['parent']['deprecationReason']    = __( 'This content type is not hierarchical and typically will not have a parent', 'wp-graphql' );
 		}
 
 		$fields['template'] = [

--- a/tests/functional/ErrorHandlingCept.php
+++ b/tests/functional/ErrorHandlingCept.php
@@ -1,0 +1,48 @@
+<?php
+
+$I = new FunctionalTester( $scenario );
+$I->wantTo('get proper error message on syntax error');
+
+$query = '
+{
+	posts  # syntax error
+		edges {
+			node {
+				id
+				title
+				link
+				date
+			}
+		}
+	}
+}';
+
+
+/**
+ * Set the content-type so we get a proper response from the API
+ */
+$I->haveHttpHeader( 'Content-Type', 'application/json' );
+$I->sendPOST( 'http://wpgraphql.test/graphql', json_encode( [ 'query' => $query ] ) );
+
+
+/**
+ * The error response 200 as the error in put in the 'errors' key
+ */
+$I->seeResponseCodeIs( 200 );
+
+$I->seeResponseIsJson();
+$response = $I->grabResponse();
+$response_array = json_decode( $response, true );
+
+/**
+ * Make sure the errors key exists
+ */
+$I->assertArrayHasKey( 'errors', $response_array  );
+
+/**
+ * Assert it's proper readable syntax error array
+ */
+$I->assertCount( 1, $response_array['errors']  );
+$I->assertEquals( 'Syntax Error: Unexpected }', $response_array['errors'][0]['message']  );
+$I->assertArrayHasKey( 'locations', $response_array['errors'][0]  );
+$I->assertArrayHasKey( 'extensions', $response_array['errors'][0]  );

--- a/tests/wpunit/RequestTest.php
+++ b/tests/wpunit/RequestTest.php
@@ -86,6 +86,7 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertArrayHasKey( 'errors', $results );
 		$this->assertArrayNotHasKey( 'data', $results );
 		$this->assertEquals( 1, count( $results['errors'] ) );
+		$this->assertArrayHasKey( 'message',  $results['errors'][0] );
 	}
 
 	/**


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

This add two filters `graphql_ast` and `graphql_pre_ast` which allow AST of the GraphQL queries to be inspected, transformed and cached. There are more detailed docs in the doc blocks.


Does this close any currently open issues?
------------------------------------------
Closes #112

