### PR TITLE
#1602 - Fix countable php warning

### DIFF
--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -502,7 +502,7 @@ abstract class AbstractConnectionResolver {
 	 */
 	public function has_next_page() {
 		if ( ! empty( $this->args['first'] ) ) {
-			return count( $this->ids ) > $this->query_amount;
+			return ! empty( $this->ids ) ? count( $this->ids ) > $this->query_amount : false;
 		}
 
 		if ( ! empty( $this->args['before'] ) ) {
@@ -525,7 +525,7 @@ abstract class AbstractConnectionResolver {
 	 */
 	public function has_previous_page() {
 		if ( ! empty( $this->args['last'] ) ) {
-			return count( $this->ids ) > $this->query_amount;
+			return ! empty( $this->ids ) ? count( $this->ids ) > $this->query_amount : false;
 		}
 
 		if ( ! empty( $this->args['after'] ) ) {
@@ -556,7 +556,7 @@ abstract class AbstractConnectionResolver {
 	 * @return mixed string|null
 	 */
 	public function get_end_cursor() {
-		$last_edge = $this->edges && ! empty( $this->edges ) ? $this->edges[ count( $this->edges ) - 1 ] : null;
+		$last_edge = ! empty( $this->edges ) ? $this->edges[ count( $this->edges ) - 1 ] : null;
 
 		return isset( $last_edge['cursor'] ) ? $last_edge['cursor'] : null;
 	}
@@ -585,20 +585,18 @@ abstract class AbstractConnectionResolver {
 		$ids = array_slice( $ids, 0, $this->query_amount, true );
 
 		if ( ! empty( $this->get_offset() ) ) {
-			if ( ! empty( $this->get_offset() ) ) {
-				// Determine if the offset is in the array
-				$key = array_search( $this->get_offset(), $ids, true );
-				// If the offset is in the array
-				if ( false !== $key ) {
-					$key = absint( $key );
-					// Slice the array from the back
-					if ( ! empty( $this->args['before'] ) ) {
-						$ids = array_slice( $ids, 0, $key, true );
-						// Slice the array from the front
-					} else {
-						$key++;
-						$ids = array_slice( $ids, $key, null, true );
-					}
+			// Determine if the offset is in the array
+			$key = array_search( $this->get_offset(), $ids, true );
+			// If the offset is in the array
+			if ( false !== $key ) {
+				$key = absint( $key );
+				// Slice the array from the back
+				if ( ! empty( $this->args['before'] ) ) {
+					$ids = array_slice( $ids, 0, $key, true );
+					// Slice the array from the front
+				} else {
+					$key++;
+					$ids = array_slice( $ids, $key, null, true );
 				}
 			}
 		}

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -269,20 +269,18 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 					return absint( $id );
 				}, $ids );
 				if ( ! empty( $this->get_offset() ) ) {
-					if ( ! empty( $this->get_offset() ) ) {
-						// Determine if the offset is in the array
-						$key = array_search( $this->get_offset(), $ids, true );
-						// If the offset is in the array
-						if ( false !== $key ) {
-							$key = absint( $key );
-							// Slice the array from the back
-							if ( ! empty( $this->args['before'] ) ) {
-								$ids = array_slice( $ids, 0, $key, true );
-								// Slice the array from the front
-							} else {
-								$key++;
-								$ids = array_slice( $ids, $key, null, true );
-							}
+					// Determine if the offset is in the array
+					$key = array_search( $this->get_offset(), $ids, true );
+					// If the offset is in the array
+					if ( false !== $key ) {
+						$key = absint( $key );
+						// Slice the array from the back
+						if ( ! empty( $this->args['before'] ) ) {
+							$ids = array_slice( $ids, 0, $key, true );
+							// Slice the array from the front
+						} else {
+							$key++;
+							$ids = array_slice( $ids, $key, null, true );
 						}
 					}
 				}

--- a/src/Router.php
+++ b/src/Router.php
@@ -461,10 +461,11 @@ class Router {
 		 * @param string $operation_name The name of the operation
 		 * @param string $query          The request that GraphQL executed
 		 * @param array  $variables      Variables to passed to your GraphQL query
+		 * @param mixed  $status_code    The status code for the response
 		 *
 		 * @since 0.0.5
 		 */
-		do_action( 'graphql_process_http_request_response', $response, $result, $operation_name, $query, $variables );
+		do_action( 'graphql_process_http_request_response', $response, $result, $operation_name, $query, $variables, self::$http_status_code );
 
 		/**
 		 * Send the response


### PR DESCRIPTION
- pass $status_code through to the `graphql_process_http_request_response` action
- only count the ids if the ids are not empty
- remove duplicate checks for `! empty( $this->get_offset() )`

---- 

closes #1602 