### PR TITLE
Add new filter for meta field order

### DIFF
--- a/src/Data/Cursor/CursorBuilder.php
+++ b/src/Data/Cursor/CursorBuilder.php
@@ -43,7 +43,7 @@ class CursorBuilder {
 		 * @param null | PostObjectCursor $object_cursor The PostObjectCursor class
 		 */
 		$field = apply_filters(
-			'wpgraphql_cursor_ordering_field',
+			'graphql_cursor_ordering_field',
 			[
 				'key'   => esc_sql( $key ),
 				'value' => esc_sql( $value ),

--- a/src/Data/Cursor/CursorBuilder.php
+++ b/src/Data/Cursor/CursorBuilder.php
@@ -21,28 +21,34 @@ class CursorBuilder {
 		$this->compare = $compare;
 		$this->fields  = [];
 	}
-
+	
 	/**
 	 * Add ordering field. The order you call this method matters. First field
 	 * will be the primary field and latters ones will be used if the primary
 	 * field has duplicate values
 	 *
-	 * @param string $key   database colum
-	 * @param string $value value from the current cursor
-	 * @param string $type  type cast
-	 * @param string $order custom order
+	 * @param string                  $key           database column
+	 * @param string                  $value         value from the current cursor
+	 * @param null                    $type          type cast
+	 * @param null                    $order         custom order
+	 * @param null | PostObjectCursor $object_cursor The PostObjectCursor class
 	 */
-	public function add_field( $key, $value, $type = null, $order = null ) {
+	public function add_field( $key, $value, $type = null, $order = null, $object_cursor = null ) {
 		/**
 		 * This only input for variables which are used in the SQL generation. So
 		 * escape them here.
 		 */
-		$this->fields[] = [
-			'key'   => esc_sql( $key ),
-			'value' => esc_sql( $value ),
-			'type'  => esc_sql( $type ),
-			'order' => esc_sql( $order ),
-		];
+		$this->fields[] = apply_filters(
+			'wpgraphql_cursor_ordering_field',
+			[
+				'key'   => esc_sql( $key ),
+				'value' => esc_sql( $value ),
+				'type'  => esc_sql( $type ),
+				'order' => esc_sql( $order ),
+			],
+			$this,
+			$object_cursor
+		);
 	}
 
 	/**

--- a/src/Data/Cursor/CursorBuilder.php
+++ b/src/Data/Cursor/CursorBuilder.php
@@ -34,6 +34,7 @@ class CursorBuilder {
 	 * @param null | PostObjectCursor $object_cursor The PostObjectCursor class
 	 */
 	public function add_field( $key, $value, $type = null, $order = null, $object_cursor = null ) {
+		
 		/**
 		 * Filters the field used for ordering when cursors are used for pagination
 		 *
@@ -41,7 +42,7 @@ class CursorBuilder {
 		 * @param CursorBuilder           $this          The CursorBuilder class
 		 * @param null | PostObjectCursor $object_cursor The PostObjectCursor class
 		 */
-		$this->fields[] = apply_filters(
+		$field = apply_filters(
 			'wpgraphql_cursor_ordering_field',
 			[
 				'key'   => esc_sql( $key ),
@@ -52,6 +53,25 @@ class CursorBuilder {
 			$this,
 			$object_cursor
 		);
+		
+		// Bail if the filtered field comes back empty
+		if ( empty( $field ) ) {
+			return;
+		}
+		
+		// Bail if the filtered field doesn't come back as an array
+		if ( ! is_array( $field ) ) {
+			return;
+		}
+		
+		$escaped_field = [];
+		
+		// Escape the filtered array
+		foreach ( $field as $key => $value ) {
+			$escaped_field[$key] = esc_sql( $value );
+		}
+		
+		$this->fields[] = $escaped_field;
 	}
 
 	/**

--- a/src/Data/Cursor/CursorBuilder.php
+++ b/src/Data/Cursor/CursorBuilder.php
@@ -35,8 +35,11 @@ class CursorBuilder {
 	 */
 	public function add_field( $key, $value, $type = null, $order = null, $object_cursor = null ) {
 		/**
-		 * This only input for variables which are used in the SQL generation. So
-		 * escape them here.
+		 * Filters the field used for ordering when cursors are used for pagination
+		 *
+		 * @param array                   $field         The field key, value, type and order
+		 * @param CursorBuilder           $this          The CursorBuilder class
+		 * @param null | PostObjectCursor $object_cursor The PostObjectCursor class
 		 */
 		$this->fields[] = apply_filters(
 			'wpgraphql_cursor_ordering_field',

--- a/src/Data/Cursor/PostObjectCursor.php
+++ b/src/Data/Cursor/PostObjectCursor.php
@@ -247,7 +247,7 @@ class PostObjectCursor {
 
 		$this->meta_join_alias ++;
 
-		$this->builder->add_field( $key, $meta_value, $meta_type, $order );
+		$this->builder->add_field( $key, $meta_value, $meta_type, $order, $this );
 	}
 
 	/**


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds a new filter so that consumer can handle types before the SQL query is set. There are instances where a float is being passed but the type value is set to null. This creates unexpected SQL results.

An example implementation would be something like this:

```php
/**
 * Ensure meta field type is set to decimal (float)
 */
add_filter( 'wpgraphql_cursor_ordering_field', function ( $fields, $builder, $object_cursor ) {
	// Bail if not a float
	if ( empty( strpos( $fields['value'], '.' ) ) ) {
		return $fields;
	}
	
	
	$fields['type'] = 'DECIMAL(10,' . wc_get_price_decimals() . ')';
	
	return $fields;
}, 10, 3 );
```


Does this close any currently open issues?
------------------------------------------
#1545 

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
See issue.

