### PR TITLE
Bug/#1810 fix regression to user connection resolver

### DIFF
--- a/src/Data/Connection/UserConnectionResolver.php
+++ b/src/Data/Connection/UserConnectionResolver.php
@@ -98,6 +98,14 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 		 */
 		$query_args['fields'] = 'ID';
 
+		/**
+		 * If the request is not authenticated, limit the query to users that have
+		 * published posts, as they're considered publicly facing users.
+		 */
+		if ( ! is_user_logged_in() ) {
+			$query_args['has_published_posts'] = true;
+		}
+
 		if ( ! empty( $query_args['search'] ) ) {
 			$query_args['search']  = '*' . $query_args['search'] . '*';
 			$query_args['orderby'] = 'user_login';

--- a/tests/wpunit/CustomPostTypeTest.php
+++ b/tests/wpunit/CustomPostTypeTest.php
@@ -2,9 +2,22 @@
 
 class CustomPostTypeTest extends \Codeception\TestCase\WPTestCase {
 
+	public $post_id;
+	public $admin;
+
 	public function setUp(): void {
 		parent::setUp();
 		WPGraphQL::clear_schema();
+
+		$this->post_id = $this->factory()->post->create([
+			'post_type' => 'bootstrap_cpt',
+			'post_status' => 'publish',
+			'post_title' => 'Test'
+		]);
+
+		$this->admin = $this->factory()->user->create([
+			'role' => 'administrator'
+		]);
 
 	}
 
@@ -18,11 +31,7 @@ class CustomPostTypeTest extends \Codeception\TestCase\WPTestCase {
 	 */
 	public function testQueryCustomPostType() {
 
-		$id = $this->factory()->post->create([
-			'post_type' => 'bootstrap_cpt',
-			'post_status' => 'publish',
-			'post_title' => 'Test'
-		]);
+
 
 		codecept_debug( WPGraphQL::get_allowed_post_types() );
 
@@ -47,14 +56,188 @@ class CustomPostTypeTest extends \Codeception\TestCase\WPTestCase {
 		$actual = graphql([
 			'query' => $query,
 			'variables' => [
-				'id' => $id
+				'id' => $this->post_id
 			]
 		]);
 
 		codecept_debug( $actual );
-		$this->assertEquals( $id, $actual['data']['bootstrapPostBy']['bootstrapPostId']);
-		$this->assertEquals( $id, $actual['data']['bootstrapPosts']['nodes'][0]['bootstrapPostId']);
-		$this->assertEquals( $id, $actual['data']['bootstrapPosts']['edges'][0]['node']['bootstrapPostId']);
+		$this->assertEquals( $this->post_id, $actual['data']['bootstrapPostBy']['bootstrapPostId']);
+		$this->assertEquals( $this->post_id, $actual['data']['bootstrapPosts']['nodes'][0]['bootstrapPostId']);
+		$this->assertEquals( $this->post_id, $actual['data']['bootstrapPosts']['edges'][0]['node']['bootstrapPostId']);
+
+	}
+
+	public function testQueryCustomPostTypeByUri() {
+
+		global $wp_rewrite;
+
+		update_option( 'permalink_structure', '/%year%/%monthnum%/%day%/%postname%/' );
+		create_initial_taxonomies();
+		$GLOBALS['wp_rewrite']->init();
+
+
+		register_post_type(
+			'test_cpt',
+			[
+				'show_in_graphql'     => true,
+				'graphql_single_name' => 'testCpt',
+				'graphql_plural_name' => 'testCpts',
+				'hierarchical'        => true,
+				'public'              => true,
+				'taxonomies'          => [ 'category' ],
+				'rewrite'             => true,
+			]
+		);
+
+		flush_rewrite_rules();
+
+		$post_id = $this->factory()->post->create([
+			'post_type' => 'test_cpt',
+			'post_status' => 'publish',
+			'post_title' => 'Test',
+			'post_author' => $this->admin
+		]);
+
+		$child_post_id = $this->factory()->post->create([
+			'post_type' => 'test_cpt',
+			'post_status' => 'publish',
+			'post_title' => 'Child Post',
+			'post_author' => $this->admin,
+		]);
+
+		WPGraphQL::show_in_graphql();
+
+		$query = '
+		query GET_CUSTOM_POSTS( $id: ID! ) {
+			testCpt(id: $id idType: URI ) {
+			  __typename
+			  databaseId
+			}
+		}
+		';
+
+		$uri = get_permalink( $post_id );
+
+		codecept_debug( $uri );
+
+		// Query a parent (top-level) post by URI
+		$actual = graphql([
+			'query' => $query,
+			'variables' => [
+				'id' => $uri
+			]
+		]);
+
+		codecept_debug( $actual );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+
+		$this->assertSame( 'TestCpt', $actual['data']['testCpt']['__typename'] );
+		$this->assertSame( $post_id, $actual['data']['testCpt']['databaseId'] );
+
+		$child_uri = get_permalink( $child_post_id );
+
+		// Query a child post of CPT by uri
+		$actual = graphql([
+			'query' => $query,
+			'variables' => [
+				'id' => $child_uri
+			]
+		]);
+
+		codecept_debug( $actual );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+
+		$this->assertSame( 'TestCpt', $actual['data']['testCpt']['__typename'] );
+		$this->assertSame( $child_post_id, $actual['data']['testCpt']['databaseId'] );
+
+	}
+
+	public function testQueryCustomPostTypeByDatabaseId() {
+
+		global $wp_rewrite;
+
+		update_option( 'permalink_structure', '/%year%/%monthnum%/%day%/%postname%/' );
+		create_initial_taxonomies();
+		$GLOBALS['wp_rewrite']->init();
+
+
+		register_post_type(
+			'test_cpt',
+			[
+				'show_in_graphql'     => true,
+				'graphql_single_name' => 'testCpt',
+				'graphql_plural_name' => 'testCpts',
+				'hierarchical'        => true,
+				'public'              => true,
+				'taxonomies'          => [ 'category' ],
+				'rewrite'             => true,
+			]
+		);
+
+		flush_rewrite_rules();
+
+		$post_id = $this->factory()->post->create([
+			'post_type' => 'test_cpt',
+			'post_status' => 'publish',
+			'post_title' => 'Test',
+			'post_author' => $this->admin
+		]);
+
+		$child_post_id = $this->factory()->post->create([
+			'post_type' => 'test_cpt',
+			'post_status' => 'publish',
+			'post_title' => 'Child Post',
+			'post_author' => $this->admin,
+		]);
+
+		WPGraphQL::show_in_graphql();
+
+		$query = '
+		query GET_CUSTOM_POSTS( $id: ID! ) {
+			testCpt(id: $id idType: DATABASE_ID ) {
+			  __typename
+			  databaseId
+			}
+		}
+		';
+
+		$uri = get_permalink( $post_id );
+
+		codecept_debug( $uri );
+
+		// Query a parent (top-level) post by URI
+		$actual = graphql([
+			'query' => $query,
+			'variables' => [
+				'id' => $post_id
+			]
+		]);
+
+		codecept_debug( $actual );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+
+		$this->assertSame( 'TestCpt', $actual['data']['testCpt']['__typename'] );
+		$this->assertSame( $post_id, $actual['data']['testCpt']['databaseId'] );
+
+		$child_uri = get_permalink( $child_post_id );
+
+		// Query a child post of CPT by uri
+		$actual = graphql([
+			'query' => $query,
+			'variables' => [
+				'id' => $child_post_id
+			]
+		]);
+
+		codecept_debug( $actual );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+
+		$this->assertSame( 'TestCpt', $actual['data']['testCpt']['__typename'] );
+		$this->assertSame( $child_post_id, $actual['data']['testCpt']['databaseId'] );
 
 	}
 

--- a/tests/wpunit/PostObjectQueriesTest.php
+++ b/tests/wpunit/PostObjectQueriesTest.php
@@ -1547,6 +1547,9 @@ class PostObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 		$actual = do_graphql_request( $graphql_query );
 
+		codecept_debug( $user );
+		codecept_debug( $actual );
+
 		$expected = [
 			'post' => [
 				'id' => $global_id,

--- a/tests/wpunit/UserObjectQueriesTest.php
+++ b/tests/wpunit/UserObjectQueriesTest.php
@@ -1553,4 +1553,154 @@ class UserObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 	}
 
+	public function testQueryUsersAsPublicUserShouldReturnOnlyPublishedAuthors() {
+
+		$alphabet = range( 'A', 'Z' );
+		$published_users = [];
+		$unpublished_users = [];
+		foreach ( $alphabet as $letter ) {
+			$unpublished_users[] = $this->factory()->user->create([
+				'user_login' => 'unpublished_' . $letter,
+				'user_email' => $letter . '_unpublishded@example.com'
+			]);
+			$author_id = $this->factory()->user->create([
+				'user_login' => 'published_' . $letter,
+				'user_email' => $letter . '_published@example.com',
+				'role' => 'administrator'
+			]);
+
+			$published_users[] = $author_id;
+			$this->factory()->post->create([
+				'post_status' => 'publish',
+				'post_title' => $letter . '_Post',
+				'post_author' => $author_id,
+				'role' => 'administrator'
+			]);
+		}
+
+		$query = '
+		{
+		  users(first:100) {
+		    nodes {
+		      databaseId
+		    }
+		  }
+		}
+		';
+
+		$actual = graphql([
+			'query' => $query,
+		]);
+
+		codecept_debug( $actual );
+
+		$ids = wp_list_pluck( $actual['data']['users']['nodes'], 'databaseId' );
+
+		// There should be 26 users. One published user for each letter of the alphabet.
+		$this->assertEquals( 26, count( $ids ) );
+
+		foreach ($ids as $id ) {
+			$this->assertTrue( in_array( $id, $published_users, true  ) );
+			$this->assertTrue( ! in_array( $id, $unpublished_users, true  ) );
+		}
+
+		$query = '
+		{
+		  users(last:100) {
+		    nodes {
+		      databaseId
+		    }
+		  }
+		}
+		';
+
+		$actual = graphql([
+			'query' => $query,
+		]);
+
+		codecept_debug( $actual );
+
+		$ids = wp_list_pluck( $actual['data']['users']['nodes'], 'databaseId' );
+
+		// There should be 26 users. One published user for each letter of the alphabet.
+		$this->assertEquals( 26, count( $ids ) );
+		foreach ($ids as $id ) {
+			$this->assertTrue( in_array( $id, $published_users, true  ) );
+			$this->assertTrue( ! in_array( $id, $unpublished_users, true  ) );
+		}
+
+		$query = '
+		{
+		  users(last:10) {
+		    nodes {
+		      databaseId
+		    }
+		  }
+		}
+		';
+
+		$actual = graphql([
+			'query' => $query,
+		]);
+
+		codecept_debug( $actual );
+
+		$ids = wp_list_pluck( $actual['data']['users']['nodes'], 'databaseId' );
+
+		// There should be 10 users.
+		$this->assertEquals( 10, count( $ids ) );
+		foreach ($ids as $id ) {
+			$this->assertTrue( in_array( $id, $published_users, true  ) );
+			$this->assertTrue( ! in_array( $id, $unpublished_users, true  ) );
+		}
+
+		codecept_debug( $published_users );
+
+		// Query as an admin
+		wp_set_current_user( absint( $published_users[0] ) );
+
+		$query = '
+		{
+		  users(first:100) {
+		    nodes {
+		      databaseId
+		    }
+		  }
+		}
+		';
+
+		$actual = graphql([
+			'query' => $query,
+		]);
+
+		codecept_debug( $actual );
+
+		$ids = wp_list_pluck( $actual['data']['users']['nodes'], 'databaseId' );
+		// There should be 52 users. One published and one unpublished user for each letter of the alphabet.
+		$this->assertEquals( 52, count( $ids ) );
+
+		$query = '
+		{
+		  users(last:100) {
+		    nodes {
+		      databaseId
+		    }
+		  }
+		}
+		';
+
+		$actual = graphql([
+			'query' => $query,
+		]);
+
+		codecept_debug( $actual );
+
+		$ids = wp_list_pluck( $actual['data']['users']['nodes'], 'databaseId' );
+		// There should be 52 users. One published and one unpublished user for each letter of the alphabet.
+		$this->assertEquals( 52, count( $ids ) );
+
+		$this->delete_users();
+
+	}
+
 }

--- a/tests/wpunit/UserObjectQueriesTest.php
+++ b/tests/wpunit/UserObjectQueriesTest.php
@@ -32,7 +32,7 @@ class UserObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 		global $wpdb;
 		$wpdb->query( $wpdb->prepare(
 			"DELETE FROM {$wpdb->prefix}users WHERE ID <> %d",
-			array( 1 )
+			array( 0 )
 		) );
 		$this->created_user_ids = [ 1 ];
 	}
@@ -1554,6 +1554,8 @@ class UserObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	public function testQueryUsersAsPublicUserShouldReturnOnlyPublishedAuthors() {
+
+		$this->delete_users();
 
 		$alphabet = range( 'A', 'Z' );
 		$published_users = [];


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This updates the `UserConnectionResolver` to include the `has_published_posts` argument passed to WP_User_Query when 
 the query is made as part of a non-authenticated request. 
 
 ### Overview of the issue: 

Let's say we have the following list of users, conveniently named with one letter of the alphabet: 

```json
A published
B published
C published
D published
E published
F published
G published
H published
I published
J published
K published
L not-published
M not-published
N not-published
O not-published
P not-published
Q not-published
R not-published
S not-published
T not-published
U not-published
V not-published
W not-published
X not-published
Y not-published
Z not-published
```

The bug right now, is that SQL queries the number of items that were asked for (+1 for cursor pagination), then the Model Layer determines if the object can be returned. 

So, asking for `first:10` will return authors `A-K`, slice `K` off the list (and set `hasNextPage` as true) and the Model Layer will see that the authors are all published and can be returned so we will get authors `A-J` returned. 

Now, if we ask for `last:10` the bug can be seen. 

SQL will ask for authors `P-Z`, slice off `P` (and set `hasPreviousPage` as true) then pass the rest to the Model Layer. Since none of them are published authors, the Model Layer will prevent them from being returned to a non-authenticated user and it will appear as if there are no users at all. 

What should happen, though, is that a public request for `last: 10` should return the `last 10 users that the requesting user has permission to see`. 

So the expectation is that the public user should get users `B-K` returned when asking for `{ users(last:10) { ... } }`

Does this close any currently open issues?
------------------------------------------
Closes #1810 
Closes #1605 

Any other comments?
-------------------
This unfortunately reverses the change made by @jmartinhoj in #1654. 

@jmartinhoj feel free to open another issue with more specifics about your use case so we can work toward a solution that works for both cases. I'm confident that with a bit more information on what you were experiencing with Co Authors Plus we can find a solution that works all around.

