### PR TITLE
Release/v1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## Upcoming
+## 1.1.2
 
 ### Bugfixes
 
-- Add a `nav_menu_item` loader to allow previous menu item IDs to work properly with WPGraphQL should they be passed to a node query (like, if the ID were persisted somewhere already)
+- ([#1676](https://github.com/wp-graphql/wp-graphql/pull/1676)) Add a `nav_menu_item` loader to allow previous menu item IDs to work properly with WPGraphQL should they be passed to a node query (like, if the ID were persisted somewhere already)
 - Update cases of menu item IDs to be `post:$id` instead of `nav_menu_item:$id`
 - Update tests to test that both the old `nav_menu_item:$id` and `post:$id` work for nav menu item node queries to support previously issued IDs
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, API, Gatsby, Headless, Decoupled, React, Nextjs, Vue, Apollo, RES
 Requires at least: 5.0
 Tested up to: 5.6
 Requires PHP: 7.1
-Stable tag: 1.1.1
+Stable tag: 1.1.2
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.1.1
+ * Version: 1.1.2
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.1.1
+ * @version  1.1.2
  */
 
 // Exit if accessed directly.
@@ -186,7 +186,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 
 			// Plugin version.
 			if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-				define( 'WPGRAPHQL_VERSION', '1.1.1' );
+				define( 'WPGRAPHQL_VERSION', '1.1.2' );
 			}
 
 			// Plugin Folder Path.


### PR DESCRIPTION
# Release Notes

## Bugfixes

- (#1676) MenuItems are stored in the post table and should use the post loader. To use the post loader properly, the menu item IDs should be encoded as `post:$id` but were encoded as `nav_menu_item:$id` which breaks the principles of the Relay spec. This fixes that. MenuItems now output ids encoded as `post:$id`