### PR TITLE
Update CommentMutation.php

### DIFF
--- a/src/Data/CommentMutation.php
+++ b/src/Data/CommentMutation.php
@@ -114,20 +114,20 @@ class CommentMutation {
 	}
 
 	/**
- 	* This updates commentmeta.
-	*
-	* @param int         $comment_id              The ID of the postObject the comment is connected to
-	* @param array       $input                   The input for the mutation
-	* @param string      $mutation_name           The name of the mutation ( ex: create, update, delete )
-	* @param AppContext  $context                 The AppContext passed down to all resolvers
-	* @param ResolveInfo $info                    The ResolveInfo passed down to all resolvers
-	* @param string      $intended_comment_status The intended post_status the post should have according to the mutation input
-	* @param string      $intended_comment_status The default status posts should use if an intended status wasn't set
-	*/
+	 * This updates commentmeta.
+	 *
+	 * @param int         $comment_id              The ID of the postObject the comment is connected to
+	 * @param array       $input                   The input for the mutation
+	 * @param string      $mutation_name           The name of the mutation ( ex: create, update, delete )
+	 * @param AppContext  $context                 The AppContext passed down to all resolvers
+	 * @param ResolveInfo $info                    The ResolveInfo passed down to all resolvers
+	 * @param string      $intended_comment_status The intended post_status the post should have according to the mutation input
+	 * @param string      $intended_comment_status The default status posts should use if an intended status wasn't set
+	 */
 	public static function update_additional_comment_data( $comment_id, $input, $mutation_name, AppContext $context, ResolveInfo $info ) {
 		/**
-		* @todo: should account for authentication
-		*/
+		 * @todo: should account for authentication
+		 */
 		$intended_comment_status = 0;
 		$intended_comment_status = 0;
 

--- a/src/Data/CommentMutation.php
+++ b/src/Data/CommentMutation.php
@@ -114,7 +114,7 @@ class CommentMutation {
 	}
 
 	/**
-	 * This updates commentmeta.
+ 	 * This updates commentmeta.
 	 *
 	 * @param int         $comment_id              The ID of the postObject the comment is connected to
 	 * @param array       $input                   The input for the mutation
@@ -126,11 +126,11 @@ class CommentMutation {
 	 */
 	public static function update_additional_comment_data( $comment_id, $input, $mutation_name, AppContext $context, ResolveInfo $info ) {
 		/**
-		 * @todo: should account for authentication
-		 */
+		* @todo: should account for authentication
+		*/
 		$intended_comment_status = 0;
-		$intended_comment_status = 0;
+		$default_comment_status = 0;
 
-		do_action( 'graphql_comment_object_mutation_update_additional_data', $comment_id, $input, $output_args, $mutation_name, $context, $info, $intended_comment_status, $default_comment_status );
+		do_action( 'graphql_comment_object_mutation_update_additional_data', $comment_id, $input, $mutation_name, $context, $info, $intended_comment_status, $default_comment_status );
 	}
 }

--- a/src/Data/CommentMutation.php
+++ b/src/Data/CommentMutation.php
@@ -114,15 +114,23 @@ class CommentMutation {
 	}
 
 	/**
-	 * This updates comment meta.
-	 *
-	 * @param int         $comment_id    The ID of the Comment the comment is connected to
-	 * @param array       $input         The input for the mutation
-	 * @param string      $mutation_name The name of the mutation ( ex: create, update, delete )
-	 * @param AppContext  $context       The AppContext passed down to all resolvers
-	 * @param ResolveInfo $info          The ResolveInfo passed down to all resolvers
-	 */
+ 	* This updates commentmeta.
+	*
+	* @param int         $comment_id              The ID of the postObject the comment is connected to
+	* @param array       $input                   The input for the mutation
+	* @param string      $mutation_name           The name of the mutation ( ex: create, update, delete )
+	* @param AppContext  $context                 The AppContext passed down to all resolvers
+	* @param ResolveInfo $info                    The ResolveInfo passed down to all resolvers
+	* @param string      $intended_comment_status The intended post_status the post should have according to the mutation input
+	* @param string      $intended_comment_status The default status posts should use if an intended status wasn't set
+	*/
 	public static function update_additional_comment_data( $comment_id, $input, $mutation_name, AppContext $context, ResolveInfo $info ) {
+		/**
+		* @todo: should account for authentication
+		*/
+		$intended_comment_status = 0;
+		$intended_comment_status = 0;
 
+		do_action( 'graphql_comment_object_mutation_update_additional_data', $comment_id, $input, $output_args, $mutation_name, $context, $info, $intended_comment_status, $default_comment_status );
 	}
 }


### PR DESCRIPTION
This one is over a year old, so just submitting it as a PR. Note line 126, because I'm not sure how to have this account for authentication (i.e. logged in admins' comments are auto-approved)

Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the guidelines for contributing to this repository.

 Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
 Make sure you are requesting to pull request from a topic/feature/bugfix branch (right side). Don't pull request from your master!
What does this implement/fix? Explain your changes.
The update_additional_comment_data function is empty. It should call a hook (as other similar methods do).

Does this close any currently open issues?
#942

Any other comments?
This one is pretty straightforward, and should be able to be pulled in as is, as comments are inserted with a status of "unapproved". In the future, the method could be updated to account for if the user is a logged in admin (and thus would auto-approve).

Where has this been tested?
Operating System: Ubuntu

WordPress Version: Every current version over the last year.