### PR TITLE
Fix for tax query term to post connection by wrapping it an extra array

### DIFF
--- a/src/Connection/PostObjects.php
+++ b/src/Connection/PostObjects.php
@@ -243,10 +243,12 @@ class PostObjects {
 										'resolve'  => function( Term $term, $args, AppContext $context, ResolveInfo $info ) use ( $post_type_object ) {
 											$resolver = new PostObjectConnectionResolver( $term, $args, $context, $info, $post_type_object->name );
 											$resolver->set_query_arg( 'tax_query', [
-												'taxonomy' => $term->taxonomyName,
-												'terms'    => [ $term->term_id ],
-												'field'    => 'term_id',
-												'include_children' => false,
+												[
+													'taxonomy' => $term->taxonomyName,
+													'terms'    => [ $term->term_id ],
+													'field'    => 'term_id',
+													'include_children' => false,
+												]
 											] );
 
 											return $resolver->get_connection();


### PR DESCRIPTION
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix?
---------------------------------------------------
When adding taxonomy parameters as query arg, it takes an array of arrays. (see: 
https://developer.wordpress.org/reference/classes/wp_query/#taxonomy-parameters )
In the connection from term to post, the tax query arg value was not wrapped in array. This PR adds the additional array. 
Without this fix, unexpected posts were returned when using this connection.


Where has this been tested?
---------------------------
**WordPress Version:** 5.2.6
