### PR TITLE
#1648 - update PHPStan to level 2

### DIFF
--- a/access-functions.php
+++ b/access-functions.php
@@ -358,11 +358,11 @@ function graphql_debug( $message, $config = [] ) {
 /**
  * Check if the name is valid for use in GraphQL
  *
- * @param $type_name
+ * @param string $type_name The name of the type to validate
  *
  * @return bool
  */
-function is_valid_graphql_name( $type_name ) {
+function is_valid_graphql_name( string $type_name ) {
 	if ( preg_match( '/^\d/', $type_name ) ) {
 		return false;
 	}
@@ -391,7 +391,7 @@ function register_graphql_settings_fields( $group, $fields ) {
  *
  * @return mixed|string|int|boolean
  */
-function get_graphql_setting( $option_name, $default = '', $section_name = 'graphql_general_settings' ) {
+function get_graphql_setting( string $option_name, $default = '', $section_name = 'graphql_general_settings' ) {
 
 	$section_fields = get_option( $section_name );
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    level: 1
+    level: 2
     inferPrivatePropertyTypeFromConstructor: true
     bootstrapFiles:
         - phpstan/constants.php
@@ -13,3 +13,11 @@ parameters:
         # Uses func_get_args()
         # Ignore any filters that are applied with more than 2 paramaters
         - '#^Function apply_filters(_ref_array)? invoked with [0[1-9]|1[0-2]] parameters, 2 required\.$#'
+        - "#Access to an undefined property WP_Post_Type::\\$graphql_single_name.#"
+        - "#Access to an undefined property WP_Post_Type::\\$graphql_plural_name.#"
+        - "#Access to an undefined property WP_Post_Type::\\$show_in_graphql.#"
+        - "#Cannot access property \\$graphql_single_name on WP_Taxonomy\\|false.#"
+        - "#Cannot access property \\$graphql_plural_name on WP_Taxonomy\\|false.#"
+        - "#Access to an undefined property WP_Taxonomy::\\$graphql_single_name.#"
+        - "#Access to an undefined property WP_Taxonomy::\\$graphql_plural_name.#"
+        - "#Access to an undefined property WP_Taxonomy::\\$show_in_graphql.#"

--- a/src/Admin/Settings/SettingsRegistry.php
+++ b/src/Admin/Settings/SettingsRegistry.php
@@ -417,10 +417,8 @@ class SettingsRegistry {
 	 * Displays the html for a settings field
 	 *
 	 * @param array $args settings field args
-	 *
-	 * @return string
 	 */
-	function callback_html( $args ) {
+	function callback_html( array $args ) {
 		echo wp_kses( $this->get_field_description( $args ), Utils::get_allowed_wp_kses_html() );
 	}
 

--- a/src/AppContext.php
+++ b/src/AppContext.php
@@ -3,6 +3,7 @@
 namespace WPGraphQL;
 
 use GraphQL\Error\UserError;
+use WP_User;
 use WPGraphQL\Data\Loader\CommentAuthorLoader;
 use WPGraphQL\Data\Loader\CommentLoader;
 use WPGraphQL\Data\Loader\EnqueuedScriptLoader;
@@ -18,6 +19,7 @@ use WPGraphQL\Data\Loader\UserLoader;
 use WPGraphQL\Data\Loader\UserRoleLoader;
 use WPGraphQL\Data\NodeResolver;
 use WPGraphQL\Model\Term;
+use WPGraphQL\Registry\TypeRegistry;
 
 /**
  * Class AppContext
@@ -42,28 +44,33 @@ class AppContext {
 	/**
 	 * Stores the WP_User object of the current user
 	 *
-	 * @var \WP_User $viewer
+	 * @var WP_User $viewer
 	 */
 	public $viewer;
 
 	/**
+	 * @var TypeRegistry
+	 */
+	public $type_registry;
+
+	/**
 	 * Stores everything from the $_REQUEST global
 	 *
-	 * @var \mixed $request
+	 * @var mixed $request
 	 */
 	public $request;
 
 	/**
 	 * Stores additional $config properties
 	 *
-	 * @var \mixed $config
+	 * @var mixed $config
 	 */
 	public $config;
 
 	/**
 	 * Passes context about the current connection being resolved
 	 *
-	 * @var mixed| String | null
+	 * @var mixed|String|null
 	 */
 	public $currentConnection = null;
 

--- a/src/AppContext.php
+++ b/src/AppContext.php
@@ -8,7 +8,6 @@ use WPGraphQL\Data\Loader\CommentAuthorLoader;
 use WPGraphQL\Data\Loader\CommentLoader;
 use WPGraphQL\Data\Loader\EnqueuedScriptLoader;
 use WPGraphQL\Data\Loader\EnqueuedStylesheetLoader;
-use WPGraphQL\Data\Loader\MenuItemLoader;
 use WPGraphQL\Data\Loader\PluginLoader;
 use WPGraphQL\Data\Loader\PostObjectLoader;
 use WPGraphQL\Data\Loader\PostTypeLoader;
@@ -18,7 +17,6 @@ use WPGraphQL\Data\Loader\ThemeLoader;
 use WPGraphQL\Data\Loader\UserLoader;
 use WPGraphQL\Data\Loader\UserRoleLoader;
 use WPGraphQL\Data\NodeResolver;
-use WPGraphQL\Model\Term;
 use WPGraphQL\Registry\TypeRegistry;
 
 /**
@@ -131,7 +129,7 @@ class AppContext {
 		/**
 		 * This sets up the NodeResolver to allow nodes to be resolved by URI
 		 *
-		 * @param AppContext $this The AppContext instance
+		 * @param AppContext $app_context The AppContext instance
 		 */
 		$this->node_resolver = new NodeResolver( $this );
 

--- a/src/Data/CommentMutation.php
+++ b/src/Data/CommentMutation.php
@@ -110,10 +110,9 @@ class CommentMutation {
 	 * @param string      $mutation_name           The name of the mutation ( ex: create, update, delete )
 	 * @param AppContext  $context                 The AppContext passed down to all resolvers
 	 * @param ResolveInfo $info                    The ResolveInfo passed down to all resolvers
-	 * @param string      $intended_comment_status The intended post_status the post should have according to the mutation input
-	 * @param string      $intended_comment_status The default status posts should use if an intended status wasn't set
 	 */
-	public static function update_additional_comment_data( $comment_id, $input, $mutation_name, AppContext $context, ResolveInfo $info ) {
+	public static function update_additional_comment_data( int $comment_id, array $input, string $mutation_name, AppContext $context, ResolveInfo $info ) {
+
 		/**
 		* @todo: should account for authentication
 		*/

--- a/src/Data/Config.php
+++ b/src/Data/Config.php
@@ -2,6 +2,7 @@
 
 namespace WPGraphQL\Data;
 
+use WP_Comment_Query;
 use WPGraphQL\Data\Cursor\PostObjectCursor;
 use WPGraphQL\Data\Cursor\UserCursor;
 
@@ -288,11 +289,11 @@ class Config {
 	 * is a GraphQL Request and the query has a graphql_cursor_offset defined
 	 *
 	 * @param array             $pieces A compacted array of comment query clauses.
-	 * @param \WP_Comment_Query $query  Current instance of WP_Comment_Query, passed by reference.
+	 * @param WP_Comment_Query $query  Current instance of WP_Comment_Query, passed by reference.
 	 *
 	 * @return array $pieces
 	 */
-	public function graphql_wp_comments_query_cursor_pagination_support( array $pieces, \WP_Comment_Query $query ) {
+	public function graphql_wp_comments_query_cursor_pagination_support( array $pieces, WP_Comment_Query $query ) {
 
 		/**
 		 * Access the global $wpdb object
@@ -311,7 +312,7 @@ class Config {
 			 */
 			if ( is_integer( $cursor_offset ) && 0 < $cursor_offset ) {
 
-				$compare = ! empty( $query->get( 'graphql_cursor_compare' ) ) ? $query->get( 'graphql_cursor_compare' ) : '>';
+				$compare = ! empty( $query->query_vars['graphql_cursor_compare'] ) ? $query->query_vars['graphql_cursor_compare'] : '>';
 				$compare = in_array( $compare, [ '>', '<' ], true ) ? $compare : '>';
 
 				$order_by      = ! empty( $query->query_vars['order_by'] ) ? $query->query_vars['order_by'] : 'comment_date';

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -2,6 +2,7 @@
 
 namespace WPGraphQL\Data\Connection;
 
+use Exception;
 use GraphQL\Deferred;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
@@ -121,14 +122,16 @@ abstract class AbstractConnectionResolver {
 	/**
 	 * ConnectionResolver constructor.
 	 *
-	 * @param $source
-	 * @param $args
-	 * @param $context
-	 * @param $info
+	 * @param mixed       $source  source passed down from the resolve tree
+	 * @param array       $args    array of arguments input in the field as part of the GraphQL
+	 *                             query
+	 * @param AppContext  $context Object containing app context that gets passed down the resolve
+	 *                             tree
+	 * @param ResolveInfo $info    Info about fields passed down the resolve tree
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
-	public function __construct( $source, $args, $context, $info ) {
+	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info ) {
 
 		// Bail if the Post->ID is empty, as that indicates a private post.
 		if ( $source instanceof Post && empty( $source->ID ) ) {
@@ -199,12 +202,12 @@ abstract class AbstractConnectionResolver {
 	 * Get the loader name
 	 *
 	 * @return AbstractDataLoader
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	protected function getLoader() {
 		$name = $this->get_loader_name();
 		if ( empty( $name ) || ! is_string( $name ) ) {
-			throw new \Exception( __( 'The Connection Resolver needs to define a loader name', 'wp-graphql' ) );
+			throw new Exception( __( 'The Connection Resolver needs to define a loader name', 'wp-graphql' ) );
 		}
 
 		return $this->context->get_loader( $name );
@@ -366,7 +369,7 @@ abstract class AbstractConnectionResolver {
 	 * @param $id
 	 *
 	 * @return mixed|Model|null
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function get_node_by_id( $id ) {
 		return $this->loader->load( $id );
@@ -379,7 +382,7 @@ abstract class AbstractConnectionResolver {
 	 * ensure that queries don't exceed unwanted limits when querying data.
 	 *
 	 * @return int
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function get_query_amount() {
 
@@ -409,7 +412,7 @@ abstract class AbstractConnectionResolver {
 	 * This checks the $args to determine the amount requested, and if
 	 *
 	 * @return int|null
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function get_amount_requested() {
 
@@ -574,7 +577,7 @@ abstract class AbstractConnectionResolver {
 	 * For backward pagination, we reverse the order of nodes.
 	 *
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function get_nodes() {
 		if ( empty( $this->ids ) ) {
@@ -734,7 +737,7 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * @return array
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function execute_and_get_ids() {
 
@@ -809,7 +812,7 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * @return mixed|array|Deferred
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function get_connection() {
 

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -181,9 +181,9 @@ abstract class AbstractConnectionResolver {
 		 *
 		 * Filters the args
 		 *
-		 * @param array                      $query_args The query args to be used with the executable query to get data.
-		 *                                               This should take in the GraphQL args and return args for use in fetching the data.
-		 * @param AbstractConnectionResolver $this       Instance of the ConnectionResolver
+		 * @param array                      $query_args                   The query args to be used with the executable query to get data.
+		 *                                                                 This should take in the GraphQL args and return args for use in fetching the data.
+		 * @param AbstractConnectionResolver $connection_resolver          Instance of the ConnectionResolver
 		 */
 		$this->query_args = apply_filters( 'graphql_connection_query_args', $this->get_query_args(), $this );
 
@@ -366,7 +366,8 @@ abstract class AbstractConnectionResolver {
 	/**
 	 * Given an ID, return the model for the entity or null
 	 *
-	 * @param $id
+	 * @param mixed $id The ID to identify the object by. Could be a database ID or an in-memory ID
+	 *                  (like post_type name)
 	 *
 	 * @return mixed|Model|null
 	 * @throws Exception
@@ -622,11 +623,12 @@ abstract class AbstractConnectionResolver {
 	 * If model isn't a class with a `fields` member, this function with have be overridden in
 	 * the Connection class.
 	 *
-	 * @param mixed Model|null $model model.
+	 * @param mixed $model The model being validated
 	 *
 	 * @return bool
 	 */
 	protected function is_valid_model( $model ) {
+
 		return isset( $model->fields ) && ! empty( $model->fields );
 	}
 
@@ -664,8 +666,8 @@ abstract class AbstractConnectionResolver {
 				/**
 				 * Create the edge, pass it through a filter.
 				 *
-				 * @param array                      $edge The edge within the connection
-				 * @param AbstractConnectionResolver $this Instance of the connection resolver class
+				 * @param array                      $edge                The edge within the connection
+				 * @param AbstractConnectionResolver $connection_resolver Instance of the connection resolver class
 				 */
 				$edge = apply_filters(
 					'graphql_connection_edge',
@@ -755,8 +757,8 @@ abstract class AbstractConnectionResolver {
 		 *
 		 * Filter whether the connection should execute.
 		 *
-		 * @param bool                       $should_execute Whether the connection should execute
-		 * @param AbstractConnectionResolver $this           Instance of the Connection Resolver
+		 * @param bool                       $should_execute      Whether the connection should execute
+		 * @param AbstractConnectionResolver $connection_resolver Instance of the Connection Resolver
 		 */
 		$this->should_execute = apply_filters( 'graphql_connection_should_execute', $should_execute, $this );
 		if ( false === $this->should_execute ) {
@@ -779,16 +781,16 @@ abstract class AbstractConnectionResolver {
 		 * the query to that instead of a native WP_Query class. You could override this with a
 		 * query to that datasource instead.
 		 *
-		 * @param mixed                      $query Instance of the Query for the resolver
-		 * @param AbstractConnectionResolver $this  Instance of the Connection Resolver
+		 * @param mixed                      $query               Instance of the Query for the resolver
+		 * @param AbstractConnectionResolver $connection_resolver Instance of the Connection Resolver
 		 */
 		$this->query = apply_filters( 'graphql_connection_query', $this->get_query(), $this );
 
 		/**
 		 * Filter the connection IDs
 		 *
-		 * @param array                      $ids  Array of IDs this connection will be resolving
-		 * @param AbstractConnectionResolver $this Instance of the Connection Resolver
+		 * @param array                      $ids                 Array of IDs this connection will be resolving
+		 * @param AbstractConnectionResolver $connection_resolver Instance of the Connection Resolver
 		 */
 		$this->ids = apply_filters( 'graphql_connection_ids', $this->get_ids(), $this );
 
@@ -834,16 +836,16 @@ abstract class AbstractConnectionResolver {
 				 *
 				 * Filters the nodes in the connection
 				 *
-				 * @param array                      $nodes The nodes in the connection
-				 * @param AbstractConnectionResolver $this  Instance of the Connection Resolver
+				 * @param array                      $nodes               The nodes in the connection
+				 * @param AbstractConnectionResolver $connection_resolver Instance of the Connection Resolver
 				 */
 				$this->nodes = apply_filters( 'graphql_connection_nodes', $this->get_nodes(), $this );
 
 				/**
 				 * Filters the edges in the connection
 				 *
-				 * @param array                      $nodes The nodes in the connection
-				 * @param AbstractConnectionResolver $this  Instance of the Connection Resolver
+				 * @param array                      $nodes               The nodes in the connection
+				 * @param AbstractConnectionResolver $connection_resolver Instance of the Connection Resolver
 				 */
 				$this->edges = apply_filters( 'graphql_connection_edges', $this->get_edges(), $this );
 
@@ -865,8 +867,8 @@ abstract class AbstractConnectionResolver {
 				 *
 				 * This filter allows additional fields to be returned to the connection resolver
 				 *
-				 * @param array                      $connection The connection data being returned
-				 * @param AbstractConnectionResolver $this       The instance of the connection resolver
+				 * @param array                      $connection          The connection data being returned
+				 * @param AbstractConnectionResolver $connection_resolver The instance of the connection resolver
 				 */
 				return apply_filters( 'graphql_connection', $connection, $this );
 

--- a/src/Data/Connection/CommentConnectionResolver.php
+++ b/src/Data/Connection/CommentConnectionResolver.php
@@ -2,12 +2,10 @@
 
 namespace WPGraphQL\Data\Connection;
 
+use Exception;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
-use WPGraphQL\Model\Comment;
-use WPGraphQL\Model\Post;
-use WPGraphQL\Model\User;
 use WPGraphQL\Types;
 
 /**
@@ -19,7 +17,7 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 
 	/**
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function get_query_args() {
 
@@ -137,7 +135,7 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 	 * Return the instance of the WP_Comment_Query
 	 *
 	 * @return mixed|\WP_Comment_Query
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function get_query() {
 		return new \WP_Comment_Query( $this->query_args );
@@ -154,7 +152,7 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 
 	/**
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function get_ids() {
 		return ! empty( $this->query->get_comments() ) ? $this->query->get_comments() : [];

--- a/src/Data/Connection/ContentTypeConnectionResolver.php
+++ b/src/Data/Connection/ContentTypeConnectionResolver.php
@@ -1,6 +1,10 @@
 <?php
 namespace WPGraphQL\Data\Connection;
 
+use Exception;
+use GraphQL\Type\Definition\ResolveInfo;
+use WPGraphQL\AppContext;
+
 /**
  * Class ContentTypeConnectionResolver
  *
@@ -11,14 +15,14 @@ class ContentTypeConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * ContentTypeConnectionResolver constructor.
 	 *
-	 * @param $source
-	 * @param $args
-	 * @param $context
-	 * @param $info
+	 * @param mixed       $source     source passed down from the resolve tree
+	 * @param array       $args       array of arguments input in the field as part of the GraphQL query
+	 * @param AppContext  $context    Object containing app context that gets passed down the resolve tree
+	 * @param ResolveInfo $info       Info about fields passed down the resolve tree
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
-	public function __construct( $source, $args, $context, $info ) {
+	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info ) {
 		parent::__construct( $source, $args, $context, $info );
 	}
 
@@ -99,7 +103,7 @@ class ContentTypeConnectionResolver extends AbstractConnectionResolver {
 	 * For backward pagination, we reverse the order of nodes.
 	 *
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function get_nodes() {
 

--- a/src/Data/Connection/ContentTypeConnectionResolver.php
+++ b/src/Data/Connection/ContentTypeConnectionResolver.php
@@ -138,7 +138,7 @@ class ContentTypeConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * Determine if the offset used for pagination is valid
 	 *
-	 * @param $offset
+	 * @param mixed $offset
 	 *
 	 * @return bool
 	 */

--- a/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
@@ -1,6 +1,8 @@
 <?php
 namespace WPGraphQL\Data\Connection;
+use Exception;
 use GraphQL\Type\Definition\ResolveInfo;
+use WPGraphQL\AppContext;
 
 /**
  * Class EnqueuedScriptsConnectionResolver
@@ -12,14 +14,14 @@ class EnqueuedScriptsConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * EnqueuedScriptsConnectionResolver constructor.
 	 *
-	 * @param $source
-	 * @param $args
-	 * @param $context
-	 * @param $info
+	 * @param mixed       $source     source passed down from the resolve tree
+	 * @param array       $args       array of arguments input in the field as part of the GraphQL query
+	 * @param AppContext  $context    Object containing app context that gets passed down the resolve tree
+	 * @param ResolveInfo $info       Info about fields passed down the resolve tree
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
-	public function __construct( $source, $args, $context, $info ) {
+	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info ) {
 
 		/**
 		 * Filter the query amount to be 1000 for
@@ -91,7 +93,7 @@ class EnqueuedScriptsConnectionResolver extends AbstractConnectionResolver {
 	 * For backward pagination, we reverse the order of nodes.
 	 *
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function get_nodes() {
 

--- a/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
@@ -139,7 +139,7 @@ class EnqueuedScriptsConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * Determine if the offset used for pagination is valid
 	 *
-	 * @param $offset
+	 * @param mixed $offset
 	 *
 	 * @return bool
 	 */

--- a/src/Data/Connection/EnqueuedStylesheetConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedStylesheetConnectionResolver.php
@@ -1,6 +1,8 @@
 <?php
 namespace WPGraphQL\Data\Connection;
+use Exception;
 use GraphQL\Type\Definition\ResolveInfo;
+use WPGraphQL\AppContext;
 
 /**
  * Class EnqueuedStylesheetConnectionResolver
@@ -12,14 +14,14 @@ class EnqueuedStylesheetConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * EnqueuedStylesheetConnectionResolver constructor.
 	 *
-	 * @param $source
-	 * @param $args
-	 * @param $context
-	 * @param $info
+	 * @param mixed       $source     source passed down from the resolve tree
+	 * @param array       $args       array of arguments input in the field as part of the GraphQL query
+	 * @param AppContext  $context    Object containing app context that gets passed down the resolve tree
+	 * @param ResolveInfo $info       Info about fields passed down the resolve tree
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
-	public function __construct( $source, $args, $context, $info ) {
+	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info ) {
 
 		/**
 		 * Filter the query amount to be 1000 for
@@ -91,7 +93,7 @@ class EnqueuedStylesheetConnectionResolver extends AbstractConnectionResolver {
 	 * For backward pagination, we reverse the order of nodes.
 	 *
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function get_nodes() {
 

--- a/src/Data/Connection/EnqueuedStylesheetConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedStylesheetConnectionResolver.php
@@ -139,7 +139,7 @@ class EnqueuedStylesheetConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * Determine if the offset used for pagination is valid
 	 *
-	 * @param $offset
+	 * @param mixed $offset
 	 *
 	 * @return bool
 	 */

--- a/src/Data/Connection/MenuConnectionResolver.php
+++ b/src/Data/Connection/MenuConnectionResolver.php
@@ -2,6 +2,8 @@
 
 namespace WPGraphQL\Data\Connection;
 
+use Exception;
+
 /**
  * Class MenuConnectionResolver
  *
@@ -13,7 +15,7 @@ class MenuConnectionResolver extends TermObjectConnectionResolver {
 	 * Get the connection args for use in WP_Term_Query to query the menus
 	 *
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function get_query_args() {
 		$term_args = [

--- a/src/Data/Connection/MenuItemConnectionResolver.php
+++ b/src/Data/Connection/MenuItemConnectionResolver.php
@@ -1,6 +1,7 @@
 <?php
 namespace WPGraphQL\Data\Connection;
 
+use Exception;
 use GraphQLRelay\Relay;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
@@ -15,12 +16,12 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 	/**
 	 * MenuItemConnectionResolver constructor.
 	 *
-	 * @param             $source
-	 * @param array       $args
-	 * @param AppContext  $context
-	 * @param ResolveInfo $info
+	 * @param mixed       $source     source passed down from the resolve tree
+	 * @param array       $args       array of arguments input in the field as part of the GraphQL query
+	 * @param AppContext  $context    Object containing app context that gets passed down the resolve tree
+	 * @param ResolveInfo $info       Info about fields passed down the resolve tree
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info ) {
 		parent::__construct( $source, $args, $context, $info, 'nav_menu_item' );

--- a/src/Data/Connection/PluginConnectionResolver.php
+++ b/src/Data/Connection/PluginConnectionResolver.php
@@ -106,7 +106,7 @@ class PluginConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * @param $offset
+	 * @param mixed $offset
 	 *
 	 * @return bool
 	 */

--- a/src/Data/Connection/PluginConnectionResolver.php
+++ b/src/Data/Connection/PluginConnectionResolver.php
@@ -1,6 +1,10 @@
 <?php
 namespace WPGraphQL\Data\Connection;
 
+use Exception;
+use GraphQL\Type\Definition\ResolveInfo;
+use WPGraphQL\AppContext;
+
 /**
  * Class PluginConnectionResolver - Connects plugins to other objects
  *
@@ -12,14 +16,14 @@ class PluginConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * PluginConnectionResolver constructor.
 	 *
-	 * @param $source
-	 * @param $args
-	 * @param $context
-	 * @param $info
+	 * @param mixed       $source     source passed down from the resolve tree
+	 * @param array       $args       array of arguments input in the field as part of the GraphQL query
+	 * @param AppContext  $context    Object containing app context that gets passed down the resolve tree
+	 * @param ResolveInfo $info       Info about fields passed down the resolve tree
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
-	public function __construct( $source, $args, $context, $info ) {
+	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info ) {
 		parent::__construct( $source, $args, $context, $info );
 	}
 
@@ -73,7 +77,7 @@ class PluginConnectionResolver extends AbstractConnectionResolver {
 
 	/**
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function get_nodes() {
 		$nodes = parent::get_nodes();

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -2,6 +2,7 @@
 
 namespace WPGraphQL\Data\Connection;
 
+use Exception;
 use GraphQL\Error\InvariantViolation;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
@@ -25,17 +26,17 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * PostObjectConnectionResolver constructor.
 	 *
-	 * @param mixed       $source                         The object passed down from the previous
-	 *                                                    level in the Resolve tree
-	 * @param array       $args                           The input arguments for the query
-	 * @param AppContext  $context                        The context of the request
-	 * @param ResolveInfo $info                           The resolve info passed down the Resolve
-	 *                                                    tree
-	 * @param mixed string|array $post_type The post type to resolve for
+	 * @param mixed              $source    source passed down from the resolve tree
+	 * @param array              $args      array of arguments input in the field as part of the
+	 *                                      GraphQL query
+	 * @param AppContext         $context   Object containing app context that gets passed down the
+	 *                                      resolve tree
+	 * @param ResolveInfo        $info      Info about fields passed down the resolve tree
+	 * @param mixed|string|array $post_type The post type to resolve for
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
-	public function __construct( $source, $args, $context, $info, $post_type = 'any' ) {
+	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info, $post_type = 'any' ) {
 
 		/**
 		 * The $post_type can either be a single value or an array of post_types to
@@ -82,7 +83,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	 *
 	 * @return \WP_Query
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function get_query() {
 
@@ -279,7 +280,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 							$ids = array_slice( $ids, 0, $key, true );
 							// Slice the array from the front
 						} else {
-							$key++;
+							$key ++;
 							$ids = array_slice( $ids, $key, null, true );
 						}
 					}
@@ -366,8 +367,8 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	 * this was quick. I'd be down to explore more dynamic ways to map this, but for
 	 * now this gets the job done.
 	 *
-	 * @since  0.0.5
 	 * @return array
+	 * @since  0.0.5
 	 */
 	public function sanitize_input_fields( $where_args ) {
 
@@ -423,8 +424,8 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		 * @param ResolveInfo        $info       The ResolveInfo object
 		 * @param mixed|string|array $post_type  The post type for the query
 		 *
-		 * @since 0.0.5
 		 * @return array
+		 * @since 0.0.5
 		 */
 		$query_args = apply_filters( 'graphql_map_input_fields_to_wp_query', $query_args, $where_args, $this->source, $this->args, $this->context, $this->info, $this->post_type );
 
@@ -443,7 +444,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	 * This strips the status from the query_args if the user doesn't have permission to query for
 	 * posts of that status.
 	 *
-	 * @param $stati
+	 * @param mixed $stati The status(es) to sanitize
 	 *
 	 * @return array|null
 	 */

--- a/src/Data/Connection/TaxonomyConnectionResolver.php
+++ b/src/Data/Connection/TaxonomyConnectionResolver.php
@@ -1,6 +1,7 @@
 <?php
 namespace WPGraphQL\Data\Connection;
 
+use Exception;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
@@ -17,14 +18,14 @@ class TaxonomyConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * ContentTypeConnectionResolver constructor.
 	 *
-	 * @param $source
-	 * @param $args
-	 * @param $context
-	 * @param $info
+	 * @param mixed       $source     source passed down from the resolve tree
+	 * @param array       $args       array of arguments input in the field as part of the GraphQL query
+	 * @param AppContext  $context    Object containing app context that gets passed down the resolve tree
+	 * @param ResolveInfo $info       Info about fields passed down the resolve tree
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
-	public function __construct( $source, $args, $context, $info ) {
+	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info ) {
 		parent::__construct( $source, $args, $context, $info );
 	}
 
@@ -104,7 +105,7 @@ class TaxonomyConnectionResolver extends AbstractConnectionResolver {
 	 * For backward pagination, we reverse the order of nodes.
 	 *
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function get_nodes() {
 
@@ -139,7 +140,7 @@ class TaxonomyConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * Determine if the offset used for pagination is valid
 	 *
-	 * @param $offset
+	 * @param mixed $offset
 	 *
 	 * @return bool
 	 */

--- a/src/Data/Connection/TermObjectConnectionResolver.php
+++ b/src/Data/Connection/TermObjectConnectionResolver.php
@@ -2,6 +2,7 @@
 
 namespace WPGraphQL\Data\Connection;
 
+use Exception;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
 use WPGraphQL\Model\Post;
@@ -25,22 +26,22 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * TermObjectConnectionResolver constructor.
 	 *
-	 * @param $source
-	 * @param $args
-	 * @param $context
-	 * @param $info
-	 * @param $taxonomy
+	 * @param mixed       $source     source passed down from the resolve tree
+	 * @param array       $args       array of arguments input in the field as part of the GraphQL query
+	 * @param AppContext  $context    Object containing app context that gets passed down the resolve tree
+	 * @param ResolveInfo $info       Info about fields passed down the resolve tree
+	 * @param mixed|string|null $taxonomy The name of the Taxonomy the resolver is intended to be used for
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
-	public function __construct( $source, $args, $context, $info, $taxonomy = null ) {
+	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info, $taxonomy = null ) {
 		$this->taxonomy = $taxonomy;
 		parent::__construct( $source, $args, $context, $info );
 	}
 
 	/**
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function get_query_args() {
 
@@ -139,7 +140,7 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 	 * Return an instance of WP_Term_Query with the args mapped to the query
 	 *
 	 * @return mixed|\WP_Term_Query
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function get_query() {
 		$query = new \WP_Term_Query( $this->query_args );

--- a/src/Data/Connection/ThemeConnectionResolver.php
+++ b/src/Data/Connection/ThemeConnectionResolver.php
@@ -15,7 +15,7 @@ use WPGraphQL\Data\DataSource;
 class ThemeConnectionResolver extends AbstractConnectionResolver {
 
 	/**
-	 * @return bool|int|mixed|null|string
+	 * @return mixed
 	 */
 	public function get_offset() {
 		$offset = null;
@@ -111,7 +111,7 @@ class ThemeConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * Determine if the offset used for pagination is valid
 	 *
-	 * @param $offset
+	 * @param mixed $offset
 	 *
 	 * @return bool
 	 */

--- a/src/Data/Connection/UserRoleConnectionResolver.php
+++ b/src/Data/Connection/UserRoleConnectionResolver.php
@@ -2,6 +2,9 @@
 
 namespace WPGraphQL\Data\Connection;
 
+use Exception;
+use GraphQL\Type\Definition\ResolveInfo;
+use WPGraphQL\AppContext;
 use WPGraphQL\Model\User;
 
 /**
@@ -15,19 +18,19 @@ class UserRoleConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * UserRoleConnectionResolver constructor.
 	 *
-	 * @param $source
-	 * @param $args
-	 * @param $context
-	 * @param $info
+	 * @param mixed       $source     source passed down from the resolve tree
+	 * @param array       $args       array of arguments input in the field as part of the GraphQL query
+	 * @param AppContext  $context    Object containing app context that gets passed down the resolve tree
+	 * @param ResolveInfo $info       Info about fields passed down the resolve tree
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
-	public function __construct( $source, $args, $context, $info ) {
+	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info ) {
 		parent::__construct( $source, $args, $context, $info );
 	}
 
 	/**
-	 * @return bool|int|mixed|null|string
+	 * @return mixed
 	 */
 	public function get_offset() {
 		$offset = null;
@@ -83,7 +86,7 @@ class UserRoleConnectionResolver extends AbstractConnectionResolver {
 
 	/**
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function get_nodes() {
 		$nodes = parent::get_nodes();
@@ -113,7 +116,7 @@ class UserRoleConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * @param $offset
+	 * @param mixed $offset Whether the provided offset is valid for the connection
 	 *
 	 * @return bool
 	 */

--- a/src/Data/Cursor/CursorBuilder.php
+++ b/src/Data/Cursor/CursorBuilder.php
@@ -33,14 +33,14 @@ class CursorBuilder {
 	 * @param null                    $order         custom order
 	 * @param null | PostObjectCursor $object_cursor The PostObjectCursor class
 	 */
-	public function add_field( $key, $value, $type = null, $order = null, $object_cursor = null ) {
+	public function add_field( string $key, string $value, $type = null, $order = null, $object_cursor = null ) {
 
 		/**
 		 * Filters the field used for ordering when cursors are used for pagination
 		 *
-		 * @param array                   $field         The field key, value, type and order
-		 * @param CursorBuilder           $this          The CursorBuilder class
-		 * @param null | PostObjectCursor $object_cursor The PostObjectCursor class
+		 * @param array                   $field          The field key, value, type and order
+		 * @param CursorBuilder           $cursor_builder The CursorBuilder class
+		 * @param null | PostObjectCursor $object_cursor  The PostObjectCursor class
 		 */
 		$field = apply_filters(
 			'graphql_cursor_ordering_field',

--- a/src/Data/Cursor/PostObjectCursor.php
+++ b/src/Data/Cursor/PostObjectCursor.php
@@ -2,6 +2,9 @@
 
 namespace WPGraphQL\Data\Cursor;
 
+use WP_Query;
+use wpdb;
+
 /**
  * Post Cursor
  *
@@ -12,28 +15,28 @@ namespace WPGraphQL\Data\Cursor;
 class PostObjectCursor {
 
 	/**
-	 * The global wpdb instance
+	 * The global WordPress Database instance
 	 *
-	 * @var $wpdb
+	 * @var wpdb $wpdb
 	 */
 	public $wpdb;
 
 	/**
 	 * The WP_Query instance
 	 *
-	 * @var $query
+	 * @var WP_Query $query
 	 */
 	public $query;
 
 	/**
 	 * The current post id which is our cursor offset
 	 *
-	 * @var $post_type
+	 * @var int $cursor_offset
 	 */
 	public $cursor_offset;
 
 	/**
-	 * @var \WPGraphQL\Data\Cursor\CursorBuilder
+	 * @var CursorBuilder
 	 */
 	public $builder;
 
@@ -52,7 +55,7 @@ class PostObjectCursor {
 	/**
 	 * PostCursor constructor.
 	 *
-	 * @param \WP_Query $query The WP_Query instance
+	 * @param WP_Query $query The WP_Query instance
 	 */
 	public function __construct( $query ) {
 		global $wpdb;
@@ -184,7 +187,7 @@ class PostObjectCursor {
 	 * @param string $by    The order by key
 	 * @param string $order The order direction ASC or DESC
 	 *
-	 * @return string
+	 * @return void
 	 */
 	private function compare_with( $by, $order ) {
 
@@ -228,8 +231,6 @@ class PostObjectCursor {
 	 *
 	 * @param string $meta_key post meta key
 	 * @param string $order    The comparison string
-	 *
-	 * @return string
 	 */
 	private function compare_with_meta_field( $meta_key, $order ) {
 		$meta_type  = $this->get_query_var( 'meta_type' );

--- a/src/Data/Cursor/UserCursor.php
+++ b/src/Data/Cursor/UserCursor.php
@@ -2,6 +2,10 @@
 
 namespace WPGraphQL\Data\Cursor;
 
+use WP_User;
+use WP_User_Query;
+use wpdb;
+
 /**
  * User Cursor
  *
@@ -12,28 +16,28 @@ namespace WPGraphQL\Data\Cursor;
 class UserCursor {
 
 	/**
-	 * The global wpdb instance
+	 * The global WordPress Database instance
 	 *
-	 * @var $wpdb
+	 * @var wpdb $wpdb WordPress Database
 	 */
 	public $wpdb;
 
 	/**
 	 * The WP_User_Query instance
 	 *
-	 * @var $query
+	 * @var WP_User_Query $query The WP_User_Query Instance
 	 */
 	public $query;
 
 	/**
 	 * The current user id which is our cursor offset
 	 *
-	 * @var $user
+	 * @var int $cursor_offset The current user ID
 	 */
 	public $cursor_offset;
 
 	/**
-	 * @var \WPGraphQL\Data\Cursor\CursorBuilder
+	 * @var CursorBuilder
 	 */
 	public $builder;
 
@@ -52,7 +56,7 @@ class UserCursor {
 	/**
 	 * UserCursor constructor.
 	 *
-	 * @param \WP_User_Query $query The WP_User_Query instance
+	 * @param WP_User_Query $query The WP_User_Query instance
 	 */
 	public function __construct( $query ) {
 		global $wpdb;
@@ -173,7 +177,7 @@ class UserCursor {
 	 * @param string $by    The order by key
 	 * @param string $order The order direction ASC or DESC
 	 *
-	 * @return string
+	 * @return void
 	 */
 	private function compare_with( $by, $order ) {
 
@@ -215,10 +219,8 @@ class UserCursor {
 	 *
 	 * @param string $meta_key user meta key
 	 * @param string $order    The comparison string
-	 *
-	 * @return string
 	 */
-	private function compare_with_meta_field( $meta_key, $order ) {
+	private function compare_with_meta_field( string $meta_key, string $order ) {
 		$meta_type  = $this->get_query_var( 'meta_type' );
 		$meta_value = get_user_meta( $this->cursor_offset, $meta_key, true );
 

--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -2,11 +2,13 @@
 
 namespace WPGraphQL\Data;
 
+use Exception;
 use GraphQL\Deferred;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
 
+use WP_Taxonomy;
 use WPGraphQL\AppContext;
 use WPGraphQL\Data\Connection\PluginConnectionResolver;
 use WPGraphQL\Data\Connection\PostObjectConnectionResolver;
@@ -57,10 +59,10 @@ class DataSource {
 	 * @param AppContext $context The context of the request.
 	 *
 	 * @return Deferred object
-	 * @since      0.0.5
-	 *
 	 * @throws UserError Throws UserError.
-	 * @throws \Exception Throws UserError.
+	 * @throws Exception Throws UserError.
+	 *
+	 * @since      0.0.5
 	 *
 	 * @deprecated Use the Loader passed in $context instead
 	 */
@@ -74,7 +76,7 @@ class DataSource {
 	 * @param int $comment_id The ID of the comment the comment author is associated with.
 	 *
 	 * @return CommentAuthor
-	 * @throws \Exception Throws Exception.
+	 * @throws Exception Throws Exception.
 	 */
 	public static function resolve_comment_author( $comment_id ) {
 		global $wpdb;
@@ -87,34 +89,33 @@ class DataSource {
 	/**
 	 * Wrapper for the CommentsConnectionResolver class
 	 *
-	 * @param mixed  object $source
+	 * @param mixed       $source  The object the connection is coming from
 	 * @param array       $args    Query args to pass to the connection resolver
 	 * @param AppContext  $context The context of the query to pass along
 	 * @param ResolveInfo $info    The ResolveInfo object
 	 *
 	 * @return mixed
+	 * @throws Exception
 	 * @since 0.0.5
-	 * @throws \Exception
 	 */
-	public static function resolve_comments_connection( $source, array $args, $context, ResolveInfo $info ) {
-		$resolver   = new CommentConnectionResolver( $source, $args, $context, $info );
-		$connection = $resolver->get_connection();
+	public static function resolve_comments_connection( $source, array $args, AppContext $context, ResolveInfo $info ) {
+		$resolver = new CommentConnectionResolver( $source, $args, $context, $info );
 
-		return $connection;
+		return $resolver->get_connection();
 	}
 
 	/**
 	 * Wrapper for PluginsConnectionResolver::resolve
 	 *
-	 * @param \WP_Post    $source  WP_Post object
-	 * @param array       $args    Array of arguments to pass to reolve method
+	 * @param mixed       $source  The object the connection is coming from
+	 * @param array       $args    Array of arguments to pass to resolve method
 	 * @param AppContext  $context AppContext object passed down
 	 * @param ResolveInfo $info    The ResolveInfo object
 	 *
 	 * @return array
+	 * @throws Exception
 	 * @since  0.0.5
 	 *
-	 * @throws \Exception
 	 */
 	public static function resolve_plugins_connection( $source, array $args, AppContext $context, ResolveInfo $info ) {
 		$resolver = new PluginConnectionResolver( $source, $args, $context, $info );
@@ -128,15 +129,15 @@ class DataSource {
 	 * @param int        $id      ID of the post you are trying to retrieve
 	 * @param AppContext $context The context of the GraphQL Request
 	 *
-	 * @throws UserError
-	 * @since      0.0.5
 	 * @return Deferred
 	 *
-	 * @throws \Exception
+	 * @throws UserError
+	 * @throws Exception
 	 *
+	 * @since      0.0.5
 	 * @deprecated Use the Loader passed in $context instead
 	 */
-	public static function resolve_post_object( $id, AppContext $context ) {
+	public static function resolve_post_object( int $id, AppContext $context ) {
 		return $context->get_loader( 'post' )->load_deferred( $id );
 	}
 
@@ -145,7 +146,7 @@ class DataSource {
 	 * @param AppContext $context The context of the GraphQL request
 	 *
 	 * @return Deferred|null
-	 * @throws \Exception
+	 * @throws Exception
 	 *
 	 * @deprecated Use the Loader passed in $context instead
 	 */
@@ -156,15 +157,15 @@ class DataSource {
 	/**
 	 * Wrapper for PostObjectsConnectionResolver
 	 *
-	 * @param             $source
-	 * @param array       $args    Arguments to pass to the resolve method
-	 * @param AppContext  $context AppContext object to pass down
-	 * @param ResolveInfo $info    The ResolveInfo object
-	 * @param mixed string|array $post_type Post type of the post we are trying to resolve
+	 * @param mixed              $source    The object the connection is coming from
+	 * @param array              $args      Arguments to pass to the resolve method
+	 * @param AppContext         $context   AppContext object to pass down
+	 * @param ResolveInfo        $info      The ResolveInfo object
+	 * @param mixed|string|array $post_type Post type of the post we are trying to resolve
 	 *
 	 * @return mixed
+	 * @throws Exception
 	 * @since  0.0.5
-	 * @throws \Exception
 	 */
 	public static function resolve_post_objects_connection( $source, array $args, AppContext $context, ResolveInfo $info, $post_type ) {
 		$resolver = new PostObjectConnectionResolver( $source, $args, $context, $info, $post_type );
@@ -178,7 +179,7 @@ class DataSource {
 	 * @param string $taxonomy Name of the taxonomy you want to retrieve the taxonomy object for
 	 *
 	 * @return Taxonomy object
-	 * @throws UserError | \Exception
+	 * @throws UserError | Exception
 	 * @since  0.0.5
 	 */
 	public static function resolve_taxonomy( $taxonomy ) {
@@ -206,7 +207,7 @@ class DataSource {
 	 * @param AppContext $context The context of the GraphQL Request
 	 *
 	 * @return mixed
-	 * @throws \Exception
+	 * @throws Exception
 	 * @since      0.0.5
 	 *
 	 * @deprecated Use the Loader passed in $context instead
@@ -218,21 +219,20 @@ class DataSource {
 	/**
 	 * Wrapper for TermObjectConnectionResolver::resolve
 	 *
-	 * @param              $source
-	 * @param array        $args     Array of args to be passed to the resolve method
-	 * @param AppContext   $context  The AppContext object to be passed down
-	 * @param ResolveInfo  $info     The ResolveInfo object
-	 * @param \WP_Taxonomy $taxonomy The WP_Taxonomy object of the taxonomy the term is connected to
+	 * @param mixed       $source   The object the connection is coming from
+	 * @param array       $args     Array of args to be passed to the resolve method
+	 * @param AppContext  $context  The AppContext object to be passed down
+	 * @param ResolveInfo $info     The ResolveInfo object
+	 * @param string      $taxonomy The name of the taxonomy the term belongs to
 	 *
 	 * @return array
+	 * @throws Exception
 	 * @since  0.0.5
-	 * @throws \Exception
 	 */
-	public static function resolve_term_objects_connection( $source, array $args, $context, ResolveInfo $info, $taxonomy ) {
-		$resolver   = new TermObjectConnectionResolver( $source, $args, $context, $info, $taxonomy );
-		$connection = $resolver->get_connection();
+	public static function resolve_term_objects_connection( $source, array $args, AppContext $context, ResolveInfo $info, string $taxonomy ) {
+		$resolver = new TermObjectConnectionResolver( $source, $args, $context, $info, $taxonomy );
 
-		return $connection;
+		return $resolver->get_connection();
 	}
 
 	/**
@@ -242,9 +242,9 @@ class DataSource {
 	 *
 	 * @return Theme object
 	 * @throws UserError
+	 * @throws Exception
 	 * @since  0.0.5
 	 *
-	 * @throws \Exception
 	 */
 	public static function resolve_theme( $stylesheet ) {
 		$theme = wp_get_theme( $stylesheet );
@@ -258,16 +258,16 @@ class DataSource {
 	/**
 	 * Wrapper for the ThemesConnectionResolver::resolve method
 	 *
-	 * @param             $source
+	 * @param mixed       $source  The object the connection is coming from
 	 * @param array       $args    Passes an array of arguments to the resolve method
 	 * @param AppContext  $context The AppContext object to be passed down
 	 * @param ResolveInfo $info    The ResolveInfo object
 	 *
 	 * @return array
+	 * @throws Exception
 	 * @since  0.0.5
-	 * @throws \Exception
 	 */
-	public static function resolve_themes_connection( $source, array $args, $context, ResolveInfo $info ) {
+	public static function resolve_themes_connection( $source, array $args, AppContext $context, ResolveInfo $info ) {
 		return ThemeConnectionResolver::resolve( $source, $args, $context, $info );
 	}
 
@@ -278,9 +278,9 @@ class DataSource {
 	 * @param AppContext $context The AppContext
 	 *
 	 * @return Deferred
-	 * @since      0.0.5
-	 * @throws \Exception
+	 * @throws Exception
 	 *
+	 * @since      0.0.5
 	 * @deprecated Use the Loader passed in $context instead
 	 */
 	public static function resolve_user( $id, AppContext $context ) {
@@ -290,16 +290,16 @@ class DataSource {
 	/**
 	 * Wrapper for the UsersConnectionResolver::resolve method
 	 *
-	 * @param             $source
+	 * @param mixed       $source  The object the connection is coming from
 	 * @param array       $args    Array of args to be passed down to the resolve method
 	 * @param AppContext  $context The AppContext object to be passed down
 	 * @param ResolveInfo $info    The ResolveInfo object
 	 *
 	 * @return array
+	 * @throws Exception
 	 * @since  0.0.5
-	 * @throws \Exception
 	 */
-	public static function resolve_users_connection( $source, array $args, $context, ResolveInfo $info ) {
+	public static function resolve_users_connection( $source, array $args, AppContext $context, ResolveInfo $info ) {
 		$resolver = new UserConnectionResolver( $source, $args, $context, $info );
 
 		return $resolver->get_connection();
@@ -312,7 +312,7 @@ class DataSource {
 	 * @param string $name Name of the user role you want info for
 	 *
 	 * @return UserRole
-	 * @throws \Exception
+	 * @throws Exception
 	 * @since  0.0.30
 	 */
 	public static function resolve_user_role( $name ) {
@@ -339,7 +339,7 @@ class DataSource {
 	 * @param array $args    The args to pass to the get_avatar_data function
 	 *
 	 * @return array|null|Avatar
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public static function resolve_avatar( $user_id, $args ) {
 
@@ -363,8 +363,8 @@ class DataSource {
 	 * @param AppContext  $context The AppContext passed down to the query
 	 * @param ResolveInfo $info    The ResloveInfo object
 	 *
-	 * @throws \Exception
 	 * @return array
+	 * @throws Exception
 	 */
 	public static function resolve_user_role_connection( $source, array $args, AppContext $context, ResolveInfo $info ) {
 
@@ -413,11 +413,11 @@ class DataSource {
 		foreach ( $registered_settings as $key => $setting ) {
 			if ( ! isset( $setting['show_in_graphql'] ) ) {
 				if ( isset( $setting['show_in_rest'] ) && false !== $setting['show_in_rest'] ) {
-					$setting['key'] = $key;
+					$setting['key']                                         = $key;
 					$allowed_settings_by_group[ $setting['group'] ][ $key ] = $setting;
 				}
 			} elseif ( true === $setting['show_in_graphql'] ) {
-				$setting['key'] = $key;
+				$setting['key']                                         = $key;
 				$allowed_settings_by_group[ $setting['group'] ][ $key ] = $setting;
 			}
 		};
@@ -602,7 +602,7 @@ class DataSource {
 	 * @param ResolveInfo $info      The ResolveInfo for the GraphQL Request
 	 *
 	 * @return null|string
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public static function resolve_node( $global_id, AppContext $context, ResolveInfo $info ) {
 
@@ -664,7 +664,7 @@ class DataSource {
 	 * @param ResolveInfo $info    The ResolveInfo passed through the GraphQL Resolve tree
 	 *
 	 * @return mixed
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public static function resolve_resource_by_uri( $uri, $context, $info ) {
 		$node_resolver = new NodeResolver( $context );

--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -115,7 +115,6 @@ class DataSource {
 	 * @return array
 	 * @throws Exception
 	 * @since  0.0.5
-	 *
 	 */
 	public static function resolve_plugins_connection( $source, array $args, AppContext $context, ResolveInfo $info ) {
 		$resolver = new PluginConnectionResolver( $source, $args, $context, $info );
@@ -244,7 +243,6 @@ class DataSource {
 	 * @throws UserError
 	 * @throws Exception
 	 * @since  0.0.5
-	 *
 	 */
 	public static function resolve_theme( $stylesheet ) {
 		$theme = wp_get_theme( $stylesheet );
@@ -413,11 +411,11 @@ class DataSource {
 		foreach ( $registered_settings as $key => $setting ) {
 			if ( ! isset( $setting['show_in_graphql'] ) ) {
 				if ( isset( $setting['show_in_rest'] ) && false !== $setting['show_in_rest'] ) {
-					$setting['key']                                         = $key;
+					$setting['key'] = $key;
 					$allowed_settings_by_group[ $setting['group'] ][ $key ] = $setting;
 				}
 			} elseif ( true === $setting['show_in_graphql'] ) {
-				$setting['key']                                         = $key;
+				$setting['key'] = $key;
 				$allowed_settings_by_group[ $setting['group'] ][ $key ] = $setting;
 			}
 		};

--- a/src/Data/Loader/AbstractDataLoader.php
+++ b/src/Data/Loader/AbstractDataLoader.php
@@ -2,6 +2,8 @@
 
 namespace WPGraphQL\Data\Loader;
 
+use Exception;
+use Generator;
 use GraphQL\Deferred;
 use GraphQL\Utils\Utils;
 use WPGraphQL\AppContext;
@@ -60,7 +62,7 @@ abstract class AbstractDataLoader {
 	 * @param Int $database_id The database ID for a particular loader to load an object
 	 *
 	 * @return Deferred|null
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function load_deferred( $database_id ) {
 
@@ -83,16 +85,16 @@ abstract class AbstractDataLoader {
 	/**
 	 * Add keys to buffer to be loaded in single batch later.
 	 *
-	 * @param $keys
+	 * @param array $keys The keys of the objects to buffer
 	 *
 	 * @return $this
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function buffer( array $keys ) {
 		foreach ( $keys as $index => $key ) {
 			$key = $this->key_to_scalar( $key );
 			if ( ! is_scalar( $key ) ) {
-				throw new \Exception(
+				throw new Exception(
 					get_class( $this ) . '::buffer expects all keys to be scalars, but key ' .
 					'at position ' . $index . ' is ' . Utils::printSafe( $keys ) . '. ' .
 					$this->get_scalar_key_hint( $key )
@@ -111,13 +113,13 @@ abstract class AbstractDataLoader {
 	 * @param mixed $key
 	 *
 	 * @return mixed
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function load( $key ) {
 
 		$key = $this->key_to_scalar( $key );
 		if ( ! is_scalar( $key ) ) {
-			throw new \Exception(
+			throw new Exception(
 				get_class( $this ) . '::load expects key to be scalar, but got ' . Utils::printSafe( $key ) .
 				$this->get_scalar_key_hint( $key )
 			);
@@ -139,19 +141,19 @@ abstract class AbstractDataLoader {
 	 * @param mixed $key
 	 * @param mixed $value
 	 *
-	 * @throws \Exception
 	 * @return $this
+	 * @throws Exception
 	 */
 	public function prime( $key, $value ) {
 		$key = $this->key_to_scalar( $key );
 		if ( ! is_scalar( $key ) ) {
-			throw new \Exception(
+			throw new Exception(
 				get_class( $this ) . '::prime is expecting scalar $key, but got ' . Utils::printSafe( $key )
 				. $this->get_scalar_key_hint( $key )
 			);
 		}
 		if ( null === $value ) {
-			throw new \Exception(
+			throw new Exception(
 				get_class( $this ) . '::prime is expecting non-null $value, but got null. Double-check for null or ' .
 				' use `clear` if you want to clear the cache'
 			);
@@ -211,8 +213,8 @@ abstract class AbstractDataLoader {
 	 * @param array $keys
 	 * @param bool  $asArray
 	 *
-	 * @return array|\Generator
-	 * @throws \Exception
+	 * @return array|Generator
+	 * @throws Exception
 	 *
 	 * @deprecated Use load_many instead
 	 */
@@ -227,8 +229,8 @@ abstract class AbstractDataLoader {
 	 * @param array $keys
 	 * @param bool  $asArray
 	 *
-	 * @return array|\Generator
-	 * @throws \Exception
+	 * @return array|Generator
+	 * @throws Exception
 	 */
 	public function load_many( array $keys, $asArray = false ) {
 		if ( empty( $keys ) ) {
@@ -246,12 +248,12 @@ abstract class AbstractDataLoader {
 	/**
 	 * Given an array of keys, this yields the object from the cached results
 	 *
-	 * @param $keys
-	 * @param $result
+	 * @param array $keys   The keys to generate results for
+	 * @param array $result The results for all keys
 	 *
-	 * @return \Generator
+	 * @return Generator
 	 */
-	private function generate_many( $keys, $result ) {
+	private function generate_many( array $keys, array $result ) {
 		foreach ( $keys as $key ) {
 			$key = $this->key_to_scalar( $key );
 			yield isset( $result[ $key ] ) ? $this->get_model( $result[ $key ], $key ) : null;
@@ -264,7 +266,7 @@ abstract class AbstractDataLoader {
 	 * to the cache if necessary
 	 *
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	private function load_buffered() {
 		// Do not load previously-cached entries:
@@ -273,8 +275,8 @@ abstract class AbstractDataLoader {
 		if ( ! empty( $keysToLoad ) ) {
 			try {
 				$loaded = $this->loadKeys( $keysToLoad );
-			} catch ( \Exception $e ) {
-				throw new \Exception(
+			} catch ( Exception $e ) {
+				throw new Exception(
 					'Method ' . get_class( $this ) . '::loadKeys is expected to return array, but it threw: ' .
 					$e->getMessage(),
 					null,
@@ -283,7 +285,7 @@ abstract class AbstractDataLoader {
 			}
 
 			if ( ! is_array( $loaded ) ) {
-				throw new \Exception(
+				throw new Exception(
 					'Method ' . get_class( $this ) . '::loadKeys is expected to return an array with keys ' .
 					'but got: ' . Utils::printSafe( $loaded )
 				);
@@ -304,7 +306,7 @@ abstract class AbstractDataLoader {
 	/**
 	 * This helps to ensure null values aren't being loaded by accident.
 	 *
-	 * @param $key
+	 * @param mixed $key
 	 *
 	 * @return string
 	 */
@@ -322,7 +324,7 @@ abstract class AbstractDataLoader {
 	 * to the loader, we could have the loader centrally decode the keys into their
 	 * integer values in the PostObjectLoader by overriding this method.
 	 *
-	 * @param $key
+	 * @param mixed $key
 	 *
 	 * @return mixed
 	 */
@@ -331,7 +333,7 @@ abstract class AbstractDataLoader {
 	}
 
 	/**
-	 * @param $key
+	 * @param mixed $key
 	 *
 	 * @return mixed
 	 * @deprecated Use key_to_scalar instead
@@ -341,8 +343,8 @@ abstract class AbstractDataLoader {
 	}
 
 	/**
-	 * @param $entry
-	 * @param $key
+	 * @param mixed $entry The entry loaded from the dataloader to be used to generate a Model
+	 * @param mixed $key   The Key used to identify the loaded entry
 	 *
 	 * @return null|Model
 	 */
@@ -356,10 +358,10 @@ abstract class AbstractDataLoader {
 		 *
 		 * One example would be WooCommerce Products returning a custom Model for posts of post_type "product".
 		 *
-		 * @param null               $model  The filtered model to return. Default null
-		 * @param mixed              $entry The entry loaded from the dataloader to be used to generate a Model
-		 * @param mixed              $key   The Key used to identify the loaded entry
-		 * @param AbstractDataLoader $this  The AbstractDataLoader instance
+		 * @param null               $model                The filtered model to return. Default null
+		 * @param mixed              $entry                The entry loaded from the dataloader to be used to generate a Model
+		 * @param mixed              $key                  The Key used to identify the loaded entry
+		 * @param AbstractDataLoader $abstract_data_loader The AbstractDataLoader instance
 		 */
 		$model         = null;
 		$pre_get_model = apply_filters( 'graphql_dataloader_pre_get_model', $model, $entry, $key, $this );
@@ -392,8 +394,8 @@ abstract class AbstractDataLoader {
 	 * If the loader needs to do any tweaks between getting raw data from the DB and caching,
 	 * this can be overridden by the specific loader and used for transformations, etc.
 	 *
-	 * @param $entry
-	 * @param $key
+	 * @param mixed $entry The User Role object
+	 * @param mixed $key   The Key to identify the user role by
 	 *
 	 * @return Model
 	 */

--- a/src/Data/Loader/CommentAuthorLoader.php
+++ b/src/Data/Loader/CommentAuthorLoader.php
@@ -1,5 +1,6 @@
 <?php
 namespace WPGraphQL\Data\Loader;
+use Exception;
 use WPGraphQL\Model\CommentAuthor;
 
 /**
@@ -10,11 +11,11 @@ use WPGraphQL\Model\CommentAuthor;
 class CommentAuthorLoader extends AbstractDataLoader {
 
 	/**
-	 * @param $entry
-	 * @param $key
+	 * @param mixed $entry The User Role object
+	 * @param mixed $key The Key to identify the user role by
 	 *
 	 * @return mixed|CommentAuthor
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	protected function get_model( $entry, $key ) {
 

--- a/src/Data/Loader/CommentLoader.php
+++ b/src/Data/Loader/CommentLoader.php
@@ -2,6 +2,7 @@
 
 namespace WPGraphQL\Data\Loader;
 
+use Exception;
 use WPGraphQL\Model\Comment;
 
 /**
@@ -12,11 +13,11 @@ use WPGraphQL\Model\Comment;
 class CommentLoader extends AbstractDataLoader {
 
 	/**
-	 * @param $entry
-	 * @param $key
+	 * @param mixed $entry The User Role object
+	 * @param mixed $key The Key to identify the user role by
 	 *
 	 * @return Comment
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	protected function get_model( $entry, $key ) {
 
@@ -45,7 +46,7 @@ class CommentLoader extends AbstractDataLoader {
 	 * @param array $keys
 	 *
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function loadKeys( array $keys = [] ) {
 

--- a/src/Data/Loader/PluginLoader.php
+++ b/src/Data/Loader/PluginLoader.php
@@ -1,6 +1,8 @@
 <?php
 
 namespace WPGraphQL\Data\Loader;
+use Exception;
+use WPGraphQL\Model\Model;
 use WPGraphQL\Model\Plugin;
 
 /**
@@ -11,11 +13,11 @@ use WPGraphQL\Model\Plugin;
 class PluginLoader extends AbstractDataLoader {
 
 	/**
-	 * @param $entry
-	 * @param $key
+	 * @param mixed $entry The User Role object
+	 * @param mixed $key The Key to identify the user role by
 	 *
-	 * @return \WPGraphQL\Model\Model|Plugin
-	 * @throws \Exception
+	 * @return Model|Plugin
+	 * @throws Exception
 	 */
 	protected function get_model( $entry, $key ) {
 		return new Plugin( $entry );
@@ -27,7 +29,7 @@ class PluginLoader extends AbstractDataLoader {
 	 * @param array $keys
 	 *
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function loadKeys( array $keys ) {
 

--- a/src/Data/Loader/PostObjectLoader.php
+++ b/src/Data/Loader/PostObjectLoader.php
@@ -2,6 +2,7 @@
 
 namespace WPGraphQL\Data\Loader;
 
+use Exception;
 use GraphQL\Deferred;
 use WPGraphQL\Model\Menu;
 use WPGraphQL\Model\MenuItem;
@@ -15,11 +16,11 @@ use WPGraphQL\Model\Post;
 class PostObjectLoader extends AbstractDataLoader {
 
 	/**
-	 * @param $entry
-	 * @param $key
+	 * @param mixed $entry The User Role object
+	 * @param mixed $key The Key to identify the user role by
 	 *
 	 * @return mixed|Post
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	protected function get_model( $entry, $key ) {
 
@@ -74,7 +75,7 @@ class PostObjectLoader extends AbstractDataLoader {
 	 * @param array $keys
 	 *
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function loadKeys( array $keys ) {
 

--- a/src/Data/Loader/PostTypeLoader.php
+++ b/src/Data/Loader/PostTypeLoader.php
@@ -1,6 +1,7 @@
 <?php
 namespace WPGraphQL\Data\Loader;
 
+use Exception;
 use WPGraphQL\Model\PostType;
 
 /**
@@ -11,11 +12,11 @@ use WPGraphQL\Model\PostType;
 class PostTypeLoader extends AbstractDataLoader {
 
 	/**
-	 * @param $entry
-	 * @param $key
+	 * @param mixed $entry The User Role object
+	 * @param mixed $key The Key to identify the user role by
 	 *
 	 * @return mixed|PostType
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	protected function get_model( $entry, $key ) {
 		return new PostType( $entry );
@@ -25,7 +26,7 @@ class PostTypeLoader extends AbstractDataLoader {
 	 * @param array $keys
 	 *
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function loadKeys( array $keys ) {
 		$post_types = get_post_types( [ 'show_in_graphql' => true ], 'objects' );

--- a/src/Data/Loader/TaxonomyLoader.php
+++ b/src/Data/Loader/TaxonomyLoader.php
@@ -1,6 +1,7 @@
 <?php
 namespace WPGraphQL\Data\Loader;
 
+use Exception;
 use WPGraphQL\Model\Taxonomy;
 
 /**
@@ -11,11 +12,11 @@ use WPGraphQL\Model\Taxonomy;
 class TaxonomyLoader extends AbstractDataLoader {
 
 	/**
-	 * @param $entry
-	 * @param $key
+	 * @param mixed $entry The User Role object
+	 * @param mixed $key The Key to identify the user role by
 	 *
 	 * @return mixed|Taxonomy
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	protected function get_model( $entry, $key ) {
 		return new Taxonomy( $entry );
@@ -25,7 +26,7 @@ class TaxonomyLoader extends AbstractDataLoader {
 	 * @param array $keys
 	 *
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function loadKeys( array $keys ) {
 		$taxonomies = get_taxonomies( [ 'show_in_graphql' => true ], 'objects' );

--- a/src/Data/Loader/TermObjectLoader.php
+++ b/src/Data/Loader/TermObjectLoader.php
@@ -2,6 +2,7 @@
 
 namespace WPGraphQL\Data\Loader;
 
+use Exception;
 use GraphQL\Deferred;
 use WPGraphQL\Model\Menu;
 use WPGraphQL\Model\Term;
@@ -14,11 +15,11 @@ use WPGraphQL\Model\Term;
 class TermObjectLoader extends AbstractDataLoader {
 
 	/**
-	 * @param $entry
-	 * @param $key
+	 * @param mixed $entry The User Role object
+	 * @param mixed $key The Key to identify the user role by
 	 *
 	 * @return mixed|Term
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	protected function get_model( $entry, $key ) {
 
@@ -61,7 +62,7 @@ class TermObjectLoader extends AbstractDataLoader {
 	 * @param array $keys
 	 *
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function loadKeys( array $keys ) {
 

--- a/src/Data/Loader/ThemeLoader.php
+++ b/src/Data/Loader/ThemeLoader.php
@@ -1,6 +1,8 @@
 <?php
 namespace WPGraphQL\Data\Loader;
 
+use Exception;
+use WPGraphQL\Model\Model;
 use WPGraphQL\Model\Theme;
 
 /**
@@ -11,11 +13,11 @@ use WPGraphQL\Model\Theme;
 class ThemeLoader extends AbstractDataLoader {
 
 	/**
-	 * @param $entry
-	 * @param $key
+	 * @param mixed $entry The User Role object
+	 * @param mixed $key The Key to identify the user role by
 	 *
-	 * @return \WPGraphQL\Model\Model|Theme
-	 * @throws \Exception
+	 * @return Model|Theme
+	 * @throws Exception
 	 */
 	protected function get_model( $entry, $key ) {
 		return new Theme( $entry );
@@ -25,7 +27,7 @@ class ThemeLoader extends AbstractDataLoader {
 	 * @param array $keys
 	 *
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function loadKeys( array $keys ) {
 		$themes = wp_get_themes();

--- a/src/Data/Loader/UserLoader.php
+++ b/src/Data/Loader/UserLoader.php
@@ -1,6 +1,7 @@
 <?php
 namespace WPGraphQL\Data\Loader;
 
+use Exception;
 use WPGraphQL\Model\User;
 
 /**
@@ -11,11 +12,11 @@ use WPGraphQL\Model\User;
 class UserLoader extends AbstractDataLoader {
 
 	/**
-	 * @param $entry
-	 * @param $key
+	 * @param mixed $entry The User Role object
+	 * @param mixed $key The Key to identify the user role by
 	 *
 	 * @return mixed|User
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	protected function get_model( $entry, $key ) {
 		if ( $entry instanceof \WP_User ) {
@@ -38,7 +39,7 @@ class UserLoader extends AbstractDataLoader {
 	 * @param array $keys
 	 *
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function loadKeys( array $keys ) {
 

--- a/src/Data/Loader/UserRoleLoader.php
+++ b/src/Data/Loader/UserRoleLoader.php
@@ -2,6 +2,7 @@
 
 namespace WPGraphQL\Data\Loader;
 
+use Exception;
 use WPGraphQL\Model\UserRole;
 
 /**
@@ -12,11 +13,11 @@ use WPGraphQL\Model\UserRole;
 class UserRoleLoader extends AbstractDataLoader {
 
 	/**
-	 * @param $entry
-	 * @param $key
+	 * @param mixed $entry The User Role object
+	 * @param mixed $key The Key to identify the user role by
 	 *
 	 * @return mixed|UserRole
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	protected function get_model( $entry, $key ) {
 		return new UserRole( $entry );
@@ -26,7 +27,7 @@ class UserRoleLoader extends AbstractDataLoader {
 	 * @param array $keys
 	 *
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function loadKeys( array $keys ) {
 		$wp_roles = wp_roles()->roles;

--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -165,8 +165,6 @@ class NodeResolver {
 				// Substitute the substring matches into the query.
 				$query = addslashes( \WP_MatchesMapRegex::apply( $query, $matches ) );
 
-				$this->wp->matched_query = $query;
-
 				// Parse the query.
 				parse_str( $query, $perma_query_vars );
 
@@ -193,7 +191,7 @@ class NodeResolver {
 
 		foreach ( get_post_types( [ 'show_in_graphql' => true ], 'objects' ) as $post_type => $t ) {
 
-			if ( true === $t->show_in_graphql && $t->query_var ) {
+			if ( isset( $t->show_in_graphql ) && true === $t->show_in_graphql && $t->query_var ) {
 				$post_type_query_vars[ $t->query_var ] = $post_type;
 			}
 		}

--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -28,7 +28,6 @@ class NodeResolver {
 	 *
 	 * @return mixed
 	 * @throws \Exception
-	 *
 	 */
 	public function resolve_uri( $uri, $extra_query_vars = '' ) {
 
@@ -74,9 +73,9 @@ class NodeResolver {
 			$error                   = '404';
 			$this->wp->did_permalink = true;
 
-			$pathinfo = isset( $uri ) ? $uri : '';
+			$pathinfo         = isset( $uri ) ? $uri : '';
 			list( $pathinfo ) = explode( '?', $pathinfo );
-			$pathinfo = str_replace( '%', '%25', $pathinfo );
+			$pathinfo         = str_replace( '%', '%25', $pathinfo );
 
 			list( $req_uri ) = explode( '?', $pathinfo );
 			$home_path       = trim( wp_parse_url( home_url(), PHP_URL_PATH ), '/' );
@@ -185,7 +184,6 @@ class NodeResolver {
 		 * @param string[] $public_query_vars The array of whitelisted query variable names.
 		 *
 		 * @since 1.5.0
-		 *
 		 */
 		$this->wp->public_query_vars = apply_filters( 'query_vars', $this->wp->public_query_vars );
 
@@ -271,7 +269,6 @@ class NodeResolver {
 		 * @param array $query_vars The array of requested query variables.
 		 *
 		 * @since 2.1.0
-		 *
 		 */
 		$this->wp->query_vars = apply_filters( 'request', $this->wp->query_vars );
 

--- a/src/Data/UserMutation.php
+++ b/src/Data/UserMutation.php
@@ -191,9 +191,9 @@ class UserMutation {
 		/**
 		 * Filters the mappings for input to arguments
 		 *
-		 * @var array  $insert_user_args The arguments to ultimately be passed to the WordPress function
-		 * @var array  $input            Input data from the GraphQL mutation
-		 * @var string $mutation_name    What user mutation is being performed for context
+		 * @param array  $insert_user_args The arguments to ultimately be passed to the WordPress function
+		 * @param array  $input            Input data from the GraphQL mutation
+		 * @param string $mutation_name    What user mutation is being performed for context
 		 */
 		$insert_user_args = apply_filters( 'graphql_user_insert_post_args', $insert_user_args, $input, $mutation_name );
 

--- a/src/Model/MenuItem.php
+++ b/src/Model/MenuItem.php
@@ -2,8 +2,10 @@
 
 namespace WPGraphQL\Model;
 
+use Exception;
 use GraphQL\Error\UserError;
 use GraphQLRelay\Relay;
+use WP_Post;
 
 /**
  * Class MenuItem - Models the data for the MenuItem object type
@@ -30,19 +32,19 @@ class MenuItem extends Model {
 	/**
 	 * Stores the incoming post data
 	 *
-	 * @var \WP_Post $data
+	 * @var mixed|WP_Post|object $data
 	 */
 	protected $data;
 
 	/**
 	 * MenuItem constructor.
 	 *
-	 * @param \WP_Post $post The incoming WP_Post object that needs modeling
+	 * @param WP_Post $post The incoming WP_Post object that needs modeling
 	 *
 	 * @return void
-	 * @throws \Exception
+	 * @throws Exception
 	 */
-	public function __construct( \WP_Post $post ) {
+	public function __construct( WP_Post $post ) {
 		$this->data = wp_setup_nav_menu_item( $post );
 		parent::__construct();
 	}
@@ -54,7 +56,7 @@ class MenuItem extends Model {
 	 * it's not considered a public node
 	 *
 	 * @return bool
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function is_private() {
 
@@ -81,7 +83,7 @@ class MenuItem extends Model {
 		}
 
 		if ( is_wp_error( $menus ) ) {
-			throw new \Exception( sprintf( __( 'No menus could be found for menu item %s', 'wp-graphql' ), $this->data->ID ) );
+			throw new Exception( sprintf( __( 'No menus could be found for menu item %s', 'wp-graphql' ), $this->data->ID ) );
 		}
 		$menu_id = $menus[0];
 		if ( empty( $location_ids ) || ! in_array( $menu_id, $location_ids, true ) ) {
@@ -160,6 +162,7 @@ class MenuItem extends Model {
 							}
 						}
 					}
+
 					return $url;
 
 				},

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -56,7 +56,7 @@ use WPGraphQL\Utils\Utils;
  * @property string  $featuredImageId
  * @property int     $featuredImageDatabaseId
  * @property string  $pageTemplate
- * @property int     previewRevisionDatabaseId
+ * @property int     $previewRevisionDatabaseId
  *
  * @property string  $captionRaw
  * @property string  $captionRendered

--- a/src/Model/UserRole.php
+++ b/src/Model/UserRole.php
@@ -7,10 +7,10 @@ use GraphQLRelay\Relay;
 /**
  * Class UserRole - Models data for user roles
  *
+ * @property string $displayName
  * @property string $id
- * @property string name
+ * @property string $name
  * @property array  $capabilities
- * @property string displayName
  *
  * @package WPGraphQL\Model
  */

--- a/src/Mutation/PostObjectCreate.php
+++ b/src/Mutation/PostObjectCreate.php
@@ -122,9 +122,9 @@ class PostObjectCreate {
 		}
 
 		if ( $post_type_object->hierarchical || in_array( $post_type_object->name, [
-				'attachment',
-				'revision'
-			], true ) ) {
+			'attachment',
+			'revision',
+		], true ) ) {
 			$fields['parentId'] = [
 				'type'        => 'Id',
 				'description' => __( 'The ID of the parent object', 'wp-graphql' ),
@@ -249,9 +249,9 @@ class PostObjectCreate {
 			 * default the status to pending.
 			 */
 			if ( ! current_user_can( $post_type_object->cap->publish_posts ) && ! in_array( $intended_post_status, [
-					'draft',
-					'pending'
-				], true ) ) {
+				'draft',
+				'pending',
+			], true ) ) {
 				$intended_post_status = 'pending';
 			}
 

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -571,14 +571,14 @@ class TypeRegistry {
 	}
 
 	/**
-	 * @param $type_name
-	 * @param $config
+	 * @param string $type_name The name of the type to register
+	 * @param mixed|array|Type $config The config for the type
 	 *
 	 * @throws Exception
 	 *
 	 * @return mixed
 	 */
-	public function register_type( $type_name, $config ) {
+	public function register_type( string $type_name, $config ) {
 
 		/**
 		 * If the Type Name starts with a number, prefix it with an underscore to make it valid
@@ -615,68 +615,68 @@ class TypeRegistry {
 	}
 
 	/**
-	 * @param $type_name
-	 * @param $config
+	 * @param string $type_name The name of the type to register
+	 * @param array $config The configuration of the type
 	 *
 	 * @throws Exception
 	 */
-	public function register_object_type( $type_name, $config ) {
+	public function register_object_type( string $type_name, array $config ) {
 		$config['kind'] = 'object';
 		$this->register_type( $type_name, $config );
 	}
 
 	/**
-	 * @param $type_name
-	 * @param $config
+	 * @param string $type_name The name of the type to register
+	 * @param array $config he configuration of the type
 	 *
 	 * @throws Exception
 	 */
-	public function register_interface_type( $type_name, $config ) {
+	public function register_interface_type( string $type_name, array $config ) {
 		$config['kind'] = 'interface';
 		$this->register_type( $type_name, $config );
 	}
 
 	/**
-	 * @param $type_name
-	 * @param $config
+	 * @param string $type_name The name of the type to register
+	 * @param array $config he configuration of the type
 	 *
 	 * @throws Exception
 	 */
-	public function register_enum_type( $type_name, $config ) {
+	public function register_enum_type( string $type_name, array $config ) {
 		$config['kind'] = 'enum';
 		$this->register_type( $type_name, $config );
 	}
 
 	/**
-	 * @param $type_name
-	 * @param $config
+	 * @param string $type_name The name of the type to register
+	 * @param array $config he configuration of the type
 	 *
 	 * @throws Exception
 	 */
-	public function register_input_type( $type_name, $config ) {
+	public function register_input_type( string $type_name, array $config ) {
 		$config['kind'] = 'input';
 		$this->register_type( $type_name, $config );
 	}
 
 	/**
-	 * @param $type_name
-	 * @param $config
+	 * @param string $type_name The name of the type to register
+	 * @param array $config he configuration of the type
 	 *
 	 * @throws Exception
 	 */
-	public function register_union_type( $type_name, $config ) {
+	public function register_union_type( string $type_name, array $config ) {
 		$config['kind'] = 'union';
 		$this->register_type( $type_name, $config );
 	}
 
 	/**
-	 * @param $type_name
-	 * @param $config
+	 * @param string $type_name The name of the type to register
+	 * @param mixed|array|Type $config he configuration of the type
 	 *
 	 * @return array|WPObjectType
 	 * @throws Exception
 	 */
-	public function prepare_type( $type_name, $config ) {
+	public function prepare_type( string $type_name, $config ) {
 
 		if ( ! is_array( $config ) ) {
 			return $config;
@@ -684,7 +684,7 @@ class TypeRegistry {
 
 		$prepared_type = null;
 
-		if ( is_array( $config ) ) {
+		if ( ! empty( $config ) ) {
 
 			$kind           = isset( $config['kind'] ) ? $config['kind'] : null;
 			$config['name'] = ucfirst( $type_name );
@@ -817,7 +817,7 @@ class TypeRegistry {
 	}
 
 	/**
-	 * @param mixed string|array $type
+	 * @param mixed|string|array $type The type definition
 	 *
 	 * @return mixed
 	 * @throws Exception
@@ -1251,7 +1251,7 @@ class TypeRegistry {
 	/**
 	 * Given a Type, this returns an instance of a NonNull of that type
 	 *
-	 * @param mixed string|ObjectType|InterfaceType|UnionType|ScalarType|InputObjectType|EnumType|ListOfType $type
+	 * @param mixed $type The Type being wrapped
 	 *
 	 * @return NonNull
 	 */
@@ -1268,7 +1268,7 @@ class TypeRegistry {
 	/**
 	 * Given a Type, this returns an instance of a listOf of that type
 	 *
-	 * @param mixed string|ObjectType|InterfaceType|UnionType|ScalarType|InputObjectType|EnumType|ListOfType $type
+	 * @param mixed $type The Type being wrapped
 	 *
 	 * @return ListOfType
 	 */

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -2,6 +2,7 @@
 
 namespace WPGraphQL\Registry;
 
+use Exception;
 use GraphQL\Type\Definition\ListOfType;
 use GraphQL\Type\Definition\NonNull;
 use GraphQL\Type\Definition\ResolveInfo;
@@ -168,7 +169,7 @@ class TypeRegistry {
 	/**
 	 * Initialize the TypeRegistry
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function init() {
 
@@ -562,7 +563,7 @@ class TypeRegistry {
 	 * @param string $type_name The name of the Type to register
 	 * @param array  $config    The config for the scalar type to register
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function register_scalar( $type_name, $config ) {
 		$config['kind'] = 'scalar';
@@ -573,7 +574,7 @@ class TypeRegistry {
 	 * @param $type_name
 	 * @param $config
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 *
 	 * @return mixed
 	 */
@@ -617,7 +618,7 @@ class TypeRegistry {
 	 * @param $type_name
 	 * @param $config
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function register_object_type( $type_name, $config ) {
 		$config['kind'] = 'object';
@@ -628,7 +629,7 @@ class TypeRegistry {
 	 * @param $type_name
 	 * @param $config
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function register_interface_type( $type_name, $config ) {
 		$config['kind'] = 'interface';
@@ -639,7 +640,7 @@ class TypeRegistry {
 	 * @param $type_name
 	 * @param $config
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function register_enum_type( $type_name, $config ) {
 		$config['kind'] = 'enum';
@@ -650,7 +651,7 @@ class TypeRegistry {
 	 * @param $type_name
 	 * @param $config
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function register_input_type( $type_name, $config ) {
 		$config['kind'] = 'input';
@@ -661,7 +662,7 @@ class TypeRegistry {
 	 * @param $type_name
 	 * @param $config
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function register_union_type( $type_name, $config ) {
 		$config['kind'] = 'union';
@@ -673,7 +674,7 @@ class TypeRegistry {
 	 * @param $config
 	 *
 	 * @return array|WPObjectType
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function prepare_type( $type_name, $config ) {
 
@@ -738,7 +739,7 @@ class TypeRegistry {
 	 * @param string $type_name Name of the Type to register the fields to
 	 *
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function prepare_fields( $fields, $type_name ) {
 		$prepared_fields = [];
@@ -767,7 +768,7 @@ class TypeRegistry {
 	 * @param string $type_name    Name of the type to prepare the field for
 	 *
 	 * @return array|null
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	protected function prepare_field( $field_name, $field_config, $type_name ) {
 
@@ -819,7 +820,7 @@ class TypeRegistry {
 	 * @param mixed string|array $type
 	 *
 	 * @return mixed
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function setup_type_modifiers( $type ) {
 
@@ -977,7 +978,7 @@ class TypeRegistry {
 	 *
 	 * @return void
 	 * @throws \InvalidArgumentException
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function register_connection( $config ) {
 
@@ -1176,7 +1177,7 @@ class TypeRegistry {
 	 * @param array  $config        Info about the mutation being registered
 	 *
 	 * @return void
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function register_mutation( $mutation_name, $config ) {
 
@@ -1235,7 +1236,7 @@ class TypeRegistry {
 				'resolve'     => function( $root, $args, $context, ResolveInfo $info ) use ( $mutateAndGetPayload, $mutation_name ) {
 					if ( ! is_callable( $mutateAndGetPayload ) ) {
 						// Translators: The placeholder is the name of the mutation
-						throw new \Exception( sprintf( __( 'The resolver for the mutation %s is not callable', 'wp-graphql' ), $mutation_name ) );
+						throw new Exception( sprintf( __( 'The resolver for the mutation %s is not callable', 'wp-graphql' ), $mutation_name ) );
 					}
 					$payload                     = call_user_func( $mutateAndGetPayload, $args['input'], $context, $info );
 					$payload['clientMutationId'] = $args['input']['clientMutationId'];

--- a/src/Request.php
+++ b/src/Request.php
@@ -259,7 +259,6 @@ class Request {
 	 *
 	 * @return boolean
 	 * @throws \Exception
-	 *
 	 */
 	protected function has_authentication_errors() {
 
@@ -446,7 +445,6 @@ class Request {
 		 * @param Request    $this      Instance of the Request
 		 *
 		 * @since 0.0.4
-		 *
 		 */
 		do_action( 'graphql_execute', $response, $this->schema, $operation, $query, $variables, $this );
 
@@ -483,7 +481,6 @@ class Request {
 		 * @param Request    $request      Instance of the Request
 		 *
 		 * @since 0.0.5
-		 *
 		 */
 		$filtered_response = apply_filters( 'graphql_request_results', $response, $this->schema, $operation, $query, $variables, $this );
 
@@ -652,7 +649,6 @@ class Request {
 		 * @param OperationParams $params Request operation params
 		 *
 		 * @since 0.2.0
-		 *
 		 */
 		do_action( 'graphql_server_config', $config, $this->params );
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -60,7 +60,7 @@ class Request {
 	/**
 	 * Schema for this request.
 	 *
-	 * @var \WPGraphQL\WPSchema
+	 * @var WPSchema
 	 */
 	public $schema;
 
@@ -102,7 +102,7 @@ class Request {
 	/**
 	 * Constructor
 	 *
-	 * @param  array|null $data The request data (for non-HTTP requests).
+	 * @param array|null $data The request data (for non-HTTP requests).
 	 *
 	 * @return void
 	 *
@@ -257,9 +257,9 @@ class Request {
 	 * Anything else (true, WP_Error, thrown exception, etc) will prevent execution of the GraphQL
 	 * request.
 	 *
+	 * @return boolean
 	 * @throws \Exception
 	 *
-	 * @return boolean
 	 */
 	protected function has_authentication_errors() {
 
@@ -438,14 +438,15 @@ class Request {
 		/**
 		 * Run an action. This is a good place for debug tools to hook in to log things, etc.
 		 *
+		 * @param array      $response  The response your GraphQL request
+		 * @param WPSchema   $schema    The schema object for the root request
+		 * @param string     $operation The name of the operation
+		 * @param string     $query     The query that GraphQL executed
+		 * @param array|null $variables Variables to passed to your GraphQL query
+		 * @param Request    $this      Instance of the Request
+		 *
 		 * @since 0.0.4
 		 *
-		 * @param array               $response  The response your GraphQL request
-		 * @param \WPGraphQL\WPSchema $schema    The schema object for the root request
-		 * @param string              $operation The name of the operation
-		 * @param string              $query     The query that GraphQL executed
-		 * @param array|null          $variables Variables to passed to your GraphQL query
-		 * @param Request             $this      Instance of the Request
 		 */
 		do_action( 'graphql_execute', $response, $this->schema, $operation, $query, $variables, $this );
 
@@ -474,14 +475,15 @@ class Request {
 		 * every response, regardless of the request that was sent to it, this could allow for that
 		 * to be hooked in and included in the $response.
 		 *
+		 * @param array      $response  The response for your GraphQL query
+		 * @param WPSchema   $schema    The schema object for the root query
+		 * @param string     $operation The name of the operation
+		 * @param string     $query     The query that GraphQL executed
+		 * @param array|null $variables Variables to passed to your GraphQL request
+		 * @param Request    $request      Instance of the Request
+		 *
 		 * @since 0.0.5
 		 *
-		 * @param array               $response  The response for your GraphQL query
-		 * @param \WPGraphQL\WPSchema $schema    The schema object for the root query
-		 * @param string              $operation The name of the operation
-		 * @param string              $query     The query that GraphQL executed
-		 * @param array|null          $variables Variables to passed to your GraphQL request
-		 * @param Request             $this      Instance of the Request
 		 */
 		$filtered_response = apply_filters( 'graphql_request_results', $response, $this->schema, $operation, $query, $variables, $this );
 
@@ -489,13 +491,13 @@ class Request {
 		 * Run an action after the response has been filtered, as the response is being returned.
 		 * This is a good place for debug tools to hook in to log things, etc.
 		 *
-		 * @param array               $filtered_response The filtered response for the GraphQL request
-		 * @param array               $response          The response for your GraphQL request
-		 * @param \WPGraphQL\WPSchema $schema            The schema object for the root request
-		 * @param string              $operation         The name of the operation
-		 * @param string              $query             The query that GraphQL executed
-		 * @param array|null          $variables         Variables to passed to your GraphQL query
-		 * @param Request             $this      Instance of the Request
+		 * @param array      $filtered_response The filtered response for the GraphQL request
+		 * @param array      $response          The response for your GraphQL request
+		 * @param WPSchema   $schema            The schema object for the root request
+		 * @param string     $operation         The name of the operation
+		 * @param string     $query             The query that GraphQL executed
+		 * @param array|null $variables         Variables to passed to your GraphQL query
+		 * @param Request    $this              Instance of the Request
 		 */
 		do_action( 'graphql_return_response', $filtered_response, $response, $this->schema, $operation, $query, $variables, $this );
 
@@ -510,7 +512,7 @@ class Request {
 	/**
 	 * Run action for a request.
 	 *
-	 * @param  OperationParams $params OperationParams for the request.
+	 * @param OperationParams $params OperationParams for the request.
 	 *
 	 * @return void
 	 */
@@ -646,10 +648,11 @@ class Request {
 		 * upon directly to override default values or implement new features, e.g.,
 		 * $config->setValidationRules().
 		 *
-		 * @since 0.2.0
-		 *
 		 * @param ServerConfig    $config Server config
 		 * @param OperationParams $params Request operation params
+		 *
+		 * @since 0.2.0
+		 *
 		 */
 		do_action( 'graphql_server_config', $config, $this->params );
 

--- a/src/Telemetry/Tracker.php
+++ b/src/Telemetry/Tracker.php
@@ -153,18 +153,18 @@ class Tracker {
 	 *
 	 * @return string
 	 */
-	public function hash( $value ) {
+	public function hash( string $value ) {
 		return hash( 'sha256', $value );
 	}
 
 	/**
 	 * Given a key from the $_SERVER super global, returns sanitized data
 	 *
-	 * @param $key
+	 * @param string $key
 	 *
 	 * @return null
 	 */
-	public function clean_server_data( $key ) {
+	public function clean_server_data( string $key ) {
 		return isset( $_SERVER[ $key ] ) ? $this->sanitize( $_SERVER[ $key ] ) : null;
 	}
 

--- a/src/Type/InterfaceType/ContentNode.php
+++ b/src/Type/InterfaceType/ContentNode.php
@@ -26,7 +26,7 @@ class ContentNode {
 			'ContentNode',
 			[
 				'description' => __( 'Nodes used to manage content', 'wp-graphql' ),
-				'resolveType' => function( $post ) use ( $type_registry ) {
+				'resolveType' => function( Post $post ) use ( $type_registry ) {
 
 					/**
 					 * The resolveType callback is used at runtime to determine what Type an object

--- a/src/Type/WPInterfaceType.php
+++ b/src/Type/WPInterfaceType.php
@@ -36,12 +36,13 @@ class WPInterfaceType extends InterfaceType {
 			if ( is_callable( $config['resolveType'] ) ) {
 				$type = call_user_func( $config['resolveType'], $object );
 			}
+
 			/**
 			 * Filter the resolve type method for all interfaces
 			 *
-			 * @param mixed       $type    The Type to resolve to, based on the object being resolved.
-			 * @param mixed       $object  The Object being resolved.
-			 * @param WPInterfaceType $this    The WPInterfaceType instance.
+			 * @param mixed           $type   The Type to resolve to, based on the object being resolved.
+			 * @param mixed           $object The Object being resolved.
+			 * @param WPInterfaceType $wp_interface_type   The WPInterfaceType instance.
 			 */
 			return apply_filters( 'graphql_interface_resolve_type', $type, $object, $this );
 		};
@@ -50,7 +51,7 @@ class WPInterfaceType extends InterfaceType {
 		 * Filter the config of WPInterfaceType
 		 *
 		 * @param array           $config Array of configuration options passed to the WPInterfaceType when instantiating a new type
-		 * @param WPInterfaceType $this   The instance of the WPObjectType class
+		 * @param WPInterfaceType $wp_interface_type   The instance of the WPObjectType class
 		 */
 		$config = apply_filters( 'graphql_wp_interface_type_config', $config, $this );
 
@@ -67,7 +68,7 @@ class WPInterfaceType extends InterfaceType {
 	 * @return mixed
 	 * @since 0.0.5
 	 */
-	public function prepare_fields( $fields, $type_name ) {
+	public function prepare_fields( array $fields,string $type_name ) {
 
 		/**
 		 * Filter all object fields, passing the $typename as a param
@@ -75,8 +76,8 @@ class WPInterfaceType extends InterfaceType {
 		 * This is useful when several different types need to be easily filtered at once. . .for example,
 		 * if ALL types with a field of a certain name needed to be adjusted, or something to that tune
 		 *
-		 * @param array        $fields        The array of fields for the object config
-		 * @param string       $type_name     The name of the object type
+		 * @param array  $fields    The array of fields for the object config
+		 * @param string $type_name The name of the object type
 		 */
 		$fields = apply_filters( 'graphql_interface_fields', $fields, $type_name );
 

--- a/src/Type/WPInterfaceType.php
+++ b/src/Type/WPInterfaceType.php
@@ -68,7 +68,7 @@ class WPInterfaceType extends InterfaceType {
 	 * @return mixed
 	 * @since 0.0.5
 	 */
-	public function prepare_fields( array $fields,string $type_name ) {
+	public function prepare_fields( array $fields, string $type_name ) {
 
 		/**
 		 * Filter all object fields, passing the $typename as a param

--- a/src/Type/WPObjectType.php
+++ b/src/Type/WPObjectType.php
@@ -24,7 +24,7 @@ class WPObjectType extends ObjectType {
 	 * to easily define themselves as a node type by implementing
 	 * self::$node_interface
 	 *
-	 * @var $node_interface
+	 * @var array|Node $node_interface
 	 * @since 0.0.5
 	 */
 	private static $node_interface;
@@ -54,8 +54,8 @@ class WPObjectType extends ObjectType {
 		/**
 		 * Filter the config of WPObjectType
 		 *
-		 * @param array        $config Array of configuration options passed to the WPObjectType when instantiating a new type
-		 * @param WPObjectType $this   The instance of the WPObjectType class
+		 * @param array        $config         Array of configuration options passed to the WPObjectType when instantiating a new type
+		 * @param WPObjectType $wp_object_type The instance of the WPObjectType class
 		 */
 		$config = apply_filters( 'graphql_wp_object_type_config', $config, $this );
 
@@ -69,9 +69,9 @@ class WPObjectType extends ObjectType {
 		/**
 		 * Filters the interfaces applied to an object type
 		 *
-		 * @param array        $interfaces List of interfaces applied to the Object Type
-		 * @param array        $config     The config for the Object Type
-		 * @param WPObjectType $this       The WPObjectType instance
+		 * @param array        $interfaces     List of interfaces applied to the Object Type
+		 * @param array        $config         The config for the Object Type
+		 * @param WPObjectType $wp_object_type The WPObjectType instance
 		 */
 		$interfaces               = apply_filters( 'graphql_object_type_interfaces', $interfaces, $config, $this );
 		$config['interfaceNames'] = $interfaces;
@@ -79,7 +79,7 @@ class WPObjectType extends ObjectType {
 		/**
 		 * Convert Interfaces from Strings to Types
 		 */
-		$config['interfaces'] = function () use ( $interfaces ) {
+		$config['interfaces'] = function() use ( $interfaces ) {
 			$new_interfaces = [];
 			if ( ! is_array( $interfaces ) ) {
 				// TODO Throw an error.
@@ -153,8 +153,8 @@ class WPObjectType extends ObjectType {
 		/**
 		 * Run an action when the WPObjectType is instantiating
 		 *
-		 * @param array        $config Array of configuration options passed to the WPObjectType when instantiating a new type
-		 * @param WPObjectType $this   The instance of the WPObjectType class
+		 * @param array        $config         Array of configuration options passed to the WPObjectType when instantiating a new type
+		 * @param WPObjectType $wp_object_type The instance of the WPObjectType class
 		 */
 		do_action( 'graphql_wp_object_type', $config, $this );
 
@@ -200,10 +200,10 @@ class WPObjectType extends ObjectType {
 		 * This is useful when several different types need to be easily filtered at once. . .for example,
 		 * if ALL types with a field of a certain name needed to be adjusted, or something to that tune
 		 *
-		 * @param array        $fields        The array of fields for the object config
-		 * @param string       $type_name     The name of the object type
-		 * @param WPObjectType $this          The WPObjectType Class
-		 * @param TypeRegistry $type_registry The Type Registry
+		 * @param array        $fields         The array of fields for the object config
+		 * @param string       $type_name      The name of the object type
+		 * @param WPObjectType $wp_object_type The WPObjectType Class
+		 * @param TypeRegistry $type_registry  The Type Registry
 		 */
 		$fields = apply_filters( 'graphql_object_fields', $fields, $type_name, $this, $this->type_registry );
 
@@ -219,9 +219,9 @@ class WPObjectType extends ObjectType {
 		 * This is useful for more targeted filtering, and is applied after the general filter, to allow for
 		 * more specific overrides
 		 *
-		 * @param array        $fields        The array of fields for the object config
-		 * @param WPObjectType $this          The WPObjectType Class
-		 * @param TypeRegistry $type_registry The Type Registry
+		 * @param array        $fields         The array of fields for the object config
+		 * @param WPObjectType $wp_object_type The WPObjectType Class
+		 * @param TypeRegistry $type_registry  The Type Registry
 		 */
 		$fields = apply_filters( "graphql_{$lc_type_name}_fields", $fields, $this, $this->type_registry );
 
@@ -231,9 +231,9 @@ class WPObjectType extends ObjectType {
 		 * This is useful for more targeted filtering, and is applied after the general filter, to allow for
 		 * more specific overrides
 		 *
-		 * @param array        $fields        The array of fields for the object config
-		 * @param WPObjectType $this          The WPObjectType Class
-		 * @param TypeRegistry $type_registry The Type Registry
+		 * @param array        $fields         The array of fields for the object config
+		 * @param WPObjectType $wp_object_type The WPObjectType Class
+		 * @param TypeRegistry $type_registry  The Type Registry
 		 */
 		$fields = apply_filters( "graphql_{$uc_type_name}_fields", $fields, $this, $this->type_registry );
 

--- a/src/Type/WPUnionType.php
+++ b/src/Type/WPUnionType.php
@@ -46,6 +46,7 @@ class WPUnionType extends UnionType {
 					$prepared_types[] = $this->type_registry->get_type( $type_name );
 				}
 			}
+
 			return $prepared_types;
 		};
 
@@ -54,12 +55,13 @@ class WPUnionType extends UnionType {
 			if ( is_callable( $config['resolveType'] ) ) {
 				$type = call_user_func( $config['resolveType'], $object );
 			}
+
 			/**
 			 * Filter the resolve type method for all unions
 			 *
-			 * @param mixed $type The Type to resolve to, based on the object being resolved
-			 * @param mixed $object The Object being resolved
-			 * @param WPUnionType $this The WPUnionType instance
+			 * @param mixed       $type          The Type to resolve to, based on the object being resolved
+			 * @param mixed       $object        The Object being resolved
+			 * @param WPUnionType $wp_union_type The WPUnionType instance
 			 */
 			return apply_filters( 'graphql_union_resolve_type', $type, $object, $this );
 		};
@@ -67,18 +69,19 @@ class WPUnionType extends UnionType {
 		/**
 		 * Filter the possible_types to allow systems to add to the possible resolveTypes.
 		 *
-		 * @param $types array The possible types for the Union
-		 * @param $config array The config for the Union Type
+		 * @param array       $types         The possible types for the Union
+		 * @param array       $config        The config for the Union Type
+		 * @param WPUnionType $wp_union_type The WPUnionType instance
 		 *
 		 * @return array
 		 */
-		$config['types'] = apply_filters( 'graphql_union_possible_types', $config['types'], $config );
+		$config['types'] = apply_filters( 'graphql_union_possible_types', $config['types'], $config, $this );
 
 		/**
 		 * Filter the config of WPUnionType
 		 *
-		 * @param array       $config Array of configuration options passed to the WPUnionType when instantiating a new type
-		 * @param WPUnionType $this   The instance of the WPObjectType class
+		 * @param array       $config        Array of configuration options passed to the WPUnionType when instantiating a new type
+		 * @param WPUnionType $wp_union_type The instance of the WPObjectType class
 		 *
 		 * @since 0.0.30
 		 */
@@ -87,8 +90,8 @@ class WPUnionType extends UnionType {
 		/**
 		 * Run an action when the WPObjectType is instantiating
 		 *
-		 * @param array       $config Array of configuration options passed to the WPUnionType when instantiating a new type
-		 * @param WPUnionType $this   The instance of the WPObjectType class
+		 * @param array       $config        Array of configuration options passed to the WPUnionType when instantiating a new type
+		 * @param WPUnionType $wp_union_type The instance of the WPObjectType class
 		 */
 		do_action( 'graphql_wp_union_type', $config, $this );
 

--- a/src/Utils/InstrumentSchema.php
+++ b/src/Utils/InstrumentSchema.php
@@ -2,6 +2,7 @@
 
 namespace WPGraphQL\Utils;
 
+use Exception;
 use GraphQL\Error\UserError;
 use GraphQL\Executor\Executor;
 use GraphQL\Type\Definition\FieldDefinition;
@@ -108,13 +109,8 @@ class InstrumentSchema {
 					 * @param AppContext  $context The AppContext passed down the ResolveTree
 					 * @param ResolveInfo $info    The ResolveInfo passed down the ResolveTree
 					 *
-					 * @use   function|null $field_resolve_function
-					 * @use   string $type_name
-					 * @use   string $field_key
-					 * @use   object $field
-					 *
 					 * @return mixed
-					 * @throws \Exception
+					 * @throws Exception
 					 */
 					$field->resolveFn = function( $source, array $args, AppContext $context, ResolveInfo $info ) use ( $field_resolver, $type_name, $field_key, $field ) {
 

--- a/src/Utils/Tracing.php
+++ b/src/Utils/Tracing.php
@@ -202,7 +202,7 @@ class Tracing {
 	/**
 	 * Given input from a Resolver Path, this sanitizes the input for output in the trace
 	 *
-	 * @param $input
+	 * @param mixed $input The input to sanitize
 	 *
 	 * @return int|null|string
 	 */
@@ -222,7 +222,7 @@ class Tracing {
 	 *
 	 * @see https://github.com/apollographql/apollo-tracing
 	 *
-	 * @param $time
+	 * @param mixed|string|float|int $time The timestamp to format
 	 *
 	 * @return string
 	 */
@@ -237,11 +237,11 @@ class Tracing {
 	 * Filter the headers that WPGraphQL returns to include headers that indicate the WPGraphQL
 	 * server supports Apollo Tracing and Credentials
 	 *
-	 * @param $headers
+	 * @param array $headers The headers to return
 	 *
 	 * @return array
 	 */
-	public function return_tracing_headers( $headers ): array {
+	public function return_tracing_headers( array $headers ) {
 		$headers[] = 'X-Insights-Include-Tracing';
 		$headers[] = 'X-Apollo-Tracing';
 		$headers[] = 'Credentials';


### PR DESCRIPTION
This updates the codebase to be compatible with PHPStan Level 2 checks by: 

- Updating PHPStan config to run checks for level 2
- Update PHPStan config to ignore specific errors that will not be addressed
- Update many Docblocks to accurately define the Types for params
- Remove unused `use` statements

## Before

When already on PHPStan Level 1, updating to level 2 and running `composer run phpstan` finds 280 errors

![Screen Shot 2020-12-31 at 7 54 24 AM](https://user-images.githubusercontent.com/1260765/103414973-684e9200-4b3d-11eb-8719-c52dee91a26b.png)

## After

Running `composer run phpstan` (on level 2) finds 0 errors

![Screen Shot 2020-12-31 at 7 56 49 AM](https://user-images.githubusercontent.com/1260765/103415047-bebbd080-4b3d-11eb-8981-6f1292e4bf01.png)

----

closes #1648 