### PR TITLE
fix: terms field was not registered in custom post types

### DIFF
--- a/src/Connection/TermObjects.php
+++ b/src/Connection/TermObjects.php
@@ -177,7 +177,7 @@ class TermObjects {
 				$post_type_object = get_post_type_object( $allowed_post_type );
 
 				if ( empty( get_object_taxonomies( $allowed_post_type ) ) ) {
-					return;
+					continue;
 				}
 
 				register_graphql_connection( [


### PR DESCRIPTION
This commit prevents the terms field from not being registered in custom post types.

Closes #1771