### PR TITLE
Use key for user type when name not defined

### DIFF
--- a/src/Type/Enum/UserRoleEnum.php
+++ b/src/Type/Enum/UserRoleEnum.php
@@ -20,7 +20,7 @@ class UserRoleEnum {
 		if ( ! empty( $editable_roles ) && is_array( $editable_roles ) ) {
 			foreach ( $editable_roles as $key => $role ) {
 
-				$formatted_role = WPEnumType::get_safe_name( $role['name'] );
+				$formatted_role = WPEnumType::get_safe_name( isset( $role['name'] ) ? $role['name'] : $key );
 
 				$roles[ $formatted_role ] = [
 					'description' => __( 'User role with specific capabilities', 'wp-graphql' ),

--- a/tests/wpunit/UserRoleEnumTest.php
+++ b/tests/wpunit/UserRoleEnumTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use WPGraphQL\Type\Enum\UserRoleEnum;
+
+class UserRoleEnumTest extends \Codeception\TestCase\WPTestCase {
+
+	public function setUp(): void {
+		// before
+		WPGraphQL::clear_schema();
+		parent::setUp();
+		// your set up methods here
+	}
+
+	public function tearDown(): void {
+		// your tear down methods here
+		WPGraphQL::clear_schema();
+		// then
+		parent::tearDown();
+	}
+
+	/**
+	 * Test filter for WP enum type invokes.
+	 *
+	 * @throws Exception
+	 */
+	public function testUserEdittableRoleWhenNameEmpty() {
+
+		/**
+		 * Modify the user role enums for testing null name.
+         * Test roles that don't have an explicit name, don't fail during type registration.
+		 */
+		add_filter(
+			'editable_roles',
+			function( $roles ) {
+				return [
+                    'foo' => [
+                        'name'        => 'Foo',
+                        'extra'       => 'hello-foo',
+                    ],
+                    'bar' => [
+                        'name'        => null,
+                        'extra'       => 'hello-bar',
+                    ],
+                    'biz' => [
+                        'extra'       => 'hello-biz',
+                    ]
+                ];
+			}
+		);
+
+        /**
+         * Invoke the user role enum registration.
+         */
+        UserRoleEnum::register_type();
+        $editable_roles = get_editable_roles();
+        $this->assertArrayHasKey( 'foo', $editable_roles );
+        $this->assertArrayHasKey( 'bar', $editable_roles );
+        $this->assertArrayHasKey( 'biz', $editable_roles );
+	}
+}


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
When name field not present for a user role, use the key value as the name string.


Does this close any currently open issues?
------------------------------------------
#1761 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
