### PR TITLE
Release/v0.12.1

### DIFF
--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -665,6 +665,7 @@ class Post extends Model {
 						$revisions = wp_get_post_revisions( $this->data->ID, [
 							'posts_per_page' => 1,
 							'fields'         => 'ids',
+							'check_enabled'  => false,
 						] );
 
 						return is_array( $revisions ) && ! empty( $revisions ) ? array_values( $revisions )[0] : null;
@@ -679,6 +680,7 @@ class Post extends Model {
 						$revisions = wp_get_post_revisions( $this->parentDatabaseId, [
 							'posts_per_page' => 1,
 							'fields'         => 'ids',
+							'check_enabled'  => false,
 						] );
 
 						if ( in_array( $this->data->ID, array_values( $revisions ), true ) ) {

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -155,7 +155,9 @@ class Post extends Model {
 			'isFrontPage',
 		];
 
-		$allowed_restricted_fields[] = $this->post_type_object->graphql_single_name . 'Id';
+		if ( isset( $this->post_type_object->graphql_single_name ) ) {
+			$allowed_restricted_fields[] = $this->post_type_object->graphql_single_name . 'Id';
+		}
 
 		$restricted_cap = $this->get_restricted_cap();
 
@@ -424,10 +426,6 @@ class Post extends Model {
 	protected function init() {
 
 		if ( empty( $this->fields ) ) {
-
-			$this->fields[ $this->post_type_object->graphql_single_name . 'Id' ] = function() {
-				return absint( $this->data->ID );
-			};
 
 			$this->fields = [
 				'ID'                        => function() {

--- a/src/Type/Object/RootQuery.php
+++ b/src/Type/Object/RootQuery.php
@@ -96,6 +96,7 @@ class RootQuery {
 								$revisions = wp_get_post_revisions( $post_id, [
 									'posts_per_page' => 1,
 									'fields'         => 'ids',
+									'check_enabled'  => false,
 								] );
 								$post_id   = ! empty( $revisions ) ? array_values( $revisions )[0] : null;
 							}
@@ -525,6 +526,7 @@ class RootQuery {
 								$revisions = wp_get_post_revisions( $post_id, [
 									'posts_per_page' => 1,
 									'fields'         => 'ids',
+									'check_enabled'  => false,
 								] );
 								$post_id   = ! empty( $revisions ) ? array_values( $revisions )[0] : null;
 							}

--- a/src/Type/Object/RootQuery.php
+++ b/src/Type/Object/RootQuery.php
@@ -454,11 +454,7 @@ class RootQuery {
 						'type'        => 'User',
 						'description' => __( 'Returns the current user', 'wp-graphql' ),
 						'resolve'     => function( $source, array $args, $context, $info ) {
-							if ( ! isset( $context->viewer->ID ) || empty( $context->viewer->ID ) ) {
-								throw new \Exception( __( 'You must be logged in to access viewer fields', 'wp-graphql' ) );
-							}
-
-							return ( false !== $context->viewer->ID ) ? DataSource::resolve_user( $context->viewer->ID, $context ) : null;
+							return isset( $context->viewer->ID ) && ! empty( $context->viewer->ID ) ? DataSource::resolve_user( $context->viewer->ID, $context ) : null;
 						},
 					],
 				],

--- a/tests/wpunit/PreviewTest.php
+++ b/tests/wpunit/PreviewTest.php
@@ -133,6 +133,23 @@ class PreviewTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertNotNull( $actual['data']['post']['preview'] );
 
+		add_filter( 'wp_revisions_to_keep', function() {
+			return 0;
+		} );
+
+		$actual = graphql([ 'query' => $this->get_query(), 'variables' => [
+			'id' => $this->post,
+		] ]);
+
+		codecept_debug( $actual );
+
+		add_filter( 'wp_revisions_to_keep', function( $default ) {
+			return $default;
+		} );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertNotNull( $actual['data']['post']['preview'] );
+
 	}
 
 	public function testPreviewAuthorMatchesPublishedAuthor() {
@@ -148,7 +165,8 @@ class PreviewTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertSame( $this->admin, $actual['data']['post']['preview']['node']['author']['node']['databaseId'] );
 		$this->assertSame( $this->admin, $actual['data']['post']['author']['node']['databaseId'] );
-		$this->assertSame( $actual['data']['post']['preview']['node']['author']['node']['databaseId'], $actual['data']['post']['author']['node']['databaseId'] );
+		$this->assertSame( $this->admin, $actual['data']['post']['preview']['node']['author']['node']['databaseId'] );
+
 	}
 
 	public function testPreviewTermsMatchPublishedTerms() {

--- a/tests/wpunit/ViewerQueryTest.php
+++ b/tests/wpunit/ViewerQueryTest.php
@@ -34,7 +34,8 @@ class ViewerQueryTest extends \Codeception\TestCase\WPTestCase {
 		/**
 		 * We should get an error because no user is logged in right now
 		 */
-		$this->assertArrayHasKey( 'errors', $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertNull( $actual['data']['viewer'] );
 
 		/**
 		 * Set the current user so we can properly test the viewer query


### PR DESCRIPTION
# Release Notes

## Bugfixes
- Fixes PHP warning in Model/Post.php. Ensures graphql_single_name property exists before using it. Closes #1256.
- Remove exception from RootQuery.viewer field and instead let the Model handle things. Return null for public requests instead. Closes #1419 
- Fixes bug with Previews not working in WordPress installs where revisions are disabled (WordPress still saves the preview revision even when revisions are otherwise disabled). Closes #1426 