### PR TITLE
📕 Docs: fix broken link to connection guide page

### DIFF
--- a/docs/source/extending/connections.mdx
+++ b/docs/source/extending/connections.mdx
@@ -9,7 +9,7 @@ Below you will find information on extending WPGraphQL with custom connections.
 
 <Note title="Wait, what are connections?">
 	Not sure what connections are and how they fit in WPGraphQL?{" "}
-	<a href="/guides/extensions">Read the connections guide to learn more</a>.
+	<a href="/guides/connections">Read the connections guide to learn more</a>.
 </Note>
 
 ## register_graphql_connection( \$config )


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes a broken link in the extending -> connections documentation page.

Repro steps:

* visit https://docs.wpgraphql.com/extending/connections/
* in the blue note component at the top of the page, click on `Read the connections guide to learn more.`

Expected result:
* connections guide page renders (https://docs.wpgraphql.com/guides/connections/)

Actual result:
* 404

Does this close any currently open issues?
------------------------------------------
Nope

