### PR TITLE
Fix do_graphql_request()

### DIFF
--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -223,6 +223,12 @@ class Post extends Model {
 				$wp_query->parse_query( [
 					'attachment' => $post_name,
 				] );
+			} else {
+				$wp_query->parse_query( [
+					$post_type => $post_name,
+					'post_type' => $post_type,
+					'name' => $post_name,
+				] );
 			}
 
 			$wp_query->setup_postdata( $data );

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -225,9 +225,9 @@ class Post extends Model {
 				] );
 			} else {
 				$wp_query->parse_query( [
-					$post_type => $post_name,
+					$post_type  => $post_name,
 					'post_type' => $post_type,
-					'name' => $post_name,
+					'name'      => $post_name,
 				] );
 			}
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -43,6 +43,13 @@ class Request {
 	public $global_post;
 
 	/**
+	 * Cached global wp_the_query.
+	 *
+	 * @var \WP_Query
+	 */
+	private $global_wp_the_query;
+
+	/**
 	 * GraphQL operation parameters for this request. Can also be an array of
 	 * OperationParams.
 	 *
@@ -227,6 +234,10 @@ class Request {
 			$this->global_post = $GLOBALS['post'];
 		}
 
+		if ( ! empty( $GLOBALS['wp_query'] ) ) {
+			$this->global_wp_the_query = clone $GLOBALS['wp_the_query'];
+		}
+
 		/**
 		 * If the request is a batch request it will come back as an array
 		 */
@@ -381,6 +392,12 @@ class Request {
 		 * be anything the because the resolvers themself can set it to whatever. So we just manually reset the
 		 * post with setup_postdata we cached before this request.
 		 */
+
+		if ( ! empty( $this->global_wp_the_query ) ) {
+			$GLOBALS['wp_the_query'] = $this->global_wp_the_query;
+			wp_reset_query();
+		}
+
 		if ( ! empty( $this->global_post ) ) {
 			$GLOBALS['post'] = $this->global_post;
 			setup_postdata( $this->global_post );


### PR DESCRIPTION
What does this implement/fix?
---------------------------------------------------
This PR caches the `$GLOBALS['wp_the_query']` before making GraphQL request. And restores `$GLOBALS['wp_the_query']` after GraphQL request is done. The solution follows the same pattern as with `$GLOBALS['post']` -object

Also this PR fix the issue (that comes from `$GLOBALS['wp_the_query']` -fix) with _EnqueuedScriptsTest_ and _EnqueuedStylesheetsTest_ -tests as is explained here: https://github.com/wp-graphql/wp-graphql/issues/1525#issuecomment-715122880


Does this close any currently open issues?
------------------------------------------
This PR close #1525 


Where has this been tested?
---------------------------
WP Core in version 5.5.1 with Twentytwenty theme
