### PR TITLE
Add parentId and parentDatabaseId to comment model and comment Type

### DIFF
--- a/src/Model/Comment.php
+++ b/src/Model/Comment.php
@@ -126,10 +126,10 @@ class Comment extends Model {
 				'comment_parent_id'  => function() {
 					return ! empty( $this->data->comment_parent ) ? absint( $this->data->comment_parent ) : 0;
 				},
-				'parentDatabaseId' => function() {
+				'parentDatabaseId'   => function() {
 					return ! empty( $this->data->comment_parent ) ? absint( $this->data->comment_parent ) : 0;
 				},
-				'parentId' => function() {
+				'parentId'           => function() {
 					return ! empty( $this->comment_parent_id ) ? Relay::toGlobalId( 'comment', $this->data->comment_parent ) : null;
 				},
 				'comment_author'     => function() {

--- a/src/Model/Comment.php
+++ b/src/Model/Comment.php
@@ -14,6 +14,8 @@ use GraphQLRelay\Relay;
  * @property string     $comment_author_url
  * @property int        $comment_ID
  * @property int        $comment_parent_id
+ * @property string     $parentId
+ * @property int        $parentDatabaseId
  * @property string     $authorIp
  * @property string     $date
  * @property string     $dateGmt
@@ -59,6 +61,8 @@ class Comment extends Model {
 			'comment_post_ID',
 			'approved',
 			'comment_parent_id',
+			'parentId',
+			'parentDatabaseId',
 			'isRestricted',
 			'userId',
 		];
@@ -121,6 +125,12 @@ class Comment extends Model {
 				},
 				'comment_parent_id'  => function() {
 					return ! empty( $this->data->comment_parent ) ? absint( $this->data->comment_parent ) : 0;
+				},
+				'parentDatabaseId' => function() {
+					return ! empty( $this->data->comment_parent ) ? absint( $this->data->comment_parent ) : 0;
+				},
+				'parentId' => function() {
+					return ! empty( $this->comment_parent_id ) ? Relay::toGlobalId( 'comment', $this->data->comment_parent ) : null;
 				},
 				'comment_author'     => function() {
 					return ! empty( $this->data->comment_author ) ? absint( $this->data->comment_author ) : null;

--- a/src/Type/Object/Comment.php
+++ b/src/Type/Object/Comment.php
@@ -76,6 +76,14 @@ class Comment {
 						'type'        => 'Boolean',
 						'description' => __( 'Whether the object is restricted from the current viewer', 'wp-graphql' ),
 					],
+					'parentId'         => [
+						'type'        => 'ID',
+						'description' => __( 'The globally unique identifier of the parent comment node.', 'wp-graphql' ),
+					],
+					'parentDatabaseId' => [
+						'type'        => 'Int',
+						'description' => __( 'The database id of the parent comment node or null if it is the root comment', 'wp-graphql' ),
+					],
 				],
 			]
 		);

--- a/src/Type/Object/Comment.php
+++ b/src/Type/Object/Comment.php
@@ -19,27 +19,27 @@ class Comment {
 				'description' => __( 'A Comment object', 'wp-graphql' ),
 				'interfaces'  => [ 'Node', 'DatabaseIdentifier' ],
 				'fields'      => [
-					'id'           => [
+					'id'               => [
 						'description' => __( 'The globally unique identifier for the comment object', 'wp-graphql' ),
 					],
-					'commentId'    => [
+					'commentId'        => [
 						'type'              => 'Int',
 						'description'       => __( 'ID for the comment, unique among comments.', 'wp-graphql' ),
 						'deprecationReason' => __( 'Deprecated in favor of databaseId', 'wp-graphql' ),
 					],
-					'authorIp'     => [
+					'authorIp'         => [
 						'type'        => 'String',
 						'description' => __( 'IP address for the author. This field is equivalent to WP_Comment->comment_author_IP and the value matching the "comment_author_IP" column in SQL.', 'wp-graphql' ),
 					],
-					'date'         => [
+					'date'             => [
 						'type'        => 'String',
 						'description' => __( 'Date the comment was posted in local time. This field is equivalent to WP_Comment->date and the value matching the "date" column in SQL.', 'wp-graphql' ),
 					],
-					'dateGmt'      => [
+					'dateGmt'          => [
 						'type'        => 'String',
 						'description' => __( 'Date the comment was posted in GMT. This field is equivalent to WP_Comment->date_gmt and the value matching the "date_gmt" column in SQL.', 'wp-graphql' ),
 					],
-					'content'      => [
+					'content'          => [
 						'type'        => 'String',
 						'description' => __( 'Content of the comment. This field is equivalent to WP_Comment->comment_content and the value matching the "comment_content" column in SQL.', 'wp-graphql' ),
 						'args'        => [
@@ -56,23 +56,23 @@ class Comment {
 							}
 						},
 					],
-					'karma'        => [
+					'karma'            => [
 						'type'        => 'Int',
 						'description' => __( 'Karma value for the comment. This field is equivalent to WP_Comment->comment_karma and the value matching the "comment_karma" column in SQL.', 'wp-graphql' ),
 					],
-					'approved'     => [
+					'approved'         => [
 						'type'        => 'Boolean',
 						'description' => __( 'The approval status of the comment. This field is equivalent to WP_Comment->comment_approved and the value matching the "comment_approved" column in SQL.', 'wp-graphql' ),
 					],
-					'agent'        => [
+					'agent'            => [
 						'type'        => 'String',
 						'description' => __( 'User agent used to post the comment. This field is equivalent to WP_Comment->comment_agent and the value matching the "comment_agent" column in SQL.', 'wp-graphql' ),
 					],
-					'type'         => [
+					'type'             => [
 						'type'        => 'String',
 						'description' => __( 'Type of comment. This field is equivalent to WP_Comment->comment_type and the value matching the "comment_type" column in SQL.', 'wp-graphql' ),
 					],
-					'isRestricted' => [
+					'isRestricted'     => [
 						'type'        => 'Boolean',
 						'description' => __( 'Whether the object is restricted from the current viewer', 'wp-graphql' ),
 					],


### PR DESCRIPTION
This adds `parentId` and `parentDatabaseId` to Comment Model and Comment Type to support hierarchical query conventions such as documented here: https://www.wpgraphql.com/docs/menus/#hierarchical-data