### PR TITLE
Feature/#1511 add telemetry

### DIFF
--- a/activation.php
+++ b/activation.php
@@ -2,11 +2,11 @@
 /**
  * Runs when WPGraphQL is activated
  *
- * This cleans up data that WPGraphQL stores
- *
  * @return void
  */
 function graphql_activation_callback() {
 	do_action( 'graphql_activate' );
+
+	// store the current version of WPGraphQL
 	update_option( 'wp_graphql_version', WPGRAPHQL_VERSION );
 }

--- a/activation.php
+++ b/activation.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Runs when WPGraphQL is activated
+ *
+ * This cleans up data that WPGraphQL stores
+ *
+ * @return void
+ */
+function graphql_activation_callback() {
+	do_action( 'graphql_activate' );
+	update_option( 'wp_graphql_version', WPGRAPHQL_VERSION );
+}

--- a/deactivation.php
+++ b/deactivation.php
@@ -8,6 +8,19 @@
  */
 function graphql_deactivation_callback() {
 
+	// Fire an action when WPGraphQL is de-activating
+	do_action( 'graphql_deactivate' );
+
+	// Delete data during activation
+	delete_graphql_data();
+
+}
+
+/**
+ * Delete data on deactivation
+ */
+function delete_graphql_data() {
+
 	// Check if the plugin is set to delete data or not
 	$delete_data = get_graphql_setting( 'delete_data_on_deactivate' );
 
@@ -15,6 +28,9 @@ function graphql_deactivation_callback() {
 	if ( "on" !== $delete_data ) {
 		return;
 	}
+
+	// Delete graphql version
+	delete_option( 'wp_graphql_version' );
 
 	// Initialize the settings API
 	$settings = new WPGraphQL\Admin\Settings\Settings();
@@ -31,7 +47,6 @@ function graphql_deactivation_callback() {
 		}
 	}
 
-	// Fire an action when WPGraphQL is de-activating
-	do_action( 'graphql_deactivate' );
+	do_action( 'graphql_delete_data' );
 
 }

