### PR TITLE
#1319 - Add filter to "is_graphql_http_request"

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -115,17 +115,52 @@ class Router {
 	 * @return boolean
 	 */
 	public static function is_graphql_http_request() {
+
+		// Default is false
+		$is_graphql_http_request = false;
+
 		// Support wp-graphiql style request to /index.php?graphql.
 		if ( isset( $_GET[ self::$route ] ) ) {
-			return true;
+			$is_graphql_http_request = true;
 		}
 
-		// If before 'init' check $_SERVER.
-		if ( isset( $_SERVER['SERVER_NAME'] ) && isset( $_SERVER['SERVER_PROTOCOL'] ) ) {
-			return ( strpos($_SERVER['SERVER_PROTOCOL'], 'HTTP') !== false );
+		/**
+		 * Filter whether the request is a GraphQL HTTP Request. Default is false, as the majority
+		 * of WordPress requests are NOT GraphQL requests (at least today that's true 😆).
+		 *
+		 * The request has to "prove" that it is indeed an HTTP request via HTTP for
+		 * this to be true.
+		 *
+		 * Different servers _might_ have different needs to determine whether a request
+		 * is a GraphQL request.
+		 *
+		 * @param boolean $is_graphql_http_request Whether the request is a GraphQL HTTP Request. Default false.
+		 */
+		$is_graphql_http_request = apply_filters( 'is_graphql_http_request', $is_graphql_http_request );
+
+		/**
+		 * If true, return right away. This allows custom code to
+		 * define graphql requests if their definition doesn't match the standard
+		 * definition.
+		 */
+		if ( true === $is_graphql_http_request ) {
+			return $is_graphql_http_request;
 		}
 
-		return false;
+		// Check the server to determine if the GraphQL endpoint is being requested
+		if ( isset( $_SERVER['HTTP_HOST'] ) && isset( $_SERVER['REQUEST_URI'] ) ) {
+			$haystack = wp_unslash( $_SERVER['HTTP_HOST'] )
+			            . wp_unslash( $_SERVER['REQUEST_URI'] );
+			$needle   = site_url( self::$route );
+
+			// Strip protocol.
+			$haystack = preg_replace( '#^(http(s)?://)#', '', $haystack );
+			$needle   = preg_replace( '#^(http(s)?://)#', '', $needle );
+			$len      = strlen( $needle );
+			$is_graphql_http_request = ( substr( $haystack, 0, $len ) === $needle );
+		}
+
+		return $is_graphql_http_request;
 	}
 
 	/**

--- a/src/Router.php
+++ b/src/Router.php
@@ -121,16 +121,8 @@ class Router {
 		}
 
 		// If before 'init' check $_SERVER.
-		if ( isset( $_SERVER['SERVER_NAME'] ) && isset( $_SERVER['REQUEST_URI'] ) ) {
-			$haystack = wp_unslash( $_SERVER['SERVER_NAME'] )
-				. wp_unslash( $_SERVER['REQUEST_URI'] );
-			$needle   = site_url( self::$route );
-
-			// Strip protocol.
-			$haystack = preg_replace( '#^(http(s)?://)#', '', $haystack );
-			$needle   = preg_replace( '#^(http(s)?://)#', '', $needle );
-			$len      = strlen( $needle );
-			return ( substr( $haystack, 0, $len ) === $needle );
+		if ( isset( $_SERVER['SERVER_NAME'] ) && isset( $_SERVER['SERVER_PROTOCOL'] ) ) {
+			return ( strpos($_SERVER['SERVER_PROTOCOL'], 'HTTP') !== false );
 		}
 
 		return false;


### PR DESCRIPTION
This closes #1319. 

I'm reverting from `$_SERVER['SERVER_NAME']` back to using `$_SERVER['HTTP_HOST']` as this seems to work for most common WordPress setups. 

I have introduced a filter to allow different definitions of what makes a request a GraphQL HTTP Request, should different setups have different ways to define this. 