### PR TITLE
Reinstated extension docs 

### DIFF
--- a/docs/source/extensions/wpgraphiql.mdx
+++ b/docs/source/extensions/wpgraphiql.mdx
@@ -1,0 +1,5 @@
+---
+title: WPGraphiQL
+description: GraphiQL IDE in the WordPress Dashboard
+---
+

--- a/docs/source/extensions/wpgraphql-advanced-custom-fields.mdx
+++ b/docs/source/extensions/wpgraphql-advanced-custom-fields.mdx
@@ -1,0 +1,217 @@
+---
+title: WPGraphQL Advanced Custom Fields
+description: Expose Advanced Custom Fields to the WPGraphQL Schema
+---
+
+**Info Page:** [https://www.wpgraphql.com/acf](https://www.wpgraphql.com/acf)<br/>
+**GitHub Repository:** [https://github.com/wp-graphql/wp-graphql-acf](https://github.com/wp-graphql/wp-graphql-acf)
+
+
+## Getting Started
+
+1. Install & activate [Advanced Custom Fields](https://www.advancedcustomfields.com/).
+2. Install & activate WPGraphQL.
+3. Clone or download the [extension](https://github.com/wp-graphql/wp-graphql-acf) from GitHub & activate the **WPGraphQL Advanced Custom Fields** plugin.
+
+Now if you want to expose an ACF field group, make sure to activate `Show in GraphQL` and set the `GraphQL Field Name` in the settings of the field group. To be consistent with the schema, make sure it is written in `camelCase`.
+
+## Supported Fields
+
+WPGraphQL Advanced Custom Fields supports nearly all of the ACF (free & pro) fields. Some of the fields, such as Accordion and Tab, which are not data fields are not supported. The Clone field needs some more assessment to determine if it can properly be supported. Fields from 3rd party extensions are not supported out of the box, but we are interested in supporting the popular ones.
+
+
+### Flexible Content
+
+Lets say we have the following ACF structure with a flexible content field:
+
+#### Example Setup
+
+```json
+{
+    "title": "Flexible Content Field Group",
+    "fields": [
+        {
+            "label": "Flexible Contents",
+            "name": "flexible_contents",
+            "type": "flexible_content",
+            "show_in_graphql": 1,
+            "layouts": {
+                "layout_1": {
+                    "name": "layout_1",
+                    "label": "Layout 1",
+                    "show_in_graphql": 1,
+                    "sub_fields": [
+                        {
+                            "label": "Title",
+                            "name": "title",
+                            "type": "text",
+                            "show_in_graphql": 1
+                        }
+                    ]
+                },
+                "layout_2": {
+                    "name": "layout_2",
+                    "label": "Layout 2",
+                    "show_in_graphql": 1,
+                    "sub_fields": [
+                        {
+                            "label": "Description",
+                            "name": "description",
+                            "type": "textarea",
+                            "show_in_graphql": 1
+                        }
+                    ]
+                }
+            }
+        }
+    ],
+    "show_in_graphql": 1,
+    "graphql_field_name": "flexibleContentFieldGroup"
+}
+```
+> This is not an importable ACF JSON-File. This is simplified for illustration purposes.
+
+#### Example Query
+
+If you mapped the field group to a page, an example query would look like this:
+
+```graphql
+query GetFlexibleContentFields {
+  pages {
+    nodes {
+      flexibleContentFieldGroup {
+        flexibleContents {
+          ... on Page_Flexiblecontentfieldgroup_FlexibleContents_Layout1 {
+            title
+            fieldGroupName
+          }
+          ... on Page_Flexiblecontentfieldgroup_FlexibleContents_Layout2 {
+            description
+            fieldGroupName
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+In the response, `flexibleContents` will be an array with whatever type of layout (flexible content field) has been added to the page. With the `fieldGroupName` you can then figure out, what type of layout it is and treat it accordingly.
+
+
+### Repeater
+
+Lets say we have the following ACF structure with a repeater field:
+
+#### Example Setup
+
+```json
+{
+    "title": "Reapeater Field Group",
+    "fields": [
+        {
+            "label": "Reapeater Fields",
+            "name": "reapeater_fields",
+            "type": "repeater",
+            "show_in_graphql": 1,
+            "sub_fields": [
+                {
+                    "label": "Title",
+                    "name": "title",
+                    "type": "text",
+                    "show_in_graphql": 1
+                },
+                {
+                    "label": "Description",
+                    "name": "description",
+                    "type": "textarea",
+                    "show_in_graphql": 1
+                }
+            ]
+        }
+    ],
+    "show_in_graphql": 1,
+    "graphql_field_name": "reapeaterFieldGroup"
+}
+```
+> This is not an importable ACF JSON-File. This is simplified for illustration purposes.
+
+#### Example Query
+
+If you mapped the field group to a page, an example query would look like this:
+
+```graphql
+query GetRepeaterFields {
+  pages {
+    nodes {
+      reapeaterFieldGroup {
+        reapeaterFields {
+          title
+          description
+        }
+      }
+    }
+  }
+}
+```
+
+In the response, `reapeaterFields` will be an array of objects like: 
+
+#### Example Output
+
+```
+"reapeaterFields": [
+  {
+    "title": "test1"
+    "description": "test1"
+  },
+  {
+    "title": "test2"
+    "description": "test2"
+  },
+]
+```
+
+## ACF Options Page
+
+Reference: [https://www.advancedcustomfields.com/add-ons/options-page/](https://www.advancedcustomfields.com/add-ons/options-page/)
+
+To add an option page and expose it to the graphql schema, simply add `'show_in_graphql' => true` when you register an option page.
+
+
+#### Example Usage
+```php
+function register_acf_options_pages() {
+
+    // check function exists
+    if ( ! function_exists( 'acf_add_options_page' ) ) {
+        return;
+    }
+
+    // register options page
+    $my_options_page = acf_add_options_page(
+        array(
+            'page_title'      => __( 'My Options Page' ),
+            'menu_title'      => __( 'My Options Page' ),
+            'menu_slug'       => 'my-options-page',
+            'capability'      => 'edit_posts',
+            'show_in_graphql' => true,
+        )
+    );
+}
+
+add_action( 'acf/init', 'register_acf_options_pages' )
+```
+
+#### Example Query
+
+```graphql
+query GetMyOptionsPage {
+    myOptionsPage {
+        someCustomField
+    }
+}
+```
+
+Alternatively, it's you can check the [Fields API Reference](/extending/fields/)
+to learn about exposing your custom fields to the Schema.

--- a/docs/source/extensions/wpgraphql-content-blocks.mdx
+++ b/docs/source/extensions/wpgraphql-content-blocks.mdx
@@ -1,0 +1,136 @@
+---
+title: WPGraphQL Content Blocks
+description: Access Post Content as Blocks using GraphQL
+---
+
+## About
+
+This WPGraphQL plugin returns a WordPress post’s content as a shallow tree of blocks and allows for
+some limited validation and cleanup. This is helpful for rendering post content within
+component-based front-end ecosystems like React.
+
+## What this plugin does
+
+This plugin adds a GraphQL field called blocks to Post in WPGraphQL (and any other post types configured to appear in WPGraphQL).
+
+The blocks field contains a list of the root-level blocks that comprise the post's content. Each block is a distinct HTML element, embeddable URL, shortcode, or Gutenberg block (beta!).
+
+For example, if a post’s content field in GraphQL contained:
+
+```html
+<p>Hello world</p>
+<ul>
+	<li>Here is a list</li>
+</ul>
+```
+
+Then the `blocks` field would contain:
+
+```json
+[
+	{
+		"type": "P",
+		"innerHtml": "Hello world"
+	},
+	{
+		"type": "UL",
+		"innerHTML": "<li>Here is a list</li>"
+	}
+]
+```
+
+When consuming this field, you can now easily iterate over the blocks and map them to components in
+your component library. No more `dangerouslySetInnerHTML`-ing your entire `post_content`!
+
+## GraphQL Fields and Types
+
+An exhaustive GraphQL of a post’s blocks field would look like this:
+
+```graphql
+blocks {
+	type
+	tagName
+	innerHtml
+	attributes {
+		name
+		value
+	}
+	connections {
+		... on Post {
+			...PostParts
+		}
+		... on MediaItem {
+			...MediaItemParts
+		}
+	}
+}
+```
+
+This will return a list of BlockTypes, defined in src/types/Blocktype.php. Let’s break down each of
+these fields:
+
+### type
+
+**Type:** `BlockNameEnumType` (defined in `src/types/enums/BlockNameEnumType.php`)
+
+The name of the block. For HTML blocks, this is the uppercase version of the HTML tag name, e.g.
+`P`, `UL`, `BLOCKQUOTE`, `TABLE` etc. Shortcode and embed types are name-spaced with `SHORTCODE_` and
+`EMBED_` respectively., e.g. `SHORTCODE_CAPTION`, `EMBED_INSTAGRAM`, etc.
+
+HTML block types are hardcoded, as are Gutenberg block types (for now). Embed types are determined
+by the handlers that have been registered in global ``$wp_embed->handlers` and shortcodes are
+determined by the handlers registered with global $shortcode_tags. A complete list of permissible
+block names can seen by browsing the WPGraphQL schema.
+
+You can filter the type definitions with `graphql_blocks_definitions`.
+
+### tagName
+
+**Type:** String
+
+The suggested HTML tag name for the block. For HTML blocks, this is simply a lowercased version of
+the type field. For embeds and shortcodes, it will likely be null. This field is most useful for
+Gutenberg blocks, as a hint from the server for which tag to use when wrapping the innerHtml
+(see below).
+
+### innerHtml
+
+**Type:** String
+
+The stringified inner content of the block. Can be passed into a React component using
+`dangerouslySetInnerHTML`, for example.
+
+Note that the value of `innerHtml` is the stringified version of all the block’s descendants after
+they have been parsed. This means that any invalid tags, attributes, etc. will have been stripped
+out.
+
+### attributes
+
+**Type:** List of `BlockAttributeTypes`
+
+Each item in the list is a name/value pair describing an attribute of the block. For HTML blocks,
+these are taken from the HTML attributes, e.g.
+
+```json
+{
+	"name": "id",
+	"value": "section1"
+}
+```
+
+Note that this field will only contain valid attributes for the given Block, as defined in
+BlockDefinitions. Invalid attributes are stripped out during the parsing process
+(see How Parsing Works).
+
+### connections (beta)
+
+**Type:** List of `MenuItemObjectUnion`s
+
+The `connections` field returns an array of objects that are connected to the block. For example,
+if you wanted to upload an image and associate it with a block, that image could be queried as a
+GraphQL connection here. The `connections` field will **always be empty by default**. Presumably
+there is some way to derive these connections from the block's attributes, but we have no way of
+knowing what that correspondence is. If you'd like to use this field, it's up to you to filter
+`graphql_blocks_output` and populate the connections array as you see fit.
+
+## Blocks

--- a/docs/source/extensions/wpgraphql-dad-jokes.mdx
+++ b/docs/source/extensions/wpgraphql-dad-jokes.mdx
@@ -1,0 +1,19 @@
+---
+title: WPGraphQL Dad Jokes
+description: This is an example plugin showing how to extend the WPGraphQL Schema. This resolves data from icanhazdadjoke.com
+---
+
+# About
+
+This is an example plugin that is intended to showcase how to extend the WPGraphQL Schema.
+
+This plugin adds a new RootQuery field to the WPGraphQL Schema that allows for random a random
+Dad Joke to be queried from [icanhazdadjoke.com](https://icanhazdadjoke.com).
+
+## Example Usage
+
+```graphql
+query GetDadJoke {
+	dadJoke
+}
+```

--- a/docs/source/extensions/wpgraphql-gutenberg.mdx
+++ b/docs/source/extensions/wpgraphql-gutenberg.mdx
@@ -1,0 +1,77 @@
+---
+title: WPGraphQL Gutenberg 
+description: Expose Gutenberg content in the WPGraphQL Schema
+---
+
+
+# WPGraphQL Gutenberg
+This plugin exposes gutenberg structured content through wp-graphql.
+More information available [here](https://github.com/pristas-peter/wp-graphql-gutenberg). 
+
+
+## Query Example
+
+```graphql
+query posts {
+  postBy(slug: "hello-world") {
+    id
+    blocks {
+      __typename
+      ... on CoreHeadingBlock {
+        name
+        attributes {
+          __typename
+          ... on CoreHeadingBlockAttributes {
+            content
+            level
+          }
+        }
+      }
+      ... on CoreParagraphBlock {
+        name
+        attributes {
+          __typename
+          ... on CoreParagraphBlockAttributes {
+            backgroundColor
+            content
+          }
+          ... on CoreParagraphBlockAttributesV3 {
+            fontSize
+            content
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+```json
+{
+  "data": {
+    "postBy": {
+      "id": "cG9zdDox",
+      "blocks": [
+        {
+          "__typename": "CoreHeadingBlock",
+          "name": "core/heading",
+          "attributes": {
+            "__typename": "CoreHeadingBlockAttributes",
+            "content": "Welcome to WordPress.",
+            "level": 2
+          }
+        },
+        {
+          "__typename": "CoreParagraphBlock",
+          "name": "core/paragraph",
+          "attributes": {
+            "__typename": "CoreParagraphBlockAttributesV3",
+            "fontSize": null,
+            "content": "Welcome to WordPress. This is your first post. Edit or delete it, then start writing!"
+          }
+        }
+      ]
+    }
+  }
+}
+```

--- a/docs/source/extensions/wpgraphql-insights.mdx
+++ b/docs/source/extensions/wpgraphql-insights.mdx
@@ -1,0 +1,12 @@
+---
+title: WPGraphQL Insights
+description: Collect insights such as Tracing and Query Logs for your GraphQL Queries
+---
+
+# About WPGraphQL Insights
+
+This plugin adds additional data to the response of your GraphQL queries which can be helpful in debugging.
+
+## Trace Data
+
+This plugin adds Trace data, in accordance with the [https://github.com/apollographql/apollo-tracing](Apollo Tracing) spec.

--- a/docs/source/extensions/wpgraphql-jwt-authentication.mdx
+++ b/docs/source/extensions/wpgraphql-jwt-authentication.mdx
@@ -1,0 +1,86 @@
+---
+title: WPGraphQL JWT Authentication
+description: Authenticate to WordPress using GraphQL Mutations and use JWT tokens for subsequent requests
+---
+
+![Logo](https://www.wpgraphql.com/wp-content/uploads/2017/06/wpgraphql-logo-e1502819081849.png)
+
+[![Build Status](https://travis-ci.org/wp-graphql/wp-graphql-jwt-authentication.svg?branch=master)](https://travis-ci.org/wp-graphql/wp-graphql-jwt-authentication)
+[![Coverage Status](https://coveralls.io/repos/github/wp-graphql/wp-graphql-jwt-authentication/badge.svg?branch=master)](https://coveralls.io/github/wp-graphql/wp-graphql-jwt-authentication?branch=master)
+
+
+This plugin extends the <a href="https://github.com/wp-graphql/wp-graphql" target="_blank">WPGraphQL</a> plugin to provide authentication using JWT (JSON Web Tokens)
+
+JSON Web Tokens are an open, industry standard [RFC 7519](https://tools.ietf.org/html/rfc7519) method for representing claims securely between two parties.
+
+This plugin was initially based off the `wp-api-jwt-auth` plugin by Enrique Chavez (https://github.com/Tmeister), but modified (almost completely) for use with the <a href="https://github.com/wp-graphql/wp-graphql" target="_blank">WPGraphQL</a> plugin.
+
+## Install, Activate & Setup
+
+You can install and activate the plugin like any WordPress plugin. Download the .zip from Github and add to your plugins directory, then activate. 
+
+JWT uses a Secret defined on the server to validate the signing of tokens. 
+
+It's recommended that you use something like the WordPress Salt generator (https://api.wordpress.org/secret-key/1.1/salt/) to generate a Secret.
+
+You can define a Secret like so:
+```
+define( 'GRAPHQL_JWT_AUTH_SECRET_KEY', 'your-secret-token' );
+```
+
+Or you can use the filter `graphql_jwt_auth_secret_key` to set a Secret like so: 
+
+```
+add_filter( 'graphql_jwt_auth_secret_key', function() {
+  return 'your-secret-token';
+});
+```
+
+This secret is used in the encoding and decoding of the JWT token. If the Secret were ever changed on the server, ALL tokens that were generated with the previous Secret would become invalid. So, if you wanted to invalidate all user tokens, you can change the Secret on the server and _all_ previously issued tokens would become invalid and require users to re-authenticate.
+
+- Learn more about JWT: https://jwt.io/introduction/
+
+## HTTP_AUTHORIZATION
+
+In order to use this plugin, your WordPress environment must support the HTTP_AUTHORIZATION header. In some cases, this header is not passed to WordPress because of some server configurations.
+
+Depending on your particular environment, you may have to research how to enable these headers, but in Apache, you can do the following in your `.htaccess`:
+
+```
+SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
+```
+
+For NGINX, this may work: https://serverfault.com/questions/511206/nginx-forward-http-auth-user#answer-511612
+
+## How the plugin Works
+
+This plugin adds a new `login` mutation to the WPGraphQL Schema. 
+
+This can be used like so: 
+
+```
+mutation LoginUser {
+  login( input: {
+    clientMutationId:"uniqueId"
+    username: "your_login"
+    password: "your password"
+  } ) {
+    authToken
+    user {
+      id
+      name
+    }
+  }
+}
+```
+
+The `authToken` that is received in response to the login mutation can then be stored in local storage (or similar) and 
+used in subsequent requests as an HTTP Authorization header to Authenticate the user prior to execution of the 
+GraphQL request. 
+
+- **Set authorization header in Apollo Client**: https://www.apollographql.com/docs/react/networking/authentication/#header
+- **Set authorization header in Relay Modern**: https://relay.dev/docs/en/network-layer.html
+- **Set authorization header in Axios**: https://github.com/axios/axios#axioscreateconfig
+
+## Example using GraphiQL
+![Example using GraphiQL](https://github.com/wp-graphql/wp-graphql-jwt-authentication/blob/master/img/jwt-auth-example.gif?raw=true)

--- a/docs/source/extensions/wpgraphql-meta-query.mdx
+++ b/docs/source/extensions/wpgraphql-meta-query.mdx
@@ -1,0 +1,22 @@
+---
+title: WPGraphQL Meta Query
+description: Plugin that exposes the ability to query Post objects via Meta arguments
+---
+
+# About
+
+This extension exposes arguments to PostObject connections allowing for posts to be filtered
+by meta fields.
+
+## Examples
+
+@todo
+
+## Why isn't this in the core WPGraphQL plugin?
+
+Meta Queries can be expensive. They've even been known to take down production sites. Instead of
+enabling meta queries by default, they've been left out intentionally to allow site owners the
+chance to critically think about whether or not they would like to support the functionality.
+
+Many sites can support Meta Queries without issue, but many sites can have serious problems if
+Meta Queries are executed.

--- a/docs/source/extensions/wpgraphql-seopress.mdx
+++ b/docs/source/extensions/wpgraphql-seopress.mdx
@@ -1,0 +1,9 @@
+---
+title: WPGraphQL for SEOPress 
+description: Expose SEOPress data in WPGraphQL Schema
+---
+
+
+# WPGraphQL SEOPress
+This plugin exposes SEOPress structured content through wp-graphql.
+More information available at the [Github repository](https://github.com/moonmeister/wp-graphql-seopress). 

--- a/docs/source/extensions/wpgraphql-tax-query.mdx
+++ b/docs/source/extensions/wpgraphql-tax-query.mdx
@@ -1,0 +1,22 @@
+---
+title: WPGraphQL Tax Query
+description: Plugin that exposes the ability to query Post objects via TaxQuery arguments
+---
+
+# About
+
+This extension exposes arguments to PostObject connections allowing for posts to be filtered
+by taxonomy/term fields.
+
+## Examples
+
+`@todo`
+
+## Why isn't this in the core WPGraphQL plugin?
+
+The shape of the input fields is still under debate. The ability to filter PostObject connections
+by terms will exist in the core plugin in some form, but how it should look is still up in the air.
+
+This plugin exists as one implementation, but how it looks in the core plugin will likely be different.
+
+In the mean time, this is a good option if you need that functionality.

--- a/docs/source/extensions/wpgraphql-woocommerce.mdx
+++ b/docs/source/extensions/wpgraphql-woocommerce.mdx
@@ -1,0 +1,113 @@
+---
+title: WPGraphQL WooCommerce (WooGraphQL)
+description: Expose WooCommerce in the WPGraphQL Schema
+---
+
+import GraphiQL from '../../src/components/GraphiQL'
+import Note from '../../src/components/Note'
+
+# WPGraphQL WooCommerce
+
+[WPGraphQL WooCommerce](https://github.com/wp-graphql/wp-graphql-woocommerce) is a free, open-source WPGraphQL extension that adds WooCommerce functionality to the WPGraphQL API.
+
+<Note title="In Development" type="warning">
+  This plugin is still in the early stages of the development and may contain
+  many bugs or lack some functionality. Using in production is not recommended.
+</Note>
+
+# Getting Started
+
+1. Install & activate [WooCommerce](https://woocommerce.com/)
+2. Install & activate WPGraphQL.
+3. (Optional) Install & activate [WPGraphQL-JWT-Authentication](https://github.com/wp-graphql/wp-graphql-jwt-authentication) to add a `login` mutation that returns a JSON Web Token.
+4. Clone or download the [extension](https://github.com/wp-graphql/wp-graphql-woocommerce) & activate the **WP GraphQL WooCommerce** plugin
+
+# Playground
+
+This is a playground connected to the most stable release of the extension.
+
+<GraphiQL
+  endpoint="https://woographql.axistaylor.com/graphql"
+  authButtons={{
+    Customer: ['customer', 'graphql_rocks'],
+    ShopManager: ['shop_manager', 'graphql_rocks'],
+  }}
+  query="
+    {
+      products {
+        nodes {
+            id
+            productId
+            name
+            type
+            price
+            variations {
+                nodes {
+                    id
+                    variationId
+                }
+            }
+        }
+      }
+    }
+    "
+  withDocs={true}
+  showJoyride={false}
+/>
+
+<Note title="Query as a Customer or Shop Manager" type="success">
+  WooGraphQL has many features not available to anomymous user. Try selecting one of the users above and once the indicator on the button is green your logged in.
+
+Here an example queries exclusive to registered customer.
+
+<pre style={{ fontSize: '0.8em', padding: '0 2em' }}>
+  {`query {
+  customer {
+    firstName
+    lastName
+  }
+  cart {
+    contents {
+      nodes {
+        product {
+          id
+          name
+          sku
+        }
+      }
+    }
+  }
+}`}
+</pre>
+
+Here a query exclusive to shop managers and administrators.
+
+<pre style={{ fontSize: '0.8em', padding: '0 2em' }}>
+  {`query {
+  orders {
+    edges {
+      cursor
+      node {
+        id
+        orderId
+        lineItems {
+          nodes {
+            itemId
+            product {
+              id
+              name
+              price
+            }
+            quantity
+            total
+          }
+        }
+        subtotal
+        total
+      }
+    }
+  }
+}`}
+</pre>
+
+</Note>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Some extension docs where removed in some commit, I've tried digging them up and add them back again. I've not changed any content I just digged thought to commit to find where the .mdx files where still available 



Does this close any currently open issues?
------------------------------------------
https://github.com/wp-graphql/wp-graphql-acf/issues/162


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
Only doc changes



