### PR TITLE
Fixes querying child terms by URI

### DIFF
--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -3,11 +3,9 @@
 namespace WPGraphQL\Data;
 
 use Exception;
-use GraphQL\Error\UserError;
 use WP;
 use WPGraphQL\AppContext;
 use WPGraphQL\Model\Post;
-use WPGraphQL\Model\PostType;
 
 class NodeResolver {
 
@@ -87,6 +85,7 @@ class NodeResolver {
 
 		// Fetch the rewrite rules.
 		$rewrite = $wp_rewrite->wp_rewrite_rules();
+
 		$error   = '404';
 		if ( ! empty( $rewrite ) ) {
 			// If we match a rewrite rule, this will be cleared.
@@ -211,10 +210,13 @@ class NodeResolver {
 		 */
 		$this->wp->public_query_vars = apply_filters( 'query_vars', $this->wp->public_query_vars );
 
-		foreach ( get_post_types( [ 'show_in_graphql' => true ], 'objects' ) as $post_type => $t ) {
+		$post_type_objects = get_post_types( [ 'show_in_graphql' => true ], 'objects' );
 
-			if ( isset( $t->show_in_graphql ) && true === $t->show_in_graphql && $t->query_var ) {
-				$post_type_query_vars[ $t->query_var ] = $post_type;
+		if ( ! empty( $post_type_objects ) ) {
+			foreach ( $post_type_objects as $post_type_object ) {
+				if ( isset( $post_type_object->show_in_graphql ) && true === $post_type_object->show_in_graphql && $post_type_object->query_var ) {
+					$post_type_query_vars[ $post_type_object->query_var ] = $post_type_object->name;
+				}
 			}
 		}
 
@@ -260,6 +262,7 @@ class NodeResolver {
 				$this->wp->query_vars[ $t->query_var ] = str_replace( ' ', '+', $this->wp->query_vars[ $t->query_var ] );
 			}
 		}
+
 
 		// Limit publicly queried post_types to those that are publicly_queryable
 		if ( isset( $this->wp->query_vars['post_type'] ) ) {
@@ -365,18 +368,25 @@ class NodeResolver {
 
 			$post = get_page_by_path( $this->wp->query_vars['pagename'], 'OBJECT', get_post_types( [ 'show_in_graphql' => true ] ) );
 
-			if ( isset( $post->ID ) && (int) get_option( 'page_for_posts', 0 ) === $post->ID ) {
+			if ( ! $post instanceof \WP_Post ) {
+				return null;
+			}
+
+			if ( get_option( 'page_for_posts', 0 ) === $post->ID ) {
 				return $this->context->get_loader( 'post' )->load_deferred( $post->ID );
 			}
 
-			return ! empty( $post ) ? $this->context->get_loader( 'post' )->load_deferred( $post->ID ) : null;
+			return $this->context->get_loader( 'post' )->load_deferred( $post->ID );
 		} elseif ( isset( $this->wp->query_vars['author_name'] ) ) {
 			$user = get_user_by( 'slug', $this->wp->query_vars['author_name'] );
 
 			return isset( $user->ID ) ? $this->context->get_loader( 'user' )->load_deferred( $user->ID ) : null;
 		} elseif ( isset( $this->wp->query_vars['category_name'] ) ) {
-			$node = get_term_by( 'slug', $this->wp->query_vars['category_name'], 'category' );
-
+			$term = get_category_by_path( $this->wp->query_vars['category_name'] );
+			if ( ! $term instanceof \WP_Term ) {
+				return null;
+			}
+			$node = get_term_by( 'id', $term->term_id, 'category' );
 			return isset( $node->term_id ) ? $this->context->get_loader( 'term' )->load_deferred( $node->term_id ) : null;
 
 		} elseif ( isset( $this->wp->query_vars['post_type'] ) ) {

--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -86,7 +86,7 @@ class NodeResolver {
 		// Fetch the rewrite rules.
 		$rewrite = $wp_rewrite->wp_rewrite_rules();
 
-		$error   = '404';
+		$error = '404';
 		if ( ! empty( $rewrite ) ) {
 			// If we match a rewrite rule, this will be cleared.
 			$error                   = null;
@@ -262,7 +262,6 @@ class NodeResolver {
 				$this->wp->query_vars[ $t->query_var ] = str_replace( ' ', '+', $this->wp->query_vars[ $t->query_var ] );
 			}
 		}
-
 
 		// Limit publicly queried post_types to those that are publicly_queryable
 		if ( isset( $this->wp->query_vars['post_type'] ) ) {

--- a/src/Type/InterfaceType/UniformResourceIdentifiable.php
+++ b/src/Type/InterfaceType/UniformResourceIdentifiable.php
@@ -2,6 +2,8 @@
 
 namespace WPGraphQL\Type\InterfaceType;
 
+use WP_Post_Type;
+use WP_Taxonomy;
 use WPGraphQL\Model\Post;
 use WPGraphQL\Model\PostType;
 use WPGraphQL\Model\Term;
@@ -36,12 +38,12 @@ class UniformResourceIdentifiable {
 
 					switch ( true ) {
 						case $node instanceof Post:
-							/** @var \WP_Post_Type $post_type_object */
+							/** @var WP_Post_Type $post_type_object */
 							$post_type_object = get_post_type_object( $node->post_type );
 							$type             = $type_registry->get_type( $post_type_object->graphql_single_name );
 							break;
 						case $node instanceof Term:
-							/** @var \WP_Taxonomy $taxonomy_object */
+							/** @var WP_Taxonomy $taxonomy_object */
 							$taxonomy_object = get_taxonomy( $node->taxonomyName );
 							$type            = $type_registry->get_type( $taxonomy_object->graphql_single_name );
 							break;

--- a/tests/wpunit/NodeByUriTest.php
+++ b/tests/wpunit/NodeByUriTest.php
@@ -27,7 +27,12 @@ class NodeByUriTest extends \Codeception\TestCase\WPTestCase {
 			'graphql_plural_name' => 'CustomTaxes',
 		]);
 
-		$this->set_permalink_structure( '/%year%/%monthnum%/%day%/%postname%/' );
+		global $wp_rewrite;
+		update_option( 'permalink_structure', '/%year%/%monthnum%/%day%/%postname%/' );
+		create_initial_taxonomies();
+		$GLOBALS['wp_rewrite']->init();
+		flush_rewrite_rules();
+		WPGraphQL::show_in_graphql();
 
 		$this->user = $this->factory()->user->create([
 			'role' => 'administrator',
@@ -84,13 +89,6 @@ class NodeByUriTest extends \Codeception\TestCase\WPTestCase {
 		wp_delete_term( $this->custom_taxonomy, 'custom_tax' );
 		wp_delete_user( $this->user );
 
-	}
-
-	public function set_permalink_structure( $structure = '' ) {
-		global $wp_rewrite;
-		$wp_rewrite->init();
-		$wp_rewrite->set_permalink_structure( $structure );
-		$wp_rewrite->flush_rules( true );
 	}
 
 	/**


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- Update nodeResolver to use `get_category_by_path()` function instead of `get_term_by( 'slug' )` to allow for terms at any level of hierarchy to be queried by uri
- Update NodeByUriTest to flush permalinks then call show_in_graphql() again to setup the core post types and taxonomies in the Schema after permalinks have been flushed
- Add tests to TermObjectQueriesTest to test querying child terms by uri both as part of nodeByUri and directly. Also tests custom post types.

Does this close any currently open issues?
------------------------------------------
closes #1464 
closes #1796 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

### Before: 
![Screen Shot 2021-03-22 at 10 20 48 AM](https://user-images.githubusercontent.com/1260765/112022887-4fc89500-8af8-11eb-8911-0ee47223350f.png)

### After:

![Screen Shot 2021-03-22 at 10 20 34 AM](https://user-images.githubusercontent.com/1260765/112022882-4dfed180-8af8-11eb-9dfc-19753c9a4a4f.png)

