### PR TITLE
Make comments attached to private posts private

### DIFF
--- a/src/Model/Comment.php
+++ b/src/Model/Comment.php
@@ -74,6 +74,11 @@ class Comment extends Model {
 	 */
 	protected function is_private() {
 
+		// A comment is considered private if it is attached to a private post.
+		if ( ! empty( $this->data->comment_post_ID ) && ( new Post( get_post( $this->data->comment_post_ID ) ) )->is_private() ) {
+			return true;
+		}
+
 		// NOTE: Do a non-strict check here, as the return is a `1` or `0`.
 		// phpcs:disable WordPress.PHP.StrictComparisons.LooseComparison
 		if ( true != $this->data->comment_approved && ! current_user_can( 'moderate_comments' ) ) {

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -689,12 +689,10 @@ class Post extends Model {
 
 					return false;
 				},
-				'isSticky'                 => function() {
+				'isSticky'                  => function() {
 					return is_sticky( $this->databaseId );
 				},
 			];
-
-
 
 			if ( 'attachment' === $this->data->post_type ) {
 				$attachment_fields = [

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -304,7 +304,7 @@ class Post extends Model {
 	 *
 	 * @return bool
 	 */
-	protected function is_private() {
+	public function is_private() {
 
 		/**
 		 * If the post is of post_type "revision", we need to access the parent of the Post

--- a/tests/wpunit/CommentObjectQueriesTest.php
+++ b/tests/wpunit/CommentObjectQueriesTest.php
@@ -471,7 +471,7 @@ class CommentObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 		      }
 		    }
 		  }
-		} 
+		}
 		';
 
 		wp_set_current_user( $this->{$user} );
@@ -545,7 +545,7 @@ class CommentObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 		      }
 		    }
 		  }
-		} 
+		}
 		';
 
 		wp_set_current_user( $this->{$user} );
@@ -569,6 +569,74 @@ class CommentObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 		} else {
 			$this->assertEmpty( $admin_actual['data']['comment'] );
 		}
+
+	}
+
+	/**
+	 * Assert that comments attached to private posts are hidden from users
+	 * without proper caps
+	 *
+	 * @throws Exception
+	 */
+	public function testPrivatePostCommentsNotQueryableWithoutAuth( ) {
+
+		$post_id = $this->factory->post->create( [
+			'post_status' => 'private',
+			'post_content' => 'Test',
+		] );
+
+		$comment_args = [
+			'comment_post_ID' => $post_id,
+			'comment_content' => 'Private Post Comment',
+			'comment_approved' => 1,
+			'comment_author_email' => 'admin@test.com',
+			'comment_author_IP' => '127.0.0.1',
+			'comment_agent' => 'Admin Agent',
+		];
+		$comment = $this->createCommentObject( $comment_args );
+
+		$query = '
+		query commentQuery( $id:ID! ) {
+		  comment(id: $id) {
+			commentId
+		    id
+		    authorIp
+		    agent
+		    approved
+		    karma
+		    content
+		    commentedOn{
+		      node {
+			    ... on Post{
+			      postId
+			    }
+		      }
+		    }
+		  }
+		}
+		';
+
+		$public_actual = do_graphql_request( $query, 'commentQuery', wp_json_encode( [ 'id' => \GraphQLRelay\Relay::toGlobalId( 'comment', $comment ) ] ) );
+
+		codecept_debug( $public_actual );
+
+		wp_set_current_user( $this->admin );
+		$admin_actual = do_graphql_request( $query, 'commentQuery', wp_json_encode( [ 'id' => \GraphQLRelay\Relay::toGlobalId( 'comment', $comment ) ] ) );
+
+		codecept_debug( $admin_actual );
+
+		// Verify there are no errors.
+		$this->assertArrayNotHasKey( 'errors', $public_actual );
+		$this->assertArrayNotHasKey( 'errors', $admin_actual );
+
+		// Verify the Public request is empty.
+		$this->assertEmpty( $public_actual['data']['comment'] );
+
+		// Verify the Admin request has the correct comment.
+		$this->assertNotNull( $admin_actual['data']['comment']['authorIp'] );
+		$this->assertNotNull( $admin_actual['data']['comment']['agent'] );
+		$this->assertEquals( $comment, $admin_actual['data']['comment']['commentId'] );
+		$this->assertEquals( apply_filters( 'comment_text', $comment_args['comment_content'] ), $admin_actual['data']['comment']['content'] );
 
 	}
 


### PR DESCRIPTION
Comments that are attached to private posts are publicly available. This PR checks to see if a comment is attached to a private post and if so, it marks the comment as private.

This PR also adds a test to verify that admin users can view comments attached to private posts but anonymous users can not view comments attached to private posts.

Where has this been tested?
---------------------------
**Operating System:** macOS Catalina Version 10.15.7

**WordPress Version:** 5.5.1
