### PR TITLE
#1405 - where args missing from HierarchicalContentNode.children connections

### DIFF
--- a/src/Connection/PostObjects.php
+++ b/src/Connection/PostObjects.php
@@ -126,6 +126,8 @@ class PostObjects {
 			'fromType'      => 'HierarchicalContentNode',
 			'fromFieldName' => 'children',
 			'toType'        => 'ContentNode',
+			'connectionArgs' => self::get_connection_args(),
+			'queryClass'     => 'WP_Query',
 			'resolve'       => function( Post $post, $args, $context, $info ) {
 
 				if ( $post->isRevision ) {
@@ -146,6 +148,8 @@ class PostObjects {
 			'fromType'      => 'HierarchicalContentNode',
 			'toType'        => 'ContentNode',
 			'fromFieldName' => 'ancestors',
+			'connectionArgs' => self::get_connection_args(),
+			'queryClass'     => 'WP_Query',
 			'description'   => __( 'Returns ancestors of the node. Default ordered as lowest (closest to the child) to highest (closest to the root).', 'wp-graphql' ),
 			'resolve'       => function( Post $post, $args, $context, $info ) {
 				$ancestors = get_ancestors( $post->ID, null, 'post_type' );

--- a/src/Connection/PostObjects.php
+++ b/src/Connection/PostObjects.php
@@ -123,12 +123,12 @@ class PostObjects {
 		] );
 
 		register_graphql_connection( [
-			'fromType'      => 'HierarchicalContentNode',
-			'fromFieldName' => 'children',
-			'toType'        => 'ContentNode',
+			'fromType'       => 'HierarchicalContentNode',
+			'fromFieldName'  => 'children',
+			'toType'         => 'ContentNode',
 			'connectionArgs' => self::get_connection_args(),
 			'queryClass'     => 'WP_Query',
-			'resolve'       => function( Post $post, $args, $context, $info ) {
+			'resolve'        => function( Post $post, $args, $context, $info ) {
 
 				if ( $post->isRevision ) {
 					$id = $post->parentDatabaseId;
@@ -145,13 +145,13 @@ class PostObjects {
 		] );
 
 		register_graphql_connection( [
-			'fromType'      => 'HierarchicalContentNode',
-			'toType'        => 'ContentNode',
-			'fromFieldName' => 'ancestors',
+			'fromType'       => 'HierarchicalContentNode',
+			'toType'         => 'ContentNode',
+			'fromFieldName'  => 'ancestors',
 			'connectionArgs' => self::get_connection_args(),
 			'queryClass'     => 'WP_Query',
-			'description'   => __( 'Returns ancestors of the node. Default ordered as lowest (closest to the child) to highest (closest to the root).', 'wp-graphql' ),
-			'resolve'       => function( Post $post, $args, $context, $info ) {
+			'description'    => __( 'Returns ancestors of the node. Default ordered as lowest (closest to the child) to highest (closest to the root).', 'wp-graphql' ),
+			'resolve'        => function( Post $post, $args, $context, $info ) {
 				$ancestors = get_ancestors( $post->ID, null, 'post_type' );
 				if ( empty( $ancestors ) || ! is_array( $ancestors ) ) {
 					return null;


### PR DESCRIPTION
- This adds the connection args back to the children connections from HierarchicalContentNodes
- closes #1405 

## Before

This shows a query for children, filtering to exclude a specific ID from the children. An error is returned because the where args are not present.

![Screen Shot 2020-07-27 at 11 25 51 AM](https://user-images.githubusercontent.com/1260765/88572167-f907cb80-cffb-11ea-9cc9-65c077285e16.png)


## After

This shows a query for children, filtering to exclude a specific ID from the children. An error is not returned and the query is executed properly because the args are available on the connection.

![Screen Shot 2020-07-27 at 11 25 51 AM](https://user-images.githubusercontent.com/1260765/88572167-f907cb80-cffb-11ea-9cc9-65c077285e16.png)