### PR TITLE
Add COMMENT_COUNT inside PostObjectsConnectionOrderbyEnum

### DIFF
--- a/src/Type/Enum/PostObjectsConnectionOrderbyEnum.php
+++ b/src/Type/Enum/PostObjectsConnectionOrderbyEnum.php
@@ -45,6 +45,10 @@ class PostObjectsConnectionOrderbyEnum {
 						'value'       => 'menu_order',
 						'description' => __( 'Order by the menu order value', 'wp-graphql' ),
 					],
+					'COMMENT_COUNT' => [
+						'value'       => 'comment_count',
+						'description' => __( 'Order by the number of comments it has acquired', 'wp-graphql' ),
+					],
 				],
 			]
 		);


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](.github/CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
Currently, posts does not allow to do order by with number of comments the post (or any custom name). I added the `COMMENT_COUNT` in the `PostObjectsConnectionOrderbyEnum`.


Does this close any currently open issues?
------------------------------------------
n/a


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
https://ibb.co/mh7GcHZ


Any other comments?
-------------------
n/a


Where has this been tested?
---------------------------
**WordPress Version:** …
5.4.2