### PR TITLE
Feature/#1123 make client mutation id optional for mutations

### DIFF
--- a/src/Data/Cursor/CursorBuilder.php
+++ b/src/Data/Cursor/CursorBuilder.php
@@ -21,7 +21,7 @@ class CursorBuilder {
 		$this->compare = $compare;
 		$this->fields  = [];
 	}
-	
+
 	/**
 	 * Add ordering field. The order you call this method matters. First field
 	 * will be the primary field and latters ones will be used if the primary
@@ -34,7 +34,7 @@ class CursorBuilder {
 	 * @param null | PostObjectCursor $object_cursor The PostObjectCursor class
 	 */
 	public function add_field( $key, $value, $type = null, $order = null, $object_cursor = null ) {
-		
+
 		/**
 		 * Filters the field used for ordering when cursors are used for pagination
 		 *
@@ -53,24 +53,24 @@ class CursorBuilder {
 			$this,
 			$object_cursor
 		);
-		
+
 		// Bail if the filtered field comes back empty
 		if ( empty( $field ) ) {
 			return;
 		}
-		
+
 		// Bail if the filtered field doesn't come back as an array
 		if ( ! is_array( $field ) ) {
 			return;
 		}
-		
+
 		$escaped_field = [];
-		
+
 		// Escape the filtered array
 		foreach ( $field as $key => $value ) {
-			$escaped_field[$key] = esc_sql( $value );
+			$escaped_field[ $key ] = esc_sql( $value );
 		}
-		
+
 		$this->fields[] = $escaped_field;
 	}
 

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -1148,9 +1148,7 @@ class TypeRegistry {
 
 		$output_fields = [
 			'clientMutationId' => [
-				'type' => [
-					'non_null' => 'String',
-				],
+				'type' => 'String',
 			],
 		];
 
@@ -1168,9 +1166,7 @@ class TypeRegistry {
 
 		$input_fields = [
 			'clientMutationId' => [
-				'type' => [
-					'non_null' => 'String',
-				],
+				'type' => 'String',
 			],
 		];
 

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 0.15.0
+ * Version: 0.15.1
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 4.7.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  0.15.0
+ * @version  0.15.1
  */
 
 // Exit if accessed directly.
@@ -178,7 +178,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 
 			// Plugin version.
 			if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-				define( 'WPGRAPHQL_VERSION', '0.15.0' );
+				define( 'WPGRAPHQL_VERSION', '0.15.1' );
 			}
 
 			// Plugin Folder Path.


### PR DESCRIPTION
This changes the mutation argument `clientMutationId` from a `nonNull String` to a `String`, meaning that mutations no longer require the `clientMutationInput` argument.

## Before

Trying to execute a mutation without `clientMutationId` would throw an error. 

![Screen Shot 2020-11-13 at 9 52 35 AM](https://user-images.githubusercontent.com/1260765/99098446-39cd2580-2596-11eb-8441-dc3811571e9f.png)


## After

Now you can execute a mutation without providing `clientMutationId` and there are no errors. 

![Screen Shot 2020-11-13 at 9 52 03 AM](https://user-images.githubusercontent.com/1260765/99098426-33d74480-2596-11eb-9401-94c4df8aa6cf.png)

----

## Breaking Change?

In #1123 I expressed that this would be a breaking change, however I was mistaken. 

I thought the following mutation would need to be changed to work:

```graphql
mutation createPost($mutationId: String!, $title: String!) {
  createPost(input: {clientMutationId: $mutationId, title: $title}) {
    post {
      id
      title
    }
  }
}
```

Because the variable `$mutationId` is defined as a `String!` but it is now just `String`. 

This is not a breaking change because if the specific query defined variable as required, that specific query would still need to require the input and no changes would need to be made. But other mutations could be written with `$mutationId:String` and work, or leave out `$mutationId` altogether and work.

So, it turns out, **this is _not_ a breaking change** like I thought it was. 

----

closes #1123 