### PR TITLE
#1153 - pass the result of the resolver to the after resolve hook

### DIFF
--- a/src/Utils/InstrumentSchema.php
+++ b/src/Utils/InstrumentSchema.php
@@ -208,8 +208,9 @@ class InstrumentSchema {
 						 * @param string          $type_name The name of the type the fields belong to
 						 * @param string          $field_key The name of the field
 						 * @param FieldDefinition $field     The Field Definition for the resolving field
+						 * @param mixed           $result    The result of the field resolver
 						 */
-						do_action( 'graphql_after_resolve_field', $source, $args, $context, $info, $field_resolver, $type_name, $field_key, $field );
+						do_action( 'graphql_after_resolve_field', $source, $args, $context, $info, $field_resolver, $type_name, $field_key, $field, $result );
 
 						return $result;
 


### PR DESCRIPTION
This updates the `graphql_after_resolve_field` hook to pass the results of the resolver through as an argument on the action. 

This will allow plugins to do things such as cache results of specific fields and skip execution for future requests.