### PR TITLE
#1709 - Register the DefaultTemplate Type to the Schema always

### DIFF
--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -342,9 +342,10 @@ class TypeRegistry {
 
 		$registered_page_templates = wp_get_theme()->get_post_templates();
 
+		$page_templates['default'] = 'DefaultTemplate';
+
 		if ( ! empty( $registered_page_templates ) && is_array( $registered_page_templates ) ) {
 
-			$page_templates['default'] = 'DefaultTemplate';
 			foreach ( $registered_page_templates as $post_type_templates ) {
 				// Post templates are returned as an array of arrays. PHPStan believes they're returned as
 				// an array of strings and believes this will always evaluate to false.
@@ -372,6 +373,7 @@ class TypeRegistry {
 					$name = 'Template_' . $name;
 				}
 				$template_type_name = $name;
+
 				register_graphql_object_type(
 					$template_type_name,
 					[

--- a/tests/wpunit/PostObjectQueriesTest.php
+++ b/tests/wpunit/PostObjectQueriesTest.php
@@ -1762,7 +1762,7 @@ class PostObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 	/**
 	 * Tests to make sure the page set as the privacy page shows as the privacy page
-	 * 
+	 *
 	 * @throws Exception
 	 */
 	public function testIsPrivacyPage() {
@@ -1823,7 +1823,7 @@ class PostObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertTrue( $actual['data']['pageBy']['isPrivacyPage'] );
-		
+
 	}
 
 	/**
@@ -2189,6 +2189,52 @@ class PostObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertSame( $global_page_id, $actual['data']['page']['id'] );
+
+	}
+
+	public function testQueryPostWithTemplate() {
+
+		/**
+		 * Create a post
+		 */
+		$post_id = $this->createPostObject( [
+			'post_type' => 'post',
+		] );
+
+		$permalink = get_permalink( $post_id );
+
+		$query = '
+		query path($path: String!) {
+			nodeByUri(uri: $path) {
+				id
+				__typename
+				... on ContentType {
+					graphqlSingleName
+				}
+				... on ContentNode {
+					databaseId
+					template {
+						templateName
+						__typename
+					}
+				}
+			}
+		}
+		';
+
+		$actual = graphql([
+			'query' => $query,
+			'variables' => [
+				'path' => $permalink
+			]
+		]);
+
+		codecept_debug( $actual );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertSame( $post_id, $actual['data']['nodeByUri']['databaseId'] );
+		$this->assertSame( 'DefaultTemplate', $actual['data']['nodeByUri']['template']['__typename'] );
+		$this->assertSame( 'Default', $actual['data']['nodeByUri']['template']['templateName'] );
 
 	}
 


### PR DESCRIPTION

What does this implement/fix? Explain your changes.
---------------------------------------------------
This fixes a bug where the `DefaultTemplate` was added to the WPGraphQL Schema only if there were also other custom templates registered. This fixes it so the `DefaultTemplate` is _always_ registered and available in the Schema. 




Does this close any currently open issues?
------------------------------------------
closes #1709 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

## Before

![Screen Shot 2021-02-27 at 9 48 31 AM](https://user-images.githubusercontent.com/1260765/109393811-0a41ef00-78e1-11eb-9da6-e4941e253398.png)

## After

![Screen Shot 2021-02-27 at 9 48 38 AM](https://user-images.githubusercontent.com/1260765/109393814-0b731c00-78e1-11eb-9c55-1b36daeda2d5.png)
