### PR TITLE
#1408 - Show previews even if revisions are not enabled

### DIFF
--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -665,6 +665,7 @@ class Post extends Model {
 						$revisions = wp_get_post_revisions( $this->data->ID, [
 							'posts_per_page' => 1,
 							'fields'         => 'ids',
+							'check_enabled'  => false,
 						] );
 
 						return is_array( $revisions ) && ! empty( $revisions ) ? array_values( $revisions )[0] : null;
@@ -679,6 +680,7 @@ class Post extends Model {
 						$revisions = wp_get_post_revisions( $this->parentDatabaseId, [
 							'posts_per_page' => 1,
 							'fields'         => 'ids',
+							'check_enabled'  => false,
 						] );
 
 						if ( in_array( $this->data->ID, array_values( $revisions ), true ) ) {

--- a/src/Type/Object/RootQuery.php
+++ b/src/Type/Object/RootQuery.php
@@ -96,6 +96,7 @@ class RootQuery {
 								$revisions = wp_get_post_revisions( $post_id, [
 									'posts_per_page' => 1,
 									'fields'         => 'ids',
+									'check_enabled'  => false,
 								] );
 								$post_id   = ! empty( $revisions ) ? array_values( $revisions )[0] : null;
 							}
@@ -525,6 +526,7 @@ class RootQuery {
 								$revisions = wp_get_post_revisions( $post_id, [
 									'posts_per_page' => 1,
 									'fields'         => 'ids',
+									'check_enabled'  => false,
 								] );
 								$post_id   = ! empty( $revisions ) ? array_values( $revisions )[0] : null;
 							}

--- a/tests/wpunit/PreviewTest.php
+++ b/tests/wpunit/PreviewTest.php
@@ -133,6 +133,23 @@ class PreviewTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertNotNull( $actual['data']['post']['preview'] );
 
+		add_filter( 'wp_revisions_to_keep', function() {
+			return 0;
+		} );
+
+		$actual = graphql([ 'query' => $this->get_query(), 'variables' => [
+			'id' => $this->post,
+		] ]);
+
+		codecept_debug( $actual );
+
+		add_filter( 'wp_revisions_to_keep', function( $default ) {
+			return $default;
+		} );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertNotNull( $actual['data']['post']['preview'] );
+
 	}
 
 	public function testPreviewAuthorMatchesPublishedAuthor() {
@@ -148,7 +165,8 @@ class PreviewTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertSame( $this->admin, $actual['data']['post']['preview']['node']['author']['node']['databaseId'] );
 		$this->assertSame( $this->admin, $actual['data']['post']['author']['node']['databaseId'] );
-		$this->assertSame( $actual['data']['post']['preview']['node']['author']['node']['databaseId'], $actual['data']['post']['author']['node']['databaseId'] );
+		$this->assertSame( $this->admin, $actual['data']['post']['preview']['node']['author']['node']['databaseId'] );
+
 	}
 
 	public function testPreviewTermsMatchPublishedTerms() {


### PR DESCRIPTION
This fixes a bug where previews aren't returned by WPGraphQL when revisions are disabled. 

Includes a test to guard against regressions. 

closes #1408 

## Before
Authenticated request for a preview of a post returns null

![Screen Shot 2020-08-10 at 4 32 34 PM](https://user-images.githubusercontent.com/1260765/89837905-1faf2180-db27-11ea-9f99-52f21449f6ab.png)

## After
Authenticated request for a preview of a post returns the preview node

![Screen Shot 2020-08-10 at 4 32 15 PM](https://user-images.githubusercontent.com/1260765/89837900-1e7df480-db27-11ea-8407-9261151eaf2f.png)