### PR TITLE
Adds externally defined post-types to ContentTypeEnum

### DIFF
--- a/src/Type/Enum/ContentTypeEnum.php
+++ b/src/Type/Enum/ContentTypeEnum.php
@@ -11,7 +11,10 @@ class ContentTypeEnum {
 		/**
 		 * Get the allowed taxonomies
 		 */
-		$allowed_post_types = \WPGraphQL::get_allowed_post_types();
+		$allowed_post_types = get_post_types( [
+				'show_in_graphql' => true,
+				'public'          => true
+		] );
 
 		/**
 		 * Loop through the taxonomies and create an array


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](.github/CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
This will allow for post-types like `Product` and `ProductVariation`, as well as any post-type not returned in `get_allowed_post_types()` to be used as values for the **ContentTypeEnum**


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
