### PR TITLE
#1783 - Don't throw errors when external uri is provided as input

### DIFF
--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -60,7 +60,10 @@ class NodeResolver {
 				],
 				true
 			) ) {
-				throw new UserError( __( 'Cannot return a resource for an external URI', 'wp-graphql' ) );
+				graphql_debug( __( 'Cannot return a resource for an external URI', 'wp-graphql' ), [
+					'uri' => $uri,
+				] );
+				return null;
 			}
 		}
 

--- a/tests/wpunit/NodeByUriTest.php
+++ b/tests/wpunit/NodeByUriTest.php
@@ -569,4 +569,55 @@ class NodeByUriTest extends \Codeception\TestCase\WPTestCase {
 
 	}
 
+	public function testExternalUriReturnsNull() {
+
+		$query = '
+		query NodeByUri( $uri: String! ) {
+		  nodeByUri( uri: $uri ) {
+		     uri
+		     __typename
+		     ...on DatabaseIdentifier {
+		       databaseId
+		     }
+		  }
+		}
+		';
+
+		$actual = graphql([
+			'query' => $query,
+			'variables' => [
+				'uri' => 'https://external-uri.com/path-to-thing'
+			]
+		]);
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEquals( null, $actual['data']['nodeByUri'] );
+
+	}
+
+	public function testMediaWithExternalUriReturnsNull() {
+
+		$query = '
+		query Media( $uri: ID! ){
+		  mediaItem(id: $uri, idType: URI) {
+		    id
+		    title
+		  }
+		}
+		';
+
+		$actual = graphql([
+			'query' => $query,
+			'variables' => [
+				'uri' => 'https://icd.wordsinspace.net/wp-content/uploads/2020/10/955000_2-scaled.jpg'
+			]
+		]);
+
+		codecept_debug( $actual );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEquals( null, $actual['data']['mediaItem'] );
+
+	}
+
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

Currently when a query inputs an external uri as the input, an error is thrown. This updates the behavior to return null instead of throw an error. 


Does this close any currently open issues?
------------------------------------------
closes #1783 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

## Before
![Screen Shot 2021-03-19 at 1 55 23 PM](https://user-images.githubusercontent.com/1260765/111835629-ce37f380-88ba-11eb-8915-8f4cedaa707b.png)

## After

![Screen Shot 2021-03-19 at 1 55 04 PM](https://user-images.githubusercontent.com/1260765/111835625-cd06c680-88ba-11eb-804d-31c9af03a5ee.png)
