### PR TITLE
Edit Custom Taxonomy and Custom Post Type

### DIFF
--- a/docs/source/getting-started/custom-post-types.mdx
+++ b/docs/source/getting-started/custom-post-types.mdx
@@ -24,8 +24,8 @@ add_action( 'init', function() {
       ],
       'show_in_graphql' => true,
       'hierarchical' => true,
-      'graphql_single_name' => 'Document',
-      'graphql_plural_name' => 'Documents',
+      'graphql_single_name' => 'document',
+      'graphql_plural_name' => 'documents',
    ] );
 } );
 ```
@@ -40,8 +40,8 @@ add_filter( 'register_post_type_args', function( $args, $post_type ) {
 
 	if ( 'docs' === $post_type ) {
 		$args['show_in_graphql'] = true;
-		$args['graphql_single_name'] = 'Document';
-		$args['graphql_plural_name'] = 'Documents';
+		$args['graphql_single_name'] = 'document';
+		$args['graphql_plural_name'] = 'documents';
 	}
 
 	return $args;

--- a/docs/source/getting-started/custom-taxonomies.mdx
+++ b/docs/source/getting-started/custom-taxonomies.mdx
@@ -21,8 +21,8 @@ add_action('init', function() {
     	'menu_name' => __( 'Document Tags', 'your-textdomain' ),//@see https://developer.wordpress.org/themes/functionality/internationalization/
     ],
     'show_in_graphql' => true,
-    'graphql_single_name' => 'DocumentTag',
-    'graphql_plural_name' => 'DocumentTags',
+    'graphql_single_name' => 'documentTag',
+    'graphql_plural_name' => 'documentTags',
   ]);
 });
 ```
@@ -37,8 +37,8 @@ add_filter( 'register_taxonomy_args', function( $args, $taxonomy ) {
 
 	if ( 'doc_tag' === $taxonomy ) {
 		$args['show_in_graphql'] = true;
-		$args['graphql_single_name'] = 'DocumentTag';
-		$args['graphql_plural_name'] = 'DocumentTags';
+		$args['graphql_single_name'] = 'documentTag';
+		$args['graphql_plural_name'] = 'documentTags';
 	}
 
 	return $args;
@@ -68,7 +68,7 @@ This example shows how to query a single Document Tag by its ID.
 }
 ```
 
-### Query a DocumentTags on a Document
+### Query a documentTags on a Document
 
 Since the `doc_tags` Custom Taxonomy has been registered in connection to the docs Post Type, our
 Schema automatically exposes a connection between Document nodes and DocumentTags.

--- a/docs/source/getting-started/custom-taxonomies.mdx
+++ b/docs/source/getting-started/custom-taxonomies.mdx
@@ -68,7 +68,7 @@ This example shows how to query a single Document Tag by its ID.
 }
 ```
 
-### Query a documentTags on a Document
+### Query documentTags related to a Document
 
 Since the `doc_tags` Custom Taxonomy has been registered in connection to the docs Post Type, our
 Schema automatically exposes a connection between Document nodes and DocumentTags.


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
--------------------------------------------------
Ensures the Custom Taxonomy and Custom Post Type pages use camelCase throughout, code examples were using PascalCase but document instructed they be in camelCase.
