### PR TITLE
Fix issue #1653: removed user query arg, as it was redundant

### DIFF
--- a/src/Data/Connection/UserConnectionResolver.php
+++ b/src/Data/Connection/UserConnectionResolver.php
@@ -91,14 +91,6 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 		$query_args['fields'] = 'ID';
 
 		/**
-		 * If the request is not authenticated, limit the query to users that have
-		 * published posts, as they're considered publicly facing users.
-		 */
-		if ( ! is_user_logged_in() ) {
-			$query_args['has_published_posts'] = true;
-		}
-
-		/**
 		 * Map the orderby inputArgs to the WP_User_Query
 		 */
 		if ( ! empty( $this->args['where']['orderby'] ) && is_array( $this->args['where']['orderby'] ) ) {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.

The way users are being filtered in case the user is unauthenticated was redundant: firstly, the WPQuery has the `has_published_posts` arg set to true: `$query_args['has_published_posts'] = true;` and after, the users are filtered by the `is_private()` method of the User class.
Removing the query arg, the query then follows the count_user_posts() function behaviour and third-party plugins that filter the count_user_posts() (like co-authors plugin) are now supported

Does this close any currently open issues?
#1653 
