### PR TITLE
Release/v1.1.2

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-Remember, an issue is not the place to ask general questions. You can use [Slack](https://wp-graphql.slack.com) for that ([join here](https://wpgql-slack.herokuapp.com/)).
+Remember, an issue is not the place to ask general questions. You can use [Slack](https://wp-graphql.slack.com) for that ([join here](https://join.slack.com/t/wp-graphql/shared_invite/zt-3vloo60z-PpJV2PFIwEathWDOxCTTLA)).
 
 Before you open an issue, please check if a similar issue already exists or has been closed before.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## Upcoming
+## 1.1.2
 
 ### Bugfixes
 
-- Add a `nav_menu_item` loader to allow previous menu item IDs to work properly with WPGraphQL should they be passed to a node query (like, if the ID were persisted somewhere already)
+- ([#1676](https://github.com/wp-graphql/wp-graphql/pull/1676)) Add a `nav_menu_item` loader to allow previous menu item IDs to work properly with WPGraphQL should they be passed to a node query (like, if the ID were persisted somewhere already)
 - Update cases of menu item IDs to be `post:$id` instead of `nav_menu_item:$id`
 - Update tests to test that both the old `nav_menu_item:$id` and `post:$id` work for nav menu item node queries to support previously issued IDs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Changelog
 
+## Upcoming
+
+### Bugfixes
+
+- Add a `nav_menu_item` loader to allow previous menu item IDs to work properly with WPGraphQL should they be passed to a node query (like, if the ID were persisted somewhere already)
+- Update cases of menu item IDs to be `post:$id` instead of `nav_menu_item:$id`
+- Update tests to test that both the old `nav_menu_item:$id` and `post:$id` work for nav menu item node queries to support previously issued IDs
+
 ## 1.1.1
 
-## Bugfix
+### Bugfix
 
 - ([#1670](https://github.com/wp-graphql/wp-graphql/issues/1670)) Fixes a bug with querying pages that are set as to be the posts page
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, API, Gatsby, Headless, Decoupled, React, Nextjs, Vue, Apollo, RES
 Requires at least: 5.0
 Tested up to: 5.6
 Requires PHP: 7.1
-Stable tag: 1.1.1
+Stable tag: 1.1.2
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/src/AppContext.php
+++ b/src/AppContext.php
@@ -107,6 +107,7 @@ class AppContext {
 			'enqueued_script'     => new EnqueuedScriptLoader( $this ),
 			'enqueued_stylesheet' => new EnqueuedStylesheetLoader( $this ),
 			'plugin'              => new PluginLoader( $this ),
+			'nav_menu_item'       => new PostObjectLoader( $this ),
 			'post'                => new PostObjectLoader( $this ),
 			'post_type'           => new PostTypeLoader( $this ),
 			'taxonomy'            => new TaxonomyLoader( $this ),

--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -147,8 +147,8 @@ class DataSource {
 	 *
 	 * @deprecated Use the Loader passed in $context instead
 	 */
-	public static function resolve_menu_item( $id, AppContext $context ) {
-		return $context->get_loader( 'nav_menu_item' )->load_deferred( $id );
+	public static function resolve_menu_item( int $id, AppContext $context ) {
+		return $context->get_loader( 'post' )->load_deferred( $id );
 	}
 
 	/**

--- a/src/Data/Loader/TermObjectLoader.php
+++ b/src/Data/Loader/TermObjectLoader.php
@@ -26,7 +26,7 @@ class TermObjectLoader extends AbstractDataLoader {
 		if ( is_a( $entry, 'WP_Term' ) ) {
 
 			/**
-			 * For nav_menu_item terms, we want to pass through a different model
+			 * For nav_menu terms, we want to pass through a different model
 			 */
 			if ( 'nav_menu' === $entry->taxonomy ) {
 

--- a/src/Model/MenuItem.php
+++ b/src/Model/MenuItem.php
@@ -104,10 +104,10 @@ class MenuItem extends Model {
 
 			$this->fields = [
 				'id'               => function() {
-					return ! empty( $this->data->ID ) ? Relay::toGlobalId( 'nav_menu_item', $this->data->ID ) : null;
+					return ! empty( $this->data->ID ) ? Relay::toGlobalId( 'post', $this->data->ID ) : null;
 				},
 				'parentId'         => function() {
-					return ! empty( $this->data->menu_item_parent ) ? Relay::toGlobalId( 'nav_menu_item', $this->data->menu_item_parent ) : null;
+					return ! empty( $this->data->menu_item_parent ) ? Relay::toGlobalId( 'post', $this->data->menu_item_parent ) : null;
 				},
 				'parentDatabaseId' => function() {
 					return $this->data->menu_item_parent;

--- a/tests/wpunit/MenuItemConnectionQueriesTest.php
+++ b/tests/wpunit/MenuItemConnectionQueriesTest.php
@@ -491,7 +491,7 @@ class MenuItemConnectionQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 		// The nesting is added to the fourth item.
 		// Convernt it to the global relay id from the database id.
-		$parent_id = Relay::toGlobalId( 'nav_menu_item', $created['menu_item_ids'][3] );
+		$parent_id = Relay::toGlobalId( 'post', $created['menu_item_ids'][3] );
 
 		$query = "
 		{

--- a/tests/wpunit/MenuItemQueriesTest.php
+++ b/tests/wpunit/MenuItemQueriesTest.php
@@ -44,7 +44,7 @@ class MenuItemQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 		codecept_debug( get_theme_mod( 'nav_menu_locations' ) );
 
-		$menu_item_relay_id = Relay::toGlobalId( 'nav_menu_item', $menu_item_id );
+		$menu_item_relay_id = Relay::toGlobalId( 'post', $menu_item_id );
 
 		$query = '
 		{
@@ -79,6 +79,44 @@ class MenuItemQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertEquals( $menu_slug, $actual['data']['menuItem']['menu']['node']['slug'] );
 		$this->assertEquals( [ \WPGraphQL\Type\WPEnumType::get_safe_name( $location_name ) ], $actual['data']['menuItem']['locations'] );
 		$this->assertEquals( [ \WPGraphQL\Type\WPEnumType::get_safe_name( $location_name ) ], $actual['data']['menuItem']['menu']['node']['locations'] );
+
+		$old_id = Relay::toGlobalId( 'nav_menu_itemci', $menu_item_id );
+
+		$query = '
+		{
+			menuItem( id: "' . $old_id . '" ) {
+				id
+				databaseId
+				connectedObject {
+					... on Post {
+						id
+						postId
+					}
+				}
+				locations
+				menu {
+				  node {
+				    slug
+				    locations
+				  }
+				}
+			}
+		}
+		';
+
+		$actual = do_graphql_request( $query );
+
+
+		codecept_debug( $actual );
+
+		$this->assertEquals( $menu_item_id, $actual['data']['menuItem']['databaseId'] );
+		$this->assertEquals( $menu_item_relay_id, $actual['data']['menuItem']['id'] );
+		$this->assertEquals( $post_id, $actual['data']['menuItem']['connectedObject']['postId'] );
+		$this->assertEquals( $menu_slug, $actual['data']['menuItem']['menu']['node']['slug'] );
+		$this->assertEquals( [ \WPGraphQL\Type\WPEnumType::get_safe_name( $location_name ) ], $actual['data']['menuItem']['locations'] );
+		$this->assertEquals( [ \WPGraphQL\Type\WPEnumType::get_safe_name( $location_name ) ], $actual['data']['menuItem']['menu']['node']['locations'] );
+
+
 	}
 
 }

--- a/vendor/composer/InstalledVersions.php
+++ b/vendor/composer/InstalledVersions.php
@@ -29,7 +29,7 @@ private static $installed = array (
     'aliases' => 
     array (
     ),
-    'reference' => 'd300fec81bdc8af667d2595d24c8627c1a473974',
+    'reference' => 'a3e3b31da87f8bba0593bb0975330e32de3ef8c2',
     'name' => 'wp-graphql/wp-graphql',
   ),
   'versions' => 
@@ -59,7 +59,7 @@ private static $installed = array (
       'aliases' => 
       array (
       ),
-      'reference' => 'd300fec81bdc8af667d2595d24c8627c1a473974',
+      'reference' => 'a3e3b31da87f8bba0593bb0975330e32de3ef8c2',
     ),
   ),
 );

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -6,7 +6,7 @@
     'aliases' => 
     array (
     ),
-    'reference' => 'd300fec81bdc8af667d2595d24c8627c1a473974',
+    'reference' => 'a3e3b31da87f8bba0593bb0975330e32de3ef8c2',
     'name' => 'wp-graphql/wp-graphql',
   ),
   'versions' => 
@@ -36,7 +36,7 @@
       'aliases' => 
       array (
       ),
-      'reference' => 'd300fec81bdc8af667d2595d24c8627c1a473974',
+      'reference' => 'a3e3b31da87f8bba0593bb0975330e32de3ef8c2',
     ),
   ),
 );

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.1.1
+ * Version: 1.1.2
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.1.1
+ * @version  1.1.2
  */
 
 // Exit if accessed directly.
@@ -186,7 +186,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 
 			// Plugin version.
 			if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-				define( 'WPGRAPHQL_VERSION', '1.1.1' );
+				define( 'WPGRAPHQL_VERSION', '1.1.2' );
 			}
 
 			// Plugin Folder Path.


### PR DESCRIPTION
# Release Notes

## Bugfixes

- (#1676) MenuItems are stored in the post table and should use the post loader. To use the post loader properly, the menu item IDs should be encoded as `post:$id` but were encoded as `nav_menu_item:$id` which breaks the principles of the Relay spec. This fixes that. MenuItems now output ids encoded as `post:$id`