### PR TITLE
#1629 - Fix regression to previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Upcoming
+
+### Bugfixes
+
+- Fixes a regression to previews introduced by v1.0.3 
+
 ## 1.0.3
 
 ### Bugfixes

--- a/src/Type/Object/RootQuery.php
+++ b/src/Type/Object/RootQuery.php
@@ -7,6 +7,7 @@ use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
 use WPGraphQL\Data\DataSource;
+use WPGraphQL\Model\Post;
 use WPGraphQL\Model\Term;
 
 /**
@@ -531,11 +532,25 @@ class RootQuery {
 								$post_id   = ! empty( $revisions ) ? array_values( $revisions )[0] : null;
 							}
 
-							return $context->get_loader( 'post' )->load_deferred( $post_id )->then( function( $post ) use ( $post_type_object ) {
-								if ( ! isset( $post->post_type ) || $post->post_type !== $post_type_object->name ) {
+							return $context->get_loader( 'post' )->load_deferred( $post_id )->then( function( Post $post_object ) use ( $post_type_object ) {
+
+								if ( ! isset( $post_object->post_type ) ) {
 									return null;
 								}
-								return $post;
+
+								if ( 'revision' === $post_object->post_type ) {
+
+									if ( empty( $post_object->parentDatabaseId ) ) {
+										return null;
+									}
+
+									$post_object = get_post( $post_object->parentDatabaseId );
+								}
+
+								if ( $post_object->post_type !== $post_type_object->name ) {
+									return null;
+								}
+								return $post_object;
 							});
 						},
 					]
@@ -592,11 +607,25 @@ class RootQuery {
 								return $context->node_resolver->resolve_uri( $slug );
 							}
 
-							return $context->get_loader( 'post' )->load_deferred( $post_id )->then( function( $post ) use ( $post_type_object ) {
-								if ( ! isset( $post->post_type ) || $post->post_type !== $post_type_object->name ) {
+							return $context->get_loader( 'post' )->load_deferred( $post_id )->then( function( Post $post_object ) use ( $post_type_object ) {
+
+								if ( ! isset( $post_object->post_type ) ) {
 									return null;
 								}
-								return $post;
+
+								if ( 'revision' === $post_object->post_type ) {
+
+									if ( empty( $post_object->parentDatabaseId ) ) {
+										return null;
+									}
+
+									$post_object = get_post( $post_object->parentDatabaseId );
+								}
+
+								if ( $post_object->post_type !== $post_type_object->name ) {
+									return null;
+								}
+								return $post_object;
 							});
 						},
 					]

--- a/src/Type/Object/RootQuery.php
+++ b/src/Type/Object/RootQuery.php
@@ -532,25 +532,11 @@ class RootQuery {
 								$post_id   = ! empty( $revisions ) ? array_values( $revisions )[0] : null;
 							}
 
-							return $context->get_loader( 'post' )->load_deferred( $post_id )->then( function( Post $post_object ) use ( $post_type_object ) {
-
-								if ( ! isset( $post_object->post_type ) ) {
+							return $context->get_loader( 'post' )->load_deferred( $post_id )->then( function( $post ) use ( $post_type_object ) {
+								if ( ! isset( $post->post_type ) || ! in_array( $post->post_type, [ 'revision', $post_type_object->name ], true ) ) {
 									return null;
 								}
-
-								if ( 'revision' === $post_object->post_type ) {
-
-									if ( empty( $post_object->parentDatabaseId ) ) {
-										return null;
-									}
-
-									$post_object = get_post( $post_object->parentDatabaseId );
-								}
-
-								if ( $post_object->post_type !== $post_type_object->name ) {
-									return null;
-								}
-								return $post_object;
+								return $post;
 							});
 						},
 					]
@@ -607,26 +593,13 @@ class RootQuery {
 								return $context->node_resolver->resolve_uri( $slug );
 							}
 
-							return $context->get_loader( 'post' )->load_deferred( $post_id )->then( function( Post $post_object ) use ( $post_type_object ) {
-
-								if ( ! isset( $post_object->post_type ) ) {
+							return $context->get_loader( 'post' )->load_deferred( $post_id )->then( function( $post ) use ( $post_type_object ) {
+								if ( ! isset( $post->post_type ) || ! in_array( $post->post_type, [ 'revision', $post_type_object->name ], true ) ) {
 									return null;
 								}
-
-								if ( 'revision' === $post_object->post_type ) {
-
-									if ( empty( $post_object->parentDatabaseId ) ) {
-										return null;
-									}
-
-									$post_object = get_post( $post_object->parentDatabaseId );
-								}
-
-								if ( $post_object->post_type !== $post_type_object->name ) {
-									return null;
-								}
-								return $post_object;
+								return $post;
 							});
+
 						},
 					]
 				);

--- a/tests/wpunit/PreviewTest.php
+++ b/tests/wpunit/PreviewTest.php
@@ -77,6 +77,9 @@ class PreviewTest extends \Codeception\TestCase\WPTestCase {
 		      }
 		    }
 		  }
+		  preview:post( id: $id idType: DATABASE_ID asPreview: true ) {
+		    ...PostFields
+		  }
 		}
 		fragment PostFields on Post {
 		  __typename

--- a/tests/wpunit/PreviewTest.php
+++ b/tests/wpunit/PreviewTest.php
@@ -433,6 +433,9 @@ class PreviewTest extends \Codeception\TestCase\WPTestCase {
 				     }
 				   }
 				 }
+				 preview:post(id:$id idType: DATABASE_ID asPreview:true) {
+				   publishedMetaKey
+				 }
 				}
 			',
 			'variables' => [
@@ -443,6 +446,7 @@ class PreviewTest extends \Codeception\TestCase\WPTestCase {
 		codecept_debug( $actual );
 
 	    $this->assertSame( $published_meta_value, $actual['data']['post']['preview']['node']['publishedMetaKey'] );
+		$this->assertSame( $published_meta_value, $actual['data']['preview']['publishedMetaKey'] );
 
 		// Asking for the meta of a revision directly using the get_post_meta function should
 		// get the meta from the revision ID, which should be empty since we didn't set any


### PR DESCRIPTION
This fixes the validation of single entry points for posts to allow previews to return if their parent is of the same post type as the single entry field is intended to return. 