### PR TITLE
#1338 - Expose URI (and link) as allowed restricted field

### DIFF
--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -138,15 +138,19 @@ class Post extends Model {
 		}
 
 		$allowed_restricted_fields = [
-			'id',
-			'titleRendered',
-			'slug',
-			'post_type',
-			'status',
-			'post_status',
-			'isRestricted',
+			'databaseId',
 			'enqueuedScriptsQueue',
 			'enqueuedStylesheetsQueue',
+			'id',
+			'isRestricted',
+			'link',
+			'post_status',
+			'post_type',
+			'slug',
+			'status',
+			'titleRendered',
+			'uri',
+
 		];
 
 		$allowed_restricted_fields[] = $this->post_type_object->graphql_single_name . 'Id';
@@ -254,6 +258,7 @@ class Post extends Model {
 		if ( true === $resolve_revision_meta_from_parent && 'revision' === get_post( $object_id )->post_type ) {
 			$meta                       = get_post_meta( get_post( $object_id )->post_parent, $meta_key, $single );
 			$this->filter_revision_meta = false;
+
 			return $meta;
 		}
 
@@ -436,6 +441,9 @@ class Post extends Model {
 				'id'                        => function() {
 					return ( ! empty( $this->data->post_type ) && ! empty( $this->ID ) ) ? Relay::toGlobalId( 'post', $this->ID ) : null;
 				},
+				'databaseId'                => function() {
+					return isset( $this->data->ID ) ? absint( $this->data->ID ) : null;
+				},
 				'post_type'                 => function() {
 					return isset( $this->data->post_type ) ? $this->data->post_type : null;
 				},
@@ -576,11 +584,11 @@ class Post extends Model {
 					return ! empty( $this->data->menu_order ) ? absint( $this->data->menu_order ) : null;
 				},
 				'link'                      => function() {
+					$link = get_permalink( $this->data->ID );
+
 					if ( $this->isPreview ) {
 						$link = get_preview_post_link( $this->parentDatabaseId );
 					} elseif ( $this->isRevision ) {
-						$link = get_permalink( $this->data->ID );
-					} else {
 						$link = get_permalink( $this->data->ID );
 					}
 

--- a/src/Type/InterfaceType/ContentNode.php
+++ b/src/Type/InterfaceType/ContentNode.php
@@ -68,9 +68,6 @@ class ContentNode {
 							'non_null' => 'Int',
 						],
 						'description' => __( 'The ID of the object in the database.', 'wp-graphql' ),
-						'resolve'     => function( Post $post, $args, $context, $info ) {
-							return absint( $post->ID );
-						},
 					],
 					'date'                      => [
 						'type'        => 'String',


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This exposes the uri and link fields in the Post model as allowed restricted fields so that public requests can receive a link/uri when querying for a password protected post

Does this close any currently open issues?
------------------------------------------
closes #1338 

