### PR TITLE
#1632 - output null when deprecationReason is not set for fields

### DIFF
--- a/src/Utils/InstrumentSchema.php
+++ b/src/Utils/InstrumentSchema.php
@@ -95,7 +95,7 @@ class InstrumentSchema {
 					 * Sanitize the description and deprecation reason
 					 */
 					$field->description       = ! empty( $field->description ) && is_string( $field->description ) ? esc_html( $field->description ) : '';
-					$field->deprecationReason = ! empty( $field->deprecationReason ) && is_string( $field->description ) ? esc_html( $field->deprecationReason ) : '';
+					$field->deprecationReason = ! empty( $field->deprecationReason ) && is_string( $field->description ) ? esc_html( $field->deprecationReason ) : null;
 
 					/**
 					 * Replace the existing field resolve method with a new function that captures data about


### PR DESCRIPTION
This outputs null when the deprecationReason is not set for fields instead of outputting an empty string. 

Some clients translate an empty string as a populated deprecationReason.

## Before

When looking at the WPGraphQL Schema in GraphQL Voyager before:

![Screen Shot 2020-12-17 at 5 10 50 PM](https://user-images.githubusercontent.com/1260765/102558557-efeec800-408a-11eb-9c78-5278df13e053.png)


## After

When looking at the WPGraphQL Schema in GraphQL Voyager after:

![Screen Shot 2020-12-17 at 5 09 16 PM](https://user-images.githubusercontent.com/1260765/102558561-f41ae580-408a-11eb-88a1-3462d555af6a.png)
