### PR TITLE
Filter added to "debug_backtrace()" return value in "graphql_debug()"

### DIFF
--- a/access-functions.php
+++ b/access-functions.php
@@ -452,7 +452,19 @@ function register_graphql_settings_field( string $group, array $config ) {
  * @return void
  */
 function graphql_debug( $message, $config = [] ) {
-	$config['backtrace'] = wp_list_pluck( debug_backtrace(), 'file' );
+	$debug_backtrace = debug_backtrace();
+	$config['backtrace'] = ! empty( $debug_backtrace )
+		? array_column(
+			array_filter( // Filter out steps without files
+				$debug_backtrace,
+				function( $step ) {
+					return ! empty( $step['file'] );
+				}
+			),
+			'file'
+		)
+		: [];
+
 	add_action(
 		'graphql_get_debug_log',
 		function( \WPGraphQL\Utils\DebugLog $debug_log ) use ( $message, $config ) {


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](.github/CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
Prevents `wp_list_pluck()` from blowing up during CLI requests due to `debug_backtrace()` steps without `file` values.
![image](https://user-images.githubusercontent.com/13604318/108252479-b1c36280-7126-11eb-9d40-c8a9c97b9adc.png)



Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04

**WordPress Version:** 5.6.1
