### PR TITLE
wrapped filters around the return for get_input_fields

### DIFF
--- a/src/Mutation/PostObjectCreate.php
+++ b/src/Mutation/PostObjectCreate.php
@@ -192,7 +192,7 @@ class PostObjectCreate {
 			}
 		}
 
-		return $fields;
+		return apply_filters( 'graphql_post_object_mutation_input_fields', $fields, $post_type_object );
 	}
 
 	/**

--- a/src/Mutation/PostObjectUpdate.php
+++ b/src/Mutation/PostObjectUpdate.php
@@ -35,17 +35,21 @@ class PostObjectUpdate {
 	 * @return array
 	 */
 	public static function get_input_fields( $post_type_object ) {
-		return array_merge(
-			PostObjectCreate::get_input_fields( $post_type_object ),
-			[
-				'id' => [
-					'type'        => [
-						'non_null' => 'ID',
+		return apply_filters(
+			'graphql_post_object_mutation_input_fields_update',
+			array_merge(
+				PostObjectCreate::get_input_fields( $post_type_object ),
+				[
+					'id' => [
+						'type'        => [
+							'non_null' => 'ID',
+						],
+						// translators: the placeholder is the name of the type of post object being updated
+						'description' => sprintf( __( 'The ID of the %1$s object', 'wp-graphql' ), $post_type_object->graphql_single_name ),
 					],
-					// translators: the placeholder is the name of the type of post object being updated
-					'description' => sprintf( __( 'The ID of the %1$s object', 'wp-graphql' ), $post_type_object->graphql_single_name ),
-				],
-			]
+				]
+			),
+			$post_type_object
 		);
 	}
 


### PR DESCRIPTION
Wraps the PostObjectCreate and PostObjectUpdate with filter hooks.


Does this close any currently open issues?
------------------------------------------
https://github.com/wp-graphql/wp-graphql/issues/957
I wouldn't say it closes it, but adds a path towards fixing the issue.