--- a/src/Admin/GraphiQL/GraphiQL.php
+++ b/src/Admin/GraphiQL/GraphiQL.php
@@ -45,7 +45,7 @@ class GraphiQL {
 	 */
 	public function register_admin_bar_menu( $admin_bar ) {
 
-		if ( 'off' === get_graphql_setting( 'show_graphiql_link_in_admin_bar' ) ) {
+		if ( ! current_user_can( 'manage_options' ) || 'off' === get_graphql_setting( 'show_graphiql_link_in_admin_bar' ) ) {
 			return;
 		}
 

--- a/src/Admin/Settings/Settings.php
+++ b/src/Admin/Settings/Settings.php
@@ -83,6 +83,13 @@ class Settings {
 
 		$this->settings_api->register_fields( 'graphql_general_settings', [
 			[
+				'name'    => 'telemetry_enabled',
+				'label'   => __( 'Data Sharing Opt-In', 'wp-graphql' ),
+				'desc'    => __( 'Help us improve WPGraphQL by allowing tracking of usage. Tracking data allows us to better understand how WPGraphQL is used so we can better prioritize features & integrations with popular WordPress plugins, and can allow us to notify site owners if we detect a security issue. All data are treated in accordance with Gatsby\'s Privacy Policy. <a href="https://www.gatsbyjs.com/privacy-policy" target="_blank">Learn more</a>.', 'wp-graphql' ),
+				'type'    => 'checkbox',
+				'default' => 'off',
+			],
+			[
 				'name'    => 'graphiql_enabled',
 				'label'   => __( 'Enable GraphiQL IDE', 'wp-graphql' ),
 				'desc'    => __( 'GraphiQL IDE is a tool for exploring the GraphQL Schema and test GraphQL operations. Uncheck this to disable GraphiQL in the Dashboard.', 'wp-graphql' ),
@@ -108,7 +115,7 @@ class Settings {
 				'label'    => __( 'Enable GraphQL Debug Mode', 'wp-graphql' ),
 				'desc'     => defined( 'GRAPHQL_DEBUG' ) ? sprintf( __( 'This setting is disabled. "GRAPHQL_DEBUG" has been set to "%s" with code', 'wp-graphql' ), GRAPHQL_DEBUG ? 'true' : 'false' ) : __( 'Whether GraphQL requests should execute in "debug" mode. This setting is disabled if <strong>GRAPHQL_DEBUG</strong> is defined in wp-config.php. <br/>This will provide more information in GraphQL errors but can leak server implementation details so this setting is <strong>NOT RECOMMENDED FOR PRODUCTION ENVIRONMENTS</strong>.', 'wp-graphql' ),
 				'type'     => 'checkbox',
-				'value'    => defined( 'GRAPHQL_DEBUG' ) && true === GRAPHQL_DEBUG ? 'on' : 'off',
+				'value'    => true === \WPGraphQL::debug() ? 'on' : get_graphql_setting( 'debug_mode_enabled', 'off' ),
 				'disabled' => defined( 'GRAPHQL_DEBUG' ) ? true : false,
 			],
 			[

--- a/src/Mutation/PostObjectUpdate.php
+++ b/src/Mutation/PostObjectUpdate.php
@@ -114,10 +114,6 @@ class PostObjectUpdate {
 			}
 
 			/**
-			 * If the current user is trying to edit a post
-			 */
-
-			/**
 			 * @todo: when we add support for making posts sticky, we should check permissions to make sure users can make posts sticky
 			 * @see : https://github.com/WordPress/WordPress/blob/e357195ce303017d517aff944644a7a1232926f7/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L640-L642
 			 */

--- a/src/Mutation/PostObjectUpdate.php
+++ b/src/Mutation/PostObjectUpdate.php
@@ -96,6 +96,14 @@ class PostObjectUpdate {
 			}
 
 			/**
+			 * If the existing post was authored by another author, ensure the requesting user has permission to edit it
+			 */
+			if ( $existing_post->post_author !== get_current_user_id() && ! current_user_can( $post_type_object->cap->edit_others_posts ) ) {
+				// translators: the $post_type_object->graphql_single_name placeholder is the name of the object being mutated
+				throw new UserError( sprintf( __( 'Sorry, you are not allowed to another author\'s %1$s', 'wp-graphql' ), $post_type_object->graphql_single_name ) );
+			}
+
+			/**
 			 * If the mutation is setting the author to be someone other than the user making the request
 			 * make sure they have permission to edit others posts
 			 */
@@ -104,6 +112,10 @@ class PostObjectUpdate {
 				// translators: the $post_type_object->graphql_single_name placeholder is the name of the object being mutated
 				throw new UserError( sprintf( __( 'Sorry, you are not allowed to update %1$s as this user.', 'wp-graphql' ), $post_type_object->graphql_plural_name ) );
 			}
+
+			/**
+			 * If the current user is trying to edit a post
+			 */
 
 			/**
 			 * @todo: when we add support for making posts sticky, we should check permissions to make sure users can make posts sticky

--- a/src/Telemetry/Tracker.php
+++ b/src/Telemetry/Tracker.php
@@ -216,7 +216,7 @@ class Tracker {
 			'phpVersion'         => phpversion(),
 			'serverSoftware'     => $this->clean_server_data( 'SERVER_SOFTWARE' ),
 			'userName'           => $this->hash( $this->clean_server_data( 'USER' ) ),
-			'sessionId'          => $this->hash( $this->clean_server_data( 'HTTP_COOKIE' ) ),
+			'sessionId'          => '',
 			'httpAcceptLanguage' => $this->clean_server_data( 'HTTP_ACCEPT_LANGUAGE' ),
 			'userAgent'          => $this->clean_server_data( 'HTTP_USER_AGENT' ),
 			'host'               => $this->sanitize( site_url() ),

--- a/src/Telemetry/Tracker.php
+++ b/src/Telemetry/Tracker.php
@@ -1,0 +1,312 @@
+<?php
+
+namespace WPGraphQL\Telemetry;
+
+use WPGraphQL\Utils\Utils;
+
+/**
+ * Class Tracker
+ *
+ * @package WPGraphQL\Telemetry
+ */
+class Tracker {
+
+	/**
+	 * The name of the plugin being tracked
+	 *
+	 * @var string
+	 */
+	protected $plugin_name;
+
+	/**
+	 * The slugified name of the plugin being tracked
+	 *
+	 * @var string
+	 */
+	protected $plugin_slug;
+
+	/**
+	 * Whether tracking is enabled for the plugin
+	 *
+	 * @var mixed|void
+	 */
+	protected $tracking_enabled;
+
+	/**
+	 * The endpoint to send tracking data to
+	 *
+	 * @var string
+	 */
+	protected $endpoint_url;
+
+	/**
+	 * Events that have been tracked during this request
+	 *
+	 * @var array
+	 */
+	protected $events;
+
+	/**
+	 * The name of the option that tracks the last tracked timestamp
+	 *
+	 * @var string
+	 */
+	protected $identity_timestamp_option_name;
+
+	/**
+	 * Tracker constructor.
+	 *
+	 * @param string $plugin_name The name of the plugin
+	 */
+	public function __construct( $plugin_name ) {
+
+		$this->endpoint_url = 'https://analytics.gatsbyjs.com/events';
+
+		$this->plugin_name = $plugin_name;
+
+		$this->plugin_slug = strtolower( Utils::format_field_name( $this->plugin_name ) );
+
+		$this->identity_timestamp_option_name = '_' . $this->plugin_slug . '_telemetry_identity_last_logged';
+
+		$tracking_enabled       = 'on' === get_graphql_setting( 'telemetry_enabled', 'off' ) ? true : false;
+		$this->tracking_enabled = apply_filters( 'graphql_telemetry_enabled', $tracking_enabled, $this );
+
+		$this->init();
+
+	}
+
+	/**
+	 * Initialize the tracker.
+	 */
+	public function init() {
+
+		// If tracking is not enabled, do nothing
+		if ( ! $this->tracking_enabled ) {
+			$this->delete_timestamp();
+
+			return;
+		}
+
+		add_action( 'init', [ $this, 'track_identity' ] );
+		add_action( 'shutdown', [ $this, 'send_events' ] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function delete_timestamp() {
+		delete_option( $this->get_identity_timestamp_option_name() );
+	}
+
+	/**
+	 * Return the option name that stores the timestamp
+	 *
+	 * @return string
+	 */
+	public function get_identity_timestamp_option_name() {
+		return $this->identity_timestamp_option_name;
+	}
+
+	/**
+	 * Returns the plugin name being tracked
+	 *
+	 * @return string
+	 */
+	public function get_plugin_name() {
+		return $this->plugin_name;
+	}
+
+	/**
+	 * Returns the slug of the plugin being tracked
+	 *
+	 * @return string
+	 */
+	public function get_plugin_slug() {
+		return $this->plugin_slug;
+	}
+
+	/**
+	 * Returns whether tracking is enabled or not
+	 *
+	 * @return bool
+	 */
+	public function is_tracking_enabled() {
+		return $this->tracking_enabled;
+	}
+
+	/**
+	 * Tracks the identity of the plugin. This is done once daily.
+	 *
+	 * @return void
+	 */
+	public function track_identity() {
+
+		$last_logged = get_option( $this->get_identity_timestamp_option_name(), null );
+
+		// If the last time the identity was logged is less than 24 hours ago,
+		// Don't log again
+		if ( ! empty( $last_logged ) && ( strtotime( $last_logged ) < ( strtotime( '-1 day' ) ) ) ) {
+			return;
+		}
+		update_option( $this->get_identity_timestamp_option_name(), strtotime( 'now' ) );
+		$this->track_event( 'IDENTITY' );
+
+	}
+
+	/**
+	 * Given a string, this hashes it and returns the hashed value
+	 *
+	 * @param string $value The string to hash
+	 *
+	 * @return string
+	 */
+	public function hash( $value ) {
+		return hash( 'sha256', $value );
+	}
+
+	/**
+	 * Given a key from the $_SERVER super global, returns sanitized data
+	 *
+	 * @param $key
+	 *
+	 * @return null
+	 */
+	public function clean_server_data( $key ) {
+		return isset( $_SERVER[ $key ] ) ? $this->sanitize( $_SERVER[ $key ] ) : null;
+	}
+
+	/**
+	 * Clean variables using sanitize_text_field. Arrays are cleaned recursively.
+	 * Non-scalar values are ignored.
+	 *
+	 * @param string|array $input Data to sanitize.
+	 *
+	 * @return string|array
+	 */
+	public function sanitize( $input ) {
+
+		if ( is_array( $input ) ) {
+			return array_map( [ $this, 'sanitize' ], $input );
+		} else {
+			return is_scalar( $input ) ? sanitize_text_field( $input ) : $input;
+		}
+	}
+
+	/**
+	 * Get the info to track
+	 *
+	 * @param string $event_type The type of event being tracked
+	 * @param array  $extra_info Additional info to track for the event
+	 *
+	 * @return array
+	 */
+	public function get_info( $event_type = 'IDENTITY', $extra_info ) {
+
+		global $_SERVER;
+
+		$active_plugins = get_option( 'active_plugins', [] );
+		$active_plugins = array_map( function( $plugin ) {
+			return [
+				'path' => $plugin,
+			];
+		}, $active_plugins );
+
+		// This data is required
+		$data = [
+			'phpVersion'         => phpversion(),
+			'serverSoftware'     => $this->clean_server_data( 'SERVER_SOFTWARE' ),
+			'userName'           => $this->hash( $this->clean_server_data( 'USER' ) ),
+			'sessionId'          => $this->hash( $this->clean_server_data( 'HTTP_COOKIE' ) ),
+			'httpAcceptLanguage' => $this->clean_server_data( 'HTTP_ACCEPT_LANGUAGE' ),
+			'userAgent'          => $this->clean_server_data( 'HTTP_USER_AGENT' ),
+			'host'               => $this->sanitize( site_url() ),
+			'pwd'                => $this->hash( $this->clean_server_data( 'DOCUMENT_ROOT' ) ),
+			'filename'           => $this->hash( $this->clean_server_data( 'SCRIPT_FILENAME' ) ),
+			'activePlugins'      => ! empty( $active_plugins ) ? $this->sanitize( $active_plugins ) : null,
+			'name'               => $this->sanitize( $this->plugin_name ),
+			'adminEmail'         => $this->sanitize( get_option( 'admin_email' ) ),
+			'installationId'     => $this->sanitize( site_url() ) . ':' . $this->hash( $this->clean_server_data( 'DOCUMENT_ROOT' ) ),
+		];
+
+		if ( function_exists( 'wp_get_environment_type' ) ) {
+			$data['wpEnvironmentType'] = wp_get_environment_type();
+		}
+
+		$data = array_merge( $extra_info, $data );
+
+		/**
+		 * This data is mandatory and cannot be merged/overridden by $extra_data
+		 */
+		$data['time']        = date( DATE_RFC3339 );
+		$data['componentId'] = $this->plugin_name;
+		$data['eventType']   = $event_type;
+		$data['version']     = 1;
+
+		return $data;
+
+	}
+
+	/**
+	 * Given an Event Type and optional array of extra info, this will track an event
+	 * by adding it to an in-memory array of tracked events.
+	 *
+	 * The events will be sent to the remote endpoint on shutdown.
+	 *
+	 * @param string $event_type The name of the event to track
+	 * @param array  $extra_info Extra info to track with the event
+	 *
+	 * @return void
+	 */
+	public function track_event( $event_type, $extra_info = [] ) {
+		if ( ! $this->tracking_enabled ) {
+			return;
+		}
+
+		$this->events[] = $this->get_info( $event_type, $extra_info );
+
+	}
+
+	/**
+	 * Send any tracked events
+	 *
+	 * @return void
+	 */
+	public function send_events() {
+		if ( ! $this->tracking_enabled ) {
+			return;
+		}
+
+		if ( ! empty( $this->events ) && is_array( $this->events ) ) {
+			foreach ( $this->events as $event_info ) {
+				$this->send_request( $event_info );
+			}
+		}
+
+	}
+
+	/**
+	 * Given an array of event info, this sends a request for the event to be logged
+	 *
+	 * @param array $event_info The event info to log
+	 */
+	protected function send_request( $event_info ) {
+
+		if ( ! $this->tracking_enabled ) {
+			return;
+		}
+
+		if ( empty( $event_info ) || ! is_array( $event_info ) ) {
+			return;
+		}
+
+		wp_remote_post( $this->endpoint_url, [
+			'headers'  => [
+				'Content-Type' => 'application/json',
+			],
+			'blocking' => false,
+			'body'     => wp_json_encode( $event_info ),
+		] );
+
+	}
+
+}

--- a/tests/wpunit/PostObjectMutationsTest.php
+++ b/tests/wpunit/PostObjectMutationsTest.php
@@ -7,6 +7,7 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 	public $client_mutation_id;
 	public $admin;
 	public $subscriber;
+	public $contributor;
 	public $author;
 
 	public function setUp(): void {
@@ -23,6 +24,10 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->admin = $this->factory()->user->create( [
 			'role' => 'administrator',
+		] );
+
+		$this->contributor = $this->factory()->user->create( [
+			'role' => 'contributor',
 		] );
 
 		$this->subscriber = $this->factory()->user->create( [
@@ -799,5 +804,99 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
          */
         $this->assertNotNull( $results['data']['post']['dateGmt'] );
     }
+
+	/**
+	 * @throws Exception
+	 */
+    public function testUserWithoutProperCapabilityCannotUpdateOthersPosts() {
+
+		$admin_created_post_id = $this->factory()->post->create([
+			'post_type' => 'post',
+			'post_status' => 'publish',
+			'post_title' => 'Test Post from Admin, Edit by Contributor',
+			'post_author' => $this->admin
+		]);
+
+		$global_id = \GraphQLRelay\Relay::toGlobalId( 'post', $admin_created_post_id );
+
+		$mutation = '
+		mutation UpdatePost($input: UpdatePostInput! ) {
+		  updatePost(input:$input) {
+		    post {
+		      id
+		      title
+		      content
+		    }
+		  }
+		}
+		';
+
+		$variables = [
+			'input' => [
+				'clientMutationId' => 'UpdatePost',
+				'id' => $global_id,
+				'title' => 'New Title'
+			]
+		];
+
+		wp_set_current_user( $this->contributor );
+
+		$actual = graphql([
+			'query' => $mutation,
+			'variables' => $variables,
+		]);
+
+		codecept_debug( $actual );
+
+		$this->assertArrayHasKey( 'errors', $actual );
+
+    }
+
+	/**
+	 * @throws Exception
+	 */
+	public function testUserWithoutProperCapabilityCannotUpdateOthersPages() {
+
+		$admin_created_page_id = $this->factory()->post->create( [
+			'post_type'   => 'page',
+			'post_status' => 'publish',
+			'post_title'  => 'Test Page from Admin, Edit by Contributor',
+			'post_author' => $this->admin
+		] );
+
+		$global_id = \GraphQLRelay\Relay::toGlobalId( 'post', $admin_created_page_id );
+
+		$mutation = '
+		mutation UpdatePage($input: UpdatePageInput! ) {
+		  updatePage(input:$input) {
+		    page {
+		      id
+		      title
+		      content
+		    }
+		  }
+		}
+		';
+
+		$variables = [
+			'input' => [
+				'clientMutationId' => 'UpdatePage',
+				'id'               => $global_id,
+				'title'            => 'New Title'
+			]
+		];
+
+		wp_set_current_user( $this->contributor );
+
+		$actual = graphql( [
+			'query'     => $mutation,
+			'variables' => $variables,
+		] );
+
+		codecept_debug( $actual );
+
+		$this->assertArrayHasKey( 'errors', $actual );
+
+	}
 
 }

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -295,6 +295,7 @@ return array(
     'WPGraphQL\\Request' => $baseDir . '/src/Request.php',
     'WPGraphQL\\Router' => $baseDir . '/src/Router.php',
     'WPGraphQL\\Server\\WPHelper' => $baseDir . '/src/Server/WPHelper.php',
+    'WPGraphQL\\Telemetry\\Tracker' => $baseDir . '/src/Telemetry/Tracker.php',
     'WPGraphQL\\Type\\Enum\\AvatarRatingEnum' => $baseDir . '/src/Type/Enum/AvatarRatingEnum.php',
     'WPGraphQL\\Type\\Enum\\CommentsConnectionOrderbyEnum' => $baseDir . '/src/Type/Enum/CommentsConnectionOrderbyEnum.php',
     'WPGraphQL\\Type\\Enum\\ContentNodeIdTypeEnum' => $baseDir . '/src/Type/Enum/ContentNodeIdTypeEnum.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -318,6 +318,7 @@ class ComposerStaticInit12a14568338eb748682ecb7787c914f7
         'WPGraphQL\\Request' => __DIR__ . '/../..' . '/src/Request.php',
         'WPGraphQL\\Router' => __DIR__ . '/../..' . '/src/Router.php',
         'WPGraphQL\\Server\\WPHelper' => __DIR__ . '/../..' . '/src/Server/WPHelper.php',
+        'WPGraphQL\\Telemetry\\Tracker' => __DIR__ . '/../..' . '/src/Telemetry/Tracker.php',
         'WPGraphQL\\Type\\Enum\\AvatarRatingEnum' => __DIR__ . '/../..' . '/src/Type/Enum/AvatarRatingEnum.php',
         'WPGraphQL\\Type\\Enum\\CommentsConnectionOrderbyEnum' => __DIR__ . '/../..' . '/src/Type/Enum/CommentsConnectionOrderbyEnum.php',
         'WPGraphQL\\Type\\Enum\\ContentNodeIdTypeEnum' => __DIR__ . '/../..' . '/src/Type/Enum/ContentNodeIdTypeEnum.php',

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -39,6 +39,7 @@ if ( file_exists( __DIR__ . '/c3.php' ) ) {
  * Run this function when WPGraphQL is de-activated
  */
 register_deactivation_hook( __FILE__, 'graphql_deactivation_callback' );
+register_activation_hook( __FILE__, 'graphql_activation_callback' );
 
 /**
  * This plugin brings the power of GraphQL (http://graphql.org/) to WordPress.
@@ -233,6 +234,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 
 			// Required non-autoloaded classes.
 			require_once WPGRAPHQL_PLUGIN_DIR . 'access-functions.php';
+			require_once WPGRAPHQL_PLUGIN_DIR . 'activation.php';
 			require_once WPGRAPHQL_PLUGIN_DIR . 'deactivation.php';
 
 		}
@@ -257,6 +259,16 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 		 * Sets up actions to run at certain spots throughout WordPress and the WPGraphQL execution cycle
 		 */
 		private function actions() {
+
+			$tracker = new \WPGraphQL\Telemetry\Tracker( 'WPGraphQL' );
+			add_action( 'plugins_loaded', [ $tracker, 'init' ] );
+			add_action( 'graphql_activate', function() use ( $tracker ) {
+				$tracker->track_event( 'PLUGIN_ACTIVATE' );
+			} );
+			add_action( 'graphql_deactivate', function() use ( $tracker ) {
+				$tracker->track_event( 'PLUGIN_DEACTIVATE' );
+				$tracker->delete_timestamp();
+			} );
 
 			/**
 			 * Init WPGraphQL after themes have been setup,
@@ -380,28 +392,6 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 		public function init_admin() {
 			$admin = new \WPGraphQL\Admin\Admin();
 			$admin->init();
-		}
-
-		/**
-		 * Function to execute when the user activates the plugin.
-		 *
-		 * @since  0.0.17
-		 */
-		public function activate() {
-			flush_rewrite_rules();
-			// Save the version of the plugin as an option in order to force actions
-			// on upgrade.
-			update_option( 'wp_graphql_version', WPGRAPHQL_VERSION, 'no' );
-		}
-
-		/**
-		 * Function to execute when the user deactivates the plugin.
-		 *
-		 * @since  0.0.17
-		 */
-		public function deactivate() {
-			flush_rewrite_rules();
-			delete_option( 'wp_graphql_version' );
 		}
 
 		/**
@@ -694,7 +684,6 @@ if ( ! function_exists( 'graphql_init' ) ) {
 	 * @since 0.0.1
 	 */
 	function graphql_init() {
-
 		/**
 		 * Return an instance of the action
 		 */


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

This PR adds Telemetry to WPGraphQL. 

**How it works:**

Users can opt-in to sharing data in the GraphQL Settings page (default is off): 

![Screen Shot 2020-10-16 at 3 46 39 PM](https://user-images.githubusercontent.com/1260765/96311474-c94add00-0fc6-11eb-9fa7-c90f108fd002.png)

Once opted in, an IDENTITY event is logged once per day, and plugin de-activation is logged when it occurs. Events are logged in memory then sent during the shutdown hook. 


Does this close any currently open issues?
------------------------------------------
closes #1511 
