### PR TITLE
Fix user ID variable

### DIFF
--- a/docs/source/extending/fields.mdx
+++ b/docs/source/extending/fields.mdx
@@ -35,7 +35,7 @@ Register field for user
 			'type'        => \WPGraphQL\Types::list_of( \WPGraphQL\Types::string() ),
 			'description' => __( 'Custom field for user mutations', 'your-textdomain' ),
 			'resolve'     => function( $user ) {
-				$hobbies = get_user_meta( $user->userId, 'hobbies', true );
+				$hobbies = get_user_meta( $user->ID, 'hobbies', true );
 				return ! empty( $hobbies ) ? $hobbies : [];
 			},
 		];


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
The Extending Fields document has a PHP snippet showing how to add a field to a User. This fixes the PHP variable name to `$user->ID` from `$user->userId`. userId is the WPGraphQL field 😃 

Reference [WP_User](https://developer.wordpress.org/reference/classes/wp_user/#public-properties) public properties

Does this close any currently open issues?
------------------------------------------
Nope

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
👋  Howdy


Where has this been tested?
---------------------------
**Operating System:** N/A

**WordPress Version:** N/A
