### PR TITLE
Release/v0.15.1

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,4 +1,4 @@
-name: WordPress Coding Standards
+name: Code Quality
 
 on:
   push:
@@ -20,7 +20,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: 7.4.5
           extensions: mbstring, intl
           tools: composer
 
@@ -36,11 +36,7 @@ jobs:
           restore-keys: ${{ runner.os }}-composer
 
       - name: Install dependencies
-        run: |
-          composer require --dev \
-            phpcompatibility/phpcompatibility-wp \
-            wp-coding-standards/wpcs \
-            dealerdirect/phpcodesniffer-composer-installer
+        run: composer install --no-progress
 
-      - name: Run PHP_CodeSniffer
-        run: composer run-script check-cs
+      - name: Run PHPStan
+        run: composer run-script phpstan

--- a/composer.json
+++ b/composer.json
@@ -40,8 +40,9 @@
     "phpcompatibility/phpcompatibility-wp": "2.1.0",
     "squizlabs/php_codesniffer": "3.5.4",
     "phpstan/phpstan": "^0.12.25",
-    "szepeviktor/phpstan-wordpress": "^0.5.0",
-    "codeception/module-rest": "^1.2"
+    "szepeviktor/phpstan-wordpress": "^0.7.1",
+    "codeception/module-rest": "^1.2",
+    "phpstan/extension-installer": "^1.0"
   },
   "config": {
     "optimize-autoloader": true
@@ -49,12 +50,12 @@
   "autoload": {
     "psr-4": {
       "WPGraphQL\\": "src/"
-    },
-    "classmap": ["src/"]
+    }
   },
   "scripts": {
-    "phpcs-i": ["@php ./vendor/bin/phpcs -i"],
-    "check-cs": ["@php ./vendor/bin/phpcs"],
-    "fix-cs": ["@php ./vendor/bin/phpcbf"]
+    "phpcs-i": ["phpcs -i"],
+    "check-cs": ["phpcs"],
+    "fix-cs": ["phpcbf"],
+    "phpstan": ["phpstan analyze --ansi --memory-limit=1G"]
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8a0dac9ab28bfb3ee97b3973f0abd31a",
+    "content-hash": "69c1d360db0c0ef1fbe1d578c4245f8b",
     "packages": [
         {
             "name": "ivome/graphql-relay-php",
@@ -3262,6 +3262,51 @@
                 "stub"
             ],
             "time": "2020-09-29T09:10:42+00:00"
+        },
+        {
+            "name": "phpstan/extension-installer",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/extension-installer.git",
+                "reference": "5c2da3846819f951385cb6a25d3277051481c48a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/extension-installer/zipball/5c2da3846819f951385cb6a25d3277051481c48a",
+                "reference": "5c2da3846819f951385cb6a25d3277051481c48a",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1 || ^2.0",
+                "php": "^7.1 || ^8.0",
+                "phpstan/phpstan": ">=0.11.6"
+            },
+            "require-dev": {
+                "composer/composer": "^1.8",
+                "consistence/coding-standard": "^3.8",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+                "ergebnis/composer-normalize": "^2.0.2",
+                "phing/phing": "^2.16",
+                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "phpstan/phpstan-strict-rules": "^0.11",
+                "slevomat/coding-standard": "^5.0.4"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPStan\\ExtensionInstaller\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\ExtensionInstaller\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Composer plugin for automatic installation of PHPStan extensions",
+            "time": "2020-08-30T12:06:42+00:00"
         },
         {
             "name": "phpstan/phpstan",
@@ -6756,31 +6801,30 @@
         },
         {
             "name": "szepeviktor/phpstan-wordpress",
-            "version": "v0.5.0",
+            "version": "v0.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/szepeviktor/phpstan-wordpress.git",
-                "reference": "1946738cdec130df4727f780ac541f8c6fd746a2"
+                "reference": "6195a6a19830d5ad187df0a3fb350e77cd571a5f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/szepeviktor/phpstan-wordpress/zipball/1946738cdec130df4727f780ac541f8c6fd746a2",
-                "reference": "1946738cdec130df4727f780ac541f8c6fd746a2",
+                "url": "https://api.github.com/repos/szepeviktor/phpstan-wordpress/zipball/6195a6a19830d5ad187df0a3fb350e77cd571a5f",
+                "reference": "6195a6a19830d5ad187df0a3fb350e77cd571a5f",
                 "shasum": ""
             },
             "require": {
-                "php": "~7.1",
+                "php": "^7.1 || ^8.0",
                 "php-stubs/wordpress-stubs": "^4.7 || ^5.0",
-                "phpstan/phpstan": "^0.12.0",
+                "phpstan/phpstan": "^0.12.26",
                 "symfony/polyfill-php73": "^1.12.0"
             },
             "require-dev": {
                 "composer/composer": "^1.8.6",
-                "consistence/coding-standard": "^3.8",
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5",
-                "jakub-onderka/php-parallel-lint": "^1.0",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+                "php-parallel-lint/php-parallel-lint": "^1.1",
                 "phpstan/phpstan-strict-rules": "^0.12",
-                "slevomat/coding-standard": "^5.0.4"
+                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^0.4.3"
             },
             "type": "phpstan-extension",
             "extra": {
@@ -6807,7 +6851,13 @@
                 "static analysis",
                 "wordpress"
             ],
-            "time": "2019-12-05T22:19:53+00:00"
+            "funding": [
+                {
+                    "url": "https://www.paypal.me/szepeviktor",
+                    "type": "custom"
+                }
+            ],
+            "time": "2020-11-05T00:12:19+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,8 +1,7 @@
-includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
-    level: max
-    autoload_files:
+    level: 0
+    inferPrivatePropertyTypeFromConstructor: true
+    bootstrapFiles:
         - wp-graphql.php
         - access-functions.php
     paths:
@@ -11,4 +10,5 @@ parameters:
         - src/
     ignoreErrors:
         # Uses func_get_args()
-        - '#^Function apply_filters(_ref_array)? invoked with ([3456789]|10) parameters, 2 required\.$#'
+        # Ignore any filters that are applied with more than 2 paramaters
+        # '#^Function apply_filters(_ref_array)? invoked with [0[1-9]|1[0-2]] parameters, 2 required\.$#'

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -64,6 +64,13 @@ abstract class AbstractConnectionResolver {
 	protected $should_execute = true;
 
 	/**
+	 * The loader the resolver is configured to use.
+	 *
+	 * @var AbstractDataLoader
+	 */
+	protected $loader;
+
+	/**
 	 * Whether the connection is a one to one connection. Default false.
 	 *
 	 * @var bool

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -221,12 +221,15 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		if ( 'attachment' === $this->post_type || 'revision' === $this->post_type ) {
 			$query_args['post_status'] = 'inherit';
 
-			/**
-			 * Unset the "post_parent" for attachments, as we don't really care if they
-			 * have a post_parent set by default
-			 */
-			unset( $query_args['post_parent'] );
+			if ( isset( $query_args['post_parent'] ) ) {
 
+				/**
+				 * Unset the "post_parent" for attachments, as we don't really care if they
+				 * have a post_parent set by default
+				 */
+				unset( $query_args['post_parent'] );
+
+			}
 		}
 
 		/**

--- a/src/Data/Cursor/PostObjectCursor.php
+++ b/src/Data/Cursor/PostObjectCursor.php
@@ -247,7 +247,7 @@ class PostObjectCursor {
 
 		$this->meta_join_alias ++;
 
-		$this->builder->add_field( $key, $meta_value, $meta_type, $order );
+		$this->builder->add_field( $key, $meta_value, $meta_type, $order, $this );
 	}
 
 	/**

--- a/src/Model/MenuItem.php
+++ b/src/Model/MenuItem.php
@@ -152,8 +152,12 @@ class MenuItem extends Model {
 
 					if ( ! empty( $url ) ) {
 						$parsed = wp_parse_url( $url );
-						if ( isset( $parsed['host'] ) && strpos( site_url(), $parsed['host'] ) ) {
-							return $parsed['path'];
+						if ( isset( $parsed['host'] ) ) {
+							if ( strpos( home_url(), $parsed['host'] ) ) {
+								return $parsed['path'];
+							} elseif ( strpos( home_url(), $parsed['host'] ) ) {
+								return $parsed['path'];
+							}
 						}
 					}
 					return $url;

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -475,7 +475,6 @@ abstract class Model {
 		 * @param string                 $string     The string to decode
 		 * @param string                 $field_name The name of the field being encoded
 		 * @param \WPGraphQL\Model\Model $model      The Model the field is being decoded on
-		 *
 		 */
 		$decoding_enabled = apply_filters( 'graphql_html_entity_decoding_enabled', $enabled, $string, $field_name, $this );
 

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -500,7 +500,7 @@ class Post extends Model {
 					$id    = ! empty( $this->data->ID ) ? $this->data->ID : null;
 					$title = ! empty( $this->data->post_title ) ? $this->data->post_title : null;
 
-					return $this->html_entity_decode( apply_filters( 'the_title', $title, $id ), 'titleRendered',true );
+					return $this->html_entity_decode( apply_filters( 'the_title', $title, $id ), 'titleRendered', true );
 				},
 				'titleRaw'                  => [
 					'callback'   => function() {

--- a/src/Model/Term.php
+++ b/src/Model/Term.php
@@ -174,7 +174,7 @@ class Term extends Model {
 				},
 				'uri'                      => function() {
 					$link = get_term_link( $this->name );
-					return ! ( is_wp_error( $link ) ) ? trailingslashit( str_ireplace( home_url(), get_term_link( $this->name ) ) ) : null;
+					return ! ( is_wp_error( $link ) ) ? trailingslashit( str_ireplace( home_url(), get_term_link( $this->name ), $link ) ) : null;
 				},
 			];
 

--- a/src/Mutation/ResetUserPassword.php
+++ b/src/Mutation/ResetUserPassword.php
@@ -3,7 +3,6 @@ namespace WPGraphQL\Mutation;
 
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
-use function Patchwork\Utils\args;
 use WPGraphQL\AppContext;
 
 class ResetUserPassword {

--- a/src/Mutation/TermObjectUpdate.php
+++ b/src/Mutation/TermObjectUpdate.php
@@ -111,7 +111,7 @@ class TermObjectUpdate {
 
 			if ( $taxonomy->name !== $existing_term->taxonomy ) {
 				// translators: The first placeholder is an ID and the second placeholder is the name of the post type being edited
-				throw new UserError( sprintf( __( 'The id %1$d is not of the type "%2$s"', 'wp-graphql' ), $id_parts['id'], $post_type_object->name ) );
+				throw new UserError( sprintf( __( 'The id %1$d is not of the type "%2$s"', 'wp-graphql' ), $id_parts['id'], $taxonomy->name ) );
 			}
 
 			/**

--- a/src/Request.php
+++ b/src/Request.php
@@ -618,7 +618,13 @@ class Request {
 	 */
 	private function get_server() {
 
-		$debug_flag = true === \WPGraphQL::debug() ? 2 : 0;
+		$flag = 1;
+		if ( 0 !== get_current_user_id() ) {
+			// Flag 2 shows the trace data, which should require user to be logged in to see by default
+			$flag = 2;
+		}
+
+		$debug_flag = true === \WPGraphQL::debug() ? $flag : 0;
 
 		$config = new ServerConfig();
 		$config

--- a/src/Type/Enum/ContentTypeEnum.php
+++ b/src/Type/Enum/ContentTypeEnum.php
@@ -12,8 +12,8 @@ class ContentTypeEnum {
 		 * Get the allowed taxonomies
 		 */
 		$allowed_post_types = get_post_types( [
-				'show_in_graphql' => true,
-				'public'          => true
+			'show_in_graphql' => true,
+			'public'          => true,
 		] );
 
 		/**

--- a/src/Utils/Tracing.php
+++ b/src/Utils/Tracing.php
@@ -227,7 +227,8 @@ class Tracing {
 	 * @return string
 	 */
 	public function format_timestamp( $time ) {
-		$timestamp = \DateTime::createFromFormat( 'U.u', $time );
+		$time_as_float = sprintf( '%.4f', $time );
+		$timestamp     = \DateTime::createFromFormat( 'U.u', $time_as_float );
 
 		return $timestamp->format( 'Y-m-d\TH:i:s.uP' );
 	}

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 0.15.0
+ * Version: 0.15.1
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 4.7.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  0.15.0
+ * @version  0.15.1
  */
 
 // Exit if accessed directly.
@@ -178,7 +178,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 
 			// Plugin version.
 			if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-				define( 'WPGRAPHQL_VERSION', '0.15.0' );
+				define( 'WPGRAPHQL_VERSION', '0.15.1' );
 			}
 
 			// Plugin Folder Path.


### PR DESCRIPTION
# Release Notes

## New Features
- (#1546) adds new `graphql_cursor_ordering_field` filter for customizing cursor ordering. Thanks @jacobarriola!

## Bugfixes

- (#1570): Fixes #1532, where menu items were returning full paths for sites using a different front-end url
- (#1570): Fixes #1565 where tracing timestamp occasionally returned an integer and caused php warnings
- (#1558, #1562, #1560, #1559): Adds PHPStan code quality checks, and various updates to composer config and CI updates. Thanks @szepeviktor! 