### PR TITLE
Bug/#1174 login login not in args are incorrect type

### DIFF
--- a/src/Connection/PostObjects.php
+++ b/src/Connection/PostObjects.php
@@ -248,7 +248,7 @@ class PostObjects {
 													'terms'    => [ $term->term_id ],
 													'field'    => 'term_id',
 													'include_children' => false,
-												]
+												],
 											] );
 
 											return $resolver->get_connection();

--- a/src/Connection/Users.php
+++ b/src/Connection/Users.php
@@ -176,11 +176,15 @@ class Users {
 				'description' => __( 'The user login.', 'wp-graphql' ),
 			],
 			'loginIn'           => [
-				'type'        => 'Int',
+				'type'        => [
+					'list_of' => 'String',
+				],
 				'description' => __( 'An array of logins to include. Users matching one of these logins will be included in results.', 'wp-graphql' ),
 			],
 			'loginNotIn'        => [
-				'type'        => 'Int',
+				'type'        => [
+					'list_of' => 'String',
+				],
 				'description' => __( 'An array of logins to exclude. Users matching one of these logins will not be included in results.', 'wp-graphql' ),
 			],
 			'orderby'           => [


### PR DESCRIPTION
This fixes the loginIn and loginNotIn argument field types for User connection queries to allow for list of strings as the input.

Closes #1174 

**Examples:**

![Screen Shot 2020-07-06 at 9 37 01 AM](https://user-images.githubusercontent.com/1260765/86612007-b3ac2d00-bf6c-11ea-87c6-e87d18a9f723.png)
![Screen Shot 2020-07-06 at 9 37 13 AM](https://user-images.githubusercontent.com/1260765/86612009-b444c380-bf6c-11ea-9640-0b92557f734e.png)
![Screen Shot 2020-07-06 at 9 37 27 AM](https://user-images.githubusercontent.com/1260765/86612012-b4dd5a00-bf6c-11ea-8025-b4c205f48647.png)
![Screen Shot 2020-07-06 at 9 37 43 AM](https://user-images.githubusercontent.com/1260765/86612013-b575f080-bf6c-11ea-8e24-e0c4604f8256.png)
