### PR TITLE
#1396 - location argument not properly respected for menu item queries

### DIFF
--- a/src/Data/Connection/MenuItemConnectionResolver.php
+++ b/src/Data/Connection/MenuItemConnectionResolver.php
@@ -45,7 +45,7 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 	 * @return array
 	 */
 	public function get_query_args() {
-		$menu_locations = get_theme_mod( 'nav_menu_locations' );
+		$menu_locations = get_theme_mod( 'nav_menu_locations', [] );
 
 		$query_args = [
 			'orderby' => 'menu_order',
@@ -65,19 +65,24 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 			}
 		}
 
+		// Get unique list of locations as the default limitation of
+		// locations to allow public queries for.
+		// Public queries should only be allowed to query for
+		// Menu Items assigned to a Menu Location
 		$locations = array_unique( array_values( $menu_locations ) );
 
+		// If the location argument is set, set the argument to the input argument
 		if ( isset( $this->args['where']['location'] ) && isset( $menu_locations[ $this->args['where']['location'] ] ) ) {
-			$locations = [ $menu_locations[ $this->args['where']['location'] ] ];
-		}
 
-		if ( current_user_can( 'edit_theme_options' ) ) {
+			$locations = [ $menu_locations[ $this->args['where']['location'] ] ];
+
+			// if the $locations are NOT set and the user has proper capabilities, let the user query
+			// all menu items connected to any menu
+		} elseif ( current_user_can( 'edit_theme_options' ) ) {
 			$locations = null;
 		}
 
-		/**
-		 * Only query for menu items in assigned locations
-		 */
+		// Only query for menu items in assigned locations.
 		if ( ! empty( $locations ) && is_array( $locations ) ) {
 			$query_args['tax_query'] = [
 				[


### PR DESCRIPTION
closes #1396 

- This fixes some logic around how the location argument is applied to the resolver
- Adds a test to prevent future regressions

## Before

Here, we can see that the `where` argument is trying to limit menu items to the `PRIMARY` location, but items are returned from any location, including "no" location

![Screen Shot 2020-07-24 at 9 50 40 PM](https://user-images.githubusercontent.com/1260765/88448393-c6db4b80-cdfa-11ea-9685-d0e70dc0c4b9.png)


## After

The same query properly returns _only_ items connected to the `PRIMARY` location

![Screen Shot 2020-07-24 at 9 50 52 PM](https://user-images.githubusercontent.com/1260765/88448395-cb076900-cdfa-11ea-875e-560a105142d8.png)
