### PR TITLE
#1496 - Only apply URI interface to public Taxonomies and Post Types

### DIFF
--- a/src/Type/Object/PostObject.php
+++ b/src/Type/Object/PostObject.php
@@ -24,7 +24,7 @@ class PostObject {
 
 		$interfaces = [ 'Node', 'ContentNode', 'DatabaseIdentifier' ];
 
-		if ( true === $post_type_object->name ) {
+		if ( true === $post_type_object->public ) {
 			$interfaces[] = 'UniformResourceIdentifiable';
 		}
 

--- a/src/Type/Object/PostObject.php
+++ b/src/Type/Object/PostObject.php
@@ -22,7 +22,11 @@ class PostObject {
 
 		$single_name = $post_type_object->graphql_single_name;
 
-		$interfaces = [ 'Node', 'ContentNode', 'UniformResourceIdentifiable', 'DatabaseIdentifier' ];
+		$interfaces = [ 'Node', 'ContentNode', 'DatabaseIdentifier' ];
+
+		if ( true === $post_type_object->name ) {
+			$interfaces[] = 'UniformResourceIdentifiable';
+		}
 
 		if ( post_type_supports( $post_type_object->name, 'title' ) ) {
 			$interfaces[] = 'NodeWithTitle';

--- a/src/Type/Object/TermObject.php
+++ b/src/Type/Object/TermObject.php
@@ -2,8 +2,6 @@
 
 namespace WPGraphQL\Type\Object;
 
-use WPGraphQL\AppContext;
-use WPGraphQL\Data\DataSource;
 use WPGraphQL\Model\Term;
 
 /**
@@ -16,11 +14,15 @@ class TermObject {
 	/**
 	 * Register the Type for each kind of Taxonomy
 	 *
-	 * @param $taxonomy_object
+	 * @param \WP_Taxonomy $taxonomy_object The taxonomy being registered
 	 */
 	public static function register_taxonomy_object_type( $taxonomy_object ) {
 
-		$interfaces = [ 'Node', 'TermNode', 'UniformResourceIdentifiable', 'DatabaseIdentifier' ];
+		$interfaces = [ 'Node', 'TermNode', 'DatabaseIdentifier' ];
+
+		if ( true === $taxonomy_object->public ) {
+			$interfaces[] = 'UniformResourceIdentifiable';
+		}
 
 		if ( $taxonomy_object->hierarchical ) {
 			$interfaces[] = 'HierarchicalTermNode';


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

Instead of applying the `UniformResourceIdentifiable` Interface to _all_ Post Types and Taxonomies, this applies the interface to only public post types and taxonomies (the ones that can be accessed by URI)

Does this close any currently open issues?
------------------------------------------
closes #1496 

Any other comments?
-------------------
This is technically a breaking change as Types that used to implement this Interface no longer will implement this interface.
