### PR TITLE
Bugfix: Prevents contributors from editing other posts

### DIFF
--- a/src/Admin/GraphiQL/GraphiQL.php
+++ b/src/Admin/GraphiQL/GraphiQL.php
@@ -45,7 +45,7 @@ class GraphiQL {
 	 */
 	public function register_admin_bar_menu( $admin_bar ) {
 
-		if ( 'off' === get_graphql_setting( 'show_graphiql_link_in_admin_bar' ) ) {
+		if ( ! current_user_can( 'manage_options' ) || 'off' === get_graphql_setting( 'show_graphiql_link_in_admin_bar' ) ) {
 			return;
 		}
 

--- a/src/Mutation/PostObjectUpdate.php
+++ b/src/Mutation/PostObjectUpdate.php
@@ -114,10 +114,6 @@ class PostObjectUpdate {
 			}
 
 			/**
-			 * If the current user is trying to edit a post
-			 */
-
-			/**
 			 * @todo: when we add support for making posts sticky, we should check permissions to make sure users can make posts sticky
 			 * @see : https://github.com/WordPress/WordPress/blob/e357195ce303017d517aff944644a7a1232926f7/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L640-L642
 			 */

--- a/src/Mutation/PostObjectUpdate.php
+++ b/src/Mutation/PostObjectUpdate.php
@@ -96,6 +96,14 @@ class PostObjectUpdate {
 			}
 
 			/**
+			 * If the existing post was authored by another author, ensure the requesting user has permission to edit it
+			 */
+			if ( $existing_post->post_author !== get_current_user_id() && ! current_user_can( $post_type_object->cap->edit_others_posts ) ) {
+				// translators: the $post_type_object->graphql_single_name placeholder is the name of the object being mutated
+				throw new UserError( sprintf( __( 'Sorry, you are not allowed to another author\'s %1$s', 'wp-graphql' ), $post_type_object->graphql_single_name ) );
+			}
+
+			/**
 			 * If the mutation is setting the author to be someone other than the user making the request
 			 * make sure they have permission to edit others posts
 			 */
@@ -104,6 +112,10 @@ class PostObjectUpdate {
 				// translators: the $post_type_object->graphql_single_name placeholder is the name of the object being mutated
 				throw new UserError( sprintf( __( 'Sorry, you are not allowed to update %1$s as this user.', 'wp-graphql' ), $post_type_object->graphql_plural_name ) );
 			}
+
+			/**
+			 * If the current user is trying to edit a post
+			 */
 
 			/**
 			 * @todo: when we add support for making posts sticky, we should check permissions to make sure users can make posts sticky

--- a/tests/wpunit/PostObjectMutationsTest.php
+++ b/tests/wpunit/PostObjectMutationsTest.php
@@ -7,6 +7,7 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 	public $client_mutation_id;
 	public $admin;
 	public $subscriber;
+	public $contributor;
 	public $author;
 
 	public function setUp(): void {
@@ -23,6 +24,10 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->admin = $this->factory()->user->create( [
 			'role' => 'administrator',
+		] );
+
+		$this->contributor = $this->factory()->user->create( [
+			'role' => 'contributor',
 		] );
 
 		$this->subscriber = $this->factory()->user->create( [
@@ -799,5 +804,99 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
          */
         $this->assertNotNull( $results['data']['post']['dateGmt'] );
     }
+
+	/**
+	 * @throws Exception
+	 */
+    public function testUserWithoutProperCapabilityCannotUpdateOthersPosts() {
+
+		$admin_created_post_id = $this->factory()->post->create([
+			'post_type' => 'post',
+			'post_status' => 'publish',
+			'post_title' => 'Test Post from Admin, Edit by Contributor',
+			'post_author' => $this->admin
+		]);
+
+		$global_id = \GraphQLRelay\Relay::toGlobalId( 'post', $admin_created_post_id );
+
+		$mutation = '
+		mutation UpdatePost($input: UpdatePostInput! ) {
+		  updatePost(input:$input) {
+		    post {
+		      id
+		      title
+		      content
+		    }
+		  }
+		}
+		';
+
+		$variables = [
+			'input' => [
+				'clientMutationId' => 'UpdatePost',
+				'id' => $global_id,
+				'title' => 'New Title'
+			]
+		];
+
+		wp_set_current_user( $this->contributor );
+
+		$actual = graphql([
+			'query' => $mutation,
+			'variables' => $variables,
+		]);
+
+		codecept_debug( $actual );
+
+		$this->assertArrayHasKey( 'errors', $actual );
+
+    }
+
+	/**
+	 * @throws Exception
+	 */
+	public function testUserWithoutProperCapabilityCannotUpdateOthersPages() {
+
+		$admin_created_page_id = $this->factory()->post->create( [
+			'post_type'   => 'page',
+			'post_status' => 'publish',
+			'post_title'  => 'Test Page from Admin, Edit by Contributor',
+			'post_author' => $this->admin
+		] );
+
+		$global_id = \GraphQLRelay\Relay::toGlobalId( 'post', $admin_created_page_id );
+
+		$mutation = '
+		mutation UpdatePage($input: UpdatePageInput! ) {
+		  updatePage(input:$input) {
+		    page {
+		      id
+		      title
+		      content
+		    }
+		  }
+		}
+		';
+
+		$variables = [
+			'input' => [
+				'clientMutationId' => 'UpdatePage',
+				'id'               => $global_id,
+				'title'            => 'New Title'
+			]
+		];
+
+		wp_set_current_user( $this->contributor );
+
+		$actual = graphql( [
+			'query'     => $mutation,
+			'variables' => $variables,
+		] );
+
+		codecept_debug( $actual );
+
+		$this->assertArrayHasKey( 'errors', $actual );
+
+	}
 
 }

--- a/tests/wpunit/PostObjectMutationsTest.php
+++ b/tests/wpunit/PostObjectMutationsTest.php
@@ -7,7 +7,6 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 	public $client_mutation_id;
 	public $admin;
 	public $subscriber;
-	public $contributor;
 	public $author;
 
 	public function setUp(): void {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- Adds a check for the UpdatePost mutation to ensure the requesting user has permission to update the post object
- Adds tests for updating others posts with the PostObjectMutation
- Fixes bug with GraphiQL Admin bar showing for users that don't have capabilities to use it

**Before:**

Logged in as a contributor, I can execute a GraphQL `updatePost` mutation and change the title of a post authored by another user. 

![Screen Shot 2020-10-13 at 10 04 29 PM](https://user-images.githubusercontent.com/1260765/95942403-42b4b680-0da0-11eb-8810-ee4bfead69da.png)

**After:**

Logged in as a contributor, I can execute a GraphQL `updatePost` mutation to change the title of a post authored by another user and get an error in response. 


Does this close any currently open issues?
------------------------------------------
closes #1505 
