### PR TITLE
Feature/#1651 update phpstan to level 3

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    level: 2
+    level: 3
     inferPrivatePropertyTypeFromConstructor: true
     bootstrapFiles:
         - phpstan/constants.php

--- a/src/Data/Loader/CommentLoader.php
+++ b/src/Data/Loader/CommentLoader.php
@@ -16,7 +16,7 @@ class CommentLoader extends AbstractDataLoader {
 	 * @param mixed $entry The User Role object
 	 * @param mixed $key The Key to identify the user role by
 	 *
-	 * @return Comment
+	 * @return mixed|Comment|null
 	 * @throws Exception
 	 */
 	protected function get_model( $entry, $key ) {

--- a/src/Model/CommentAuthor.php
+++ b/src/Model/CommentAuthor.php
@@ -2,7 +2,9 @@
 
 namespace WPGraphQL\Model;
 
+use Exception;
 use GraphQLRelay\Relay;
+use WP_Comment;
 
 /**
  * Class CommentAuthor - Models the CommentAuthor object
@@ -19,18 +21,18 @@ class CommentAuthor extends Model {
 	/**
 	 * Stores the comment author to be modeled
 	 *
-	 * @var array $data
+	 * @var WP_Comment $data The raw data passed to he model
 	 */
 	protected $data;
 
 	/**
 	 * CommentAuthor constructor.
 	 *
-	 * @param \WP_Comment $comment_author The incoming comment author array to be modeled
+	 * @param WP_Comment $comment_author The incoming comment author array to be modeled
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
-	public function __construct( $comment_author ) {
+	public function __construct( WP_Comment $comment_author ) {
 		$this->data = $comment_author;
 		parent::__construct();
 	}

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -2,7 +2,11 @@
 
 namespace WPGraphQL\Model;
 
+use Exception;
 use GraphQLRelay\Relay;
+use WP_Post;
+use WP_User;
+use WPGraphQL;
 
 /**
  * Class User - Models the data for the User object type
@@ -36,36 +40,36 @@ class User extends Model {
 	/**
 	 * Stores the WP_User object for the incoming data
 	 *
-	 * @var \WP_User $data
+	 * @var WP_User $data
 	 */
 	protected $data;
 
 	/**
 	 * The Global Post at time of Model generation
 	 *
-	 * @var \WP_Post
+	 * @var WP_Post
 	 */
 	protected $global_post;
 
 	/**
 	 * The global authordata at time of Model generation
 	 *
-	 * @var \WP_User
+	 * @var WP_User
 	 */
 	protected $global_authordata;
 
 	/**
 	 * User constructor.
 	 *
-	 * @param \WP_User $user The incoming WP_User object that needs modeling
+	 * @param WP_User $user The incoming WP_User object that needs modeling
 	 *
 	 * @return void
-	 * @throws \Exception
+	 * @throws Exception
 	 */
-	public function __construct( \WP_User $user ) {
+	public function __construct( WP_User $user ) {
 
 		// Explicitly remove the user_pass early on so it doesn't show up in filters/hooks
-		$user->user_pass = null;
+		$user->user_pass = '';
 		$this->data      = $user;
 
 		$allowed_restricted_fields = [
@@ -103,9 +107,11 @@ class User extends Model {
 			$wp_query->reset_postdata();
 
 			// Parse the query to setup global state
-			$wp_query->parse_query([
-				'author_name' => $this->data->user_nicename,
-			]);
+			$wp_query->parse_query(
+				[
+					'author_name' => $this->data->user_nicename,
+				]
+			);
 
 			// Setup globals
 			$wp_query->is_author         = true;
@@ -142,7 +148,7 @@ class User extends Model {
 			 *      For now, we only query if the current user doesn't have list_users, instead of querying
 			 *      for ALL users. Slightly more efficient for authenticated users at least.
 			 */
-			if ( ! count_user_posts( absint( $this->data->ID ), \WPGraphQL::get_allowed_post_types(), true ) ) {
+			if ( ! count_user_posts( absint( $this->data->ID ), WPGraphQL::get_allowed_post_types(), true ) ) {
 				return true;
 			}
 		}
@@ -243,6 +249,7 @@ class User extends Model {
 					$queue = $wp_scripts->queue;
 					$wp_scripts->reset();
 					$wp_scripts->queue = [];
+
 					return $queue;
 				},
 				'enqueuedStylesheetsQueue' => function() {
@@ -251,6 +258,7 @@ class User extends Model {
 					$queue = $wp_styles->queue;
 					$wp_styles->reset();
 					$wp_styles->queue = [];
+
 					return $queue;
 				},
 			];

--- a/src/Registry/SchemaRegistry.php
+++ b/src/Registry/SchemaRegistry.php
@@ -2,6 +2,7 @@
 
 namespace WPGraphQL\Registry;
 
+use GraphQL\Type\SchemaConfig;
 use WPGraphQL\WPSchema;
 
 /**
@@ -35,19 +36,18 @@ class SchemaRegistry {
 
 		$this->type_registry->init();
 
+		$schema_config = new SchemaConfig();
+		$schema_config->query = $this->type_registry->get_type( 'RootQuery' );
+		$schema_config->mutation = $this->type_registry->get_type( 'RootMutation' );
+		$schema_config->typeLoader = function( $type ) {
+			return $this->type_registry->get_type( $type );
+		};
+		$schema_config->types = $this->type_registry->get_types();
+
 		/**
 		 * Create a new instance of the Schema
 		 */
-		$schema = new WPSchema(
-			[
-				'query'      => $this->type_registry->get_type( 'RootQuery' ),
-				'mutation'   => $this->type_registry->get_type( 'RootMutation' ),
-				'typeLoader' => function( $type ) {
-					return $this->type_registry->get_type( $type );
-				},
-				'types'      => $this->type_registry->get_types(),
-			]
-		);
+		$schema = new WPSchema( $schema_config );
 
 		/**
 		 * Filter the Schema

--- a/src/Registry/SchemaRegistry.php
+++ b/src/Registry/SchemaRegistry.php
@@ -36,13 +36,13 @@ class SchemaRegistry {
 
 		$this->type_registry->init();
 
-		$schema_config = new SchemaConfig();
-		$schema_config->query = $this->type_registry->get_type( 'RootQuery' );
-		$schema_config->mutation = $this->type_registry->get_type( 'RootMutation' );
+		$schema_config             = new SchemaConfig();
+		$schema_config->query      = $this->type_registry->get_type( 'RootQuery' );
+		$schema_config->mutation   = $this->type_registry->get_type( 'RootMutation' );
 		$schema_config->typeLoader = function( $type ) {
 			return $this->type_registry->get_type( $type );
 		};
-		$schema_config->types = $this->type_registry->get_types();
+		$schema_config->types      = $this->type_registry->get_types();
 
 		/**
 		 * Create a new instance of the Schema

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -342,8 +342,10 @@ class TypeRegistry {
 
 			$page_templates['default'] = 'DefaultTemplate';
 			foreach ( $registered_page_templates as $post_type_templates ) {
-				foreach ( $post_type_templates as $file => $name ) {
-					$page_templates[ $file ] = $name;
+				if ( is_array( $post_type_templates ) && ! empty( $post_type_templates ) ) {
+					foreach ( $post_type_templates as $file => $name ) {
+						$page_templates[ $file ] = $name;
+					}
 				}
 			}
 		}

--- a/src/Utils/DebugLog.php
+++ b/src/Utils/DebugLog.php
@@ -29,7 +29,7 @@ class DebugLog {
 		$this->logs = [];
 
 		// Whether WPGraphQL Debug is enabled
-		$enabled            = \WPGraphQL::debug();
+		$enabled = \WPGraphQL::debug();
 
 		/**
 		 * Filters whether GraphQL Debug is enabled enabled. Serves as the default state for enabling debug logs.

--- a/src/Utils/DebugLog.php
+++ b/src/Utils/DebugLog.php
@@ -25,12 +25,19 @@ class DebugLog {
 	 */
 	public function __construct() {
 
+		// Instantiate array to start capturing logs
 		$this->logs = [];
 
-		$enabled            = \WPGraphQL::debug() ? true : false;
-		$this->logs_enabled = apply_filters( 'graphql_debug_logs_enabled', $enabled, $this );
+		// Whether WPGraphQL Debug is enabled
+		$enabled            = \WPGraphQL::debug();
 
-		return $this;
+		/**
+		 * Filters whether GraphQL Debug is enabled enabled. Serves as the default state for enabling debug logs.
+		 *
+		 * @param bool $enabled Whether logs are enabled or not
+		 * @param DebugLog $debug_log The DebugLog class instance
+		 */
+		$this->logs_enabled = apply_filters( 'graphql_debug_logs_enabled', $enabled, $this );
 	}
 
 	/**

--- a/src/Utils/InstrumentSchema.php
+++ b/src/Utils/InstrumentSchema.php
@@ -10,6 +10,7 @@ use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
 use WPGraphQL\Type\WPObjectType;
+use WPGraphQL\WPSchema;
 
 /**
  * Class InstrumentSchema
@@ -27,11 +28,11 @@ class InstrumentSchema {
 	private static $cached_post = null;
 
 	/**
-	 * @param \WPGraphQL\WPSchema $schema Instance of the Schema.
+	 * @param WPSchema $schema Instance of the Schema.
 	 *
-	 * @return \WPGraphQL\WPSchema
+	 * @return WPSchema
 	 */
-	public static function instrument_schema( \WPGraphQL\WPSchema $schema ) {
+	public static function instrument_schema( WPSchema $schema ) {
 
 		$new_types = [];
 		$types     = $schema->getTypeMap();
@@ -51,7 +52,7 @@ class InstrumentSchema {
 		}
 
 		if ( ! empty( $new_types ) && is_array( $new_types ) ) {
-			$schema->config['types'] = $new_types;
+			$schema->config->types = $new_types;
 		}
 
 		return $schema;

--- a/src/Utils/Tracing.php
+++ b/src/Utils/Tracing.php
@@ -106,7 +106,7 @@ class Tracing {
 	/**
 	 * Sets the timestamp and microtime for the start of the request
 	 *
-	 * @return string
+	 * @return float
 	 */
 	public function init_trace() {
 		$this->request_start_microtime = microtime( true );
@@ -118,7 +118,7 @@ class Tracing {
 	/**
 	 * Sets the timestamp and microtime for the end of the request
 	 *
-	 * @return string
+	 * @return float
 	 */
 	public function end_trace() {
 		$this->request_end_microtime = microtime( true );
@@ -224,13 +224,13 @@ class Tracing {
 	 *
 	 * @param mixed|string|float|int $time The timestamp to format
 	 *
-	 * @return string
+	 * @return float
 	 */
 	public function format_timestamp( $time ) {
 		$time_as_float = sprintf( '%.4f', $time );
 		$timestamp     = \DateTime::createFromFormat( 'U.u', $time_as_float );
 
-		return $timestamp->format( 'Y-m-d\TH:i:s.uP' );
+		return (float) $timestamp->format( 'Y-m-d\TH:i:s.uP' );
 	}
 
 	/**

--- a/src/WPSchema.php
+++ b/src/WPSchema.php
@@ -32,16 +32,18 @@ class WPSchema extends Schema {
 	/**
 	 * WPSchema constructor.
 	 *
-	 * @param array|null $config The config for the Schema.
+	 * @param SchemaConfig $config The config for the Schema.
 	 *
 	 * @since 0.0.9
 	 */
-	public function __construct( $config ) {
+	public function __construct( SchemaConfig $config ) {
 
 		$this->config = $config;
 
 		/**
 		 * Set the $filterable_config as the $config that was passed to the WPSchema when instantiated
+		 *
+		 * @param SchemaConfig $config The config for the Schema.
 		 *
 		 * @since 0.0.9
 		 */

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -22,6 +22,12 @@
  */
 
 // Exit if accessed directly.
+use WPGraphQL\Admin\Admin;
+use WPGraphQL\AppContext;
+use WPGraphQL\Registry\SchemaRegistry;
+use WPGraphQL\Registry\TypeRegistry;
+use WPGraphQL\WPSchema;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -87,14 +93,14 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 		/**
 		 * Holds the Schema def
 		 *
-		 * @var \WPGraphQL\WPSchema
+		 * @var mixed|null|WPSchema $schema The Schema used for the GraphQL API
 		 */
 		protected static $schema;
 
 		/**
 		 * Holds the TypeRegistry instance
 		 *
-		 * @var \WPGraphQL\Registry\TypeRegistry $type_registry
+		 * @var mixed|null|TypeRegistry $type_registry The registry that holds all GraphQL Types
 		 */
 		protected static $type_registry;
 
@@ -389,7 +395,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 		 * Initialize admin functionality
 		 */
 		public function init_admin() {
-			$admin = new \WPGraphQL\Admin\Admin();
+			$admin = new Admin();
 			$admin->init();
 		}
 
@@ -555,7 +561,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 		 * Returns the Schema as defined by static registrations throughout
 		 * the WP Load.
 		 *
-		 * @return \WPGraphQL\WPSchema
+		 * @return WPSchema
 		 *
 		 * @throws Exception
 		 */
@@ -563,7 +569,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 
 			if ( null === self::$schema ) {
 
-				$schema_registry = new \WPGraphQL\Registry\SchemaRegistry();
+				$schema_registry = new SchemaRegistry();
 				$schema          = $schema_registry->get_schema();
 
 				/**
@@ -572,7 +578,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 				 * @since 0.0.5
 				 *
 				 * @param array                 $schema      The executable Schema that GraphQL executes against
-				 * @param \WPGraphQL\AppContext $app_context Object The AppContext object containing all of the
+				 * @param AppContext $app_context Object The AppContext object containing all of the
 				 *                                           information about the context we know at this point
 				 */
 				self::$schema = apply_filters( 'graphql_schema', $schema, self::get_app_context() );
@@ -610,7 +616,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 		 * Returns the Schema as defined by static registrations throughout
 		 * the WP Load.
 		 *
-		 * @return \WPGraphQL\Registry\TypeRegistry
+		 * @return TypeRegistry
 		 *
 		 * @throws Exception
 		 */
@@ -618,7 +624,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 
 			if ( null === self::$type_registry ) {
 
-				$type_registry = new \WPGraphQL\Registry\TypeRegistry();
+				$type_registry = new TypeRegistry();
 
 				/**
 				 * Generate & Filter the schema.
@@ -626,7 +632,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 				 * @since 0.0.5
 				 *
 				 * @param array                 $type_registry The TypeRegistry for the API
-				 * @param \WPGraphQL\AppContext $app_context   Object The AppContext object containing all of the
+				 * @param AppContext $app_context   Object The AppContext object containing all of the
 				 *                                             information about the context we know at this point
 				 */
 				self::$type_registry = apply_filters( 'graphql_type_registry', $type_registry, self::get_app_context() );
@@ -661,7 +667,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 		/**
 		 * Get the AppContext for use in passing down the Resolve Tree
 		 *
-		 * @return \WPGraphQL\AppContext
+		 * @return AppContext
 		 */
 		public static function get_app_context() {
 
@@ -670,7 +676,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 			 *
 			 * @since 0.0.4
 			 */
-			$app_context           = new \WPGraphQL\AppContext();
+			$app_context           = new AppContext();
 			$app_context->viewer   = wp_get_current_user();
 			$app_context->root_url = get_bloginfo( 'url' );
 			$app_context->request  = ! empty( $_REQUEST ) ? $_REQUEST : null; // phpcs:ignore


### PR DESCRIPTION
This updates the codebase to be compatible with PHPStan Level 3 checks by:

- Updating PHPStan config to run checks for level 2
- Update many Docblocks to accurately define the Types for params
- Remove unused use statements
- Refactor Schema to be passed a SchemaConfig instead of an array

----

closes #1651 