### PR TITLE
Add graphql_insert_term action

### DIFF
--- a/src/Mutation/TermObjectCreate.php
+++ b/src/Mutation/TermObjectCreate.php
@@ -157,6 +157,18 @@ class TermObjectCreate {
 			/**
 			 * Fires after a single term is created or updated via a GraphQL mutation
 			 *
+			 * @param int         $term_id       Inserted term object
+			 * @param \WP_Taxonomy $taxonomy     The taxonomy of the term being updated
+			 * @param array       $args          The args used to insert the term
+			 * @param string      $mutation_name The name of the mutation being performed
+			 * @param AppContext  $context       The AppContext passed down the resolve tree
+			 * @param ResolveInfo $info          The ResolveInfo passed down the resolve tree
+			 */
+			do_action( "graphql_insert_term", $term['term_id'], $taxonomy, $args, $mutation_name, $context, $info );
+
+			/**
+			 * Fires after a single term is created or updated via a GraphQL mutation
+			 *
 			 * The dynamic portion of the hook name, `$taxonomy->name` refers to the taxonomy of the term being mutated
 			 *
 			 * @param int         $term_id       Inserted term object

--- a/src/Mutation/TermObjectCreate.php
+++ b/src/Mutation/TermObjectCreate.php
@@ -164,7 +164,7 @@ class TermObjectCreate {
 			 * @param AppContext  $context       The AppContext passed down the resolve tree
 			 * @param ResolveInfo $info          The ResolveInfo passed down the resolve tree
 			 */
-			do_action( "graphql_insert_term", $term['term_id'], $taxonomy, $args, $mutation_name, $context, $info );
+			do_action( 'graphql_insert_term', $term['term_id'], $taxonomy, $args, $mutation_name, $context, $info );
 
 			/**
 			 * Fires after a single term is created or updated via a GraphQL mutation


### PR DESCRIPTION
This adds an action to TermObjectCreate.php called `graphql_insert_term`. This is very similar to the dynamic `graphql_insert_{$taxonomy->name}` action, but includes the WP_Taxonomy object as a parameter.