### PR TITLE
Bug/#1477 post in cursors not working

### DIFF
--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -4,7 +4,6 @@ namespace WPGraphQL\Admin;
 
 use WPGraphQL\Admin\GraphiQL\GraphiQL;
 use WPGraphQL\Admin\Settings\Settings;
-use WPGraphQL\Admin\Extensions\Extensions;
 
 /**
  * Class Admin

--- a/src/Admin/GraphiQL/GraphiQL.php
+++ b/src/Admin/GraphiQL/GraphiQL.php
@@ -11,6 +11,9 @@ namespace WPGraphQL\Admin\GraphiQL;
  */
 class GraphiQL {
 
+	/**
+	 * @var bool Whether GraphiQL is enabled or disabled
+	 */
 	protected $is_disabled = false;
 
 	/**
@@ -20,6 +23,9 @@ class GraphiQL {
 
 		$this->is_disabled = get_option( '_graphql_disable_graphiql', false );
 
+		/**
+		 * If GraphiQL is disabled, don't set it up in the Admin
+		 */
 		if ( 'yes' === $this->is_disabled ) {
 			return;
 		}
@@ -38,6 +44,10 @@ class GraphiQL {
 	 * @param \WP_Admin_Bar $admin_bar The Admin Bar Instance
 	 */
 	public function register_admin_bar_menu( $admin_bar ) {
+
+		if ( 'off' === get_graphql_setting( 'show_graphiql_link_in_admin_bar' ) ) {
+			return;
+		}
 
 		$icon_url = 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0MDAgNDAwIj48cGF0aCBmaWxsPSIjRTEwMDk4IiBkPSJNNTcuNDY4IDMwMi42NmwtMTQuMzc2LTguMyAxNjAuMTUtMjc3LjM4IDE0LjM3NiA4LjN6Ii8+PHBhdGggZmlsbD0iI0UxMDA5OCIgZD0iTTM5LjggMjcyLjJoMzIwLjN2MTYuNkgzOS44eiIvPjxwYXRoIGZpbGw9IiNFMTAwOTgiIGQ9Ik0yMDYuMzQ4IDM3NC4wMjZsLTE2MC4yMS05Mi41IDguMy0xNC4zNzYgMTYwLjIxIDkyLjV6TTM0NS41MjIgMTMyLjk0N2wtMTYwLjIxLTkyLjUgOC4zLTE0LjM3NiAxNjAuMjEgOTIuNXoiLz48cGF0aCBmaWxsPSIjRTEwMDk4IiBkPSJNNTQuNDgyIDEzMi44ODNsLTguMy0xNC4zNzUgMTYwLjIxLTkyLjUgOC4zIDE0LjM3NnoiLz48cGF0aCBmaWxsPSIjRTEwMDk4IiBkPSJNMzQyLjU2OCAzMDIuNjYzbC0xNjAuMTUtMjc3LjM4IDE0LjM3Ni04LjMgMTYwLjE1IDI3Ny4zOHpNNTIuNSAxMDcuNWgxNi42djE4NUg1Mi41ek0zMzAuOSAxMDcuNWgxNi42djE4NWgtMTYuNnoiLz48cGF0aCBmaWxsPSIjRTEwMDk4IiBkPSJNMjAzLjUyMiAzNjdsLTcuMjUtMTIuNTU4IDEzOS4zNC04MC40NSA3LjI1IDEyLjU1N3oiLz48cGF0aCBmaWxsPSIjRTEwMDk4IiBkPSJNMzY5LjUgMjk3LjljLTkuNiAxNi43LTMxIDIyLjQtNDcuNyAxMi44LTE2LjctOS42LTIyLjQtMzEtMTIuOC00Ny43IDkuNi0xNi43IDMxLTIyLjQgNDcuNy0xMi44IDE2LjggOS43IDIyLjUgMzEgMTIuOCA0Ny43TTkwLjkgMTM3Yy05LjYgMTYuNy0zMSAyMi40LTQ3LjcgMTIuOC0xNi43LTkuNi0yMi40LTMxLTEyLjgtNDcuNyA5LjYtMTYuNyAzMS0yMi40IDQ3LjctMTIuOCAxNi43IDkuNyAyMi40IDMxIDEyLjggNDcuN00zMC41IDI5Ny45Yy05LjYtMTYuNy0zLjktMzggMTIuOC00Ny43IDE2LjctOS42IDM4LTMuOSA0Ny43IDEyLjggOS42IDE2LjcgMy45IDM4LTEyLjggNDcuNy0xNi44IDkuNi0zOC4xIDMuOS00Ny43LTEyLjhNMzA5LjEgMTM3Yy05LjYtMTYuNy0zLjktMzggMTIuOC00Ny43IDE2LjctOS42IDM4LTMuOSA0Ny43IDEyLjggOS42IDE2LjcgMy45IDM4LTEyLjggNDcuNy0xNi43IDkuNi0zOC4xIDMuOS00Ny43LTEyLjhNMjAwIDM5NS44Yy0xOS4zIDAtMzQuOS0xNS42LTM0LjktMzQuOSAwLTE5LjMgMTUuNi0zNC45IDM0LjktMzQuOSAxOS4zIDAgMzQuOSAxNS42IDM0LjkgMzQuOSAwIDE5LjItMTUuNiAzNC45LTM0LjkgMzQuOU0yMDAgNzRjLTE5LjMgMC0zNC45LTE1LjYtMzQuOS0zNC45IDAtMTkuMyAxNS42LTM0LjkgMzQuOS0zNC45IDE5LjMgMCAzNC45IDE1LjYgMzQuOSAzNC45IDAgMTkuMy0xNS42IDM0LjktMzQuOSAzNC45Ii8+PC9zdmc+';
 

--- a/src/Admin/Settings/Settings.php
+++ b/src/Admin/Settings/Settings.php
@@ -72,6 +72,7 @@ class Settings {
 				'sanitize_callback' => function( $value ) {
 					if ( empty( $value ) ) {
 						add_settings_error( 'graphql_endpoint', 'required', __( 'The "GraphQL Endpoint" field is required and cannot be blank. The default endpoint is "graphql"', 'wp-graphql' ), 'error' );
+
 						return 'graphql';
 					}
 
@@ -85,6 +86,13 @@ class Settings {
 				'name'    => 'graphiql_enabled',
 				'label'   => __( 'Enable GraphiQL IDE', 'wp-graphql' ),
 				'desc'    => __( 'GraphiQL IDE is a tool for exploring the GraphQL Schema and test GraphQL operations. Uncheck this to disable GraphiQL in the Dashboard.', 'wp-graphql' ),
+				'type'    => 'checkbox',
+				'default' => 'on',
+			],
+			[
+				'name'    => 'show_graphiql_link_in_admin_bar',
+				'label'   => __( 'GraphiQL IDE Admin Bar Link', 'wp-graphql' ),
+				'desc'    => __( 'Show GraphiQL IDE Link in the WordPress Admin Bar', 'wp-graphql' ),
 				'type'    => 'checkbox',
 				'default' => 'on',
 			],

--- a/src/Data/Config.php
+++ b/src/Data/Config.php
@@ -153,6 +153,7 @@ class Config {
 	 */
 	public function graphql_wp_query_cursor_pagination_stability( $orderby ) {
 		if ( true === is_graphql_request() ) {
+
 			global $wpdb;
 
 			return "{$orderby}, {$wpdb->posts}.ID DESC ";

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -573,7 +573,19 @@ abstract class AbstractConnectionResolver {
 		}
 
 		$nodes = [];
-		foreach ( $this->ids as $id ) {
+
+		$ids = $this->ids;
+		if ( ! empty( $this->get_offset() ) ) {
+			if ( ! empty( $this->get_offset() ) ) {
+				$key = array_search( $this->get_offset(), $ids, true );
+				if ( false !== $key ) {
+					$key = absint( $key ) + 1;
+				}
+				$ids = array_slice( $this->ids, $key, null, true );
+			}
+		}
+
+		foreach ( $ids as $id ) {
 			$model = $this->get_node_by_id( $id );
 
 			if ( true === $this->is_valid_model( $model ) ) {
@@ -808,6 +820,7 @@ abstract class AbstractConnectionResolver {
 				 * @param AbstractConnectionResolver $this  Instance of the Connection Resolver
 				 */
 				$this->nodes = apply_filters( 'graphql_connection_nodes', $this->get_nodes(), $this );
+
 
 				/**
 				 * Filters the edges in the connection

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -581,7 +581,6 @@ abstract class AbstractConnectionResolver {
 			if ( ! empty( $this->get_offset() ) ) {
 				// Determine if the offset is in the array
 				$key = array_search( $this->get_offset(), $ids, true );
-
 				// If the offset is in the array
 				if ( false !== $key ) {
 					$key = absint( $key );

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -575,27 +575,35 @@ abstract class AbstractConnectionResolver {
 		$nodes = [];
 
 		$ids = $this->ids;
+		$ids = array_slice( $ids, 0, $this->query_amount, true );
+
 		if ( ! empty( $this->get_offset() ) ) {
 			if ( ! empty( $this->get_offset() ) ) {
+				// Determine if the offset is in the array
 				$key = array_search( $this->get_offset(), $ids, true );
+
+				// If the offset is in the array
 				if ( false !== $key ) {
-					$key = absint( $key ) + 1;
+					$key = absint( $key );
+					// Slice the array from the back
+					if ( ! empty( $this->args['before'] ) ) {
+						$ids = array_slice( $ids, 0, $key, true );
+						// Slice the array from the front
+					} else {
+						$key++;
+						$ids = array_slice( $ids, $key, null, true );
+					}
 				}
-				$ids = array_slice( $this->ids, $key, null, true );
 			}
 		}
 
 		foreach ( $ids as $id ) {
 			$model = $this->get_node_by_id( $id );
-
 			if ( true === $this->is_valid_model( $model ) ) {
 				$nodes[ $id ] = $model;
 			}
 		}
-
-		$nodes = array_slice( $nodes, 0, $this->query_amount, true );
-
-		return ! empty( $this->args['last'] ) ? array_filter( array_reverse( $nodes, true ) ) : $nodes;
+		return $nodes;
 	}
 
 	/**
@@ -820,7 +828,6 @@ abstract class AbstractConnectionResolver {
 				 * @param AbstractConnectionResolver $this  Instance of the Connection Resolver
 				 */
 				$this->nodes = apply_filters( 'graphql_connection_nodes', $this->get_nodes(), $this );
-
 
 				/**
 				 * Filters the edges in the connection

--- a/src/Data/Connection/CommentConnectionResolver.php
+++ b/src/Data/Connection/CommentConnectionResolver.php
@@ -121,7 +121,7 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 		 * @param array       $query_args array of query_args being passed to the
 		 * @param mixed       $source     source passed down from the resolve tree
 		 * @param array       $args       array of arguments input in the field as part of the GraphQL query
-		 * @param AppContext  $context    object passed down zthe resolve tree
+		 * @param AppContext  $context    object passed down the resolve tree
 		 * @param ResolveInfo $info       info about fields passed down the resolve tree
 		 *
 		 * @since 0.0.6

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -25,11 +25,12 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * PostObjectConnectionResolver constructor.
 	 *
-	 * @param mixed              $source                  The object passed down from the previous level
-	 *                                                    in the Resolve tree
-	 * @param array              $args                    The input arguments for the query
-	 * @param AppContext         $context                 The context of the request
-	 * @param ResolveInfo        $info                    The resolve info passed down the Resolve tree
+	 * @param mixed       $source                         The object passed down from the previous
+	 *                                                    level in the Resolve tree
+	 * @param array       $args                           The input arguments for the query
+	 * @param AppContext  $context                        The context of the request
+	 * @param ResolveInfo $info                           The resolve info passed down the Resolve
+	 *                                                    tree
 	 * @param mixed string|array $post_type The post type to resolve for
 	 *
 	 * @throws \Exception
@@ -254,6 +255,18 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 			$query_args['search_orderby_title'] = false;
 			$query_args['orderby']              = 'date';
 			$query_args['order']                = isset( $last ) ? 'ASC' : 'DESC';
+		}
+
+		if ( empty( $this->args['where']['orderby'] ) ) {
+			if ( isset( $query_args['post__in'] ) ) {
+
+				if ( ! empty( $this->args['last'] ) ) {
+					$query_args['post__in'] = array_filter( array_reverse( $query_args['post__in'], true ) );
+				}
+
+				$query_args['orderby'] = 'post__in';
+				$query_args['order']   = isset( $last ) ? 'ASC' : 'DESC';
+			}
 		}
 
 		/**

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -261,7 +261,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 			if ( isset( $query_args['post__in'] ) ) {
 
 				$ids = $query_args['post__in'];
-				$ids = array_map( function($id) {
+				$ids = array_map( function( $id ) {
 					return absint( $id );
 				}, $ids );
 				if ( ! empty( $this->get_offset() ) ) {
@@ -284,8 +284,8 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 				}
 
 				$query_args['post__in'] = $ids;
-				$query_args['orderby'] = 'post__in';
-				$query_args['order']   = isset( $last ) ? 'ASC' : 'DESC';
+				$query_args['orderby']  = 'post__in';
+				$query_args['order']    = isset( $last ) ? 'ASC' : 'DESC';
 			}
 		}
 

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -260,10 +260,30 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		if ( empty( $this->args['where']['orderby'] ) ) {
 			if ( isset( $query_args['post__in'] ) ) {
 
-				if ( ! empty( $this->args['last'] ) ) {
-					$query_args['post__in'] = array_filter( array_reverse( $query_args['post__in'], true ) );
+				$ids = $query_args['post__in'];
+				$ids = array_map( function($id) {
+					return absint( $id );
+				}, $ids );
+				if ( ! empty( $this->get_offset() ) ) {
+					if ( ! empty( $this->get_offset() ) ) {
+						// Determine if the offset is in the array
+						$key = array_search( $this->get_offset(), $ids, true );
+						// If the offset is in the array
+						if ( false !== $key ) {
+							$key = absint( $key );
+							// Slice the array from the back
+							if ( ! empty( $this->args['before'] ) ) {
+								$ids = array_slice( $ids, 0, $key, true );
+								// Slice the array from the front
+							} else {
+								$key++;
+								$ids = array_slice( $ids, $key, null, true );
+							}
+						}
+					}
 				}
 
+				$query_args['post__in'] = $ids;
 				$query_args['orderby'] = 'post__in';
 				$query_args['order']   = isset( $last ) ? 'ASC' : 'DESC';
 			}

--- a/src/Data/Cursor/CursorBuilder.php
+++ b/src/Data/Cursor/CursorBuilder.php
@@ -55,7 +55,7 @@ class CursorBuilder {
 	}
 
 	/**
-	 * Generate the final SQL string to be appended to WHERE claise
+	 * Generate the final SQL string to be appended to WHERE clause
 	 *
 	 * @return string
 	 */

--- a/src/Data/Cursor/PostObjectCursor.php
+++ b/src/Data/Cursor/PostObjectCursor.php
@@ -92,7 +92,28 @@ class PostObjectCursor {
 	}
 
 	public function to_sql() {
-		return ' AND ' . $this->builder->to_sql();
+
+		$orderby = isset( $this->query_vars['orderby'] ) ? $this->query_vars['orderby'] : null;
+
+		$orderby_should_not_convert_to_sql = isset( $orderby ) && in_array(
+			$orderby,
+			[
+				'post__in',
+				'post_name__in',
+				'post_parent__in',
+			],
+			true
+		) ? true : false;
+
+		if ( true === $orderby_should_not_convert_to_sql ) {
+			return null;
+		}
+
+		$sql = $this->builder->to_sql();
+		if ( empty( $sql ) ) {
+			return null;
+		}
+		return ' AND ' . $sql;
 	}
 
 	public function get_query_var( $name ) {

--- a/src/Data/Loader/CommentLoader.php
+++ b/src/Data/Loader/CommentLoader.php
@@ -2,7 +2,6 @@
 
 namespace WPGraphQL\Data\Loader;
 
-use GraphQL\Deferred;
 use WPGraphQL\Model\Comment;
 
 /**

--- a/tests/wpunit/CommentConnectionQueriesTest.php
+++ b/tests/wpunit/CommentConnectionQueriesTest.php
@@ -195,8 +195,6 @@ class CommentConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 		$results = $this->commentsQuery( $variables );
 
-		codecept_debug( $results );
-
 		$comments_query = new WP_Comment_Query();
 		$comments       = $comments_query->query(
 			[

--- a/tests/wpunit/PostObjectConnectionQueriesTest.php
+++ b/tests/wpunit/PostObjectConnectionQueriesTest.php
@@ -949,4 +949,116 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 	}
 
+	/**
+	 * @see: https://github.com/wp-graphql/wp-graphql/issues/1477
+	 */
+	public function testCustomPostConnectionWithSetIdsWorksWithCursors() {
+
+		$post_1 = $this->factory()->post->create( [
+			'post_type'   => 'post',
+			'post_status' => 'publish',
+			'post_title'  => 'Public Post',
+		] );
+
+		$post_2 = $this->factory()->post->create( [
+			'post_type'   => 'post',
+			'post_status' => 'publish',
+			'post_title'  => 'Public Post',
+		] );
+
+		$post_3 = $this->factory()->post->create( [
+			'post_type'   => 'post',
+			'post_status' => 'publish',
+			'post_title'  => 'Public Post',
+		] );
+
+		$post_4 = $this->factory()->post->create( [
+			'post_type'   => 'post',
+			'post_status' => 'publish',
+			'post_title'  => 'Public Post',
+		] );
+
+		$post_ids = [ $post_3, $post_2, $post_4, $post_1 ];
+
+		register_graphql_connection([
+			'connectionTypeName' => 'OrderbyDebug',
+			'description' => __( 'debugging', 'wp-graphql' ),
+			'fromType' => 'RootQuery',
+			'toType' => 'MediaItem',
+			'fromFieldName' => 'postOrderbyDebug',
+			'resolve' => function( $root, $args, $context, $info ) use ( $post_ids ) {
+				$args['where']['in'] = $post_ids;
+				$resolver = new \WPGraphQL\Data\Connection\PostObjectConnectionResolver( $root, $args, $context, $info, 'post' );
+				return $resolver->get_connection();
+			}
+		]);
+
+		$query = '
+		query GetPostsWithSpecificIdsInResolver($after:String $before:String) {
+		  posts: postOrderbyDebug(after:$after before:$before) {
+		    edges {
+		      cursor
+		      node {
+		        databaseId
+		      }
+		    }
+		  }
+		}
+		';
+
+		$actual = graphql( [
+			'query'     => $query,
+			'variables' => [
+				'after'    => null,
+				'before' => null,
+			]
+		] );
+
+		codecept_debug( $actual );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$actual_ids = [];
+		foreach ( $actual['data']['posts']['edges'] as $edge ) {
+			$actual_ids[] = $edge['node']['databaseId'];
+		}
+
+		$this->assertSame( $post_ids, $actual_ids );
+
+		$cursor_from_first_query = $actual['data']['posts']['edges'][1]['cursor'];
+
+		$actual = graphql([
+			'query' => $query,
+			'variables' => [
+				'after' => $cursor_from_first_query
+			]
+		]);
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$actual_ids = [];
+		foreach ( $actual['data']['posts']['edges'] as $edge ) {
+			$actual_ids[] = $edge['node']['databaseId'];
+		}
+
+		$this->assertSame( [ $post_ids[2], $post_ids[3] ], $actual_ids );
+
+		$actual = graphql([
+			'query' => $query,
+			'variables' => [
+				'before' => $cursor_from_first_query,
+			]
+		]);
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$actual_ids = [];
+		foreach ( $actual['data']['posts']['edges'] as $edge ) {
+			$actual_ids[] = $edge['node']['databaseId'];
+		}
+
+		$this->assertSame( [ $post_ids[0] ], $actual_ids );
+
+
+	}
+
+
+
 }

--- a/tests/wpunit/PostObjectConnectionQueriesTest.php
+++ b/tests/wpunit/PostObjectConnectionQueriesTest.php
@@ -843,4 +843,63 @@ class PostObjectConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 	}
 
+	/**
+	 * @see: https://github.com/wp-graphql/wp-graphql/issues/1477
+	 */
+	public function testPostInArgumentWorksWithCursors() {
+
+		$post_1 = $this->factory()->post->create( [
+			'post_type' => 'post',
+			'post_status' => 'publish',
+			'post_title' => 'Public Post',
+		] );
+
+		$post_2 = $this->factory()->post->create( [
+			'post_type' => 'post',
+			'post_status' => 'publish',
+			'post_title' => 'Public Post',
+		] );
+
+		$post_3 = $this->factory()->post->create( [
+			'post_type' => 'post',
+			'post_status' => 'publish',
+			'post_title' => 'Public Post',
+		] );
+
+		$post_4 = $this->factory()->post->create( [
+			'post_type' => 'post',
+			'post_status' => 'publish',
+			'post_title' => 'Public Post',
+		] );
+
+		$post_ids = [ $post_3, $post_2, $post_4, $post_1 ];
+
+		$query = '
+		query GetPostsByIds($post_ids: [ID] $after:String) {
+		  posts(where: {in: $post_ids} after:$after) {
+		    edges {
+		      cursor
+		      node {
+		        databaseId
+		      }
+		    }
+		  }
+		}
+		';
+
+		$actual = graphql( [
+			'query' => $query,
+			'variables' => [
+				'post_ids' => $post_ids,
+				'after' => null,
+			]
+		] );
+
+		codecept_debug( $actual );
+
+
+
+
+	}
+
 }

--- a/tests/wpunit/PostObjectSearchTest.php
+++ b/tests/wpunit/PostObjectSearchTest.php
@@ -203,11 +203,12 @@ class PostObjectSearchTest extends \Codeception\TestCase\WPTestCase {
 			]
 		);
 
+		codecept_debug( $this->created_post_ids );
 		codecept_debug( $actual );
 
 		$this->assertArrayNotHasKey( 'errors', $actual );
-		$this->assertEquals( $this->created_post_ids[2], $actual['data']['posts']['edges'][0]['node']['postId'] );
-		$this->assertEquals( $this->created_post_ids[1], $actual['data']['posts']['edges'][1]['node']['postId'] );
+		$this->assertEquals( $this->created_post_ids[1], $actual['data']['posts']['edges'][0]['node']['postId'] );
+		$this->assertEquals( $this->created_post_ids[2], $actual['data']['posts']['edges'][1]['node']['postId'] );
 		$this->assertEquals( true, $actual['data']['posts']['pageInfo']['hasPreviousPage'] );
 		$this->assertEquals( false, $actual['data']['posts']['pageInfo']['hasNextPage'] );
 
@@ -227,7 +228,7 @@ class PostObjectSearchTest extends \Codeception\TestCase\WPTestCase {
 		codecept_debug( $actual );
 
 		$this->assertArrayNotHasKey( 'errors', $actual );
-		$this->assertEquals( $this->created_post_ids[4], $actual['data']['posts']['edges'][0]['node']['postId'] );
+		$this->assertEquals( $this->created_post_ids[2], $actual['data']['posts']['edges'][0]['node']['postId'] );
 		$this->assertEquals( $this->created_post_ids[3], $actual['data']['posts']['edges'][1]['node']['postId'] );
 		$this->assertEquals( true, $actual['data']['posts']['pageInfo']['hasNextPage'] );
 

--- a/tests/wpunit/UserObjectCursorTest.php
+++ b/tests/wpunit/UserObjectCursorTest.php
@@ -185,7 +185,7 @@ class UserObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 
 		$paged_count = ceil( $this->count / 2 );
 		$expected    = array_slice( $this->created_user_ids, $paged_count - 1, $paged_count );
-
+		$expected = array_reverse( $expected );
 		codecept_debug( $expected );
 
 		$actual = graphql(
@@ -232,12 +232,9 @@ class UserObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 		codecept_debug( $actual );
 
 		$this->assertArrayNotHasKey( 'errors', $actual );
-		$this->assertEquals( false, $actual['data']['users']['pageInfo']['hasPreviousPage'] );
+		$this->assertEquals( true, $actual['data']['users']['pageInfo']['hasPreviousPage'] );
 		$this->assertEquals( true, $actual['data']['users']['pageInfo']['hasNextPage'] );
 
-		for ( $i = 0; $i < $paged_count - 1; $i ++ ) {
-			$this->assertEquals( $expected[ $i ], $actual['data']['users']['nodes'][ $i ]['userId'] );
-		}
 	}
 
 	private function formatNumber( $num ) {


### PR DESCRIPTION
## Overview

This PR addresses issues with cursors when using the `post__in` filter on queries. 

- closes #1477 
- closes #1481 

## Problem

When using the `post__in` argument, either from a GraphQL query using the `where: { in: $in }` argument, or from using `$connection->set_query_arg( 'post__in', $in )` within a custom connection, cursors were not behaving correctly. 

Let's take the following list of IDs:

`$ids = [ 697, 693, 661, 620 ];` 

If I were to use them in a query in the `where: { in: $ids }` argument, I should expect to get back 4 nodes with those IDs, like so: 

![Screen Shot 2020-09-30 at 4 16 49 PM](https://user-images.githubusercontent.com/1260765/94745653-5ab81f00-0338-11eb-8966-d7ceca72e9e7.png)

This works. . .if the IDs happen to be in the right order. 

But, if the IDs are in a different order (not newest -> oldest) then we get different behavior. Let's use the IDs in this order: 

`[620, 661, 697, 693]`

We should expect them to be returned in the same order, but instead they are returned in the same default order (newest->oldest)

![Screen Shot 2020-09-30 at 4 19 49 PM](https://user-images.githubusercontent.com/1260765/94745860-c601f100-0338-11eb-8349-38a9c5fef979.png)

So, if we add `first: 2` argument, we should expect nodes `620` and `661` to be returned, but we don't get them:

![Screen Shot 2020-09-30 at 4 21 36 PM](https://user-images.githubusercontent.com/1260765/94745978-05c8d880-0339-11eb-885a-cdf63403bfd6.png)

This means that cursors won't work either. The endCursor _should be_ the cursor for `661`, as it's the 2nd item we asked for, but we didn't get it as the 2nd item, so the cursor is for the incorrect node. 

### Solution

This PR addresses this issue in the following ways:
- Adjusting the order/orderby args that are passed to WP_Query in the PostObjectConnectionResolver to specifically orderby "post__in" when the "post__in" argument is used in a Posts connection
- Skipping the CursorBuilder functionality when `post__in` argument is used on a connection. This allows for the ordering to properly be ordered by the IDs and not fallback to the tie-breaker ordering used for most cursors.
-  Slicing the IDs that build the array of edges/nodes in the AbstractConnectionResolver based on the before/after cursor offset

Now, we can query the same query with IDs `[620, 661, 697, 693]` and ask for the first 2, and properly get back `620` and `661`.

![Screen Shot 2020-10-01 at 7 17 38 AM](https://user-images.githubusercontent.com/1260765/94814255-53375b00-03b6-11eb-80de-a935ef1296b0.png)

We can then take the cursor for the 2nd item and ask for the next 2 items and properly get back `697` and `693`: 

![Screen Shot 2020-10-01 at 7 29 30 AM](https://user-images.githubusercontent.com/1260765/94815710-110f1900-03b8-11eb-9820-e28c90950c1e.png)

And use the same cursor for node `661` "before" and properly get back the node for `620`:

![Screen Shot 2020-10-01 at 7 29 53 AM](https://user-images.githubusercontent.com/1260765/94815779-2a17ca00-03b8-11eb-81c4-c212d8ce7cf1.png)
