### PR TITLE
#1500 - createComment mutation should not allow userId to be set as input

### DIFF
--- a/src/Data/CommentMutation.php
+++ b/src/Data/CommentMutation.php
@@ -35,8 +35,6 @@ class CommentMutation {
 		 *    'comment_content' => 'content here',
 		 *    'comment_type' => '',
 		 *    'comment_parent' => 0,
-		 *    'comment_author_IP' => '127.0.0.1',
-		 *    'comment_agent' => 'Mozilla/5.0 ( Windows; U; Windows NT 5.1; en-US; rv:1.9.0.10 ) Gecko/2009042316 Firefox/3.0.10 ( .NET CLR 3.5.30729 )',
 		 *    'comment_date' => $time,
 		 *    'comment_approved' => 1,
 		 */
@@ -52,14 +50,14 @@ class CommentMutation {
 		} else {
 			if ( empty( $input['author'] ) ) {
 				if ( ! $update ) {
-					throw new UserError( __( 'Must enter a valid user_id or author name', 'graphql' ) );
+					throw new UserError( __( 'Comment must include an authorName', 'wp-graphql' ) );
 				}
 			} else {
 				$output_args['comment_author'] = $input['author'];
 			}
 			if ( ! empty( $input['authorEmail'] ) ) {
 				if ( false === is_email( apply_filters( 'pre_user_email', $input['authorEmail'] ) ) ) {
-					throw new UserError( __( 'The email address you are trying to use is invalid', 'graphql' ) );
+					throw new UserError( __( 'The email address you are trying to use is invalid', 'wp-graphql' ) );
 				}
 				$output_args['comment_author_email'] = $input['authorEmail'];
 			}
@@ -86,14 +84,6 @@ class CommentMutation {
 
 		if ( ! empty( $input['type'] ) ) {
 			$output_args['comment_type'] = $input['type'];
-		}
-
-		if ( ! empty( $input['authorIp'] ) ) {
-			$output_args['comment_author_IP'] = $input['authorIp'];
-		}
-
-		if ( ! empty( $input['agent'] ) ) {
-			$output_args['comment_agent'] = $input['agent'];
 		}
 
 		if ( ! empty( $input['approved'] ) ) {

--- a/src/Data/CommentMutation.php
+++ b/src/Data/CommentMutation.php
@@ -35,15 +35,14 @@ class CommentMutation {
 		 *    'comment_content' => 'content here',
 		 *    'comment_type' => '',
 		 *    'comment_parent' => 0,
-		 *    'user_id' => 1,
 		 *    'comment_author_IP' => '127.0.0.1',
 		 *    'comment_agent' => 'Mozilla/5.0 ( Windows; U; Windows NT 5.1; en-US; rv:1.9.0.10 ) Gecko/2009042316 Firefox/3.0.10 ( .NET CLR 3.5.30729 )',
 		 *    'comment_date' => $time,
 		 *    'comment_approved' => 1,
 		 */
 
-		$user = ! empty( $input['userId'] ) ? get_user_by( 'ID', $input['userId'] ) : false;
-		if ( $user instanceof \WP_User ) {
+		$user = wp_get_current_user();
+		if ( $user instanceof \WP_User && 0 !== $user->ID ) {
 			$output_args['user_id']              = $user->ID;
 			$output_args['comment_author']       = $user->display_name;
 			$output_args['comment_author_email'] = $user->user_email;

--- a/src/Mutation/CommentCreate.php
+++ b/src/Mutation/CommentCreate.php
@@ -141,8 +141,6 @@ class CommentCreate {
 				'comment_type'       => '',
 				'comment_parent'     => 0,
 				'user_id'            => 0,
-				'comment_author_IP'  => ':1',
-				'comment_agent'      => '',
 				'comment_date'       => date( 'Y-m-d H:i:s' ),
 			];
 

--- a/src/Mutation/CommentCreate.php
+++ b/src/Mutation/CommentCreate.php
@@ -34,10 +34,6 @@ class CommentCreate {
 				'type'        => 'Int',
 				'description' => __( 'The ID of the post object the comment belongs to.', 'wp-graphql' ),
 			],
-			'userId'      => [
-				'type'        => 'Int',
-				'description' => __( 'The userID of the comment\'s author.', 'wp-graphql' ),
-			],
 			'author'      => [
 				'type'        => 'String',
 				'description' => __( 'The name of the comment\'s author.', 'wp-graphql' ),

--- a/src/Mutation/CommentCreate.php
+++ b/src/Mutation/CommentCreate.php
@@ -46,10 +46,6 @@ class CommentCreate {
 				'type'        => 'String',
 				'description' => __( 'The url of the comment\'s author.', 'wp-graphql' ),
 			],
-			'authorIp'    => [
-				'type'        => 'String',
-				'description' => __( 'IP address for the comment\'s author.', 'wp-graphql' ),
-			],
 			'content'     => [
 				'type'        => 'String',
 				'description' => __( 'Content of the comment.', 'wp-graphql' ),
@@ -61,10 +57,6 @@ class CommentCreate {
 			'parent'      => [
 				'type'        => 'ID',
 				'description' => __( 'Parent comment of current comment.', 'wp-graphql' ),
-			],
-			'agent'       => [
-				'type'        => 'String',
-				'description' => __( 'User agent used to post the comment.', 'wp-graphql' ),
 			],
 			'date'        => [
 				'type'        => 'String',

--- a/tests/wpunit/CommentMutationsTest.php
+++ b/tests/wpunit/CommentMutationsTest.php
@@ -37,6 +37,80 @@ class CommentMutationsTest extends \Codeception\TestCase\WPTestCase {
 		parent::tearDown();
 	}
 
+	public function testCreateCommentByLoggedInUserShouldSetUserProperly() {
+
+		$post_id = $this->factory()->post->create([
+			'post_type' => 'post',
+			'post_status' => 'publish',
+			'post_title' => 'Test for comments...'
+		]);
+
+		$query = '
+		mutation createComment($input: CreateCommentInput!) {
+		  createComment(input: $input) {
+		    clientMutationId
+		    success
+		    comment {
+		      id
+		      content
+		      author {
+		        node {
+		          name
+		          ... on User {
+		            id
+		            databaseId
+		            username
+		          }
+		        }
+		      }
+		    }
+		  }
+		}
+		';
+
+		$variables = [
+			'input' => [
+				'clientMutationId' => 'Create...',
+				'content' => 'Test comment ' . uniqid(),
+				'commentOn' => $post_id
+			]
+		];
+
+		wp_set_current_user( $this->admin );
+
+		$actual = graphql([
+			'query' => $query,
+			'variables' => $variables,
+		]);
+
+
+		codecept_debug( $actual );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertTrue( $actual['data']['createComment']['success'] );
+		$this->assertSame( $this->admin, $actual['data']['createComment']['comment']['author']['node']['databaseId'] );
+
+		add_filter( 'comment_flood_filter', '__return_false' );
+
+		wp_set_current_user( 0 );
+
+		$variables['input']['author'] = 'joe';
+		$variables['input']['authorEmail'] = 'joe@example.com';
+
+		sleep(1);
+		$actual = graphql([
+			'query' => $query,
+			'variables' => $variables,
+		]);
+
+
+		codecept_debug( $actual );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertTrue( $actual['data']['createComment']['success'] );
+
+	}
+
 	public function createComment( &$post_id, &$comment_id, $postCreator, $commentCreator ) {
 		wp_set_current_user( $postCreator );
 		$post_args = [

--- a/tests/wpunit/CommentMutationsTest.php
+++ b/tests/wpunit/CommentMutationsTest.php
@@ -169,7 +169,7 @@ class CommentMutationsTest extends \Codeception\TestCase\WPTestCase {
 		wp_set_current_user( $this->admin );
 
 		$mutation  = '
-		mutation createCommentTest( $clientMutationId:String!, $commentOn:Int!, $author:String!, $email: String!, $content:String!, $ip:String ){
+		mutation createCommentTest( $clientMutationId:String!, $commentOn:Int!, $author:String!, $email: String!, $content:String! ){
 		  createComment( 
 		    input: {
 		      clientMutationId: $clientMutationId
@@ -177,14 +177,12 @@ class CommentMutationsTest extends \Codeception\TestCase\WPTestCase {
               content: $content
               author: $author
               authorEmail: $email
-              authorIp: $ip
 		    }
           )
           {
 		    clientMutationId
 		    comment {
               content
-              authorIp
 		    }
           }
         }
@@ -195,7 +193,6 @@ class CommentMutationsTest extends \Codeception\TestCase\WPTestCase {
 			'content'          => $this->content,
 			'author'           => 'Comment Author',
 			'email'            => 'subscriber@example.com',
-			'ip'               => ':1',
 		] );
 
 		$actual = do_graphql_request( $mutation, 'createCommentTest', $variables );
@@ -206,7 +203,6 @@ class CommentMutationsTest extends \Codeception\TestCase\WPTestCase {
 					'clientMutationId' => $this->client_mutation_id,
 					'comment'          => [
 						'content'  => apply_filters( 'comment_text', $this->content ),
-						'authorIp' => ':1',
 					],
 				],
 			],
@@ -243,13 +239,12 @@ class CommentMutationsTest extends \Codeception\TestCase\WPTestCase {
 
 		$content   = 'Updated Content';
 		$mutation  = '
-		mutation updateCommentTest( $clientMutationId: String!, $id: ID!, $content: String!, $ip: String ) {
+		mutation updateCommentTest( $clientMutationId: String!, $id: ID!, $content: String! ) {
 		  updateComment( 
 		    input: {
 		      clientMutationId: $clientMutationId
               id: $id
               content: $content
-              authorIp: $ip
 		    }
           )
           {
@@ -258,7 +253,6 @@ class CommentMutationsTest extends \Codeception\TestCase\WPTestCase {
               id
               commentId
               content
-              authorIp
 		    }
           }
         }
@@ -267,7 +261,6 @@ class CommentMutationsTest extends \Codeception\TestCase\WPTestCase {
 			'clientMutationId' => $this->client_mutation_id,
 			'id'               => \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_id ),
 			'content'          => $content,
-			'ip'               => ':2',
 		] );
 
 		$actual = do_graphql_request( $mutation, 'updateCommentTest', $variables );
@@ -280,8 +273,7 @@ class CommentMutationsTest extends \Codeception\TestCase\WPTestCase {
 						'id'        => \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_id ),
 						'commentId' => $comment_id,
 						'content'   => apply_filters( 'comment_text', $content ),
-						'authorIp'  => ':2',
-					],
+					]
 				],
 			],
 		];
@@ -466,7 +458,7 @@ class CommentMutationsTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertEquals( $new_post->post_content, 'Original Content' );
 
 		$mutation  = '
-		mutation createCommentTest( $clientMutationId:String!, $commentOn:Int!, $author:String!, $email: String!, $content:String!, $ip:String ){
+		mutation createCommentTest( $clientMutationId:String!, $commentOn:Int!, $author:String!, $email: String!, $content:String! ){
 		  createComment(
 		    input: {
 		      clientMutationId: $clientMutationId
@@ -474,14 +466,12 @@ class CommentMutationsTest extends \Codeception\TestCase\WPTestCase {
 		      content: $content
 		      author: $author
 		      authorEmail: $email
-		      authorIp: $ip
 		    }
 		  )
 		  {
 		    clientMutationId
 		    comment {
 		      content
-		      authorIp
 		    }
 		  }
 		}
@@ -493,7 +483,6 @@ class CommentMutationsTest extends \Codeception\TestCase\WPTestCase {
 			'content'          => $this->content,
 			'author'           => 'Comment Author',
 			'email'            => 'subscriber@example.com',
-			'ip'               => ':1',
 		] );
 
 		$actual = do_graphql_request( $mutation, 'createCommentTest', $variables );
@@ -536,7 +525,7 @@ class CommentMutationsTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertEquals( $new_post->post_content, 'Original Content' );
 
 		$mutation  = '
-		mutation createCommentTest( $clientMutationId:String!, $commentOn:Int!, $author:String!, $email: String!, $content:String!, $ip:String ){
+		mutation createCommentTest( $clientMutationId:String!, $commentOn:Int!, $author:String!, $email: String!, $content:String! ){
 		  createComment(
 		    input: {
 		      clientMutationId: $clientMutationId
@@ -544,7 +533,6 @@ class CommentMutationsTest extends \Codeception\TestCase\WPTestCase {
 		      content: $content
 		      author: $author
 		      authorEmail: $email
-		      authorIp: $ip
 		    }
 		  )
 		  {
@@ -560,7 +548,6 @@ class CommentMutationsTest extends \Codeception\TestCase\WPTestCase {
 			'content'          => $this->content,
 			'author'           => 'Comment Author',
 			'email'            => 'subscriber@example.com',
-			'ip'               => ':1',
 		] );
 
 		wp_set_current_user( 0 );


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Currently the `createComment` mutation allows for a `userId` input. 

Inputting a valid ID of a user allows for public users to create a comment as if it were created by a site user. 

This PR removes the `userId` input from the mutation and instead sets the user of the comment from the currently logged in user. If no user is logged in (public request) the author is set from the author input. If a public request and no author input, the comment is not created and an error is returned.

**BREAKING:**
- Removes `userId` input from createComment mutation
- Removes `agent` input from createComment mutation
- Removes `authorIp` input from createComment mutation

Any client application that was using these inputs in their mutations will need to update their mutations.


Does this close any currently open issues?
------------------------------------------
closes #1500 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

**Public Request with no author input**
![Screen Shot 2020-10-07 at 11 52 51 PM](https://user-images.githubusercontent.com/1260765/95420240-5ff90900-08f8-11eb-8ffc-c3d50419ba1e.png)

**Public request with author input**
![Screen Shot 2020-10-07 at 11 53 09 PM](https://user-images.githubusercontent.com/1260765/95420245-612a3600-08f8-11eb-952d-1b95e4fc9c0e.png)

**Authenticated Request, no author input**
![Screen Shot 2020-10-07 at 11 53 40 PM](https://user-images.githubusercontent.com/1260765/95420250-61c2cc80-08f8-11eb-863c-593c8c13a903.png)
