### PR TITLE
Release/v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.1.0
+
+### New
+- This updates the codebase to be compliant with PHPStan Level 8 checks.
+
+### Bugfixes
+- Fixes some inconsistencies with return Types and Docblocks
+- Adds early returns in places where execution should not reach
+- Adds some checks for possible unset values on objects and arrays before using their values
+
 ## 1.0.5
 
 ### New

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,19 @@
 
 ## 1.1.0
 
-### New
-- This updates the codebase to be compliant with PHPStan Level 8 checks.
+This release centers around updating code quality by implementing [PHPStan](https://phpstan.org/) checks. PHPStan is a tool that statically analyzes PHP codebases to detect bugs. This release centers around updating Docblocks and overall code quality, and implements automated tests to check code quality on every pull request.
 
-### Bugfixes
-- Fixes some inconsistencies with return Types and Docblocks
-- Adds early returns in places where execution should not reach
-- Adds some checks for possible unset values on objects and arrays before using their values
+## New
+
+- Update PHPStan (Code Quality checker) to v0.12.64
+- Increases PHPStan code quality checks to Level 8 (highest level).
+
+## Bugfixes
+- ([#1653](https://github.com/wp-graphql/wp-graphql/issues/1653)) Fixes bug where WPGraphQL was explicitly setting `has_published_posts` on WP_Query but WP_Query does this under the hood already. Thanks @jmartinhoj!
+- Fixes issue with Comment Model returning comments that are not associated with a Post object. Comments with no associated Post object are not public entities.
+- Update docblocks to be compatible with PHPStan Level 8. 
+- Removed some uncalled code
+- Added early returns in some places to prevent unnecessary added execution
 
 ## 1.0.5
 

--- a/access-functions.php
+++ b/access-functions.php
@@ -5,6 +5,8 @@
  * @since 0.0.2
  */
 
+use WPGraphQL\Router;
+
 /**
  * Formats the name of a field so that it plays nice with GraphiQL
  *
@@ -14,8 +16,14 @@
  * @since  0.0.2
  */
 function graphql_format_field_name( $field_name ) {
-	$field_name = preg_replace( '/[^A-Za-z0-9]/i', ' ', $field_name );
-	$field_name = preg_replace( '/[^A-Za-z0-9]/i', '', ucwords( $field_name ) );
+	$replace_field_name = preg_replace( '/[^A-Za-z0-9]/i', ' ', $field_name );
+	if ( ! empty( $replace_field_name ) ) {
+		$field_name = $replace_field_name;
+	}
+	$replace_field_name = preg_replace( '/[^A-Za-z0-9]/i', '', ucwords( $field_name ) );
+	if ( ! empty( $replace_field_name ) ) {
+		$field_name = $replace_field_name;
+	}
 	$field_name = lcfirst( $field_name );
 
 	return $field_name;
@@ -30,8 +38,14 @@ function graphql_format_field_name( $field_name ) {
  * @since  0.0.2
  */
 function graphql_format_type_name( $type_name ) {
-	$type_name = preg_replace( '/[^A-Za-z0-9]/i', ' ', $type_name );
-	$type_name = preg_replace( '/[^A-Za-z0-9]/i', '', ucwords( $type_name ) );
+	$replace_type_name = preg_replace( '/[^A-Za-z0-9]/i', ' ', $type_name );
+	if ( ! empty( $replace_type_name ) ) {
+		$type_name = $replace_type_name;
+	}
+	$replace_type_name = preg_replace( '/[^A-Za-z0-9]/i', '', ucwords( $type_name ) );
+	if ( ! empty( $replace_type_name ) ) {
+		$type_name = $replace_type_name;
+	}
 	$type_name = ucfirst( $type_name );
 
 	return $type_name;
@@ -44,8 +58,8 @@ function graphql_format_type_name( $type_name ) {
  * @param array $request_data The GraphQL request data (query, variables, operation_name).
  *
  * @return array
- * @since  0.2.0
  * @throws Exception
+ * @since  0.2.0
  */
 function graphql( $request_data = [] ) {
 	$request = new \WPGraphQL\Request( $request_data );
@@ -62,15 +76,17 @@ function graphql( $request_data = [] ) {
  * @param array  $variables      Variables to be passed to your GraphQL request
  *
  * @return array
- * @since  0.0.2
  * @throws \Exception
+ * @since  0.0.2
  */
 function do_graphql_request( $query, $operation_name = '', $variables = [] ) {
-	return graphql( [
-		'query'          => $query,
-		'variables'      => $variables,
-		'operation_name' => $operation_name,
-	] );
+	return graphql(
+		[
+			'query'          => $query,
+			'variables'      => $variables,
+			'operation_name' => $operation_name,
+		]
+	);
 }
 
 /**
@@ -94,16 +110,18 @@ function get_graphql_register_action() {
  *
  * Should be used at the `graphql_register_types` hook.
  *
- * @param array $interface_names Array of one or more names of the GraphQL Interfaces to apply to
- *                               the GraphQL Types
- * @param array $type_names      Array of one or more names of the GraphQL Types to apply the
- *                               interfaces to
+ * @param mixed|string|array<string> $interface_names Array of one or more names of the GraphQL
+ *                                                    Interfaces to apply to the GraphQL Types
+ * @param mixed|string|array<string> $type_names      Array of one or more names of the GraphQL
+ *                                                    Types to apply the interfaces to
  *
  * example:
  * The following would register the "MyNewInterface" interface to the Post and Page type in the
  * Schema.
  *
  * register_graphql_interfaces_to_types( [ 'MyNewInterface' ], [ 'Post', 'Page' ] );
+ *
+ * @return void
  */
 function register_graphql_interfaces_to_types( $interface_names, $type_names ) {
 
@@ -112,23 +130,28 @@ function register_graphql_interfaces_to_types( $interface_names, $type_names ) {
 	}
 
 	if ( is_string( $interface_names ) ) {
-		$interface_names[] = $interface_names;
+		$interface_names = [ $interface_names ];
 	}
 
 	if ( ! empty( $type_names ) && is_array( $type_names ) && ! empty( $interface_names ) && is_array( $interface_names ) ) {
 		foreach ( $type_names as $type_name ) {
 
 			// Filter the GraphQL Object Type Interface to apply the interface
-			add_filter( 'graphql_object_type_interfaces', function( $interfaces, $config ) use ( $type_name, $interface_names ) {
+			add_filter(
+				'graphql_object_type_interfaces',
+				function( $interfaces, $config ) use ( $type_name, $interface_names ) {
 
-				$interfaces = is_array( $interfaces ) ? $interfaces : [];
+					$interfaces = is_array( $interfaces ) ? $interfaces : [];
 
-				if ( strtolower( $type_name ) === strtolower( $config['name'] ) ) {
-					$interfaces = array_unique( array_merge( $interfaces, $interface_names ) );
-				}
+					if ( strtolower( $type_name ) === strtolower( $config['name'] ) ) {
+						$interfaces = array_unique( array_merge( $interfaces, $interface_names ) );
+					}
 
-				return $interfaces;
-			}, 10, 2 );
+					return $interfaces;
+				},
+				10,
+				2
+			);
 
 		}
 	}
@@ -139,11 +162,18 @@ function register_graphql_interfaces_to_types( $interface_names, $type_names ) {
  *
  * @param string $type_name The name of the Type to register
  * @param array  $config    The Type config
+ *
+ * @throws Exception
+ * @return void
  */
-function register_graphql_type( $type_name, $config ) {
-	add_action( get_graphql_register_action(), function( \WPGraphQL\Registry\TypeRegistry $type_registry ) use ( $type_name, $config ) {
-		$type_registry->register_type( $type_name, $config );
-	}, 10 );
+function register_graphql_type( string $type_name, array $config ) {
+	add_action(
+		get_graphql_register_action(),
+		function( \WPGraphQL\Registry\TypeRegistry $type_registry ) use ( $type_name, $config ) {
+			$type_registry->register_type( $type_name, $config );
+		},
+		10
+	);
 }
 
 /**
@@ -151,11 +181,18 @@ function register_graphql_type( $type_name, $config ) {
  *
  * @param string $type_name The name of the Type to register
  * @param array  $config    The Type config
+ *
+ * @throws Exception
+ * @return void
  */
-function register_graphql_interface_type( $type_name, $config ) {
-	add_action( get_graphql_register_action(), function( \WPGraphQL\Registry\TypeRegistry $type_registry ) use ( $type_name, $config ) {
-		$type_registry->register_interface_type( $type_name, $config );
-	}, 10 );
+function register_graphql_interface_type( string $type_name, array $config ) {
+	add_action(
+		get_graphql_register_action(),
+		function( \WPGraphQL\Registry\TypeRegistry $type_registry ) use ( $type_name, $config ) {
+			$type_registry->register_interface_type( $type_name, $config );
+		},
+		10
+	);
 }
 
 /**
@@ -163,8 +200,10 @@ function register_graphql_interface_type( $type_name, $config ) {
  *
  * @param string $type_name The name of the Type to register
  * @param array  $config    The Type config
+ *
+ * @return void
  */
-function register_graphql_object_type( $type_name, $config ) {
+function register_graphql_object_type( string $type_name, array $config ) {
 	$config['kind'] = 'object';
 	register_graphql_type( $type_name, $config );
 }
@@ -174,8 +213,10 @@ function register_graphql_object_type( $type_name, $config ) {
  *
  * @param string $type_name The name of the Type to register
  * @param array  $config    The Type config
+ *
+ * @return void
  */
-function register_graphql_input_type( $type_name, $config ) {
+function register_graphql_input_type( string $type_name, array $config ) {
 	$config['kind'] = 'input';
 	register_graphql_type( $type_name, $config );
 }
@@ -185,13 +226,21 @@ function register_graphql_input_type( $type_name, $config ) {
  *
  * @param string $type_name The name of the Type to register
  * @param array  $config    The Type config
+ *
+ * @throws Exception
+ *
+ * @return void
  */
-function register_graphql_union_type( $type_name, $config ) {
+function register_graphql_union_type( string $type_name, array $config ) {
 
-	add_action( get_graphql_register_action(), function( \WPGraphQL\Registry\TypeRegistry $type_registry ) use ( $type_name, $config ) {
-		$config['kind'] = 'union';
-		$type_registry->register_type( $type_name, $config );
-	}, 10 );
+	add_action(
+		get_graphql_register_action(),
+		function( \WPGraphQL\Registry\TypeRegistry $type_registry ) use ( $type_name, $config ) {
+			$config['kind'] = 'union';
+			$type_registry->register_type( $type_name, $config );
+		},
+		10
+	);
 }
 
 /**
@@ -199,8 +248,10 @@ function register_graphql_union_type( $type_name, $config ) {
  *
  * @param string $type_name The name of the Type to register
  * @param array  $config    The Type config
+ *
+ * @return void
  */
-function register_graphql_enum_type( $type_name, $config ) {
+function register_graphql_enum_type( string $type_name, array $config ) {
 	$config['kind'] = 'enum';
 	register_graphql_type( $type_name, $config );
 }
@@ -212,11 +263,17 @@ function register_graphql_enum_type( $type_name, $config ) {
  * @param string $type_name  The name of the Type to add the field to
  * @param string $field_name The name of the Field to add to the Type
  * @param array  $config     The Type config
+ *
+ * @return void
  */
-function register_graphql_field( $type_name, $field_name, $config ) {
-	add_action( get_graphql_register_action(), function( \WPGraphQL\Registry\TypeRegistry $type_registry ) use ( $type_name, $field_name, $config ) {
-		$type_registry->register_field( $type_name, $field_name, $config );
-	}, 10 );
+function register_graphql_field( string $type_name, string $field_name, array $config ) {
+	add_action(
+		get_graphql_register_action(),
+		function( \WPGraphQL\Registry\TypeRegistry $type_registry ) use ( $type_name, $field_name, $config ) {
+			$type_registry->register_field( $type_name, $field_name, $config );
+		},
+		10
+	);
 }
 
 /**
@@ -225,11 +282,17 @@ function register_graphql_field( $type_name, $field_name, $config ) {
  *
  * @param string $type_name The name of the Type to add the fields to
  * @param array  $fields    An array of field configs
+ *
+ * @return void
  */
-function register_graphql_fields( $type_name, array $fields ) {
-	add_action( get_graphql_register_action(), function( \WPGraphQL\Registry\TypeRegistry $type_registry ) use ( $type_name, $fields ) {
-		$type_registry->register_fields( $type_name, $fields );
-	}, 10 );
+function register_graphql_fields( string $type_name, array $fields ) {
+	add_action(
+		get_graphql_register_action(),
+		function( \WPGraphQL\Registry\TypeRegistry $type_registry ) use ( $type_name, $fields ) {
+			$type_registry->register_fields( $type_name, $fields );
+		},
+		10
+	);
 }
 
 /**
@@ -237,11 +300,18 @@ function register_graphql_fields( $type_name, array $fields ) {
  * fields and types for the connection
  *
  * @param array $config Array to configure the connection
+ *
+ * @throws Exception
+ * @return void
  */
 function register_graphql_connection( array $config ) {
-	add_action( get_graphql_register_action(), function( \WPGraphQL\Registry\TypeRegistry $type_registry ) use ( $config ) {
-		$type_registry->register_connection( $config );
-	}, 10 );
+	add_action(
+		get_graphql_register_action(),
+		function( \WPGraphQL\Registry\TypeRegistry $type_registry ) use ( $config ) {
+			$type_registry->register_connection( $config );
+		},
+		10
+	);
 }
 
 /**
@@ -249,11 +319,18 @@ function register_graphql_connection( array $config ) {
  *
  * @param string $type_name The name of the Type to register
  * @param array  $config    The config for the scalar type to register
+ *
+ * @throws Exception
+ * @return void
  */
-function register_graphql_scalar( $type_name, array $config ) {
-	add_action( get_graphql_register_action(), function( \WPGraphQL\Registry\TypeRegistry $type_registry ) use ( $type_name, $config ) {
-		$type_registry->register_scalar( $type_name, $config );
-	}, 10 );
+function register_graphql_scalar( string $type_name, array $config ) {
+	add_action(
+		get_graphql_register_action(),
+		function( \WPGraphQL\Registry\TypeRegistry $type_registry ) use ( $type_name, $config ) {
+			$type_registry->register_scalar( $type_name, $config );
+		},
+		10
+	);
 }
 
 /**
@@ -261,11 +338,17 @@ function register_graphql_scalar( $type_name, array $config ) {
  *
  * @param string $type_name  The name of the Type to remove the field from
  * @param string $field_name The name of the field to remove
+ *
+ * @return void
  */
-function deregister_graphql_field( $type_name, $field_name ) {
-	add_action( get_graphql_register_action(), function( \WPGraphQL\Registry\TypeRegistry $type_registry ) use ( $type_name, $field_name ) {
-		$type_registry->deregister_field( $type_name, $field_name );
-	}, 10 );
+function deregister_graphql_field( string $type_name, string $field_name ) {
+	add_action(
+		get_graphql_register_action(),
+		function( \WPGraphQL\Registry\TypeRegistry $type_registry ) use ( $type_name, $field_name ) {
+			$type_registry->deregister_field( $type_name, $field_name );
+		},
+		10
+	);
 }
 
 /**
@@ -273,11 +356,19 @@ function deregister_graphql_field( $type_name, $field_name ) {
  *
  * @param string $mutation_name The name of the Mutation to register
  * @param array  $config        The config for the mutation
+ *
+ * @throws Exception
+ *
+ * @return void
  */
-function register_graphql_mutation( $mutation_name, $config ) {
-	add_action( get_graphql_register_action(), function( \WPGraphQL\Registry\TypeRegistry $type_registry ) use ( $mutation_name, $config ) {
-		$type_registry->register_mutation( $mutation_name, $config );
-	}, 10 );
+function register_graphql_mutation( string $mutation_name, array $config ) {
+	add_action(
+		get_graphql_register_action(),
+		function( \WPGraphQL\Registry\TypeRegistry $type_registry ) use ( $mutation_name, $config ) {
+			$type_registry->register_mutation( $mutation_name, $config );
+		},
+		10
+	);
 }
 
 /**
@@ -289,8 +380,8 @@ function register_graphql_mutation( $mutation_name, $config ) {
  *
  * Default false.
  *
- * @since 0.4.1
  * @return bool
+ * @since 0.4.1
  */
 function is_graphql_request() {
 	return WPGraphQL::is_graphql_request();
@@ -307,11 +398,11 @@ function is_graphql_request() {
  *
  * Default false.
  *
- * @since 0.4.1
  * @return bool
+ * @since 0.4.1
  */
 function is_graphql_http_request() {
-	return \WPGraphQL\Router::is_graphql_http_request();
+	return Router::is_graphql_http_request();
 }
 
 /**
@@ -319,11 +410,16 @@ function is_graphql_http_request() {
  *
  * @param string $slug   The slug of the group being registered
  * @param array  $config Array configuring the section. Should include: title
+ *
+ * @return void
  */
-function register_graphql_settings_section( $slug, $config ) {
-	add_action( 'graphql_init_settings', function( \WPGraphQL\Admin\Settings\SettingsRegistry $registry ) use ( $slug, $config ) {
-		$registry->register_section( $slug, $config );
-	} );
+function register_graphql_settings_section( string $slug, array $config ) {
+	add_action(
+		'graphql_init_settings',
+		function( \WPGraphQL\Admin\Settings\SettingsRegistry $registry ) use ( $slug, $config ) {
+			$registry->register_section( $slug, $config );
+		}
+	);
 }
 
 /**
@@ -331,11 +427,16 @@ function register_graphql_settings_section( $slug, $config ) {
  *
  * @param string $group  The name of the group to register a setting field to
  * @param array  $config The config for the settings field being registered
+ *
+ * @return void
  */
-function register_graphql_settings_field( $group, $config ) {
-	add_action( 'graphql_init_settings', function( \WPGraphQL\Admin\Settings\SettingsRegistry $registry ) use ( $group, $config ) {
-		$registry->register_field( $group, $config );
-	} );
+function register_graphql_settings_field( string $group, array $config ) {
+	add_action(
+		'graphql_init_settings',
+		function( \WPGraphQL\Admin\Settings\SettingsRegistry $registry ) use ( $group, $config ) {
+			$registry->register_field( $group, $config );
+		}
+	);
 }
 
 /**
@@ -347,22 +448,27 @@ function register_graphql_settings_field( $group, $config ) {
  *                                    $config['type'] will set the "type" of the log, default type
  *                                    is GRAPHQL_DEBUG. Other fields added to $config will be
  *                                    merged into the debug entry.
+ *
+ * @return void
  */
 function graphql_debug( $message, $config = [] ) {
 	$config['backtrace'] = wp_list_pluck( debug_backtrace(), 'file' );
-	add_action( 'graphql_get_debug_log', function( \WPGraphQL\Utils\DebugLog $debug_log ) use ( $message, $config ) {
-		return $debug_log->add_log_entry( $message, $config );
-	} );
+	add_action(
+		'graphql_get_debug_log',
+		function( \WPGraphQL\Utils\DebugLog $debug_log ) use ( $message, $config ) {
+			return $debug_log->add_log_entry( $message, $config );
+		}
+	);
 }
 
 /**
  * Check if the name is valid for use in GraphQL
  *
- * @param $type_name
+ * @param string $type_name The name of the type to validate
  *
  * @return bool
  */
-function is_valid_graphql_name( $type_name ) {
+function is_valid_graphql_name( string $type_name ) {
 	if ( preg_match( '/^\d/', $type_name ) ) {
 		return false;
 	}
@@ -375,11 +481,16 @@ function is_valid_graphql_name( $type_name ) {
  *
  * @param string $group  The name of the settings group to register fields to
  * @param array  $fields Array of field configs to register to the group
+ *
+ * @return void
  */
-function register_graphql_settings_fields( $group, $fields ) {
-	add_action( 'graphql_init_settings', function( \WPGraphQL\Admin\Settings\SettingsRegistry $registry ) use ( $group, $fields ) {
-		$registry->register_fields( $group, $fields );
-	} );
+function register_graphql_settings_fields( string $group, array $fields ) {
+	add_action(
+		'graphql_init_settings',
+		function( \WPGraphQL\Admin\Settings\SettingsRegistry $registry ) use ( $group, $fields ) {
+			$registry->register_fields( $group, $fields );
+		}
+	);
 }
 
 /**
@@ -391,7 +502,7 @@ function register_graphql_settings_fields( $group, $fields ) {
  *
  * @return mixed|string|int|boolean
  */
-function get_graphql_setting( $option_name, $default = '', $section_name = 'graphql_general_settings' ) {
+function get_graphql_setting( string $option_name, $default = '', $section_name = 'graphql_general_settings' ) {
 
 	$section_fields = get_option( $section_name );
 
@@ -424,13 +535,20 @@ function get_graphql_setting( $option_name, $default = '', $section_name = 'grap
 /**
  * Polyfill for PHP versions below 7.3
  *
- * @return mixed|string|int
+ * @return int|string|null
  */
 if ( ! function_exists( 'array_key_first' ) ) {
+
+	/**
+	 * @param array $array
+	 *
+	 * @return int|string|null
+	 */
 	function array_key_first( array $array ) {
 		foreach ( $array as $key => $value ) {
 			return $key;
 		}
+		return null;
 	}
 }
 
@@ -440,6 +558,12 @@ if ( ! function_exists( 'array_key_first' ) ) {
  * @return mixed|string|int
  */
 if ( ! function_exists( 'array_key_last' ) ) {
+
+	/**
+	 * @param array $array
+	 *
+	 * @return int|string|null
+	 */
 	function array_key_last( array $array ) {
 		end( $array );
 

--- a/composer.json
+++ b/composer.json
@@ -39,12 +39,13 @@
     "wp-coding-standards/wpcs": "2.1.1",
     "phpcompatibility/phpcompatibility-wp": "2.1.0",
     "squizlabs/php_codesniffer": "3.5.4",
-    "phpstan/phpstan": "^0.12.25",
+    "phpstan/phpstan": "^0.12.64",
     "szepeviktor/phpstan-wordpress": "^0.7.1",
     "codeception/module-rest": "^1.2",
     "wp-graphql/wp-graphql-testcase": "^1.0",
     "phpunit/phpunit": "9.4.1",
-    "simpod/php-coveralls-mirror": "^3.0"
+    "simpod/php-coveralls-mirror": "^3.0",
+    "phpstan/extension-installer": "^1.1"
   },
   "config": {
     "optimize-autoloader": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "678a05910da4ef18c3dbcfd5af74e39c",
+    "content-hash": "17f0921d8eeb791ecd49b6a3a609f511",
     "packages": [
         {
             "name": "ivome/graphql-relay-php",
@@ -381,16 +381,16 @@
         },
         {
             "name": "codeception/lib-innerbrowser",
-            "version": "1.3.4",
+            "version": "1.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeception/lib-innerbrowser.git",
-                "reference": "fd921e089147057b456ca3660de72112167e40a4"
+                "reference": "956101b060a0d898a1ed8c106fd4d81adf25fd87"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeception/lib-innerbrowser/zipball/fd921e089147057b456ca3660de72112167e40a4",
-                "reference": "fd921e089147057b456ca3660de72112167e40a4",
+                "url": "https://api.github.com/repos/Codeception/lib-innerbrowser/zipball/956101b060a0d898a1ed8c106fd4d81adf25fd87",
+                "reference": "956101b060a0d898a1ed8c106fd4d81adf25fd87",
                 "shasum": ""
             },
             "require": {
@@ -435,9 +435,9 @@
             ],
             "support": {
                 "issues": "https://github.com/Codeception/lib-innerbrowser/issues",
-                "source": "https://github.com/Codeception/lib-innerbrowser/tree/1.3.4"
+                "source": "https://github.com/Codeception/lib-innerbrowser/tree/1.3.5"
             },
-            "time": "2020-10-22T05:45:03+00:00"
+            "time": "2021-01-02T18:59:34+00:00"
         },
         {
             "name": "codeception/module-asserts",
@@ -2182,7 +2182,7 @@
         },
         {
             "name": "illuminate/collections",
-            "version": "v8.20.1",
+            "version": "v8.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
@@ -2236,7 +2236,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v8.20.1",
+            "version": "v8.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
@@ -2284,7 +2284,7 @@
         },
         {
             "name": "illuminate/macroable",
-            "version": "v8.20.1",
+            "version": "v8.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
@@ -2330,16 +2330,16 @@
         },
         {
             "name": "illuminate/support",
-            "version": "v8.20.1",
+            "version": "v8.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
-                "reference": "f221a31bfd107d173510e15e34c3aa667c75602d"
+                "reference": "2393bca6dc657b4364cebb59be160ee7a8fa10e3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/support/zipball/f221a31bfd107d173510e15e34c3aa667c75602d",
-                "reference": "f221a31bfd107d173510e15e34c3aa667c75602d",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/2393bca6dc657b4364cebb59be160ee7a8fa10e3",
+                "reference": "2393bca6dc657b4364cebb59be160ee7a8fa10e3",
                 "shasum": ""
             },
             "require": {
@@ -2393,7 +2393,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2020-12-22T16:13:18+00:00"
+            "time": "2020-12-29T15:08:35+00:00"
         },
         {
             "name": "justinrainbow/json-schema",
@@ -3601,17 +3601,62 @@
             "time": "2020-12-19T10:15:11+00:00"
         },
         {
-            "name": "phpstan/phpstan",
-            "version": "0.12.64",
+            "name": "phpstan/extension-installer",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "23eb1cb7ae125f45f1d0e48051bcf67a9a9b08aa"
+                "url": "https://github.com/phpstan/extension-installer.git",
+                "reference": "66c7adc9dfa38b6b5838a9fb728b68a7d8348051"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/23eb1cb7ae125f45f1d0e48051bcf67a9a9b08aa",
-                "reference": "23eb1cb7ae125f45f1d0e48051bcf67a9a9b08aa",
+                "url": "https://api.github.com/repos/phpstan/extension-installer/zipball/66c7adc9dfa38b6b5838a9fb728b68a7d8348051",
+                "reference": "66c7adc9dfa38b6b5838a9fb728b68a7d8348051",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1 || ^2.0",
+                "php": "^7.1 || ^8.0",
+                "phpstan/phpstan": ">=0.11.6"
+            },
+            "require-dev": {
+                "composer/composer": "^1.8",
+                "phing/phing": "^2.16.3",
+                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "phpstan/phpstan-strict-rules": "^0.11 || ^0.12"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPStan\\ExtensionInstaller\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\ExtensionInstaller\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Composer plugin for automatic installation of PHPStan extensions",
+            "support": {
+                "issues": "https://github.com/phpstan/extension-installer/issues",
+                "source": "https://github.com/phpstan/extension-installer/tree/1.1.0"
+            },
+            "time": "2020-12-13T13:06:13+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "0.12.65",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "1c7658668b28f8d647a8b874372acf14c4352688"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/1c7658668b28f8d647a8b874372acf14c4352688",
+                "reference": "1c7658668b28f8d647a8b874372acf14c4352688",
                 "shasum": ""
             },
             "require": {
@@ -3642,7 +3687,7 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/0.12.64"
+                "source": "https://github.com/phpstan/phpstan/tree/0.12.65"
             },
             "funding": [
                 {
@@ -3658,7 +3703,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-12-21T11:59:02+00:00"
+            "time": "2021-01-06T16:51:10+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -7640,16 +7685,16 @@
         },
         {
             "name": "szepeviktor/phpstan-wordpress",
-            "version": "v0.7.1",
+            "version": "v0.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/szepeviktor/phpstan-wordpress.git",
-                "reference": "6195a6a19830d5ad187df0a3fb350e77cd571a5f"
+                "reference": "191eafa7283497645de920d262133cf17de5353f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/szepeviktor/phpstan-wordpress/zipball/6195a6a19830d5ad187df0a3fb350e77cd571a5f",
-                "reference": "6195a6a19830d5ad187df0a3fb350e77cd571a5f",
+                "url": "https://api.github.com/repos/szepeviktor/phpstan-wordpress/zipball/191eafa7283497645de920d262133cf17de5353f",
+                "reference": "191eafa7283497645de920d262133cf17de5353f",
                 "shasum": ""
             },
             "require": {
@@ -7692,7 +7737,7 @@
             ],
             "support": {
                 "issues": "https://github.com/szepeviktor/phpstan-wordpress/issues",
-                "source": "https://github.com/szepeviktor/phpstan-wordpress/tree/v0.7.1"
+                "source": "https://github.com/szepeviktor/phpstan-wordpress/tree/v0.7.2"
             },
             "funding": [
                 {
@@ -7700,7 +7745,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2020-11-05T00:12:19+00:00"
+            "time": "2021-01-03T13:45:42+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,7 +1,9 @@
 parameters:
-    level: 0
+    level: 8
     inferPrivatePropertyTypeFromConstructor: true
+    checkMissingIterableValueType: false
     bootstrapFiles:
+        - phpstan/constants.php
         - wp-graphql.php
         - access-functions.php
     paths:
@@ -11,4 +13,15 @@ parameters:
     ignoreErrors:
         # Uses func_get_args()
         # Ignore any filters that are applied with more than 2 paramaters
-        # '#^Function apply_filters(_ref_array)? invoked with [0[1-9]|1[0-2]] parameters, 2 required\.$#'
+        - '#^Function apply_filters(_ref_array)? invoked with [0[1-9]|1[0-2]] parameters, 2 required\.$#'
+        - "#Access to an undefined property WP_Post_Type::\\$graphql_single_name.#"
+        - "#Access to an undefined property WP_Post_Type::\\$graphql_plural_name.#"
+        - "#Access to an undefined property WP_Post_Type::\\$show_in_graphql.#"
+        - "#Cannot access property \\$graphql_single_name on WP_Taxonomy\\|false.#"
+        - "#Cannot access property \\$graphql_plural_name on WP_Taxonomy\\|false.#"
+        - "#Cannot access property \\$graphql_single_name on WP_Post_Type\\|null.#"
+        - "#Access to an undefined property WP_Taxonomy::\\$graphql_single_name.#"
+        - "#Access to an undefined property WP_Taxonomy::\\$graphql_plural_name.#"
+        - "#Access to an undefined property WP_Taxonomy::\\$show_in_graphql.#"
+        - "#^Parameter \\#1 \\$taxonomy of function get_taxonomy expects string, WP_Taxonomy given.#"
+        - "#^Parameter \\#1 \\$post_type of function get_post_type_object expects string, string|WP_Taxonomy given.#"

--- a/phpstan/constants.php
+++ b/phpstan/constants.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Constants defined in this file are to help phpstan analyze code where constants outside the plugin (WordPress core constants, etc) are being used
+ */
+
+define( 'WP_LANG_DIR', true );
+define( 'SAVEQUERIES', true );
+

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, API, Gatsby, Headless, Decoupled, React, Nextjs, Vue, Apollo, RES
 Requires at least: 5.0
 Tested up to: 5.6
 Requires PHP: 7.1
-Stable tag: 1.0.5
+Stable tag: 1.1.0
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/src/Admin/GraphiQL/GraphiQL.php
+++ b/src/Admin/GraphiQL/GraphiQL.php
@@ -2,6 +2,8 @@
 
 namespace WPGraphQL\Admin\GraphiQL;
 
+use WP_Admin_Bar;
+
 /**
  * Class GraphiQL
  *
@@ -18,6 +20,8 @@ class GraphiQL {
 
 	/**
 	 * Initialize Admin functionality for WPGraphQL
+	 *
+	 * @return void
 	 */
 	public function init() {
 
@@ -41,9 +45,11 @@ class GraphiQL {
 	/**
 	 * Registers admin bar menu
 	 *
-	 * @param \WP_Admin_Bar $admin_bar The Admin Bar Instance
+	 * @param WP_Admin_Bar $admin_bar The Admin Bar Instance
+	 *
+	 * @return void
 	 */
-	public function register_admin_bar_menu( $admin_bar ) {
+	public function register_admin_bar_menu( WP_Admin_Bar $admin_bar ) {
 
 		if ( ! current_user_can( 'manage_options' ) || 'off' === get_graphql_setting( 'show_graphiql_link_in_admin_bar' ) ) {
 			return;
@@ -66,6 +72,8 @@ class GraphiQL {
 
 	/**
 	 * Register the admin page as a subpage
+	 *
+	 * @return void
 	 */
 	public function register_admin_page() {
 		add_submenu_page(
@@ -80,6 +88,8 @@ class GraphiQL {
 
 	/**
 	 * Render the markup to load GraphiQL to
+	 *
+	 * @return void
 	 */
 	public function render_graphiql_admin_page() {
 		echo '<div class="wrap"><div id="graphiql" class="graphiql-container">Loading ...</div></div>';
@@ -88,11 +98,11 @@ class GraphiQL {
 	/**
 	 * Gets the contents of the Create React App manifest file
 	 *
-	 * @return array|bool|string
+	 * @return array
 	 */
 	public function get_app_manifest() {
 		$manifest = file_get_contents( dirname( __FILE__ ) . '/app/build/asset-manifest.json' );
-		$manifest = (array) json_decode( $manifest );
+		$manifest = ! empty( $manifest ) ? (array) json_decode( $manifest ) : [];
 		return $manifest;
 	}
 
@@ -137,15 +147,17 @@ class GraphiQL {
 
 	/**
 	 * Enqueues the stylesheet and js for the WPGraphiQL app
+	 *
+	 * @return void
 	 */
 	public function enqueue_graphiql() {
 
 		/**
 		 * Only enqueue the assets on the proper admin page, and only if WPGraphQL is also active
 		 */
-		if ( strpos( get_current_screen()->id, 'graphiql' ) ) {
+		if ( ! empty( get_current_screen() ) && strpos( get_current_screen()->id, 'graphiql' ) ) {
 
-			wp_enqueue_style( 'graphiql', $this->get_app_stylesheet(), [], false, false );
+			wp_enqueue_style( 'graphiql', $this->get_app_stylesheet(), [], false );
 			wp_enqueue_script( 'graphiql-helpers', $this->get_app_script_helpers(), [ 'jquery' ], false, true );
 			wp_enqueue_script( 'graphiql', $this->get_app_script(), [], false, true );
 

--- a/src/Admin/Settings/Settings.php
+++ b/src/Admin/Settings/Settings.php
@@ -49,6 +49,8 @@ class Settings {
 
 	/**
 	 * Add the options page to the WP Admin
+	 *
+	 * @return void
 	 */
 	public function add_options_page() {
 		add_menu_page(
@@ -73,6 +75,8 @@ class Settings {
 
 	/**
 	 * Registers the initial settings for WPGraphQL
+	 *
+	 * @return void
 	 */
 	public function register_settings() {
 
@@ -174,7 +178,7 @@ class Settings {
 				'type'     => 'checkbox',
 				'default'  => ( 'local' === $this->get_wp_environment() || 'development' === $this->get_wp_environment() ) ? 'on' : 'off',
 				'value'    => true === \WPGraphQL::debug() ? 'on' : get_graphql_setting( 'public_introspection_enabled', 'off' ),
-				'disabled' => true === \WPGraphQL::debug() ? true : false,
+				'disabled' => true === \WPGraphQL::debug(),
 			],
 		] );
 

--- a/src/Admin/Settings/SettingsRegistry.php
+++ b/src/Admin/Settings/SettingsRegistry.php
@@ -33,21 +33,31 @@ class SettingsRegistry {
 
 	/**
 	 * SettingsRegistry constructor.
+	 *
+	 * @return void
 	 */
 	public function __construct() {
 		add_action( 'admin_enqueue_scripts', [ $this, 'admin_enqueue_scripts' ] );
 	}
 
+	/**
+	 * @return array
+	 */
 	public function get_settings_sections() {
 		return $this->settings_sections;
 	}
 
+	/**
+	 * @return array
+	 */
 	public function get_settings_fields() {
 		return $this->settings_fields;
 	}
 
 	/**
 	 * Enqueue scripts and styles
+	 *
+	 * @return void
 	 */
 	function admin_enqueue_scripts() {
 		wp_enqueue_style( 'wp-color-picker' );
@@ -65,7 +75,7 @@ class SettingsRegistry {
 	 *
 	 * @return SettingsRegistry
 	 */
-	function register_section( $slug, $section ) {
+	function register_section( string $slug, array $section ) {
 		$section['id']                    = $slug;
 		$this->settings_sections[ $slug ] = $section;
 
@@ -80,7 +90,7 @@ class SettingsRegistry {
 	 *
 	 * @return SettingsRegistry
 	 */
-	function register_fields( $section, $fields ) {
+	function register_fields( string $section, array $fields ) {
 		foreach ( $fields as $field ) {
 			$this->register_field( $section, $field );
 		}
@@ -96,7 +106,7 @@ class SettingsRegistry {
 	 *
 	 * @return SettingsRegistry
 	 */
-	function register_field( $section, $field ) {
+	function register_field( string $section, array $field ) {
 		$defaults = [
 			'name'  => '',
 			'label' => '',
@@ -137,6 +147,8 @@ class SettingsRegistry {
 	 *
 	 * This function gets the initiated settings sections and fields. Then
 	 * registers them to WordPress and ready for use.
+	 *
+	 * @return void
 	 */
 	function admin_init() {
 
@@ -218,7 +230,7 @@ class SettingsRegistry {
 	 *
 	 * @return string
 	 */
-	public function get_field_description( $args ): string {
+	public function get_field_description( array $args ): string {
 		if ( ! empty( $args['desc'] ) ) {
 			$desc = sprintf( '<p class="description">%s</p>', $args['desc'] );
 		} else {
@@ -232,8 +244,10 @@ class SettingsRegistry {
 	 * Displays a text field for a settings field
 	 *
 	 * @param array $args settings field args
+	 *
+	 * @return void
 	 */
-	function callback_text( $args ) {
+	function callback_text( array $args ) {
 		$value       = isset( $args['value'] ) && ! empty( $args['value'] ) ? esc_attr( $args['value'] ) : esc_attr( $this->get_option( $args['id'], $args['section'], $args['std'] ) );
 		$size        = isset( $args['size'] ) && ! is_null( $args['size'] ) ? $args['size'] : 'regular';
 		$type        = isset( $args['type'] ) ? $args['type'] : 'text';
@@ -242,42 +256,6 @@ class SettingsRegistry {
 		$html        = sprintf( '<input type="%1$s" class="%2$s-text" id="%3$s[%4$s]" name="%3$s[%4$s]" value="%5$s"%6$s %7$s/>', $type, $size, $args['section'], $args['id'], $value, $placeholder, $disabled );
 		$html       .= $this->get_field_description( $args );
 
-		$allowedtags = [
-			'a'          => [
-				'href'  => true,
-				'title' => true,
-			],
-			'abbr'       => [
-				'title' => true,
-			],
-			'acronym'    => [
-				'title' => true,
-			],
-			'b'          => [],
-			'blockquote' => [
-				'cite' => true,
-			],
-			'cite'       => [],
-			'code'       => [],
-			'del'        => [
-				'datetime' => true,
-			],
-			'em'         => [],
-			'i'          => [],
-			'q'          => [
-				'cite' => true,
-			],
-			'strike'     => [],
-			'strong'     => [],
-			'input'      => [
-				'type'    => [],
-				'name'    => [],
-				'value'   => [],
-				'checked' => [],
-			],
-			'p'          => [],
-		];
-
 		echo wp_kses( $html, Utils::get_allowed_wp_kses_html() );
 	}
 
@@ -285,8 +263,10 @@ class SettingsRegistry {
 	 * Displays a url field for a settings field
 	 *
 	 * @param array $args settings field args
+	 *
+	 * @return void
 	 */
-	function callback_url( $args ) {
+	function callback_url( array $args ) {
 		$this->callback_text( $args );
 	}
 
@@ -294,8 +274,10 @@ class SettingsRegistry {
 	 * Displays a number field for a settings field
 	 *
 	 * @param array $args settings field args
+	 *
+	 * @return void
 	 */
-	function callback_number( $args ) {
+	function callback_number( array $args ) {
 		$value       = esc_attr( $this->get_option( $args['id'], $args['section'], $args['std'] ) );
 		$size        = isset( $args['size'] ) && ! is_null( $args['size'] ) ? $args['size'] : 'regular';
 		$type        = isset( $args['type'] ) ? $args['type'] : 'number';
@@ -314,8 +296,10 @@ class SettingsRegistry {
 	 * Displays a checkbox for a settings field
 	 *
 	 * @param array $args settings field args
+	 *
+	 * @return void
 	 */
-	function callback_checkbox( $args ) {
+	function callback_checkbox( array $args ) {
 
 		$value    = isset( $args['value'] ) && ! empty( $args['value'] ) ? esc_attr( $args['value'] ) : esc_attr( $this->get_option( $args['id'], $args['section'], $args['std'] ) );
 		$disabled = isset( $args['disabled'] ) && true === $args['disabled'] ? 'disabled' : null;
@@ -334,8 +318,10 @@ class SettingsRegistry {
 	 * Displays a multicheckbox for a settings field
 	 *
 	 * @param array $args settings field args
+	 *
+	 * @return void
 	 */
-	function callback_multicheck( $args ) {
+	function callback_multicheck( array $args ) {
 
 		$value = $this->get_option( $args['id'], $args['section'], $args['std'] );
 		$html  = '<fieldset>';
@@ -357,8 +343,10 @@ class SettingsRegistry {
 	 * Displays a radio button for a settings field
 	 *
 	 * @param array $args settings field args
+	 *
+	 * @return void
 	 */
-	function callback_radio( $args ) {
+	function callback_radio( array $args ) {
 
 		$value = $this->get_option( $args['id'], $args['section'], $args['std'] );
 		$html  = '<fieldset>';
@@ -379,8 +367,10 @@ class SettingsRegistry {
 	 * Displays a selectbox for a settings field
 	 *
 	 * @param array $args settings field args
+	 *
+	 * @return void
 	 */
-	function callback_select( $args ) {
+	function callback_select( array $args ) {
 
 		$value = esc_attr( $this->get_option( $args['id'], $args['section'], $args['std'] ) );
 		$size  = isset( $args['size'] ) && ! is_null( $args['size'] ) ? $args['size'] : 'regular';
@@ -400,8 +390,10 @@ class SettingsRegistry {
 	 * Displays a textarea for a settings field
 	 *
 	 * @param array $args settings field args
+	 *
+	 * @return void
 	 */
-	function callback_textarea( $args ) {
+	function callback_textarea( array $args ) {
 
 		$value       = esc_textarea( $this->get_option( $args['id'], $args['section'], $args['std'] ) );
 		$size        = isset( $args['size'] ) && ! is_null( $args['size'] ) ? $args['size'] : 'regular';
@@ -418,9 +410,9 @@ class SettingsRegistry {
 	 *
 	 * @param array $args settings field args
 	 *
-	 * @return string
+	 * @return void
 	 */
-	function callback_html( $args ) {
+	function callback_html( array $args ) {
 		echo wp_kses( $this->get_field_description( $args ), Utils::get_allowed_wp_kses_html() );
 	}
 
@@ -428,8 +420,10 @@ class SettingsRegistry {
 	 * Displays a rich text textarea for a settings field
 	 *
 	 * @param array $args settings field args
+	 *
+	 * @return void
 	 */
-	function callback_wysiwyg( $args ) {
+	function callback_wysiwyg( array $args ) {
 
 		$value = $this->get_option( $args['id'], $args['section'], $args['std'] );
 		$size  = isset( $args['size'] ) && ! is_null( $args['size'] ) ? $args['size'] : '500px';
@@ -457,8 +451,10 @@ class SettingsRegistry {
 	 * Displays a file upload field for a settings field
 	 *
 	 * @param array $args settings field args
+	 *
+	 * @return void
 	 */
-	function callback_file( $args ) {
+	function callback_file( array $args ) {
 
 		$value = esc_attr( $this->get_option( $args['id'], $args['section'], $args['std'] ) );
 		$size  = isset( $args['size'] ) && ! is_null( $args['size'] ) ? $args['size'] : 'regular';
@@ -476,8 +472,10 @@ class SettingsRegistry {
 	 * Displays a password field for a settings field
 	 *
 	 * @param array $args settings field args
+	 *
+	 * @return void
 	 */
-	function callback_password( $args ) {
+	function callback_password( array $args ) {
 
 		$value = esc_attr( $this->get_option( $args['id'], $args['section'], $args['std'] ) );
 		$size  = isset( $args['size'] ) && ! is_null( $args['size'] ) ? $args['size'] : 'regular';
@@ -492,6 +490,8 @@ class SettingsRegistry {
 	 * Displays a color picker field for a settings field
 	 *
 	 * @param array $args settings field args
+	 *
+	 * @return void
 	 */
 	function callback_color( $args ) {
 
@@ -509,25 +509,33 @@ class SettingsRegistry {
 	 * Displays a select box for creating the pages select box
 	 *
 	 * @param array $args settings field args
+	 *
+	 * @return void
 	 */
-	function callback_pages( $args ) {
+	function callback_pages( array $args ) {
 
-		$dropdown_args = [
+		$dropdown_args = array_merge( [
 			'selected' => esc_attr( $this->get_option( $args['id'], $args['section'], $args['std'] ) ),
 			'name'     => $args['section'] . '[' . $args['id'] . ']',
 			'id'       => $args['section'] . '[' . $args['id'] . ']',
 			'echo'     => 0,
-		];
-		$html          = wp_dropdown_pages( wp_kses( $dropdown_args, Utils::get_allowed_wp_kses_html() ) );
-		echo wp_kses( $html, Utils::get_allowed_wp_kses_html() );
+		], $args );
+
+		$clean_args = [];
+		foreach ( $dropdown_args as $key => $arg ) {
+			$clean_args[ $key ] = wp_kses( $arg, Utils::get_allowed_wp_kses_html() );
+		}
+		echo wp_dropdown_pages( $clean_args );
 	}
 
 	/**
 	 * Displays a select box for user roles
 	 *
 	 * @param array $args settings field args
+	 *
+	 * @return void
 	 */
-	function callback_user_role_select( $args ) {
+	function callback_user_role_select( array $args ) {
 		$selected = esc_attr( $this->get_option( $args['id'], $args['section'], $args['std'] ) );
 
 		if ( empty( $selected ) ) {
@@ -547,9 +555,11 @@ class SettingsRegistry {
 	/**
 	 * Sanitize callback for Settings API
 	 *
+	 * @param array $options
+	 *
 	 * @return mixed
 	 */
-	function sanitize_options( $options ) {
+	function sanitize_options( array $options ) {
 
 		if ( ! $options ) {
 			return $options;
@@ -619,6 +629,8 @@ class SettingsRegistry {
 	 * Show navigations as tab
 	 *
 	 * Shows all the settings section labels as tab
+	 *
+	 * @return void
 	 */
 	function show_navigation() {
 		$html = '<h2 class="nav-tab-wrapper">';
@@ -643,6 +655,8 @@ class SettingsRegistry {
 	 * Show the section settings forms
 	 *
 	 * This function displays every sections in a different form
+	 *
+	 * @return void
 	 */
 	function show_forms() {
 		?>
@@ -673,6 +687,8 @@ class SettingsRegistry {
 	 * Tabbable JavaScript codes & Initiate Color Picker
 	 *
 	 * This code uses localstorage for displaying active tabs
+	 *
+	 * @return void
 	 */
 	function script() {
 		?>
@@ -684,14 +700,14 @@ class SettingsRegistry {
 				// Switches option sections
 				$('.group').hide();
 				var activetab = '';
-				if (typeof(localStorage) != 'undefined') {
+				if (typeof (localStorage) != 'undefined') {
 					activetab = localStorage.getItem("activetab");
 				}
 
 				//if url has section id as hash then set it as active or override the current local storage value
 				if (window.location.hash) {
 					activetab = window.location.hash;
-					if (typeof(localStorage) != 'undefined') {
+					if (typeof (localStorage) != 'undefined') {
 						localStorage.setItem("activetab", activetab);
 					}
 				}
@@ -714,15 +730,14 @@ class SettingsRegistry {
 
 				if (activetab != '' && $(activetab + '-tab').length) {
 					$(activetab + '-tab').addClass('nav-tab-active');
-				}
-				else {
+				} else {
 					$('.nav-tab-wrapper a:first').addClass('nav-tab-active');
 				}
 				$('.nav-tab-wrapper a').click(function (evt) {
 					$('.nav-tab-wrapper a').removeClass('nav-tab-active');
 					$(this).addClass('nav-tab-active').blur();
 					var clicked_group = $(this).attr('href');
-					if (typeof(localStorage) != 'undefined') {
+					if (typeof (localStorage) != 'undefined') {
 						localStorage.setItem("activetab", $(this).attr('href'));
 					}
 					$('.group').hide();
@@ -758,6 +773,11 @@ class SettingsRegistry {
 		$this->_style_fix();
 	}
 
+	/**
+	 * Add styles to adjust some settings
+	 *
+	 * @return void
+	 */
 	function _style_fix() {
 		global $wp_version;
 

--- a/src/AppContext.php
+++ b/src/AppContext.php
@@ -3,11 +3,11 @@
 namespace WPGraphQL;
 
 use GraphQL\Error\UserError;
+use WP_User;
 use WPGraphQL\Data\Loader\CommentAuthorLoader;
 use WPGraphQL\Data\Loader\CommentLoader;
 use WPGraphQL\Data\Loader\EnqueuedScriptLoader;
 use WPGraphQL\Data\Loader\EnqueuedStylesheetLoader;
-use WPGraphQL\Data\Loader\MenuItemLoader;
 use WPGraphQL\Data\Loader\PluginLoader;
 use WPGraphQL\Data\Loader\PostObjectLoader;
 use WPGraphQL\Data\Loader\PostTypeLoader;
@@ -17,7 +17,7 @@ use WPGraphQL\Data\Loader\ThemeLoader;
 use WPGraphQL\Data\Loader\UserLoader;
 use WPGraphQL\Data\Loader\UserRoleLoader;
 use WPGraphQL\Data\NodeResolver;
-use WPGraphQL\Model\Term;
+use WPGraphQL\Registry\TypeRegistry;
 
 /**
  * Class AppContext
@@ -42,28 +42,33 @@ class AppContext {
 	/**
 	 * Stores the WP_User object of the current user
 	 *
-	 * @var \WP_User $viewer
+	 * @var WP_User $viewer
 	 */
 	public $viewer;
 
 	/**
+	 * @var TypeRegistry
+	 */
+	public $type_registry;
+
+	/**
 	 * Stores everything from the $_REQUEST global
 	 *
-	 * @var \mixed $request
+	 * @var mixed $request
 	 */
 	public $request;
 
 	/**
 	 * Stores additional $config properties
 	 *
-	 * @var \mixed $config
+	 * @var mixed $config
 	 */
 	public $config;
 
 	/**
 	 * Passes context about the current connection being resolved
 	 *
-	 * @var mixed| String | null
+	 * @var mixed|String|null
 	 */
 	public $currentConnection = null;
 
@@ -124,7 +129,7 @@ class AppContext {
 		/**
 		 * This sets up the NodeResolver to allow nodes to be resolved by URI
 		 *
-		 * @param AppContext $this The AppContext instance
+		 * @param AppContext $app_context The AppContext instance
 		 */
 		$this->node_resolver = new NodeResolver( $this );
 

--- a/src/Connection/Commenter.php
+++ b/src/Connection/Commenter.php
@@ -14,6 +14,8 @@ class Commenter {
 
 	/**
 	 * Register connections to Commenter type
+	 *
+	 * @return void
 	 */
 	public static function register_connections() {
 

--- a/src/Connection/Comments.php
+++ b/src/Connection/Comments.php
@@ -2,6 +2,7 @@
 
 namespace WPGraphQL\Connection;
 
+use Exception;
 use WPGraphQL\Data\Connection\CommentConnectionResolver;
 use WPGraphQL\Data\DataSource;
 use WPGraphQL\Model\Comment;
@@ -19,6 +20,9 @@ class Comments {
 
 	/**
 	 * Register connections to Comments
+	 *
+	 * @return void
+	 * @throws Exception
 	 */
 	public static function register_connections() {
 
@@ -77,6 +81,11 @@ class Comments {
 		if ( ! empty( $allowed_post_types ) && is_array( $allowed_post_types ) ) {
 			foreach ( $allowed_post_types as $post_type ) {
 				$post_type_object = get_post_type_object( $post_type );
+
+				if ( empty( $post_type_object ) ) {
+					return;
+				}
+
 				if ( post_type_supports( $post_type_object->name, 'comments' ) ) {
 					register_graphql_connection(
 						self::get_connection_config(

--- a/src/Connection/ContentTypes.php
+++ b/src/Connection/ContentTypes.php
@@ -9,6 +9,11 @@ use WPGraphQL\Model\Taxonomy;
 
 class ContentTypes {
 
+	/**
+	 * Registers connections to the ContentType Type
+	 *
+	 * @return void
+	 */
 	public static function register_connections() {
 
 		/**

--- a/src/Connection/EnqueuedScripts.php
+++ b/src/Connection/EnqueuedScripts.php
@@ -12,6 +12,8 @@ class EnqueuedScripts {
 
 	/**
 	 * Register connections to Enqueued Assets
+	 *
+	 * @return void
 	 */
 	public static function register_connections() {
 

--- a/src/Connection/EnqueuedStylesheets.php
+++ b/src/Connection/EnqueuedStylesheets.php
@@ -12,6 +12,8 @@ class EnqueuedStylesheets {
 
 	/**
 	 * Register connections to Enqueued Assets
+	 *
+	 * @return void
 	 */
 	public static function register_connections() {
 

--- a/src/Connection/MediaItems.php
+++ b/src/Connection/MediaItems.php
@@ -15,6 +15,8 @@ class MediaItems {
 
 	/**
 	 * Register connections to MediaItems
+	 *
+	 * @return void
 	 */
 	public static function register_connections() {
 

--- a/src/Connection/MenuItemLinkableConnection.php
+++ b/src/Connection/MenuItemLinkableConnection.php
@@ -9,6 +9,11 @@ use WPGraphQL\Model\MenuItem;
 
 class MenuItemLinkableConnection {
 
+	/**
+	 * Registers connections to the MenuItemLinkable type
+	 *
+	 * @return void
+	 */
 	public static function register_connections() {
 
 		register_graphql_connection([

--- a/src/Connection/MenuItems.php
+++ b/src/Connection/MenuItems.php
@@ -19,6 +19,8 @@ class MenuItems {
 
 	/**
 	 * Register connections to MenuItems
+	 *
+	 * @return void
 	 */
 	public static function register_connections() {
 

--- a/src/Connection/Menus.php
+++ b/src/Connection/Menus.php
@@ -18,6 +18,8 @@ class Menus {
 
 	/**
 	 * Registers connections to Menus
+	 *
+	 * @return void
 	 */
 	public static function register_connections() {
 

--- a/src/Connection/Plugins.php
+++ b/src/Connection/Plugins.php
@@ -15,6 +15,8 @@ class Plugins {
 
 	/**
 	 * Register connections to Plugins
+	 *
+	 * @return void
 	 */
 	public static function register_connections() {
 		register_graphql_connection(

--- a/src/Connection/Revisions.php
+++ b/src/Connection/Revisions.php
@@ -10,6 +10,8 @@ class Revisions {
 	 * Register connections to Revisions
 	 *
 	 * @param TypeRegistry $type_registry Instance of the TypeRegistry
+	 *
+	 * @return void
 	 */
 	public static function register_connections( TypeRegistry $type_registry ) {
 

--- a/src/Connection/Taxonomies.php
+++ b/src/Connection/Taxonomies.php
@@ -7,6 +7,12 @@ use WPGraphQL\Model\PostType;
 use WPGraphQL\Model\Term;
 
 class Taxonomies {
+
+	/**
+	 * Registers connections to the Taxonomy type
+	 *
+	 * @return void
+	 */
 	public static function register_connections() {
 
 		register_graphql_connection(

--- a/src/Connection/Themes.php
+++ b/src/Connection/Themes.php
@@ -16,6 +16,8 @@ class Themes {
 
 	/**
 	 * Register the connections
+	 *
+	 * @return void
 	 */
 	public static function register_connections() {
 

--- a/src/Connection/UserRoles.php
+++ b/src/Connection/UserRoles.php
@@ -17,6 +17,8 @@ class UserRoles {
 
 	/**
 	 * Register the connections
+	 *
+	 * @return void
 	 */
 	public static function register_connections() {
 

--- a/src/Connection/Users.php
+++ b/src/Connection/Users.php
@@ -20,6 +20,8 @@ class Users {
 
 	/**
 	 * Register connections to Users
+	 *
+	 * @return void
 	 */
 	public static function register_connections() {
 
@@ -50,7 +52,7 @@ class Users {
 						if ( isset( $edge['source'] ) && ( $edge['source'] instanceof Post ) ) {
 							$edit_lock = $edge['source']->editLock;
 							$time      = ( is_array( $edit_lock ) && ! empty( $edit_lock[0] ) ) ? $edit_lock[0] : null;
-							return ! empty( $time ) ? Utils::prepare_date_response( null, gmdate( 'Y-m-d H:i:s', $time ) ) : null;
+							return ! empty( $time ) ? Utils::prepare_date_response( $time, gmdate( 'Y-m-d H:i:s', $time ) ) : null;
 						}
 						return null;
 					},

--- a/src/Data/CommentMutation.php
+++ b/src/Data/CommentMutation.php
@@ -2,6 +2,7 @@
 
 namespace WPGraphQL\Data;
 
+use Exception;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
@@ -17,12 +18,14 @@ class CommentMutation {
 	 * This handles inserting the comment and creating
 	 *
 	 * @param array  $input         The input for the mutation
+	 * @param array  $output_args   The output args
 	 * @param string $mutation_name The name of the mutation being performed
+	 * @param bool   $update        Whether it's an update action
 	 *
 	 * @return array $output_args
-	 * @throws \Exception
+	 * @throws Exception
 	 */
-	public static function prepare_comment_object( $input, &$output_args, $mutation_name, $update = false ) {
+	public static function prepare_comment_object( array $input, array &$output_args, string $mutation_name, $update = false ) {
 		/**
 		 * Prepare the data for inserting the comment
 		 * NOTE: These are organized in the same order as: https://developer.wordpress.org/reference/functions/wp_insert_comment/
@@ -44,7 +47,7 @@ class CommentMutation {
 			$output_args['user_id']              = $user->ID;
 			$output_args['comment_author']       = $user->display_name;
 			$output_args['comment_author_email'] = $user->user_email;
-			if ( ! is_null( $user->user_url ) ) {
+			if ( ! empty( $user->user_url ) ) {
 				$output_args['comment_author_url'] = $user->user_url;
 			}
 		} else {
@@ -105,18 +108,19 @@ class CommentMutation {
 	/**
 	 * This updates commentmeta.
 	 *
-	 * @param int         $comment_id              The ID of the postObject the comment is connected to
-	 * @param array       $input                   The input for the mutation
-	 * @param string      $mutation_name           The name of the mutation ( ex: create, update, delete )
-	 * @param AppContext  $context                 The AppContext passed down to all resolvers
-	 * @param ResolveInfo $info                    The ResolveInfo passed down to all resolvers
-	 * @param string      $intended_comment_status The intended post_status the post should have according to the mutation input
-	 * @param string      $intended_comment_status The default status posts should use if an intended status wasn't set
+	 * @param int         $comment_id    The ID of the postObject the comment is connected to
+	 * @param array       $input         The input for the mutation
+	 * @param string      $mutation_name The name of the mutation ( ex: create, update, delete )
+	 * @param AppContext  $context       The AppContext passed down to all resolvers
+	 * @param ResolveInfo $info          The ResolveInfo passed down to all resolvers
+	 *
+	 * @return void
 	 */
-	public static function update_additional_comment_data( $comment_id, $input, $mutation_name, AppContext $context, ResolveInfo $info ) {
+	public static function update_additional_comment_data( int $comment_id, array $input, string $mutation_name, AppContext $context, ResolveInfo $info ) {
+
 		/**
-		* @todo: should account for authentication
-		*/
+		 * @todo: should account for authentication
+		 */
 		$intended_comment_status = 0;
 		$default_comment_status  = 0;
 

--- a/src/Data/Config.php
+++ b/src/Data/Config.php
@@ -2,6 +2,7 @@
 
 namespace WPGraphQL\Data;
 
+use WP_Comment_Query;
 use WPGraphQL\Data\Cursor\PostObjectCursor;
 use WPGraphQL\Data\Cursor\UserCursor;
 
@@ -288,11 +289,11 @@ class Config {
 	 * is a GraphQL Request and the query has a graphql_cursor_offset defined
 	 *
 	 * @param array             $pieces A compacted array of comment query clauses.
-	 * @param \WP_Comment_Query $query  Current instance of WP_Comment_Query, passed by reference.
+	 * @param WP_Comment_Query $query  Current instance of WP_Comment_Query, passed by reference.
 	 *
 	 * @return array $pieces
 	 */
-	public function graphql_wp_comments_query_cursor_pagination_support( array $pieces, \WP_Comment_Query $query ) {
+	public function graphql_wp_comments_query_cursor_pagination_support( array $pieces, WP_Comment_Query $query ) {
 
 		/**
 		 * Access the global $wpdb object
@@ -311,7 +312,7 @@ class Config {
 			 */
 			if ( is_integer( $cursor_offset ) && 0 < $cursor_offset ) {
 
-				$compare = ! empty( $query->get( 'graphql_cursor_compare' ) ) ? $query->get( 'graphql_cursor_compare' ) : '>';
+				$compare = ! empty( $query->query_vars['graphql_cursor_compare'] ) ? $query->query_vars['graphql_cursor_compare'] : '>';
 				$compare = in_array( $compare, [ '>', '<' ], true ) ? $compare : '>';
 
 				$order_by      = ! empty( $query->query_vars['order_by'] ) ? $query->query_vars['order_by'] : 'comment_date';

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -2,6 +2,7 @@
 
 namespace WPGraphQL\Data\Connection;
 
+use Exception;
 use GraphQL\Deferred;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
@@ -121,14 +122,16 @@ abstract class AbstractConnectionResolver {
 	/**
 	 * ConnectionResolver constructor.
 	 *
-	 * @param $source
-	 * @param $args
-	 * @param $context
-	 * @param $info
+	 * @param mixed       $source  source passed down from the resolve tree
+	 * @param array       $args    array of arguments input in the field as part of the GraphQL
+	 *                             query
+	 * @param AppContext  $context Object containing app context that gets passed down the resolve
+	 *                             tree
+	 * @param ResolveInfo $info    Info about fields passed down the resolve tree
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
-	public function __construct( $source, $args, $context, $info ) {
+	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info ) {
 
 		// Bail if the Post->ID is empty, as that indicates a private post.
 		if ( $source instanceof Post && empty( $source->ID ) ) {
@@ -178,9 +181,9 @@ abstract class AbstractConnectionResolver {
 		 *
 		 * Filters the args
 		 *
-		 * @param array                      $query_args The query args to be used with the executable query to get data.
-		 *                                               This should take in the GraphQL args and return args for use in fetching the data.
-		 * @param AbstractConnectionResolver $this       Instance of the ConnectionResolver
+		 * @param array                      $query_args                   The query args to be used with the executable query to get data.
+		 *                                                                 This should take in the GraphQL args and return args for use in fetching the data.
+		 * @param AbstractConnectionResolver $connection_resolver          Instance of the ConnectionResolver
 		 */
 		$this->query_args = apply_filters( 'graphql_connection_query_args', $this->get_query_args(), $this );
 
@@ -198,13 +201,13 @@ abstract class AbstractConnectionResolver {
 	/**
 	 * Get the loader name
 	 *
-	 * @throws \Exception
 	 * @return AbstractDataLoader
+	 * @throws Exception
 	 */
 	protected function getLoader() {
 		$name = $this->get_loader_name();
 		if ( empty( $name ) || ! is_string( $name ) ) {
-			throw new \Exception( __( 'The Connection Resolver needs to define a loader name', 'wp-graphql' ) );
+			throw new Exception( __( 'The Connection Resolver needs to define a loader name', 'wp-graphql' ) );
 		}
 
 		return $this->context->get_loader( $name );
@@ -269,6 +272,7 @@ abstract class AbstractConnectionResolver {
 	 */
 	public function set_query_arg( $key, $value ) {
 		$this->query_args[ $key ] = $value;
+
 		return $this;
 	}
 
@@ -279,6 +283,7 @@ abstract class AbstractConnectionResolver {
 	 */
 	public function one_to_one() {
 		$this->one_to_one = true;
+
 		return $this;
 	}
 
@@ -354,6 +359,8 @@ abstract class AbstractConnectionResolver {
 	 * exists. Offset is equivalent to WordPress ID (e.g post_id, term_id). So this function is
 	 * equivalent to checking if the WordPress object exists for the given ID.
 	 *
+	 * @param mixed $offset The offset to validate. Typically a WordPress Database ID
+	 *
 	 * @return bool
 	 */
 	abstract public function is_valid_offset( $offset );
@@ -361,10 +368,11 @@ abstract class AbstractConnectionResolver {
 	/**
 	 * Given an ID, return the model for the entity or null
 	 *
-	 * @param $id
+	 * @param mixed $id The ID to identify the object by. Could be a database ID or an in-memory ID
+	 *                  (like post_type name)
 	 *
 	 * @return mixed|Model|null
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function get_node_by_id( $id ) {
 		return $this->loader->load( $id );
@@ -377,7 +385,7 @@ abstract class AbstractConnectionResolver {
 	 * ensure that queries don't exceed unwanted limits when querying data.
 	 *
 	 * @return int
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function get_query_amount() {
 
@@ -407,7 +415,7 @@ abstract class AbstractConnectionResolver {
 	 * This checks the $args to determine the amount requested, and if
 	 *
 	 * @return int|null
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function get_amount_requested() {
 
@@ -452,7 +460,7 @@ abstract class AbstractConnectionResolver {
 		 * This filter allows to modify the requested connection page size
 		 *
 		 * @param int                        $amount the requested amount
-		 * @param AbstractConnectionResolver $this Instance of the connection resolver class
+		 * @param AbstractConnectionResolver $this   Instance of the connection resolver class
 		 */
 		return max( 0, apply_filters( 'graphql_connection_amount_requested', $amount_requested, $this ) );
 
@@ -572,7 +580,7 @@ abstract class AbstractConnectionResolver {
 	 * For backward pagination, we reverse the order of nodes.
 	 *
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function get_nodes() {
 		if ( empty( $this->ids ) ) {
@@ -595,7 +603,7 @@ abstract class AbstractConnectionResolver {
 					$ids = array_slice( $ids, 0, $key, true );
 					// Slice the array from the front
 				} else {
-					$key++;
+					$key ++;
 					$ids = array_slice( $ids, $key, null, true );
 				}
 			}
@@ -607,6 +615,7 @@ abstract class AbstractConnectionResolver {
 				$nodes[ $id ] = $model;
 			}
 		}
+
 		return $nodes;
 	}
 
@@ -616,12 +625,13 @@ abstract class AbstractConnectionResolver {
 	 * If model isn't a class with a `fields` member, this function with have be overridden in
 	 * the Connection class.
 	 *
-	 * @param array $model model.
+	 * @param mixed $model The model being validated
 	 *
 	 * @return bool
 	 */
 	protected function is_valid_model( $model ) {
-		return isset( $model ) && ! empty( $model->fields );
+
+		return isset( $model->fields ) && ! empty( $model->fields );
 	}
 
 	/**
@@ -658,8 +668,8 @@ abstract class AbstractConnectionResolver {
 				/**
 				 * Create the edge, pass it through a filter.
 				 *
-				 * @param array                      $edge The edge within the connection
-				 * @param AbstractConnectionResolver $this Instance of the connection resolver class
+				 * @param array                      $edge                The edge within the connection
+				 * @param AbstractConnectionResolver $connection_resolver Instance of the connection resolver class
 				 */
 				$edge = apply_filters(
 					'graphql_connection_edge',
@@ -731,7 +741,7 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * @return array
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function execute_and_get_ids() {
 
@@ -749,8 +759,8 @@ abstract class AbstractConnectionResolver {
 		 *
 		 * Filter whether the connection should execute.
 		 *
-		 * @param bool                       $should_execute Whether the connection should execute
-		 * @param AbstractConnectionResolver $this           Instance of the Connection Resolver
+		 * @param bool                       $should_execute      Whether the connection should execute
+		 * @param AbstractConnectionResolver $connection_resolver Instance of the Connection Resolver
 		 */
 		$this->should_execute = apply_filters( 'graphql_connection_should_execute', $should_execute, $this );
 		if ( false === $this->should_execute ) {
@@ -773,16 +783,16 @@ abstract class AbstractConnectionResolver {
 		 * the query to that instead of a native WP_Query class. You could override this with a
 		 * query to that datasource instead.
 		 *
-		 * @param mixed                      $query Instance of the Query for the resolver
-		 * @param AbstractConnectionResolver $this  Instance of the Connection Resolver
+		 * @param mixed                      $query               Instance of the Query for the resolver
+		 * @param AbstractConnectionResolver $connection_resolver Instance of the Connection Resolver
 		 */
 		$this->query = apply_filters( 'graphql_connection_query', $this->get_query(), $this );
 
 		/**
 		 * Filter the connection IDs
 		 *
-		 * @param array                      $ids  Array of IDs this connection will be resolving
-		 * @param AbstractConnectionResolver $this Instance of the Connection Resolver
+		 * @param array                      $ids                 Array of IDs this connection will be resolving
+		 * @param AbstractConnectionResolver $connection_resolver Instance of the Connection Resolver
 		 */
 		$this->ids = apply_filters( 'graphql_connection_ids', $this->get_ids(), $this );
 
@@ -806,7 +816,7 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * @return mixed|array|Deferred
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function get_connection() {
 
@@ -828,16 +838,16 @@ abstract class AbstractConnectionResolver {
 				 *
 				 * Filters the nodes in the connection
 				 *
-				 * @param array                      $nodes The nodes in the connection
-				 * @param AbstractConnectionResolver $this  Instance of the Connection Resolver
+				 * @param array                      $nodes               The nodes in the connection
+				 * @param AbstractConnectionResolver $connection_resolver Instance of the Connection Resolver
 				 */
 				$this->nodes = apply_filters( 'graphql_connection_nodes', $this->get_nodes(), $this );
 
 				/**
 				 * Filters the edges in the connection
 				 *
-				 * @param array                      $nodes The nodes in the connection
-				 * @param AbstractConnectionResolver $this  Instance of the Connection Resolver
+				 * @param array                      $nodes               The nodes in the connection
+				 * @param AbstractConnectionResolver $connection_resolver Instance of the Connection Resolver
 				 */
 				$this->edges = apply_filters( 'graphql_connection_edges', $this->get_edges(), $this );
 
@@ -859,8 +869,8 @@ abstract class AbstractConnectionResolver {
 				 *
 				 * This filter allows additional fields to be returned to the connection resolver
 				 *
-				 * @param array                      $connection The connection data being returned
-				 * @param AbstractConnectionResolver $this       The instance of the connection resolver
+				 * @param array                      $connection          The connection data being returned
+				 * @param AbstractConnectionResolver $connection_resolver The instance of the connection resolver
 				 */
 				return apply_filters( 'graphql_connection', $connection, $this );
 

--- a/src/Data/Connection/CommentConnectionResolver.php
+++ b/src/Data/Connection/CommentConnectionResolver.php
@@ -2,12 +2,10 @@
 
 namespace WPGraphQL\Data\Connection;
 
+use Exception;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
-use WPGraphQL\Model\Comment;
-use WPGraphQL\Model\Post;
-use WPGraphQL\Model\User;
 use WPGraphQL\Types;
 
 /**
@@ -19,7 +17,7 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 
 	/**
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function get_query_args() {
 
@@ -137,7 +135,7 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 	 * Return the instance of the WP_Comment_Query
 	 *
 	 * @return mixed|\WP_Comment_Query
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function get_query() {
 		return new \WP_Comment_Query( $this->query_args );
@@ -154,7 +152,7 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 
 	/**
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function get_ids() {
 		return ! empty( $this->query->get_comments() ) ? $this->query->get_comments() : [];

--- a/src/Data/Connection/ContentTypeConnectionResolver.php
+++ b/src/Data/Connection/ContentTypeConnectionResolver.php
@@ -1,6 +1,10 @@
 <?php
 namespace WPGraphQL\Data\Connection;
 
+use Exception;
+use GraphQL\Type\Definition\ResolveInfo;
+use WPGraphQL\AppContext;
+
 /**
  * Class ContentTypeConnectionResolver
  *
@@ -11,14 +15,14 @@ class ContentTypeConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * ContentTypeConnectionResolver constructor.
 	 *
-	 * @param $source
-	 * @param $args
-	 * @param $context
-	 * @param $info
+	 * @param mixed       $source     source passed down from the resolve tree
+	 * @param array       $args       array of arguments input in the field as part of the GraphQL query
+	 * @param AppContext  $context    Object containing app context that gets passed down the resolve tree
+	 * @param ResolveInfo $info       Info about fields passed down the resolve tree
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
-	public function __construct( $source, $args, $context, $info ) {
+	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info ) {
 		parent::__construct( $source, $args, $context, $info );
 	}
 
@@ -99,7 +103,7 @@ class ContentTypeConnectionResolver extends AbstractConnectionResolver {
 	 * For backward pagination, we reverse the order of nodes.
 	 *
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function get_nodes() {
 
@@ -134,7 +138,7 @@ class ContentTypeConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * Determine if the offset used for pagination is valid
 	 *
-	 * @param $offset
+	 * @param mixed $offset
 	 *
 	 * @return bool
 	 */

--- a/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
@@ -1,6 +1,8 @@
 <?php
 namespace WPGraphQL\Data\Connection;
+use Exception;
 use GraphQL\Type\Definition\ResolveInfo;
+use WPGraphQL\AppContext;
 
 /**
  * Class EnqueuedScriptsConnectionResolver
@@ -12,14 +14,14 @@ class EnqueuedScriptsConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * EnqueuedScriptsConnectionResolver constructor.
 	 *
-	 * @param $source
-	 * @param $args
-	 * @param $context
-	 * @param $info
+	 * @param mixed       $source     source passed down from the resolve tree
+	 * @param array       $args       array of arguments input in the field as part of the GraphQL query
+	 * @param AppContext  $context    Object containing app context that gets passed down the resolve tree
+	 * @param ResolveInfo $info       Info about fields passed down the resolve tree
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
-	public function __construct( $source, $args, $context, $info ) {
+	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info ) {
 
 		/**
 		 * Filter the query amount to be 1000 for
@@ -91,7 +93,7 @@ class EnqueuedScriptsConnectionResolver extends AbstractConnectionResolver {
 	 * For backward pagination, we reverse the order of nodes.
 	 *
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function get_nodes() {
 
@@ -137,7 +139,7 @@ class EnqueuedScriptsConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * Determine if the offset used for pagination is valid
 	 *
-	 * @param $offset
+	 * @param mixed $offset
 	 *
 	 * @return bool
 	 */

--- a/src/Data/Connection/EnqueuedStylesheetConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedStylesheetConnectionResolver.php
@@ -1,6 +1,8 @@
 <?php
 namespace WPGraphQL\Data\Connection;
+use Exception;
 use GraphQL\Type\Definition\ResolveInfo;
+use WPGraphQL\AppContext;
 
 /**
  * Class EnqueuedStylesheetConnectionResolver
@@ -12,14 +14,14 @@ class EnqueuedStylesheetConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * EnqueuedStylesheetConnectionResolver constructor.
 	 *
-	 * @param $source
-	 * @param $args
-	 * @param $context
-	 * @param $info
+	 * @param mixed       $source     source passed down from the resolve tree
+	 * @param array       $args       array of arguments input in the field as part of the GraphQL query
+	 * @param AppContext  $context    Object containing app context that gets passed down the resolve tree
+	 * @param ResolveInfo $info       Info about fields passed down the resolve tree
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
-	public function __construct( $source, $args, $context, $info ) {
+	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info ) {
 
 		/**
 		 * Filter the query amount to be 1000 for
@@ -91,7 +93,7 @@ class EnqueuedStylesheetConnectionResolver extends AbstractConnectionResolver {
 	 * For backward pagination, we reverse the order of nodes.
 	 *
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function get_nodes() {
 
@@ -137,7 +139,7 @@ class EnqueuedStylesheetConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * Determine if the offset used for pagination is valid
 	 *
-	 * @param $offset
+	 * @param mixed $offset
 	 *
 	 * @return bool
 	 */

--- a/src/Data/Connection/MenuConnectionResolver.php
+++ b/src/Data/Connection/MenuConnectionResolver.php
@@ -2,6 +2,8 @@
 
 namespace WPGraphQL\Data\Connection;
 
+use Exception;
+
 /**
  * Class MenuConnectionResolver
  *
@@ -13,7 +15,7 @@ class MenuConnectionResolver extends TermObjectConnectionResolver {
 	 * Get the connection args for use in WP_Term_Query to query the menus
 	 *
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function get_query_args() {
 		$term_args = [

--- a/src/Data/Connection/MenuItemConnectionResolver.php
+++ b/src/Data/Connection/MenuItemConnectionResolver.php
@@ -1,6 +1,7 @@
 <?php
 namespace WPGraphQL\Data\Connection;
 
+use Exception;
 use GraphQLRelay\Relay;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
@@ -15,12 +16,12 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 	/**
 	 * MenuItemConnectionResolver constructor.
 	 *
-	 * @param             $source
-	 * @param array       $args
-	 * @param AppContext  $context
-	 * @param ResolveInfo $info
+	 * @param mixed       $source     source passed down from the resolve tree
+	 * @param array       $args       array of arguments input in the field as part of the GraphQL query
+	 * @param AppContext  $context    Object containing app context that gets passed down the resolve tree
+	 * @param ResolveInfo $info       Info about fields passed down the resolve tree
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info ) {
 		parent::__construct( $source, $args, $context, $info, 'nav_menu_item' );
@@ -32,7 +33,8 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 	 * @return array
 	 */
 	public function get_query_args() {
-		$menu_locations = get_theme_mod( 'nav_menu_locations', [] );
+
+		$menu_locations = get_theme_mod( 'nav_menu_locations' );
 
 		$query_args = [
 			'orderby' => 'menu_order',

--- a/src/Data/Connection/PluginConnectionResolver.php
+++ b/src/Data/Connection/PluginConnectionResolver.php
@@ -1,6 +1,10 @@
 <?php
 namespace WPGraphQL\Data\Connection;
 
+use Exception;
+use GraphQL\Type\Definition\ResolveInfo;
+use WPGraphQL\AppContext;
+
 /**
  * Class PluginConnectionResolver - Connects plugins to other objects
  *
@@ -12,14 +16,14 @@ class PluginConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * PluginConnectionResolver constructor.
 	 *
-	 * @param $source
-	 * @param $args
-	 * @param $context
-	 * @param $info
+	 * @param mixed       $source     source passed down from the resolve tree
+	 * @param array       $args       array of arguments input in the field as part of the GraphQL query
+	 * @param AppContext  $context    Object containing app context that gets passed down the resolve tree
+	 * @param ResolveInfo $info       Info about fields passed down the resolve tree
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
-	public function __construct( $source, $args, $context, $info ) {
+	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info ) {
 		parent::__construct( $source, $args, $context, $info );
 	}
 
@@ -73,7 +77,7 @@ class PluginConnectionResolver extends AbstractConnectionResolver {
 
 	/**
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function get_nodes() {
 		$nodes = parent::get_nodes();
@@ -102,7 +106,7 @@ class PluginConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * @param $offset
+	 * @param mixed $offset
 	 *
 	 * @return bool
 	 */

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -2,6 +2,7 @@
 
 namespace WPGraphQL\Data\Connection;
 
+use Exception;
 use GraphQL\Error\InvariantViolation;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
@@ -25,17 +26,17 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * PostObjectConnectionResolver constructor.
 	 *
-	 * @param mixed       $source                         The object passed down from the previous
-	 *                                                    level in the Resolve tree
-	 * @param array       $args                           The input arguments for the query
-	 * @param AppContext  $context                        The context of the request
-	 * @param ResolveInfo $info                           The resolve info passed down the Resolve
-	 *                                                    tree
-	 * @param mixed string|array $post_type The post type to resolve for
+	 * @param mixed              $source    source passed down from the resolve tree
+	 * @param array              $args      array of arguments input in the field as part of the
+	 *                                      GraphQL query
+	 * @param AppContext         $context   Object containing app context that gets passed down the
+	 *                                      resolve tree
+	 * @param ResolveInfo        $info      Info about fields passed down the resolve tree
+	 * @param mixed|string|array $post_type The post type to resolve for
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
-	public function __construct( $source, $args, $context, $info, $post_type = 'any' ) {
+	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info, $post_type = 'any' ) {
 
 		/**
 		 * The $post_type can either be a single value or an array of post_types to
@@ -82,7 +83,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	 *
 	 * @return \WP_Query
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function get_query() {
 
@@ -130,7 +131,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 
 			if ( $this->source instanceof Post ) {
 				$parent_post_type_obj = get_post_type_object( $this->source->post_type );
-				if ( ! current_user_can( $parent_post_type_obj->cap->edit_post, $this->source->ID ) ) {
+				if ( ! isset( $parent_post_type_obj->cap->edit_post ) || ! current_user_can( $parent_post_type_obj->cap->edit_post, $this->source->ID ) ) {
 					$this->should_execute = false;
 				}
 				/**
@@ -279,7 +280,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 							$ids = array_slice( $ids, 0, $key, true );
 							// Slice the array from the front
 						} else {
-							$key++;
+							$key ++;
 							$ids = array_slice( $ids, $key, null, true );
 						}
 					}
@@ -366,10 +367,12 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	 * this was quick. I'd be down to explore more dynamic ways to map this, but for
 	 * now this gets the job done.
 	 *
-	 * @since  0.0.5
+	 * @param array $where_args The args passed to the connection
+	 *
 	 * @return array
+	 * @since  0.0.5
 	 */
-	public function sanitize_input_fields( $where_args ) {
+	public function sanitize_input_fields( array $where_args ) {
 
 		$arg_mapping = [
 			'authorName'    => 'author_name',
@@ -423,8 +426,8 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		 * @param ResolveInfo        $info       The ResolveInfo object
 		 * @param mixed|string|array $post_type  The post type for the query
 		 *
-		 * @since 0.0.5
 		 * @return array
+		 * @since 0.0.5
 		 */
 		$query_args = apply_filters( 'graphql_map_input_fields_to_wp_query', $query_args, $where_args, $this->source, $this->args, $this->context, $this->info, $this->post_type );
 
@@ -443,7 +446,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	 * This strips the status from the query_args if the user doesn't have permission to query for
 	 * posts of that status.
 	 *
-	 * @param $stati
+	 * @param mixed $stati The status(es) to sanitize
 	 *
 	 * @return array|null
 	 */
@@ -486,11 +489,16 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 						if ( 'publish' === $status ) {
 							return $status;
 						}
-						if ( current_user_can( $post_type_object->cap->edit_posts ) || 'private' === $status && current_user_can( $post_type_object->cap->read_private_posts ) ) {
-							return $status;
-						} else {
+
+						if ( 'private' === $status && ( ! isset( $post_type_object->cap->read_private_posts ) || ! current_user_can( $post_type_object->cap->read_private_posts ) ) ) {
 							return null;
 						}
+
+						if ( ! isset( $post_type_object->cap->edit_posts ) || ! current_user_can( $post_type_object->cap->edit_posts ) ) {
+							return null;
+						}
+
+						return $status;
 					}
 				},
 				$statuses

--- a/src/Data/Connection/TaxonomyConnectionResolver.php
+++ b/src/Data/Connection/TaxonomyConnectionResolver.php
@@ -1,6 +1,7 @@
 <?php
 namespace WPGraphQL\Data\Connection;
 
+use Exception;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
@@ -17,14 +18,14 @@ class TaxonomyConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * ContentTypeConnectionResolver constructor.
 	 *
-	 * @param $source
-	 * @param $args
-	 * @param $context
-	 * @param $info
+	 * @param mixed       $source     source passed down from the resolve tree
+	 * @param array       $args       array of arguments input in the field as part of the GraphQL query
+	 * @param AppContext  $context    Object containing app context that gets passed down the resolve tree
+	 * @param ResolveInfo $info       Info about fields passed down the resolve tree
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
-	public function __construct( $source, $args, $context, $info ) {
+	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info ) {
 		parent::__construct( $source, $args, $context, $info );
 	}
 
@@ -104,7 +105,7 @@ class TaxonomyConnectionResolver extends AbstractConnectionResolver {
 	 * For backward pagination, we reverse the order of nodes.
 	 *
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function get_nodes() {
 
@@ -139,7 +140,7 @@ class TaxonomyConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * Determine if the offset used for pagination is valid
 	 *
-	 * @param $offset
+	 * @param mixed $offset
 	 *
 	 * @return bool
 	 */

--- a/src/Data/Connection/TermObjectConnectionResolver.php
+++ b/src/Data/Connection/TermObjectConnectionResolver.php
@@ -2,6 +2,7 @@
 
 namespace WPGraphQL\Data\Connection;
 
+use Exception;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
 use WPGraphQL\Model\Post;
@@ -25,22 +26,22 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * TermObjectConnectionResolver constructor.
 	 *
-	 * @param $source
-	 * @param $args
-	 * @param $context
-	 * @param $info
-	 * @param $taxonomy
+	 * @param mixed       $source     source passed down from the resolve tree
+	 * @param array       $args       array of arguments input in the field as part of the GraphQL query
+	 * @param AppContext  $context    Object containing app context that gets passed down the resolve tree
+	 * @param ResolveInfo $info       Info about fields passed down the resolve tree
+	 * @param mixed|string|null $taxonomy The name of the Taxonomy the resolver is intended to be used for
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
-	public function __construct( $source, $args, $context, $info, $taxonomy = null ) {
+	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info, $taxonomy = null ) {
 		$this->taxonomy = $taxonomy;
 		parent::__construct( $source, $args, $context, $info );
 	}
 
 	/**
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function get_query_args() {
 
@@ -139,7 +140,7 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 	 * Return an instance of WP_Term_Query with the args mapped to the query
 	 *
 	 * @return mixed|\WP_Term_Query
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function get_query() {
 		$query = new \WP_Term_Query( $this->query_args );

--- a/src/Data/Connection/ThemeConnectionResolver.php
+++ b/src/Data/Connection/ThemeConnectionResolver.php
@@ -15,7 +15,7 @@ use WPGraphQL\Data\DataSource;
 class ThemeConnectionResolver extends AbstractConnectionResolver {
 
 	/**
-	 * @return bool|int|mixed|null|string
+	 * @return mixed
 	 */
 	public function get_offset() {
 		$offset = null;
@@ -111,7 +111,7 @@ class ThemeConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * Determine if the offset used for pagination is valid
 	 *
-	 * @param $offset
+	 * @param mixed $offset
 	 *
 	 * @return bool
 	 */
@@ -163,7 +163,7 @@ class ThemeConnectionResolver extends AbstractConnectionResolver {
 
 		$connection['nodes'] = ! empty( $nodes ) ? $nodes : null;
 
-		return ! empty( $themes_array ) ? $connection : null;
+		return ! empty( $themes_array ) ? $connection : [];
 	}
 
 }

--- a/src/Data/Connection/UserConnectionResolver.php
+++ b/src/Data/Connection/UserConnectionResolver.php
@@ -91,14 +91,6 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 		$query_args['fields'] = 'ID';
 
 		/**
-		 * If the request is not authenticated, limit the query to users that have
-		 * published posts, as they're considered publicly facing users.
-		 */
-		if ( ! is_user_logged_in() ) {
-			$query_args['has_published_posts'] = true;
-		}
-
-		/**
 		 * Map the orderby inputArgs to the WP_User_Query
 		 */
 		if ( ! empty( $this->args['where']['orderby'] ) && is_array( $this->args['where']['orderby'] ) ) {

--- a/src/Data/Connection/UserRoleConnectionResolver.php
+++ b/src/Data/Connection/UserRoleConnectionResolver.php
@@ -2,6 +2,9 @@
 
 namespace WPGraphQL\Data\Connection;
 
+use Exception;
+use GraphQL\Type\Definition\ResolveInfo;
+use WPGraphQL\AppContext;
 use WPGraphQL\Model\User;
 
 /**
@@ -15,19 +18,19 @@ class UserRoleConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * UserRoleConnectionResolver constructor.
 	 *
-	 * @param $source
-	 * @param $args
-	 * @param $context
-	 * @param $info
+	 * @param mixed       $source     source passed down from the resolve tree
+	 * @param array       $args       array of arguments input in the field as part of the GraphQL query
+	 * @param AppContext  $context    Object containing app context that gets passed down the resolve tree
+	 * @param ResolveInfo $info       Info about fields passed down the resolve tree
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
-	public function __construct( $source, $args, $context, $info ) {
+	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info ) {
 		parent::__construct( $source, $args, $context, $info );
 	}
 
 	/**
-	 * @return bool|int|mixed|null|string
+	 * @return mixed
 	 */
 	public function get_offset() {
 		$offset = null;
@@ -83,7 +86,7 @@ class UserRoleConnectionResolver extends AbstractConnectionResolver {
 
 	/**
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function get_nodes() {
 		$nodes = parent::get_nodes();
@@ -113,7 +116,7 @@ class UserRoleConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * @param $offset
+	 * @param mixed $offset Whether the provided offset is valid for the connection
 	 *
 	 * @return bool
 	 */

--- a/src/Data/Cursor/CursorBuilder.php
+++ b/src/Data/Cursor/CursorBuilder.php
@@ -9,14 +9,25 @@ class CursorBuilder {
 
 	/**
 	 * The field by which the cursor should order the results
+	 *
+	 * @var array
 	 */
 	public $fields;
 
 	/**
 	 * Default comparison operator. < or >
+	 *
+	 * @var string
 	 */
-	public $compare = null;
+	public $compare;
 
+	/**
+	 * CursorBuilder constructor.
+	 *
+	 * @param string $compare
+	 *
+	 * @return void
+	 */
 	public function __construct( $compare = '>' ) {
 		$this->compare = $compare;
 		$this->fields  = [];
@@ -24,31 +35,33 @@ class CursorBuilder {
 
 	/**
 	 * Add ordering field. The order you call this method matters. First field
-	 * will be the primary field and latters ones will be used if the primary
+	 * will be the primary field and latter ones will be used if the primary
 	 * field has duplicate values
 	 *
-	 * @param string                  $key           database column
-	 * @param string                  $value         value from the current cursor
-	 * @param null                    $type          type cast
-	 * @param null                    $order         custom order
-	 * @param null | PostObjectCursor $object_cursor The PostObjectCursor class
+	 * @param string           $key           database column
+	 * @param mixed|string|int $value         value from the current cursor
+	 * @param string           $type          type cast
+	 * @param string           $order         custom order
+	 * @param PostObjectCursor $object_cursor The PostObjectCursor class
+	 *
+	 * @return void
 	 */
-	public function add_field( $key, $value, $type = null, $order = null, $object_cursor = null ) {
+	public function add_field( string $key, $value, string $type = null, string $order = null, PostObjectCursor $object_cursor = null ) {
 
 		/**
 		 * Filters the field used for ordering when cursors are used for pagination
 		 *
-		 * @param array                   $field         The field key, value, type and order
-		 * @param CursorBuilder           $this          The CursorBuilder class
-		 * @param null | PostObjectCursor $object_cursor The PostObjectCursor class
+		 * @param array                   $field          The field key, value, type and order
+		 * @param CursorBuilder           $cursor_builder The CursorBuilder class
+		 * @param null | PostObjectCursor $object_cursor  The PostObjectCursor class
 		 */
 		$field = apply_filters(
 			'graphql_cursor_ordering_field',
 			[
 				'key'   => esc_sql( $key ),
 				'value' => esc_sql( $value ),
-				'type'  => esc_sql( $type ),
-				'order' => esc_sql( $order ),
+				'type'  => ! empty( $type ) ? esc_sql( $type ) : '',
+				'order' => ! empty( $order ) ? esc_sql( $order ) : '',
 			],
 			$this,
 			$object_cursor
@@ -85,6 +98,8 @@ class CursorBuilder {
 
 	/**
 	 * Generate the final SQL string to be appended to WHERE clause
+	 *
+	 * @param mixed|array|null $fields
 	 *
 	 * @return string
 	 */

--- a/src/Data/Cursor/UserCursor.php
+++ b/src/Data/Cursor/UserCursor.php
@@ -2,6 +2,9 @@
 
 namespace WPGraphQL\Data\Cursor;
 
+use WP_User_Query;
+use wpdb;
+
 /**
  * User Cursor
  *
@@ -12,28 +15,28 @@ namespace WPGraphQL\Data\Cursor;
 class UserCursor {
 
 	/**
-	 * The global wpdb instance
+	 * The global WordPress Database instance
 	 *
-	 * @var $wpdb
+	 * @var wpdb $wpdb WordPress Database
 	 */
 	public $wpdb;
 
 	/**
 	 * The WP_User_Query instance
 	 *
-	 * @var $query
+	 * @var WP_User_Query $query The WP_User_Query Instance
 	 */
 	public $query;
 
 	/**
 	 * The current user id which is our cursor offset
 	 *
-	 * @var $user
+	 * @var int $cursor_offset The current user ID
 	 */
 	public $cursor_offset;
 
 	/**
-	 * @var \WPGraphQL\Data\Cursor\CursorBuilder
+	 * @var CursorBuilder
 	 */
 	public $builder;
 
@@ -46,15 +49,19 @@ class UserCursor {
 
 	/**
 	 * Copy of query vars so we can modify them safely
+	 *
+	 * @var array
 	 */
-	public $query_vars = null;
+	public $query_vars = [];
 
 	/**
 	 * UserCursor constructor.
 	 *
-	 * @param \WP_User_Query $query The WP_User_Query instance
+	 * @param WP_User_Query $query The WP_User_Query instance
+	 *
+	 * @return void
 	 */
-	public function __construct( $query ) {
+	public function __construct( WP_User_Query $query ) {
 		global $wpdb;
 		$this->wpdb       = $wpdb;
 		$this->query      = $query;
@@ -103,14 +110,18 @@ class UserCursor {
 	/**
 	 * Get current WP_User_Query instance's query variables.
 	 *
+	 * @param string $name The query var to get
+	 *
 	 * @return mixed array|null
 	 */
-	public function get_query_var( $name ) {
+	public function get_query_var( string $name ) {
 		return empty( $this->query_vars[ $name ] ) ? null : $this->query_vars[ $name ];
 	}
 
 	/**
 	 * Return the additional AND operators for the where statement
+	 *
+	 * @return string
 	 */
 	public function get_where() {
 
@@ -155,13 +166,15 @@ class UserCursor {
 			$this->compare_with_login();
 		}
 
-		$this->builder->add_field( "{$this->wpdb->users}.ID", $this->cursor_offset, 'ID' );
+		$this->builder->add_field( "{$this->wpdb->users}.ID", (string) $this->cursor_offset, 'ID' );
 
 		return $this->to_sql();
 	}
 
 	/**
 	 * Use user login based comparison
+	 *
+	 * @return void
 	 */
 	private function compare_with_login() {
 		$this->builder->add_field( "{$this->wpdb->users}.user_login", $this->get_cursor_user()->user_login, 'CHAR' );
@@ -173,7 +186,7 @@ class UserCursor {
 	 * @param string $by    The order by key
 	 * @param string $order The order direction ASC or DESC
 	 *
-	 * @return string
+	 * @return void
 	 */
 	private function compare_with( $by, $order ) {
 
@@ -216,9 +229,9 @@ class UserCursor {
 	 * @param string $meta_key user meta key
 	 * @param string $order    The comparison string
 	 *
-	 * @return string
+	 * @return void
 	 */
-	private function compare_with_meta_field( $meta_key, $order ) {
+	private function compare_with_meta_field( string $meta_key, string $order ) {
 		$meta_type  = $this->get_query_var( 'meta_type' );
 		$meta_value = get_user_meta( $this->cursor_offset, $meta_key, true );
 

--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -2,6 +2,7 @@
 
 namespace WPGraphQL\Data;
 
+use Exception;
 use GraphQL\Deferred;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
@@ -57,10 +58,10 @@ class DataSource {
 	 * @param AppContext $context The context of the request.
 	 *
 	 * @return Deferred object
-	 * @since      0.0.5
-	 *
 	 * @throws UserError Throws UserError.
-	 * @throws \Exception Throws UserError.
+	 * @throws Exception Throws UserError.
+	 *
+	 * @since      0.0.5
 	 *
 	 * @deprecated Use the Loader passed in $context instead
 	 */
@@ -73,48 +74,45 @@ class DataSource {
 	 *
 	 * @param int $comment_id The ID of the comment the comment author is associated with.
 	 *
-	 * @return CommentAuthor
-	 * @throws \Exception Throws Exception.
+	 * @return mixed|CommentAuthor|null
+	 * @throws Exception Throws Exception.
 	 */
-	public static function resolve_comment_author( $comment_id ) {
-		global $wpdb;
-		$comment_author = $wpdb->get_row( $wpdb->prepare( "SELECT comment_id, comment_author_email, comment_author, comment_author_url, comment_author_email from $wpdb->comments WHERE comment_id = %s LIMIT 1", esc_sql( $comment_id ) ) );
-		$comment_author = ! empty( $comment_author ) ? (array) $comment_author : [];
+	public static function resolve_comment_author( int $comment_id ) {
 
-		return new CommentAuthor( $comment_author );
+		$comment_author = get_comment( $comment_id );
+
+		return ! empty( $comment_author ) ? new CommentAuthor( $comment_author ) : null;
 	}
 
 	/**
 	 * Wrapper for the CommentsConnectionResolver class
 	 *
-	 * @param mixed  object $source
+	 * @param mixed       $source  The object the connection is coming from
 	 * @param array       $args    Query args to pass to the connection resolver
 	 * @param AppContext  $context The context of the query to pass along
 	 * @param ResolveInfo $info    The ResolveInfo object
 	 *
 	 * @return mixed
+	 * @throws Exception
 	 * @since 0.0.5
-	 * @throws \Exception
 	 */
-	public static function resolve_comments_connection( $source, array $args, $context, ResolveInfo $info ) {
-		$resolver   = new CommentConnectionResolver( $source, $args, $context, $info );
-		$connection = $resolver->get_connection();
+	public static function resolve_comments_connection( $source, array $args, AppContext $context, ResolveInfo $info ) {
+		$resolver = new CommentConnectionResolver( $source, $args, $context, $info );
 
-		return $connection;
+		return $resolver->get_connection();
 	}
 
 	/**
 	 * Wrapper for PluginsConnectionResolver::resolve
 	 *
-	 * @param \WP_Post    $source  WP_Post object
-	 * @param array       $args    Array of arguments to pass to reolve method
+	 * @param mixed       $source  The object the connection is coming from
+	 * @param array       $args    Array of arguments to pass to resolve method
 	 * @param AppContext  $context AppContext object passed down
 	 * @param ResolveInfo $info    The ResolveInfo object
 	 *
 	 * @return array
+	 * @throws Exception
 	 * @since  0.0.5
-	 *
-	 * @throws \Exception
 	 */
 	public static function resolve_plugins_connection( $source, array $args, AppContext $context, ResolveInfo $info ) {
 		$resolver = new PluginConnectionResolver( $source, $args, $context, $info );
@@ -128,15 +126,15 @@ class DataSource {
 	 * @param int        $id      ID of the post you are trying to retrieve
 	 * @param AppContext $context The context of the GraphQL Request
 	 *
-	 * @throws UserError
-	 * @since      0.0.5
 	 * @return Deferred
 	 *
-	 * @throws \Exception
+	 * @throws UserError
+	 * @throws Exception
 	 *
+	 * @since      0.0.5
 	 * @deprecated Use the Loader passed in $context instead
 	 */
-	public static function resolve_post_object( $id, AppContext $context ) {
+	public static function resolve_post_object( int $id, AppContext $context ) {
 		return $context->get_loader( 'post' )->load_deferred( $id );
 	}
 
@@ -145,7 +143,7 @@ class DataSource {
 	 * @param AppContext $context The context of the GraphQL request
 	 *
 	 * @return Deferred|null
-	 * @throws \Exception
+	 * @throws Exception
 	 *
 	 * @deprecated Use the Loader passed in $context instead
 	 */
@@ -156,15 +154,15 @@ class DataSource {
 	/**
 	 * Wrapper for PostObjectsConnectionResolver
 	 *
-	 * @param             $source
-	 * @param array       $args    Arguments to pass to the resolve method
-	 * @param AppContext  $context AppContext object to pass down
-	 * @param ResolveInfo $info    The ResolveInfo object
-	 * @param mixed string|array $post_type Post type of the post we are trying to resolve
+	 * @param mixed              $source    The object the connection is coming from
+	 * @param array              $args      Arguments to pass to the resolve method
+	 * @param AppContext         $context   AppContext object to pass down
+	 * @param ResolveInfo        $info      The ResolveInfo object
+	 * @param mixed|string|array $post_type Post type of the post we are trying to resolve
 	 *
 	 * @return mixed
+	 * @throws Exception
 	 * @since  0.0.5
-	 * @throws \Exception
 	 */
 	public static function resolve_post_objects_connection( $source, array $args, AppContext $context, ResolveInfo $info, $post_type ) {
 		$resolver = new PostObjectConnectionResolver( $source, $args, $context, $info, $post_type );
@@ -178,7 +176,7 @@ class DataSource {
 	 * @param string $taxonomy Name of the taxonomy you want to retrieve the taxonomy object for
 	 *
 	 * @return Taxonomy object
-	 * @throws UserError | \Exception
+	 * @throws UserError | Exception
 	 * @since  0.0.5
 	 */
 	public static function resolve_taxonomy( $taxonomy ) {
@@ -192,7 +190,13 @@ class DataSource {
 		 * If the $post_type is one of the allowed_post_types
 		 */
 		if ( in_array( $taxonomy, $allowed_taxonomies, true ) ) {
-			return new Taxonomy( get_taxonomy( $taxonomy ) );
+			$tax_object = get_taxonomy( $taxonomy );
+
+			if ( ! $tax_object instanceof \WP_Taxonomy ) {
+				throw new UserError( sprintf( __( 'No taxonomy was found with the name %s', 'wp-graphql' ), $taxonomy ) );
+			}
+
+			return new Taxonomy( $tax_object );
 		} else {
 			throw new UserError( sprintf( __( 'No taxonomy was found with the name %s', 'wp-graphql' ), $taxonomy ) );
 		}
@@ -206,7 +210,7 @@ class DataSource {
 	 * @param AppContext $context The context of the GraphQL Request
 	 *
 	 * @return mixed
-	 * @throws \Exception
+	 * @throws Exception
 	 * @since      0.0.5
 	 *
 	 * @deprecated Use the Loader passed in $context instead
@@ -218,21 +222,20 @@ class DataSource {
 	/**
 	 * Wrapper for TermObjectConnectionResolver::resolve
 	 *
-	 * @param              $source
-	 * @param array        $args     Array of args to be passed to the resolve method
-	 * @param AppContext   $context  The AppContext object to be passed down
-	 * @param ResolveInfo  $info     The ResolveInfo object
-	 * @param \WP_Taxonomy $taxonomy The WP_Taxonomy object of the taxonomy the term is connected to
+	 * @param mixed       $source   The object the connection is coming from
+	 * @param array       $args     Array of args to be passed to the resolve method
+	 * @param AppContext  $context  The AppContext object to be passed down
+	 * @param ResolveInfo $info     The ResolveInfo object
+	 * @param string      $taxonomy The name of the taxonomy the term belongs to
 	 *
 	 * @return array
+	 * @throws Exception
 	 * @since  0.0.5
-	 * @throws \Exception
 	 */
-	public static function resolve_term_objects_connection( $source, array $args, $context, ResolveInfo $info, $taxonomy ) {
-		$resolver   = new TermObjectConnectionResolver( $source, $args, $context, $info, $taxonomy );
-		$connection = $resolver->get_connection();
+	public static function resolve_term_objects_connection( $source, array $args, AppContext $context, ResolveInfo $info, string $taxonomy ) {
+		$resolver = new TermObjectConnectionResolver( $source, $args, $context, $info, $taxonomy );
 
-		return $connection;
+		return $resolver->get_connection();
 	}
 
 	/**
@@ -242,9 +245,8 @@ class DataSource {
 	 *
 	 * @return Theme object
 	 * @throws UserError
+	 * @throws Exception
 	 * @since  0.0.5
-	 *
-	 * @throws \Exception
 	 */
 	public static function resolve_theme( $stylesheet ) {
 		$theme = wp_get_theme( $stylesheet );
@@ -258,16 +260,16 @@ class DataSource {
 	/**
 	 * Wrapper for the ThemesConnectionResolver::resolve method
 	 *
-	 * @param             $source
+	 * @param mixed       $source  The object the connection is coming from
 	 * @param array       $args    Passes an array of arguments to the resolve method
 	 * @param AppContext  $context The AppContext object to be passed down
 	 * @param ResolveInfo $info    The ResolveInfo object
 	 *
 	 * @return array
+	 * @throws Exception
 	 * @since  0.0.5
-	 * @throws \Exception
 	 */
-	public static function resolve_themes_connection( $source, array $args, $context, ResolveInfo $info ) {
+	public static function resolve_themes_connection( $source, array $args, AppContext $context, ResolveInfo $info ) {
 		return ThemeConnectionResolver::resolve( $source, $args, $context, $info );
 	}
 
@@ -278,9 +280,9 @@ class DataSource {
 	 * @param AppContext $context The AppContext
 	 *
 	 * @return Deferred
-	 * @since      0.0.5
-	 * @throws \Exception
+	 * @throws Exception
 	 *
+	 * @since      0.0.5
 	 * @deprecated Use the Loader passed in $context instead
 	 */
 	public static function resolve_user( $id, AppContext $context ) {
@@ -290,16 +292,16 @@ class DataSource {
 	/**
 	 * Wrapper for the UsersConnectionResolver::resolve method
 	 *
-	 * @param             $source
+	 * @param mixed       $source  The object the connection is coming from
 	 * @param array       $args    Array of args to be passed down to the resolve method
 	 * @param AppContext  $context The AppContext object to be passed down
 	 * @param ResolveInfo $info    The ResolveInfo object
 	 *
 	 * @return array
+	 * @throws Exception
 	 * @since  0.0.5
-	 * @throws \Exception
 	 */
-	public static function resolve_users_connection( $source, array $args, $context, ResolveInfo $info ) {
+	public static function resolve_users_connection( $source, array $args, AppContext $context, ResolveInfo $info ) {
 		$resolver = new UserConnectionResolver( $source, $args, $context, $info );
 
 		return $resolver->get_connection();
@@ -312,7 +314,7 @@ class DataSource {
 	 * @param string $name Name of the user role you want info for
 	 *
 	 * @return UserRole
-	 * @throws \Exception
+	 * @throws Exception
 	 * @since  0.0.30
 	 */
 	public static function resolve_user_role( $name ) {
@@ -339,7 +341,7 @@ class DataSource {
 	 * @param array $args    The args to pass to the get_avatar_data function
 	 *
 	 * @return array|null|Avatar
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public static function resolve_avatar( $user_id, $args ) {
 
@@ -363,8 +365,8 @@ class DataSource {
 	 * @param AppContext  $context The AppContext passed down to the query
 	 * @param ResolveInfo $info    The ResloveInfo object
 	 *
-	 * @throws \Exception
 	 * @return array
+	 * @throws Exception
 	 */
 	public static function resolve_user_role_connection( $source, array $args, AppContext $context, ResolveInfo $info ) {
 
@@ -381,7 +383,7 @@ class DataSource {
 	 *
 	 * @return array $settings_groups[ $group ]
 	 */
-	public static function get_setting_group_fields( $group ) {
+	public static function get_setting_group_fields( string $group ) {
 
 		/**
 		 * Get all of the settings, sorted by group
@@ -516,6 +518,13 @@ class DataSource {
 		return self::$node_definition;
 	}
 
+	/**
+	 * Given a node, returns the GraphQL Type
+	 *
+	 * @param mixed $node The node to resolve the type of
+	 *
+	 * @return string
+	 */
 	public static function resolve_node_type( $node ) {
 		$type = null;
 
@@ -524,8 +533,11 @@ class DataSource {
 			switch ( true ) {
 				case $node instanceof Post:
 					if ( $node->isRevision ) {
-						$parent_post_type = get_post( $node->parentDatabaseId )->post_type;
-						$type             = get_post_type_object( $parent_post_type )->graphql_single_name;
+						$parent_post = get_post( $node->parentDatabaseId );
+						if ( ! empty( $parent_post ) ) {
+							$parent_post_type = $parent_post->post_type;
+							$type             = get_post_type_object( $parent_post_type )->graphql_single_name;
+						}
 					} else {
 						$type = get_post_type_object( $node->post_type )->graphql_single_name;
 					}
@@ -582,7 +594,7 @@ class DataSource {
 		 *
 		 * @since 0.0.6
 		 */
-		if ( null === $type ) {
+		if ( empty( $type ) ) {
 			throw new UserError( __( 'No type was found matching the node', 'wp-graphql' ) );
 		}
 
@@ -602,7 +614,7 @@ class DataSource {
 	 * @param ResolveInfo $info      The ResolveInfo for the GraphQL Request
 	 *
 	 * @return null|string
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public static function resolve_node( $global_id, AppContext $context, ResolveInfo $info ) {
 
@@ -664,7 +676,7 @@ class DataSource {
 	 * @param ResolveInfo $info    The ResolveInfo passed through the GraphQL Resolve tree
 	 *
 	 * @return mixed
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public static function resolve_resource_by_uri( $uri, $context, $info ) {
 		$node_resolver = new NodeResolver( $context );

--- a/src/Data/Loader/CommentAuthorLoader.php
+++ b/src/Data/Loader/CommentAuthorLoader.php
@@ -1,5 +1,6 @@
 <?php
 namespace WPGraphQL\Data\Loader;
+use Exception;
 use WPGraphQL\Model\CommentAuthor;
 
 /**
@@ -10,11 +11,11 @@ use WPGraphQL\Model\CommentAuthor;
 class CommentAuthorLoader extends AbstractDataLoader {
 
 	/**
-	 * @param $entry
-	 * @param $key
+	 * @param mixed $entry The User Role object
+	 * @param mixed $key The Key to identify the user role by
 	 *
 	 * @return mixed|CommentAuthor
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	protected function get_model( $entry, $key ) {
 

--- a/src/Data/Loader/CommentLoader.php
+++ b/src/Data/Loader/CommentLoader.php
@@ -2,6 +2,7 @@
 
 namespace WPGraphQL\Data\Loader;
 
+use Exception;
 use WPGraphQL\Model\Comment;
 
 /**
@@ -12,11 +13,11 @@ use WPGraphQL\Model\Comment;
 class CommentLoader extends AbstractDataLoader {
 
 	/**
-	 * @param $entry
-	 * @param $key
+	 * @param mixed $entry The User Role object
+	 * @param mixed $key The Key to identify the user role by
 	 *
-	 * @return Comment
-	 * @throws \Exception
+	 * @return mixed|Comment|null
+	 * @throws Exception
 	 */
 	protected function get_model( $entry, $key ) {
 
@@ -45,7 +46,7 @@ class CommentLoader extends AbstractDataLoader {
 	 * @param array $keys
 	 *
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function loadKeys( array $keys = [] ) {
 

--- a/src/Data/Loader/PluginLoader.php
+++ b/src/Data/Loader/PluginLoader.php
@@ -1,6 +1,8 @@
 <?php
 
 namespace WPGraphQL\Data\Loader;
+use Exception;
+use WPGraphQL\Model\Model;
 use WPGraphQL\Model\Plugin;
 
 /**
@@ -11,11 +13,11 @@ use WPGraphQL\Model\Plugin;
 class PluginLoader extends AbstractDataLoader {
 
 	/**
-	 * @param $entry
-	 * @param $key
+	 * @param mixed $entry The User Role object
+	 * @param mixed $key The Key to identify the user role by
 	 *
-	 * @return \WPGraphQL\Model\Model|Plugin
-	 * @throws \Exception
+	 * @return Model|Plugin
+	 * @throws Exception
 	 */
 	protected function get_model( $entry, $key ) {
 		return new Plugin( $entry );
@@ -27,7 +29,7 @@ class PluginLoader extends AbstractDataLoader {
 	 * @param array $keys
 	 *
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function loadKeys( array $keys ) {
 

--- a/src/Data/Loader/PostObjectLoader.php
+++ b/src/Data/Loader/PostObjectLoader.php
@@ -2,6 +2,7 @@
 
 namespace WPGraphQL\Data\Loader;
 
+use Exception;
 use GraphQL\Deferred;
 use WPGraphQL\Model\Menu;
 use WPGraphQL\Model\MenuItem;
@@ -15,11 +16,11 @@ use WPGraphQL\Model\Post;
 class PostObjectLoader extends AbstractDataLoader {
 
 	/**
-	 * @param $entry
-	 * @param $key
+	 * @param mixed $entry The User Role object
+	 * @param mixed $key The Key to identify the user role by
 	 *
 	 * @return mixed|Post
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	protected function get_model( $entry, $key ) {
 
@@ -74,7 +75,7 @@ class PostObjectLoader extends AbstractDataLoader {
 	 * @param array $keys
 	 *
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function loadKeys( array $keys ) {
 

--- a/src/Data/Loader/PostTypeLoader.php
+++ b/src/Data/Loader/PostTypeLoader.php
@@ -1,6 +1,7 @@
 <?php
 namespace WPGraphQL\Data\Loader;
 
+use Exception;
 use WPGraphQL\Model\PostType;
 
 /**
@@ -11,11 +12,11 @@ use WPGraphQL\Model\PostType;
 class PostTypeLoader extends AbstractDataLoader {
 
 	/**
-	 * @param $entry
-	 * @param $key
+	 * @param mixed $entry The User Role object
+	 * @param mixed $key The Key to identify the user role by
 	 *
 	 * @return mixed|PostType
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	protected function get_model( $entry, $key ) {
 		return new PostType( $entry );
@@ -25,7 +26,7 @@ class PostTypeLoader extends AbstractDataLoader {
 	 * @param array $keys
 	 *
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function loadKeys( array $keys ) {
 		$post_types = get_post_types( [ 'show_in_graphql' => true ], 'objects' );

--- a/src/Data/Loader/TaxonomyLoader.php
+++ b/src/Data/Loader/TaxonomyLoader.php
@@ -1,6 +1,7 @@
 <?php
 namespace WPGraphQL\Data\Loader;
 
+use Exception;
 use WPGraphQL\Model\Taxonomy;
 
 /**
@@ -11,11 +12,11 @@ use WPGraphQL\Model\Taxonomy;
 class TaxonomyLoader extends AbstractDataLoader {
 
 	/**
-	 * @param $entry
-	 * @param $key
+	 * @param mixed $entry The User Role object
+	 * @param mixed $key The Key to identify the user role by
 	 *
 	 * @return mixed|Taxonomy
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	protected function get_model( $entry, $key ) {
 		return new Taxonomy( $entry );
@@ -25,7 +26,7 @@ class TaxonomyLoader extends AbstractDataLoader {
 	 * @param array $keys
 	 *
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function loadKeys( array $keys ) {
 		$taxonomies = get_taxonomies( [ 'show_in_graphql' => true ], 'objects' );

--- a/src/Data/Loader/TermObjectLoader.php
+++ b/src/Data/Loader/TermObjectLoader.php
@@ -2,6 +2,7 @@
 
 namespace WPGraphQL\Data\Loader;
 
+use Exception;
 use GraphQL\Deferred;
 use WPGraphQL\Model\Menu;
 use WPGraphQL\Model\Term;
@@ -14,11 +15,11 @@ use WPGraphQL\Model\Term;
 class TermObjectLoader extends AbstractDataLoader {
 
 	/**
-	 * @param $entry
-	 * @param $key
+	 * @param mixed $entry The User Role object
+	 * @param mixed $key The Key to identify the user role by
 	 *
 	 * @return mixed|Term
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	protected function get_model( $entry, $key ) {
 
@@ -61,7 +62,7 @@ class TermObjectLoader extends AbstractDataLoader {
 	 * @param array $keys
 	 *
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function loadKeys( array $keys ) {
 

--- a/src/Data/Loader/ThemeLoader.php
+++ b/src/Data/Loader/ThemeLoader.php
@@ -1,6 +1,8 @@
 <?php
 namespace WPGraphQL\Data\Loader;
 
+use Exception;
+use WPGraphQL\Model\Model;
 use WPGraphQL\Model\Theme;
 
 /**
@@ -11,11 +13,11 @@ use WPGraphQL\Model\Theme;
 class ThemeLoader extends AbstractDataLoader {
 
 	/**
-	 * @param $entry
-	 * @param $key
+	 * @param mixed $entry The User Role object
+	 * @param mixed $key The Key to identify the user role by
 	 *
-	 * @return \WPGraphQL\Model\Model|Theme
-	 * @throws \Exception
+	 * @return Model|Theme
+	 * @throws Exception
 	 */
 	protected function get_model( $entry, $key ) {
 		return new Theme( $entry );
@@ -25,7 +27,7 @@ class ThemeLoader extends AbstractDataLoader {
 	 * @param array $keys
 	 *
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function loadKeys( array $keys ) {
 		$themes = wp_get_themes();

--- a/src/Data/Loader/UserLoader.php
+++ b/src/Data/Loader/UserLoader.php
@@ -1,6 +1,7 @@
 <?php
 namespace WPGraphQL\Data\Loader;
 
+use Exception;
 use WPGraphQL\Model\User;
 
 /**
@@ -11,11 +12,11 @@ use WPGraphQL\Model\User;
 class UserLoader extends AbstractDataLoader {
 
 	/**
-	 * @param $entry
-	 * @param $key
+	 * @param mixed $entry The User Role object
+	 * @param mixed $key The Key to identify the user role by
 	 *
 	 * @return mixed|User
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	protected function get_model( $entry, $key ) {
 		if ( $entry instanceof \WP_User ) {
@@ -38,7 +39,7 @@ class UserLoader extends AbstractDataLoader {
 	 * @param array $keys
 	 *
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function loadKeys( array $keys ) {
 

--- a/src/Data/Loader/UserRoleLoader.php
+++ b/src/Data/Loader/UserRoleLoader.php
@@ -2,6 +2,7 @@
 
 namespace WPGraphQL\Data\Loader;
 
+use Exception;
 use WPGraphQL\Model\UserRole;
 
 /**
@@ -12,11 +13,11 @@ use WPGraphQL\Model\UserRole;
 class UserRoleLoader extends AbstractDataLoader {
 
 	/**
-	 * @param $entry
-	 * @param $key
+	 * @param mixed $entry The User Role object
+	 * @param mixed $key The Key to identify the user role by
 	 *
 	 * @return mixed|UserRole
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	protected function get_model( $entry, $key ) {
 		return new UserRole( $entry );
@@ -26,7 +27,7 @@ class UserRoleLoader extends AbstractDataLoader {
 	 * @param array $keys
 	 *
 	 * @return array
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function loadKeys( array $keys ) {
 		$wp_roles = wp_roles()->roles;

--- a/src/Data/MediaItemMutation.php
+++ b/src/Data/MediaItemMutation.php
@@ -4,6 +4,7 @@ namespace WPGraphQL\Data;
 
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
+use WP_Post_Type;
 use WPGraphQL\AppContext;
 
 /**
@@ -16,14 +17,15 @@ class MediaItemMutation {
 	/**
 	 * This prepares the media item for insertion
 	 *
-	 * @param array         $input            The input for the mutation from the GraphQL request
-	 * @param \WP_Post_Type $post_type_object The post_type_object for the mediaItem (attachment)
-	 * @param string        $mutation_name    The name of the mutation being performed (create, update, etc.)
-	 * @param mixed         $file             The mediaItem (attachment) file
+	 * @param array        $input            The input for the mutation from the GraphQL request
+	 * @param WP_Post_Type $post_type_object The post_type_object for the mediaItem (attachment)
+	 * @param string       $mutation_name    The name of the mutation being performed (create,
+	 *                                       update, etc.)
+	 * @param mixed        $file             The mediaItem (attachment) file
 	 *
 	 * @return array $media_item_args
 	 */
-	public static function prepare_media_item( $input, $post_type_object, $mutation_name, $file ) {
+	public static function prepare_media_item( array $input, WP_Post_Type $post_type_object, string $mutation_name, $file ) {
 
 		/**
 		 * Set the post_type (attachment) for the insert
@@ -103,10 +105,10 @@ class MediaItemMutation {
 		/**
 		 * Filter the $insert_post_args
 		 *
-		 * @param array         $insert_post_args The array of $input_post_args that will be passed to wp_insert_attachment
-		 * @param array         $input            The data that was entered as input for the mutation
-		 * @param \WP_Post_Type $post_type_object The post_type_object that the mutation is affecting
-		 * @param string        $mutation_type    The type of mutation being performed (create, update, delete)
+		 * @param array        $insert_post_args The array of $input_post_args that will be passed to wp_insert_attachment
+		 * @param array        $input            The data that was entered as input for the mutation
+		 * @param WP_Post_Type $post_type_object The post_type_object that the mutation is affecting
+		 * @param string       $mutation_type    The type of mutation being performed (create, update, delete)
 		 */
 		$insert_post_args = apply_filters( 'graphql_media_item_insert_post_args', $insert_post_args, $input, $post_type_object, $mutation_name );
 
@@ -116,14 +118,16 @@ class MediaItemMutation {
 	/**
 	 * This updates additional data related to a mediaItem, such as postmeta.
 	 *
-	 * @param int           $media_item_id    The ID of the media item being mutated
-	 * @param array         $input            The input on the mutation
-	 * @param \WP_Post_Type $post_type_object The Post Type Object for the item being mutated
-	 * @param string        $mutation_name    The name of the mutation
-	 * @param AppContext    $context          The AppContext that is passed down the resolve tree
-	 * @param ResolveInfo   $info             The ResolveInfo that is passed down the resolve tree
+	 * @param int          $media_item_id    The ID of the media item being mutated
+	 * @param array        $input            The input on the mutation
+	 * @param WP_Post_Type $post_type_object The Post Type Object for the item being mutated
+	 * @param string       $mutation_name    The name of the mutation
+	 * @param AppContext   $context          The AppContext that is passed down the resolve tree
+	 * @param ResolveInfo  $info             The ResolveInfo that is passed down the resolve tree
+	 *
+	 * @return void
 	 */
-	public static function update_additional_media_item_data( $media_item_id, $input, $post_type_object, $mutation_name, AppContext $context, ResolveInfo $info ) {
+	public static function update_additional_media_item_data( int $media_item_id, array $input, WP_Post_Type $post_type_object, string $mutation_name, AppContext $context, ResolveInfo $info ) {
 
 		/**
 		 * Update alt text postmeta for the mediaItem
@@ -137,12 +141,12 @@ class MediaItemMutation {
 		 * update additional data related to mediaItems, such as updating additional postmeta,
 		 * or sending emails to Kevin. . .whatever you need to do with the mediaItem.
 		 *
-		 * @param int           $media_item_id    The ID of the mediaItem being mutated
-		 * @param array         $input            The input for the mutation
-		 * @param \WP_Post_Type $post_type_object The Post Type Object for the type of post being mutated
-		 * @param string        $mutation_name    The name of the mutation (ex: create, update, delete)
-		 * @param AppContext    $context          The AppContext that is passed down the resolve tree
-		 * @param ResolveInfo   $info             The ResolveInfo that is passed down the resolve tree
+		 * @param int          $media_item_id    The ID of the mediaItem being mutated
+		 * @param array        $input            The input for the mutation
+		 * @param WP_Post_Type $post_type_object The Post Type Object for the type of post being mutated
+		 * @param string       $mutation_name    The name of the mutation (ex: create, update, delete)
+		 * @param AppContext   $context          The AppContext that is passed down the resolve tree
+		 * @param ResolveInfo  $info             The ResolveInfo that is passed down the resolve tree
 		 */
 		do_action( 'graphql_media_item_mutation_update_additional_data', $media_item_id, $input, $post_type_object, $mutation_name, $context, $info );
 

--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -2,16 +2,29 @@
 
 namespace WPGraphQL\Data;
 
+use Exception;
 use GraphQL\Error\UserError;
+use WP;
 use WPGraphQL\AppContext;
 
 class NodeResolver {
 
+	/**
+	 * @var WP
+	 */
 	protected $wp;
+
+	/**
+	 * @var AppContext
+	 */
 	protected $context;
 
 	/**
 	 * NodeResolver constructor.
+	 *
+	 * @param AppContext $context
+	 *
+	 * @return void
 	 */
 	public function __construct( AppContext $context ) {
 		global $wp;
@@ -23,14 +36,14 @@ class NodeResolver {
 	 * Given the URI of a resource, this method attempts to resolve it and return the
 	 * appropriate related object
 	 *
-	 * @param array|string $uri              The path to be used as an identifier for the resource.
-	 * @param string       $extra_query_vars Any extra query vars to consider
-	 *
-	 * @throws \Exception
+	 * @param string       $uri              The path to be used as an identifier for the
+	 *                                             resource.
+	 * @param mixed|array|string $extra_query_vars Any extra query vars to consider
 	 *
 	 * @return mixed
+	 * @throws Exception
 	 */
-	public function resolve_uri( $uri, $extra_query_vars = '' ) {
+	public function resolve_uri( string $uri, $extra_query_vars = '' ) {
 
 		global $wp_rewrite;
 
@@ -86,12 +99,22 @@ class NodeResolver {
 			// front. For path info requests, this leaves us with the requesting
 			// filename, if any. For 404 requests, this leaves us with the
 			// requested permalink.
-			$req_uri  = str_replace( $pathinfo, '', $req_uri );
-			$req_uri  = trim( $req_uri, '/' );
-			$req_uri  = preg_replace( $home_path_regex, '', $req_uri );
-			$req_uri  = trim( $req_uri, '/' );
-			$pathinfo = trim( $pathinfo, '/' );
-			$pathinfo = preg_replace( $home_path_regex, '', $pathinfo );
+			$query        = '';
+			$matches      = null;
+			$req_uri      = str_replace( $pathinfo, '', $req_uri );
+			$req_uri      = trim( $req_uri, '/' );
+			$replaced_uri = preg_replace( $home_path_regex, '', $req_uri );
+
+			if ( ! empty( $replaced_uri ) ) {
+				$req_uri = $replaced_uri;
+			}
+
+			$req_uri           = trim( $req_uri, '/' );
+			$pathinfo          = trim( $pathinfo, '/' );
+			$replaced_pathinfo = preg_replace( $home_path_regex, '', $pathinfo );
+			if ( ! empty( $replaced_pathinfo ) ) {
+				$pathinfo = $replaced_pathinfo;
+			}
 			$pathinfo = trim( $pathinfo, '/' );
 
 			// The requested permalink is in $pathinfo for path info requests and
@@ -139,10 +162,10 @@ class NodeResolver {
 
 							$post_status_obj = get_post_status_object( $page->post_status );
 							if (
-								! $post_status_obj->public &&
-								! $post_status_obj->protected &&
-								! $post_status_obj->private &&
-								$post_status_obj->exclude_from_search
+								( ! isset( $post_status_obj->public ) || ! $post_status_obj->public ) &&
+								( ! isset( $post_status_obj->protected ) || ! $post_status_obj->protected ) &&
+								( ! isset( $post_status_obj->private ) || ! $post_status_obj->private ) &&
+								( ! isset( $post_status_obj->exclude_from_search ) || $post_status_obj->exclude_from_search )
 							) {
 								continue;
 							}
@@ -163,8 +186,6 @@ class NodeResolver {
 				// Substitute the substring matches into the query.
 				$query = addslashes( \WP_MatchesMapRegex::apply( $query, $matches ) );
 
-				$this->wp->matched_query = $query;
-
 				// Parse the query.
 				parse_str( $query, $perma_query_vars );
 
@@ -182,15 +203,15 @@ class NodeResolver {
 		 * to executing the query. Needed to allow custom rewrite rules using your own arguments
 		 * to work, or any other custom query variables you want to be publicly available.
 		 *
-		 * @since 1.5.0
-		 *
 		 * @param string[] $public_query_vars The array of whitelisted query variable names.
+		 *
+		 * @since 1.5.0
 		 */
 		$this->wp->public_query_vars = apply_filters( 'query_vars', $this->wp->public_query_vars );
 
 		foreach ( get_post_types( [ 'show_in_graphql' => true ], 'objects' ) as $post_type => $t ) {
 
-			if ( true === $t->show_in_graphql && $t->query_var ) {
+			if ( isset( $t->show_in_graphql ) && true === $t->show_in_graphql && $t->query_var ) {
 				$post_type_query_vars[ $t->query_var ] = $post_type;
 			}
 		}
@@ -267,9 +288,9 @@ class NodeResolver {
 		/**
 		 * Filters the array of parsed query variables.
 		 *
-		 * @since 2.1.0
-		 *
 		 * @param array $query_vars The array of requested query variables.
+		 *
+		 * @since 2.1.0
 		 */
 		$this->wp->query_vars = apply_filters( 'request', $this->wp->query_vars );
 
@@ -305,18 +326,20 @@ class NodeResolver {
 			if ( isset( $this->wp->query_vars['post_type'] ) && in_array( $this->wp->query_vars['post_type'], $allowed_post_types, true ) ) {
 				$post_type = $this->wp->query_vars['post_type'];
 			}
+			// @phpstan-ignore-next-line
 			$post = get_page_by_path( $this->wp->query_vars['name'], 'OBJECT', $post_type );
-			return ! empty( $post ) ? $this->context->get_loader( 'post' )->load_deferred( $post->ID ) : null;
+
+			return isset( $post->ID ) ? $this->context->get_loader( 'post' )->load_deferred( $post->ID ) : null;
 
 		} elseif ( isset( $this->wp->query_vars['cat'] ) ) {
 			$node = get_term( absint( $this->wp->query_vars['cat'] ), 'category' );
 
-			return ! empty( $node ) ? $this->context->get_loader( 'term' )->load_deferred( (int) $node->term_id ) : null;
+			return isset( $node->term_id ) ? $this->context->get_loader( 'term' )->load_deferred( (int) $node->term_id ) : null;
 
 		} elseif ( isset( $this->wp->query_vars['tag'] ) ) {
 			$node = get_term_by( 'slug', $this->wp->query_vars['tag'], 'post_tag' );
 
-			return ! empty( $node ) ? $this->context->get_loader( 'term' )->load_deferred( (int) $node->term_id ) : null;
+			return isset( $node->term_id ) ? $this->context->get_loader( 'term' )->load_deferred( (int) $node->term_id ) : null;
 		} elseif ( isset( $this->wp->query_vars['pagename'] ) && ! empty( $this->wp->query_vars['pagename'] ) ) {
 
 			$post = get_page_by_path( $this->wp->query_vars['pagename'], 'OBJECT', get_post_types( [ 'show_in_graphql' => true ] ) );
@@ -328,21 +351,24 @@ class NodeResolver {
 			return ! empty( $post ) ? $this->context->get_loader( 'post' )->load_deferred( $post->ID ) : null;
 		} elseif ( isset( $this->wp->query_vars['author_name'] ) ) {
 			$user = get_user_by( 'slug', $this->wp->query_vars['author_name'] );
-			return $this->context->get_loader( 'user' )->load_deferred( $user->ID );
+
+			return isset( $user->ID ) ? $this->context->get_loader( 'user' )->load_deferred( $user->ID ) : null;
 		} elseif ( isset( $this->wp->query_vars['category_name'] ) ) {
 			$node = get_term_by( 'slug', $this->wp->query_vars['category_name'], 'category' );
-			return $this->context->get_loader( 'term' )->load_deferred( $node->term_id );
+
+			return isset( $node->term_id ) ? $this->context->get_loader( 'term' )->load_deferred( $node->term_id ) : null;
 
 		} elseif ( isset( $this->wp->query_vars['post_type'] ) ) {
-				$post_type_object = get_post_type_object( $this->wp->query_vars['post_type'] );
-				return ! empty( $post_type_object ) ? $this->context->get_loader( 'post_type' )->load_deferred( $post_type_object->name ) : null;
+			$post_type_object = get_post_type_object( $this->wp->query_vars['post_type'] );
+
+			return ! empty( $post_type_object ) ? $this->context->get_loader( 'post_type' )->load_deferred( $post_type_object->name ) : null;
 		} else {
 			$taxonomies = get_taxonomies( [ 'show_in_graphql' => true ], 'objects' );
 			foreach ( $taxonomies as $taxonomy ) {
 				if ( isset( $this->wp->query_vars[ $taxonomy->query_var ] ) ) {
 					$node = get_term_by( 'slug', $this->wp->query_vars[ $taxonomy->query_var ], $taxonomy->name );
 
-					return $this->context->get_loader( 'term' )->load_deferred( $node->term_id );
+					return isset( $node->term_id ) ? $this->context->get_loader( 'term' )->load_deferred( $node->term_id ) : null;
 				}
 			}
 		}

--- a/src/Data/PostObjectMutation.php
+++ b/src/Data/PostObjectMutation.php
@@ -4,6 +4,7 @@ namespace WPGraphQL\Data;
 
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
+use WP_Post_Type;
 use WPGraphQL\AppContext;
 
 /**
@@ -16,9 +17,10 @@ class PostObjectMutation {
 	/**
 	 * This handles inserting the post object
 	 *
-	 * @param array         $input            The input for the mutation
-	 * @param \WP_Post_Type $post_type_object The post_type_object for the type of post being mutated
-	 * @param string        $mutation_name    The name of the mutation being performed
+	 * @param array        $input             The input for the mutation
+	 * @param WP_Post_Type $post_type_object  The post_type_object for the type of post being
+	 *                                        mutated
+	 * @param string       $mutation_name     The name of the mutation being performed
 	 *
 	 * @return array $insert_post_args
 	 * @throws \Exception
@@ -103,10 +105,10 @@ class PostObjectMutation {
 		/**
 		 * Filter the $insert_post_args
 		 *
-		 * @param array         $insert_post_args The array of $input_post_args that will be passed to wp_insert_post
-		 * @param array         $input            The data that was entered as input for the mutation
-		 * @param \WP_Post_Type $post_type_object The post_type_object that the mutation is affecting
-		 * @param string        $mutation_type    The type of mutation being performed (create, edit, etc)
+		 * @param array        $insert_post_args The array of $input_post_args that will be passed to wp_insert_post
+		 * @param array        $input            The data that was entered as input for the mutation
+		 * @param WP_Post_Type $post_type_object The post_type_object that the mutation is affecting
+		 * @param string       $mutation_type    The type of mutation being performed (create, edit, etc)
 		 */
 		$insert_post_args = apply_filters( 'graphql_post_object_insert_post_args', $insert_post_args, $input, $post_type_object, $mutation_name );
 
@@ -118,31 +120,38 @@ class PostObjectMutation {
 	}
 
 	/**
-	 * This updates additional data related to a post object, such as postmeta, term relationships, etc.
+	 * This updates additional data related to a post object, such as postmeta, term relationships,
+	 * etc.
 	 *
-	 * @param int           $post_id              $post_id      The ID of the postObject being mutated
-	 * @param array         $input                The input for the mutation
-	 * @param \WP_Post_Type $post_type_object     The Post Type Object for the type of post being mutated
-	 * @param string        $mutation_name        The name of the mutation (ex: create, update, delete)
-	 * @param AppContext    $context              The AppContext passed down to all resolvers
-	 * @param ResolveInfo   $info                 The ResolveInfo passed down to all resolvers
-	 * @param string        $intended_post_status The intended post_status the post should have according to the
-	 *                                            mutation input
-	 * @param string        $default_post_status  The default status posts should use if an intended status wasn't set
+	 * @param int          $post_id               $post_id      The ID of the postObject being
+	 *                                            mutated
+	 * @param array        $input                 The input for the mutation
+	 * @param WP_Post_Type $post_type_object      The Post Type Object for the type of post being
+	 *                                            mutated
+	 * @param string       $mutation_name         The name of the mutation (ex: create, update,
+	 *                                            delete)
+	 * @param AppContext   $context               The AppContext passed down to all resolvers
+	 * @param ResolveInfo  $info                  The ResolveInfo passed down to all resolvers
+	 * @param string       $intended_post_status  The intended post_status the post should have
+	 *                                            according to the mutation input
+	 * @param string       $default_post_status   The default status posts should use if an
+	 *                                            intended status wasn't set
+	 *
+	 * @return void
 	 */
 	public static function update_additional_post_object_data( $post_id, $input, $post_type_object, $mutation_name, AppContext $context, ResolveInfo $info, $default_post_status = null, $intended_post_status = null ) {
 
 		/**
 		 * Sets the post lock
 		 *
-		 * @param int           $post_id              The ID of the postObject being mutated
-		 * @param array         $input                The input for the mutation
-		 * @param \WP_Post_Type $post_type_object     The Post Type Object for the type of post being mutated
-		 * @param string        $mutation_name        The name of the mutation (ex: create, update, delete)
-		 * @param AppContext    $context              The AppContext passed down to all resolvers
-		 * @param ResolveInfo   $info                 The ResolveInfo passed down to all resolvers
-		 * @param string        $intended_post_status The intended post_status the post should have according to the mutation input
-		 * @param string        $default_post_status  The default status posts should use if an intended status wasn't set
+		 * @param int          $post_id              The ID of the postObject being mutated
+		 * @param array        $input                The input for the mutation
+		 * @param WP_Post_Type $post_type_object     The Post Type Object for the type of post being mutated
+		 * @param string       $mutation_name        The name of the mutation (ex: create, update, delete)
+		 * @param AppContext   $context              The AppContext passed down to all resolvers
+		 * @param ResolveInfo  $info                 The ResolveInfo passed down to all resolvers
+		 * @param string       $intended_post_status The intended post_status the post should have according to the mutation input
+		 * @param string       $default_post_status  The default status posts should use if an intended status wasn't set
 		 *
 		 * @return bool
 		 */
@@ -168,10 +177,10 @@ class PostObjectMutation {
 		/**
 		 * Set the object terms
 		 *
-		 * @param int           $post_id          The ID of the postObject being mutated
-		 * @param array         $input            The input for the mutation
-		 * @param \WP_Post_Type $post_type_object The Post Type Object for the type of post being mutated
-		 * @param string        $mutation_name    The name of the mutation (ex: create, update, delete)
+		 * @param int          $post_id          The ID of the postObject being mutated
+		 * @param array        $input            The input for the mutation
+		 * @param WP_Post_Type $post_type_object The Post Type Object for the type of post being mutated
+		 * @param string       $mutation_name    The name of the mutation (ex: create, update, delete)
 		 */
 		self::set_object_terms( $post_id, $input, $post_type_object, $mutation_name );
 
@@ -180,28 +189,28 @@ class PostObjectMutation {
 		 * update additional data related to postObjects, such as setting relationships, updating additional postmeta,
 		 * or sending emails to Kevin. . .whatever you need to do with the postObject.
 		 *
-		 * @param int           $post_id              The ID of the postObject being mutated
-		 * @param array         $input                The input for the mutation
-		 * @param \WP_Post_Type $post_type_object     The Post Type Object for the type of post being mutated
-		 * @param string        $mutation_name        The name of the mutation (ex: create, update, delete)
-		 * @param AppContext    $context              The AppContext passed down to all resolvers
-		 * @param ResolveInfo   $info                 The ResolveInfo passed down to all resolvers
-		 * @param string        $intended_post_status The intended post_status the post should have according to the mutation input
-		 * @param string        $default_post_status  The default status posts should use if an intended status wasn't set
+		 * @param int          $post_id              The ID of the postObject being mutated
+		 * @param array        $input                The input for the mutation
+		 * @param WP_Post_Type $post_type_object     The Post Type Object for the type of post being mutated
+		 * @param string       $mutation_name        The name of the mutation (ex: create, update, delete)
+		 * @param AppContext   $context              The AppContext passed down to all resolvers
+		 * @param ResolveInfo  $info                 The ResolveInfo passed down to all resolvers
+		 * @param string       $intended_post_status The intended post_status the post should have according to the mutation input
+		 * @param string       $default_post_status  The default status posts should use if an intended status wasn't set
 		 */
 		do_action( 'graphql_post_object_mutation_update_additional_data', $post_id, $input, $post_type_object, $mutation_name, $context, $info, $default_post_status, $intended_post_status );
 
 		/**
 		 * Sets the post lock
 		 *
-		 * @param int           $post_id              The ID of the postObject being mutated
-		 * @param array         $input                The input for the mutation
-		 * @param \WP_Post_Type $post_type_object     The Post Type Object for the type of post being mutated
-		 * @param string        $mutation_name        The name of the mutation (ex: create, update, delete)
-		 * @param AppContext    $context              The AppContext passed down to all resolvers
-		 * @param ResolveInfo   $info                 The ResolveInfo passed down to all resolvers
-		 * @param string        $intended_post_status The intended post_status the post should have according to the mutation input
-		 * @param string        $default_post_status  The default status posts should use if an intended status wasn't set
+		 * @param int          $post_id              The ID of the postObject being mutated
+		 * @param array        $input                The input for the mutation
+		 * @param WP_Post_Type $post_type_object     The Post Type Object for the type of post being mutated
+		 * @param string       $mutation_name        The name of the mutation (ex: create, update, delete)
+		 * @param AppContext   $context              The AppContext passed down to all resolvers
+		 * @param ResolveInfo  $info                 The ResolveInfo passed down to all resolvers
+		 * @param string       $intended_post_status The intended post_status the post should have according to the mutation input
+		 * @param string       $default_post_status  The default status posts should use if an intended status wasn't set
 		 *
 		 * @return bool
 		 */
@@ -215,25 +224,28 @@ class PostObjectMutation {
 	}
 
 	/**
-	 * Given a $post_id and $input from the mutation, check to see if any term associations are being made, and
-	 * properly set the relationships
+	 * Given a $post_id and $input from the mutation, check to see if any term associations are
+	 * being made, and properly set the relationships
 	 *
-	 * @param int           $post_id          The ID of the postObject being mutated
-	 * @param array         $input            The input for the mutation
-	 * @param \WP_Post_Type $post_type_object The Post Type Object for the type of post being mutated
-	 * @param string        $mutation_name    The name of the mutation (ex: create, update, delete)
+	 * @param int          $post_id           The ID of the postObject being mutated
+	 * @param array        $input             The input for the mutation
+	 * @param WP_Post_Type $post_type_object  The Post Type Object for the type of post being
+	 *                                        mutated
+	 * @param string       $mutation_name     The name of the mutation (ex: create, update, delete)
+	 *
+	 * @return void
 	 */
-	protected static function set_object_terms( $post_id, $input, $post_type_object, $mutation_name ) {
+	protected static function set_object_terms( int $post_id, array $input, WP_Post_Type $post_type_object, string $mutation_name ) {
 
 		/**
 		 * Fire an action before setting object terms during a GraphQL Post Object Mutation.
 		 *
 		 * One example use for this hook would be to create terms from the input that may not exist yet, so that they can be set as a relation below.
 		 *
-		 * @param int           $post_id          The ID of the postObject being mutated
-		 * @param array         $input            The input for the mutation
-		 * @param \WP_Post_Type $post_type_object The Post Type Object for the type of post being mutated
-		 * @param string        $mutation_name    The name of the mutation (ex: create, update, delete)
+		 * @param int          $post_id          The ID of the postObject being mutated
+		 * @param array        $input            The input for the mutation
+		 * @param WP_Post_Type $post_type_object The Post Type Object for the type of post being mutated
+		 * @param string       $mutation_name    The name of the mutation (ex: create, update, delete)
 		 */
 		do_action( 'graphql_post_object_mutation_set_object_terms', $post_id, $input, $post_type_object, $mutation_name );
 
@@ -243,7 +255,6 @@ class PostObjectMutation {
 		$allowed_taxonomies = \WPGraphQL::get_allowed_taxonomies();
 
 		if ( ! empty( $allowed_taxonomies ) && is_array( $allowed_taxonomies ) ) {
-
 			foreach ( $allowed_taxonomies as $taxonomy ) {
 
 				/**
@@ -255,6 +266,10 @@ class PostObjectMutation {
 					 * Get the tax object
 					 */
 					$tax_object = get_taxonomy( $taxonomy );
+
+					if ( ! $tax_object instanceof \WP_Taxonomy ) {
+						return;
+					}
 
 					/**
 					 * If there is input for the taxonomy, process it
@@ -306,13 +321,13 @@ class PostObjectMutation {
 
 										if ( ! empty( $id_parts['id'] ) ) {
 											$term_exists = get_term_by( 'id', absint( $id_parts['id'] ), $tax_object->name );
-											if ( $term_exists ) {
+											if ( isset( $term_exists->term_id ) ) {
 												$terms_to_connect[] = $term_exists->term_id;
 											}
 										}
 									} else {
 										$term_exists = get_term_by( 'id', absint( $node['id'] ), $tax_object->name );
-										if ( $term_exists ) {
+										if ( isset( $term_exists->term_id ) ) {
 											$terms_to_connect[] = $term_exists->term_id;
 										}
 									}
@@ -323,7 +338,7 @@ class PostObjectMutation {
 								} elseif ( ! empty( $node['slug'] ) ) {
 									$sanitized_slug = sanitize_text_field( $node['slug'] );
 									$term_exists    = get_term_by( 'slug', $sanitized_slug, $tax_object->name );
-									if ( $term_exists ) {
+									if ( isset( $term_exists->term_id ) ) {
 										$terms_to_connect[] = $term_exists->term_id;
 									}
 									/**
@@ -342,7 +357,7 @@ class PostObjectMutation {
 									/**
 									 * If the current user cannot edit terms, don't create terms to connect
 									 */
-									if ( ! current_user_can( $tax_object->cap->edit_terms ) ) {
+									if ( ! isset( $tax_object->cap->edit_terms ) || ! current_user_can( $tax_object->cap->edit_terms ) ) {
 										return;
 									}
 
@@ -358,7 +373,7 @@ class PostObjectMutation {
 						/**
 						 * If the current user cannot edit terms, don't create terms to connect
 						 */
-						if ( ! current_user_can( $tax_object->cap->assign_terms ) ) {
+						if ( ! isset( $tax_object->cap->assign_terms ) || ! current_user_can( $tax_object->cap->assign_terms ) ) {
 							return;
 						}
 
@@ -372,7 +387,8 @@ class PostObjectMutation {
 	}
 
 	/**
-	 * Given an array of Term properties (slug, name, description, etc), create the term and return a term_id
+	 * Given an array of Term properties (slug, name, description, etc), create the term and return
+	 * a term_id
 	 *
 	 * @param array  $node     The node input for the term
 	 * @param string $taxonomy The taxonomy the term input is for
@@ -403,18 +419,24 @@ class PostObjectMutation {
 		 * @todo: consider supporting "parent" input in $term_args
 		 */
 
-		if ( ! empty( $term_to_create['name'] ) ) {
+		if ( isset( $term_to_create['name'] ) && ! empty( $term_to_create['name'] ) ) {
 			$created_term = wp_insert_term( $term_to_create['name'], $taxonomy, $term_args );
 		}
 
-		if ( is_wp_error( $created_term ) && isset( $created_term->error_data['term_exists'] ) ) {
-			return $created_term->error_data['term_exists'];
+		if ( is_wp_error( $created_term ) ) {
+
+			if ( isset( $created_term->error_data['term_exists'] ) ) {
+				return $created_term->error_data['term_exists'];
+			}
+
+			return 0;
+
 		}
 
 		/**
 		 * Return the created term, or 0
 		 */
-		return ! empty( $created_term['term_id'] ) ? $created_term['term_id'] : 0;
+		return isset( $created_term['term_id'] ) ? absint( $created_term['term_id'] ) : 0;
 
 	}
 
@@ -457,11 +479,11 @@ class PostObjectMutation {
 	 *
 	 * @return bool
 	 */
-	public static function remove_edit_lock( $post_id ) {
+	public static function remove_edit_lock( int $post_id ) {
 
 		$post = get_post( $post_id );
 
-		if ( ! is_a( $post, 'WP_Post' ) ) {
+		if ( empty( $post ) ) {
 			return false;
 		}
 

--- a/src/Data/TermObjectMutation.php
+++ b/src/Data/TermObjectMutation.php
@@ -71,13 +71,12 @@ class TermObjectMutation {
 				 */
 				$parent_term = get_term( absint( $parent_id ), $taxonomy->name );
 
-				if ( ! $parent_term || is_wp_error( $parent_term ) ) {
+				if ( $parent_term instanceof \WP_Term ) {
+					// Otherwise set the parent as the parent term's ID
+					$insert_args['parent'] = $parent_term->term_id;
+				} else {
 					throw new UserError( __( 'The parent does not exist', 'wp-graphql' ) );
 				}
-
-				// Otherwise set the parent as the parent term's ID
-				$insert_args['parent'] = $parent_term->term_id;
-
 			} else {
 				throw new UserError( __( 'The parent ID is not a valid ID', 'wp-graphql' ) );
 			} // End if().

--- a/src/Data/UserMutation.php
+++ b/src/Data/UserMutation.php
@@ -2,10 +2,10 @@
 
 namespace WPGraphQL\Data;
 
+use Exception;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
-use WPGraphQL\Types;
 
 /**
  * Class UserMutation
@@ -191,9 +191,9 @@ class UserMutation {
 		/**
 		 * Filters the mappings for input to arguments
 		 *
-		 * @var array  $insert_user_args The arguments to ultimately be passed to the WordPress function
-		 * @var array  $input            Input data from the GraphQL mutation
-		 * @var string $mutation_name    What user mutation is being performed for context
+		 * @param array  $insert_user_args The arguments to ultimately be passed to the WordPress function
+		 * @param array  $input            Input data from the GraphQL mutation
+		 * @param string $mutation_name    What user mutation is being performed for context
 		 */
 		$insert_user_args = apply_filters( 'graphql_user_insert_post_args', $insert_user_args, $input, $mutation_name );
 
@@ -211,7 +211,8 @@ class UserMutation {
 	 * @param AppContext  $context       The AppContext passed down the resolve tree
 	 * @param ResolveInfo $info          The ResolveInfo passed down the Resolve Tree
 	 *
-	 * @throws \Exception
+	 * @return void
+	 * @throws Exception
 	 */
 	public static function update_additional_user_object_data( $user_id, $input, $mutation_name, AppContext $context, ResolveInfo $info ) {
 
@@ -239,7 +240,8 @@ class UserMutation {
 	 * @param int   $user_id The ID of the user
 	 * @param array $roles   List of roles that need to get added to the user
 	 *
-	 * @throws \Exception
+	 * @return void
+	 * @throws Exception
 	 */
 	private static function add_user_roles( $user_id, $roles ) {
 
@@ -259,10 +261,10 @@ class UserMutation {
 					$user->add_role( $role );
 				} elseif ( is_wp_error( $verified ) ) {
 					$message = $verified->get_error_message();
-					throw new \Exception( $message );
+					throw new Exception( $message );
 				} elseif ( false === $verified ) {
 					// Translators: The placeholder is the name of the user role
-					throw new \Exception( sprintf( __( 'The %s role cannot be added to this user', 'wp-graphql' ), $role ) );
+					throw new Exception( sprintf( __( 'The %s role cannot be added to this user', 'wp-graphql' ), $role ) );
 				}
 			}
 		}

--- a/src/Model/CommentAuthor.php
+++ b/src/Model/CommentAuthor.php
@@ -2,7 +2,9 @@
 
 namespace WPGraphQL\Model;
 
+use Exception;
 use GraphQLRelay\Relay;
+use WP_Comment;
 
 /**
  * Class CommentAuthor - Models the CommentAuthor object
@@ -19,18 +21,18 @@ class CommentAuthor extends Model {
 	/**
 	 * Stores the comment author to be modeled
 	 *
-	 * @var array $data
+	 * @var WP_Comment $data The raw data passed to he model
 	 */
 	protected $data;
 
 	/**
 	 * CommentAuthor constructor.
 	 *
-	 * @param \WP_Comment $comment_author The incoming comment author array to be modeled
+	 * @param WP_Comment $comment_author The incoming comment author array to be modeled
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
-	public function __construct( $comment_author ) {
+	public function __construct( WP_Comment $comment_author ) {
 		$this->data = $comment_author;
 		parent::__construct();
 	}

--- a/src/Model/Menu.php
+++ b/src/Model/Menu.php
@@ -77,7 +77,7 @@ class Menu extends Model {
 
 			$this->fields = [
 				'id'         => function() {
-					return ! empty( $this->data->term_id ) ? Relay::toGlobalId( 'term', $this->data->term_id ) : null;
+					return ! empty( $this->data->term_id ) ? Relay::toGlobalId( 'term', (string) $this->data->term_id ) : null;
 				},
 				'count'      => function() {
 					return ! empty( $this->data->count ) ? absint( $this->data->count ) : null;

--- a/src/Model/MenuItem.php
+++ b/src/Model/MenuItem.php
@@ -2,8 +2,10 @@
 
 namespace WPGraphQL\Model;
 
+use Exception;
 use GraphQL\Error\UserError;
 use GraphQLRelay\Relay;
+use WP_Post;
 
 /**
  * Class MenuItem - Models the data for the MenuItem object type
@@ -30,19 +32,19 @@ class MenuItem extends Model {
 	/**
 	 * Stores the incoming post data
 	 *
-	 * @var \WP_Post $data
+	 * @var mixed|WP_Post|object $data
 	 */
 	protected $data;
 
 	/**
 	 * MenuItem constructor.
 	 *
-	 * @param \WP_Post $post The incoming WP_Post object that needs modeling
+	 * @param WP_Post $post The incoming WP_Post object that needs modeling
 	 *
 	 * @return void
-	 * @throws \Exception
+	 * @throws Exception
 	 */
-	public function __construct( \WP_Post $post ) {
+	public function __construct( WP_Post $post ) {
 		$this->data = wp_setup_nav_menu_item( $post );
 		parent::__construct();
 	}
@@ -54,7 +56,7 @@ class MenuItem extends Model {
 	 * it's not considered a public node
 	 *
 	 * @return bool
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function is_private() {
 
@@ -81,7 +83,7 @@ class MenuItem extends Model {
 		}
 
 		if ( is_wp_error( $menus ) ) {
-			throw new \Exception( sprintf( __( 'No menus could be found for menu item %s', 'wp-graphql' ), $this->data->ID ) );
+			throw new Exception( sprintf( __( 'No menus could be found for menu item %s', 'wp-graphql' ), $this->data->ID ) );
 		}
 		$menu_id = $menus[0];
 		if ( empty( $location_ids ) || ! in_array( $menu_id, $location_ids, true ) ) {
@@ -160,6 +162,7 @@ class MenuItem extends Model {
 							}
 						}
 					}
+
 					return $url;
 
 				},

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -2,6 +2,9 @@
 
 namespace WPGraphQL\Model;
 
+use Exception;
+use WP_User;
+
 /**
  * Class Model - Abstract class for modeling data for all core types
  *
@@ -48,7 +51,7 @@ abstract class Model {
 	/**
 	 * Stores the WP_User object for the current user in the session
 	 *
-	 * @var \WP_User $current_user
+	 * @var WP_User $current_user
 	 */
 	protected $current_user;
 
@@ -77,12 +80,12 @@ abstract class Model {
 	 *                                            data to compare with the current user ID
 	 *
 	 * @return void
-	 * @throws \Exception Throws Exception.
+	 * @throws Exception Throws Exception.
 	 */
 	protected function __construct( $restricted_cap = '', $allowed_restricted_fields = [], $owner = null ) {
 
 		if ( empty( $this->data ) ) {
-			throw new \Exception( sprintf( __( 'An empty data set was used to initialize the modeling of this %s object', 'wp-graphql' ), $this->get_model_name() ) );
+			throw new Exception( sprintf( __( 'An empty data set was used to initialize the modeling of this %s object', 'wp-graphql' ), $this->get_model_name() ) );
 		}
 
 		$this->restricted_cap            = $restricted_cap;
@@ -158,6 +161,8 @@ abstract class Model {
 
 	/**
 	 * Generic model setup before the resolver function executes
+	 *
+	 * @return void
 	 */
 	public function setup() {
 	}
@@ -165,6 +170,8 @@ abstract class Model {
 	/**
 	 * Generic model tear down after the fields are setup. This can be used
 	 * to reset state to where it was before the model was setup.
+	 *
+	 * @return void
 	 */
 	public function tear_down() {
 	}
@@ -176,16 +183,19 @@ abstract class Model {
 	 */
 	protected function get_model_name() {
 
+		$name = static::class;
+
 		if ( empty( $this->model_name ) ) {
 			if ( false !== strpos( static::class, '\\' ) ) {
-				$name = substr( strrchr( static::class, '\\' ), 1 );
-			} else {
-				$name = static::class;
+				$starting_character = strrchr( static::class, '\\' );
+				if ( ! empty( $starting_character ) ) {
+					$name = substr( $starting_character, 1 );
+				}
 			}
 			$this->model_name = $name . 'Object';
 		}
 
-		return $this->model_name;
+		return ! empty( $this->model_name ) ? $this->model_name : $name;
 
 	}
 
@@ -206,7 +216,7 @@ abstract class Model {
 			 * @param mixed       $data           The un-modeled incoming data
 			 * @param string|null $visibility     The visibility that has currently been set for the data at this point
 			 * @param null|int    $owner          The user ID for the owner of this piece of data
-			 * @param \WP_User    $current_user   The current user for the session
+			 * @param WP_User     $current_user   The current user for the session
 			 *
 			 * @return string
 			 */
@@ -219,7 +229,7 @@ abstract class Model {
 			 * @param mixed       $data         The un-modeled incoming data
 			 * @param string|null $visibility   The visibility that has currently been set for the data at this point
 			 * @param null|int    $owner        The user ID for the owner of this piece of data
-			 * @param \WP_User    $current_user The current user for the session
+			 * @param WP_User     $current_user The current user for the session
 			 *
 			 * @return bool
 			 */
@@ -243,7 +253,7 @@ abstract class Model {
 		 * @param string      $model_name   Name of the model the filter is currently being executed in
 		 * @param mixed       $data         The un-modeled incoming data
 		 * @param null|int    $owner        The user ID for the owner of this piece of data
-		 * @param \WP_User    $current_user The current user for the session
+		 * @param WP_User     $current_user The current user for the session
 		 *
 		 * @return string
 		 */
@@ -271,7 +281,7 @@ abstract class Model {
 			return false;
 		}
 
-		return ( absint( $this->owner ) === absint( $this->current_user->ID ) ) ? true : false;
+		return absint( $this->owner ) === absint( $this->current_user->ID );
 	}
 
 	/**
@@ -291,7 +301,7 @@ abstract class Model {
 			 * @param mixed       $data                      The un-modeled incoming data
 			 * @param string|null $visibility                The visibility that has currently been set for the data at this point
 			 * @param null|int    $owner                     The user ID for the owner of this piece of data
-			 * @param \WP_User    $current_user              The current user for the session
+			 * @param WP_User     $current_user              The current user for the session
 			 *
 			 * @return array
 			 */
@@ -328,7 +338,7 @@ abstract class Model {
 					 * @param mixed    $data         The un-modeled incoming data
 					 * @param string   $visibility   The visibility setting for this piece of data
 					 * @param null|int $owner        The user ID for the owner of this piece of data
-					 * @param \WP_User $current_user The current user for the session
+					 * @param WP_User  $current_user The current user for the session
 					 *
 					 * @return string
 					 */
@@ -352,7 +362,7 @@ abstract class Model {
 				 * @param mixed    $data         The un-modeled incoming data
 				 * @param string   $visibility   The visibility setting for this piece of data
 				 * @param null|int $owner        The user ID for the owner of this piece of data
-				 * @param \WP_User $current_user The current user for the session
+				 * @param WP_User  $current_user The current user for the session
 				 *
 				 * @return null|callable|int|string|array|mixed
 				 */
@@ -378,7 +388,7 @@ abstract class Model {
 					 * @param mixed    $data         The un-modeled incoming data
 					 * @param string   $visibility   The visibility setting for this piece of data
 					 * @param null|int $owner        The user ID for the owner of this piece of data
-					 * @param \WP_User $current_user The current user for the session
+					 * @param WP_User  $current_user The current user for the session
 					 *
 					 * @return mixed
 					 */
@@ -394,7 +404,7 @@ abstract class Model {
 				 * @param mixed    $data         The un-modeled incoming data
 				 * @param string   $visibility   The visibility setting for this piece of data
 				 * @param null|int $owner        The user ID for the owner of this piece of data
-				 * @param \WP_User $current_user The current user for the session
+				 * @param WP_User  $current_user The current user for the session
 				 */
 				do_action( 'graphql_after_return_field_from_model', $result, $key, $this->get_model_name(), $this->data, $this->visibility, $this->owner, $this->current_user );
 
@@ -417,13 +427,13 @@ abstract class Model {
 		 * @TODO: potentially abstract this out into a more central spot
 		 */
 		$this->fields['isPublic']     = function() {
-			return ( 'public' === $this->get_visibility() ) ? true : false;
+			return 'public' === $this->get_visibility();
 		};
 		$this->fields['isRestricted'] = function() {
-			return ( 'restricted' === $this->get_visibility() ) ? true : false;
+			return 'restricted' === $this->get_visibility();
 		};
 		$this->fields['isPrivate']    = function() {
-			return ( 'private' === $this->get_visibility() ) ? true : false;
+			return 'private' === $this->get_visibility();
 		};
 
 	}
@@ -446,7 +456,7 @@ abstract class Model {
 		 * @param string   $model_name   Name of the model the filter is currently being executed in
 		 * @param string   $visibility   The visibility setting for this piece of data
 		 * @param null|int $owner        The user ID for the owner of this piece of data
-		 * @param \WP_User $current_user The current user for the session
+		 * @param WP_User  $current_user The current user for the session
 		 *
 		 * @return array
 		 */
@@ -509,6 +519,9 @@ abstract class Model {
 
 	}
 
+	/**
+	 * @return mixed
+	 */
 	abstract protected function init();
 
 }

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -7,7 +7,11 @@
 
 namespace WPGraphQL\Model;
 
+use Exception;
 use GraphQLRelay\Relay;
+use WP_Post;
+use WP_Post_Type;
+use WP_Query;
 use WPGraphQL\Utils\Utils;
 
 /**
@@ -19,6 +23,7 @@ use WPGraphQL\Utils\Utils;
  * @property string  $post_type
  * @property string  $authorId
  * @property string  $authorDatabaseId
+ * @property int     $databaseId
  * @property string  $date
  * @property string  $dateGmt
  * @property string  $contentRendered
@@ -55,7 +60,7 @@ use WPGraphQL\Utils\Utils;
  * @property string  $featuredImageId
  * @property int     $featuredImageDatabaseId
  * @property string  $pageTemplate
- * @property int     previewRevisionDatabaseId
+ * @property int     $previewRevisionDatabaseId
  *
  * @property string  $captionRaw
  * @property string  $captionRendered
@@ -74,40 +79,40 @@ class Post extends Model {
 	/**
 	 * Stores the incoming post data
 	 *
-	 * @var \WP_Post $data
+	 * @var WP_Post $data
 	 */
 	protected $data;
 
 	/**
 	 * Store the global post to reset during model tear down
 	 *
-	 * @var \WP_Post
+	 * @var WP_Post
 	 */
 	protected $global_post;
 
 	/**
 	 * Stores the incoming post type object for the post being modeled
 	 *
-	 * @var null|\WP_Post_Type $post_type_object
+	 * @var null|WP_Post_Type $post_type_object
 	 */
 	protected $post_type_object;
 
 	/**
 	 * Store the instance of the WP_Query
 	 *
-	 * @var \WP_Query
+	 * @var WP_Query
 	 */
 	protected $wp_query;
 
 	/**
 	 * Post constructor.
 	 *
-	 * @param \WP_Post $post The incoming WP_Post object that needs modeling.
+	 * @param WP_Post $post The incoming WP_Post object that needs modeling.
 	 *
-	 * @throws \Exception
 	 * @return void
+	 * @throws Exception
 	 */
-	public function __construct( \WP_Post $post ) {
+	public function __construct( WP_Post $post ) {
 
 		/**
 		 * Set the data as the Post object
@@ -120,8 +125,10 @@ class Post extends Model {
 		 * of the parent post type to determine capabilities from
 		 */
 		if ( 'revision' === $post->post_type && ! empty( $post->post_parent ) ) {
-			$parent                 = get_post( absint( $post->post_parent ) );
-			$this->post_type_object = get_post_type_object( $parent->post_type );
+			$parent = get_post( absint( $post->post_parent ) );
+			if ( ! empty( $parent ) ) {
+				$this->post_type_object = get_post_type_object( $parent->post_type );
+			}
 		}
 
 		/**
@@ -155,12 +162,14 @@ class Post extends Model {
 
 		$restricted_cap = $this->get_restricted_cap();
 
-		parent::__construct( $restricted_cap, $allowed_restricted_fields, $post->post_author );
+		parent::__construct( $restricted_cap, $allowed_restricted_fields, (int) $post->post_author );
 
 	}
 
 	/**
 	 * Setup the global data for the model to have proper context when resolving
+	 *
+	 * @return void
 	 */
 	public function setup() {
 
@@ -176,7 +185,7 @@ class Post extends Model {
 		 * might be applied when resolving fields can rely on global post and
 		 * post data being set up.
 		 */
-		if ( $this->data ) {
+		if ( ! empty( $this->data ) ) {
 
 			$id        = $this->data->ID;
 			$post_type = $this->data->post_type;
@@ -184,8 +193,12 @@ class Post extends Model {
 			$data      = $this->data;
 
 			if ( 'revision' === $this->data->post_type ) {
-				$id        = $this->data->post_parent;
-				$parent    = get_post( $this->data->post_parent );
+				$id     = $this->data->post_parent;
+				$parent = get_post( $this->data->post_parent );
+				if ( empty( $parent ) ) {
+					$this->fields = [];
+					return;
+				}
 				$post_type = $parent->post_type;
 				$post_name = $parent->post_name;
 				$data      = $parent;
@@ -201,25 +214,33 @@ class Post extends Model {
 			 * setup global state
 			 */
 			if ( 'post' === $post_type ) {
-				$wp_query->parse_query( [
-					'page' => '',
-					'p'    => $id,
-				] );
+				$wp_query->parse_query(
+					[
+						'page' => '',
+						'p'    => $id,
+					]
+				);
 			} elseif ( 'page' === $post_type ) {
-				$wp_query->parse_query( [
-					'page'     => '',
-					'pagename' => $post_name,
-				] );
+				$wp_query->parse_query(
+					[
+						'page'     => '',
+						'pagename' => $post_name,
+					]
+				);
 			} elseif ( 'attachment' === $post_type ) {
-				$wp_query->parse_query( [
-					'attachment' => $post_name,
-				] );
+				$wp_query->parse_query(
+					[
+						'attachment' => $post_name,
+					]
+				);
 			} else {
-				$wp_query->parse_query( [
-					$post_type  => $post_name,
-					'post_type' => $post_type,
-					'name'      => $post_name,
-				] );
+				$wp_query->parse_query(
+					[
+						$post_type  => $post_name,
+						'post_type' => $post_type,
+						'name'      => $post_name,
+					]
+				);
 			}
 
 			$wp_query->setup_postdata( $data );
@@ -237,17 +258,17 @@ class Post extends Model {
 	 */
 	protected function get_restricted_cap() {
 		if ( ! empty( $this->data->post_password ) ) {
-			return $this->post_type_object->cap->edit_others_posts;
+			return isset( $this->post_type_object->cap->edit_others_posts ) ? $this->post_type_object->cap->edit_others_posts : 'edit_others_posts';
 		}
 
 		switch ( $this->data->post_status ) {
 			case 'trash':
-				$cap = $this->post_type_object->cap->edit_posts;
+				$cap = isset( $this->post_type_object->cap->edit_posts ) ? $this->post_type_object->cap->edit_posts : 'edit_posts';
 				break;
 			case 'draft':
 			case 'future':
 			case 'pending':
-				$cap = $this->post_type_object->cap->edit_others_posts;
+				$cap = isset( $this->post_type_object->cap->edit_others_posts ) ? $this->post_type_object->cap->edit_others_posts : 'edit_others_posts';
 				break;
 			default:
 				$cap = '';
@@ -276,7 +297,7 @@ class Post extends Model {
 			$parent_post = get_post( $this->data->post_parent );
 
 			// If the parent post doesn't exist, the revision should be considered private
-			if ( ! $parent_post instanceof \WP_Post ) {
+			if ( ! $parent_post instanceof WP_Post ) {
 				return true;
 			}
 
@@ -315,7 +336,7 @@ class Post extends Model {
 	/**
 	 * Method for determining if the data should be considered private or not
 	 *
-	 * @param \WP_Post $post_object The object of the post we need to verify permissions for
+	 * @param WP_Post $post_object The object of the post we need to verify permissions for
 	 *
 	 * @return bool
 	 */
@@ -335,7 +356,7 @@ class Post extends Model {
 		 * If the status is NOT publish and the user does NOT have capabilities to edit posts,
 		 * consider the post private.
 		 */
-		if ( ! current_user_can( $post_type_object->cap->edit_posts ) ) {
+		if ( ! isset( $post_type_object->cap->edit_posts ) || ! current_user_can( $post_type_object->cap->edit_posts ) ) {
 			return true;
 		}
 
@@ -355,18 +376,27 @@ class Post extends Model {
 			return true;
 		}
 
-		if ( 'private' === $this->data->post_status && ! current_user_can( $post_type_object->cap->read_private_posts ) ) {
+		if ( 'private' === $this->data->post_status && ( ! isset( $post_type_object->cap->read_private_posts ) || ! current_user_can( $post_type_object->cap->read_private_posts ) ) ) {
 			return true;
 		}
 
 		if ( 'revision' === $this->data->post_type || 'auto-draft' === $this->data->post_status ) {
-			$parent               = get_post( (int) $this->data->post_parent );
+			$parent = get_post( (int) $this->data->post_parent );
+
+			if ( empty( $parent ) ) {
+				return true;
+			}
+
 			$parent_post_type_obj = $post_type_object;
 
+			if ( empty( $parent_post_type_obj ) ) {
+				return true;
+			}
+
 			if ( 'private' === $parent->post_status ) {
-				$cap = $parent_post_type_obj->cap->read_private_posts;
+				$cap = isset( $parent_post_type_obj->cap->read_private_posts ) ? $parent_post_type_obj->cap->read_private_posts : 'read_private_posts';
 			} else {
-				$cap = $parent_post_type_obj->cap->edit_post;
+				$cap = isset( $parent_post_type_obj->cap->edit_post ) ? $parent_post_type_obj->cap->edit_post : 'edit_post';
 			}
 
 			if ( ! current_user_can( $cap, $parent->ID ) ) {
@@ -393,13 +423,18 @@ class Post extends Model {
 				},
 				'post_author'               => function() {
 					if ( $this->isPreview ) {
-						return get_post( $this->parentDatabaseId )->post_author;
+						$parent_post = get_post( $this->parentDatabaseId );
+						if ( empty( $parent_post ) ) {
+							return null;
+						}
+
+						return (int) $parent_post->post_author;
 					}
 
 					return ! empty( $this->data->post_author ) ? $this->data->post_author : null;
 				},
 				'id'                        => function() {
-					return ( ! empty( $this->data->post_type ) && ! empty( $this->databaseId ) ) ? Relay::toGlobalId( 'post', $this->databaseId ) : null;
+					return ( ! empty( $this->data->post_type ) && ! empty( $this->databaseId ) ) ? Relay::toGlobalId( 'post', (string) $this->databaseId ) : null;
 				},
 				'databaseId'                => function() {
 					return isset( $this->data->ID ) ? absint( $this->data->ID ) : null;
@@ -410,24 +445,33 @@ class Post extends Model {
 				'authorId'                  => function() {
 
 					if ( true === $this->isPreview ) {
-						$id = get_post( $this->data->post_parent )->post_author;
+						$parent_post = get_post( $this->data->post_parent );
+						if ( empty( $parent_post ) ) {
+							return null;
+						}
+						$id = (int) $parent_post->post_author;
 
 					} else {
-						$id = isset( $this->data->post_author ) ? $this->data->post_author : null;
+						$id = isset( $this->data->post_author ) ? (int) $this->data->post_author : null;
 					}
 
-					return Relay::toGlobalId( 'user', $id );
+					return Relay::toGlobalId( 'user', (string) $id );
 				},
 				'authorDatabaseId'          => function() {
 					if ( true === $this->isPreview ) {
-						return get_post( $this->data->post_parent )->post_author;
+						$parent_post = get_post( $this->data->post_parent );
+						if ( empty( $parent_post ) ) {
+							return null;
+						}
+
+						return $parent_post->post_author;
 					}
 
 					return isset( $this->data->post_author ) ? $this->data->post_author : null;
 
 				},
 				'date'                      => function() {
-					return ! empty( $this->data->post_date ) && '0000-00-00 00:00:00' !== $this->data->post_date ? Utils::prepare_date_response( null, $this->data->post_date ) : null;
+					return ! empty( $this->data->post_date ) && '0000-00-00 00:00:00' !== $this->data->post_date ? Utils::prepare_date_response( $this->data->post_date_gmt, $this->data->post_date ) : null;
 				},
 				'dateGmt'                   => function() {
 					return ! empty( $this->data->post_date_gmt ) ? Utils::prepare_date_response( $this->data->post_date_gmt ) : null;
@@ -446,7 +490,7 @@ class Post extends Model {
 					'callback'   => function() {
 						return ! empty( $this->data->post_content ) ? $this->data->post_content : null;
 					},
-					'capability' => $this->post_type_object->cap->edit_posts,
+					'capability' => isset( $this->post_type_object->cap->edit_posts ) ? $this->post_type_object->cap->edit_posts : 'edit_posts',
 				],
 				'titleRendered'             => function() {
 					$id    = ! empty( $this->data->ID ) ? $this->data->ID : null;
@@ -458,7 +502,7 @@ class Post extends Model {
 					'callback'   => function() {
 						return ! empty( $this->data->post_title ) ? $this->data->post_title : null;
 					},
-					'capability' => $this->post_type_object->cap->edit_posts,
+					'capability' => isset( $this->post_type_object->cap->edit_posts ) ? $this->post_type_object->cap->edit_posts : 'edit_posts',
 				],
 				'excerptRendered'           => function() {
 					$excerpt = ! empty( $this->data->post_excerpt ) ? $this->data->post_excerpt : null;
@@ -470,7 +514,7 @@ class Post extends Model {
 					'callback'   => function() {
 						return ! empty( $this->data->post_excerpt ) ? $this->data->post_excerpt : null;
 					},
-					'capability' => $this->post_type_object->cap->edit_posts,
+					'capability' => isset( $this->post_type_object->cap->edit_posts ) ? $this->post_type_object->cap->edit_posts : 'edit_posts',
 				],
 				'post_status'               => function() {
 					return ! empty( $this->data->post_status ) ? $this->data->post_status : null;
@@ -496,9 +540,16 @@ class Post extends Model {
 						'templateName' => 'Default',
 					];
 
-					if ( $this->isPreview ) {
+					if ( true === $this->isPreview ) {
 
-						$post_type = get_post( $this->parentDatabaseId )->post_type;
+						$parent_post = get_post( $this->parentDatabaseId );
+
+						if ( empty( $parent_post ) ) {
+							return $template;
+						}
+
+						$post_type = $parent_post->post_type;
+
 						if ( ! isset( $registered_templates[ $post_type ] ) ) {
 							return $template;
 						}
@@ -527,8 +578,12 @@ class Post extends Model {
 					}
 
 					if ( ! empty( $template_name ) && ! empty( $registered_templates[ $post_type ][ $set_template ] ) ) {
-						$name = ucwords( $registered_templates[ $post_type ][ $set_template ] );
-						$name = preg_replace( '/[^\w]/', '', $name );
+						$name          = ucwords( $registered_templates[ $post_type ][ $set_template ] );
+						$replaced_name = preg_replace( '/[^\w]/', '', $name );
+
+						if ( ! empty( $replaced_name ) ) {
+							$name = $replaced_name;
+						}
 						if ( preg_match( '/^\d/', $name ) || false === strpos( strtolower( $name ), 'template' ) ) {
 							$name = 'Template_' . $name;
 						}
@@ -551,7 +606,7 @@ class Post extends Model {
 
 					return false;
 				},
-				'isPostsPage'               => function () {
+				'isPostsPage'               => function() {
 					if ( 'page' !== $this->data->post_type ) {
 						return false;
 					}
@@ -562,10 +617,14 @@ class Post extends Model {
 					return false;
 				},
 				'toPing'                    => function() {
-					return ! empty( $this->data->to_ping ) && is_array( $this->data->to_ping ) ? implode( ',', (array) $this->data->to_ping ) : null;
+					$to_ping = get_to_ping( $this->databaseId );
+
+					return ! empty( $to_ping ) ? implode( ',', (array) $to_ping ) : null;
 				},
 				'pinged'                    => function() {
-					return ! empty( $this->data->pinged ) && is_array( $this->data->pinged ) ? implode( ',', (array) $this->data->pinged ) : null;
+					$punged = get_pung( $this->databaseId );
+
+					return ! empty( $punged ) ? implode( ',', (array) $punged ) : null;
 				},
 				'modified'                  => function() {
 					return ! empty( $this->data->post_modified ) && '0000-00-00 00:00:00' !== $this->data->post_modified ? $this->data->post_modified : null;
@@ -574,7 +633,7 @@ class Post extends Model {
 					return ! empty( $this->data->post_modified_gmt ) ? Utils::prepare_date_response( $this->data->post_modified_gmt ) : null;
 				},
 				'parentId'                  => function() {
-					return ( ! empty( $this->data->post_type ) && ! empty( $this->data->post_parent ) ) ? Relay::toGlobalId( 'post', $this->data->post_parent ) : null;
+					return ( ! empty( $this->data->post_type ) && ! empty( $this->data->post_parent ) ) ? Relay::toGlobalId( 'post', (string) $this->data->post_parent ) : null;
 				},
 				'parentDatabaseId'          => function() {
 					return ! empty( $this->data->post_parent ) ? absint( $this->data->post_parent ) : null;
@@ -631,7 +690,7 @@ class Post extends Model {
 					return ! empty( $this->data->comment_count ) ? absint( $this->data->comment_count ) : null;
 				},
 				'featuredImageId'           => function() {
-					return ! empty( $this->featuredImageDatabaseId ) ? Relay::toGlobalId( 'post', absint( $this->featuredImageDatabaseId ) ) : null;
+					return ! empty( $this->featuredImageDatabaseId ) ? Relay::toGlobalId( 'post', (string) $this->featuredImageDatabaseId ) : null;
 				},
 				'featuredImageDatabaseId'   => function() {
 
@@ -649,7 +708,7 @@ class Post extends Model {
 					'callback'   => function() {
 						return ! empty( $this->data->post_password ) ? $this->data->post_password : null;
 					},
-					'capability' => $this->post_type_object->cap->edit_others_posts,
+					'capability' => isset( $this->post_type_object->cap->edit_others_posts ) ?: 'edit_others_posts',
 				],
 				'enqueuedScriptsQueue'      => function() {
 					global $wp_scripts;
@@ -670,30 +729,36 @@ class Post extends Model {
 					return $queue;
 				},
 				'isRevision'                => function() {
-					return 'revision' === $this->data->post_type ? true : false;
+					return 'revision' === $this->data->post_type;
 				},
 				'previewRevisionDatabaseId' => [
 					'callback'   => function() {
-						$revisions = wp_get_post_revisions( $this->data->ID, [
-							'posts_per_page' => 1,
-							'fields'         => 'ids',
-							'check_enabled'  => false,
-						] );
+						$revisions = wp_get_post_revisions(
+							$this->data->ID,
+							[
+								'posts_per_page' => 1,
+								'fields'         => 'ids',
+								'check_enabled'  => false,
+							]
+						);
 
 						return is_array( $revisions ) && ! empty( $revisions ) ? array_values( $revisions )[0] : null;
 					},
-					'capability' => $this->post_type_object->cap->edit_posts,
+					'capability' => isset( $this->post_type_object->cap->edit_posts ) ? $this->post_type_object->cap->edit_posts : 'edit_posts',
 				],
 				'previewRevisionId'         => function() {
-					return ! empty( $this->previewRevisionDatabaseId ) ? Relay::toGlobalId( 'post', $this->previewRevisionDatabaseId ) : null;
+					return ! empty( $this->previewRevisionDatabaseId ) ? Relay::toGlobalId( 'post', (string) $this->previewRevisionDatabaseId ) : null;
 				},
 				'isPreview'                 => function() {
 					if ( $this->isRevision ) {
-						$revisions = wp_get_post_revisions( $this->parentDatabaseId, [
-							'posts_per_page' => 1,
-							'fields'         => 'ids',
-							'check_enabled'  => false,
-						] );
+						$revisions = wp_get_post_revisions(
+							$this->parentDatabaseId,
+							[
+								'posts_per_page' => 1,
+								'fields'         => 'ids',
+								'check_enabled'  => false,
+							]
+						);
 
 						if ( in_array( $this->data->ID, array_values( $revisions ), true ) ) {
 							return true;
@@ -718,7 +783,7 @@ class Post extends Model {
 						'callback'   => function() {
 							return ! empty( $this->data->post_excerpt ) ? $this->data->post_excerpt : null;
 						},
-						'capability' => $this->post_type_object->cap->edit_posts,
+						'capability' => isset( $this->post_type_object->cap->edit_posts ) ? $this->post_type_object->cap->edit_posts : 'edit_posts',
 					],
 					'altText'             => function() {
 						return get_post_meta( $this->data->ID, '_wp_attachment_image_alt', true );
@@ -730,7 +795,7 @@ class Post extends Model {
 						'callback'   => function() {
 							return ! empty( $this->data->post_content ) ? $this->data->post_content : null;
 						},
-						'capability' => $this->post_type_object->cap->edit_posts,
+						'capability' => isset( $this->post_type_object->cap->edit_posts ) ? $this->post_type_object->cap->edit_posts : 'edit_posts',
 					],
 					'mediaType'           => function() {
 						return wp_attachment_is_image( $this->data->ID ) ? 'image' : 'file';
@@ -741,14 +806,15 @@ class Post extends Model {
 					'sourceUrl'           => function() {
 						$source_url = wp_get_attachment_image_src( $this->data->ID, 'full' );
 
-						return isset( $source_url[0] ) ? $source_url[0] : null;
+						return ! empty( $source_url ) && isset( $source_url[0] ) ? $source_url[0] : null;
 					},
 					'sourceUrlsBySize'    => function() {
 						$sizes = get_intermediate_image_sizes();
 						$urls  = [];
 						if ( ! empty( $sizes ) && is_array( $sizes ) ) {
 							foreach ( $sizes as $size ) {
-								$urls[ $size ] = wp_get_attachment_image_src( $this->data->ID, $size )[0];
+								$img_src       = wp_get_attachment_image_src( $this->data->ID, $size );
+								$urls[ $size ] = ! empty( $img_src ) && isset( $img_src[0] ) ? $img_src[0] : null;
 							}
 						}
 

--- a/src/Model/PostType.php
+++ b/src/Model/PostType.php
@@ -74,7 +74,9 @@ class PostType extends Model {
 			'isFrontPage',
 		];
 
-		parent::__construct( $post_type->cap->edit_posts, $allowed_restricted_fields );
+		$capability = isset( $post_type->cap->edit_posts ) ? $post_type->cap->edit_posts : 'edit_posts';
+
+		parent::__construct( $capability, $allowed_restricted_fields );
 
 	}
 
@@ -85,7 +87,7 @@ class PostType extends Model {
 	 */
 	protected function is_private() {
 
-		if ( false === $this->data->public && ! current_user_can( $this->data->cap->edit_posts ) ) {
+		if ( false === $this->data->public && ( ! isset( $this->data->cap->edit_posts ) || ! current_user_can( $this->data->cap->edit_posts ) ) ) {
 			return true;
 		}
 

--- a/src/Model/Taxonomy.php
+++ b/src/Model/Taxonomy.php
@@ -66,7 +66,9 @@ class Taxonomy extends Model {
 			'isRestricted',
 		];
 
-		parent::__construct( $this->data->cap->edit_terms, $allowed_restricted_fields );
+		$capability = isset( $this->data->cap->edit_terms ) ? $this->data->cap->edit_terms : 'edit_terms';
+
+		parent::__construct( $capability, $allowed_restricted_fields );
 
 	}
 
@@ -77,7 +79,7 @@ class Taxonomy extends Model {
 	 */
 	protected function is_private() {
 
-		if ( false === $this->data->public && ! current_user_can( $this->data->cap->edit_terms ) ) {
+		if ( false === $this->data->public && ( ! isset( $this->data->cap->edit_terms ) || ! current_user_can( $this->data->cap->edit_terms ) ) ) {
 			return true;
 		}
 

--- a/src/Model/UserRole.php
+++ b/src/Model/UserRole.php
@@ -7,10 +7,10 @@ use GraphQLRelay\Relay;
 /**
  * Class UserRole - Models data for user roles
  *
+ * @property string $displayName
  * @property string $id
- * @property string name
+ * @property string $name
  * @property array  $capabilities
- * @property string displayName
  *
  * @package WPGraphQL\Model
  */

--- a/src/Mutation/CommentCreate.php
+++ b/src/Mutation/CommentCreate.php
@@ -2,6 +2,7 @@
 
 namespace WPGraphQL\Mutation;
 
+use Exception;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
@@ -11,6 +12,9 @@ use WPGraphQL\Data\DataSource;
 class CommentCreate {
 	/**
 	 * Registers the CommentCreate mutation.
+	 *
+	 * @return void
+	 * @throws Exception
 	 */
 	public static function register_mutation() {
 		register_graphql_mutation(
@@ -122,10 +126,16 @@ class CommentCreate {
 				throw new UserError( __( 'Mutation not processed. There was no input for the mutation or the comment_object was invalid', 'wp-graphql' ) );
 			}
 
+			$commented_on = get_post( absint( $input['commentOn'] ) );
+
+			if ( empty( $commented_on ) ) {
+				return new UserError( __( 'The ID of the node to comment on is invalid', 'wp-graphql' ) );
+			}
+
 			/**
 			 * Stop if post not open to comments
 			 */
-			if ( empty( $input['commentOn'] ) || get_post( $input['commentOn'] )->comment_status === 'closed' ) {
+			if ( empty( $input['commentOn'] ) || $commented_on->comment_status === 'closed' ) {
 				throw new UserError( __( 'Sorry, this post is closed to comments at the moment', 'wp-graphql' ) );
 			}
 

--- a/src/Mutation/CommentCreate.php
+++ b/src/Mutation/CommentCreate.php
@@ -135,7 +135,7 @@ class CommentCreate {
 			/**
 			 * Stop if post not open to comments
 			 */
-			if ( empty( $input['commentOn'] ) || $commented_on->comment_status === 'closed' ) {
+			if ( empty( $input['commentOn'] ) || 'closed' === $commented_on->comment_status ) {
 				throw new UserError( __( 'Sorry, this post is closed to comments at the moment', 'wp-graphql' ) );
 			}
 

--- a/src/Mutation/CommentRestore.php
+++ b/src/Mutation/CommentRestore.php
@@ -16,6 +16,8 @@ use WPGraphQL\Data\DataSource;
 class CommentRestore {
 	/**
 	 * Registers the CommentRestore mutation.
+	 *
+	 * @return void
 	 */
 	public static function register_mutation() {
 		register_graphql_mutation(
@@ -57,7 +59,7 @@ class CommentRestore {
 				'resolve'     => function ( $payload ) {
 					$restore = (object) $payload['commentObject'];
 
-					return ! empty( $restore->comment_ID ) ? Relay::toGlobalId( 'comment', absint( $restore->comment_ID ) ) : null;
+					return ! empty( $restore->comment_ID ) ? Relay::toGlobalId( 'comment', $restore->comment_ID ) : null;
 				},
 			],
 			'comment'    => [

--- a/src/Mutation/MediaItemCreate.php
+++ b/src/Mutation/MediaItemCreate.php
@@ -2,6 +2,7 @@
 
 namespace WPGraphQL\Mutation;
 
+use Exception;
 use GraphQL\Deferred;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
@@ -12,6 +13,9 @@ use WPGraphQL\Data\MediaItemMutation;
 class MediaItemCreate {
 	/**
 	 * Registers the MediaItemCreate mutation.
+	 *
+	 * @return void
+	 * @throws Exception
 	 */
 	public static function register_mutation() {
 		register_graphql_mutation(
@@ -136,11 +140,13 @@ class MediaItemCreate {
 			 */
 			require_once ABSPATH . 'wp-admin/includes/file.php';
 
+			$file_contents = file_get_contents( $input['filePath'] );
+
 			/**
 			 * If the mediaItem file is from a local server, use wp_upload_bits before saving it to the uploads folder
 			 */
-			if ( 'file' === wp_parse_url( $input['filePath'], PHP_URL_SCHEME ) ) {
-				$uploaded_file     = wp_upload_bits( $file_name, null, file_get_contents( $input['filePath'] ) );
+			if ( 'file' === wp_parse_url( $input['filePath'], PHP_URL_SCHEME ) && ! empty( $file_contents ) ) {
+				$uploaded_file     = wp_upload_bits( $file_name, null, $file_contents );
 				$uploaded_file_url = ( empty( $uploaded_file['error'] ) ? $uploaded_file['url'] : null );
 			}
 
@@ -190,33 +196,46 @@ class MediaItemCreate {
 				throw new UserError( __( 'Sorry, the URL for this file is invalid, it must be a path to the mediaItem file', 'wp-graphql' ) );
 			}
 
+			$post_type_object = get_post_type_object( 'attachment' );
+
+			if ( empty( $post_type_object ) ) {
+				return null;
+			}
+
 			/**
 			 * Insert the mediaItem object and get the ID
 			 */
-			$media_item_args = MediaItemMutation::prepare_media_item( $input, get_post_type_object( 'attachment' ), 'createMediaItem', $file );
+			$media_item_args = MediaItemMutation::prepare_media_item( $input, $post_type_object, 'createMediaItem', $file );
 
 			/**
-			 * Get the post parent and if it's not set, set it to false
+			 * Get the post parent and if it's not set, set it to 0
 			 */
-			$attachment_parent_id = ( ! empty( $media_item_args['post_parent'] ) ? absint( $media_item_args['post_parent'] ) : false );
+			$attachment_parent_id = ! empty( $media_item_args['post_parent'] ) ? absint( $media_item_args['post_parent'] ) : 0;
 
 			/**
 			 * Stop now if a user isn't allowed to edit the parent post
 			 */
 			$parent = get_post( $attachment_parent_id );
 
-			if ( null !== get_post( $attachment_parent_id ) ) {
+			if ( null !== $parent ) {
 				$post_parent_type = get_post_type_object( $parent->post_type );
-				if ( 'attachment' !== $post_parent_type && ! current_user_can( $post_parent_type->cap->edit_post, $attachment_parent_id ) ) {
+
+				if ( empty( $post_parent_type ) ) {
+					throw new UserError( __( 'The parent of the Media Item is of an invalid type', 'wp-graphql' ) );
+				}
+
+				if ( 'attachment' !== $post_parent_type->name && ( ! isset( $post_parent_type->cap->edit_post ) || ! current_user_can( $post_parent_type->cap->edit_post, $attachment_parent_id ) ) ) {
 					throw new UserError( __( 'Sorry, you are not allowed to upload mediaItems assigned to this parent node', 'wp-graphql' ) );
 				}
 			}
+
+			$post_type_object = get_post_type_object( 'attachment' );
 
 			/**
 			 * If the mediaItem being created is being assigned to another user that's not the current user, make sure
 			 * the current user has permission to edit others mediaItems
 			 */
-			if ( ! empty( $input['authorId'] ) && get_current_user_id() !== $input['authorId'] && ! current_user_can( get_post_type_object( 'attachment' )->cap->edit_others_posts ) ) {
+			if ( ! empty( $input['authorId'] ) && get_current_user_id() !== $input['authorId'] && ( ! isset( $post_type_object->cap->edit_others_posts ) || ! current_user_can( $post_type_object->cap->edit_others_posts ) ) ) {
 				throw new UserError( __( 'Sorry, you are not allowed to create mediaItems as this user', 'wp-graphql' ) );
 			}
 
@@ -232,6 +251,10 @@ class MediaItemCreate {
 			 */
 			$attachment_id = wp_insert_attachment( $media_item_args, $file['file'], $attachment_parent_id );
 
+			if ( is_wp_error( $attachment_id ) ) {
+				throw new UserError( __( 'The Media Item failed to create', 'wp-graphql' ) );
+			}
+
 			/**
 			 * Check if the wp_generate_attachment_metadata method exists and include it if not
 			 */
@@ -245,10 +268,16 @@ class MediaItemCreate {
 			$attachment_data = wp_generate_attachment_metadata( $attachment_id, $file['file'] );
 			wp_update_attachment_metadata( $attachment_id, $attachment_data );
 
+			$post_type_object = get_post_type_object( 'attachment' );
+
+			if ( empty( $post_type_object ) ) {
+				throw new UserError( __( 'The Media Item could not be created', 'wp-graphql' ) );
+			}
+
 			/**
 			 * Update alt text postmeta for mediaItem
 			 */
-			MediaItemMutation::update_additional_media_item_data( $attachment_id, $input, get_post_type_object( 'attachment' ), 'createMediaItem', $context, $info );
+			MediaItemMutation::update_additional_media_item_data( $attachment_id, $input, $post_type_object, 'createMediaItem', $context, $info );
 
 			return [
 				'postObjectId' => $attachment_id,

--- a/src/Mutation/PostObjectDelete.php
+++ b/src/Mutation/PostObjectDelete.php
@@ -2,18 +2,22 @@
 
 namespace WPGraphQL\Mutation;
 
+use Exception;
 use GraphQL\Error\UserError;
 use GraphQLRelay\Relay;
-use WPGraphQL\Data\DataSource;
+use WP_Post_Type;
 use WPGraphQL\Model\Post;
 
 class PostObjectDelete {
 	/**
 	 * Registers the PostObjectDelete mutation.
 	 *
-	 * @param \WP_Post_Type $post_type_object The post type of the mutation.
+	 * @param WP_Post_Type $post_type_object The post type of the mutation.
+	 *
+	 * @return void
+	 * @throws Exception
 	 */
-	public static function register_mutation( \WP_Post_Type $post_type_object ) {
+	public static function register_mutation( WP_Post_Type $post_type_object ) {
 		$mutation_name = 'delete' . ucwords( $post_type_object->graphql_single_name );
 
 		register_graphql_mutation(
@@ -29,7 +33,7 @@ class PostObjectDelete {
 	/**
 	 * Defines the mutation input field configuration.
 	 *
-	 * @param \WP_Post_Type $post_type_object The post type of the mutation.
+	 * @param WP_Post_Type $post_type_object The post type of the mutation.
 	 *
 	 * @return array
 	 */
@@ -52,25 +56,25 @@ class PostObjectDelete {
 	/**
 	 * Defines the mutation output field configuration.
 	 *
-	 * @param \WP_Post_Type $post_type_object The post type of the mutation.
+	 * @param WP_Post_Type $post_type_object The post type of the mutation.
 	 *
 	 * @return array
 	 */
-	public static function get_output_fields( $post_type_object ) {
+	public static function get_output_fields( WP_Post_Type $post_type_object ) {
 		return [
 			'deletedId'                            => [
 				'type'        => 'Id',
 				'description' => __( 'The ID of the deleted object', 'wp-graphql' ),
-				'resolve'     => function( $payload ) use ( $post_type_object ) {
+				'resolve'     => function( $payload ) {
 					$deleted = (object) $payload['postObject'];
 
-					return ! empty( $deleted->ID ) ? Relay::toGlobalId( 'post', absint( $deleted->ID ) ) : null;
+					return ! empty( $deleted->ID ) ? Relay::toGlobalId( 'post', $deleted->ID ) : null;
 				},
 			],
 			$post_type_object->graphql_single_name => [
 				'type'        => $post_type_object->graphql_single_name,
 				'description' => __( 'The object before it was deleted', 'wp-graphql' ),
-				'resolve'     => function( $payload ) use ( $post_type_object ) {
+				'resolve'     => function( $payload ) {
 					$deleted = (object) $payload['postObject'];
 
 					return ! empty( $deleted ) ? $deleted : null;
@@ -82,13 +86,13 @@ class PostObjectDelete {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @param \WP_Post_Type $post_type_object The post type of the mutation.
-	 * @param string        $mutation_name    The mutation name.
+	 * @param WP_Post_Type $post_type_object The post type of the mutation.
+	 * @param string       $mutation_name    The mutation name.
 	 *
 	 * @return callable
 	 */
-	public static function mutate_and_get_payload( $post_type_object, $mutation_name ) {
-		return function( $input ) use ( $post_type_object, $mutation_name ) {
+	public static function mutate_and_get_payload( WP_Post_Type $post_type_object, string $mutation_name ) {
+		return function( $input ) use ( $post_type_object ) {
 
 			/**
 			 * Get the ID from the global ID
@@ -98,7 +102,7 @@ class PostObjectDelete {
 			/**
 			 * Stop now if a user isn't allowed to delete a post
 			 */
-			if ( ! current_user_can( $post_type_object->cap->delete_post, absint( $id_parts['id'] ) ) ) {
+			if ( ! isset( $post_type_object->cap->delete_post ) || ! current_user_can( $post_type_object->cap->delete_post, absint( $id_parts['id'] ) ) ) {
 				// translators: the $post_type_object->graphql_plural_name placeholder is the name of the object being mutated
 				throw new UserError( sprintf( __( 'Sorry, you are not allowed to delete %1$s', 'wp-graphql' ), $post_type_object->graphql_plural_name ) );
 			}
@@ -106,12 +110,17 @@ class PostObjectDelete {
 			/**
 			 * Check if we should force delete or not
 			 */
-			$force_delete = ( ! empty( $input['forceDelete'] ) && true === $input['forceDelete'] ) ? true : false;
+			$force_delete = ! empty( $input['forceDelete'] ) && true === $input['forceDelete'];
 
 			/**
 			 * Get the post object before deleting it
 			 */
 			$post_before_delete = get_post( absint( $id_parts['id'] ) );
+
+			if ( empty( $post_before_delete ) ) {
+				throw new UserError( __( 'The post could not be deleted', 'wp-graphql' ) );
+			}
+
 			$post_before_delete = new Post( $post_before_delete );
 
 			/**

--- a/src/Mutation/ResetUserPassword.php
+++ b/src/Mutation/ResetUserPassword.php
@@ -8,6 +8,9 @@ use WPGraphQL\AppContext;
 class ResetUserPassword {
 	/**
 	 * Registers the ResetUserPassword mutation.
+	 *
+	 * @return void
+	 * @throws \Exception
 	 */
 	public static function register_mutation() {
 		register_graphql_mutation(

--- a/src/Mutation/SendPasswordResetEmail.php
+++ b/src/Mutation/SendPasswordResetEmail.php
@@ -2,12 +2,21 @@
 
 namespace WPGraphQL\Mutation;
 
+use Exception;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
+use WP_User;
 use WPGraphQL\AppContext;
 use WPGraphQL\Model\User;
 
 class SendPasswordResetEmail {
+
+	/**
+	 * Registers the sendPasswordResetEmail Mutation
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
 	public static function register_mutation() {
 		register_graphql_mutation(
 			'sendPasswordResetEmail',
@@ -27,6 +36,11 @@ class SendPasswordResetEmail {
 						'description' => __( 'The user that the password reset email was sent to', 'wp-graphql' ),
 						'resolve'     => function ( $payload ) {
 							$user = get_user_by( 'ID', absint( $payload['id'] ) );
+
+							if ( empty( $user ) ) {
+								return null;
+							}
+
 							return new User( $user );
 						},
 					],
@@ -50,6 +64,9 @@ class SendPasswordResetEmail {
 
 					$email_sent = wp_mail( $user_data->user_email, wp_specialchars_decode( $subject ), $message );
 
+					// wp_mail can return a wp_error, but the docblock for it in WP Core is incorrect.
+					// phpstan should ignore this check.
+					// @phpstan-ignore-next-line
 					if ( is_wp_error( $email_sent ) ) {
 
 						$message = __( 'The email could not be sent.' ) . "<br />\n" . __( 'Possible reason: your host may have disabled the mail() function.' );
@@ -87,11 +104,18 @@ class SendPasswordResetEmail {
 	 *
 	 * @param  string $username The user's username or email address.
 	 *
-	 * @return \WP_User|false WP_User object on success, false on failure.
+	 * @return WP_User|false WP_User object on success, false on failure.
 	 */
 	private static function get_user_data( $username ) {
 		if ( self::is_email_address( $username ) ) {
-			return get_user_by( 'email', trim( wp_unslash( $username ) ) );
+
+			$username = wp_unslash( $username );
+
+			if ( ! is_string( $username ) ) {
+				return false;
+			}
+
+			return get_user_by( 'email', trim( $username ) );
 		}
 
 		return get_user_by( 'login', trim( $username ) );
@@ -104,7 +128,7 @@ class SendPasswordResetEmail {
 	 *
 	 * @return string
 	 */
-	private static function get_user_not_found_error_message( $username ) {
+	private static function get_user_not_found_error_message( string $username ) {
 		if ( self::is_email_address( $username ) ) {
 			return __( 'There is no user registered with that email address.', 'wp-graphql' );
 		}
@@ -119,14 +143,14 @@ class SendPasswordResetEmail {
 	 *
 	 * @return bool
 	 */
-	private static function is_email_address( $username ) {
-		return strpos( $username, '@' );
+	private static function is_email_address( string $username ) {
+		return (bool) strpos( $username, '@' );
 	}
 
 	/**
 	 * Get the subject of the password reset email
 	 *
-	 * @param \WP_User $user_data User data
+	 * @param WP_User $user_data User data
 	 *
 	 * @return string
 	 */
@@ -139,7 +163,7 @@ class SendPasswordResetEmail {
 		 *
 		 * @param string   $title      Default email title.
 		 * @param string   $user_login The username for the user.
-		 * @param \WP_User $user_data  WP_User object.
+		 * @param WP_User $user_data  WP_User object.
 		 */
 		return apply_filters( 'retrieve_password_title', $title, $user_data->user_login, $user_data );
 	}
@@ -151,7 +175,10 @@ class SendPasswordResetEmail {
 	 */
 	private static function get_site_name() {
 		if ( is_multisite() ) {
-			return get_network()->site_name;
+			$network = get_network();
+			if ( isset( $network->site_name ) ) {
+				return $network->site_name;
+			}
 		}
 
 		/*
@@ -165,7 +192,7 @@ class SendPasswordResetEmail {
 	/**
 	 * Get the message body of the password reset email
 	 *
-	 * @param \WP_User $user_data User data
+	 * @param WP_User $user_data User data
 	 * @param string   $key       Password reset key
 	 *
 	 * @return string
@@ -188,7 +215,7 @@ class SendPasswordResetEmail {
 		 * @param string   $message    Default mail message.
 		 * @param string   $key        The activation key.
 		 * @param string   $user_login The username for the user.
-		 * @param \WP_User $user_data  WP_User object.
+		 * @param WP_User $user_data  WP_User object.
 		 */
 		return apply_filters( 'retrieve_password_message', $message, $key, $user_data->user_login, $user_data );
 	}

--- a/src/Mutation/TermObjectCreate.php
+++ b/src/Mutation/TermObjectCreate.php
@@ -1,19 +1,22 @@
 <?php
+
 namespace WPGraphQL\Mutation;
 
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
+use WP_Taxonomy;
 use WPGraphQL\AppContext;
-use WPGraphQL\Data\DataSource;
 use WPGraphQL\Data\TermObjectMutation;
 
 class TermObjectCreate {
 	/**
 	 * Registers the TermObjectCreate mutation.
 	 *
-	 * @param \WP_Taxonomy $taxonomy    The taxonomy type of the mutation.
+	 * @param WP_Taxonomy $taxonomy The taxonomy type of the mutation.
+	 *
+	 * @return void
 	 */
-	public static function register_mutation( \WP_Taxonomy $taxonomy ) {
+	public static function register_mutation( WP_Taxonomy $taxonomy ) {
 		$mutation_name = 'create' . ucwords( $taxonomy->graphql_single_name );
 
 		register_graphql_mutation(
@@ -40,11 +43,11 @@ class TermObjectCreate {
 	/**
 	 * Defines the mutation input field configuration.
 	 *
-	 * @param \WP_Taxonomy $taxonomy    The taxonomy type of the mutation.
+	 * @param WP_Taxonomy $taxonomy The taxonomy type of the mutation.
 	 *
 	 * @return array
 	 */
-	public static function get_input_fields( \WP_Taxonomy $taxonomy ) {
+	public static function get_input_fields( WP_Taxonomy $taxonomy ) {
 		$fields = [
 			'aliasOf'     => [
 				'type'        => 'String',
@@ -79,18 +82,19 @@ class TermObjectCreate {
 	/**
 	 * Defines the mutation output field configuration.
 	 *
-	 * @param \WP_Taxonomy $taxonomy    The taxonomy type of the mutation.
+	 * @param WP_Taxonomy $taxonomy The taxonomy type of the mutation.
 	 *
 	 * @return array
 	 */
-	public static function get_output_fields( \WP_Taxonomy $taxonomy ) {
+	public static function get_output_fields( WP_Taxonomy $taxonomy ) {
 		return [
 			$taxonomy->graphql_single_name => [
 				'type'        => $taxonomy->graphql_single_name,
 				// translators: Placeholder is the name of the taxonomy
 				'description' => sprintf( __( 'The created %s', 'wp-graphql' ), $taxonomy->name ),
-				'resolve'     => function ( $payload, $args, AppContext $context, ResolveInfo $info ) use ( $taxonomy ) {
+				'resolve'     => function( $payload, $args, AppContext $context, ResolveInfo $info ) {
 					$id = isset( $payload['termId'] ) ? absint( $payload['termId'] ) : null;
+
 					return $context->get_loader( 'term' )->load_deferred( $id );
 
 				},
@@ -101,18 +105,18 @@ class TermObjectCreate {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @param \WP_Taxonomy $taxonomy       The taxonomy type of the mutation.
-	 * @param string       $mutation_name  The name of the mutation.
+	 * @param WP_Taxonomy $taxonomy      The taxonomy type of the mutation.
+	 * @param string      $mutation_name The name of the mutation.
 	 *
 	 * @return callable
 	 */
-	public static function mutate_and_get_payload( \WP_Taxonomy $taxonomy, $mutation_name ) {
+	public static function mutate_and_get_payload( WP_Taxonomy $taxonomy, string $mutation_name ) {
 		return function( $input, AppContext $context, ResolveInfo $info ) use ( $taxonomy, $mutation_name ) {
 
 			/**
 			 * Ensure the user can edit_terms
 			 */
-			if ( ! current_user_can( $taxonomy->cap->edit_terms ) ) {
+			if ( ! isset( $taxonomy->cap->edit_terms ) || ! current_user_can( $taxonomy->cap->edit_terms ) ) {
 				// translators: the $taxonomy->graphql_plural_name placeholder is the name of the object being mutated
 				throw new UserError( sprintf( __( 'Sorry, you are not allowed to create %1$s', 'wp-graphql' ), $taxonomy->graphql_plural_name ) );
 			}
@@ -130,10 +134,16 @@ class TermObjectCreate {
 				throw new UserError( sprintf( __( 'A name is required to create a %1$s' ), $taxonomy->name ) );
 			}
 
+			$term_name = wp_slash( $args['name'] );
+
+			if ( ! is_string( $term_name ) ) {
+				throw new UserError( sprintf( __( 'A valid name is required to create a %1$s' ), $taxonomy->name ) );
+			}
+
 			/**
 			 * Insert the term
 			 */
-			$term = wp_insert_term( wp_slash( $args['name'] ), $taxonomy->name, wp_slash( (array) $args ) );
+			$term = wp_insert_term( $term_name, $taxonomy->name, wp_slash( (array) $args ) );
 
 			/**
 			 * If it was an error, return the message as an exception
@@ -158,7 +168,7 @@ class TermObjectCreate {
 			 * Fires after a single term is created or updated via a GraphQL mutation
 			 *
 			 * @param int         $term_id       Inserted term object
-			 * @param \WP_Taxonomy $taxonomy     The taxonomy of the term being updated
+			 * @param WP_Taxonomy $taxonomy      The taxonomy of the term being updated
 			 * @param array       $args          The args used to insert the term
 			 * @param string      $mutation_name The name of the mutation being performed
 			 * @param AppContext  $context       The AppContext passed down the resolve tree

--- a/src/Mutation/TermObjectDelete.php
+++ b/src/Mutation/TermObjectDelete.php
@@ -1,8 +1,10 @@
 <?php
+
 namespace WPGraphQL\Mutation;
 
 use GraphQL\Error\UserError;
 use GraphQLRelay\Relay;
+use WP_Taxonomy;
 use WPGraphQL\Model\Term;
 
 /**
@@ -14,9 +16,11 @@ class TermObjectDelete {
 	/**
 	 * Registers the TermObjectDelete mutation.
 	 *
-	 * @param \WP_Taxonomy $taxonomy    The taxonomy type of the mutation.
+	 * @param WP_Taxonomy $taxonomy The taxonomy type of the mutation.
+	 *
+	 * @return void
 	 */
-	public static function register_mutation( \WP_Taxonomy $taxonomy ) {
+	public static function register_mutation( WP_Taxonomy $taxonomy ) {
 		$mutation_name = 'delete' . ucfirst( $taxonomy->graphql_single_name );
 
 		register_graphql_mutation(
@@ -32,11 +36,11 @@ class TermObjectDelete {
 	/**
 	 * Defines the mutation input field configuration.
 	 *
-	 * @param \WP_Taxonomy $taxonomy    The taxonomy type of the mutation.
+	 * @param WP_Taxonomy $taxonomy The taxonomy type of the mutation.
 	 *
 	 * @return array
 	 */
-	public static function get_input_fields( \WP_Taxonomy $taxonomy ) {
+	public static function get_input_fields( WP_Taxonomy $taxonomy ) {
 		return [
 			'id' => [
 				'type'        => [
@@ -51,16 +55,16 @@ class TermObjectDelete {
 	/**
 	 * Defines the mutation output field configuration.
 	 *
-	 * @param \WP_Taxonomy $taxonomy    The taxonomy type of the mutation.
+	 * @param WP_Taxonomy $taxonomy The taxonomy type of the mutation.
 	 *
 	 * @return array
 	 */
-	public static function get_output_fields( \WP_Taxonomy $taxonomy ) {
+	public static function get_output_fields( WP_Taxonomy $taxonomy ) {
 		return [
 			'deletedId'                    => [
 				'type'        => 'ID',
 				'description' => __( 'The ID of the deleted object', 'wp-graphql' ),
-				'resolve'     => function( $payload ) use ( $taxonomy ) {
+				'resolve'     => function( $payload ) {
 					$deleted = (object) $payload['termObject'];
 
 					return ! empty( $deleted->term_id ) ? Relay::toGlobalId( 'term', $deleted->term_id ) : null;
@@ -69,7 +73,7 @@ class TermObjectDelete {
 			$taxonomy->graphql_single_name => [
 				'type'        => $taxonomy->graphql_single_name,
 				'description' => __( 'The deteted term object', 'wp-graphql' ),
-				'resolve'     => function( $payload ) use ( $taxonomy ) {
+				'resolve'     => function( $payload ) {
 					return new Term( $payload['termObject'] );
 				},
 			],
@@ -79,13 +83,13 @@ class TermObjectDelete {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @param \WP_Taxonomy $taxonomy       The taxonomy type of the mutation.
-	 * @param string       $mutation_name  The name of the mutation.
+	 * @param WP_Taxonomy $taxonomy      The taxonomy type of the mutation.
+	 * @param string      $mutation_name The name of the mutation.
 	 *
 	 * @return callable
 	 */
-	public static function mutate_and_get_payload( \WP_Taxonomy $taxonomy, $mutation_name ) {
-		return function( $input ) use ( $taxonomy, $mutation_name ) {
+	public static function mutate_and_get_payload( WP_Taxonomy $taxonomy, string $mutation_name ) {
+		return function( $input ) use ( $taxonomy ) {
 
 			$id_parts = Relay::fromGlobalId( $input['id'] );
 
@@ -100,6 +104,10 @@ class TermObjectDelete {
 			 * Get the term before deleting it
 			 */
 			$term_object = get_term( $term_id, $taxonomy->name );
+
+			if ( ! $term_object instanceof \WP_Term ) {
+				throw new UserError( __( 'The ID passed is invalid', 'wp-graphql' ) );
+			}
 
 			/**
 			 * Ensure the type for the Global ID matches the type being mutated

--- a/src/Mutation/UpdateSettings.php
+++ b/src/Mutation/UpdateSettings.php
@@ -14,6 +14,9 @@ class UpdateSettings {
 
 	/**
 	 * Registers the CommentCreate mutation.
+	 *
+	 * @return void
+	 * @throws \Exception
 	 */
 	public static function register_mutation() {
 		register_graphql_mutation(
@@ -55,7 +58,13 @@ class UpdateSettings {
 					$individual_setting_key = lcfirst( $setting['group'] . 'Settings' . str_replace( '_', '', ucwords( $key, '_' ) ) );
 				}
 
-				$individual_setting_key = lcfirst( preg_replace( '[^a-zA-Z0-9 -]', ' ', $individual_setting_key ) );
+				$replaced_setting_key = preg_replace( '[^a-zA-Z0-9 -]', ' ', $individual_setting_key );
+
+				if ( ! empty( $replaced_setting_key ) ) {
+					$individual_setting_key = $replaced_setting_key;
+				}
+
+				$individual_setting_key = lcfirst( $individual_setting_key );
 				$individual_setting_key = lcfirst( str_replace( '_', ' ', ucwords( $individual_setting_key, '_' ) ) );
 				$individual_setting_key = lcfirst( str_replace( '-', ' ', ucwords( $individual_setting_key, '_' ) ) );
 				$individual_setting_key = lcfirst( str_replace( ' ', '', ucwords( $individual_setting_key, ' ' ) ) );
@@ -91,7 +100,13 @@ class UpdateSettings {
 		if ( ! empty( $allowed_setting_groups ) && is_array( $allowed_setting_groups ) ) {
 			foreach ( $allowed_setting_groups as $group => $setting_type ) {
 
-				$setting_type = lcfirst( preg_replace( '[^a-zA-Z0-9 -]', ' ', $group ) );
+				$replaced_group = preg_replace( '[^a-zA-Z0-9 -]', ' ', $group );
+
+				if ( ! empty( $replaced_group ) ) {
+					$group = $replaced_group;
+				}
+
+				$setting_type = lcfirst( $group );
 				$setting_type = lcfirst( str_replace( '_', ' ', ucwords( $setting_type, '_' ) ) );
 				$setting_type = lcfirst( str_replace( '-', ' ', ucwords( $setting_type, '_' ) ) );
 				$setting_type = lcfirst( str_replace( ' ', '', ucwords( $setting_type, ' ' ) ) );
@@ -151,7 +166,7 @@ class UpdateSettings {
 				 * REST API name, if not use the option name.
 				 * Sanitize the field name to be camelcase
 				 */
-				if ( ! empty( $setting['show_in_rest']['name'] ) ) {
+				if ( isset( $setting['show_in_rest']['name'] ) && ! empty( $setting['show_in_rest']['name'] ) ) {
 					$individual_setting_key = lcfirst( $setting['group'] . 'Settings' . str_replace( '_', '', ucwords( $setting['show_in_rest']['name'], '_' ) ) );
 				} else {
 					$individual_setting_key = lcfirst( $setting['group'] . 'Settings' . str_replace( '_', '', ucwords( $key, '_' ) ) );

--- a/src/Mutation/UserCreate.php
+++ b/src/Mutation/UserCreate.php
@@ -16,6 +16,8 @@ use WPGraphQL\Model\User;
 class UserCreate {
 	/**
 	 * Registers the CommentCreate mutation.
+	 *
+	 * @return void
 	 */
 	public static function register_mutation() {
 		register_graphql_mutation(
@@ -125,7 +127,12 @@ class UserCreate {
 			'user' => [
 				'type'    => 'User',
 				'resolve' => function( $payload ) {
-					$user = get_user_by( 'ID', $payload['id'] );
+
+					$user = get_user_by( 'ID', (int) $payload['id'] );
+
+					if ( empty( $user ) ) {
+						return null;
+					}
 
 					return new User( $user );
 				},

--- a/src/Mutation/UserDelete.php
+++ b/src/Mutation/UserDelete.php
@@ -14,6 +14,8 @@ use WPGraphQL\Model\User;
 class UserDelete {
 	/**
 	 * Registers the CommentCreate mutation.
+	 *
+	 * @return void
 	 */
 	public static function register_mutation() {
 		register_graphql_mutation(

--- a/src/Mutation/UserRegister.php
+++ b/src/Mutation/UserRegister.php
@@ -10,6 +10,8 @@ use WPGraphQL\Data\UserMutation;
 class UserRegister {
 	/**
 	 * Registers the CommentCreate mutation.
+	 *
+	 * @return void
 	 */
 	public static function register_mutation() {
 		register_graphql_mutation(

--- a/src/Mutation/UserUpdate.php
+++ b/src/Mutation/UserUpdate.php
@@ -1,6 +1,7 @@
 <?php
 namespace WPGraphQL\Mutation;
 
+use Exception;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
@@ -10,6 +11,9 @@ use WPGraphQL\Data\UserMutation;
 class UserUpdate {
 	/**
 	 * Registers the CommentCreate mutation.
+	 *
+	 * @return void
+	 * @throws Exception
 	 */
 	public static function register_mutation() {
 		register_graphql_mutation(
@@ -60,13 +64,13 @@ class UserUpdate {
 		return function ( $input, AppContext $context, ResolveInfo $info ) {
 
 			$id_parts      = ! empty( $input['id'] ) ? Relay::fromGlobalId( $input['id'] ) : null;
-			$existing_user = get_user_by( 'ID', $id_parts['id'] );
+			$existing_user = isset( $id_parts['id'] ) && absint( $id_parts['id'] ) ? get_user_by( 'ID', absint( $id_parts['id'] ) ) : null;
 
 			/**
 			 * If there's no existing user, throw an exception
 			 */
-			if ( empty( $id_parts['id'] ) || false === $existing_user ) {
-				throw new UserError( $id_parts['id'] );
+			if ( ! isset( $id_parts['id'] ) || empty( $existing_user ) ) {
+				throw new UserError( __( 'A user could not be updated with the provided ID', 'wp-graphql' ) );
 			}
 
 			if ( ! current_user_can( 'edit_user', $existing_user->ID ) ) {

--- a/src/Registry/SchemaRegistry.php
+++ b/src/Registry/SchemaRegistry.php
@@ -2,6 +2,7 @@
 
 namespace WPGraphQL\Registry;
 
+use GraphQL\Type\SchemaConfig;
 use WPGraphQL\WPSchema;
 
 /**
@@ -35,19 +36,18 @@ class SchemaRegistry {
 
 		$this->type_registry->init();
 
+		$schema_config             = new SchemaConfig();
+		$schema_config->query      = $this->type_registry->get_type( 'RootQuery' );
+		$schema_config->mutation   = $this->type_registry->get_type( 'RootMutation' );
+		$schema_config->typeLoader = function( $type ) {
+			return $this->type_registry->get_type( $type );
+		};
+		$schema_config->types      = $this->type_registry->get_types();
+
 		/**
 		 * Create a new instance of the Schema
 		 */
-		$schema = new WPSchema(
-			[
-				'query'      => $this->type_registry->get_type( 'RootQuery' ),
-				'mutation'   => $this->type_registry->get_type( 'RootMutation' ),
-				'typeLoader' => function( $type ) {
-					return $this->type_registry->get_type( $type );
-				},
-				'types'      => $this->type_registry->get_types(),
-			]
-		);
+		$schema = new WPSchema( $schema_config );
 
 		/**
 		 * Filter the Schema

--- a/src/Server/WPHelper.php
+++ b/src/Server/WPHelper.php
@@ -12,6 +12,7 @@ use GraphQL\Server\RequestError;
  * @package WPGraphQL\Server
  */
 class WPHelper extends Helper {
+
 	/**
 	 * Parses normalized request params and returns instance of OperationParams
 	 * or array of OperationParams in case of batch operation.
@@ -26,7 +27,8 @@ class WPHelper extends Helper {
 		// Apply wp_unslash to query (GET) variables to undo wp_magic_quotes. We
 		// don't need to do this for POST variables because graphql-php reads the
 		// HTTP body directly.
-		$parsed_body_params  = $this->parse_params( $bodyParams );
+		$parsed_body_params = $this->parse_params( $bodyParams );
+		// @phpstan-ignore-next-line
 		$parsed_query_params = $this->parse_extensions( wp_unslash( $queryParams ) );
 
 		$request_context = [

--- a/src/Telemetry/Tracker.php
+++ b/src/Telemetry/Tracker.php
@@ -72,6 +72,8 @@ class Tracker {
 
 	/**
 	 * Initialize the tracker.
+	 *
+	 * @return void
 	 */
 	public function init() {
 
@@ -153,36 +155,31 @@ class Tracker {
 	 *
 	 * @return string
 	 */
-	public function hash( $value ) {
+	public function hash( string $value ) {
 		return hash( 'sha256', $value );
 	}
 
 	/**
 	 * Given a key from the $_SERVER super global, returns sanitized data
 	 *
-	 * @param $key
+	 * @param string $key
 	 *
-	 * @return null
+	 * @return string
 	 */
-	public function clean_server_data( $key ) {
-		return isset( $_SERVER[ $key ] ) ? $this->sanitize( $_SERVER[ $key ] ) : null;
+	public function clean_server_data( string $key ) {
+		return isset( $_SERVER[ $key ] ) ? $this->sanitize( $_SERVER[ $key ] ) : '';
 	}
 
 	/**
 	 * Clean variables using sanitize_text_field. Arrays are cleaned recursively.
 	 * Non-scalar values are ignored.
 	 *
-	 * @param string|array $input Data to sanitize.
+	 * @param string $input String to sanitize.
 	 *
-	 * @return string|array
+	 * @return string
 	 */
-	public function sanitize( $input ) {
-
-		if ( is_array( $input ) ) {
-			return array_map( [ $this, 'sanitize' ], $input );
-		} else {
-			return is_scalar( $input ) ? sanitize_text_field( $input ) : $input;
-		}
+	public function sanitize( string $input ) {
+		return sanitize_text_field( $input );
 	}
 
 	/**
@@ -200,7 +197,7 @@ class Tracker {
 		$active_plugins = get_option( 'active_plugins', [] );
 		$active_plugins = array_map( function( $plugin ) {
 			return [
-				'path' => $plugin,
+				'path' => $this->sanitize( $plugin ),
 			];
 		}, $active_plugins );
 
@@ -215,7 +212,7 @@ class Tracker {
 			'host'               => $this->sanitize( site_url() ),
 			'pwd'                => $this->hash( $this->clean_server_data( 'DOCUMENT_ROOT' ) ),
 			'filename'           => $this->hash( $this->clean_server_data( 'SCRIPT_FILENAME' ) ),
-			'activePlugins'      => ! empty( $active_plugins ) ? $this->sanitize( $active_plugins ) : null,
+			'activePlugins'      => ! empty( $active_plugins ) ? $active_plugins : null,
 			'name'               => $this->sanitize( $this->plugin_name ),
 			'adminEmail'         => $this->sanitize( get_option( 'admin_email' ) ),
 			'installationId'     => $this->sanitize( site_url() ) . ':' . $this->hash( $this->clean_server_data( 'DOCUMENT_ROOT' ) ),
@@ -300,6 +297,8 @@ class Tracker {
 	 * Given an array of event info, this sends a request for the event to be logged
 	 *
 	 * @param array $event_info The event info to log
+	 *
+	 * @return void
 	 */
 	protected function send_request( array $event_info ) {
 

--- a/src/Type/Enum/AvatarRatingEnum.php
+++ b/src/Type/Enum/AvatarRatingEnum.php
@@ -2,6 +2,12 @@
 namespace WPGraphQL\Type\Enum;
 
 class AvatarRatingEnum {
+
+	/**
+	 * Register the AvatarRatingEnum Type to the Schema
+	 *
+	 * @return void
+	 */
 	public static function register_type() {
 		register_graphql_enum_type(
 			'AvatarRatingEnum',

--- a/src/Type/Enum/CommentsConnectionOrderbyEnum.php
+++ b/src/Type/Enum/CommentsConnectionOrderbyEnum.php
@@ -2,6 +2,12 @@
 namespace WPGraphQL\Type\Enum;
 
 class CommentsConnectionOrderbyEnum {
+
+	/**
+	 * Register the CommentsConnectionOrderbyEnum Type to the Schema
+	 *
+	 * @return void
+	 */
 	public static function register_type() {
 		register_graphql_enum_type(
 			'CommentsConnectionOrderbyEnum',

--- a/src/Type/Enum/ContentNodeIdTypeEnum.php
+++ b/src/Type/Enum/ContentNodeIdTypeEnum.php
@@ -23,7 +23,12 @@ class ContentNodeIdTypeEnum {
 		if ( ! empty( $allowed_post_types ) && is_array( $allowed_post_types ) ) {
 			foreach ( $allowed_post_types as $post_type ) {
 				$post_type_object = get_post_type_object( $post_type );
-				$values           = self::get_values();
+
+				if ( empty( $post_type_object ) ) {
+					return;
+				}
+
+				$values = self::get_values();
 				if ( ! $post_type_object->hierarchical ) {
 					$values['slug'] = [
 						'name'        => 'SLUG',

--- a/src/Type/Enum/ContentTypeEnum.php
+++ b/src/Type/Enum/ContentTypeEnum.php
@@ -5,6 +5,12 @@ namespace WPGraphQL\Type\Enum;
 use WPGraphQL\Type\WPEnumType;
 
 class ContentTypeEnum {
+
+	/**
+	 * Register the ContentTypeEnum Type to the Schema
+	 *
+	 * @return void
+	 */
 	public static function register_type() {
 		$values = [];
 
@@ -22,6 +28,10 @@ class ContentTypeEnum {
 		 */
 		if ( ! empty( $allowed_post_types ) && is_array( $allowed_post_types ) ) {
 			foreach ( $allowed_post_types as $allowed_post_type ) {
+
+				if ( $allowed_post_type instanceof \WP_Post_Type ) {
+					$allowed_post_type = $allowed_post_type->name;
+				}
 
 				$values[ WPEnumType::get_safe_name( $allowed_post_type ) ] = [
 					'value'       => $allowed_post_type,

--- a/src/Type/Enum/ContentTypeIdTypeEnum.php
+++ b/src/Type/Enum/ContentTypeIdTypeEnum.php
@@ -3,6 +3,12 @@
 namespace WPGraphQL\Type\Enum;
 
 class ContentTypeIdTypeEnum {
+
+	/**
+	 * Register the ContentTypeIdTypeEnum Type to the Schema
+	 *
+	 * @return void
+	 */
 	public static function register_type() {
 
 		register_graphql_enum_type(

--- a/src/Type/Enum/MediaItemSizeEnum.php
+++ b/src/Type/Enum/MediaItemSizeEnum.php
@@ -5,6 +5,12 @@ namespace WPGraphQL\Type\Enum;
 use WPGraphQL\Type\WPEnumType;
 
 class MediaItemSizeEnum {
+
+	/**
+	 * Register the MediaItemSizeEnum Type to the Schema
+	 *
+	 * @return void
+	 */
 	public static function register_type() {
 		$values = [];
 

--- a/src/Type/Enum/MediaItemStatusEnum.php
+++ b/src/Type/Enum/MediaItemStatusEnum.php
@@ -5,6 +5,12 @@ namespace WPGraphQL\Type\Enum;
 use WPGraphQL\Type\WPEnumType;
 
 class MediaItemStatusEnum {
+
+	/**
+	 * Register the MediaItemStatusEnum Type to the Schema
+	 *
+	 * @return void
+	 */
 	public static function register_type() {
 		$values = [];
 

--- a/src/Type/Enum/MenuLocationEnum.php
+++ b/src/Type/Enum/MenuLocationEnum.php
@@ -5,6 +5,12 @@ use WPGraphQL\Data\DataSource;
 use WPGraphQL\Type\WPEnumType;
 
 class MenuLocationEnum {
+
+	/**
+	 * Register the MenuLocationEnum Type to the Schema
+	 *
+	 * @return void
+	 */
 	public static function register_type() {
 		$values = [];
 

--- a/src/Type/Enum/MimeTypeEnum.php
+++ b/src/Type/Enum/MimeTypeEnum.php
@@ -5,6 +5,12 @@ namespace WPGraphQL\Type\Enum;
 use WPGraphQL\Type\WPEnumType;
 
 class MimeTypeEnum {
+
+	/**
+	 * Register the MimeTypeEnum Type to the Schema
+	 *
+	 * @return void
+	 */
 	public static function register_type() {
 		$values = [
 			'IMAGE_JPEG' => [

--- a/src/Type/Enum/OrderEnum.php
+++ b/src/Type/Enum/OrderEnum.php
@@ -3,6 +3,12 @@
 namespace WPGraphQL\Type\Enum;
 
 class OrderEnum {
+
+	/**
+	 * Register the OrderEnum Type to the Schema
+	 *
+	 * @return void
+	 */
 	public static function register_type() {
 		register_graphql_enum_type(
 			'OrderEnum',

--- a/src/Type/Enum/PostObjectFieldFormatEnum.php
+++ b/src/Type/Enum/PostObjectFieldFormatEnum.php
@@ -3,6 +3,12 @@
 namespace WPGraphQL\Type\Enum;
 
 class PostObjectFieldFormatEnum {
+
+	/**
+	 * Register the PostObjectFieldFormatEnum Type to the Schema
+	 *
+	 * @return void
+	 */
 	public static function register_type() {
 		register_graphql_enum_type(
 			'PostObjectFieldFormatEnum',

--- a/src/Type/Enum/PostObjectsConnectionDateColumnEnum.php
+++ b/src/Type/Enum/PostObjectsConnectionDateColumnEnum.php
@@ -3,6 +3,12 @@
 namespace WPGraphQL\Type\Enum;
 
 class PostObjectsConnectionDateColumnEnum {
+
+	/**
+	 * Register the PostObjectsConnectionDateColumnEnum Type to the Schema
+	 *
+	 * @return void
+	 */
 	public static function register_type() {
 		register_graphql_enum_type(
 			'PostObjectsConnectionDateColumnEnum',

--- a/src/Type/Enum/PostObjectsConnectionOrderbyEnum.php
+++ b/src/Type/Enum/PostObjectsConnectionOrderbyEnum.php
@@ -3,6 +3,12 @@
 namespace WPGraphQL\Type\Enum;
 
 class PostObjectsConnectionOrderbyEnum {
+
+	/**
+	 * Register the PostObjectsConnectionOrderbyEnum Type to the Schema
+	 *
+	 * @return void
+	 */
 	public static function register_type() {
 		register_graphql_enum_type(
 			'PostObjectsConnectionOrderbyEnum',

--- a/src/Type/Enum/PostStatusEnum.php
+++ b/src/Type/Enum/PostStatusEnum.php
@@ -5,6 +5,12 @@ namespace WPGraphQL\Type\Enum;
 use WPGraphQL\Type\WPEnumType;
 
 class PostStatusEnum {
+
+	/**
+	 * Register the PostStatusEnum Type to the Schema
+	 *
+	 * @return void
+	 */
 	public static function register_type() {
 		$post_status_enum_values = [
 			'name'  => 'PUBLISH',

--- a/src/Type/Enum/RelationEnum.php
+++ b/src/Type/Enum/RelationEnum.php
@@ -3,6 +3,12 @@
 namespace WPGraphQL\Type\Enum;
 
 class RelationEnum {
+
+	/**
+	 * Register the RelationEnum Type to the Schema
+	 *
+	 * @return void
+	 */
 	public static function register_type() {
 		register_graphql_enum_type(
 			'RelationEnum',

--- a/src/Type/Enum/TaxonomyEnum.php
+++ b/src/Type/Enum/TaxonomyEnum.php
@@ -5,6 +5,12 @@ namespace WPGraphQL\Type\Enum;
 use WPGraphQL\Type\WPEnumType;
 
 class TaxonomyEnum {
+
+	/**
+	 * Register the TaxonomyEnum Type to the Schema
+	 *
+	 * @return void
+	 */
 	public static function register_type() {
 		$allowed_taxonomies = \WPGraphQL::get_allowed_taxonomies();
 

--- a/src/Type/Enum/TaxonomyIdTypeEnum.php
+++ b/src/Type/Enum/TaxonomyIdTypeEnum.php
@@ -3,6 +3,12 @@
 namespace WPGraphQL\Type\Enum;
 
 class TaxonomyIdTypeEnum {
+
+	/**
+	 * Register the TaxonomyIdTypeEnum Type to the Schema
+	 *
+	 * @return void
+	 */
 	public static function register_type() {
 
 		register_graphql_enum_type(

--- a/src/Type/Enum/TermObjectsConnectionOrderbyEnum.php
+++ b/src/Type/Enum/TermObjectsConnectionOrderbyEnum.php
@@ -2,6 +2,12 @@
 namespace WPGraphQL\Type\Enum;
 
 class TermObjectsConnectionOrderbyEnum {
+
+	/**
+	 * Register the TermObjectsConnectionOrderbyEnum Type to the Schema
+	 *
+	 * @return void
+	 */
 	public static function register_type() {
 		register_graphql_enum_type(
 			'TermObjectsConnectionOrderbyEnum',

--- a/src/Type/Enum/TimezoneEnum.php
+++ b/src/Type/Enum/TimezoneEnum.php
@@ -5,6 +5,12 @@ namespace WPGraphQL\Type\Enum;
 use WPGraphQL\Type\WPEnumType;
 
 class TimezoneEnum {
+
+	/**
+	 * Register the TimezoneEnum Type to the Schema
+	 *
+	 * @return void
+	 */
 	public static function register_type() {
 		/**
 		 * Logic for this taken from the `wp_timezone_choice` here:

--- a/src/Type/Enum/UserRoleEnum.php
+++ b/src/Type/Enum/UserRoleEnum.php
@@ -5,6 +5,12 @@ namespace WPGraphQL\Type\Enum;
 use WPGraphQL\Type\WPEnumType;
 
 class UserRoleEnum {
+
+	/**
+	 * Register the UserRoleEnum Type to the Schema
+	 *
+	 * @return void
+	 */
 	public static function register_type() {
 		global $wp_roles;
 		$all_roles      = $wp_roles->roles;

--- a/src/Type/Enum/UsersConnectionOrderbyEnum.php
+++ b/src/Type/Enum/UsersConnectionOrderbyEnum.php
@@ -3,6 +3,12 @@
 namespace WPGraphQL\Type\Enum;
 
 class UsersConnectionOrderbyEnum {
+
+	/**
+	 * Register the UsersConnectionOrderbyEnum Type to the Schema
+	 *
+	 * @return void
+	 */
 	public static function register_type() {
 
 		register_graphql_enum_type(

--- a/src/Type/Enum/UsersConnectionSearchColumnEnum.php
+++ b/src/Type/Enum/UsersConnectionSearchColumnEnum.php
@@ -5,6 +5,12 @@ namespace WPGraphQL\Type\Enum;
 use WPGraphQL\Type\WPEnumType;
 
 class UsersConnectionSearchColumnEnum {
+
+	/**
+	 * Register the UsersConnectionSearchColumnEnum Type to the Schema
+	 *
+	 * @return void
+	 */
 	public static function register_type() {
 		global $wp_roles;
 		$all_roles      = $wp_roles->roles;

--- a/src/Type/Input/DateInput.php
+++ b/src/Type/Input/DateInput.php
@@ -2,6 +2,12 @@
 namespace WPGraphQL\Type\Input;
 
 class DateInput {
+
+	/**
+	 * Register the DateInput Input
+	 *
+	 * @return void
+	 */
 	public static function register_type() {
 		register_graphql_input_type(
 			'DateInput',

--- a/src/Type/Input/DateQueryInput.php
+++ b/src/Type/Input/DateQueryInput.php
@@ -3,6 +3,12 @@
 namespace WPGraphQL\Type\Input;
 
 class DateQueryInput {
+
+	/**
+	 * Register the DateQueryInput Input
+	 *
+	 * @return void
+	 */
 	public static function register_type() {
 		register_graphql_input_type(
 			'DateQueryInput',

--- a/src/Type/Input/MenuItemsConnectionWhereArgs.php
+++ b/src/Type/Input/MenuItemsConnectionWhereArgs.php
@@ -3,6 +3,12 @@
 namespace WPGraphQL\Type\Input;
 
 class MenuItemsConnectionWhereArgs {
+
+	/**
+	 * Register the MenuItemsWhereArgs Input
+	 *
+	 * @return void
+	 */
 	public static function register_type() {
 		register_graphql_input_type(
 			'MenuItemsWhereArgs',

--- a/src/Type/Input/PostObjectsConnectionOrderbyInput.php
+++ b/src/Type/Input/PostObjectsConnectionOrderbyInput.php
@@ -3,6 +3,12 @@
 namespace WPGraphQL\Type\Input;
 
 class PostObjectsConnectionOrderbyInput {
+
+	/**
+	 * Register the PostObjectsConnectionOrderbyInput Input
+	 *
+	 * @return void
+	 */
 	public static function register_type() {
 		register_graphql_input_type(
 			'PostObjectsConnectionOrderbyInput',

--- a/src/Type/Input/UsersConnectionOrderbyInput.php
+++ b/src/Type/Input/UsersConnectionOrderbyInput.php
@@ -3,6 +3,12 @@
 namespace WPGraphQL\Type\Input;
 
 class UsersConnectionOrderbyInput {
+
+	/**
+	 * Register the UsersConnectionOrderbyInput Input
+	 *
+	 * @return void
+	 */
 	public static function register_type() {
 
 		register_graphql_input_type(

--- a/src/Type/InterfaceType/CommenterInterface.php
+++ b/src/Type/InterfaceType/CommenterInterface.php
@@ -16,6 +16,8 @@ class CommenterInterface {
 	 * Register the Commenter Interface
 	 *
 	 * @param TypeRegistry $type_registry
+	 *
+	 * @return void
 	 */
 	public static function register_type( TypeRegistry $type_registry ) {
 

--- a/src/Type/InterfaceType/ContentNode.php
+++ b/src/Type/InterfaceType/ContentNode.php
@@ -1,6 +1,7 @@
 <?php
 namespace WPGraphQL\Type\InterfaceType;
 
+use Exception;
 use GraphQL\Deferred;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
@@ -15,6 +16,9 @@ class ContentNode {
 	 * Adds the ContentNode Type to the WPGraphQL Registry
 	 *
 	 * @param TypeRegistry $type_registry
+	 *
+	 * @return void
+	 * @throws Exception
 	 */
 	public static function register_type( TypeRegistry $type_registry ) {
 
@@ -26,7 +30,7 @@ class ContentNode {
 			'ContentNode',
 			[
 				'description' => __( 'Nodes used to manage content', 'wp-graphql' ),
-				'resolveType' => function( $post ) use ( $type_registry ) {
+				'resolveType' => function( Post $post ) use ( $type_registry ) {
 
 					/**
 					 * The resolveType callback is used at runtime to determine what Type an object
@@ -37,13 +41,13 @@ class ContentNode {
 					 * $post->post_type attribute.
 					 */
 					$type      = null;
-					$post_type = null;
+					$post_type = isset( $post->post_type ) ? $post->post_type : null;
 
 					if ( isset( $post->post_type ) && 'revision' === $post->post_type ) {
-						$parent    = get_post( $post->parentDatabaseId );
-						$post_type = $parent->post_type;
-					} else {
-						$post_type = isset( $post->post_type ) ? $post->post_type : null;
+						$parent = get_post( $post->parentDatabaseId );
+						if ( ! empty( $parent ) && isset( $parent->post_type ) ) {
+							$post_type = $parent->post_type;
+						}
 					}
 
 					$post_type_object = ! empty( $post_type ) ? get_post_type_object( $post_type ) : null;

--- a/src/Type/InterfaceType/ContentTemplate.php
+++ b/src/Type/InterfaceType/ContentTemplate.php
@@ -2,8 +2,18 @@
 
 namespace WPGraphQL\Type\InterfaceType;
 
+use WPGraphQL\Registry\TypeRegistry;
+
 class ContentTemplate {
-	public static function register_type( $type_registry ) {
+
+	/**
+	 * Register the ContentTemplate Interface
+	 *
+	 * @param TypeRegistry $type_registry
+	 *
+	 * @return void
+	 */
+	public static function register_type( TypeRegistry $type_registry ) {
 		register_graphql_interface_type(
 			'ContentTemplate',
 			[
@@ -14,7 +24,7 @@ class ContentTemplate {
 						'description' => __( 'The name of the template', 'wp-graphql' ),
 					],
 				],
-				'resolveType' => function( $value ) use ( $type_registry ) {
+				'resolveType' => function( $value ) {
 					return isset( $value['__typename'] ) ? $value['__typename'] : 'DefaultTemplate';
 				},
 			]

--- a/src/Type/InterfaceType/DatabaseIdentifier.php
+++ b/src/Type/InterfaceType/DatabaseIdentifier.php
@@ -14,6 +14,8 @@ class DatabaseIdentifier {
 	 * Register the DatabaseIdentifier Interface
 	 *
 	 * @param TypeRegistry $type_registry
+	 *
+	 * @return void
 	 */
 	public static function register_type( TypeRegistry $type_registry ) {
 

--- a/src/Type/InterfaceType/EnqueuedAsset.php
+++ b/src/Type/InterfaceType/EnqueuedAsset.php
@@ -13,6 +13,8 @@ class EnqueuedAsset {
 	 * Register the Enqueued Script Type
 	 *
 	 * @param TypeRegistry $type_registry The WPGraphQL Type Registry
+	 *
+	 * @return void
 	 */
 	public static function register_type( TypeRegistry $type_registry ) {
 

--- a/src/Type/InterfaceType/HierarchicalContentNode.php
+++ b/src/Type/InterfaceType/HierarchicalContentNode.php
@@ -14,6 +14,8 @@ class HierarchicalContentNode {
 	 * Register the HierarchicalContentNode Interface Type
 	 *
 	 * @param TypeRegistry $type_registry
+	 *
+	 * @return void
 	 */
 	public static function register_type( TypeRegistry $type_registry ) {
 		register_graphql_interface_type(

--- a/src/Type/InterfaceType/HierarchicalTermNode.php
+++ b/src/Type/InterfaceType/HierarchicalTermNode.php
@@ -14,6 +14,8 @@ class HierarchicalTermNode {
 	 * Register the HierarchicalTermNode Interface Type
 	 *
 	 * @param TypeRegistry $type_registry
+	 *
+	 * @return void
 	 */
 	public static function register_type( TypeRegistry $type_registry ) {
 

--- a/src/Type/InterfaceType/Node.php
+++ b/src/Type/InterfaceType/Node.php
@@ -4,6 +4,12 @@ namespace WPGraphQL\Type\InterfaceType;
 use WPGraphQL\Data\DataSource;
 
 class Node {
+
+	/**
+	 * Register the Node interface
+	 *
+	 * @return void
+	 */
 	public static function register_type() {
 		register_graphql_interface_type(
 			'Node',

--- a/src/Type/InterfaceType/NodeWithAuthor.php
+++ b/src/Type/InterfaceType/NodeWithAuthor.php
@@ -9,9 +9,13 @@ use WPGraphQL\Registry\TypeRegistry;
 
 class NodeWithAuthor {
 	/**
-	 * @param TypeRegistry $type_registry Instance of the Type Registry
+	 * Registers the NodeWithAuthor Type to the Schema
+	 *
+	 * @param TypeRegistry $type_registry
+	 *
+	 * @return void
 	 */
-	public static function register_type( $type_registry ) {
+	public static function register_type( TypeRegistry $type_registry ) {
 		register_graphql_interface_type(
 			'NodeWithAuthor',
 			[

--- a/src/Type/InterfaceType/NodeWithComments.php
+++ b/src/Type/InterfaceType/NodeWithComments.php
@@ -5,9 +5,13 @@ use WPGraphQL\Registry\TypeRegistry;
 
 class NodeWithComments {
 	/**
-	 * @param TypeRegistry $type_registry Instance of the Type Registry
+	 * Registers the NodeWithComments Type to the Schema
+	 *
+	 * @param TypeRegistry $type_registry
+	 *
+	 * @return void
 	 */
-	public static function register_type( $type_registry ) {
+	public static function register_type( TypeRegistry $type_registry ) {
 		register_graphql_interface_type(
 			'NodeWithComments',
 			[

--- a/src/Type/InterfaceType/NodeWithContentEditor.php
+++ b/src/Type/InterfaceType/NodeWithContentEditor.php
@@ -5,9 +5,13 @@ use WPGraphQL\Registry\TypeRegistry;
 
 class NodeWithContentEditor {
 	/**
-	 * @param TypeRegistry $type_registry Instance of the Type Registry
+	 * Registers the NodeWithContentEditor Type to the Schema
+	 *
+	 * @param TypeRegistry $type_registry
+	 *
+	 * @return void
 	 */
-	public static function register_type( $type_registry ) {
+	public static function register_type( TypeRegistry $type_registry ) {
 		register_graphql_interface_type(
 			'NodeWithContentEditor',
 			[

--- a/src/Type/InterfaceType/NodeWithExcerpt.php
+++ b/src/Type/InterfaceType/NodeWithExcerpt.php
@@ -4,10 +4,15 @@ namespace WPGraphQL\Type\InterfaceType;
 use WPGraphQL\Registry\TypeRegistry;
 
 class NodeWithExcerpt {
+
 	/**
-	 * @param TypeRegistry $type_registry Instance of the Type Registry
+	 * Registers the NodeWithExcerpt Type to the Schema
+	 *
+	 * @param TypeRegistry $type_registry
+	 *
+	 * @return void
 	 */
-	public static function register_type( $type_registry ) {
+	public static function register_type( TypeRegistry $type_registry ) {
 		register_graphql_interface_type(
 			'NodeWithExcerpt',
 			[

--- a/src/Type/InterfaceType/NodeWithFeaturedImage.php
+++ b/src/Type/InterfaceType/NodeWithFeaturedImage.php
@@ -4,10 +4,15 @@ namespace WPGraphQL\Type\InterfaceType;
 use WPGraphQL\Registry\TypeRegistry;
 
 class NodeWithFeaturedImage {
+
 	/**
-	 * @param TypeRegistry $type_registry Instance of the Type Registry
+	 * Registers the NodeWithFeaturedImage Type to the Schema
+	 *
+	 * @param TypeRegistry $type_registry
+	 *
+	 * @return void
 	 */
-	public static function register_type( $type_registry ) {
+	public static function register_type( TypeRegistry $type_registry ) {
 
 		register_graphql_interface_type(
 			'NodeWithFeaturedImage',

--- a/src/Type/InterfaceType/NodeWithPageAttributes.php
+++ b/src/Type/InterfaceType/NodeWithPageAttributes.php
@@ -4,6 +4,14 @@ namespace WPGraphQL\Type\InterfaceType;
 use WPGraphQL\Registry\TypeRegistry;
 
 class NodeWithPageAttributes {
+
+	/**
+	 * Registers the NodeWithPageAttributes Type to the Schema
+	 *
+	 * @param TypeRegistry $type_registry
+	 *
+	 * @return void
+	 */
 	public static function register_type( TypeRegistry $type_registry ) {
 		register_graphql_interface_type(
 			'NodeWithPageAttributes',

--- a/src/Type/InterfaceType/NodeWithRevisions.php
+++ b/src/Type/InterfaceType/NodeWithRevisions.php
@@ -4,6 +4,14 @@ namespace WPGraphQL\Type\InterfaceType;
 use WPGraphQL\Registry\TypeRegistry;
 
 class NodeWithRevisions {
+
+	/**
+	 * Registers the NodeWithRevisions Type to the Schema
+	 *
+	 * @param TypeRegistry $type_registry
+	 *
+	 * @return void
+	 */
 	public static function register_type( TypeRegistry $type_registry ) {
 		register_graphql_interface_type(
 			'NodeWithRevisions',

--- a/src/Type/InterfaceType/NodeWithTemplate.php
+++ b/src/Type/InterfaceType/NodeWithTemplate.php
@@ -4,6 +4,14 @@ namespace WPGraphQL\Type\InterfaceType;
 use WPGraphQL\Registry\TypeRegistry;
 
 class NodeWithTemplate {
+
+	/**
+	 * Registers the NodeWithTemplate Type to the Schema
+	 *
+	 * @param TypeRegistry $type_registry
+	 *
+	 * @return void
+	 */
 	public static function register_type( TypeRegistry $type_registry ) {
 		register_graphql_interface_type( 'NodeWithTemplate', [
 			'description' => __( 'A node that can have a template associated with it', 'wp-graphql' ),

--- a/src/Type/InterfaceType/NodeWithTitle.php
+++ b/src/Type/InterfaceType/NodeWithTitle.php
@@ -8,6 +8,14 @@ use WPGraphQL\Model\Post;
 use WPGraphQL\Registry\TypeRegistry;
 
 class NodeWithTitle {
+
+	/**
+	 * Registers the NodeWithTitle Type to the Schema
+	 *
+	 * @param TypeRegistry $type_registry
+	 *
+	 * @return void
+	 */
 	public static function register_type( TypeRegistry $type_registry ) {
 
 		register_graphql_interface_type(

--- a/src/Type/InterfaceType/NodeWithTrackbacks.php
+++ b/src/Type/InterfaceType/NodeWithTrackbacks.php
@@ -4,6 +4,14 @@ namespace WPGraphQL\Type\InterfaceType;
 use WPGraphQL\Registry\TypeRegistry;
 
 class NodeWithTrackbacks {
+
+	/**
+	 * Registers the NodeWithTrackbacks Type to the Schema
+	 *
+	 * @param TypeRegistry $type_registry
+	 *
+	 * @return void
+	 */
 	public static function register_type( TypeRegistry $type_registry ) {
 		register_graphql_interface_type(
 			'NodeWithTrackbacks',

--- a/src/Type/InterfaceType/TermNode.php
+++ b/src/Type/InterfaceType/TermNode.php
@@ -12,6 +12,8 @@ class TermNode {
 	 * Register the TermNode Interface
 	 *
 	 * @param TypeRegistry $type_registry
+	 *
+	 * @return void
 	 */
 	public static function register_type( TypeRegistry $type_registry ) {
 

--- a/src/Type/InterfaceType/UniformResourceIdentifiable.php
+++ b/src/Type/InterfaceType/UniformResourceIdentifiable.php
@@ -9,6 +9,14 @@ use WPGraphQL\Model\User;
 use WPGraphQL\Registry\TypeRegistry;
 
 class UniformResourceIdentifiable {
+
+	/**
+	 * Registers the UniformResourceIdentifiable Interface to the Schema.
+	 *
+	 * @param TypeRegistry $type_registry
+	 *
+	 * @return void
+	 */
 	public static function register_type( TypeRegistry $type_registry ) {
 		register_graphql_interface_type(
 			'UniformResourceIdentifiable',

--- a/src/Type/Object/Avatar.php
+++ b/src/Type/Object/Avatar.php
@@ -3,6 +3,12 @@
 namespace WPGraphQL\Type\Object;
 
 class Avatar {
+
+	/**
+	 * Register the Avatar Type to the Schema
+	 *
+	 * @return void
+	 */
 	public static function register_type() {
 		register_graphql_object_type(
 			'Avatar',

--- a/src/Type/Object/Comment.php
+++ b/src/Type/Object/Comment.php
@@ -11,6 +11,8 @@ class Comment {
 
 	/**
 	 * Register Comment Type
+	 *
+	 * @return void
 	 */
 	public static function register_type() {
 		register_graphql_object_type(

--- a/src/Type/Object/CommentAuthor.php
+++ b/src/Type/Object/CommentAuthor.php
@@ -3,6 +3,12 @@
 namespace WPGraphQL\Type\Object;
 
 class CommentAuthor {
+
+	/**
+	 * Register the CommentAuthor Type to the Schema
+	 *
+	 * @return void
+	 */
 	public static function register_type() {
 		register_graphql_object_type(
 			'CommentAuthor',

--- a/src/Type/Object/ContentType.php
+++ b/src/Type/Object/ContentType.php
@@ -3,6 +3,12 @@
 namespace WPGraphQL\Type\Object;
 
 class ContentType {
+
+	/**
+	 * Register the ContentType Type to the Schema
+	 *
+	 * @return void
+	 */
 	public static function register_type() {
 
 		$interfaces = [ 'Node', 'UniformResourceIdentifiable' ];

--- a/src/Type/Object/EnqueuedScript.php
+++ b/src/Type/Object/EnqueuedScript.php
@@ -13,6 +13,8 @@ class EnqueuedScript {
 
 	/**
 	 * Register the EnqueuedScript Type
+	 *
+	 * @return void
 	 */
 	public static function register_type() {
 		register_graphql_object_type( 'EnqueuedScript', [

--- a/src/Type/Object/EnqueuedStylesheet.php
+++ b/src/Type/Object/EnqueuedStylesheet.php
@@ -13,6 +13,8 @@ class EnqueuedStylesheet {
 
 	/**
 	 * Register the EnqueuedStylesheet Type
+	 *
+	 * @return void
 	 */
 	public static function register_type() {
 		register_graphql_object_type( 'EnqueuedStylesheet', [

--- a/src/Type/Object/MediaDetails.php
+++ b/src/Type/Object/MediaDetails.php
@@ -3,6 +3,12 @@
 namespace WPGraphQL\Type\Object;
 
 class MediaDetails {
+
+	/**
+	 * Register the MediaDetails type to the Schema
+	 *
+	 * @return void
+	 */
 	public static function register_type() {
 		register_graphql_object_type(
 			'MediaDetails',

--- a/src/Type/Object/MediaItemMeta.php
+++ b/src/Type/Object/MediaItemMeta.php
@@ -11,6 +11,8 @@ class MediaItemMeta {
 
 	/**
 	 * Register the MediaItemMeta Type
+	 *
+	 * @return void
 	 */
 	public static function register_type() {
 		register_graphql_object_type(

--- a/src/Type/Object/MediaSize.php
+++ b/src/Type/Object/MediaSize.php
@@ -3,6 +3,12 @@
 namespace WPGraphQL\Type\Object;
 
 class MediaSize {
+
+	/**
+	 * Register the MediaSize
+	 *
+	 * @return void
+	 */
 	public static function register_type() {
 		register_graphql_object_type(
 			'MediaSize',
@@ -41,8 +47,8 @@ class MediaSize {
 
 							if ( ! empty( $image['ID'] ) && ! empty( $image['file'] ) ) {
 								$original_file = get_attached_file( absint( $image['ID'] ) );
-								$filesize_path = path_join( dirname( $original_file ), $image['file'] );
-								return filesize( $filesize_path );
+								$filesize_path = ! empty( $original_file ) ? path_join( dirname( $original_file ), $image['file'] ) : null;
+								return ! empty( $filesize_path ) ? filesize( $filesize_path ) : null;
 							}
 
 							return null;
@@ -58,7 +64,7 @@ class MediaSize {
 
 							if ( ! empty( $image['ID'] ) ) {
 								$src = wp_get_attachment_image_src( absint( $image['ID'] ), $image['name'] );
-								if ( ! empty( $src[0] ) ) {
+								if ( is_array( $src ) && isset( $src[0] ) && ! empty( $src[0] ) ) {
 									$src_url = $src[0];
 								}
 							} else {

--- a/src/Type/Object/Menu.php
+++ b/src/Type/Object/Menu.php
@@ -3,6 +3,12 @@
 namespace WPGraphQL\Type\Object;
 
 class Menu {
+
+	/**
+	 * Register the Menu object type
+	 *
+	 * @return void
+	 */
 	public static function register_type() {
 		register_graphql_object_type(
 			'Menu',

--- a/src/Type/Object/MenuItem.php
+++ b/src/Type/Object/MenuItem.php
@@ -4,9 +4,14 @@ namespace WPGraphQL\Type\Object;
 
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
-use WPGraphQL\Data\DataSource;
 
 class MenuItem {
+
+	/**
+	 * Register the MenuItem Type
+	 *
+	 * @return void
+	 */
 	public static function register_type() {
 		register_graphql_object_type(
 			'MenuItem',

--- a/src/Type/Object/PageInfo.php
+++ b/src/Type/Object/PageInfo.php
@@ -3,6 +3,12 @@
 namespace WPGraphQL\Type\Object;
 
 class PageInfo {
+
+	/**
+	 * Register WPPageInfo Type to the Schema
+	 *
+	 * @return void
+	 */
 	public static function register_type() {
 
 		/**

--- a/src/Type/Object/Plugin.php
+++ b/src/Type/Object/Plugin.php
@@ -11,6 +11,8 @@ class Plugin {
 
 	/**
 	 * Registers the Plugin Type to the Schema
+	 *
+	 * @return void
 	 */
 	public static function register_type() {
 		register_graphql_object_type(

--- a/src/Type/Object/PostObject.php
+++ b/src/Type/Object/PostObject.php
@@ -2,6 +2,7 @@
 
 namespace WPGraphQL\Type\Object;
 
+use WP_Post_Type;
 use WPGraphQL\Model\Post;
 use WPGraphQL\Registry\TypeRegistry;
 
@@ -15,10 +16,12 @@ class PostObject {
 	/**
 	 * Registers a post_type WPObject type to the schema.
 	 *
-	 * @param \WP_Post_Type $post_type_object Post type.
-	 * @param TypeRegistry  $type_registry    The Type Registry
+	 * @param WP_Post_Type $post_type_object Post type.
+	 * @param TypeRegistry $type_registry    The Type Registry
+	 *
+	 * @return void
 	 */
-	public static function register_post_object_types( $post_type_object, $type_registry ) {
+	public static function register_post_object_types( WP_Post_Type $post_type_object, TypeRegistry $type_registry ) {
 
 		$single_name = $post_type_object->graphql_single_name;
 
@@ -159,7 +162,7 @@ class PostObject {
 							}
 
 							$url = wp_get_attachment_image_src( $source->ID, $size );
-							if ( empty( $url[0] ) ) {
+							if ( ! is_array( $url ) || ! isset( $url[0] ) ) {
 								return null;
 							}
 
@@ -234,8 +237,9 @@ class PostObject {
 							$sourceUrl     = ! empty( $size ) ? $image->sourceUrlsBySize[ $size ] : $image->mediaItemUrl;
 							$path_parts    = pathinfo( $sourceUrl );
 							$original_file = get_attached_file( absint( $image->databaseId ) );
-							$filesize_path = path_join( dirname( $original_file ), $path_parts['basename'] );
-							return filesize( $filesize_path );
+							$filesize_path = ! empty( $original_file ) ? path_join( dirname( $original_file ), $path_parts['basename'] ) : null;
+
+							return ! empty( $filesize_path ) ? filesize( $filesize_path ) : null;
 
 						},
 					],
@@ -255,8 +259,8 @@ class PostObject {
 	/**
 	 * Registers common post type fields on schema type corresponding to provided post type object.
 	 *
-	 * @param \WP_Post_Type $post_type_object Post type.
-	 * @param TypeRegistry  $type_registry    The Type Registry
+	 * @param WP_Post_Type $post_type_object Post type.
+	 * @param TypeRegistry $type_registry    The Type Registry
 	 *
 	 * @return array
 	 */

--- a/src/Type/Object/PostTypeLabelDetails.php
+++ b/src/Type/Object/PostTypeLabelDetails.php
@@ -11,6 +11,8 @@ class PostTypeLabelDetails {
 
 	/**
 	 * Register the PostTypeLabelDetails type
+	 *
+	 * @return void
 	 */
 	public static function register_type() {
 		register_graphql_object_type(

--- a/src/Type/Object/RootMutation.php
+++ b/src/Type/Object/RootMutation.php
@@ -3,6 +3,12 @@
 namespace WPGraphQL\Type\Object;
 
 class RootMutation {
+
+	/**
+	 * Register RootMutation type
+	 *
+	 * @return void
+	 */
 	public static function register_type() {
 
 		register_graphql_object_type(

--- a/src/Type/Object/RootQuery.php
+++ b/src/Type/Object/RootQuery.php
@@ -7,8 +7,6 @@ use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
 use WPGraphQL\Data\DataSource;
-use WPGraphQL\Model\Post;
-use WPGraphQL\Model\Term;
 
 /**
  * Class RootQuery
@@ -19,6 +17,8 @@ class RootQuery {
 
 	/**
 	 * Register the RootQuery type
+	 *
+	 * @return void
 	 */
 	public static function register_type() {
 		register_graphql_object_type(
@@ -79,7 +79,6 @@ class RootQuery {
 							switch ( $idType ) {
 								case 'uri':
 									return $context->node_resolver->resolve_uri( $args['id'] );
-									break;
 								case 'database_id':
 									$post_id = absint( $args['id'] );
 									break;
@@ -341,7 +340,6 @@ class RootQuery {
 									break;
 								case 'uri':
 									return $context->node_resolver->resolve_uri( $args['id'] );
-									break;
 								case 'global_id':
 								default:
 									$id_components = Relay::fromGlobalId( $args['id'] );
@@ -396,7 +394,6 @@ class RootQuery {
 									break;
 								case 'uri':
 									return $context->node_resolver->resolve_uri( $args['id'] );
-									break;
 								case 'login':
 									$current_user = wp_get_current_user();
 									if ( $current_user->user_login !== $args['id'] ) {
@@ -454,7 +451,7 @@ class RootQuery {
 					'viewer'      => [
 						'type'        => 'User',
 						'description' => __( 'Returns the current user', 'wp-graphql' ),
-						'resolve'     => function( $source, array $args, $context, $info ) {
+						'resolve'     => function( $source, array $args, AppContext $context, ResolveInfo $info ) {
 							return isset( $context->viewer->ID ) && ! empty( $context->viewer->ID ) ? DataSource::resolve_user( $context->viewer->ID, $context ) : null;
 						},
 					],
@@ -465,6 +462,8 @@ class RootQuery {
 
 	/**
 	 * Register RootQuery fields for Post Objects of supported post types
+	 *
+	 * @return void
 	 */
 	public static function register_post_object_fields() {
 
@@ -472,6 +471,10 @@ class RootQuery {
 		if ( ! empty( $allowed_post_types ) && is_array( $allowed_post_types ) ) {
 			foreach ( $allowed_post_types as $post_type ) {
 				$post_type_object = get_post_type_object( $post_type );
+
+				if ( ! $post_type_object instanceof \WP_Post_Type ) {
+					return;
+				}
 
 				register_graphql_field(
 					'RootQuery',
@@ -505,7 +508,6 @@ class RootQuery {
 									] );
 								case 'uri':
 									return $context->node_resolver->resolve_uri( $args['id'], [ 'post_type' => $post_type_object->name ] );
-									break;
 								case 'database_id':
 									$post_id = absint( $args['id'] );
 									break;
@@ -594,6 +596,11 @@ class RootQuery {
 							}
 
 							return $context->get_loader( 'post' )->load_deferred( $post_id )->then( function( $post ) use ( $post_type_object ) {
+
+								if ( ! $post_type_object instanceof \WP_Post_Type ) {
+									return null;
+								}
+
 								if ( ! isset( $post->post_type ) || ! in_array( $post->post_type, [ 'revision', $post_type_object->name ], true ) ) {
 									return null;
 								}
@@ -609,6 +616,8 @@ class RootQuery {
 
 	/**
 	 * Register RootQuery fields for Term Objects of supported taxonomies
+	 *
+	 * @return void
 	 */
 	public static function register_term_object_fields() {
 
@@ -645,12 +654,11 @@ class RootQuery {
 									if ( 'database_id' === $idType ) {
 										$idType = 'id';
 									}
-									$term    = get_term_by( $idType, $args['id'], $taxonomy_object->name );
+									$term    = isset( $taxonomy_object->name ) ? get_term_by( $idType, $args['id'], $taxonomy_object->name ) : null;
 									$term_id = isset( $term->term_id ) ? absint( $term->term_id ) : null;
 									break;
 								case 'uri':
 									return $context->node_resolver->resolve_uri( $args['id'] );
-									break;
 								case 'global_id':
 								default:
 									$id_components = Relay::fromGlobalId( $args['id'] );

--- a/src/Type/Object/SettingGroup.php
+++ b/src/Type/Object/SettingGroup.php
@@ -8,9 +8,14 @@ use WPGraphQL\Data\DataSource;
 class SettingGroup {
 
 	/**
-	 * @param string $group_name
+	 * Register each settings group to the GraphQL Schema
+	 *
+	 * @param string $group_name The name of the setting group
+	 * @param string $group      The settings group config
+	 *
+	 * @return void
 	 */
-	public static function register_settings_group( $group_name, $group ) {
+	public static function register_settings_group( string $group_name, string $group ) {
 		register_graphql_object_type(
 			ucfirst( $group_name ) . 'Settings',
 			[
@@ -23,11 +28,12 @@ class SettingGroup {
 	/**
 	 * Given the name of a registered settings group, retrieve GraphQL fields for the group
 	 *
-	 * @param string $group_name Name  of the settings group to retrieve fields for
+	 * @param string $group_name Name of the settings group to retrieve fields for
+	 * @param string $group      The settings group config
 	 *
 	 * @return array
 	 */
-	public static function get_settings_group_fields( $group_name, $group ) {
+	public static function get_settings_group_fields( string $group_name, string $group ) {
 
 		$setting_fields = DataSource::get_setting_group_fields( $group );
 
@@ -62,7 +68,7 @@ class SettingGroup {
 					$fields[ $field_key ] = [
 						'type'        => $setting_field['type'],
 						'description' => $setting_field['description'],
-						'resolve'     => function( $root, array $args, $context, $info ) use ( $setting_field, $field_key, $key ) {
+						'resolve'     => function( $root, array $args, $context, $info ) use ( $setting_field ) {
 
 							/**
 							 * Check to see if the user querying the email field has the 'manage_options' capability
@@ -80,18 +86,14 @@ class SettingGroup {
 								case 'integer':
 								case 'int':
 									return absint( $option );
-									break;
 								case 'string':
 									return (string) $option;
-									break;
 								case 'boolean':
 								case 'bool':
 									return (bool) $option;
-									break;
 								case 'number':
 								case 'float':
 									return (float) $option;
-									break;
 							}
 
 							return ! empty( $option ) ? $option : null;

--- a/src/Type/Object/Settings.php
+++ b/src/Type/Object/Settings.php
@@ -81,7 +81,7 @@ class Settings {
 						'type'        => $setting_field['type'],
 						'description' => $setting_field['description'],
 
-						'resolve'     => function( $root, $args, $context, $info ) use ( $setting_field, $field_key, $key ) {
+						'resolve'     => function( $root, $args, $context, $info ) use ( $setting_field, $key ) {
 							/**
 							 * Check to see if the user querying the email field has the 'manage_options' capability
 							 * All other options should be public by default
@@ -90,7 +90,7 @@ class Settings {
 								throw new UserError( __( 'Sorry, you do not have permission to view this setting.', 'wp-graphql' ) );
 							}
 
-							$option = ! empty( $key ) ? get_option( $key ) : null;
+							$option = ! empty( $key ) ? get_option( (string) $key ) : null;
 
 							switch ( $setting_field['type'] ) {
 								case 'integer':

--- a/src/Type/Object/Taxonomy.php
+++ b/src/Type/Object/Taxonomy.php
@@ -2,9 +2,13 @@
 
 namespace WPGraphQL\Type\Object;
 
-use WPGraphQL\Model\Taxonomy as TaxonomyModel;
-
 class Taxonomy {
+
+	/**
+	 * Register the Taxonomy type to the GraphQL Schema
+	 *
+	 * @return void
+	 */
 	public static function register_type() {
 
 		$allowed_post_types = \WPGraphQL::get_allowed_post_types();

--- a/src/Type/Object/TermObject.php
+++ b/src/Type/Object/TermObject.php
@@ -2,6 +2,7 @@
 
 namespace WPGraphQL\Type\Object;
 
+use WP_Taxonomy;
 use WPGraphQL\Model\Term;
 
 /**
@@ -14,9 +15,11 @@ class TermObject {
 	/**
 	 * Register the Type for each kind of Taxonomy
 	 *
-	 * @param \WP_Taxonomy $taxonomy_object The taxonomy being registered
+	 * @param WP_Taxonomy $taxonomy_object The taxonomy being registered
+	 *
+	 * @return void
 	 */
-	public static function register_taxonomy_object_type( $taxonomy_object ) {
+	public static function register_taxonomy_object_type( WP_Taxonomy $taxonomy_object ) {
 
 		$interfaces = [ 'Node', 'TermNode', 'DatabaseIdentifier' ];
 

--- a/src/Type/Object/Theme.php
+++ b/src/Type/Object/Theme.php
@@ -11,6 +11,8 @@ class Theme {
 
 	/**
 	 * Register the Theme Type
+	 *
+	 * @return void
 	 */
 	public static function register_type() {
 		register_graphql_object_type(

--- a/src/Type/Object/User.php
+++ b/src/Type/Object/User.php
@@ -14,6 +14,8 @@ class User {
 
 	/**
 	 * Registers the User type
+	 *
+	 * @return void
 	 */
 	public static function register_type() {
 		register_graphql_object_type(
@@ -143,7 +145,7 @@ class User {
 
 							$avatar = DataSource::resolve_avatar( $user->userId, $avatar_args );
 
-							return ( ! empty( $avatar ) && true === $avatar->foundAvatar ) ? $avatar : null;
+							return isset( $avatar->foundAvatar ) && true === $avatar->foundAvatar ? $avatar : null;
 						},
 					],
 				],

--- a/src/Type/Object/UserRole.php
+++ b/src/Type/Object/UserRole.php
@@ -3,6 +3,12 @@
 namespace WPGraphQL\Type\Object;
 
 class UserRole {
+
+	/**
+	 * Register the UserRole Type
+	 *
+	 * @return void
+	 */
 	public static function register_type() {
 		register_graphql_object_type(
 			'UserRole',

--- a/src/Type/Union/ContentRevisionUnion.php
+++ b/src/Type/Union/ContentRevisionUnion.php
@@ -6,6 +6,14 @@ use WPGraphQL\Model\Post;
 use WPGraphQL\Registry\TypeRegistry;
 
 class ContentRevisionUnion {
+
+	/**
+	 * Register the ContentRevisionUnion Type
+	 *
+	 * @param TypeRegistry $type_registry
+	 *
+	 * @return void
+	 */
 	public static function register_type( TypeRegistry $type_registry ) {
 
 		$cpts_with_revisions              = get_post_types_by_support( 'revisions' );
@@ -30,7 +38,7 @@ class ContentRevisionUnion {
 					'resolveType' => function( Post $object ) use ( $type_registry ) {
 
 						$type   = 'Post';
-						$parent = get_post( $object->parentId );
+						$parent = get_post( (int) $object->parentDatabaseId );
 						if ( ! empty( $parent ) && isset( $parent->post_type ) ) {
 							$parent_post_type_object = get_post_type_object( $parent->post_type );
 							if ( isset( $parent_post_type_object->graphql_single_name ) ) {

--- a/src/Type/Union/MenuItemObjectUnion.php
+++ b/src/Type/Union/MenuItemObjectUnion.php
@@ -2,6 +2,7 @@
 
 namespace WPGraphQL\Type\Union;
 
+use Exception;
 use WPGraphQL\Model\Post;
 use WPGraphQL\Model\Term;
 use WPGraphQL\Registry\TypeRegistry;
@@ -20,6 +21,7 @@ class MenuItemObjectUnion {
 	 * @param TypeRegistry $type_registry
 	 *
 	 * @return void
+	 * @throws Exception
 	 */
 	public static function register_type( TypeRegistry $type_registry ) {
 
@@ -30,7 +32,7 @@ class MenuItemObjectUnion {
 				'description' => __( 'Deprecated in favor of MenuItemLinkeable Interface', 'wp-graphql' ),
 				'resolveType' => function( $object ) use ( $type_registry ) {
 					// Post object
-					if ( $object instanceof Post && ! empty( $object->post_type ) ) {
+					if ( $object instanceof Post && isset( $object->post_type ) && ! empty( $object->post_type ) ) {
 						$post_type_object = get_post_type_object( $object->post_type );
 
 						return $type_registry->get_type( $post_type_object->graphql_single_name );

--- a/src/Type/WPEnumType.php
+++ b/src/Type/WPEnumType.php
@@ -29,8 +29,15 @@ class WPEnumType extends EnumType {
 	 * @param  string $value Enum value.
 	 * @return string
 	 */
-	public static function get_safe_name( $value ) {
-		$safe_name = strtoupper( preg_replace( '#[^A-z0-9]#', '_', $value ) );
+	public static function get_safe_name( string $value ) {
+
+		$replaced = preg_replace( '#[^A-z0-9]#', '_', $value );
+
+		if ( ! empty( $replaced ) ) {
+			$value = $replaced;
+		}
+
+		$safe_name = strtoupper( $value );
 
 		// Enum names must start with a letter or underscore.
 		if ( ! preg_match( '#^[_a-zA-Z]#', $value ) ) {

--- a/src/Type/WPInterfaceType.php
+++ b/src/Type/WPInterfaceType.php
@@ -36,12 +36,13 @@ class WPInterfaceType extends InterfaceType {
 			if ( is_callable( $config['resolveType'] ) ) {
 				$type = call_user_func( $config['resolveType'], $object );
 			}
+
 			/**
 			 * Filter the resolve type method for all interfaces
 			 *
-			 * @param mixed       $type    The Type to resolve to, based on the object being resolved.
-			 * @param mixed       $object  The Object being resolved.
-			 * @param WPInterfaceType $this    The WPInterfaceType instance.
+			 * @param mixed           $type   The Type to resolve to, based on the object being resolved.
+			 * @param mixed           $object The Object being resolved.
+			 * @param WPInterfaceType $wp_interface_type   The WPInterfaceType instance.
 			 */
 			return apply_filters( 'graphql_interface_resolve_type', $type, $object, $this );
 		};
@@ -50,7 +51,7 @@ class WPInterfaceType extends InterfaceType {
 		 * Filter the config of WPInterfaceType
 		 *
 		 * @param array           $config Array of configuration options passed to the WPInterfaceType when instantiating a new type
-		 * @param WPInterfaceType $this   The instance of the WPObjectType class
+		 * @param WPInterfaceType $wp_interface_type   The instance of the WPObjectType class
 		 */
 		$config = apply_filters( 'graphql_wp_interface_type_config', $config, $this );
 
@@ -67,7 +68,7 @@ class WPInterfaceType extends InterfaceType {
 	 * @return mixed
 	 * @since 0.0.5
 	 */
-	public function prepare_fields( $fields, $type_name ) {
+	public function prepare_fields( array $fields, string $type_name ) {
 
 		/**
 		 * Filter all object fields, passing the $typename as a param
@@ -75,8 +76,8 @@ class WPInterfaceType extends InterfaceType {
 		 * This is useful when several different types need to be easily filtered at once. . .for example,
 		 * if ALL types with a field of a certain name needed to be adjusted, or something to that tune
 		 *
-		 * @param array        $fields        The array of fields for the object config
-		 * @param string       $type_name     The name of the object type
+		 * @param array  $fields    The array of fields for the object config
+		 * @param string $type_name The name of the object type
 		 */
 		$fields = apply_filters( 'graphql_interface_fields', $fields, $type_name );
 

--- a/src/Type/WPObjectType.php
+++ b/src/Type/WPObjectType.php
@@ -24,7 +24,7 @@ class WPObjectType extends ObjectType {
 	 * to easily define themselves as a node type by implementing
 	 * self::$node_interface
 	 *
-	 * @var $node_interface
+	 * @var array|Node $node_interface
 	 * @since 0.0.5
 	 */
 	private static $node_interface;
@@ -54,8 +54,8 @@ class WPObjectType extends ObjectType {
 		/**
 		 * Filter the config of WPObjectType
 		 *
-		 * @param array        $config Array of configuration options passed to the WPObjectType when instantiating a new type
-		 * @param WPObjectType $this   The instance of the WPObjectType class
+		 * @param array        $config         Array of configuration options passed to the WPObjectType when instantiating a new type
+		 * @param WPObjectType $wp_object_type The instance of the WPObjectType class
 		 */
 		$config = apply_filters( 'graphql_wp_object_type_config', $config, $this );
 
@@ -69,9 +69,9 @@ class WPObjectType extends ObjectType {
 		/**
 		 * Filters the interfaces applied to an object type
 		 *
-		 * @param array        $interfaces List of interfaces applied to the Object Type
-		 * @param array        $config     The config for the Object Type
-		 * @param WPObjectType $this       The WPObjectType instance
+		 * @param array        $interfaces     List of interfaces applied to the Object Type
+		 * @param array        $config         The config for the Object Type
+		 * @param WPObjectType $wp_object_type The WPObjectType instance
 		 */
 		$interfaces               = apply_filters( 'graphql_object_type_interfaces', $interfaces, $config, $this );
 		$config['interfaceNames'] = $interfaces;
@@ -79,7 +79,7 @@ class WPObjectType extends ObjectType {
 		/**
 		 * Convert Interfaces from Strings to Types
 		 */
-		$config['interfaces'] = function () use ( $interfaces ) {
+		$config['interfaces'] = function() use ( $interfaces ) {
 			$new_interfaces = [];
 			if ( ! is_array( $interfaces ) ) {
 				// TODO Throw an error.
@@ -153,8 +153,8 @@ class WPObjectType extends ObjectType {
 		/**
 		 * Run an action when the WPObjectType is instantiating
 		 *
-		 * @param array        $config Array of configuration options passed to the WPObjectType when instantiating a new type
-		 * @param WPObjectType $this   The instance of the WPObjectType class
+		 * @param array        $config         Array of configuration options passed to the WPObjectType when instantiating a new type
+		 * @param WPObjectType $wp_object_type The instance of the WPObjectType class
 		 */
 		do_action( 'graphql_wp_object_type', $config, $this );
 
@@ -200,10 +200,10 @@ class WPObjectType extends ObjectType {
 		 * This is useful when several different types need to be easily filtered at once. . .for example,
 		 * if ALL types with a field of a certain name needed to be adjusted, or something to that tune
 		 *
-		 * @param array        $fields        The array of fields for the object config
-		 * @param string       $type_name     The name of the object type
-		 * @param WPObjectType $this          The WPObjectType Class
-		 * @param TypeRegistry $type_registry The Type Registry
+		 * @param array        $fields         The array of fields for the object config
+		 * @param string       $type_name      The name of the object type
+		 * @param WPObjectType $wp_object_type The WPObjectType Class
+		 * @param TypeRegistry $type_registry  The Type Registry
 		 */
 		$fields = apply_filters( 'graphql_object_fields', $fields, $type_name, $this, $this->type_registry );
 
@@ -219,9 +219,9 @@ class WPObjectType extends ObjectType {
 		 * This is useful for more targeted filtering, and is applied after the general filter, to allow for
 		 * more specific overrides
 		 *
-		 * @param array        $fields        The array of fields for the object config
-		 * @param WPObjectType $this          The WPObjectType Class
-		 * @param TypeRegistry $type_registry The Type Registry
+		 * @param array        $fields         The array of fields for the object config
+		 * @param WPObjectType $wp_object_type The WPObjectType Class
+		 * @param TypeRegistry $type_registry  The Type Registry
 		 */
 		$fields = apply_filters( "graphql_{$lc_type_name}_fields", $fields, $this, $this->type_registry );
 
@@ -231,9 +231,9 @@ class WPObjectType extends ObjectType {
 		 * This is useful for more targeted filtering, and is applied after the general filter, to allow for
 		 * more specific overrides
 		 *
-		 * @param array        $fields        The array of fields for the object config
-		 * @param WPObjectType $this          The WPObjectType Class
-		 * @param TypeRegistry $type_registry The Type Registry
+		 * @param array        $fields         The array of fields for the object config
+		 * @param WPObjectType $wp_object_type The WPObjectType Class
+		 * @param TypeRegistry $type_registry  The Type Registry
 		 */
 		$fields = apply_filters( "graphql_{$uc_type_name}_fields", $fields, $this, $this->type_registry );
 

--- a/src/Type/WPUnionType.php
+++ b/src/Type/WPUnionType.php
@@ -46,6 +46,7 @@ class WPUnionType extends UnionType {
 					$prepared_types[] = $this->type_registry->get_type( $type_name );
 				}
 			}
+
 			return $prepared_types;
 		};
 
@@ -54,12 +55,13 @@ class WPUnionType extends UnionType {
 			if ( is_callable( $config['resolveType'] ) ) {
 				$type = call_user_func( $config['resolveType'], $object );
 			}
+
 			/**
 			 * Filter the resolve type method for all unions
 			 *
-			 * @param mixed $type The Type to resolve to, based on the object being resolved
-			 * @param mixed $object The Object being resolved
-			 * @param WPUnionType $this The WPUnionType instance
+			 * @param mixed       $type          The Type to resolve to, based on the object being resolved
+			 * @param mixed       $object        The Object being resolved
+			 * @param WPUnionType $wp_union_type The WPUnionType instance
 			 */
 			return apply_filters( 'graphql_union_resolve_type', $type, $object, $this );
 		};
@@ -67,18 +69,19 @@ class WPUnionType extends UnionType {
 		/**
 		 * Filter the possible_types to allow systems to add to the possible resolveTypes.
 		 *
-		 * @param $types array The possible types for the Union
-		 * @param $config array The config for the Union Type
+		 * @param array       $types         The possible types for the Union
+		 * @param array       $config        The config for the Union Type
+		 * @param WPUnionType $wp_union_type The WPUnionType instance
 		 *
 		 * @return array
 		 */
-		$config['types'] = apply_filters( 'graphql_union_possible_types', $config['types'], $config );
+		$config['types'] = apply_filters( 'graphql_union_possible_types', $config['types'], $config, $this );
 
 		/**
 		 * Filter the config of WPUnionType
 		 *
-		 * @param array       $config Array of configuration options passed to the WPUnionType when instantiating a new type
-		 * @param WPUnionType $this   The instance of the WPObjectType class
+		 * @param array       $config        Array of configuration options passed to the WPUnionType when instantiating a new type
+		 * @param WPUnionType $wp_union_type The instance of the WPObjectType class
 		 *
 		 * @since 0.0.30
 		 */
@@ -87,8 +90,8 @@ class WPUnionType extends UnionType {
 		/**
 		 * Run an action when the WPObjectType is instantiating
 		 *
-		 * @param array       $config Array of configuration options passed to the WPUnionType when instantiating a new type
-		 * @param WPUnionType $this   The instance of the WPObjectType class
+		 * @param array       $config        Array of configuration options passed to the WPUnionType when instantiating a new type
+		 * @param WPUnionType $wp_union_type The instance of the WPObjectType class
 		 */
 		do_action( 'graphql_wp_union_type', $config, $this );
 

--- a/src/Utils/DebugLog.php
+++ b/src/Utils/DebugLog.php
@@ -25,12 +25,19 @@ class DebugLog {
 	 */
 	public function __construct() {
 
+		// Instantiate array to start capturing logs
 		$this->logs = [];
 
-		$enabled            = \WPGraphQL::debug() ? true : false;
-		$this->logs_enabled = apply_filters( 'graphql_debug_logs_enabled', $enabled, $this );
+		// Whether WPGraphQL Debug is enabled
+		$enabled = \WPGraphQL::debug();
 
-		return $this;
+		/**
+		 * Filters whether GraphQL Debug is enabled enabled. Serves as the default state for enabling debug logs.
+		 *
+		 * @param bool $enabled Whether logs are enabled or not
+		 * @param DebugLog $debug_log The DebugLog class instance
+		 */
+		$this->logs_enabled = apply_filters( 'graphql_debug_logs_enabled', $enabled, $this );
 	}
 
 	/**

--- a/src/Utils/Preview.php
+++ b/src/Utils/Preview.php
@@ -48,7 +48,7 @@ class Preview {
 
 		if ( 'revision' === $post->post_type ) {
 			$parent = get_post( $post->post_parent );
-			return get_post_meta( $parent->ID, $meta_key, $single );
+			return isset( $parent->ID ) && absint( $parent->ID ) ? get_post_meta( $parent->ID, $meta_key, $single ) : $default_value;
 		}
 
 		return $default_value;

--- a/src/Utils/QueryLog.php
+++ b/src/Utils/QueryLog.php
@@ -27,6 +27,8 @@ class QueryLog {
 
 	/**
 	 * Initialize Query Logging
+	 *
+	 * @return void
 	 */
 	public function init() {
 
@@ -48,6 +50,8 @@ class QueryLog {
 	 * Tell WordPress to start saving queries.
 	 *
 	 * NOTE: This will affect all requests, not just GraphQL requests.
+	 *
+	 * @return void
 	 */
 	public function init_save_queries() {
 		if ( is_graphql_http_request() && ! defined( 'SAVEQUERIES' ) ) {
@@ -117,6 +121,7 @@ class QueryLog {
 			if ( is_array( $response ) ) {
 				$response['extensions']['queryLog'] = $query_log;
 			} elseif ( is_object( $response ) ) {
+				// @phpstan-ignore-next-line
 				$response->extensions['queryLog'] = $query_log;
 			}
 		}
@@ -133,8 +138,11 @@ class QueryLog {
 	public function get_query_log() {
 		global $wpdb;
 
+		$save_queries_value = defined( 'SAVEQUERIES' ) && true === SAVEQUERIES ? 'true' : 'false';
+		$default_message    = sprintf( __( 'Query Logging has been disabled. The \'SAVEQUERIES\' Constant is set to \'%s\' on your server.', 'wp-graphql' ), $save_queries_value );
+
 		// Default message
-		$trace = [ sprintf( __( 'Query Logging has been disabled. The \'SAVEQUERIES\' Constant is set to \'%s\' on your server.', 'wp-graphql' ), SAVEQUERIES ? 'true' : 'false' ) ];
+		$trace = [ $default_message ];
 
 		if ( ! empty( $wpdb->queries ) && is_array( $wpdb->queries ) ) {
 			$queries = array_map( function( $query ) {

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -9,11 +9,11 @@ class Utils {
 	/**
 	 * Maps new input query args and sanitizes the input
 	 *
-	 * @param array $args The raw query args from the GraphQL query
-	 * @param array $map  The mapping of where each of the args should go
+	 * @param mixed|array|string $args The raw query args from the GraphQL query
+	 * @param mixed|array|string $map  The mapping of where each of the args should go
 	 *
-	 * @since  0.5.0
 	 * @return array
+	 * @since  0.5.0
 	 */
 	public static function map_input( $args, $map ) {
 
@@ -55,14 +55,13 @@ class Utils {
 	 * Checks the post_date_gmt or modified_gmt and prepare any post or
 	 * modified date for single post output.
 	 *
-	 * @since 4.7.0
-	 *
-	 * @param string      $date_gmt GMT publication time.
-	 * @param string|null $date     Optional. Local publication time. Default null.
+	 * @param string $date_gmt GMT publication time.
+	 * @param mixed|string|null $date Optional. Local publication time. Default null.
 	 *
 	 * @return string|null ISO8601/RFC3339 formatted datetime.
+	 * @since 4.7.0
 	 */
-	public static function prepare_date_response( $date_gmt, $date = null ) {
+	public static function prepare_date_response( string $date_gmt, $date = null ) {
 		// Use the date if passed.
 		if ( isset( $date ) ) {
 			return mysql_to_rfc3339( $date );
@@ -83,8 +82,16 @@ class Utils {
 	 *
 	 * @return string
 	 */
-	public static function format_field_name( $field_name ) {
-		$field_name = lcfirst( preg_replace( '[^a-zA-Z0-9 -]', '_', $field_name ) );
+	public static function format_field_name( string $field_name ) {
+
+		$replaced = preg_replace( '[^a-zA-Z0-9 -]', '_', $field_name );
+
+		// If any values were replaced, use the replaced string as the new field name
+		if ( ! empty( $replaced ) ) {
+			$field_name = $replaced;
+		}
+
+		$field_name = lcfirst( $field_name );
 		$field_name = lcfirst( str_replace( '_', ' ', ucwords( $field_name, '_' ) ) );
 		$field_name = lcfirst( str_replace( '-', ' ', ucwords( $field_name, '_' ) ) );
 		$field_name = lcfirst( str_replace( ' ', '', ucwords( $field_name, ' ' ) ) );
@@ -138,6 +145,7 @@ class Utils {
 			'checked'    => [],
 			'disabled'   => [],
 		];
+
 		return [
 			'form'     => $allowed_atts,
 			'label'    => $allowed_atts,

--- a/src/WPSchema.php
+++ b/src/WPSchema.php
@@ -32,16 +32,18 @@ class WPSchema extends Schema {
 	/**
 	 * WPSchema constructor.
 	 *
-	 * @param array|null $config The config for the Schema.
+	 * @param SchemaConfig $config The config for the Schema.
 	 *
 	 * @since 0.0.9
 	 */
-	public function __construct( $config ) {
+	public function __construct( SchemaConfig $config ) {
 
 		$this->config = $config;
 
 		/**
 		 * Set the $filterable_config as the $config that was passed to the WPSchema when instantiated
+		 *
+		 * @param SchemaConfig $config The config for the Schema.
 		 *
 		 * @since 0.0.9
 		 */

--- a/tests/wpunit/AvatarObjectQueriesTest.php
+++ b/tests/wpunit/AvatarObjectQueriesTest.php
@@ -192,15 +192,15 @@ class AvatarObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 		query {
 			user(id: \"{$global_id}\") {
 				avatar(size: 48) {
-					default,
-					extraAttr,
-					forceDefault,
-					foundAvatar,
-					height,
-					rating,
-					scheme,
-					size,
-					url,
+					default
+					extraAttr
+					forceDefault
+					foundAvatar
+					height
+					rating
+					scheme
+					size
+					url
 					width
 				}
 			}

--- a/tests/wpunit/CommentConnectionQueriesTest.php
+++ b/tests/wpunit/CommentConnectionQueriesTest.php
@@ -13,7 +13,7 @@ class CommentConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		// before
 		parent::setUp();
 
-		$this->post_id = $this->factory->post->create();
+		$this->post_id = $this->factory()->post->create();
 
 		$this->current_time        = strtotime( '- 1 day' );
 		$this->current_date        = date( 'Y-m-d H:i:s', $this->current_time );
@@ -32,10 +32,19 @@ class CommentConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	public function createCommentObject( $args = [] ) {
+
+		$post_id = $this->factory()->post->create([
+			'post_type' => 'post',
+			'post_status' => 'publish',
+			'post_title' => 'Post for commenting...',
+			'post_author' => $this->admin
+		]);
+
 		/**
 		 * Set up the $defaults
 		 */
 		$defaults = [
+			'comment_post_ID' => $post_id,
 			'comment_author'   => $this->admin,
 			'comment_content'  => 'Test comment content',
 			'comment_approved' => 1,
@@ -50,7 +59,7 @@ class CommentConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 		/**
 		 * Create the page
 		 */
-		$comment_id = $this->factory->comment->create( $args );
+		$comment_id = $this->factory()->comment->create( $args );
 
 		/**
 		 * Return the $id of the comment_object that was created

--- a/tests/wpunit/NodesTest.php
+++ b/tests/wpunit/NodesTest.php
@@ -402,11 +402,19 @@ class NodesTest extends \Codeception\TestCase\WPTestCase {
 
 		$user_id = $this->factory->user->create( $user_args );
 
+		$post_id = $this->factory()->post->create([
+			'post_type' => 'post',
+			'post_status' => 'publish',
+			'post_title' => 'Post for commenting...',
+			'post_author' => $this->admin
+		]);
+
 		$comment_args = array(
 			'user_id'         => $user_id,
 			'comment_content' => 'GraphQL is really awesome, dude!',
+			'comment_post_ID' => $post_id
 		);
-		$comment_id   = $this->factory->comment->create( $comment_args );
+		$comment_id   = $this->factory()->comment->create( $comment_args );
 
 		$global_id = \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_id );
 		$query     = "

--- a/tests/wpunit/PostObjectQueriesTest.php
+++ b/tests/wpunit/PostObjectQueriesTest.php
@@ -238,7 +238,7 @@ class PostObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 				'commentCount'  => null,
 				'commentStatus' => 'open',
 				'content'       => apply_filters( 'the_content', 'Test page content' ),
-				'date'          => \WPGraphQL\Utils\Utils::prepare_date_response( null, $this->current_date ),
+				'date'          => \WPGraphQL\Utils\Utils::prepare_date_response( 'now', $this->current_date ),
 				'dateGmt'       => \WPGraphQL\Utils\Utils::prepare_date_response( get_post( $post_id )->post_modified_gmt ),
 				'desiredSlug'   => null,
 				'lastEditedBy'      => [

--- a/tests/wpunit/UserObjectQueriesTest.php
+++ b/tests/wpunit/UserObjectQueriesTest.php
@@ -222,7 +222,17 @@ class UserObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 		 */
 		$user_id = $this->createUserObject();
 
-		$comment_id = $this->factory()->comment->create( [ 'user_id' => $user_id ] );
+		$post_id = $this->factory()->post->create([
+			'post_type' => 'post',
+			'post_status' => 'publish',
+			'post_title' => 'Post for commenting...',
+			'post_author' => $this->admin
+		]);
+
+		$comment_id = $this->factory()->comment->create( [
+			'user_id' => $user_id,
+			'comment_post_ID' => $post_id,
+		] );
 
 		/**
 		 * Create the global ID based on the user_type and the created $id

--- a/vendor/composer/InstalledVersions.php
+++ b/vendor/composer/InstalledVersions.php
@@ -24,12 +24,12 @@ class InstalledVersions
 private static $installed = array (
   'root' => 
   array (
-    'pretty_version' => 'dev-develop',
-    'version' => 'dev-develop',
+    'pretty_version' => 'dev-master',
+    'version' => 'dev-master',
     'aliases' => 
     array (
     ),
-    'reference' => 'b618eb0929f7011c9f969bd92aaae555d4cd54f5',
+    'reference' => '7ecdfe86990b9f3a635ae97ba27a69dc15a7d0a5',
     'name' => 'wp-graphql/wp-graphql',
   ),
   'versions' => 
@@ -54,12 +54,12 @@ private static $installed = array (
     ),
     'wp-graphql/wp-graphql' => 
     array (
-      'pretty_version' => 'dev-develop',
-      'version' => 'dev-develop',
+      'pretty_version' => 'dev-master',
+      'version' => 'dev-master',
       'aliases' => 
       array (
       ),
-      'reference' => 'b618eb0929f7011c9f969bd92aaae555d4cd54f5',
+      'reference' => '7ecdfe86990b9f3a635ae97ba27a69dc15a7d0a5',
     ),
   ),
 );

--- a/vendor/composer/InstalledVersions.php
+++ b/vendor/composer/InstalledVersions.php
@@ -24,12 +24,12 @@ class InstalledVersions
 private static $installed = array (
   'root' => 
   array (
-    'pretty_version' => 'dev-master',
-    'version' => 'dev-master',
+    'pretty_version' => 'dev-develop',
+    'version' => 'dev-develop',
     'aliases' => 
     array (
     ),
-    'reference' => '7ecdfe86990b9f3a635ae97ba27a69dc15a7d0a5',
+    'reference' => 'b8e69b013262219d8af99641cd189e7fbceb0be9',
     'name' => 'wp-graphql/wp-graphql',
   ),
   'versions' => 
@@ -54,12 +54,12 @@ private static $installed = array (
     ),
     'wp-graphql/wp-graphql' => 
     array (
-      'pretty_version' => 'dev-master',
-      'version' => 'dev-master',
+      'pretty_version' => 'dev-develop',
+      'version' => 'dev-develop',
       'aliases' => 
       array (
       ),
-      'reference' => '7ecdfe86990b9f3a635ae97ba27a69dc15a7d0a5',
+      'reference' => 'b8e69b013262219d8af99641cd189e7fbceb0be9',
     ),
   ),
 );

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -1,12 +1,12 @@
 <?php return array (
   'root' => 
   array (
-    'pretty_version' => 'dev-develop',
-    'version' => 'dev-develop',
+    'pretty_version' => 'dev-master',
+    'version' => 'dev-master',
     'aliases' => 
     array (
     ),
-    'reference' => 'b618eb0929f7011c9f969bd92aaae555d4cd54f5',
+    'reference' => '7ecdfe86990b9f3a635ae97ba27a69dc15a7d0a5',
     'name' => 'wp-graphql/wp-graphql',
   ),
   'versions' => 
@@ -31,12 +31,12 @@
     ),
     'wp-graphql/wp-graphql' => 
     array (
-      'pretty_version' => 'dev-develop',
-      'version' => 'dev-develop',
+      'pretty_version' => 'dev-master',
+      'version' => 'dev-master',
       'aliases' => 
       array (
       ),
-      'reference' => 'b618eb0929f7011c9f969bd92aaae555d4cd54f5',
+      'reference' => '7ecdfe86990b9f3a635ae97ba27a69dc15a7d0a5',
     ),
   ),
 );

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -1,12 +1,12 @@
 <?php return array (
   'root' => 
   array (
-    'pretty_version' => 'dev-master',
-    'version' => 'dev-master',
+    'pretty_version' => 'dev-develop',
+    'version' => 'dev-develop',
     'aliases' => 
     array (
     ),
-    'reference' => '7ecdfe86990b9f3a635ae97ba27a69dc15a7d0a5',
+    'reference' => 'b8e69b013262219d8af99641cd189e7fbceb0be9',
     'name' => 'wp-graphql/wp-graphql',
   ),
   'versions' => 
@@ -31,12 +31,12 @@
     ),
     'wp-graphql/wp-graphql' => 
     array (
-      'pretty_version' => 'dev-master',
-      'version' => 'dev-master',
+      'pretty_version' => 'dev-develop',
+      'version' => 'dev-develop',
       'aliases' => 
       array (
       ),
-      'reference' => '7ecdfe86990b9f3a635ae97ba27a69dc15a7d0a5',
+      'reference' => 'b8e69b013262219d8af99641cd189e7fbceb0be9',
     ),
   ),
 );

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.0.5
+ * Version: 1.1.0
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.0.5
+ * @version  1.1.0
  */
 
 // Exit if accessed directly.
@@ -179,7 +179,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 
 			// Plugin version.
 			if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-				define( 'WPGRAPHQL_VERSION', '1.0.5' );
+				define( 'WPGRAPHQL_VERSION', '1.1.0' );
 			}
 
 			// Plugin Folder Path.

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -22,6 +22,13 @@
  */
 
 // Exit if accessed directly.
+use GraphQL\Error\UserError;
+use WPGraphQL\Admin\Admin;
+use WPGraphQL\AppContext;
+use WPGraphQL\Registry\SchemaRegistry;
+use WPGraphQL\Registry\TypeRegistry;
+use WPGraphQL\WPSchema;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -87,14 +94,14 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 		/**
 		 * Holds the Schema def
 		 *
-		 * @var \WPGraphQL\WPSchema
+		 * @var mixed|null|WPSchema $schema The Schema used for the GraphQL API
 		 */
 		protected static $schema;
 
 		/**
 		 * Holds the TypeRegistry instance
 		 *
-		 * @var \WPGraphQL\Registry\TypeRegistry $type_registry
+		 * @var mixed|null|TypeRegistry $type_registry The registry that holds all GraphQL Types
 		 */
 		protected static $type_registry;
 
@@ -127,7 +134,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 		 */
 		public static function instance() {
 
-			if ( ! isset( self::$instance ) && ! ( self::$instance instanceof WPGraphQL ) ) {
+			if ( ! isset( self::$instance ) || ! ( self::$instance instanceof WPGraphQL ) ) {
 				self::$instance = new WPGraphQL();
 				self::$instance->setup_constants();
 				self::$instance->includes();
@@ -249,6 +256,8 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 		 * Set whether the request is a GraphQL request or not
 		 *
 		 * @param bool $is_graphql_request
+		 *
+		 * @return void
 		 */
 		public static function set_is_graphql_request( $is_graphql_request = false ) {
 			self::$is_graphql_request = $is_graphql_request;
@@ -263,6 +272,8 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 
 		/**
 		 * Sets up actions to run at certain spots throughout WordPress and the WPGraphQL execution cycle
+		 *
+		 * @return void
 		 */
 		private function actions() {
 
@@ -298,6 +309,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 			);
 
 			// Prevent WPGraphQL Insights from running
+			// @phpstan-ignore-next-line
 			remove_action( 'init', '\WPGraphQL\Extensions\graphql_insights_init' );
 
 			/**
@@ -338,6 +350,8 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 		 * further execution.
 		 *
 		 * @throws Exception
+		 *
+		 * @return void
 		 */
 		public function min_php_version_check() {
 
@@ -349,6 +363,8 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 
 		/**
 		 * Determine the post_types and taxonomies, etc that should show in GraphQL
+		 *
+		 * @return void
 		 */
 		public function setup_types() {
 
@@ -360,6 +376,8 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 
 		/**
 		 * Flush permalinks if the GraphQL Endpoint route isn't yet registered
+		 *
+		 * @return void
 		 */
 		public function maybe_flush_permalinks() {
 			$rules = get_option( 'rewrite_rules' );
@@ -370,6 +388,8 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 
 		/**
 		 * Setup filters
+		 *
+		 * @return void
 		 */
 		private function filters() {
 
@@ -387,9 +407,11 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 
 		/**
 		 * Initialize admin functionality
+		 *
+		 * @return void
 		 */
 		public function init_admin() {
-			$admin = new \WPGraphQL\Admin\Admin();
+			$admin = new Admin();
 			$admin->init();
 		}
 
@@ -469,8 +491,13 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 			array_map(
 				function( $post_type ) {
 					$post_type_object = get_post_type_object( $post_type );
-					if ( empty( $post_type_object->graphql_single_name ) || empty( $post_type_object->graphql_plural_name ) ) {
-						throw new \GraphQL\Error\UserError(
+
+					if ( ! $post_type_object instanceof WP_Post_Type ) {
+						return;
+					}
+
+					if ( empty( $post_type_object ) || empty( $post_type_object->graphql_single_name ) || empty( $post_type_object->graphql_plural_name ) ) {
+						throw new UserError(
 							sprintf(
 							/* translators: %s will replaced with the registered type */
 								__( 'The %s post_type isn\'t configured properly to show in GraphQL. It needs a "graphql_single_name" and a "graphql_plural_name"', 'wp-graphql' ),
@@ -521,9 +548,15 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 			 */
 			array_map(
 				function( $taxonomy ) {
+
 					$tax_object = get_taxonomy( $taxonomy );
-					if ( empty( $tax_object->graphql_single_name ) || empty( $tax_object->graphql_plural_name ) ) {
-						throw new \GraphQL\Error\UserError(
+
+					if ( ! $tax_object instanceof WP_Taxonomy ) {
+						return;
+					}
+
+					if ( ! isset( $tax_object->graphql_single_name ) || ! isset( $tax_object->graphql_plural_name ) ) {
+						throw new UserError(
 							sprintf(
 							/* translators: %s will replaced with the registered taxonomty */
 								__( 'The %s taxonomy isn\'t configured properly to show in GraphQL. It needs a "graphql_single_name" and a "graphql_plural_name"', 'wp-graphql' ),
@@ -545,6 +578,8 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 
 		/**
 		 * Allow Schema to be cleared
+		 *
+		 * @return void
 		 */
 		public static function clear_schema() {
 			self::$type_registry = null;
@@ -555,7 +590,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 		 * Returns the Schema as defined by static registrations throughout
 		 * the WP Load.
 		 *
-		 * @return \WPGraphQL\WPSchema
+		 * @return WPSchema
 		 *
 		 * @throws Exception
 		 */
@@ -563,7 +598,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 
 			if ( null === self::$schema ) {
 
-				$schema_registry = new \WPGraphQL\Registry\SchemaRegistry();
+				$schema_registry = new SchemaRegistry();
 				$schema          = $schema_registry->get_schema();
 
 				/**
@@ -572,7 +607,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 				 * @since 0.0.5
 				 *
 				 * @param array                 $schema      The executable Schema that GraphQL executes against
-				 * @param \WPGraphQL\AppContext $app_context Object The AppContext object containing all of the
+				 * @param AppContext $app_context Object The AppContext object containing all of the
 				 *                                           information about the context we know at this point
 				 */
 				self::$schema = apply_filters( 'graphql_schema', $schema, self::get_app_context() );
@@ -590,6 +625,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 		}
 
 		/**
+		 * Whether WPGraphQL is operating in Debug mode
 		 * @return bool
 		 */
 		public static function debug(): bool {
@@ -597,7 +633,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 				$enabled = (bool) GRAPHQL_DEBUG;
 			} else {
 				$enabled = get_graphql_setting( 'debug_mode_enabled', 'off' );
-				$enabled = 'on' === $enabled ? true : false;
+				$enabled = 'on' === $enabled;
 			}
 
 			/**
@@ -610,7 +646,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 		 * Returns the Schema as defined by static registrations throughout
 		 * the WP Load.
 		 *
-		 * @return \WPGraphQL\Registry\TypeRegistry
+		 * @return TypeRegistry
 		 *
 		 * @throws Exception
 		 */
@@ -618,7 +654,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 
 			if ( null === self::$type_registry ) {
 
-				$type_registry = new \WPGraphQL\Registry\TypeRegistry();
+				$type_registry = new TypeRegistry();
 
 				/**
 				 * Generate & Filter the schema.
@@ -626,7 +662,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 				 * @since 0.0.5
 				 *
 				 * @param array                 $type_registry The TypeRegistry for the API
-				 * @param \WPGraphQL\AppContext $app_context   Object The AppContext object containing all of the
+				 * @param AppContext $app_context   Object The AppContext object containing all of the
 				 *                                             information about the context we know at this point
 				 */
 				self::$type_registry = apply_filters( 'graphql_type_registry', $type_registry, self::get_app_context() );
@@ -661,7 +697,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 		/**
 		 * Get the AppContext for use in passing down the Resolve Tree
 		 *
-		 * @return \WPGraphQL\AppContext
+		 * @return AppContext
 		 */
 		public static function get_app_context() {
 
@@ -670,7 +706,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 			 *
 			 * @since 0.0.4
 			 */
-			$app_context           = new \WPGraphQL\AppContext();
+			$app_context           = new AppContext();
 			$app_context->viewer   = wp_get_current_user();
 			$app_context->root_url = get_bloginfo( 'url' );
 			$app_context->request  = ! empty( $_REQUEST ) ? $_REQUEST : null; // phpcs:ignore
@@ -685,6 +721,8 @@ if ( ! function_exists( 'graphql_init' ) ) {
 	 * Function that instantiates the plugins main class
 	 *
 	 * @since 0.0.1
+	 *
+	 * @return object
 	 */
 	function graphql_init() {
 		/**


### PR DESCRIPTION
# Release Notes

This release is centered around updating code quality by implementing PHPStan checks. PHPStan is a tool that statically analyzes PHP codebases to detect bugs. This release centers around updating Docblocks and overall code quality, and implements automated tests to check code quality on every pull request.

## New

- Update PHPStan (Code Quality checker) to v0.12.64
- Increases PHPStan code quality checks to Level 8 (highest level).


## Bugfixes
- (#1653) Fixes bug where WPGraphQL was explicitly setting `has_published_posts` on WP_Query but WP_Query does this under the hood already. Thanks @jmartinhoj!
- Fixes issue with Comment Model returning comments that are not associated with a Post object. Comments with no associated Post object are not public entities.
- Update dockblocks to be compatible with PHPStan Level 8. 
- Removed some uncalled code
- Added early returns in some places to prevent unnecessary added execution