### PR TITLE
Fix UsersConnectionSearchColumnEnum

### DIFF
--- a/src/Connection/Users.php
+++ b/src/Connection/Users.php
@@ -147,7 +147,7 @@ class Users {
 				'type'        => [
 					'list_of' => 'UsersConnectionSearchColumnEnum',
 				],
-				'description' => __( 'Array of column names to be searched. Accepts \'ID\', \'login\', \'nicename\', \'email\', \'url\'.', 'wp-graphql' ),
+				'description' => __( 'Array of column names to be searched. Accepts \'ID\', \'LOGIN\', \'NICE_NAME\', \'EMAIL\', \'URL\'.', 'wp-graphql' ),
 			],
 			'hasPublishedPosts' => [
 				'type'        => [

--- a/src/Type/Enum/UsersConnectionSearchColumnEnum.php
+++ b/src/Type/Enum/UsersConnectionSearchColumnEnum.php
@@ -6,30 +6,34 @@ use WPGraphQL\Type\WPEnumType;
 
 class UsersConnectionSearchColumnEnum {
 	public static function register_type() {
-		global $wp_roles;
-		$all_roles      = $wp_roles->roles;
-		$editable_roles = apply_filters( 'editable_roles', $all_roles );
-		$roles          = [];
 
-		if ( ! empty( $editable_roles ) && is_array( $editable_roles ) ) {
-			foreach ( $editable_roles as $key => $role ) {
-
-				$formatted_role = WPEnumType::get_safe_name( $role['name'] );
-
-				$roles[ $formatted_role ] = [
-					'value' => $key,
-				];
-			}
-		}
-
-		if ( ! empty( $roles ) && is_array( $roles ) ) {
-			register_graphql_enum_type(
-				'UsersConnectionSearchColumnEnum',
-				[
-					'description' => __( 'Names of available user roles', 'wp-graphql' ),
-					'values'      => $roles,
-				]
-			);
-		}
+		register_graphql_enum_type(
+			'UsersConnectionSearchColumnEnum',
+			[
+				'description' => __( 'Column name to be searched.', 'wp-graphql' ),
+				'values'      => [
+					'ID'        => [
+						'value'       => 'ID',
+						'description' => __( 'Search users by ID', 'wp-graphql' ),
+					],
+					'LOGIN'     => [
+						'value'       => 'user_login',
+						'description' => __( 'Search users by login', 'wp-graphql' ),
+					],
+					'NICE_NAME' => [
+						'value'       => 'user_nicename',
+						'description' => __( 'Search users by nicename', 'wp-graphql' ),
+					],
+					'EMAIL'     => [
+						'value'       => 'user_email',
+						'description' => __( 'Search users by email address', 'wp-graphql' ),
+					],
+					'URL'       => [
+						'value'       => 'user_url',
+						'description' => __( 'Search users by url', 'wp-graphql' ),
+					],
+				],
+			]
+		);
 	}
 }


### PR DESCRIPTION
This PR fixes the `UsersConnectionSearchColumnEnum` which was wrongly showing the roles instead of user columns.

Closes #1539 