### PR TITLE
Add tests for draft pages in menus

### DIFF
--- a/tests/wpunit/MenuItemConnectionQueriesTest.php
+++ b/tests/wpunit/MenuItemConnectionQueriesTest.php
@@ -10,6 +10,16 @@ class MenuItemConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		set_theme_mod( 'nav_menu_locations', [ 'my-menu-location' => 0 ] );
 	}
 
+	public function setUp() {
+		parent::setUp();
+
+		$this->admin = $this->factory()->user->create( [
+			'role'       => 'administrator',
+			'user_email' => 'test@test.com'
+		] );
+
+	}
+
 	private function createMenuItem( $menu_id, $options ) {
 		return wp_update_nav_menu_item( $menu_id, 0, $options );
 	}
@@ -289,6 +299,110 @@ class MenuItemConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$menu_item_ids = array_slice( $created['menu_item_ids'], 0, $limit );
 		$post_ids = array_slice( $created['post_ids'], 0, $limit );
 		$this->compareResults( $menu_item_ids, $post_ids, $actual );
+	}
+
+	public function testDraftPostsAreNotVisibleForAnonymous() {
+		$count = 2;
+		$created = $this->createMenuItems( 'my-test-menu-location', $count );
+
+		wp_update_post(
+			[
+				'ID' => $created['post_ids'][0],
+				'post_status' => 'draft'
+			]
+		);
+
+
+		$query = '
+		{
+			menuItems( where: { location: MY_MENU_LOCATION } ) {
+				nodes {
+					connectedObject {
+						... on Post {
+							status
+						}
+					}
+				}
+			}
+		}
+		';
+
+		// Ensure unauthenticated request
+		wp_set_current_user( 0 );
+
+		$actual = do_graphql_request( $query );
+
+		$this->assertArrayNotHasKey( 'errors', $actual, print_r( $actual, true ) );
+
+		// Unauthenticated request still returns two _menu_ items
+		$this->assertEquals( $count, count( $actual['data']['menuItems']['nodes'] ) );
+
+		$expected = [
+			0 => [
+				// But actual connected data is not available because there's no permission to do so
+				'connectedObject' => null,
+			],
+			1 => [
+				'connectedObject' => [
+					'status' => 'publish',
+				],
+			],
+		];
+
+		$this->assertEquals( $expected, $actual['data']['menuItems']['nodes'] );
+
+	}
+
+	public function testDraftPostsAreVisibleForAdmin() {
+		$count = 2;
+		$created = $this->createMenuItems( 'my-test-menu-location', $count );
+
+		wp_update_post(
+			[
+				'ID' => $created['post_ids'][0],
+				'post_status' => 'draft'
+			]
+		);
+
+
+		$query = '
+		{
+			menuItems( where: { location: MY_MENU_LOCATION } ) {
+				nodes {
+					connectedObject {
+						... on Post {
+							status
+						}
+					}
+				}
+			}
+		}
+		';
+
+		// Authenticate as admin
+		wp_set_current_user( $this->admin );
+
+		$actual = do_graphql_request( $query );
+
+		$this->assertArrayNotHasKey( 'errors', $actual, print_r( $actual, true ) );
+
+		$this->assertEquals( $count, count( $actual['data']['menuItems']['nodes'] ) );
+
+		$expected = [
+			0 => [
+				'connectedObject' => [
+					'status' => 'draft',
+				],
+			],
+			1 => [
+				'connectedObject' => [
+					'status' => 'publish',
+				],
+			],
+		];
+
+		$this->assertEquals( $expected, $actual['data']['menuItems']['nodes'] );
+
 	}
 
 }


### PR DESCRIPTION
Found a bug where wp-graphql would crash when fetching menu items list that has draft posts connected to it. But I realized too late that I was running an old version of wp-graphql and it was already fixed in the latest one 🤦‍♂️.

But before realizing it I already managed to write tests for it. Sending them anyway because there doesn't seem to be auth tests for menus ATM.