### PR TITLE
PHPCS: Update testVersion to match support PHP

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -49,7 +49,7 @@
 
 	<!-- Tests for PHP version compatibility -->
 	<rule ref="PHPCompatibilityWP">
-		<config name="testVersion" value="7.0-"/>
+		<config name="testVersion" value="7.1-"/>
 	</rule>
 
 	<!-- Enforce short array syntax -->


### PR DESCRIPTION
Composer and readme says minimum supported version of PHP is 7.1, so the testVersion value should match this.

What does this implement/fix? Explain your changes.
---------------------------------------------------
Brings PHPCompatibility coding standards config into line with min PHP version.


Does this close any currently open issues?
------------------------------------------
No.


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
N/A
