### PR TITLE
#1419 - Remove exception from RootQuery.viewer field

### DIFF
--- a/src/Type/Object/RootQuery.php
+++ b/src/Type/Object/RootQuery.php
@@ -453,11 +453,7 @@ class RootQuery {
 						'type'        => 'User',
 						'description' => __( 'Returns the current user', 'wp-graphql' ),
 						'resolve'     => function( $source, array $args, $context, $info ) {
-							if ( ! isset( $context->viewer->ID ) || empty( $context->viewer->ID ) ) {
-								throw new \Exception( __( 'You must be logged in to access viewer fields', 'wp-graphql' ) );
-							}
-
-							return ( false !== $context->viewer->ID ) ? DataSource::resolve_user( $context->viewer->ID, $context ) : null;
+							return isset( $context->viewer->ID ) && ! empty( $context->viewer->ID ) ? DataSource::resolve_user( $context->viewer->ID, $context ) : null;
 						},
 					],
 				],

--- a/tests/wpunit/ViewerQueryTest.php
+++ b/tests/wpunit/ViewerQueryTest.php
@@ -34,7 +34,8 @@ class ViewerQueryTest extends \Codeception\TestCase\WPTestCase {
 		/**
 		 * We should get an error because no user is logged in right now
 		 */
-		$this->assertArrayHasKey( 'errors', $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertNull( $actual['data']['viewer'] );
 
 		/**
 		 * Set the current user so we can properly test the viewer query


### PR DESCRIPTION
closes #1419 

This removes the exception from the RootQuery.viewer field and instead returns a null if the request is made by an unauthenticated user. 