### PR TITLE
Release/v1.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Changelog
 
+## 1.1.4
+
+### Bugfixes
+
+- ([#1715](https://github.com/wp-graphql/wp-graphql/pull/1715)) Updates `WPGraphQL\Type\Object` namespace to be `WPGraphQL\Type\ObjectType` to play nice with newer versions of PHP where `Object` is a reserved namespace.
+- ([#1711](https://github.com/wp-graphql/wp-graphql/pull/1711)) Updates regex in phpstan.neon.dist. Thanks @szepeviktor!
+- ([#1719](https://github.com/wp-graphql/wp-graphql/pull/1719)) Update to backtrace that is output with graphql_debug messages to ensure it includes a `file` key in the returned array, before returning the trace. Thanks @kidunot89!
+
 ## 1.1.3
 
-### Bugfix
+### Bugfixes
 
 - ([#1693](https://github.com/wp-graphql/wp-graphql/pull/1693)) Clear global user in the Router in case plugins have attempted to set the user before API authentication has been executed. Thanks @therealgilles!
 
@@ -21,7 +29,7 @@
 
 ## 1.1.1
 
-### Bugfix
+### Bugfixes
 
 - ([#1670](https://github.com/wp-graphql/wp-graphql/issues/1670)) Fixes a bug with querying pages that are set as to be the posts page
 

--- a/readme.txt
+++ b/readme.txt
@@ -67,13 +67,18 @@ WPGraphQL turns your WordPress site into a GraphQL API. Any client that can make
 
 WPGraphQL Swag is available on the Gatsby Swag store.
 
-= What's the relationship between Gatsby and WPGraphQL? =
+= What's the relationship between Gatsby, WP Engine, and WPGraphQL? =
 
-[Gatsby](https://gatsbyjs.com) employs Jason Bahl, the creator and maintainer of WPGraphQL. Gatsby believes that a strong GraphQL API for WordPress is a benefit for the web. Gatsby makes no restrictions on how you use WPGraphQL, however Gatsby is investing a lot into making the Gatsby + WordPress experience a great one, and WPGraphQL is a central part of that experience.
+[WP Engine](https://wpengine.com/) is the employer of Jason Bahl, the creator and maintainer of WPGraphQL. He was previously employed by [Gatsby](https://gatsbyjs.com).
+
+You can read more about this [here](https://www.wpgraphql.com/2021/02/07/whats-next-for-wpgraphql/).
+
+Gatsby and WP Engine both believe that a strong GraphQL API for WordPress is a benefit for the web. Neither Gatsby or WP Engine are required to be used with WPGraphQL, however it's important to acknowledge and understand what's possible because of their investments into WPGraphQL and the future of headless WordPress!
+
 
 == Upgrade Notice ==
 
 
 == Changelog ==
 
-See [Release Notes](https://github.com/wp-graphql/wp-graphql/releases)
+See [Github Changelog](https://github.com/wp-graphql/wp-graphql/blob/master/CHANGELOG.md)

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.1.3
+ * Version: 1.1.4
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.1.3
+ * @version  1.1.4
  */
 
 // Exit if accessed directly.
@@ -186,7 +186,7 @@ if ( ! class_exists( 'WPGraphQL' ) ) :
 
 			// Plugin version.
 			if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-				define( 'WPGRAPHQL_VERSION', '1.1.3' );
+				define( 'WPGRAPHQL_VERSION', '1.1.4' );
 			}
 
 			// Plugin Folder Path.


### PR DESCRIPTION
# Release Notes

## Bugfixes

- (#1715) Updates `WPGraphQL\Type\Object` namespace to be `WPGraphQL\Type\ObjectType` to play nice with newer versions of PHP where `Object` is a reserved namespace. 
- (#1711) Updates regex in phpstan.neon.dist. Thanks @szepeviktor!
- (#1719) Update to backtrace that is output with graphql_debug messages to ensure it includes a `file` key in the returned array, before returning the trace. Thanks @kidunot89!
