### PR TITLE
📕 Docs: remove WooCommerce production warning in notice

### DIFF
--- a/docs/source/extensions/wpgraphql-woocommerce.mdx
+++ b/docs/source/extensions/wpgraphql-woocommerce.mdx
@@ -11,8 +11,8 @@ import Note from '../../src/components/Note'
 [WPGraphQL WooCommerce](https://github.com/wp-graphql/wp-graphql-woocommerce) is a free, open-source WPGraphQL extension that adds WooCommerce functionality to the WPGraphQL API.
 
 <Note title="In Development" type="warning">
-  This plugin is still in the early stages of the development and may contain
-  many bugs or lack some functionality. Using in production is not recommended.
+  This plugin is still in the early stages of the development; as a result, it may contain
+  many bugs, lack some functionality, and have frequent updates.
 </Note>
 
 # Getting Started


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Documentation update for WooCommerce extension.

The notice states that 'using it in production is not recommended'; however, there are sites that are using it production now. Keeping this as is may discourage other devs from trying the extension out - or even use it in production.

The development warning is suffice.


Does this close any currently open issues?
------------------------------------------
No

