### PR TITLE
Bug/#1596 single and plural names are same

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, API, Gatsby, Headless, Decoupled, React, Nextjs, Vue, Apollo, RES
 Requires at least: 5.0
 Tested up to: 5.5.3
 Requires PHP: 7.1
-Stable tag: 0.15.4
+Stable tag: 0.15.6
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -51,9 +51,9 @@ WPGraphQL publishes [release notes on Github](https://github.com/wp-graphql/wp-g
 
 WPGraphQL has been following Semver practices for a few years. We will continue to follow Semver and let version numbers communicate meaning. The summary of Semver versioning is as follows:
 
-- * MAJOR * version when you make incompatible API changes,
-- * MINOR * version when you add functionality in a backwards compatible manner, and
-- * PATCH * version when you make backwards compatible bug fixes.
+- *MAJOR* version when you make incompatible API changes,
+- *MINOR* version when you add functionality in a backwards compatible manner, and
+- *PATCH* version when you make backwards compatible bug fixes.
 
 You can read more about the details of Semver at semver.org
 

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -381,7 +381,19 @@ class TypeRegistry {
 		$allowed_post_types = \WPGraphQL::get_allowed_post_types();
 		if ( ! empty( $allowed_post_types ) && is_array( $allowed_post_types ) ) {
 			foreach ( $allowed_post_types as $post_type ) {
+
 				$post_type_object = get_post_type_object( $post_type );
+
+				if ( $post_type_object->graphql_single_name === $post_type_object->graphql_plural_name ) {
+					throw new \GraphQL\Error\InvariantViolation(
+						sprintf(
+						/* translators: %s will replaced with the registered type */
+							__( 'The %s post_type cannot declare the same value for "graphql_single_name" and "graphql_plural_name".', 'wp-graphql' ),
+							$post_type_object->name
+						)
+					);
+				}
+
 				PostObject::register_post_object_types( $post_type_object, $type_registry );
 
 				/**
@@ -406,7 +418,19 @@ class TypeRegistry {
 				$allowed_taxonomies = \WPGraphQL::get_allowed_taxonomies();
 				if ( ! empty( $allowed_taxonomies ) && is_array( $allowed_taxonomies ) ) {
 					foreach ( $allowed_taxonomies as $taxonomy ) {
+
 						$tax_object = get_taxonomy( $taxonomy );
+
+						if ( $tax_object->graphql_single_name === $tax_object->graphql_plural_name ) {
+							throw new \GraphQL\Error\InvariantViolation(
+								sprintf(
+								/* translators: %s will replaced with the registered type */
+									__( 'The %s taxonomy cannot declare the same value for "graphql_single_name" and "graphql_plural_name".', 'wp-graphql' ),
+									$tax_object->name
+								)
+							);
+						}
+
 						// If the taxonomy is in the array of taxonomies registered to the post_type
 						if ( in_array( $taxonomy, get_object_taxonomies( $post_type_object->name ), true ) ) {
 							register_graphql_input_type(

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 0.15.4
+ * Version: 0.15.6
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  0.15.4
+ * @version  0.15.6
  */
 
 // Exit if accessed directly.
@@ -178,7 +178,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 
 			// Plugin version.
 			if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-				define( 'WPGRAPHQL_VERSION', '0.15.4' );
+				define( 'WPGRAPHQL_VERSION', '0.15.6' );
 			}
 
 			// Plugin Folder Path.

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -341,16 +341,6 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 		}
 
 		/**
-		 * This gets the allowed post types and taxonomies when a GraphQL request has started
-		 *
-		 * @deprecated v0.4.3
-		 */
-		public function get_allowed_types() {
-			self::get_allowed_post_types();
-			self::get_allowed_taxonomies();
-		}
-
-		/**
 		 * Flush permalinks if the GraphQL Endpoint route isn't yet registered
 		 */
 		public function maybe_flush_permalinks() {
@@ -541,6 +531,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 								$tax_object->name
 							)
 						);
+
 					}
 				},
 				$taxonomies


### PR DESCRIPTION
This throws an InvariantViolation (causes a GraphQL Error) if a post_type or taxonomy is registered with the same value as its graphql_single_name and graphql_plural_name. 

Ex: 

**Register Post Type with same value for graphql_single_name and graphql_plural_name**

```php
add_action( 'init', function() {

	register_post_type( 'test_dupe_post_type', [
		'show_in_graphql' => true,
		'graphql_single_name' => 'testTaxName',
		'graphql_plural_name' => 'testTaxName', // same value as graphql_single_name.
	] );

} );
```

**Output in GraphiQL**

<img width="1122" alt="Screen Shot 2020-11-23 at 8 40 45 AM" src="https://user-images.githubusercontent.com/1260765/99982269-97682b80-2d67-11eb-8d41-fae97aa941cb.png">

----

closes #1596 