### PR TITLE
#1532 - Fixes menu item paths

### DIFF
--- a/src/Model/MenuItem.php
+++ b/src/Model/MenuItem.php
@@ -152,8 +152,12 @@ class MenuItem extends Model {
 
 					if ( ! empty( $url ) ) {
 						$parsed = wp_parse_url( $url );
-						if ( isset( $parsed['host'] ) && strpos( site_url(), $parsed['host'] ) ) {
-							return $parsed['path'];
+						if ( isset( $parsed['host'] ) ) {
+							if ( strpos( home_url(), $parsed['host'] ) ) {
+								return $parsed['path'];
+							} else if ( strpos( home_url(), $parsed['host'] ) ) {
+								return $parsed['path'];
+							}
 						}
 					}
 					return $url;

--- a/src/Model/MenuItem.php
+++ b/src/Model/MenuItem.php
@@ -155,7 +155,7 @@ class MenuItem extends Model {
 						if ( isset( $parsed['host'] ) ) {
 							if ( strpos( home_url(), $parsed['host'] ) ) {
 								return $parsed['path'];
-							} else if ( strpos( home_url(), $parsed['host'] ) ) {
+							} elseif ( strpos( home_url(), $parsed['host'] ) ) {
 								return $parsed['path'];
 							}
 						}

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -475,7 +475,6 @@ abstract class Model {
 		 * @param string                 $string     The string to decode
 		 * @param string                 $field_name The name of the field being encoded
 		 * @param \WPGraphQL\Model\Model $model      The Model the field is being decoded on
-		 *
 		 */
 		$decoding_enabled = apply_filters( 'graphql_html_entity_decoding_enabled', $enabled, $string, $field_name, $this );
 

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -500,7 +500,7 @@ class Post extends Model {
 					$id    = ! empty( $this->data->ID ) ? $this->data->ID : null;
 					$title = ! empty( $this->data->post_title ) ? $this->data->post_title : null;
 
-					return $this->html_entity_decode( apply_filters( 'the_title', $title, $id ), 'titleRendered',true );
+					return $this->html_entity_decode( apply_filters( 'the_title', $title, $id ), 'titleRendered', true );
 				},
 				'titleRaw'                  => [
 					'callback'   => function() {

--- a/src/Request.php
+++ b/src/Request.php
@@ -618,7 +618,13 @@ class Request {
 	 */
 	private function get_server() {
 
-		$debug_flag = true === \WPGraphQL::debug() ? 2 : 0;
+		$flag = 1;
+		if ( 0 !== get_current_user_id() ) {
+			// Flag 2 shows the trace data, which should require user to be logged in to see by default
+			$flag = 2;
+		}
+
+		$debug_flag = true === \WPGraphQL::debug() ? $flag : 0;
 
 		$config = new ServerConfig();
 		$config

--- a/src/Type/Enum/ContentTypeEnum.php
+++ b/src/Type/Enum/ContentTypeEnum.php
@@ -12,8 +12,8 @@ class ContentTypeEnum {
 		 * Get the allowed taxonomies
 		 */
 		$allowed_post_types = get_post_types( [
-				'show_in_graphql' => true,
-				'public'          => true
+			'show_in_graphql' => true,
+			'public'          => true,
 		] );
 
 		/**

--- a/src/Utils/Tracing.php
+++ b/src/Utils/Tracing.php
@@ -109,7 +109,7 @@ class Tracing {
 	 * @return string
 	 */
 	public function init_trace() {
-		$this->request_start_microtime = microtime( true );
+		$this->request_start_microtime = microtime( TRUE );
 		$this->request_start_timestamp = $this->format_timestamp( $this->request_start_microtime );
 
 		return $this->request_start_timestamp;
@@ -121,7 +121,7 @@ class Tracing {
 	 * @return string
 	 */
 	public function end_trace() {
-		$this->request_end_microtime = microtime( true );
+		$this->request_end_microtime = microtime( TRUE );
 		$this->request_end_timestamp = $this->format_timestamp( $this->request_end_microtime );
 
 		return $this->request_end_timestamp;
@@ -138,7 +138,7 @@ class Tracing {
 			'fieldName'      => $info->fieldName,
 			'returnType'     => $info->returnType->name ? $info->returnType->name : $info->returnType,
 			'startOffset'    => $this->get_start_offset(),
-			'startMicrotime' => microtime( true ),
+			'startMicrotime' => microtime( TRUE ),
 		];
 
 	}
@@ -164,7 +164,7 @@ class Tracing {
 	 * @return float|int
 	 */
 	public function get_field_resolver_duration() {
-		return ( microtime( true ) - $this->field_trace['startMicrotime'] ) * 1000000;
+		return ( microtime( TRUE ) - $this->field_trace['startMicrotime'] ) * 1000000;
 	}
 
 	/**
@@ -173,7 +173,7 @@ class Tracing {
 	 * @return float|int
 	 */
 	public function get_start_offset() {
-		return ( microtime( true ) - $this->request_start_microtime ) * 1000000;
+		return ( microtime( TRUE ) - $this->request_start_microtime ) * 1000000;
 	}
 
 	/**
@@ -227,7 +227,8 @@ class Tracing {
 	 * @return string
 	 */
 	public function format_timestamp( $time ) {
-		$timestamp = \DateTime::createFromFormat( 'U.u', $time );
+		$time_as_float = sprintf('%.4f', $time );
+		$timestamp = \DateTime::createFromFormat( 'U.u', $time_as_float );
 
 		return $timestamp->format( 'Y-m-d\TH:i:s.uP' );
 	}

--- a/src/Utils/Tracing.php
+++ b/src/Utils/Tracing.php
@@ -109,7 +109,7 @@ class Tracing {
 	 * @return string
 	 */
 	public function init_trace() {
-		$this->request_start_microtime = microtime( TRUE );
+		$this->request_start_microtime = microtime( true );
 		$this->request_start_timestamp = $this->format_timestamp( $this->request_start_microtime );
 
 		return $this->request_start_timestamp;
@@ -121,7 +121,7 @@ class Tracing {
 	 * @return string
 	 */
 	public function end_trace() {
-		$this->request_end_microtime = microtime( TRUE );
+		$this->request_end_microtime = microtime( true );
 		$this->request_end_timestamp = $this->format_timestamp( $this->request_end_microtime );
 
 		return $this->request_end_timestamp;
@@ -138,7 +138,7 @@ class Tracing {
 			'fieldName'      => $info->fieldName,
 			'returnType'     => $info->returnType->name ? $info->returnType->name : $info->returnType,
 			'startOffset'    => $this->get_start_offset(),
-			'startMicrotime' => microtime( TRUE ),
+			'startMicrotime' => microtime( true ),
 		];
 
 	}
@@ -164,7 +164,7 @@ class Tracing {
 	 * @return float|int
 	 */
 	public function get_field_resolver_duration() {
-		return ( microtime( TRUE ) - $this->field_trace['startMicrotime'] ) * 1000000;
+		return ( microtime( true ) - $this->field_trace['startMicrotime'] ) * 1000000;
 	}
 
 	/**
@@ -173,7 +173,7 @@ class Tracing {
 	 * @return float|int
 	 */
 	public function get_start_offset() {
-		return ( microtime( TRUE ) - $this->request_start_microtime ) * 1000000;
+		return ( microtime( true ) - $this->request_start_microtime ) * 1000000;
 	}
 
 	/**
@@ -227,8 +227,8 @@ class Tracing {
 	 * @return string
 	 */
 	public function format_timestamp( $time ) {
-		$time_as_float = sprintf('%.4f', $time );
-		$timestamp = \DateTime::createFromFormat( 'U.u', $time_as_float );
+		$time_as_float = sprintf( '%.4f', $time );
+		$timestamp     = \DateTime::createFromFormat( 'U.u', $time_as_float );
 
 		return $timestamp->format( 'Y-m-d\TH:i:s.uP' );
 	}


### PR DESCRIPTION
## Summary

- Fixes menu item paths to only return the path if the domain is either the site_url() or the home_url()
- also fixes a bug with Debug Flag exposing too much info to public users on errors

### Before:

Query shows full paths for menu items:

![Screen Shot 2020-11-12 at 11 57 21 PM](https://user-images.githubusercontent.com/1260765/99039194-23967980-2544-11eb-8592-a7756960f601.png)

### After:

Query shows relative paths for menu items:

![Screen Shot 2020-11-12 at 11 57 08 PM](https://user-images.githubusercontent.com/1260765/99039189-22654c80-2544-11eb-8661-2c6d595a6fe0.png)



----

closes #1532 
closes #1565 