### PR TITLE
#1400 - cannot query children of hierarchical post type by uri

### DIFF
--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -305,19 +305,8 @@ class NodeResolver {
 			if ( isset( $this->wp->query_vars['post_type'] ) && in_array( $this->wp->query_vars['post_type'], $allowed_post_types, true ) ) {
 				$post_type = $this->wp->query_vars['post_type'];
 			}
-
-			$args  = [
-				'name'                => $this->wp->query_vars['name'],
-				'post_type'           => $post_type,
-				'post_status'         => 'publish',
-				'posts_per_page'      => 1,
-				'ignore_sticky_posts' => true,
-				'no_found_rows'       => true,
-				'fields'              => 'ids',
-			];
-			$posts = new \WP_Query( $args );
-
-			return ! empty( $posts->posts[0] ) ? $this->context->get_loader( 'post' )->load_deferred( $posts->posts[0] ) : null;
+			$post = get_page_by_path( $this->wp->query_vars['name'], 'OBJECT', $post_type );
+			return ! empty( $post ) ? $this->context->get_loader( 'post' )->load_deferred( $post->ID ) : null;
 
 		} elseif ( isset( $this->wp->query_vars['cat'] ) ) {
 			$node = get_term( absint( $this->wp->query_vars['cat'] ), 'category' );
@@ -329,9 +318,10 @@ class NodeResolver {
 
 			return ! empty( $node ) ? $this->context->get_loader( 'term' )->load_deferred( (int) $node->term_id ) : null;
 		} elseif ( isset( $this->wp->query_vars['pagename'] ) && ! empty( $this->wp->query_vars['pagename'] ) ) {
+
 			$post = get_page_by_path( $this->wp->query_vars['pagename'], 'OBJECT', get_post_types( [ 'show_in_graphql' => true ] ) );
 
-			if ( (int) get_option( 'page_for_posts', 0 ) === $post->ID ) {
+			if ( isset( $post->ID ) && (int) get_option( 'page_for_posts', 0 ) === $post->ID ) {
 				return $this->context->get_loader( 'post_type' )->load_deferred( 'post' );
 			}
 

--- a/tests/wpunit/CustomPostTypeTest.php
+++ b/tests/wpunit/CustomPostTypeTest.php
@@ -4,6 +4,7 @@ class CustomPostTypeTest extends \Codeception\TestCase\WPTestCase {
 
 	public function setUp(): void {
 		parent::setUp();
+		WPGraphQL::clear_schema();
 
 	}
 

--- a/tests/wpunit/NodeByUriTest.php
+++ b/tests/wpunit/NodeByUriTest.php
@@ -406,7 +406,115 @@ class NodeByUriTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertTrue( $actual['data']['nodeByUri']['isFrontPage'] );
 		$this->assertFalse( $actual['data']['nodeByUri']['isPostsPage'] );
 
+	}
 
+	/**
+	 * @throws Exception
+	 */
+	public function testHierarchicalCptNodesByUri() {
+
+		register_post_type( 'test_hierarchical', [
+			'public'              => true,
+			'publicly_queryable'  => true,
+			'show_ui'             => true,
+			'show_in_menu'        => true,
+			'query_var'           => true,
+			'rewrite'             => [
+				'slug' => 'test_hierarchical',
+				'with_front' => false
+			],
+			'capability_type'     => 'page',
+			'has_archive'         => false,
+			'hierarchical'        => true,
+			'menu_position'       => null,
+			'supports'            => array( 'title', 'editor', 'author', 'thumbnail', 'excerpt', 'page-attributes' ),
+			'show_in_rest'        => true,
+			'rest_base'           => 'test-hierarchical',
+			'show_in_graphql'     => true,
+			'graphql_single_name' => 'testHierarchical',
+			'graphql_plural_name' => 'testHierarchicals',
+		]);
+
+		flush_rewrite_rules( true );
+
+		$parent = $this->factory()->post->create([
+			'post_type' => 'test_hierarchical',
+			'post_title' => 'test',
+			'post_content' => 'test',
+			'post_status' => 'publish',
+		]);
+
+		$child = $this->factory()->post->create([
+			'post_type' => 'test_hierarchical',
+			'post_title' => 'child',
+			'post_content' => 'child',
+			'post_parent' => $parent,
+			'post_status' => 'publish',
+		]);
+
+		$query = '
+		{
+		  testHierarchicals {
+		    nodes {
+		      id
+		      databaseId
+		      title
+		      uri
+		    }
+		  }
+		}
+		';
+
+		$actual = graphql(['query' => $query]);
+		codecept_debug( $actual );
+		codecept_debug( parse_url( get_permalink( $child ), PHP_URL_PATH ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$database_ids = wp_list_pluck( $actual['data']['testHierarchicals']['nodes'], 'databaseId' );
+		codecept_debug( $database_ids );
+		$this->assertTrue( in_array( $child, $database_ids, true ) );
+		$this->assertTrue( in_array( $parent, $database_ids, true ) );
+
+		$query = '
+		query NodeByUri( $uri: String! ) {
+		  nodeByUri( uri: $uri ) {
+		     databaseId
+		     uri
+		     __typename
+		  }
+		}
+		';
+
+		$child_uri = parse_url( get_permalink( $child ), PHP_URL_PATH );
+		codecept_debug( $child_uri );
+
+		$actual = graphql([
+			'query' => $query,
+			'variables' => [
+				'uri' => $child_uri,
+			],
+		]);
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertSame( $child_uri, $actual['data']['nodeByUri']['uri'], 'Makes sure the uri of the node matches the uri queried with' );
+		$this->assertSame( 'TestHierarchical', $actual['data']['nodeByUri']['__typename'] );
+		$this->assertSame( $child, $actual['data']['nodeByUri']['databaseId'] );
+
+		codecept_debug( $actual );
+
+		$parent_uri = parse_url( get_permalink( $parent ), PHP_URL_PATH );
+		$actual = graphql([
+			'query' => $query,
+			'variables' => [
+				'uri' => $parent_uri,
+			],
+		]);
+
+		codecept_debug( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertSame( $parent_uri, $actual['data']['nodeByUri']['uri'], 'Makes sure the uri of the node matches the uri queried with' );
+		$this->assertSame( 'TestHierarchical', $actual['data']['nodeByUri']['__typename'] );
+		$this->assertSame( $parent, $actual['data']['nodeByUri']['databaseId'] );
 
 	}
 }


### PR DESCRIPTION
closes #1400 

- This fixes a bug in the NodeResolver class where children of custom post types can't resolve when querying by uri
- adds a test to prevent regressions

---

## Before:
Querying a child post of a hierarchical post type returns null

![Screen Shot 2020-07-24 at 10 22 35 PM](https://user-images.githubusercontent.com/1260765/88449894-f17fd100-ce07-11ea-8817-549295ba999b.png)


## After:
Querying a child post of a hierarchical post type returns the node

![Screen Shot 2020-07-24 at 10 47 20 PM](https://user-images.githubusercontent.com/1260765/88449904-fb093900-ce07-11ea-97a0-59e2571ef354.png)
