### PR TITLE
Change isset to !empty on the ordering to match WordPress's behavior.

### DIFF
--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -258,7 +258,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		}
 
 		if ( empty( $this->args['where']['orderby'] ) ) {
-			if ( isset( $query_args['post__in'] ) ) {
+			if ( ! empty( $query_args['post__in'] ) ) {
 
 				$ids = $query_args['post__in'];
 				$ids = array_map( function( $id ) {


### PR DESCRIPTION
When passing an empty array to ['where']['in'], wp-graphql will return posts back in ASC order starting from the oldest. WP_Query's default behavior is returning the set in DESC order from the newest. Changing this function will use WordPress's behavior.