### PR TITLE
Add filters for connection args

### DIFF
--- a/src/Connection/PostObjects.php
+++ b/src/Connection/PostObjects.php
@@ -670,6 +670,15 @@ class PostObjects {
 			}
 		}
 
-		return array_merge( $fields, $args );
+		$connection_args = array_merge( $fields, $args );
+
+		/**
+		 * Filter the $connection_args args to allow custom query args
+		 *
+		 * @param array         $connection_args  The connection args
+		 * @param \WP_Post_Type $post_type_object The post type the connection is going to
+		 * @param array         $args             The defaults args
+		 */
+		return apply_filters( 'graphql_post_objects_connection_args', $connection_args, $post_type_object, $args );
 	}
 }

--- a/src/Connection/PostObjects.php
+++ b/src/Connection/PostObjects.php
@@ -675,10 +675,20 @@ class PostObjects {
 		/**
 		 * Filter the $connection_args args to allow custom query args
 		 *
-		 * @param array         $connection_args  The connection args
-		 * @param \WP_Post_Type $post_type_object The post type the connection is going to
-		 * @param array         $args             The defaults args
+		 * @param array         $connection_args  The connection args.
+		 * @param \WP_Post_Type $post_type_object The post type the connection is going to.
+		 * @param array         $args             The defaults arguments.
 		 */
-		return apply_filters( 'graphql_post_objects_connection_args', $connection_args, $post_type_object, $args );
+		$connection_args = apply_filters( 'graphql_post_objects_connection_args', $connection_args, $post_type_object, $args );
+
+		/**
+		 * Filter the $connection_args args to allow custom query args.
+		 * Dynamic part of the hook being the post type
+		 *
+		 * @param array         $connection_args  The connection args.
+		 * @param \WP_Post_Type $post_type_object The post type the connection is going to.
+		 * @param array         $args             The defaults arguments.
+		 */
+		return apply_filters( "graphql_{$post_type_object->graphql_single_name}_connection_args", $connection_args, $post_type_object, $args );
 	}
 }

--- a/src/Connection/Users.php
+++ b/src/Connection/Users.php
@@ -196,9 +196,9 @@ class Users {
 		];
 
 		/**
-		 * Filter the $connection_args args to allow custom query args
+		 * Filter the $connection_args args to allow custom query args.
 		 *
-		 * @param array $connection_args The connection args
+		 * @param array $connection_args The connection arguments.
 		 */
 		return apply_filters( 'graphql_users_connection_args', $connection_args );
 	}

--- a/src/Connection/Users.php
+++ b/src/Connection/Users.php
@@ -110,7 +110,7 @@ class Users {
 	 * @return array
 	 */
 	public static function get_connection_args() {
-		return [
+		$connection_args = [
 			'role'              => [
 				'type'        => 'UserRoleEnum',
 				'description' => __( 'An array of role names that users must match to be included in results. Note that this is an inclusive list: users must match *each* role.', 'wp-graphql' ),
@@ -194,6 +194,13 @@ class Users {
 				'description' => __( 'What paramater to use to order the objects by.', 'wp-graphql' ),
 			],
 		];
+
+		/**
+		 * Filter the $connection_args args to allow custom query args
+		 *
+		 * @param array $connection_args The connection args
+		 */
+		return apply_filters( 'graphql_users_connection_args', $connection_args );
 	}
 
 }

--- a/src/Data/Connection/UserConnectionResolver.php
+++ b/src/Data/Connection/UserConnectionResolver.php
@@ -142,13 +142,13 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 		}
 
 		/**
-		 * Filter the $query args to allow folks to customize queries programmatically
+		 * Filter the $query args to allow folks to customize queries programmatically.
 		 *
-		 * @param array       $query_args The args that will be passed to the WP_User_Query
-		 * @param mixed       $source     The source that's passed down the GraphQL queries
-		 * @param array       $args       The inputArgs on the field
-		 * @param AppContext  $context    The AppContext passed down the GraphQL tree
-		 * @param ResolveInfo $info       The ResolveInfo passed down the GraphQL tree
+		 * @param array       $query_args The args that will be passed to the WP_User_Query.
+		 * @param mixed       $source     The source that's passed down the GraphQL queries.
+		 * @param array       $args       The inputArgs on the field.
+		 * @param AppContext  $context    The AppContext passed down the GraphQL tree.
+		 * @param ResolveInfo $info       The ResolveInfo passed down the GraphQL tree.
 		 */
 		return apply_filters( 'graphql_user_connection_query_args', $query_args, $this->source, $this->args, $this->context, $this->info );
 	}

--- a/src/Data/Connection/UserConnectionResolver.php
+++ b/src/Data/Connection/UserConnectionResolver.php
@@ -141,7 +141,16 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 			$query_args['order'] = ! empty( $last ) ? 'ASC' : 'DESC';
 		}
 
-		return $query_args;
+		/**
+		 * Filter the $query args to allow folks to customize queries programmatically
+		 *
+		 * @param array       $query_args The args that will be passed to the WP_User_Query
+		 * @param mixed       $source     The source that's passed down the GraphQL queries
+		 * @param array       $args       The inputArgs on the field
+		 * @param AppContext  $context    The AppContext passed down the GraphQL tree
+		 * @param ResolveInfo $info       The ResolveInfo passed down the GraphQL tree
+		 */
+		return apply_filters( 'graphql_user_connection_query_args', $query_args, $this->source, $this->args, $this->context, $this->info );
 	}
 
 	/**


### PR DESCRIPTION
This PR:
- Adds filters for connection args of `User` and `PostObject` connections
- Adds an explicit filter for `UserConnectionResolver` query args - `graphql_user_connection_query_args`

Closes #1537 

Example usage:

**To filter users based on their Language (`locale`):**

```php
// register the field in connection where args
add_filter( 'graphql_users_connection_args', function ( $connection_args ) {
	$connection_args['localeIn'] = array(
		'type'        => array(
			'list_of' => 'String', // or may be an enum
		),
		'description' => __( 'An array of locales. Matched users must have at least one of these locales.' ),
	);

	return $connection_args;
}, 10, 1 );

// use the field in user query
add_filter( 'graphql_user_connection_query_args', function ( $query_args ) {
	// `localeIn` should already be in $query_args
	if ( isset( $query_args['localeIn'] ) ) {
		// it is already sanitized by `UserConnectionResolver`
		$localeIn = $query_args['localeIn'];
		// remove `localeIn` from the array to avoid it going to WP_User_Query
		unset( $query_args['localeIn'] );

		// locale meta query
		$meta_query = array(
			array(
				'key'     => 'locale',
				'value'   => $localeIn,
				'compare' => 'IN',
			),
		);
		// if there is already a meta_query
		if ( ! empty( $query_args['meta_query'] ) ) {
			$meta_query[] = $query_args['meta_query'];
		}
		// add the meta query
		$query_args['meta_query'] = $meta_query;
	}

	return $query_args;
}, 10, 1 );
```

GQL Query
```gql
query GET_USERS {
  users( where: { localeIn:[ "en_US" ] } ) {
    nodes {
      id
      name
    }
  }
}
```