### PR TITLE
Feature/#1656 update phpstan to level 4

### DIFF
--- a/access-functions.php
+++ b/access-functions.php
@@ -44,8 +44,8 @@ function graphql_format_type_name( $type_name ) {
  * @param array $request_data The GraphQL request data (query, variables, operation_name).
  *
  * @return array
- * @since  0.2.0
  * @throws Exception
+ * @since  0.2.0
  */
 function graphql( $request_data = [] ) {
 	$request = new \WPGraphQL\Request( $request_data );
@@ -62,8 +62,8 @@ function graphql( $request_data = [] ) {
  * @param array  $variables      Variables to be passed to your GraphQL request
  *
  * @return array
- * @since  0.0.2
  * @throws \Exception
+ * @since  0.0.2
  */
 function do_graphql_request( $query, $operation_name = '', $variables = [] ) {
 	return graphql( [
@@ -94,10 +94,10 @@ function get_graphql_register_action() {
  *
  * Should be used at the `graphql_register_types` hook.
  *
- * @param array $interface_names Array of one or more names of the GraphQL Interfaces to apply to
- *                               the GraphQL Types
- * @param array $type_names      Array of one or more names of the GraphQL Types to apply the
- *                               interfaces to
+ * @param mixed|string|array<string> $interface_names Array of one or more names of the GraphQL
+ *                                                    Interfaces to apply to the GraphQL Types
+ * @param mixed|string|array<string> $type_names      Array of one or more names of the GraphQL
+ *                                                    Types to apply the interfaces to
  *
  * example:
  * The following would register the "MyNewInterface" interface to the Post and Page type in the
@@ -112,7 +112,7 @@ function register_graphql_interfaces_to_types( $interface_names, $type_names ) {
 	}
 
 	if ( is_string( $interface_names ) ) {
-		$interface_names[] = $interface_names;
+		$interface_names = [ $interface_names ];
 	}
 
 	if ( ! empty( $type_names ) && is_array( $type_names ) && ! empty( $interface_names ) && is_array( $interface_names ) ) {
@@ -289,8 +289,8 @@ function register_graphql_mutation( $mutation_name, $config ) {
  *
  * Default false.
  *
- * @since 0.4.1
  * @return bool
+ * @since 0.4.1
  */
 function is_graphql_request() {
 	return WPGraphQL::is_graphql_request();
@@ -307,8 +307,8 @@ function is_graphql_request() {
  *
  * Default false.
  *
- * @since 0.4.1
  * @return bool
+ * @since 0.4.1
  */
 function is_graphql_http_request() {
 	return \WPGraphQL\Router::is_graphql_http_request();

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    level: 3
+    level: 4
     inferPrivatePropertyTypeFromConstructor: true
     bootstrapFiles:
         - phpstan/constants.php

--- a/src/Data/CommentMutation.php
+++ b/src/Data/CommentMutation.php
@@ -44,7 +44,7 @@ class CommentMutation {
 			$output_args['user_id']              = $user->ID;
 			$output_args['comment_author']       = $user->display_name;
 			$output_args['comment_author_email'] = $user->user_email;
-			if ( ! is_null( $user->user_url ) ) {
+			if ( ! empty( $user->user_url ) ) {
 				$output_args['comment_author_url'] = $user->user_url;
 			}
 		} else {

--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -8,7 +8,6 @@ use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
 
-use WP_Taxonomy;
 use WPGraphQL\AppContext;
 use WPGraphQL\Data\Connection\PluginConnectionResolver;
 use WPGraphQL\Data\Connection\PostObjectConnectionResolver;
@@ -580,7 +579,7 @@ class DataSource {
 		 *
 		 * @since 0.0.6
 		 */
-		if ( null === $type ) {
+		if ( empty( $type ) ) {
 			throw new UserError( __( 'No type was found matching the node', 'wp-graphql' ) );
 		}
 

--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -23,8 +23,9 @@ class NodeResolver {
 	 * Given the URI of a resource, this method attempts to resolve it and return the
 	 * appropriate related object
 	 *
-	 * @param array|string $uri              The path to be used as an identifier for the resource.
-	 * @param string       $extra_query_vars Any extra query vars to consider
+	 * @param array|string       $uri              The path to be used as an identifier for the
+	 *                                             resource.
+	 * @param mixed|array|string $extra_query_vars Any extra query vars to consider
 	 *
 	 * @return mixed
 	 * @throws \Exception

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -177,7 +177,7 @@ class Post extends Model {
 		 * might be applied when resolving fields can rely on global post and
 		 * post data being set up.
 		 */
-		if ( $this->data ) {
+		if ( ! empty( $this->data ) ) {
 
 			$id        = $this->data->ID;
 			$post_type = $this->data->post_type;
@@ -563,10 +563,13 @@ class Post extends Model {
 					return false;
 				},
 				'toPing'                    => function() {
-					return ! empty( $this->data->to_ping ) && is_array( $this->data->to_ping ) ? implode( ',', (array) $this->data->to_ping ) : null;
+					$to_ping = get_to_ping( $this->databaseId );
+
+					return ! empty( $to_ping ) ? implode( ',', (array) $to_ping ) : null;
 				},
 				'pinged'                    => function() {
-					return ! empty( $this->data->pinged ) && is_array( $this->data->pinged ) ? implode( ',', (array) $this->data->pinged ) : null;
+					$punged = get_pung( $this->databaseId );
+					return ! empty( $punged ) ? implode( ',', (array) $punged ) : null;
 				},
 				'modified'                  => function() {
 					return ! empty( $this->data->post_modified ) && '0000-00-00 00:00:00' !== $this->data->post_modified ? $this->data->post_modified : null;

--- a/src/Model/Term.php
+++ b/src/Model/Term.php
@@ -68,7 +68,7 @@ class Term extends Model {
 		 */
 		$this->global_post = $post;
 
-		if ( $this->data ) {
+		if ( ! empty( $this->data ) ) {
 
 			/**
 			 * Reset global post

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -101,7 +101,7 @@ class User extends Model {
 		$this->global_post       = $post;
 		$this->global_authordata = $authordata;
 
-		if ( $this->data ) {
+		if ( ! empty( $this->data ) ) {
 
 			// Reset postdata
 			$wp_query->reset_postdata();

--- a/src/Mutation/PostObjectUpdate.php
+++ b/src/Mutation/PostObjectUpdate.php
@@ -77,7 +77,7 @@ class PostObjectUpdate {
 			/**
 			 * If there's no existing post, throw an exception
 			 */
-			if ( empty( $id_parts['id'] ) || false === $existing_post ) {
+			if ( empty( $id_parts['id'] ) || empty( $existing_post ) ) {
 				// translators: the placeholder is the name of the type of post being updated
 				throw new UserError( sprintf( __( 'No %1$s could be found to update', 'wp-graphql' ), $post_type_object->graphql_single_name ) );
 			}

--- a/src/Mutation/SendPasswordResetEmail.php
+++ b/src/Mutation/SendPasswordResetEmail.php
@@ -50,6 +50,9 @@ class SendPasswordResetEmail {
 
 					$email_sent = wp_mail( $user_data->user_email, wp_specialchars_decode( $subject ), $message );
 
+					// wp_mail can return a wp_error, but the docblock for it in WP Core is incorrect.
+					// phpstan should ignore this check.
+					// @phpstan-ignore-next-line
 					if ( is_wp_error( $email_sent ) ) {
 
 						$message = __( 'The email could not be sent.' ) . "<br />\n" . __( 'Possible reason: your host may have disabled the mail() function.' );

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -342,7 +342,11 @@ class TypeRegistry {
 
 			$page_templates['default'] = 'DefaultTemplate';
 			foreach ( $registered_page_templates as $post_type_templates ) {
-				if ( is_array( $post_type_templates ) && ! empty( $post_type_templates ) ) {
+				// Post templates are returned as an array of arrays. PHPStan believes they're returned as
+				// an array of strings and believes this will always evaluate to false.
+				// We should ignore the phpstan check here.
+				// @phpstan-ignore-next-line
+				if ( ! empty( $post_type_templates ) && is_array( $post_type_templates ) ) {
 					foreach ( $post_type_templates as $file => $name ) {
 						$page_templates[ $file ] = $name;
 					}

--- a/src/Request.php
+++ b/src/Request.php
@@ -412,8 +412,8 @@ class Request {
 	/**
 	 * Apply filters and do actions after GraphQL execution
 	 *
-	 * @param array          $response The response for your GraphQL request
-	 * @param mixed|Int|null $key      The array key of the params for batch requests
+	 * @param mixed|array|object $response The response for your GraphQL request
+	 * @param mixed|Int|null     $key      The array key of the params for batch requests
 	 *
 	 * @return array
 	 */
@@ -437,12 +437,12 @@ class Request {
 		/**
 		 * Run an action. This is a good place for debug tools to hook in to log things, etc.
 		 *
-		 * @param array      $response  The response your GraphQL request
-		 * @param WPSchema   $schema    The schema object for the root request
-		 * @param string     $operation The name of the operation
-		 * @param string     $query     The query that GraphQL executed
-		 * @param array|null $variables Variables to passed to your GraphQL query
-		 * @param Request    $this      Instance of the Request
+		 * @param mixed|array $response  The response your GraphQL request
+		 * @param WPSchema    $schema    The schema object for the root request
+		 * @param string      $operation The name of the operation
+		 * @param string      $query     The query that GraphQL executed
+		 * @param array|null  $variables Variables to passed to your GraphQL query
+		 * @param Request     $this      Instance of the Request
 		 *
 		 * @since 0.0.4
 		 */
@@ -454,7 +454,7 @@ class Request {
 		if ( ! empty( $response ) ) {
 			if ( is_array( $response ) ) {
 				$response['extensions']['debug'] = $this->debug_log->get_logs();
-			} elseif ( is_object( $response ) ) {
+			} else {
 				$response->extensions = [ 'debug' => $this->debug_log->get_logs() ];
 			}
 		}
@@ -478,7 +478,7 @@ class Request {
 		 * @param string     $operation The name of the operation
 		 * @param string     $query     The query that GraphQL executed
 		 * @param array|null $variables Variables to passed to your GraphQL request
-		 * @param Request    $request      Instance of the Request
+		 * @param Request    $request   Instance of the Request
 		 *
 		 * @since 0.0.5
 		 */

--- a/src/Telemetry/Tracker.php
+++ b/src/Telemetry/Tracker.php
@@ -181,7 +181,7 @@ class Tracker {
 		if ( is_array( $input ) ) {
 			return array_map( [ $this, 'sanitize' ], $input );
 		} else {
-			return is_scalar( $input ) ? sanitize_text_field( $input ) : $input;
+			return sanitize_text_field( $input );
 		}
 	}
 

--- a/src/Type/Object/RootQuery.php
+++ b/src/Type/Object/RootQuery.php
@@ -79,7 +79,6 @@ class RootQuery {
 							switch ( $idType ) {
 								case 'uri':
 									return $context->node_resolver->resolve_uri( $args['id'] );
-									break;
 								case 'database_id':
 									$post_id = absint( $args['id'] );
 									break;
@@ -341,7 +340,6 @@ class RootQuery {
 									break;
 								case 'uri':
 									return $context->node_resolver->resolve_uri( $args['id'] );
-									break;
 								case 'global_id':
 								default:
 									$id_components = Relay::fromGlobalId( $args['id'] );
@@ -396,7 +394,6 @@ class RootQuery {
 									break;
 								case 'uri':
 									return $context->node_resolver->resolve_uri( $args['id'] );
-									break;
 								case 'login':
 									$current_user = wp_get_current_user();
 									if ( $current_user->user_login !== $args['id'] ) {
@@ -505,7 +502,6 @@ class RootQuery {
 									] );
 								case 'uri':
 									return $context->node_resolver->resolve_uri( $args['id'], [ 'post_type' => $post_type_object->name ] );
-									break;
 								case 'database_id':
 									$post_id = absint( $args['id'] );
 									break;
@@ -650,7 +646,6 @@ class RootQuery {
 									break;
 								case 'uri':
 									return $context->node_resolver->resolve_uri( $args['id'] );
-									break;
 								case 'global_id':
 								default:
 									$id_components = Relay::fromGlobalId( $args['id'] );

--- a/src/Type/Object/SettingGroup.php
+++ b/src/Type/Object/SettingGroup.php
@@ -80,18 +80,14 @@ class SettingGroup {
 								case 'integer':
 								case 'int':
 									return absint( $option );
-									break;
 								case 'string':
 									return (string) $option;
-									break;
 								case 'boolean':
 								case 'bool':
 									return (bool) $option;
-									break;
 								case 'number':
 								case 'float':
 									return (float) $option;
-									break;
 							}
 
 							return ! empty( $option ) ? $option : null;

--- a/src/Utils/InstrumentSchema.php
+++ b/src/Utils/InstrumentSchema.php
@@ -39,7 +39,7 @@ class InstrumentSchema {
 
 		if ( ! empty( $types ) && is_array( $types ) ) {
 			foreach ( $types as $type_name => $type_object ) {
-				if ( $type_object instanceof ObjectType || $type_object instanceof WPObjectType ) {
+				if ( $type_object instanceof ObjectType ) {
 					$fields                            = $type_object->getFields();
 					$new_fields                        = self::wrap_fields( $fields, $type_name );
 					$new_type_object                   = $type_object;

--- a/src/Utils/QueryLog.php
+++ b/src/Utils/QueryLog.php
@@ -133,8 +133,11 @@ class QueryLog {
 	public function get_query_log() {
 		global $wpdb;
 
+		$save_queries_value = defined( 'SAVEQUERIES' ) && true === SAVEQUERIES ? 'true' : 'false';
+		$default_message    = sprintf( __( 'Query Logging has been disabled. The \'SAVEQUERIES\' Constant is set to \'%s\' on your server.', 'wp-graphql' ), $save_queries_value );
+
 		// Default message
-		$trace = [ sprintf( __( 'Query Logging has been disabled. The \'SAVEQUERIES\' Constant is set to \'%s\' on your server.', 'wp-graphql' ), SAVEQUERIES ? 'true' : 'false' ) ];
+		$trace = [ $default_message ];
 
 		if ( ! empty( $wpdb->queries ) && is_array( $wpdb->queries ) ) {
 			$queries = array_map( function( $query ) {

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -9,8 +9,8 @@ class Utils {
 	/**
 	 * Maps new input query args and sanitizes the input
 	 *
-	 * @param array $args The raw query args from the GraphQL query
-	 * @param array $map  The mapping of where each of the args should go
+	 * @param mixed|array|string $args The raw query args from the GraphQL query
+	 * @param mixed|array|string $map  The mapping of where each of the args should go
 	 *
 	 * @since  0.5.0
 	 * @return array

--- a/vendor/composer/InstalledVersions.php
+++ b/vendor/composer/InstalledVersions.php
@@ -29,7 +29,7 @@ private static $installed = array (
     'aliases' => 
     array (
     ),
-    'reference' => 'ba89f4f8d5adc05ed34d7fc3dcfd2cefa8010e9b',
+    'reference' => '4c768b1d533d069ad93900045f88b1609a551a69',
     'name' => 'wp-graphql/wp-graphql',
   ),
   'versions' => 
@@ -59,7 +59,7 @@ private static $installed = array (
       'aliases' => 
       array (
       ),
-      'reference' => 'ba89f4f8d5adc05ed34d7fc3dcfd2cefa8010e9b',
+      'reference' => '4c768b1d533d069ad93900045f88b1609a551a69',
     ),
   ),
 );

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -6,7 +6,7 @@
     'aliases' => 
     array (
     ),
-    'reference' => 'ba89f4f8d5adc05ed34d7fc3dcfd2cefa8010e9b',
+    'reference' => '4c768b1d533d069ad93900045f88b1609a551a69',
     'name' => 'wp-graphql/wp-graphql',
   ),
   'versions' => 
@@ -36,7 +36,7 @@
       'aliases' => 
       array (
       ),
-      'reference' => 'ba89f4f8d5adc05ed34d7fc3dcfd2cefa8010e9b',
+      'reference' => '4c768b1d533d069ad93900045f88b1609a551a69',
     ),
   ),
 );

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -133,7 +133,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 		 */
 		public static function instance() {
 
-			if ( ! isset( self::$instance ) && ! ( self::$instance instanceof WPGraphQL ) ) {
+			if ( ! isset( self::$instance ) || ! ( self::$instance instanceof WPGraphQL ) ) {
 				self::$instance = new WPGraphQL();
 				self::$instance->setup_constants();
 				self::$instance->includes();


### PR DESCRIPTION
This updates the codebase to be compatible with PHPStan Level 4 checks by: 

- update docblocks
- update code formatting
- fix improper setting of string to array in register_graphql_interfaces_to_types function
- fix some improper elseif checks
- update is_null check to use empty() check
- update toPing and pinged on Post model to use core WP functions
- add a few explicit ignores for phpstan
- remove some unreached breaks in switch statements

## Before

When already on PHPStan Level 3, updating to level 4 and running `composer run phpstan` finds 31 errors

![Screen Shot 2021-01-04 at 9 21 51 AM](https://user-images.githubusercontent.com/1260765/103571303-dcfc3600-4e87-11eb-9ec1-f171b940a659.png)

## After

Running `composer run phpstan` (on level 2) finds 0 errors

![Screen Shot 2021-01-04 at 12 25 23 PM](https://user-images.githubusercontent.com/1260765/103571340-ee454280-4e87-11eb-897b-cf3a9aa0cba2.png)
