### PR TITLE
#1796 - Allow tests to properly set different permalink structures

### DIFF
--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -89,8 +89,8 @@ final class WPGraphQL {
 	 * The whole idea of the singleton design pattern is that there is a single object
 	 * therefore, we don't want the object to be cloned.
 	 *
-	 * @since  0.0.1
 	 * @return void
+	 * @since  0.0.1
 	 */
 	public function __clone() {
 
@@ -102,8 +102,8 @@ final class WPGraphQL {
 	/**
 	 * Disable unserializing of the class.
 	 *
-	 * @since  0.0.1
 	 * @return void
+	 * @since  0.0.1
 	 */
 	public function __wakeup() {
 
@@ -115,8 +115,8 @@ final class WPGraphQL {
 	/**
 	 * Setup plugin constants.
 	 *
-	 * @since  0.0.1
 	 * @return void
+	 * @since  0.0.1
 	 */
 	private function setup_constants() {
 
@@ -154,8 +154,8 @@ final class WPGraphQL {
 	 * Include required files.
 	 * Uses composer's autoload
 	 *
-	 * @since  0.0.1
 	 * @return bool
+	 * @since  0.0.1
 	 */
 	private function includes() {
 
@@ -182,7 +182,7 @@ final class WPGraphQL {
 
 				add_action(
 					'admin_notices',
-					function () {
+					function() {
 
 						if ( ! current_user_can( 'manage_options' ) ) {
 							return;
@@ -224,7 +224,8 @@ final class WPGraphQL {
 	}
 
 	/**
-	 * Sets up actions to run at certain spots throughout WordPress and the WPGraphQL execution cycle
+	 * Sets up actions to run at certain spots throughout WordPress and the WPGraphQL execution
+	 * cycle
 	 *
 	 * @return void
 	 */
@@ -317,9 +318,8 @@ final class WPGraphQL {
 	 * If the server is running a lower version than required, throw an exception and prevent
 	 * further execution.
 	 *
-	 * @throws Exception
-	 *
 	 * @return void
+	 * @throws Exception
 	 */
 	public function min_php_version_check() {
 
@@ -389,7 +389,10 @@ final class WPGraphQL {
 		);
 
 		// Filter how metadata is retrieved during GraphQL requests
-		add_filter( 'get_post_metadata', [ '\WPGraphQL\Utils\Preview', 'filter_post_meta_for_previews' ], 10, 4 );
+		add_filter( 'get_post_metadata', [
+			'\WPGraphQL\Utils\Preview',
+			'filter_post_meta_for_previews',
+		], 10, 4 );
 	}
 
 	/**
@@ -405,54 +408,62 @@ final class WPGraphQL {
 	/**
 	 * This sets up built-in post_types and taxonomies to show in the GraphQL Schema
 	 *
-	 * @since  0.0.2
 	 * @return void
+	 * @since  0.0.2
 	 */
 	public static function show_in_graphql() {
 
-		global $wp_post_types, $wp_taxonomies;
+		add_filter( 'register_post_type_args', function( $args, $post_type ) {
 
-		// Adds GraphQL support for attachments.
-		if ( isset( $wp_post_types['attachment'] ) ) {
-			$wp_post_types['attachment']->show_in_graphql     = true;
-			$wp_post_types['attachment']->graphql_single_name = 'mediaItem';
-			$wp_post_types['attachment']->graphql_plural_name = 'mediaItems';
-		}
+			if ( 'attachment' === $post_type ) {
+				$args['show_in_graphql']     = true;
+				$args['graphql_single_name'] = 'mediaItem';
+				$args['graphql_plural_name'] = 'mediaItems';
+			}
 
-		// Adds GraphQL support for pages.
-		if ( isset( $wp_post_types['page'] ) ) {
-			$wp_post_types['page']->show_in_graphql     = true;
-			$wp_post_types['page']->graphql_single_name = 'page';
-			$wp_post_types['page']->graphql_plural_name = 'pages';
-		}
+			if ( 'page' === $post_type ) {
+				$args['show_in_graphql']     = true;
+				$args['graphql_single_name'] = 'page';
+				$args['graphql_plural_name'] = 'pages';
+			}
 
-		// Adds GraphQL support for posts.
-		if ( isset( $wp_post_types['post'] ) ) {
-			$wp_post_types['post']->show_in_graphql     = true;
-			$wp_post_types['post']->graphql_single_name = 'post';
-			$wp_post_types['post']->graphql_plural_name = 'posts';
-		}
+			if ( 'post' === $post_type ) {
+				$args['show_in_graphql']     = true;
+				$args['graphql_single_name'] = 'post';
+				$args['graphql_plural_name'] = 'posts';
+			}
 
-		// Adds GraphQL support for categories.
-		if ( isset( $wp_taxonomies['category'] ) ) {
-			$wp_taxonomies['category']->show_in_graphql     = true;
-			$wp_taxonomies['category']->graphql_single_name = 'category';
-			$wp_taxonomies['category']->graphql_plural_name = 'categories';
-		}
+			return $args;
 
-		// Adds GraphQL support for tags.
-		if ( isset( $wp_taxonomies['post_tag'] ) ) {
-			$wp_taxonomies['post_tag']->show_in_graphql     = true;
-			$wp_taxonomies['post_tag']->graphql_single_name = 'tag';
-			$wp_taxonomies['post_tag']->graphql_plural_name = 'tags';
-		}
+		}, 10, 2 );
 
-		// Adds GraphQL support for post formats.
-		if ( isset( $wp_taxonomies['post_format'] ) ) {
-			$wp_taxonomies['post_format']->show_in_graphql     = true;
-			$wp_taxonomies['post_format']->graphql_single_name = 'postFormat';
-			$wp_taxonomies['post_format']->graphql_plural_name = 'postFormats';
-		}
+		add_filter( 'register_taxonomy_args', function( $args, $taxonomy ) {
+
+			// Adds GraphQL support for categories.
+			if ( 'category' === $taxonomy ) {
+				$args['show_in_graphql']     = true;
+				$args['graphql_single_name'] = 'category';
+				$args['graphql_plural_name'] = 'categories';
+			}
+
+			// Adds GraphQL support for tags.
+			if ( 'post_tag' === $taxonomy ) {
+				$args['show_in_graphql']     = true;
+				$args['graphql_single_name'] = 'tag';
+				$args['graphql_plural_name'] = 'tags';
+			}
+
+			// Adds GraphQL support for post formats.
+			if ( 'post_format' === $taxonomy ) {
+				$args['show_in_graphql']     = true;
+				$args['graphql_single_name'] = 'postFormat';
+				$args['graphql_plural_name'] = 'postFormats';
+			}
+
+			return $args;
+
+		}, 10, 2 );
+
 	}
 
 	/**
@@ -501,11 +512,10 @@ final class WPGraphQL {
 		 * to allow the post_types to be modified (for example if a certain post_type should
 		 * not be exposed to the GraphQL API)
 		 *
-		 * @since 0.0.2
-		 *
 		 * @param array $post_types Array of post types
 		 *
 		 * @return array
+		 * @since 0.0.2
 		 */
 		return apply_filters( 'graphql_post_entities_allowed_post_types', $post_types );
 
@@ -516,8 +526,8 @@ final class WPGraphQL {
 	 * are set to "show_in_graphql" but allows for external code (plugins/themes) to filter
 	 * the list of allowed_taxonomies to add/remove additional taxonomies
 	 *
-	 * @since  0.0.4
 	 * @return array
+	 * @since  0.0.4
 	 */
 	public static function get_allowed_taxonomies() {
 
@@ -571,6 +581,8 @@ final class WPGraphQL {
 	public static function clear_schema() {
 		self::$type_registry = null;
 		self::$schema        = null;
+		create_initial_taxonomies();
+		create_initial_post_types();
 	}
 
 	/**
@@ -591,11 +603,11 @@ final class WPGraphQL {
 			/**
 			 * Generate & Filter the schema.
 			 *
-			 * @since 0.0.5
-			 *
-			 * @param array                 $schema      The executable Schema that GraphQL executes against
-			 * @param AppContext $app_context Object The AppContext object containing all of the
+			 * @param array      $schema                 The executable Schema that GraphQL executes against
+			 * @param AppContext $app_context            Object The AppContext object containing all of the
 			 *                                           information about the context we know at this point
+			 *
+			 * @since 0.0.5
 			 */
 			self::$schema = apply_filters( 'graphql_schema', $schema, self::get_app_context() );
 		}
@@ -647,11 +659,11 @@ final class WPGraphQL {
 			/**
 			 * Generate & Filter the schema.
 			 *
-			 * @since 0.0.5
-			 *
-			 * @param array                 $type_registry The TypeRegistry for the API
-			 * @param AppContext $app_context   Object The AppContext object containing all of the
+			 * @param array      $type_registry            The TypeRegistry for the API
+			 * @param AppContext $app_context              Object The AppContext object containing all of the
 			 *                                             information about the context we know at this point
+			 *
+			 * @since 0.0.5
 			 */
 			self::$type_registry = apply_filters( 'graphql_type_registry', $type_registry, self::get_app_context() );
 		}


### PR DESCRIPTION

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR updates WPGraphQL.php to make use of register_post_type_args and register_taxonomy_args instead of overriding global $wp_post_types and $wp_taxonomies variables when setting up support for initial WP types in the Schema. This allows for testing environments to better reset state and clear the Schema and re-generate it.

- add create_initital_taxonomies() and create_initial_post_types() calls to the clear_schema() method so that post types and taxonomies can be re-generated when the schema is cleared. This is especially useful for resetting/testing with different permalink structures.
- remove set_permalink_structure from NodeByUriTest as it's included in the WPUnit test case already


Does this close any currently open issues?
------------------------------------------
closes #1796 
