### PR TITLE
v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.2.1
+
+### Bugfixes / Chores
+
+- ([#1741](https://github.com/wp-graphql/wp-graphql/pull/1741)) Fix issue with DefaultTemplate not being registered to the Schema and throwing errors when no other templates are registered.
+
 ## 1.2.0
 
 ### New
@@ -76,12 +82,12 @@
 
 This release centers around updating code quality by implementing [PHPStan](https://phpstan.org/) checks. PHPStan is a tool that statically analyzes PHP codebases to detect bugs. This release centers around updating Docblocks and overall code quality, and implements automated tests to check code quality on every pull request.
 
-## New
+### New
 
 - Update PHPStan (Code Quality checker) to v0.12.64
 - Increases PHPStan code quality checks to Level 8 (highest level).
 
-## Bugfixes
+### Bugfixes
 - ([#1653](https://github.com/wp-graphql/wp-graphql/issues/1653)) Fixes bug where WPGraphQL was explicitly setting `has_published_posts` on WP_Query but WP_Query does this under the hood already. Thanks @jmartinhoj!
 - Fixes issue with Comment Model returning comments that are not associated with a Post object. Comments with no associated Post object are not public entities.
 - Update docblocks to be compatible with PHPStan Level 8. 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, API, Gatsby, Headless, Decoupled, React, Nextjs, Vue, Apollo, RES
 Requires at least: 5.0
 Tested up to: 5.6
 Requires PHP: 7.1
-Stable tag: 1.1.8
+Stable tag: 1.2.1
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -342,9 +342,10 @@ class TypeRegistry {
 
 		$registered_page_templates = wp_get_theme()->get_post_templates();
 
+		$page_templates['default'] = 'DefaultTemplate';
+
 		if ( ! empty( $registered_page_templates ) && is_array( $registered_page_templates ) ) {
 
-			$page_templates['default'] = 'DefaultTemplate';
 			foreach ( $registered_page_templates as $post_type_templates ) {
 				// Post templates are returned as an array of arrays. PHPStan believes they're returned as
 				// an array of strings and believes this will always evaluate to false.
@@ -372,6 +373,7 @@ class TypeRegistry {
 					$name = 'Template_' . $name;
 				}
 				$template_type_name = $name;
+
 				register_graphql_object_type(
 					$template_type_name,
 					[

--- a/tests/wpunit/PostObjectQueriesTest.php
+++ b/tests/wpunit/PostObjectQueriesTest.php
@@ -1762,7 +1762,7 @@ class PostObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 	/**
 	 * Tests to make sure the page set as the privacy page shows as the privacy page
-	 * 
+	 *
 	 * @throws Exception
 	 */
 	public function testIsPrivacyPage() {
@@ -1823,7 +1823,7 @@ class PostObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertTrue( $actual['data']['pageBy']['isPrivacyPage'] );
-		
+
 	}
 
 	/**
@@ -2189,6 +2189,52 @@ class PostObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertSame( $global_page_id, $actual['data']['page']['id'] );
+
+	}
+
+	public function testQueryPostWithTemplate() {
+
+		/**
+		 * Create a post
+		 */
+		$post_id = $this->createPostObject( [
+			'post_type' => 'post',
+		] );
+
+		$permalink = get_permalink( $post_id );
+
+		$query = '
+		query path($path: String!) {
+			nodeByUri(uri: $path) {
+				id
+				__typename
+				... on ContentType {
+					graphqlSingleName
+				}
+				... on ContentNode {
+					databaseId
+					template {
+						templateName
+						__typename
+					}
+				}
+			}
+		}
+		';
+
+		$actual = graphql([
+			'query' => $query,
+			'variables' => [
+				'path' => $permalink
+			]
+		]);
+
+		codecept_debug( $actual );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertSame( $post_id, $actual['data']['nodeByUri']['databaseId'] );
+		$this->assertSame( 'DefaultTemplate', $actual['data']['nodeByUri']['template']['__typename'] );
+		$this->assertSame( 'Default', $actual['data']['nodeByUri']['template']['templateName'] );
 
 	}
 

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.1.9
+ * Version: 1.2.1
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.1.9
+ * @version  1.2.1
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
# Release Notes

## Bugfixes / Chores

- ([#1741](https://github.com/wp-graphql/wp-graphql/pull/1741)) Fix issue with `DefaultTemplate` not being registered to the Schema and throwing errors when no other templates are registered.