### PR TITLE
fixes wp-graphql/wp-graphql#1689 (not the right fix)

### DIFF
--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -287,6 +287,11 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 				$tracker->delete_timestamp();
 			} );
 
+      /**
+       * Set up router actions/filters as early as possible
+       */
+			new \WPGraphQL\Router();
+
 			/**
 			 * Init WPGraphQL after themes have been setup,
 			 * allowing for both plugins and themes to register
@@ -297,7 +302,6 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 				function() {
 
 					new \WPGraphQL\Data\Config();
-					new \WPGraphQL\Router();
 
 					/**
 					 * Fire off init action


### PR DESCRIPTION
• Move Router setup during plugin initialization so that the application_password_is_api_request filter is always added before any user authentication.


Does this close any currently open issues?
------------------------------------------
Fixes wp-graphql/wp-graphql#1689


Where has this been tested?
---------------------------
**Operating System:**
Ubuntu 20.04.1 LTS
**WordPress Version:**
5.6


Any other comments?
----------------------
Let me know if there is a better to make this change, or if you have any change suggestions.