### PR TITLE
#1788 - update WPGRAPHQL_PLUGIN_URL to be defined at the `init` hook.

### DIFF
--- a/phpstan/constants.php
+++ b/phpstan/constants.php
@@ -5,4 +5,5 @@
 
 define( 'WP_LANG_DIR', true );
 define( 'SAVEQUERIES', true );
+define( 'WPGRAPHQL_PLUGIN_URL', true );
 

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -133,11 +133,6 @@ final class WPGraphQL {
 			define( 'WPGRAPHQL_PLUGIN_DIR', plugin_dir_path( $main_file_path ) );
 		}
 
-		// Plugin Folder URL.
-		if ( ! defined( 'WPGRAPHQL_PLUGIN_URL' ) ) {
-			define( 'WPGRAPHQL_PLUGIN_URL', plugin_dir_url( $main_file_path ) );
-		}
-
 		// Plugin Root File.
 		if ( ! defined( 'WPGRAPHQL_PLUGIN_FILE' ) ) {
 			define( 'WPGRAPHQL_PLUGIN_FILE', $main_file_path );
@@ -272,6 +267,10 @@ final class WPGraphQL {
 			}
 		);
 
+		// Initialize the plugin url constant
+		// see: https://developer.wordpress.org/reference/functions/plugins_url/#more-information
+		add_action( 'init', [ $this, 'setup_plugin_url' ] );
+
 		// Prevent WPGraphQL Insights from running
 		// @phpstan-ignore-next-line
 		remove_action( 'init', '\WPGraphQL\Extensions\graphql_insights_init' );
@@ -326,6 +325,18 @@ final class WPGraphQL {
 
 		if ( defined( 'GRAPHQL_MIN_PHP_VERSION' ) && version_compare( PHP_VERSION, GRAPHQL_MIN_PHP_VERSION, '<' ) ) {
 			throw new \Exception( sprintf( __( 'The server\'s current PHP version %1$s is lower than the WPGraphQL minimum required version: %2$s', 'wp-graphql' ), PHP_VERSION, GRAPHQL_MIN_PHP_VERSION ) );
+		}
+
+	}
+
+	/**
+	 * Sets up the plugin url
+	 */
+	public function setup_plugin_url() {
+
+		// Plugin Folder URL.
+		if ( ! defined( 'WPGRAPHQL_PLUGIN_URL' ) ) {
+			define( 'WPGRAPHQL_PLUGIN_URL', plugin_dir_url( dirname( __DIR__ ) . '/wp-graphql.php' ) );
 		}
 
 	}

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -331,6 +331,8 @@ final class WPGraphQL {
 
 	/**
 	 * Sets up the plugin url
+	 *
+	 * @return void
 	 */
 	public function setup_plugin_url() {
 

--- a/tests/wpunit/WPGraphQLTest.php
+++ b/tests/wpunit/WPGraphQLTest.php
@@ -40,6 +40,7 @@ class WPGraphQLTest extends \Codeception\TestCase\WPTestCase {
 	 * @covers WPGraphQL::setup_constants()
 	 */
 	public function testSetupConstants() {
+		do_action( 'init' );
 		$this->assertTrue( defined( 'WPGRAPHQL_VERSION' ) );
 		$this->assertTrue( defined( 'WPGRAPHQL_PLUGIN_DIR' ) );
 		$this->assertTrue( defined( 'WPGRAPHQL_PLUGIN_URL' ) );


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This defines the `WPGRAPHQL_PLUGIN_URL` constant at the init hook, as recommended by https://developer.wordpress.org/reference/functions/plugins_url/#more-information

Does this close any currently open issues?
------------------------------------------
closes #1788 