### PR TITLE
Feature/#1347 update phpstan to level 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
     "codeception/module-rest": "^1.2",
     "wp-graphql/wp-graphql-testcase": "^1.0",
     "phpunit/phpunit": "9.4.1",
-    "simpod/php-coveralls-mirror": "^3.0"
+    "simpod/php-coveralls-mirror": "^3.0",
+    "phpstan/extension-installer": "^1.1"
   },
   "config": {
     "optimize-autoloader": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "678a05910da4ef18c3dbcfd5af74e39c",
+    "content-hash": "83a9390264d827dfb966bf1571f1b79e",
     "packages": [
         {
             "name": "ivome/graphql-relay-php",
@@ -3599,6 +3599,51 @@
                 "source": "https://github.com/phpspec/prophecy/tree/1.12.2"
             },
             "time": "2020-12-19T10:15:11+00:00"
+        },
+        {
+            "name": "phpstan/extension-installer",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/extension-installer.git",
+                "reference": "66c7adc9dfa38b6b5838a9fb728b68a7d8348051"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/extension-installer/zipball/66c7adc9dfa38b6b5838a9fb728b68a7d8348051",
+                "reference": "66c7adc9dfa38b6b5838a9fb728b68a7d8348051",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1 || ^2.0",
+                "php": "^7.1 || ^8.0",
+                "phpstan/phpstan": ">=0.11.6"
+            },
+            "require-dev": {
+                "composer/composer": "^1.8",
+                "phing/phing": "^2.16.3",
+                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "phpstan/phpstan-strict-rules": "^0.11 || ^0.12"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPStan\\ExtensionInstaller\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\ExtensionInstaller\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Composer plugin for automatic installation of PHPStan extensions",
+            "support": {
+                "issues": "https://github.com/phpstan/extension-installer/issues",
+                "source": "https://github.com/phpstan/extension-installer/tree/1.1.0"
+            },
+            "time": "2020-12-13T13:06:13+00:00"
         },
         {
             "name": "phpstan/phpstan",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,7 +1,8 @@
 parameters:
-    level: 0
+    level: 1
     inferPrivatePropertyTypeFromConstructor: true
     bootstrapFiles:
+        - phpstan/constants.php
         - wp-graphql.php
         - access-functions.php
     paths:
@@ -11,4 +12,4 @@ parameters:
     ignoreErrors:
         # Uses func_get_args()
         # Ignore any filters that are applied with more than 2 paramaters
-        # '#^Function apply_filters(_ref_array)? invoked with [0[1-9]|1[0-2]] parameters, 2 required\.$#'
+        - '#^Function apply_filters(_ref_array)? invoked with [0[1-9]|1[0-2]] parameters, 2 required\.$#'

--- a/phpstan/constants.php
+++ b/phpstan/constants.php
@@ -2,4 +2,7 @@
 /**
  * Constants defined in this file are to help phpstan analyze code where constants outside the plugin (WordPress core constants, etc) are being used
  */
+
+define( 'WP_LANG_DIR', true );
 define( 'SAVEQUERIES', true );
+

--- a/phpstan/constants.php
+++ b/phpstan/constants.php
@@ -1,0 +1,5 @@
+<?php
+/**
+ * Constants defined in this file are to help phpstan analyze code where constants outside the plugin (WordPress core constants, etc) are being used
+ */
+define( 'SAVEQUERIES', true );

--- a/src/Connection/TermObjects.php
+++ b/src/Connection/TermObjects.php
@@ -76,7 +76,7 @@ class TermObjects {
 										'fromType'      => $post_type_object->graphql_single_name,
 										'toType'        => $tax_object->graphql_single_name,
 										'fromFieldName' => $tax_object->graphql_plural_name,
-										'resolve'       => function( Post $post, $args, AppContext $context, $info ) use ( $post_type_object, $tax_object ) {
+										'resolve'       => function( Post $post, $args, AppContext $context, $info ) use ( $tax_object ) {
 
 											$object_id = true === $post->isPreview && ! empty( $post->parentDatabaseId ) ? $post->parentDatabaseId : $post->ID;
 
@@ -196,7 +196,7 @@ class TermObjects {
 						return $resolver->get_connection();
 
 					},
-				]);
+				] );
 			}
 		}
 

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -619,11 +619,11 @@ abstract class AbstractConnectionResolver {
 	 * If model isn't a class with a `fields` member, this function with have be overridden in
 	 * the Connection class.
 	 *
-	 * @param Model $model model.
+	 * @param mixed Model|null $model model.
 	 *
 	 * @return bool
 	 */
-	protected function is_valid_model( Model $model ) {
+	protected function is_valid_model( $model ) {
 		return isset( $model->fields ) && ! empty( $model->fields );
 	}
 

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -198,8 +198,8 @@ abstract class AbstractConnectionResolver {
 	/**
 	 * Get the loader name
 	 *
-	 * @throws \Exception
 	 * @return AbstractDataLoader
+	 * @throws \Exception
 	 */
 	protected function getLoader() {
 		$name = $this->get_loader_name();
@@ -269,6 +269,7 @@ abstract class AbstractConnectionResolver {
 	 */
 	public function set_query_arg( $key, $value ) {
 		$this->query_args[ $key ] = $value;
+
 		return $this;
 	}
 
@@ -279,6 +280,7 @@ abstract class AbstractConnectionResolver {
 	 */
 	public function one_to_one() {
 		$this->one_to_one = true;
+
 		return $this;
 	}
 
@@ -452,7 +454,7 @@ abstract class AbstractConnectionResolver {
 		 * This filter allows to modify the requested connection page size
 		 *
 		 * @param int                        $amount the requested amount
-		 * @param AbstractConnectionResolver $this Instance of the connection resolver class
+		 * @param AbstractConnectionResolver $this   Instance of the connection resolver class
 		 */
 		return max( 0, apply_filters( 'graphql_connection_amount_requested', $amount_requested, $this ) );
 
@@ -595,7 +597,7 @@ abstract class AbstractConnectionResolver {
 					$ids = array_slice( $ids, 0, $key, true );
 					// Slice the array from the front
 				} else {
-					$key++;
+					$key ++;
 					$ids = array_slice( $ids, $key, null, true );
 				}
 			}
@@ -607,6 +609,7 @@ abstract class AbstractConnectionResolver {
 				$nodes[ $id ] = $model;
 			}
 		}
+
 		return $nodes;
 	}
 
@@ -616,12 +619,12 @@ abstract class AbstractConnectionResolver {
 	 * If model isn't a class with a `fields` member, this function with have be overridden in
 	 * the Connection class.
 	 *
-	 * @param array $model model.
+	 * @param Model $model model.
 	 *
 	 * @return bool
 	 */
-	protected function is_valid_model( $model ) {
-		return isset( $model ) && ! empty( $model->fields );
+	protected function is_valid_model( Model $model ) {
+		return isset( $model->fields ) && ! empty( $model->fields );
 	}
 
 	/**

--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -28,7 +28,6 @@ class NodeResolver {
 	 *
 	 * @return mixed
 	 * @throws \Exception
-	 *
 	 */
 	public function resolve_uri( $uri, $extra_query_vars = '' ) {
 
@@ -74,9 +73,9 @@ class NodeResolver {
 			$error                   = '404';
 			$this->wp->did_permalink = true;
 
-			$pathinfo = isset( $uri ) ? $uri : '';
+			$pathinfo         = isset( $uri ) ? $uri : '';
 			list( $pathinfo ) = explode( '?', $pathinfo );
-			$pathinfo = str_replace( '%', '%25', $pathinfo );
+			$pathinfo         = str_replace( '%', '%25', $pathinfo );
 
 			list( $req_uri ) = explode( '?', $pathinfo );
 			$home_path       = trim( wp_parse_url( home_url(), PHP_URL_PATH ), '/' );
@@ -187,7 +186,6 @@ class NodeResolver {
 		 * @param string[] $public_query_vars The array of whitelisted query variable names.
 		 *
 		 * @since 1.5.0
-		 *
 		 */
 		$this->wp->public_query_vars = apply_filters( 'query_vars', $this->wp->public_query_vars );
 
@@ -273,7 +271,6 @@ class NodeResolver {
 		 * @param array $query_vars The array of requested query variables.
 		 *
 		 * @since 2.1.0
-		 *
 		 */
 		$this->wp->query_vars = apply_filters( 'request', $this->wp->query_vars );
 

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -19,6 +19,7 @@ use WPGraphQL\Utils\Utils;
  * @property string  $post_type
  * @property string  $authorId
  * @property string  $authorDatabaseId
+ * @property int     $databaseId
  * @property string  $date
  * @property string  $dateGmt
  * @property string  $contentRendered
@@ -104,8 +105,8 @@ class Post extends Model {
 	 *
 	 * @param \WP_Post $post The incoming WP_Post object that needs modeling.
 	 *
-	 * @throws \Exception
 	 * @return void
+	 * @throws \Exception
 	 */
 	public function __construct( \WP_Post $post ) {
 
@@ -551,7 +552,7 @@ class Post extends Model {
 
 					return false;
 				},
-				'isPostsPage'               => function () {
+				'isPostsPage'               => function() {
 					if ( 'page' !== $this->data->post_type ) {
 						return false;
 					}

--- a/src/Mutation/PostObjectCreate.php
+++ b/src/Mutation/PostObjectCreate.php
@@ -4,6 +4,7 @@ namespace WPGraphQL\Mutation;
 
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
+use WP_Post_Type;
 use WPGraphQL\AppContext;
 use WPGraphQL\Data\DataSource;
 use WPGraphQL\Data\PostObjectMutation;
@@ -17,9 +18,9 @@ class PostObjectCreate {
 	/**
 	 * Registers the PostObjectCreate mutation.
 	 *
-	 * @param \WP_Post_Type $post_type_object   The post type of the mutation.
+	 * @param WP_Post_Type $post_type_object The post type of the mutation.
 	 */
-	public static function register_mutation( \WP_Post_Type $post_type_object ) {
+	public static function register_mutation( WP_Post_Type $post_type_object ) {
 		$mutation_name = 'create' . ucwords( $post_type_object->graphql_single_name );
 
 		register_graphql_mutation(
@@ -35,7 +36,7 @@ class PostObjectCreate {
 	/**
 	 * Defines the mutation input field configuration.
 	 *
-	 * @param \WP_Post_Type $post_type_object   The post type of the mutation.
+	 * @param WP_Post_Type $post_type_object The post type of the mutation.
 	 *
 	 * @return array
 	 */
@@ -120,7 +121,10 @@ class PostObjectCreate {
 			];
 		}
 
-		if ( $post_type_object->hierarchical || in_array( $post_type_object->name, [ 'attachment', 'revision' ], true ) ) {
+		if ( $post_type_object->hierarchical || in_array( $post_type_object->name, [
+				'attachment',
+				'revision'
+			], true ) ) {
 			$fields['parentId'] = [
 				'type'        => 'Id',
 				'description' => __( 'The ID of the parent object', 'wp-graphql' ),
@@ -155,21 +159,21 @@ class PostObjectCreate {
 	/**
 	 * Defines the mutation output field configuration.
 	 *
-	 * @param \WP_Post_Type $post_type_object   The post type of the mutation.
+	 * @param WP_Post_Type $post_type_object The post type of the mutation.
 	 *
 	 * @return array
 	 */
-	public static function get_output_fields( $post_type_object ) {
+	public static function get_output_fields( WP_Post_Type $post_type_object ) {
 		return [
 			$post_type_object->graphql_single_name => [
 				'type'    => $post_type_object->graphql_single_name,
-				'resolve' => function ( $payload, $args, AppContext $context, ResolveInfo $info ) use ( $post_type_object ) {
+				'resolve' => function( $payload, $args, AppContext $context, ResolveInfo $info ) {
 
 					if ( empty( $payload['postObjectId'] ) || ! absint( $payload['postObjectId'] ) ) {
 						return null;
 					}
 
-					return DataSource::resolve_post_object( $payload['postObjectId'], $context );
+					return $context->get_loader( 'post' )->load_deferred( $payload['postObjectId'] );
 				},
 			],
 		];
@@ -178,13 +182,13 @@ class PostObjectCreate {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @param \WP_Post_Type $post_type_object   The post type of the mutation.
-	 * @param string        $mutation_name      The mutation name.
+	 * @param WP_Post_Type $post_type_object The post type of the mutation.
+	 * @param string       $mutation_name    The mutation name.
 	 *
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload( $post_type_object, $mutation_name ) {
-		return function ( $input, AppContext $context, ResolveInfo $info ) use ( $post_type_object, $mutation_name ) {
+		return function( $input, AppContext $context, ResolveInfo $info ) use ( $post_type_object, $mutation_name ) {
 
 			/**
 			 * Throw an exception if there's no input
@@ -226,9 +230,9 @@ class PostObjectCreate {
 			 * allow other plugins to override the default (for example, Edit Flow, which provides control over
 			 * customizing stati or various E-commerce plugins that make heavy use of custom stati)
 			 *
-			 * @param string        $default_status   The default status to be used when the post is initially inserted
-			 * @param \WP_Post_Type $post_type_object The Post Type that is being inserted
-			 * @param string        $mutation_name    The name of the mutation currently in progress
+			 * @param string       $default_status   The default status to be used when the post is initially inserted
+			 * @param WP_Post_Type $post_type_object The Post Type that is being inserted
+			 * @param string       $mutation_name    The name of the mutation currently in progress
 			 */
 			$default_post_status = apply_filters( 'graphql_post_object_create_default_post_status', 'draft', $post_type_object, $mutation_name );
 
@@ -244,7 +248,10 @@ class PostObjectCreate {
 			 * If the current user cannot publish posts but their intent was to publish,
 			 * default the status to pending.
 			 */
-			if ( ! current_user_can( $post_type_object->cap->publish_posts ) && ! in_array( $intended_post_status, [ 'draft', 'pending' ], true ) ) {
+			if ( ! current_user_can( $post_type_object->cap->publish_posts ) && ! in_array( $intended_post_status, [
+					'draft',
+					'pending'
+				], true ) ) {
 				$intended_post_status = 'pending';
 			}
 
@@ -297,13 +304,13 @@ class PostObjectCreate {
 			 * be deferred (cron or whatever), and when those actions complete they could come back and set
 			 * the $intended_status.
 			 *
-			 * @param boolean       $should_set_intended_status Whether to set the intended post_status or not. Default true.
-			 * @param \WP_Post_Type $post_type_object           The Post Type Object for the post being mutated
-			 * @param string        $mutation_name              The name of the mutation currently in progress
-			 * @param AppContext    $context                    The AppContext passed down to all resolvers
-			 * @param ResolveInfo   $info                       The ResolveInfo passed down to all resolvers
-			 * @param string        $intended_post_status       The intended post_status the post should have according to the mutation input
-			 * @param string        $default_post_status        The default status posts should use if an intended status wasn't set
+			 * @param boolean      $should_set_intended_status Whether to set the intended post_status or not. Default true.
+			 * @param WP_Post_Type $post_type_object           The Post Type Object for the post being mutated
+			 * @param string       $mutation_name              The name of the mutation currently in progress
+			 * @param AppContext   $context                    The AppContext passed down to all resolvers
+			 * @param ResolveInfo  $info                       The ResolveInfo passed down to all resolvers
+			 * @param string       $intended_post_status       The intended post_status the post should have according to the mutation input
+			 * @param string       $default_post_status        The default status posts should use if an intended status wasn't set
 			 */
 			$should_set_intended_status = apply_filters( 'graphql_post_object_create_should_set_intended_post_status', true, $post_type_object, $mutation_name, $context, $info, $intended_post_status, $default_post_status );
 

--- a/src/Mutation/PostObjectCreate.php
+++ b/src/Mutation/PostObjectCreate.php
@@ -122,9 +122,9 @@ class PostObjectCreate {
 		}
 
 		if ( $post_type_object->hierarchical || in_array( $post_type_object->name, [
-				'attachment',
-				'revision'
-			], true ) ) {
+			'attachment',
+			'revision',
+		], true ) ) {
 			$fields['parentId'] = [
 				'type'        => 'Id',
 				'description' => __( 'The ID of the parent object', 'wp-graphql' ),
@@ -249,9 +249,9 @@ class PostObjectCreate {
 			 * default the status to pending.
 			 */
 			if ( ! current_user_can( $post_type_object->cap->publish_posts ) && ! in_array( $intended_post_status, [
-					'draft',
-					'pending'
-				], true ) ) {
+				'draft',
+				'pending',
+			], true ) ) {
 				$intended_post_status = 'pending';
 			}
 

--- a/src/Mutation/PostObjectDelete.php
+++ b/src/Mutation/PostObjectDelete.php
@@ -4,6 +4,7 @@ namespace WPGraphQL\Mutation;
 
 use GraphQL\Error\UserError;
 use GraphQLRelay\Relay;
+use WP_Post_Type;
 use WPGraphQL\Data\DataSource;
 use WPGraphQL\Model\Post;
 
@@ -11,9 +12,9 @@ class PostObjectDelete {
 	/**
 	 * Registers the PostObjectDelete mutation.
 	 *
-	 * @param \WP_Post_Type $post_type_object The post type of the mutation.
+	 * @param WP_Post_Type $post_type_object The post type of the mutation.
 	 */
-	public static function register_mutation( \WP_Post_Type $post_type_object ) {
+	public static function register_mutation( WP_Post_Type $post_type_object ) {
 		$mutation_name = 'delete' . ucwords( $post_type_object->graphql_single_name );
 
 		register_graphql_mutation(
@@ -29,7 +30,7 @@ class PostObjectDelete {
 	/**
 	 * Defines the mutation input field configuration.
 	 *
-	 * @param \WP_Post_Type $post_type_object The post type of the mutation.
+	 * @param WP_Post_Type $post_type_object The post type of the mutation.
 	 *
 	 * @return array
 	 */
@@ -52,7 +53,7 @@ class PostObjectDelete {
 	/**
 	 * Defines the mutation output field configuration.
 	 *
-	 * @param \WP_Post_Type $post_type_object The post type of the mutation.
+	 * @param WP_Post_Type $post_type_object The post type of the mutation.
 	 *
 	 * @return array
 	 */
@@ -61,7 +62,7 @@ class PostObjectDelete {
 			'deletedId'                            => [
 				'type'        => 'Id',
 				'description' => __( 'The ID of the deleted object', 'wp-graphql' ),
-				'resolve'     => function( $payload ) use ( $post_type_object ) {
+				'resolve'     => function( $payload ) {
 					$deleted = (object) $payload['postObject'];
 
 					return ! empty( $deleted->ID ) ? Relay::toGlobalId( 'post', absint( $deleted->ID ) ) : null;
@@ -70,7 +71,7 @@ class PostObjectDelete {
 			$post_type_object->graphql_single_name => [
 				'type'        => $post_type_object->graphql_single_name,
 				'description' => __( 'The object before it was deleted', 'wp-graphql' ),
-				'resolve'     => function( $payload ) use ( $post_type_object ) {
+				'resolve'     => function( $payload ) {
 					$deleted = (object) $payload['postObject'];
 
 					return ! empty( $deleted ) ? $deleted : null;
@@ -82,13 +83,13 @@ class PostObjectDelete {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @param \WP_Post_Type $post_type_object The post type of the mutation.
-	 * @param string        $mutation_name    The mutation name.
+	 * @param WP_Post_Type $post_type_object The post type of the mutation.
+	 * @param string       $mutation_name    The mutation name.
 	 *
 	 * @return callable
 	 */
-	public static function mutate_and_get_payload( $post_type_object, $mutation_name ) {
-		return function( $input ) use ( $post_type_object, $mutation_name ) {
+	public static function mutate_and_get_payload( WP_Post_Type $post_type_object, string $mutation_name ) {
+		return function( $input ) use ( $post_type_object ) {
 
 			/**
 			 * Get the ID from the global ID

--- a/src/Mutation/TermObjectCreate.php
+++ b/src/Mutation/TermObjectCreate.php
@@ -1,19 +1,20 @@
 <?php
+
 namespace WPGraphQL\Mutation;
 
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
+use WP_Taxonomy;
 use WPGraphQL\AppContext;
-use WPGraphQL\Data\DataSource;
 use WPGraphQL\Data\TermObjectMutation;
 
 class TermObjectCreate {
 	/**
 	 * Registers the TermObjectCreate mutation.
 	 *
-	 * @param \WP_Taxonomy $taxonomy    The taxonomy type of the mutation.
+	 * @param WP_Taxonomy $taxonomy The taxonomy type of the mutation.
 	 */
-	public static function register_mutation( \WP_Taxonomy $taxonomy ) {
+	public static function register_mutation( WP_Taxonomy $taxonomy ) {
 		$mutation_name = 'create' . ucwords( $taxonomy->graphql_single_name );
 
 		register_graphql_mutation(
@@ -40,11 +41,11 @@ class TermObjectCreate {
 	/**
 	 * Defines the mutation input field configuration.
 	 *
-	 * @param \WP_Taxonomy $taxonomy    The taxonomy type of the mutation.
+	 * @param WP_Taxonomy $taxonomy The taxonomy type of the mutation.
 	 *
 	 * @return array
 	 */
-	public static function get_input_fields( \WP_Taxonomy $taxonomy ) {
+	public static function get_input_fields( WP_Taxonomy $taxonomy ) {
 		$fields = [
 			'aliasOf'     => [
 				'type'        => 'String',
@@ -79,18 +80,19 @@ class TermObjectCreate {
 	/**
 	 * Defines the mutation output field configuration.
 	 *
-	 * @param \WP_Taxonomy $taxonomy    The taxonomy type of the mutation.
+	 * @param WP_Taxonomy $taxonomy The taxonomy type of the mutation.
 	 *
 	 * @return array
 	 */
-	public static function get_output_fields( \WP_Taxonomy $taxonomy ) {
+	public static function get_output_fields( WP_Taxonomy $taxonomy ) {
 		return [
 			$taxonomy->graphql_single_name => [
 				'type'        => $taxonomy->graphql_single_name,
 				// translators: Placeholder is the name of the taxonomy
 				'description' => sprintf( __( 'The created %s', 'wp-graphql' ), $taxonomy->name ),
-				'resolve'     => function ( $payload, $args, AppContext $context, ResolveInfo $info ) use ( $taxonomy ) {
+				'resolve'     => function( $payload, $args, AppContext $context, ResolveInfo $info ) {
 					$id = isset( $payload['termId'] ) ? absint( $payload['termId'] ) : null;
+
 					return $context->get_loader( 'term' )->load_deferred( $id );
 
 				},
@@ -101,12 +103,12 @@ class TermObjectCreate {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @param \WP_Taxonomy $taxonomy       The taxonomy type of the mutation.
-	 * @param string       $mutation_name  The name of the mutation.
+	 * @param WP_Taxonomy $taxonomy      The taxonomy type of the mutation.
+	 * @param string      $mutation_name The name of the mutation.
 	 *
 	 * @return callable
 	 */
-	public static function mutate_and_get_payload( \WP_Taxonomy $taxonomy, $mutation_name ) {
+	public static function mutate_and_get_payload( WP_Taxonomy $taxonomy, string $mutation_name ) {
 		return function( $input, AppContext $context, ResolveInfo $info ) use ( $taxonomy, $mutation_name ) {
 
 			/**
@@ -158,7 +160,7 @@ class TermObjectCreate {
 			 * Fires after a single term is created or updated via a GraphQL mutation
 			 *
 			 * @param int         $term_id       Inserted term object
-			 * @param \WP_Taxonomy $taxonomy     The taxonomy of the term being updated
+			 * @param WP_Taxonomy $taxonomy      The taxonomy of the term being updated
 			 * @param array       $args          The args used to insert the term
 			 * @param string      $mutation_name The name of the mutation being performed
 			 * @param AppContext  $context       The AppContext passed down the resolve tree

--- a/src/Mutation/TermObjectDelete.php
+++ b/src/Mutation/TermObjectDelete.php
@@ -1,8 +1,10 @@
 <?php
+
 namespace WPGraphQL\Mutation;
 
 use GraphQL\Error\UserError;
 use GraphQLRelay\Relay;
+use WP_Taxonomy;
 use WPGraphQL\Model\Term;
 
 /**
@@ -14,9 +16,9 @@ class TermObjectDelete {
 	/**
 	 * Registers the TermObjectDelete mutation.
 	 *
-	 * @param \WP_Taxonomy $taxonomy    The taxonomy type of the mutation.
+	 * @param WP_Taxonomy $taxonomy The taxonomy type of the mutation.
 	 */
-	public static function register_mutation( \WP_Taxonomy $taxonomy ) {
+	public static function register_mutation( WP_Taxonomy $taxonomy ) {
 		$mutation_name = 'delete' . ucfirst( $taxonomy->graphql_single_name );
 
 		register_graphql_mutation(
@@ -32,11 +34,11 @@ class TermObjectDelete {
 	/**
 	 * Defines the mutation input field configuration.
 	 *
-	 * @param \WP_Taxonomy $taxonomy    The taxonomy type of the mutation.
+	 * @param WP_Taxonomy $taxonomy The taxonomy type of the mutation.
 	 *
 	 * @return array
 	 */
-	public static function get_input_fields( \WP_Taxonomy $taxonomy ) {
+	public static function get_input_fields( WP_Taxonomy $taxonomy ) {
 		return [
 			'id' => [
 				'type'        => [
@@ -51,16 +53,16 @@ class TermObjectDelete {
 	/**
 	 * Defines the mutation output field configuration.
 	 *
-	 * @param \WP_Taxonomy $taxonomy    The taxonomy type of the mutation.
+	 * @param WP_Taxonomy $taxonomy The taxonomy type of the mutation.
 	 *
 	 * @return array
 	 */
-	public static function get_output_fields( \WP_Taxonomy $taxonomy ) {
+	public static function get_output_fields( WP_Taxonomy $taxonomy ) {
 		return [
 			'deletedId'                    => [
 				'type'        => 'ID',
 				'description' => __( 'The ID of the deleted object', 'wp-graphql' ),
-				'resolve'     => function( $payload ) use ( $taxonomy ) {
+				'resolve'     => function( $payload ) {
 					$deleted = (object) $payload['termObject'];
 
 					return ! empty( $deleted->term_id ) ? Relay::toGlobalId( 'term', $deleted->term_id ) : null;
@@ -69,7 +71,7 @@ class TermObjectDelete {
 			$taxonomy->graphql_single_name => [
 				'type'        => $taxonomy->graphql_single_name,
 				'description' => __( 'The deteted term object', 'wp-graphql' ),
-				'resolve'     => function( $payload ) use ( $taxonomy ) {
+				'resolve'     => function( $payload ) {
 					return new Term( $payload['termObject'] );
 				},
 			],
@@ -79,13 +81,13 @@ class TermObjectDelete {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @param \WP_Taxonomy $taxonomy       The taxonomy type of the mutation.
-	 * @param string       $mutation_name  The name of the mutation.
+	 * @param WP_Taxonomy $taxonomy      The taxonomy type of the mutation.
+	 * @param string      $mutation_name The name of the mutation.
 	 *
 	 * @return callable
 	 */
-	public static function mutate_and_get_payload( \WP_Taxonomy $taxonomy, $mutation_name ) {
-		return function( $input ) use ( $taxonomy, $mutation_name ) {
+	public static function mutate_and_get_payload( WP_Taxonomy $taxonomy, string $mutation_name ) {
+		return function( $input ) use ( $taxonomy ) {
 
 			$id_parts = Relay::fromGlobalId( $input['id'] );
 

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -364,7 +364,7 @@ class TypeRegistry {
 						'description' => __( 'The template assigned to the node', 'wp-graphql' ),
 						'fields'      => [
 							'templateName' => [
-								'resolve' => function( $template ) use ( $page_templates ) {
+								'resolve' => function( $template ) {
 									return isset( $template['templateName'] ) ? $template['templateName'] : null;
 								},
 							],
@@ -855,10 +855,10 @@ class TypeRegistry {
 	 *
 	 * @return void
 	 */
-	public function register_fields( $type_name, $fields ) {
-		if ( isset( $type_name ) && is_string( $type_name ) && ! empty( $fields ) && is_array( $fields ) ) {
+	public function register_fields( string $type_name, array $fields = [] ) {
+		if ( is_string( $type_name ) && ! empty( $fields ) && is_array( $fields ) ) {
 			foreach ( $fields as $field_name => $config ) {
-				if ( isset( $field_name ) && is_string( $field_name ) && ! empty( $config ) && is_array( $config ) ) {
+				if ( is_string( $field_name ) && ! empty( $config ) && is_array( $config ) ) {
 					$this->register_field( $type_name, $field_name, $config );
 				}
 			}
@@ -874,7 +874,7 @@ class TypeRegistry {
 	 *
 	 * @return void
 	 */
-	public function register_field( $type_name, $field_name, $config ) {
+	public function register_field( string $type_name, string $field_name, array $config ) {
 
 		add_filter(
 			'graphql_' . $type_name . '_fields',
@@ -934,7 +934,7 @@ class TypeRegistry {
 
 		add_filter(
 			'graphql_' . $type_name . '_fields',
-			function( $fields ) use ( $type_name, $field_name ) {
+			function( $fields ) use ( $field_name ) {
 
 				if ( isset( $fields[ $field_name ] ) ) {
 					unset( $fields[ $field_name ] );
@@ -1158,7 +1158,7 @@ class TypeRegistry {
 				'type'        => true === $one_to_one ? $connection_name . 'Edge' : $connection_name,
 				'args'        => array_merge( $pagination_args, $where_args ),
 				'description' => ! empty( $config['description'] ) ? $config['description'] : sprintf( __( 'Connection between the %1$s type and the %2$s type', 'wp-graphql' ), $from_type, $to_type ),
-				'resolve'     => function( $root, $args, $context, $info ) use ( $resolve_connection, $connection_name, $one_to_one ) {
+				'resolve'     => function( $root, $args, $context, $info ) use ( $resolve_connection ) {
 					/**
 					 * Return the results
 					 */

--- a/src/Request.php
+++ b/src/Request.php
@@ -598,7 +598,7 @@ class Request {
 		$server   = $this->get_server();
 		$response = $server->executeRequest( $this->params );
 
-		return $this->after_execute( $response, $this->params );
+		return $this->after_execute( $response );
 	}
 
 	/**

--- a/src/Type/InterfaceType/ContentTemplate.php
+++ b/src/Type/InterfaceType/ContentTemplate.php
@@ -2,8 +2,10 @@
 
 namespace WPGraphQL\Type\InterfaceType;
 
+use WPGraphQL\Registry\TypeRegistry;
+
 class ContentTemplate {
-	public static function register_type( $type_registry ) {
+	public static function register_type( TypeRegistry $type_registry ) {
 		register_graphql_interface_type(
 			'ContentTemplate',
 			[
@@ -14,7 +16,7 @@ class ContentTemplate {
 						'description' => __( 'The name of the template', 'wp-graphql' ),
 					],
 				],
-				'resolveType' => function( $value ) use ( $type_registry ) {
+				'resolveType' => function( $value ) {
 					return isset( $value['__typename'] ) ? $value['__typename'] : 'DefaultTemplate';
 				},
 			]

--- a/src/Type/Object/SettingGroup.php
+++ b/src/Type/Object/SettingGroup.php
@@ -62,7 +62,7 @@ class SettingGroup {
 					$fields[ $field_key ] = [
 						'type'        => $setting_field['type'],
 						'description' => $setting_field['description'],
-						'resolve'     => function( $root, array $args, $context, $info ) use ( $setting_field, $field_key, $key ) {
+						'resolve'     => function( $root, array $args, $context, $info ) use ( $setting_field ) {
 
 							/**
 							 * Check to see if the user querying the email field has the 'manage_options' capability

--- a/src/Type/Object/Settings.php
+++ b/src/Type/Object/Settings.php
@@ -81,7 +81,7 @@ class Settings {
 						'type'        => $setting_field['type'],
 						'description' => $setting_field['description'],
 
-						'resolve'     => function( $root, $args, $context, $info ) use ( $setting_field, $field_key, $key ) {
+						'resolve'     => function( $root, $args, $context, $info ) use ( $setting_field, $key ) {
 							/**
 							 * Check to see if the user querying the email field has the 'manage_options' capability
 							 * All other options should be public by default

--- a/vendor/composer/InstalledVersions.php
+++ b/vendor/composer/InstalledVersions.php
@@ -24,12 +24,12 @@ class InstalledVersions
 private static $installed = array (
   'root' => 
   array (
-    'pretty_version' => 'dev-develop',
-    'version' => 'dev-develop',
+    'pretty_version' => 'dev-master',
+    'version' => 'dev-master',
     'aliases' => 
     array (
     ),
-    'reference' => 'b618eb0929f7011c9f969bd92aaae555d4cd54f5',
+    'reference' => '3492c5425aa3cbb6aabaec3b42f20aa8d2451796',
     'name' => 'wp-graphql/wp-graphql',
   ),
   'versions' => 
@@ -54,12 +54,12 @@ private static $installed = array (
     ),
     'wp-graphql/wp-graphql' => 
     array (
-      'pretty_version' => 'dev-develop',
-      'version' => 'dev-develop',
+      'pretty_version' => 'dev-master',
+      'version' => 'dev-master',
       'aliases' => 
       array (
       ),
-      'reference' => 'b618eb0929f7011c9f969bd92aaae555d4cd54f5',
+      'reference' => '3492c5425aa3cbb6aabaec3b42f20aa8d2451796',
     ),
   ),
 );

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -1,12 +1,12 @@
 <?php return array (
   'root' => 
   array (
-    'pretty_version' => 'dev-develop',
-    'version' => 'dev-develop',
+    'pretty_version' => 'dev-master',
+    'version' => 'dev-master',
     'aliases' => 
     array (
     ),
-    'reference' => 'b618eb0929f7011c9f969bd92aaae555d4cd54f5',
+    'reference' => '3492c5425aa3cbb6aabaec3b42f20aa8d2451796',
     'name' => 'wp-graphql/wp-graphql',
   ),
   'versions' => 
@@ -31,12 +31,12 @@
     ),
     'wp-graphql/wp-graphql' => 
     array (
-      'pretty_version' => 'dev-develop',
-      'version' => 'dev-develop',
+      'pretty_version' => 'dev-master',
+      'version' => 'dev-master',
       'aliases' => 
       array (
       ),
-      'reference' => 'b618eb0929f7011c9f969bd92aaae555d4cd54f5',
+      'reference' => '3492c5425aa3cbb6aabaec3b42f20aa8d2451796',
     ),
   ),
 );


### PR DESCRIPTION
This updates the codebase to be compatible with PHPStan Level 1 checks by: 

- Removing many unused variables
- Setting default values for conditional variables that weren't always guaranteed to be set
- Updating PHPStan config to run checks for level 1
- Updating composer.json to include the proper phpstan installer for CI runs
- Add phpstan/constants.php to allow phpstan to analyze use of constants defined outside of WPGraphQL codebase (WP Core Constants) 

## Before

Running `composer run phpstan` would find 24 errors

![Screen Shot 2020-12-30 at 12 51 22 PM](https://user-images.githubusercontent.com/1260765/103377844-b9a74480-4a9d-11eb-951b-d2906aabb3ae.png)

## After

Running `composer run phpstan` finds 0 errors

![Screen Shot 2020-12-30 at 12 52 26 PM](https://user-images.githubusercontent.com/1260765/103377896-e0657b00-4a9d-11eb-80e4-a9117f0da558.png)

---- 

closes #1347 
