### PR TITLE
Change type of `tagId` from String to Int

### DIFF
--- a/src/Connection/PostObjects.php
+++ b/src/Connection/PostObjects.php
@@ -650,7 +650,7 @@ class PostObjects {
 					'description' => __( 'Tag Slug', 'wp-graphql' ),
 				];
 				$fields['tagId']      = [
-					'type'        => 'String',
+					'type'        => 'Int',
 					'description' => __( 'Use Tag ID', 'wp-graphql' ),
 				];
 				$fields['tagIn']      = [


### PR DESCRIPTION


What does this implement/fix? Explain your changes.
---------------------------------------------------
Change type of `tagId` from String to Int.

Probably just a typo for tagId.


Any other comments?
-------------------
I suggest changing all the `..Id` to the type `ID` to be consistent.



