### PR TITLE
Release/v1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.1.3
+
+## New
+
+- ([#972](https://github.com/wp-graphql/wp-graphql/pull/972)) `graphql_pre_model_data_is_private` filter was added to the Abstract Model.php allowing Model's `is_private()` check to be bypassed.
+
+
 ## 1.1.2
 
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## 1.1.3
 
-## New
+### Bugfix
+
+- ([#1693](https://github.com/wp-graphql/wp-graphql/pull/1693)) Clear global user in the Router in case plugins have attempted to set the user before API authentication has been executed. Thanks @therealgilles!
+
+### New
 
 - ([#972](https://github.com/wp-graphql/wp-graphql/pull/972)) `graphql_pre_model_data_is_private` filter was added to the Abstract Model.php allowing Model's `is_private()` check to be bypassed.
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ into how to design GraphQL schemas, etc. Check them out: http://www.apollodata.c
 
 ## Contributors
 
-This project exists thanks to all the people who contribute. [[Contribute](CONTRIBUTING.md)].
+This project exists thanks to all the people who contribute. [[Contribute](.github/CONTRIBUTING.md)].
 <a href="https://github.com/wp-graphql/wp-graphql/graphs/contributors"><img src="https://opencollective.com/wp-graphql/contributors.svg?width=890&button=false" /></a>
 
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, API, Gatsby, Headless, Decoupled, React, Nextjs, Vue, Apollo, RES
 Requires at least: 5.0
 Tested up to: 5.6
 Requires PHP: 7.1
-Stable tag: 1.1.2
+Stable tag: 1.1.3
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -223,8 +223,31 @@ abstract class Model {
 			$protected_cap = apply_filters( 'graphql_restricted_data_cap', $this->restricted_cap, $this->get_model_name(), $this->data, $this->visibility, $this->owner, $this->current_user );
 
 			/**
+			 * Filter to short circuit default is_private check for the model. This is expensive in some cases so
+			 * this filter lets you prevent this from running by returning a true or false value.
+			 *
+			 * @param string      $model_name   Name of the model the filter is currently being executed in
+			 * @param mixed       $data         The un-modeled incoming data
+			 * @param string|null $visibility   The visibility that has currently been set for the data at this point
+			 * @param null|int    $owner        The user ID for the owner of this piece of data
+			 * @param WP_User     $current_user The current user for the session
+			 *
+			 * @return bool|null
+			 */
+			$pre_is_private = apply_filters( 'graphql_pre_model_data_is_private', null, $this->get_model_name(), $this->data, $this->visibility, $this->owner, $this->current_user );
+
+			// If 3rd party code has not filtered this, use the Models default logic to determine
+			// whether the model should be considered private
+			if ( null !== $pre_is_private ) {
+				$is_private = $pre_is_private;
+			} else {
+				$is_private = $this->is_private();
+			}
+
+			/**
 			 * Filter to determine if the data should be considered private or not
 			 *
+			 * @param boolean     $is_private   Whether the model is private
 			 * @param string      $model_name   Name of the model the filter is currently being executed in
 			 * @param mixed       $data         The un-modeled incoming data
 			 * @param string|null $visibility   The visibility that has currently been set for the data at this point
@@ -233,7 +256,7 @@ abstract class Model {
 			 *
 			 * @return bool
 			 */
-			$is_private = apply_filters( 'graphql_data_is_private', $this->is_private(), $this->get_model_name(), $this->data, $this->visibility, $this->owner, $this->current_user );
+			$is_private = apply_filters( 'graphql_data_is_private', $is_private, $this->get_model_name(), $this->data, $this->visibility, $this->owner, $this->current_user );
 
 			if ( true === $is_private ) {
 				$this->visibility = 'private';

--- a/src/Router.php
+++ b/src/Router.php
@@ -408,11 +408,30 @@ class Router {
 	 * This processes the graphql requests that come into the /graphql endpoint via an HTTP request
 	 *
 	 * @since  0.0.1
+	 * @global WP_User $current_user The currently authenticated user.
 	 * @return mixed
 	 * @throws \Exception Throws Exception.
 	 * @throws \Throwable Throws Exception.
 	 */
 	public static function process_http_request() {
+		/* @var WP_User|null $current_user */
+		global $current_user;
+
+		if ( $current_user instanceof WP_User && ! $current_user->exists() ) {
+			/*
+			 * If there is no current user authenticated via other means, clear
+			 * the cached lack of user, so that an authenticate check can set it
+			 * properly.
+			 *
+			 * This is done because for authentications such as Application
+			 * Passwords, we don't want it to be accepted unless the current HTTP
+			 * request is a GraphQL API request, which can't always be identified early
+			 * enough in evaluation.
+			 *
+			 * See serve_request in wp-includes/rest-api/class-wp-rest-server.php.
+			 */
+			$current_user = null;
+		}
 
 		/**
 		 * This action can be hooked to to enable various debug tools,

--- a/vendor/composer/InstalledVersions.php
+++ b/vendor/composer/InstalledVersions.php
@@ -29,7 +29,7 @@ private static $installed = array (
     'aliases' => 
     array (
     ),
-    'reference' => 'a3e3b31da87f8bba0593bb0975330e32de3ef8c2',
+    'reference' => 'b83e64dfb9553315db4f5ac766adcb576dadd628',
     'name' => 'wp-graphql/wp-graphql',
   ),
   'versions' => 
@@ -59,7 +59,7 @@ private static $installed = array (
       'aliases' => 
       array (
       ),
-      'reference' => 'a3e3b31da87f8bba0593bb0975330e32de3ef8c2',
+      'reference' => 'b83e64dfb9553315db4f5ac766adcb576dadd628',
     ),
   ),
 );

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -6,7 +6,7 @@
     'aliases' => 
     array (
     ),
-    'reference' => 'a3e3b31da87f8bba0593bb0975330e32de3ef8c2',
+    'reference' => 'b83e64dfb9553315db4f5ac766adcb576dadd628',
     'name' => 'wp-graphql/wp-graphql',
   ),
   'versions' => 
@@ -36,7 +36,7 @@
       'aliases' => 
       array (
       ),
-      'reference' => 'a3e3b31da87f8bba0593bb0975330e32de3ef8c2',
+      'reference' => 'b83e64dfb9553315db4f5ac766adcb576dadd628',
     ),
   ),
 );

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.1.2
+ * Version: 1.1.3
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.1.2
+ * @version  1.1.3
  */
 
 // Exit if accessed directly.
@@ -186,7 +186,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 
 			// Plugin version.
 			if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-				define( 'WPGRAPHQL_VERSION', '1.1.2' );
+				define( 'WPGRAPHQL_VERSION', '1.1.3' );
 			}
 
 			// Plugin Folder Path.


### PR DESCRIPTION
## Release Notes

### Bugfix

- ([#1693](https://github.com/wp-graphql/wp-graphql/pull/1693)) Clear global user in the Router in case plugins have attempted to set the user before API authentication has been executed. Thanks @therealgilles!
- ([#1691](https://github.com/wp-graphql/wp-graphql/pull/1691)) Fix link to Contributing.md in the README. Thanks @therealgilles!

### New

- ([#972](https://github.com/wp-graphql/wp-graphql/pull/972)) `graphql_pre_model_data_is_private` filter was added to the Abstract Model.php allowing Model's `is_private()` check to be bypassed. Thanks for your work on this @CodeProKid @zacscott!
