### PR TITLE
Fallback functionality added to "TypeRegistry::get_connection_name()"

### DIFF
--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -927,13 +927,23 @@ class TypeRegistry {
 	 * Utility method that formats the connection name given the name of the from Type and the to
 	 * Type
 	 *
-	 * @param string $from_type Name of the Type the connection is coming from
-	 * @param string $to_type   Name of the Type the connection is going to
+	 * @param string $from_type        Name of the Type the connection is coming from
+	 * @param string $to_type          Name of the Type the connection is going to
+	 * @param string $from_field_name  Acts as an alternative "fromType" if connection type already defined using $from_type.
 	 *
 	 * @return string
 	 */
-	protected function get_connection_name( $from_type, $to_type ) {
-		return ucfirst( $from_type ) . 'To' . ucfirst( $to_type ) . 'Connection';
+	protected function get_connection_name( $from_type, $to_type, $from_field_name ) {
+		// Create connection name using $from_type + To + $to_type.
+		$connection_name = ucfirst( $from_type ) . 'To' . ucfirst( $to_type ) . 'Connection';
+
+		// If connection type already exists with that connection name. Set connection name using 
+		// $from_field_name + To + $to_type + Connection.
+		if ( $this->get_type( $connection_name ) ) {
+			$connection_name = ucfirst( $from_field_name ) . 'To' . ucfirst( $to_type ) . 'Connection';
+		}
+
+		return $connection_name;
 	}
 
 	/**
@@ -970,7 +980,7 @@ class TypeRegistry {
 		$resolve_connection = array_key_exists( 'resolve', $config ) && is_callable( $config['resolve'] ) ? $config['resolve'] : function() {
 			return null;
 		};
-		$connection_name    = ! empty( $config['connectionTypeName'] ) ? $config['connectionTypeName'] : $this->get_connection_name( $from_type, $to_type );
+		$connection_name    = ! empty( $config['connectionTypeName'] ) ? $config['connectionTypeName'] : $this->get_connection_name( $from_type, $to_type, $from_field_name );
 		$where_args         = [];
 		$one_to_one         = isset( $config['oneToOne'] ) && true === $config['oneToOne'] ? true : false;
 

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -934,12 +934,12 @@ class TypeRegistry {
 	 * @return string
 	 */
 	protected function get_connection_name( $from_type, $to_type, $from_field_name ) {
-		// Create connection name using $from_type + To + $to_type.
+		// Create connection name using $from_type + To + $to_type + Connection.
 		$connection_name = ucfirst( $from_type ) . 'To' . ucfirst( $to_type ) . 'Connection';
 
 		// If connection type already exists with that connection name. Set connection name using 
 		// $from_field_name + To + $to_type + Connection.
-		if ( $this->get_type( $connection_name ) ) {
+		if ( ! empty( $this->get_type( $connection_name ) ) ) {
 			$connection_name = ucfirst( $from_field_name ) . 'To' . ucfirst( $to_type ) . 'Connection';
 		}
 

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -929,7 +929,7 @@ class TypeRegistry {
 	 *
 	 * @param string $from_type        Name of the Type the connection is coming from
 	 * @param string $to_type          Name of the Type the connection is going to
-	 * @param string $from_field_name  Acts as an alternative "fromType" if connection type already defined using $from_type.
+	 * @param string $from_field_name  Acts as an alternative "toType" if connection type already defined using $to_type.
 	 *
 	 * @return string
 	 */
@@ -940,7 +940,7 @@ class TypeRegistry {
 		// If connection type already exists with that connection name. Set connection name using 
 		// $from_field_name + To + $to_type + Connection.
 		if ( ! empty( $this->get_type( $connection_name ) ) ) {
-			$connection_name = ucfirst( $from_field_name ) . 'To' . ucfirst( $to_type ) . 'Connection';
+			$connection_name = ucfirst( $from_type ) . 'To' . ucfirst( $from_field_name ) . 'Connection';
 		}
 
 		return $connection_name;


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](.github/CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds functionality to the `TypeRegistry::get_connection_name()` that uses `$from_field_name` as a fallback for `$to_type`.

@jasonbahl This is meant to resolve the `DUPLICATE_TYPE` error that comes in to effect when making multiple connections with the same `from` and `to` types without a designated `type_name` set in the connection configurations.


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04

**WordPress Version:** 5.5.3
