### PR TITLE
bugfix/taxonomy terms cannot be removed

### DIFF
--- a/src/Data/PostObjectMutation.php
+++ b/src/Data/PostObjectMutation.php
@@ -355,20 +355,17 @@ class PostObjectMutation {
 							}
 						}
 
+					
+
 						/**
-						 * If there are terms to connect, set the connection
+						 * If the current user cannot edit terms, don't create terms to connect
 						 */
-						if ( ! empty( $terms_to_connect ) && is_array( $terms_to_connect ) ) {
-
-							/**
-							 * If the current user cannot edit terms, don't create terms to connect
-							 */
-							if ( ! current_user_can( $tax_object->cap->assign_terms ) ) {
-								return;
-							}
-
-							wp_set_object_terms( $post_id, $terms_to_connect, $tax_object->name, $append );
+						if ( ! current_user_can( $tax_object->cap->assign_terms ) ) {
+							return;
 						}
+
+						wp_set_object_terms( $post_id, $terms_to_connect, $tax_object->name, $append );
+						
 					}
 				}
 			}


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](.github/CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
… Custom Taxonomy Terms cannot be removed. Example

Currently,  we can update a post's taxonomy terms by doing the following. 

````
mutation update {
  updatePost(input: {
		clientMutationId: "123", 
		id: "cG9zdDoxNzk4", 
		customTaxonomyTerm: {append: false, nodes:[{slug:"first"},{slug:"second"}]}}) {
    clientMutationId
  }
}

````

However, we cannot remove those terms (we can set `append` to `true` to replace the terms with another array of terms, but that array has to be non- empty). As a consequence, the following mutation has no affect.


````
mutation update {
  updateCorrectiveAction(input: {
		clientMutationId: "123", 
		id: "cG9zdDoxNzk4", 
		severities: {append: false, nodes:[]}}) {
    clientMutationId
  }
}

````

It is caused by the `if` block here https://github.com/wp-graphql/wp-graphql/blob/develop/src/Data/PostObjectMutation.php#L361

`is_array( $terms_to_connect )` is redundant since `$terms_to_connect` is initialized to be an array.

`! empty( $terms_to_connect )` is the cause of this issue. 

Therefore we can simply remove the `if` block all together



Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
