### PR TITLE
make PostObjectLoader.loadKeys robust against non-existent keys

### DIFF
--- a/src/Data/Loader/PostObjectLoader.php
+++ b/src/Data/Loader/PostObjectLoader.php
@@ -91,9 +91,7 @@ class PostObjectLoader extends AbstractDataLoader {
 
 			if ( ! $post_object instanceof \WP_Post ) {
 				$loaded_posts[ $key ] = null;
-			}
-
-            if (!empty($post_object)) {
+			} else {
                 /**
                  * If there's a Post Author connected to the post, we need to resolve the
                  * user as it gets set in the globals via `setup_post_data()` and doing it this way


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

We have a complex setup with wpgraphql + acf. In our situation `PostObjectLoader.loadKeys()` is called with post ids that no longer exists. 
In such a case the loaded `post_object` will be empty which will lead to errors when trying to dereference attributes of this object.


Does this close any currently open issues?
------------------------------------------
- did not find any


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)

```
[Wed May 20 14:34:54.489400 2020] [php7:notice] [pid 798] [client 10.42.1.0:56692] PHP Notice:  Trying to get property 'post_type' of non-object in /var/www/html/wp-content/plugins/wp-graphql-0.8.4/src/Data/Loader/PostObjectLoader.php on line 114,
```

Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** linux

**WordPress Version:** 5.4.1
