### PR TITLE
#1256 - undefined property graphql_single_name

### DIFF
--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -155,7 +155,9 @@ class Post extends Model {
 			'isFrontPage',
 		];
 
-		$allowed_restricted_fields[] = $this->post_type_object->graphql_single_name . 'Id';
+		if ( isset( $this->post_type_object->graphql_single_name ) ) {
+			$allowed_restricted_fields[] = $this->post_type_object->graphql_single_name . 'Id';
+		}
 
 		$restricted_cap = $this->get_restricted_cap();
 
@@ -424,10 +426,6 @@ class Post extends Model {
 	protected function init() {
 
 		if ( empty( $this->fields ) ) {
-
-			$this->fields[ $this->post_type_object->graphql_single_name . 'Id' ] = function() {
-				return absint( $this->data->ID );
-			};
 
 			$this->fields = [
 				'ID'                        => function() {


### PR DESCRIPTION
- This avoids a PHP warning by checking if  graphql_single_name is set before using it

closes #1256 