### PR TITLE
Add isSticky Boolean field to Posts

### DIFF
--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -36,6 +36,7 @@ use WPGraphQL\Utils\Utils;
  * @property boolean $isPostsPage
  * @property boolean $isPreview
  * @property boolean $isRevision
+ * @property boolean $isSticky
  * @property string  $toPing
  * @property string  $pinged
  * @property string  $modified
@@ -687,6 +688,9 @@ class Post extends Model {
 					}
 
 					return false;
+				},
+				'isSticky'                 => function() {
+					return is_sticky( $this->parentDatabaseId );
 				},
 			];
 

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -689,7 +689,7 @@ class Post extends Model {
 
 					return false;
 				},
-				'isSticky'                 => function() {
+				'isSticky'                  => function() {
 					return is_sticky( $this->parentDatabaseId );
 				},
 			];

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -689,10 +689,12 @@ class Post extends Model {
 
 					return false;
 				},
-				'isSticky'                  => function() {
-					return is_sticky( $this->parentDatabaseId );
+				'isSticky'                 => function() {
+					return is_sticky( $this->databaseId );
 				},
 			];
+
+
 
 			if ( 'attachment' === $this->data->post_type ) {
 				$attachment_fields = [

--- a/src/Type/Object/PostObject.php
+++ b/src/Type/Object/PostObject.php
@@ -290,6 +290,13 @@ class PostObject {
 			];
 		}
 
+		if ( 'post' === $post_type_object->name ) {
+			$fields['isSticky'] = [
+				'type'        => [ 'non_null' => 'Bool' ],
+				'description' => __( 'Whether this page is sticky', 'wp-graphql' ),
+			];
+		}
+
 		if ( ! $post_type_object->hierarchical &&
 			! in_array(
 				$post_type_object->name,


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This adds an `isSticky` field to Post types.


Does this close any currently open issues?
------------------------------------------
Closes #1465 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
![image](https://user-images.githubusercontent.com/1393742/95389051-df66e800-08b8-11eb-8459-fecec7c8c7bc.png)


Where has this been tested?
---------------------------
**Operating System:** MacOs Catalina 10.15.6

**WordPress Version:** 5.5.1
