### PR TITLE
#1493 - CreatePostMutation should not allow contributors to publish posts

### DIFF
--- a/src/Mutation/PostObjectCreate.php
+++ b/src/Mutation/PostObjectCreate.php
@@ -284,6 +284,14 @@ class PostObjectCreate {
 			$intended_post_status = ! empty( $post_args['post_status'] ) ? $post_args['post_status'] : $default_post_status;
 
 			/**
+			 * If the current user cannot publish posts but their intent was to publish,
+			 * default the status to pending.
+			 */
+			if ( ! current_user_can( $post_type_object->cap->publish_posts ) && ! in_array( $intended_post_status, [ 'draft', 'pending' ], true ) ) {
+				$intended_post_status = 'pending';
+			}
+
+			/**
 			 * Set the post_status as the default for the initial insert. The intended $post_status will be set after
 			 * side effects are complete.
 			 */

--- a/tests/wpunit/PostObjectMutationsTest.php
+++ b/tests/wpunit/PostObjectMutationsTest.php
@@ -8,6 +8,7 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 	public $admin;
 	public $subscriber;
 	public $author;
+	public $contributor;
 
 	public function setUp(): void {
 		// before
@@ -23,6 +24,10 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->admin = $this->factory()->user->create( [
 			'role' => 'administrator',
+		] );
+
+		$this->contributor = $this->factory()->user->create( [
+			'role' => 'contributor',
 		] );
 
 		$this->subscriber = $this->factory()->user->create( [
@@ -558,6 +563,90 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 		 * Make sure we're throwing an error if there's no $input with the mutation
 		 */
 		$this->assertArrayHasKey( 'errors', $actual );
+
+	}
+
+	public function testCreatePostByAuthorCanHavePublishStatus() {
+
+		$mutation = '
+		mutation createPost($input:CreatePostInput!){
+		  createPost(input:$input){
+		    clientMutationId
+		    post{
+		      id
+		      title
+		      status
+		    }
+		  }
+		}
+		';
+
+		$variables = [
+			'input' => [
+				'clientMutationId' => 'CreatePost',
+				'title' => 'Test Post as Contributor',
+				'status' => 'PUBLISH',
+			],
+		];
+
+		wp_set_current_user( $this->author );
+
+		$actual = graphql([
+			'query' => $mutation,
+			'variables' => $variables
+		]);
+
+		codecept_debug( $actual );
+
+		/**
+		 * Make sure we're throwing an error if there's no $input with the mutation
+		 */
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertSame( 'publish', $actual['data']['createPost']['post']['status'] );
+		$this->assertSame( $variables['input']['title'], $actual['data']['createPost']['post']['title'] );
+		$this->assertSame( $variables['input']['clientMutationId'], $actual['data']['createPost']['clientMutationId'] );
+
+	}
+
+	public function testCreatePostByContributorCannotHavePublishStatus() {
+
+		$mutation = '
+		mutation createPost($input:CreatePostInput!){
+		  createPost(input:$input){
+		    clientMutationId
+		    post{
+		      id
+		      title
+		      status
+		    }
+		  }
+		}
+		';
+
+		$variables = [
+			'input' => [
+				'clientMutationId' => 'CreatePost',
+				'title' => 'Test Post as Contributor',
+				'status' => 'PUBLISH',
+			],
+		];
+
+		wp_set_current_user( $this->contributor );
+
+		$actual = graphql([
+			'query' => $mutation,
+			'variables' => $variables
+		]);
+
+		codecept_debug( $actual );
+
+		/**
+		 * Make sure we're throwing an error if there's no $input with the mutation
+		 */
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertSame( 'pending', $actual['data']['createPost']['post']['status'] );
+		$this->assertSame( $variables['input']['title'], $actual['data']['createPost']['post']['title'] );
+		$this->assertSame( $variables['input']['clientMutationId'], $actual['data']['createPost']['clientMutationId'] );
 
 	}
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

According to WordPress role definitions, Contributors can write and manage their own posts, but cannot publish them. 

Currently, WPGraphQL allows contributors to publish posts. 

This PR prevents users without `publish_posts` capability from publishing. If the mutation is set to publish, future or private, the status defaults to pending instead.

Does this close any currently open issues?
------------------------------------------
closes #1493 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
Mutation executed as a Contributor.

![Screen Shot 2020-10-07 at 11 11 55 PM](https://user-images.githubusercontent.com/1260765/95417521-83b95080-08f2-11eb-89db-090acafe78fc.png)

