### PR TITLE
Bug/#1747 install to trellis causes wp die

### DIFF
--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -187,6 +187,11 @@ final class WPGraphQL {
 				add_action(
 					'admin_notices',
 					function () {
+
+						if ( ! current_user_can( 'manage_options' ) ) {
+							return;
+						}
+
 						echo sprintf(
 							'<div class="notice notice-error">' .
 							'<p>%s</p>' .


### PR DESCRIPTION

What does this implement/fix? Explain your changes.
---------------------------------------------------
This updates the warning for users that have installed WPGraphQL without dependencies. 

Instead of checking for the plugins `vendor/autoload.php` class relative to the plugin directory, it checks for the existence of the main GraphQL class from GraphQL-PHP. 

This allows for playing nice with installing the dependencies in the plugin from running `composer install` at the plugin root, and also plays nice with installing WPGraphQL as a dependency of another project (like Roots/Trellis). 

Also, instead of taking users to a `wp_die()` page, it now warns users using an Admin Notice:

![Screen Shot 2021-03-01 at 10 43 26 AM](https://user-images.githubusercontent.com/1260765/109536449-f8944f00-7a7a-11eb-8285-9c240e07963c.png)



Does this close any currently open issues?
-----------------------------------------
Closes #1747 
