### PR TITLE
Fix issue #1397 custom post types not queryable with slug

### DIFF
--- a/src/Type/Object/RootQuery.php
+++ b/src/Type/Object/RootQuery.php
@@ -500,9 +500,10 @@ class RootQuery {
 							$idType  = isset( $args['idType'] ) ? $args['idType'] : 'global_id';
 							$post_id = null;
 							switch ( $idType ) {
-								case 'uri':
-								case 'slug':
-									return $context->node_resolver->resolve_uri( $args['id'], ['post_type' => $post_type_object->name] );
+                                case 'slug':
+                                    return $context->node_resolver->resolve_uri( $args['id'], [ 'name' => $args['id'], 'post_type' => $post_type_object->name] );
+                                case 'uri':
+                                    return $context->node_resolver->resolve_uri( $args['id'], ['post_type' => $post_type_object->name] );
 								case 'database_id':
 									$post_id = absint( $args['id'] );
 									break;

--- a/src/Type/Object/RootQuery.php
+++ b/src/Type/Object/RootQuery.php
@@ -500,15 +500,16 @@ class RootQuery {
 							$idType  = isset( $args['idType'] ) ? $args['idType'] : 'global_id';
 							$post_id = null;
 							switch ( $idType ) {
-								case 'slug':
-									return $context->node_resolver->resolve_uri( $args['id'], [
-										'name'      => $args['id'],
-										'post_type' => $post_type_object->name,
-									] );
-									break;
-								case 'uri':
-									return $context->node_resolver->resolve_uri( $args['id'], [ 'post_type' => $post_type_object->name ] );
-									break;
+                                case 'slug':
+                                    return $context->node_resolver->resolve_uri( $args['id'], [
+                                        'name'      => $args['id'],
+                                        'post_type' => $post_type_object->name,
+                                    ] );
+                                case 'uri':
+                                    $slug        = esc_html( $args['id'] );
+                                    $post_object = get_page_by_path( $slug, 'OBJECT', $post_type_object->name );
+                                    $post_id     = isset( $post_object->ID ) ? absint( $post_object->ID ) : null;
+                                    break;
 								case 'database_id':
 									$post_id = absint( $args['id'] );
 									break;

--- a/src/Type/Object/RootQuery.php
+++ b/src/Type/Object/RootQuery.php
@@ -502,8 +502,7 @@ class RootQuery {
 							switch ( $idType ) {
 								case 'uri':
 								case 'slug':
-									return $context->node_resolver->resolve_uri( $args['id'] );
-									break;
+									return $context->node_resolver->resolve_uri( $args['id'], ['post_type' => $post_type_object->name] );
 								case 'database_id':
 									$post_id = absint( $args['id'] );
 									break;

--- a/tests/wpunit/NodeBySlugTest.php
+++ b/tests/wpunit/NodeBySlugTest.php
@@ -102,7 +102,7 @@ class NodeBySlugTest extends \Codeception\TestCase\WPTestCase {
 
 		codecept_debug( $actual );
 
-		$this->assertArrayNotHasKey( 'Errors', $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertSame( $this->post, $actual['data']['post']['databaseId'] );
 		$this->assertSame( $post->post_title, $actual['data']['post']['title'] );
 
@@ -111,7 +111,7 @@ class NodeBySlugTest extends \Codeception\TestCase\WPTestCase {
 
         codecept_debug( $actual );
 
-        $this->assertArrayNotHasKey( 'Errors', $actual );
+        $this->assertArrayNotHasKey( 'errors', $actual );
         $this->assertSame( $this->post, $actual['data']['post']['databaseId'] );
         $this->assertSame( $post->post_title, $actual['data']['post']['title'] );
 
@@ -120,7 +120,7 @@ class NodeBySlugTest extends \Codeception\TestCase\WPTestCase {
 
 		codecept_debug( $actual );
 
-        $this->assertArrayNotHasKey( 'Errors', $actual );
+        $this->assertArrayNotHasKey( 'errors', $actual );
         $this->assertSame( $this->post, $actual['data']['post']['databaseId'] );
         $this->assertSame( $post->post_title, $actual['data']['post']['title'] );
 	}
@@ -154,7 +154,7 @@ class NodeBySlugTest extends \Codeception\TestCase\WPTestCase {
 
         codecept_debug( $actual );
 
-        $this->assertArrayNotHasKey( 'Errors', $actual );
+        $this->assertArrayNotHasKey( 'errors', $actual );
         $this->assertSame( $this->custom_type, $actual['data']['customType']['databaseId'] );
         $this->assertSame( $post->post_title, $actual['data']['customType']['title'] );
 
@@ -163,7 +163,7 @@ class NodeBySlugTest extends \Codeception\TestCase\WPTestCase {
 
         codecept_debug( $actual );
 
-        $this->assertArrayNotHasKey( 'Errors', $actual );
+        $this->assertArrayNotHasKey( 'errors', $actual );
         $this->assertSame( $this->custom_type, $actual['data']['customType']['databaseId'] );
         $this->assertSame( $post->post_title, $actual['data']['customType']['title'] );
 
@@ -172,7 +172,7 @@ class NodeBySlugTest extends \Codeception\TestCase\WPTestCase {
 
         codecept_debug( $actual );
 
-        $this->assertArrayNotHasKey( 'Errors', $actual );
+        $this->assertArrayNotHasKey( 'errors', $actual );
         $this->assertSame( $this->custom_type, $actual['data']['customType']['databaseId'] );
         $this->assertSame( $post->post_title, $actual['data']['customType']['title'] );
     }

--- a/tests/wpunit/NodeBySlugTest.php
+++ b/tests/wpunit/NodeBySlugTest.php
@@ -1,0 +1,199 @@
+<?php
+
+class NodeBySlugTest extends \Codeception\TestCase\WPTestCase {
+
+	public $post;
+	public $page;
+	public $user;
+	public $tag;
+	public $category;
+	public $custom_type;
+	public $custom_taxonomy;
+
+	public function setUp(): void {
+
+		WPGraphQL::clear_schema();
+
+		register_post_type('custom_type', [
+			'show_in_graphql' => true,
+			'graphql_single_name' => 'CustomType',
+			'graphql_plural_name' => 'CustomTypes',
+			'public' => true,
+		]);
+
+		register_taxonomy( 'custom_tax', 'custom_type', [
+			'show_in_graphql' => true,
+			'graphql_single_name' => 'CustomTax',
+			'graphql_plural_name' => 'CustomTaxes',
+		]);
+
+		$this->set_permalink_structure( '/%year%/%monthnum%/%day%/%postname%/' );
+
+		$this->user = $this->factory()->user->create([
+			'role' => 'administrator',
+		]);
+
+		$this->tag = $this->factory()->term->create([
+			'taxonomy' => 'post_tag',
+		]);
+
+		$this->category = $this->factory()->term->create([
+			'taxonomy' => 'category',
+		]);
+
+		$this->custom_taxonomy = $this->factory()->term->create([
+			'taxonomy' => 'custom_tax',
+		]);
+
+		$this->post = $this->factory()->post->create( [
+			'post_type' => 'post',
+			'post_status' => 'publish',
+			'post_title' => 'Test',
+			'post_author' => $this->user,
+		] );
+
+		$this->page = $this->factory()->post->create( [
+			'post_type' => 'page',
+			'post_status' => 'publish',
+			'post_title' => 'Test Page',
+			'post_author' => $this->user
+		] );
+
+		$this->custom_type = $this->factory()->post->create( [
+			'post_type' => 'custom_type',
+			'post_status' => 'publish',
+			'post_title' => 'Test Page',
+			'post_author' => $this->user
+		] );
+
+		parent::setUp();
+
+	}
+
+	public function tearDown(): void {
+
+		unregister_post_type( 'custom_type' );
+		WPGraphQL::clear_schema();
+		$this->set_permalink_structure( '/%year%/%monthnum%/%day%/%postname%/' );
+		parent::tearDown();
+		wp_delete_post( $this->post );
+		wp_delete_post( $this->page );
+		wp_delete_post( $this->custom_post_type );
+		wp_delete_term( $this->tag, 'post_tag' );
+		wp_delete_term( $this->category, 'category' );
+		wp_delete_term( $this->custom_taxonomy, 'custom_tax' );
+		wp_delete_user( $this->user );
+
+	}
+
+	public function set_permalink_structure( $structure = '' ) {
+		global $wp_rewrite;
+		$wp_rewrite->init();
+		$wp_rewrite->set_permalink_structure( $structure );
+		$wp_rewrite->flush_rules( true );
+	}
+
+	/**
+	 * Get a Post by it's permalink
+	 * @throws Exception
+	 */
+	public function testPostBySlug() {
+
+	    $post = get_post($this->post);
+
+
+		$query = '
+        query GET_POST_BY_URI( $slug: ID! ) {
+           post(id: $slug, idType: SLUG) {
+                databaseId
+                title
+           }
+		}
+		';
+
+		codecept_debug( get_post( $this->post ) );
+
+		$actual = graphql([
+			'query' => $query,
+			'variables' => [
+				'slug' => $post->post_name,
+			],
+		]);
+
+		codecept_debug( $actual );
+
+		$this->assertArrayNotHasKey( 'Errors', $actual );
+		$this->assertSame( $this->post, $actual['data']['post']['databaseId'] );
+		$this->assertSame( $post->post_title, $actual['data']['post']['title'] );
+
+
+        $this->set_permalink_structure( "/$post->post_type/%postname%" );
+
+        codecept_debug( $actual );
+
+        $this->assertArrayNotHasKey( 'Errors', $actual );
+        $this->assertSame( $this->post, $actual['data']['post']['databaseId'] );
+        $this->assertSame( $post->post_title, $actual['data']['post']['title'] );
+
+
+		$this->set_permalink_structure( '' );
+
+		codecept_debug( $actual );
+
+        $this->assertArrayNotHasKey( 'Errors', $actual );
+        $this->assertSame( $this->post, $actual['data']['post']['databaseId'] );
+        $this->assertSame( $post->post_title, $actual['data']['post']['title'] );
+	}
+
+
+    /**
+     * Get a Post by it's permalink
+     * @throws Exception
+     */
+    public function testCustomPostBySlug() {
+
+        $post = get_post($this->custom_type);
+
+        $query = '
+        query GET_POST_BY_URI( $slug: ID! ) {
+           customType(id: $slug, idType: SLUG) {
+                databaseId
+                title
+           }
+		}
+		';
+
+        codecept_debug( get_post( $this->custom_type ) );
+
+        $actual = graphql([
+            'query' => $query,
+            'variables' => [
+                'slug' => $post->post_name,
+            ],
+        ]);
+
+        codecept_debug( $actual );
+
+        $this->assertArrayNotHasKey( 'Errors', $actual );
+        $this->assertSame( $this->custom_type, $actual['data']['customType']['databaseId'] );
+        $this->assertSame( $post->post_title, $actual['data']['customType']['title'] );
+
+
+        $this->set_permalink_structure( "/$post->post_type/%postname%" );
+
+        codecept_debug( $actual );
+
+        $this->assertArrayNotHasKey( 'Errors', $actual );
+        $this->assertSame( $this->custom_type, $actual['data']['customType']['databaseId'] );
+        $this->assertSame( $post->post_title, $actual['data']['customType']['title'] );
+
+
+        $this->set_permalink_structure( '' );
+
+        codecept_debug( $actual );
+
+        $this->assertArrayNotHasKey( 'Errors', $actual );
+        $this->assertSame( $this->custom_type, $actual['data']['customType']['databaseId'] );
+        $this->assertSame( $post->post_title, $actual['data']['customType']['title'] );
+    }
+}

--- a/tests/wpunit/NodeBySlugTest.php
+++ b/tests/wpunit/NodeBySlugTest.php
@@ -21,28 +21,10 @@ class NodeBySlugTest extends \Codeception\TestCase\WPTestCase {
 			'public' => true,
 		]);
 
-		register_taxonomy( 'custom_tax', 'custom_type', [
-			'show_in_graphql' => true,
-			'graphql_single_name' => 'CustomTax',
-			'graphql_plural_name' => 'CustomTaxes',
-		]);
-
 		$this->set_permalink_structure( '/%year%/%monthnum%/%day%/%postname%/' );
 
 		$this->user = $this->factory()->user->create([
 			'role' => 'administrator',
-		]);
-
-		$this->tag = $this->factory()->term->create([
-			'taxonomy' => 'post_tag',
-		]);
-
-		$this->category = $this->factory()->term->create([
-			'taxonomy' => 'category',
-		]);
-
-		$this->custom_taxonomy = $this->factory()->term->create([
-			'taxonomy' => 'custom_tax',
 		]);
 
 		$this->post = $this->factory()->post->create( [
@@ -50,13 +32,6 @@ class NodeBySlugTest extends \Codeception\TestCase\WPTestCase {
 			'post_status' => 'publish',
 			'post_title' => 'Test',
 			'post_author' => $this->user,
-		] );
-
-		$this->page = $this->factory()->post->create( [
-			'post_type' => 'page',
-			'post_status' => 'publish',
-			'post_title' => 'Test Page',
-			'post_author' => $this->user
 		] );
 
 		$this->custom_type = $this->factory()->post->create( [
@@ -77,11 +52,7 @@ class NodeBySlugTest extends \Codeception\TestCase\WPTestCase {
 		$this->set_permalink_structure( '/%year%/%monthnum%/%day%/%postname%/' );
 		parent::tearDown();
 		wp_delete_post( $this->post );
-		wp_delete_post( $this->page );
 		wp_delete_post( $this->custom_post_type );
-		wp_delete_term( $this->tag, 'post_tag' );
-		wp_delete_term( $this->category, 'category' );
-		wp_delete_term( $this->custom_taxonomy, 'custom_tax' );
 		wp_delete_user( $this->user );
 
 	}


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](.github/CONTRIBUTING.md) to this repository.

- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
Fix custom post types returning null when queried with SLUG idType  


Does this close any currently open issues?
------------------------------------------
#1397 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
![Screen Shot 2020-08-08 at 2 56 21 PM](https://user-images.githubusercontent.com/49703444/89701005-577f6300-d987-11ea-8685-0db07f1eb372.png)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** MacOS 10.15.6

**WordPress Version:** 5.4.2
