### PR TITLE
Feature/#1504 template interface

### DIFF
--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -545,22 +545,40 @@ class Post extends Model {
 					];
 
 
-					if ( ! isset( $registered_templates[ $this->data->post_type ] ) ) {
-						return $template;
+
+					if ( $this->isPreview ) {
+
+						$post_type = get_post( $this->parentDatabaseId )->post_type;
+						if ( ! isset( $registered_templates[ $post_type ] ) ) {
+							return $template;
+						}
+						$set_template = get_post_meta( $this->parentDatabaseId, '_wp_page_template', true );
+						$template_name = get_page_template_slug( $this->parentDatabaseId );
+
+						if ( empty( $set_template ) ) {
+							$set_template = get_post_meta( $this->data->ID, '_wp_page_template', true );
+						}
+
+						if ( empty( $template_name ) ) {
+							$template_name = get_page_template_slug( $this->data->ID );
+						}
+
+						$template_name = ! empty( $template_name ) ? $template_name : 'Default';
+
+
+					} else {
+						if ( ! isset( $registered_templates[ $this->data->post_type ] ) ) {
+							return $template;
+						}
+						$post_type = $this->data->post_type;
+						$set_template = get_post_meta( $this->data->ID, '_wp_page_template', true );
+						$template_name = get_page_template_slug( $this->data->ID );
+
+						$template_name = ! empty( $template_name ) ? $template_name : 'Default';
 					}
 
-					$set_template = get_post_meta( $this->data->ID, '_wp_page_template', true );
-
-					$template_name = get_page_template_slug( $this->data->ID );
-
-					$template = [
-						'__typename'   => 'DefaultTemplate',
-						'templateName' => ! empty( $template_name ) ? $template_name : 'Default',
-					];
-
-
-					if ( ! empty( $registered_templates[ $this->data->post_type ][ $set_template ] ) ) {
-						$name     = ucwords( $registered_templates[ $this->data->post_type ][ $set_template ] );
+					if ( ! empty( $template_name ) && ! empty( $registered_templates[ $post_type ][ $set_template ] ) ) {
+						$name     = ucwords( $registered_templates[ $post_type ][ $set_template ] );
 						$name     = preg_replace( '/[^\w]/', '', $name );
 						if ( preg_match('/^\d/', $name ) || false === strpos( strtolower( $name ), 'template' ) ) {
 							$name = 'Template_' . $name;
@@ -568,7 +586,7 @@ class Post extends Model {
 
 						$template = [
 							'__typename'   => $name,
-							'templateName' => ucwords( $registered_templates[ $this->data->post_type ][ $set_template ] ),
+							'templateName' => ucwords( $registered_templates[ $post_type ][ $set_template ] ),
 						];
 					}
 

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -535,7 +535,7 @@ class Post extends Model {
 				'slug'                      => function() {
 					return ! empty( $this->data->post_name ) ? $this->data->post_name : null;
 				},
-				'template' => function() {
+				'template'                  => function() {
 
 					$registered_templates = wp_get_theme()->get_post_templates();
 
@@ -544,15 +544,13 @@ class Post extends Model {
 						'templateName' => 'Default',
 					];
 
-
-
 					if ( $this->isPreview ) {
 
 						$post_type = get_post( $this->parentDatabaseId )->post_type;
 						if ( ! isset( $registered_templates[ $post_type ] ) ) {
 							return $template;
 						}
-						$set_template = get_post_meta( $this->parentDatabaseId, '_wp_page_template', true );
+						$set_template  = get_post_meta( $this->parentDatabaseId, '_wp_page_template', true );
 						$template_name = get_page_template_slug( $this->parentDatabaseId );
 
 						if ( empty( $set_template ) ) {
@@ -565,22 +563,21 @@ class Post extends Model {
 
 						$template_name = ! empty( $template_name ) ? $template_name : 'Default';
 
-
 					} else {
 						if ( ! isset( $registered_templates[ $this->data->post_type ] ) ) {
 							return $template;
 						}
-						$post_type = $this->data->post_type;
-						$set_template = get_post_meta( $this->data->ID, '_wp_page_template', true );
+						$post_type     = $this->data->post_type;
+						$set_template  = get_post_meta( $this->data->ID, '_wp_page_template', true );
 						$template_name = get_page_template_slug( $this->data->ID );
 
 						$template_name = ! empty( $template_name ) ? $template_name : 'Default';
 					}
 
 					if ( ! empty( $template_name ) && ! empty( $registered_templates[ $post_type ][ $set_template ] ) ) {
-						$name     = ucwords( $registered_templates[ $post_type ][ $set_template ] );
-						$name     = preg_replace( '/[^\w]/', '', $name );
-						if ( preg_match('/^\d/', $name ) || false === strpos( strtolower( $name ), 'template' ) ) {
+						$name = ucwords( $registered_templates[ $post_type ][ $set_template ] );
+						$name = preg_replace( '/[^\w]/', '', $name );
+						if ( preg_match( '/^\d/', $name ) || false === strpos( strtolower( $name ), 'template' ) ) {
 							$name = 'Template_' . $name;
 						}
 

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -32,6 +32,7 @@ use WPGraphQL\Utils\Utils;
  * @property string  $commentStatus
  * @property string  $pingStatus
  * @property string  $slug
+ * @property array   $template
  * @property boolean $isFrontPage
  * @property boolean $isPostsPage
  * @property boolean $isPreview
@@ -533,6 +534,45 @@ class Post extends Model {
 				},
 				'slug'                      => function() {
 					return ! empty( $this->data->post_name ) ? $this->data->post_name : null;
+				},
+				'template' => function() {
+
+					$registered_templates = wp_get_theme()->get_post_templates();
+
+					$template = [
+						'__typename'   => 'DefaultTemplate',
+						'templateName' => 'Default',
+					];
+
+
+					if ( ! isset( $registered_templates[ $this->data->post_type ] ) ) {
+						return $template;
+					}
+
+					$set_template = get_post_meta( $this->data->ID, '_wp_page_template', true );
+
+					$template_name = get_page_template_slug( $this->data->ID );
+
+					$template = [
+						'__typename'   => 'DefaultTemplate',
+						'templateName' => ! empty( $template_name ) ? $template_name : 'Default',
+					];
+
+
+					if ( ! empty( $registered_templates[ $this->data->post_type ][ $set_template ] ) ) {
+						$name     = ucwords( $registered_templates[ $this->data->post_type ][ $set_template ] );
+						$name     = preg_replace( '/[^\w]/', '', $name );
+						if ( preg_match('/^\d/', $name ) || false === strpos( strtolower( $name ), 'template' ) ) {
+							$name = 'Template_' . $name;
+						}
+
+						$template = [
+							'__typename'   => $name,
+							'templateName' => ucwords( $registered_templates[ $this->data->post_type ][ $set_template ] ),
+						];
+					}
+
+					return $template;
 				},
 				'isFrontPage'               => function() {
 					if ( 'page' !== $this->data->post_type || 'page' !== get_option( 'show_on_front' ) ) {

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -350,9 +350,9 @@ class TypeRegistry {
 		if ( ! empty( $page_templates ) && is_array( $page_templates ) ) {
 
 			foreach ( $page_templates as $file => $name ) {
-				$name               = ucwords( $name );
-				$name               = preg_replace( '/[^\w]/', '', $name );
-				if ( preg_match('/^\d/', $name ) || false === strpos( strtolower( $name ), 'template' ) ) {
+				$name = ucwords( $name );
+				$name = preg_replace( '/[^\w]/', '', $name );
+				if ( preg_match( '/^\d/', $name ) || false === strpos( strtolower( $name ), 'template' ) ) {
 					$name = 'Template_' . $name;
 				}
 				$template_type_name = $name;

--- a/src/Type/InterfaceType/ContentNode.php
+++ b/src/Type/InterfaceType/ContentNode.php
@@ -62,8 +62,8 @@ class ContentNode {
 						],
 						'description' => __( 'The globally unique identifier of the node.', 'wp-graphql' ),
 					],
-					'template' => [
-						'type' => 'ContentTemplate',
+					'template'                  => [
+						'type'        => 'ContentTemplate',
 						'description' => __( 'The template assigned to a node of content', 'wp-graphql' ),
 					],
 					'databaseId'                => [

--- a/src/Type/InterfaceType/ContentNode.php
+++ b/src/Type/InterfaceType/ContentNode.php
@@ -62,6 +62,10 @@ class ContentNode {
 						],
 						'description' => __( 'The globally unique identifier of the node.', 'wp-graphql' ),
 					],
+					'template' => [
+						'type' => 'ContentTemplate',
+						'description' => __( 'The template assigned to a node of content', 'wp-graphql' ),
+					],
 					'databaseId'                => [
 						'type'        => [
 							'non_null' => 'Int',

--- a/src/Type/InterfaceType/ContentTemplate.php
+++ b/src/Type/InterfaceType/ContentTemplate.php
@@ -13,10 +13,6 @@ class ContentTemplate {
 						'type'        => 'String',
 						'description' => __( 'The name of the template', 'wp-graphql' ),
 					],
-					'templateFile' => [
-						'type'        => 'String',
-						'description' => __( 'The file the template uses', 'wp-graphql' ),
-					],
 				],
 				'resolveType' => function( $value ) use ( $type_registry ) {
 					return isset( $value['__typename'] ) ? $value['__typename'] : 'DefaultTemplate';

--- a/src/Type/InterfaceType/NodeWithTemplate.php
+++ b/src/Type/InterfaceType/NodeWithTemplate.php
@@ -1,0 +1,18 @@
+<?php
+namespace WPGraphQL\Type\InterfaceType;
+
+use WPGraphQL\Registry\TypeRegistry;
+
+class NodeWithTemplate {
+	public static function register_type( TypeRegistry $type_registry ) {
+		register_graphql_interface_type( 'NodeWithTemplate', [
+			'description' => __( 'A node that can have a template associated with it', 'wp-graphql' ),
+			'fields' => [
+				'template' => [
+					'description' => __( 'The template assigned to the node', 'wp-graphql' ),
+					'type'        => 'ContentTemplate',
+				],
+			],
+		]);
+	}
+}

--- a/src/Type/InterfaceType/NodeWithTemplate.php
+++ b/src/Type/InterfaceType/NodeWithTemplate.php
@@ -7,7 +7,7 @@ class NodeWithTemplate {
 	public static function register_type( TypeRegistry $type_registry ) {
 		register_graphql_interface_type( 'NodeWithTemplate', [
 			'description' => __( 'A node that can have a template associated with it', 'wp-graphql' ),
-			'fields' => [
+			'fields'      => [
 				'template' => [
 					'description' => __( 'The template assigned to the node', 'wp-graphql' ),
 					'type'        => 'ContentTemplate',

--- a/src/Type/Object/PostObject.php
+++ b/src/Type/Object/PostObject.php
@@ -22,7 +22,7 @@ class PostObject {
 
 		$single_name = $post_type_object->graphql_single_name;
 
-		$interfaces = [ 'Node', 'ContentNode', 'DatabaseIdentifier' ];
+		$interfaces = [ 'Node', 'ContentNode', 'DatabaseIdentifier', 'NodeWithTemplate' ];
 
 		if ( true === $post_type_object->public ) {
 			$interfaces[] = 'UniformResourceIdentifiable';
@@ -313,39 +313,6 @@ class PostObject {
 			$fields['ancestors']['deprecationReason'] = __( 'This content type is not hierarchical and typcially will not have ancestors', 'wp-graphql' );
 			$fields['parent']['deprecationReason']    = __( 'This content type is not hierarchical and typcially will not have a parent', 'wp-graphql' );
 		}
-
-		$fields['template'] = [
-			'description' => __( 'The template assigned to the node', 'wp-graphql' ),
-			'type'        => 'ContentTemplate',
-			'resolve'     => function( Post $post_object, $args, $context, $info ) use ( $post_type_object, $type_registry ) {
-
-				$registered_templates = wp_get_theme()->get_post_templates();
-				if ( ! isset( $registered_templates[ $post_object->post_type ] ) ) {
-					return null;
-				}
-
-				$set_template = get_post_meta( $post_object->ID, '_wp_page_template', true );
-
-				$template_name = get_page_template_slug( $post_object->ID );
-
-				$template = [
-					'__typename'   => 'DefaultTemplate',
-					'templateName' => ! empty( $template_name ) ? $template_name : 'Default',
-				];
-
-				if ( ! empty( $registered_templates[ $post_object->post_type ][ $set_template ] ) ) {
-					$name     = ucwords( $registered_templates[ $post_object->post_type ][ $set_template ] );
-					$name     = preg_replace( '/[^\w]/', '', $name );
-					$template = [
-						'__typename'   => $name . 'Template',
-						'templateName' => ucwords( $registered_templates[ $post_object->post_type ][ $set_template ] ),
-						'templateFile' => ! empty( $template_name ) ? $template_name : null,
-					];
-				}
-
-				return $template;
-			},
-		];
 
 		return $fields;
 

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -347,6 +347,7 @@ return array(
     'WPGraphQL\\Type\\InterfaceType\\NodeWithFeaturedImage' => $baseDir . '/src/Type/InterfaceType/NodeWithFeaturedImage.php',
     'WPGraphQL\\Type\\InterfaceType\\NodeWithPageAttributes' => $baseDir . '/src/Type/InterfaceType/NodeWithPageAttributes.php',
     'WPGraphQL\\Type\\InterfaceType\\NodeWithRevisions' => $baseDir . '/src/Type/InterfaceType/NodeWithRevisions.php',
+    'WPGraphQL\\Type\\InterfaceType\\NodeWithTemplate' => $baseDir . '/src/Type/InterfaceType/NodeWithTemplate.php',
     'WPGraphQL\\Type\\InterfaceType\\NodeWithTitle' => $baseDir . '/src/Type/InterfaceType/NodeWithTitle.php',
     'WPGraphQL\\Type\\InterfaceType\\NodeWithTrackbacks' => $baseDir . '/src/Type/InterfaceType/NodeWithTrackbacks.php',
     'WPGraphQL\\Type\\InterfaceType\\TermNode' => $baseDir . '/src/Type/InterfaceType/TermNode.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -370,6 +370,7 @@ class ComposerStaticInita74000dd84470923841fe31227868e4c
         'WPGraphQL\\Type\\InterfaceType\\NodeWithFeaturedImage' => __DIR__ . '/../..' . '/src/Type/InterfaceType/NodeWithFeaturedImage.php',
         'WPGraphQL\\Type\\InterfaceType\\NodeWithPageAttributes' => __DIR__ . '/../..' . '/src/Type/InterfaceType/NodeWithPageAttributes.php',
         'WPGraphQL\\Type\\InterfaceType\\NodeWithRevisions' => __DIR__ . '/../..' . '/src/Type/InterfaceType/NodeWithRevisions.php',
+        'WPGraphQL\\Type\\InterfaceType\\NodeWithTemplate' => __DIR__ . '/../..' . '/src/Type/InterfaceType/NodeWithTemplate.php',
         'WPGraphQL\\Type\\InterfaceType\\NodeWithTitle' => __DIR__ . '/../..' . '/src/Type/InterfaceType/NodeWithTitle.php',
         'WPGraphQL\\Type\\InterfaceType\\NodeWithTrackbacks' => __DIR__ . '/../..' . '/src/Type/InterfaceType/NodeWithTrackbacks.php',
         'WPGraphQL\\Type\\InterfaceType\\TermNode' => __DIR__ . '/../..' . '/src/Type/InterfaceType/TermNode.php',


### PR DESCRIPTION
**Before**
This shows a query asking for the template on a page and preview and getting null for the template on the preview.

![Screen Shot 2020-11-06 at 2 27 57 PM](https://user-images.githubusercontent.com/1260765/98416425-4d2f3c80-203c-11eb-8828-f019f28fe064.png)


**After**

This shows the same query and getting results for the template on the preview, and notice the template is supported on the ContentNode interface too. 💪 

![Screen Shot 2020-11-06 at 2 14 27 PM](https://user-images.githubusercontent.com/1260765/98416349-23761580-203c-11eb-95e1-eeeff537222c.png)

----

**BREAKING**

This removes the `templateFile` field from the `ContentTemplate` Type, as it is a potential security risk and in most cases the name and __typename should provide enough information to anyone, even a backend developer using GraphQL to troubleshoot.

----

closes #1504 
closes #1544 
