### PR TITLE
#1374 - Password Protected posts returning errors in queries for posts

### DIFF
--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -150,7 +150,6 @@ class Post extends Model {
 			'status',
 			'titleRendered',
 			'uri',
-
 		];
 
 		$allowed_restricted_fields[] = $this->post_type_object->graphql_single_name . 'Id';
@@ -439,7 +438,7 @@ class Post extends Model {
 					return ! empty( $this->data->post_author ) ? $this->data->post_author : null;
 				},
 				'id'                        => function() {
-					return ( ! empty( $this->data->post_type ) && ! empty( $this->ID ) ) ? Relay::toGlobalId( 'post', $this->ID ) : null;
+					return ( ! empty( $this->data->post_type ) && ! empty( $this->databaseId ) ) ? Relay::toGlobalId( 'post', $this->databaseId ) : null;
 				},
 				'databaseId'                => function() {
 					return isset( $this->data->ID ) ? absint( $this->data->ID ) : null;


### PR DESCRIPTION
This fixes a bug where restricted models (including password protected posts) might return null for ID and cause errors in the connection response. 

Closes #1374 