### PR TITLE
WordPress Application Password Support

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -72,6 +72,11 @@ class Router {
 		 */
 		add_action( 'parse_request', [ $this, 'resolve_http_request' ], 10 );
 
+		/**
+		 * Adds support for application passwords
+		 */
+		add_filter( 'application_password_is_api_request', [ $this, 'is_api_request' ] );
+
 	}
 
 	/**
@@ -89,6 +94,19 @@ class Router {
 			'top'
 		);
 
+	}
+
+	/**
+	 * Determines whether the request is an API request to play nice with
+	 * application passwords and potential other WordPress core functionality
+	 * for APIs
+	 *
+	 * @param bool $is_api_request Whether the request is an API request
+	 *
+	 * @return bool
+	 */
+	public function is_api_request( $is_api_request ) {
+		return true === is_graphql_http_request() ? true : $is_api_request;
 	}
 
 	/**


### PR DESCRIPTION
This adds initial support for the upcoming WordPress Application Passwords feature by telling WordPress core that GraphQL HTTP Requests are API requests and that application passwords should set the current user for WPGraphQL requests the same way it does for REST / XML-RPC requests. 

Here's a screenshot testing the functionality:

## Public request, no password:

This is a public request asking for the viewer, and getting nothing back.

![Screen Shot 2020-10-22 at 3 50 05 PM (1)](https://user-images.githubusercontent.com/1260765/96959612-aedc9c00-14bd-11eb-835d-f730fea65608.png)

## Request with Application Password in the header:

This request passes an application password in the headers of the GraphQL request and in response the viewer data is returned. 

![Screen Shot 2020-10-22 at 3 50 17 PM](https://user-images.githubusercontent.com/1260765/96959627-b56b1380-14bd-11eb-87bd-278d70ba062e.png)

## Application Passwords

You can verify this functionality using the Application Passwords plugin: https://wordpress.org/plugins/application-passwords/

And you can learn more about Application Passwords in this helpful guide: https://maheshwaghmare.com/doc/application-passwords/