### PR TITLE
Use get_allowed_post_types() in documentation.

### DIFF
--- a/docs/source/getting-started/custom-fields-and-meta.mdx
+++ b/docs/source/getting-started/custom-fields-and-meta.mdx
@@ -66,7 +66,7 @@ We could to that like so:
 ```php
 add_action( 'graphql_register_types', function() {
 
-  $post_types = \WPGraphQL::$allowed_post_types;
+  $post_types = \WPGraphQL::get_allowed_post_types();
 
   if ( ! empty( $post_types ) && is_array( $post_types ) ) {
     foreach ( $post_types as $post_type ) {


### PR DESCRIPTION
`\WPGraphQL::$allowed_post_types;` returns `null`. I think it should be `\WPGraphQL::get_allowed_post_types();`