### PR TITLE
Update test Dockerfile to reduce errors and warnings

### DIFF
--- a/docker/Dockerfile.test-base
+++ b/docker/Dockerfile.test-base
@@ -19,12 +19,12 @@ FROM ${OFFICIAL_WORDPRESS_DOCKER_IMAGE}
 # Set timezone, install XDebug, PHP Composer, WP-CLI
 RUN echo 'date.timezone = "UTC"' > /usr/local/etc/php/conf.d/timezone.ini \
   && apt-get update -y \
-  && apt-get install --no-install-recommends -y mariadb-client subversion \
+  && apt-get install --no-install-recommends -y mariadb-client subversion unzip \
   && rm -rf /var/lib/apt/lists/* \
   && if echo "${PHP_VERSION}" | grep '^7'; then \
-        pecl install xdebug; \
-        docker-php-ext-enable xdebug; \
-     fi \
+  pecl install xdebug; \
+  docker-php-ext-enable xdebug; \
+  fi \
   && docker-php-ext-install pdo_mysql \
   && curl -Ls 'https://raw.githubusercontent.com/composer/getcomposer.org/fc4099e0ac116a1c8f61fffaf6693594dda79d16/web/installer' | php -- --quiet \
   && chmod +x composer.phar \
@@ -47,10 +47,8 @@ RUN mkdir -p "${WP_TESTS_DIR}" \
   && curl -Lsv "https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php" > "${WP_TESTS_DIR}/wp-tests-config.php" \
   && chown -R 'www-data:www-data' "${WP_TESTS_DIR}"
 
-
 # Add WP-CLI config for SUT to flush rewrite rules: https://developer.wordpress.org/cli/commands/rewrite/flush/
 COPY --chown='www-data:www-data' docker/wp-cli.yml /var/www/html/
-
 
 # First copy the files needed for PHP composer install so that the Docker build only re-executes the install when those
 # files change.
@@ -59,9 +57,11 @@ COPY --chown='www-data:www-data' src/ "${SUT_PLUGIN_DIR}/src/"
 COPY --chown='www-data:www-data' vendor/ "${SUT_PLUGIN_DIR}/vendor/"
 
 # Run PHP Composer install so that Codeception dependencies are available
+RUN mkdir -p /var/www/.composer/cache \
+  && chown -R www-data:www-data /var/www/.composer/cache
 USER www-data
 RUN cd "${SUT_PLUGIN_DIR}" \
-  && composer install --prefer-source --no-interaction --dev
+  && composer install --prefer-dist --no-interaction
 
 # Copy in all other files from repo, but preserve the files used by/modified by composer install.
 USER root


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

This fixes a number of errors and warnings output by the Docker testing setup when building the containers. These didn't necessarily cause any issues, but this cuts down on the noise. 

All tests still run successfully locally after these changes.

- Add `unzip` to the installed packages. 

```
As there is no 'unzip' command installed zip files are being unpacked using the PHP zip extension.
This may cause invalid reports of corrupted archives. Besides, any UNIX permissions (e.g. executable) defined in the archives will be lost.
Installing 'unzip' may remediate them
```

- Remove `--dev` argument from `composer`. Prompted by `composer` dependency installation:

```
You are using the deprecated option "dev". Dev packages are installed by default now.
```

- Create and assign proper permissions to `compose` cache directory. Prompted by `composer` dependency installation:

```
Cannot create cache directory /var/www/.composer/cache/repo/https---repo.packagist.org/, or directory is not writable. Proceeding without cache
Cannot create cache directory /var/www/.composer/cache/files/, or directory is not writable. Proceeding without cache
```

- Switch `composer` installation to use `--prefer-dist` specifically. It was already using it be default since the image does not have `git` installed and was falling back to distribution version installations. 

```
sh: 1: git: not found

    Now trying to download from dist
  - Installing codeception/codeception (4.1.6): Downloading (100%)
  - Installing codeception/module-asserts (1.2.1): Cloning 79f13d05b6
    Failed to download codeception/module-asserts from source: Failed to clone https://github.com/Codeception/module-asserts.git, git was not found, check that it is installed and in your PATH env.
```

Does this close any currently open issues?
------------------------------------------

No.

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

No.

Any other comments?
-------------------

No.

Where has this been tested?
---------------------------
**Operating System:**

macOS Catalina 10.15.7 (19H2)

**WordPress Version:** …

5.4 as noted in `docker-compose.tests.yml`.
