### PR TITLE
#1610 Fix Author Comparison in PostObjectUpdate Mutation

### DIFF
--- a/src/Mutation/PostObjectUpdate.php
+++ b/src/Mutation/PostObjectUpdate.php
@@ -94,11 +94,12 @@ class PostObjectUpdate {
 				// translators: the $post_type_object->graphql_single_name placeholder is the name of the object being mutated
 				throw new UserError( sprintf( __( 'Sorry, you are not allowed to update a %1$s', 'wp-graphql' ), $post_type_object->graphql_single_name ) );
 			}
-
+			
 			/**
 			 * If the existing post was authored by another author, ensure the requesting user has permission to edit it
 			 */
-			if ( get_current_user_id() !== (int) $existing_post->post_author && ! current_user_can( $post_type_object->cap->edit_others_posts ) ) {
+			if ( get_current_user_id() !== (int) $existing_post->post_author && true !== current_user_can( $post_type_object->cap->edit_others_posts ) ) {
+				codecept_debug( 'cannot edit' );
 				// translators: the $post_type_object->graphql_single_name placeholder is the name of the object being mutated
 				throw new UserError( sprintf( __( 'Sorry, you are not allowed to update another author\'s %1$s', 'wp-graphql' ), $post_type_object->graphql_single_name ) );
 			}

--- a/src/Mutation/PostObjectUpdate.php
+++ b/src/Mutation/PostObjectUpdate.php
@@ -98,7 +98,7 @@ class PostObjectUpdate {
 			/**
 			 * If the existing post was authored by another author, ensure the requesting user has permission to edit it
 			 */
-			if ( get_current_user_id() !== (int)$existing_post->post_author && ! current_user_can( $post_type_object->cap->edit_others_posts ) ) {
+			if ( get_current_user_id() !== (int) $existing_post->post_author && ! current_user_can( $post_type_object->cap->edit_others_posts ) ) {
 				// translators: the $post_type_object->graphql_single_name placeholder is the name of the object being mutated
 				throw new UserError( sprintf( __( 'Sorry, you are not allowed to update another author\'s %1$s', 'wp-graphql' ), $post_type_object->graphql_single_name ) );
 			}

--- a/src/Mutation/PostObjectUpdate.php
+++ b/src/Mutation/PostObjectUpdate.php
@@ -100,7 +100,7 @@ class PostObjectUpdate {
 			 */
 			if ( get_current_user_id() !== (int)$existing_post->post_author && ! current_user_can( $post_type_object->cap->edit_others_posts ) ) {
 				// translators: the $post_type_object->graphql_single_name placeholder is the name of the object being mutated
-				throw new UserError( sprintf( __( 'Sorry, you are not allowed to another author\'s %1$s', 'wp-graphql' ), $post_type_object->graphql_single_name ) );
+				throw new UserError( sprintf( __( 'Sorry, you are not allowed to update another author\'s %1$s', 'wp-graphql' ), $post_type_object->graphql_single_name ) );
 			}
 
 			/**

--- a/src/Mutation/PostObjectUpdate.php
+++ b/src/Mutation/PostObjectUpdate.php
@@ -98,7 +98,7 @@ class PostObjectUpdate {
 			/**
 			 * If the existing post was authored by another author, ensure the requesting user has permission to edit it
 			 */
-			if ( get_current_user_id() !== $existing_post->post_author && ! current_user_can( $post_type_object->cap->edit_others_posts ) ) {
+			if ( get_current_user_id() !== (int)$existing_post->post_author && ! current_user_can( $post_type_object->cap->edit_others_posts ) ) {
 				// translators: the $post_type_object->graphql_single_name placeholder is the name of the object being mutated
 				throw new UserError( sprintf( __( 'Sorry, you are not allowed to another author\'s %1$s', 'wp-graphql' ), $post_type_object->graphql_single_name ) );
 			}


### PR DESCRIPTION
- Cast `$existing_post->post_author` as `Integer` (by default it's a `String`) to make sure the comparison with `get_current_user_id()` (which is `Integer`) doesn't always return true
- Add missing word in the comparisons `UserError`

Closes #1610