### PR TITLE
Handle multiple magic gets of falsey values on model fields correctly

### DIFF
--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -134,7 +134,7 @@ abstract class Model {
 	 * @return mixed|null
 	 */
 	public function __get( $key ) {
-		if ( ! empty( $this->fields[ $key ] ) ) {
+		if ( isset( $this->fields[ $key ] ) ) {
 			/**
 			 * If the property has already been processed and cached to the model
 			 * return the processed value.


### PR DESCRIPTION
This query results in an error:

```graphql
query MyQuery {
  pages {
    nodes {
      uri
      isFrontPage
    }
  }
}
```

The error is reported as internal server error on the `isFrontPage` field. I’ve pinpointed this to the implementation of `__get` on `WPGraphQL\Model\Model`. The reason it fails is because it’s called twice for `isFrontPage`—first when resolving the `uri` field and then when resolving the actual `isFrontPage` field. The implementation checks if it’s been called before by use of `!empty()` which doesn’t work if it’s been set to `false` because the type-checking later fails when the field returns `null` instead of `false`. This PR changes this check to `isset()` instead.

I’ve tested this very briefly, but I will use this is an actual project in the next few days so I will soon know if it breaks anything.

Where has this been tested?
---------------------------
**Operating System:** MacOS

**WordPress Version:** 5.5.1
