### PR TITLE
#1641 - Fix regression with page by uri queries

### DIFF
--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -610,7 +610,7 @@ class Post extends Model {
 					if ( 'page' !== $this->data->post_type ) {
 						return false;
 					}
-					if ( absint( get_option( 'page_for_posts', 0 ) ) === $this->data->ID ) {
+					if ( 'posts' !== get_option( 'show_on_front', 'posts' ) && absint( get_option( 'page_for_posts', 0 ) ) === $this->data->ID ) {
 						return true;
 					}
 

--- a/src/Type/Object/RootQuery.php
+++ b/src/Type/Object/RootQuery.php
@@ -507,7 +507,11 @@ class RootQuery {
 										'post_type' => $post_type_object->name,
 									] );
 								case 'uri':
-									return $context->node_resolver->resolve_uri( $args['id'], [ 'post_type' => $post_type_object->name ] );
+									return $context->node_resolver->resolve_uri( $args['id'], [
+										'post_type' => $post_type_object->name,
+										'archive'   => false,
+										'nodeType'  => 'Page',
+									] );
 								case 'database_id':
 									$post_id = absint( $args['id'] );
 									break;

--- a/vendor/composer/InstalledVersions.php
+++ b/vendor/composer/InstalledVersions.php
@@ -29,7 +29,7 @@ private static $installed = array (
     'aliases' => 
     array (
     ),
-    'reference' => 'b8e69b013262219d8af99641cd189e7fbceb0be9',
+    'reference' => '8741ceae3a22dcd5d9caa4d0f1826e21d2022bf8',
     'name' => 'wp-graphql/wp-graphql',
   ),
   'versions' => 
@@ -59,7 +59,7 @@ private static $installed = array (
       'aliases' => 
       array (
       ),
-      'reference' => 'b8e69b013262219d8af99641cd189e7fbceb0be9',
+      'reference' => '8741ceae3a22dcd5d9caa4d0f1826e21d2022bf8',
     ),
   ),
 );

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -6,7 +6,7 @@
     'aliases' => 
     array (
     ),
-    'reference' => 'b8e69b013262219d8af99641cd189e7fbceb0be9',
+    'reference' => '8741ceae3a22dcd5d9caa4d0f1826e21d2022bf8',
     'name' => 'wp-graphql/wp-graphql',
   ),
   'versions' => 
@@ -36,7 +36,7 @@
       'aliases' => 
       array (
       ),
-      'reference' => 'b8e69b013262219d8af99641cd189e7fbceb0be9',
+      'reference' => '8741ceae3a22dcd5d9caa4d0f1826e21d2022bf8',
     ),
   ),
 );


### PR DESCRIPTION
- Fixes a regression with querying for pages by URI. Since the homepage can be either a page or a ContentType (post archive) there were some gaps in the logic for what to return if a page queries for the homepage, but the options are set to post archive, etc. This adds a test to help prevent regressions.

## Before

![Screen Shot 2021-01-07 at 2 35 24 PM](https://user-images.githubusercontent.com/1260765/103947630-a3c8fd80-50f5-11eb-886d-22615faec0c7.png)


## After

![Screen Shot 2021-01-07 at 2 36 07 PM](https://user-images.githubusercontent.com/1260765/103947653-b0e5ec80-50f5-11eb-80b7-e1586c4dc6bb.png)

---- 

closes #1641 



