### PR TITLE
Remove deprecated pageBy documentation

### DIFF
--- a/docs/source/guides/the-graphql-query-language.mdx
+++ b/docs/source/guides/the-graphql-query-language.mdx
@@ -148,14 +148,14 @@ If we know the Global ID of a page, we can query for it like so:
 ### PageBy
 
 Since pages are hierarchical, many pages can have the same slug, so we can't reliably use a slug as
-an identifier and thus there's no option to query a `pageBy` using the slug field in the same way
+an identifier and thus there's no option to query a page using the slug field in the same way
 non-hierarchical Post Types can be queried. However, if we know the URI, we can that as a unique
-identifier to fetch an individual Page.
+identifier to fetch an individual Page, together with the `idType` parameter.
 
 <GraphiQL
 	query='
     {
-      pageBy( uri: "home-2" ) {
+      page( id: "/blog/", idType: URI ) {
         id
         title
         slug


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](.github/CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
Currently the docs explain how to use `pageBy`. This is deprecated, according to the GraphQL client I use, so this is updated to use the new `idType` parameter.


Does this close any currently open issues?
------------------------------------------
Not that I can find.


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

![image](https://user-images.githubusercontent.com/21159570/87164543-cd2cdc00-c2c0-11ea-9b21-86f74f8e3825.png)


Any other comments?
-------------------
Nu-uh


Where has this been tested?
---------------------------
**Operating System:** N/A (Documentation change)

**WordPress Version:** N/A (Documentation change)