### PR TITLE
Add the  filter to User::is_private() so users can choose to bypass o…

### DIFF
--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -143,6 +143,26 @@ class User extends Model {
 	 */
 	protected function is_private() {
 
+		/**
+		 * Filter whether the user is private.
+		 *
+		 * If true, the user will be considered private without further checks.
+		 *
+		 * @param mixed|null|boolean $is_private If set, return without executing the manual query
+		 *                                       to see if the user has published posts.
+		 * @param User               $this       Instance of the User Model
+		 */
+		$is_private = apply_filters( 'graphql_user_model_is_private', null, $this );
+
+		/**
+		 * If the filter returns true, we can return now as the user is considered private.
+		 *
+		 * Otherwise we need to continue and check if the User should be considered private or not
+		 */
+		if ( null !== $is_private ) {
+			return (bool) $is_private;
+		}
+
 		if ( ! current_user_can( 'list_users' ) && false === $this->owner_matches_current_user() ) {
 
 			/**


### PR DESCRIPTION
…r modify this functionality (relates to issue #961)

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](.github/CONTRIBUTING.md) to this repository.

- [X] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [X] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------

This change adds a filter `graphql_user_model_is_private` to the `User::is_private()` method.

Importantly this filter is BEFORE the normal code of the method is executed and can be used to bypass the rest of the function.

Ordinarily this method does a very expensive query via the use of the count_user_posts() function. This is called multiple times for some GraphQL queries adding considerable load as documented in the issue - https://github.com/wp-graphql/wp-graphql/issues/961

This filter can be used to bypass this count_user_posts() at the developers discretion, like so:

```
add_filter( 'graphql_user_model_is_private', __NAMESPACE__ .'\\graphql_user_model_is_private' );

function graphql_user_model_is_private( $is_private ) {
	return false;
}
```

Does this close any currently open issues?
------------------------------------------

This addresses this issue - https://github.com/wp-graphql/wp-graphql/issues/961


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

N/A / everything is noted on the issue - https://github.com/wp-graphql/wp-graphql/issues/961


Any other comments?
-------------------

This was based on this declined PR https://github.com/wp-graphql/wp-graphql/pull/962


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04

**WordPress Version:** 5.6
