### PR TITLE
Resolve user visibility in UserLoader

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -23,5 +23,6 @@ parameters:
         - "#Access to an undefined property WP_Taxonomy::\\$graphql_single_name.#"
         - "#Access to an undefined property WP_Taxonomy::\\$graphql_plural_name.#"
         - "#Access to an undefined property WP_Taxonomy::\\$show_in_graphql.#"
+        - "#Access to an undefined property WP_User::\\$is_private.#"
         - "#^Parameter \\#1 \\$taxonomy of function get_taxonomy expects string, WP_Taxonomy given.#"
         - "#^Parameter \\#1 \\$post_type of function get_post_type_object expects string, string|WP_Taxonomy given.#"

--- a/src/Data/Loader/UserLoader.php
+++ b/src/Data/Loader/UserLoader.php
@@ -41,7 +41,7 @@ class UserLoader extends AbstractDataLoader {
 	 * In this example, user 1 is not public (has no published posts) and is
 	 * omitted from the returned array.
 	 *
-	 * @param array[int] $keys Array of author IDs.
+	 * @param array $keys Array of author IDs (int).
 	 *
 	 * @return array
 	 */
@@ -89,7 +89,7 @@ class UserLoader extends AbstractDataLoader {
 		 */
 		return array_reduce(
 			$results,
-			function ( $carry, $result ) use ( $results ) {
+			function ( $carry, $result ) {
 				$carry[ intval( $result->post_author ) ] = true;
 				return $carry;
 			},

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -142,23 +142,11 @@ class User extends Model {
 	 * @return bool
 	 */
 	protected function is_private() {
-
-		if ( ! current_user_can( 'list_users' ) && false === $this->owner_matches_current_user() ) {
-
-			/**
-			 * @todo: We should handle this check in a Deferred resolver. Right now it queries once per user
-			 *      but we _could_ query once for _all_ users.
-			 *
-			 *      For now, we only query if the current user doesn't have list_users, instead of querying
-			 *      for ALL users. Slightly more efficient for authenticated users at least.
-			 */
-			if ( ! count_user_posts( absint( $this->data->ID ), WPGraphQL::get_allowed_post_types(), true ) ) {
-				return true;
-			}
-		}
-
-		return false;
-
+		/**
+		 * NB: Caps check for 'list_users' and 'owner_matches_current_user' is
+		 * handled by Model abstract class.
+		 */
+		return $this->data->is_private;
 	}
 
 	/**

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -143,9 +143,19 @@ class User extends Model {
 	 */
 	protected function is_private() {
 		/**
-		 * NB: Caps check for 'list_users' and 'owner_matches_current_user' is
-		 * handled by Model abstract class.
+		 * If the user has permissions to list users.
 		 */
+		if ( current_user_can( $this->restricted_cap ) ) {
+			return false;
+		}
+
+		/**
+		 * If the owner of the content is the current user
+		 */
+		if ( true === $this->owner_matches_current_user() ) {
+			return false;
+		}
+
 		return $this->data->is_private;
 	}
 


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](.github/CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
There has been a long-standing performance issue with the is_private method of the User model, because it attempts to count the number of published posts for each user, a potentially very expensive operation. And since the operation is uncached, this can very quickly overwhelm the database.

More discussion of the issue:
https://github.com/wp-graphql/wp-graphql/issues/961

At Quartz, this has prevented us from upgrading WPGraphQL, and it appears to have affected other users as well. A few different PRs exist to address this issue:

https://github.com/wp-graphql/wp-graphql/pull/962
https://github.com/wp-graphql/wp-graphql/pull/972
https://github.com/wp-graphql/wp-graphql/pull/1677

This PR is my attempt to fix this issue the way that Jason and others have described as ideal: using DataLoader.

Instead of creating a new loader (e.g., "UserVisibilityLoader"), I am including this in UserLoader. The reason is that they seem tightly coupled and making them separate would just introduce unnecessary complexity. You'd need to remember to use UserVisibilityLoader everywhere you used UserLoader or risk losing the performance benefit it provides.

My fix simply plugs into the existing "loadKeys" implementation and produces a single query that determines visibility for each user. ~I'd love feedback on the efficiency of this query; I hope that this is good enough to sidestep the need for caching.~ **This is not an efficient query, apologies. Working on a better one.** If its not possible to generate a single efficient query, generating an extra query for each user along the lines of `SELECT id FROM wp_posts WHERE post_author = X LIMIT 1` seems like the next best approach.

Finally, we need a way to provide the visibility to the User model. Luckily, WP_User is not a final class and provides a setter:

https://developer.wordpress.org/reference/classes/wp_user/__set/

This allows us to set an "is_private" property on the WP_User instance, which is then available to the model via "$this->data". This seems to be done widely, but we could implement a wrapper around WP_User if we wanted to avoid mutating WP_User instances.

From there, it's a very simple matter of having the User model check this property.

Looking forward to getting this bug squashed and happy to jump on any feedback. Also paging @abhijitrakas and @zacscott since they seem to have been negatively impacted by this issue as well.

Does this close any currently open issues?
------------------------------------------
Fixes https://github.com/wp-graphql/wp-graphql/issues/961


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Linux

**WordPress Version:** 5.3.2
