### PR TITLE
Update to xdebug 3 config and add ability to build app docker with xdebug

### DIFF
--- a/.github/workflows/testing-integration.yml
+++ b/.github/workflows/testing-integration.yml
@@ -54,13 +54,13 @@ jobs:
         env:
           PHP_VERSION: ${{ matrix.php }}
           WP_VERSION: ${{ matrix.wordpress }}
-          USE_XDEBUG: ${{ matrix.coverage }}
+          USE_CODE_COVERAGE: ${{ matrix.coverage }}
         run: composer build-test
 
       - name: Run Tests w/ Docker.
         env:
           COVERAGE: ${{ matrix.coverage }}
-          USE_XDEBUG: ${{ matrix.coverage }}
+          USE_CODE_COVERAGE: ${{ matrix.coverage }}
           DEBUG: ${{ matrix.debug }}
           SKIP_TESTS_CLEANUP: ${{ matrix.coverage }}
           LOWEST: ${{ matrix.lowest }}

--- a/.github/workflows/testing-integration.yml
+++ b/.github/workflows/testing-integration.yml
@@ -54,13 +54,12 @@ jobs:
         env:
           PHP_VERSION: ${{ matrix.php }}
           WP_VERSION: ${{ matrix.wordpress }}
-          USE_CODE_COVERAGE: ${{ matrix.coverage }}
         run: composer build-test
 
       - name: Run Tests w/ Docker.
         env:
           COVERAGE: ${{ matrix.coverage }}
-          USE_CODE_COVERAGE: ${{ matrix.coverage }}
+          USING_XDEBUG: ${{ matrix.coverage }}
           DEBUG: ${{ matrix.debug }}
           SKIP_TESTS_CLEANUP: ${{ matrix.coverage }}
           LOWEST: ${{ matrix.lowest }}

--- a/bin/run-docker.sh
+++ b/bin/run-docker.sh
@@ -42,7 +42,7 @@ case "$subcommand" in
 
                 docker build -f docker/testing.Dockerfile \
                     -t wpgraphql-testing:latest \
-                    --build-arg USE_XDEBUG=${USE_XDEBUG-} \
+                    --build-arg USE_CODE_COVERAGE=${USE_CODE_COVERAGE-} \
                     .
                     ;;
                 \? ) print_usage_instructions;;

--- a/bin/run-docker.sh
+++ b/bin/run-docker.sh
@@ -42,7 +42,6 @@ case "$subcommand" in
 
                 docker build -f docker/testing.Dockerfile \
                     -t wpgraphql-testing:latest \
-                    --build-arg USE_CODE_COVERAGE=${USE_CODE_COVERAGE-} \
                     .
                     ;;
                 \? ) print_usage_instructions;;
@@ -66,6 +65,7 @@ case "$subcommand" in
                 docker-compose run --rm \
                     -e SUITES=${SUITES-} \
                     -e COVERAGE=${COVERAGE-} \
+                    -e USING_XDEBUG=${USING_XDEBUG-} \
                     -e DEBUG=${DEBUG-} \
                     -e SKIP_TESTS_CLEANUP=${SKIP_TESTS_CLEANUP-} \
 					-e LOWEST=${LOWEST-} \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,6 @@ services:
       DB_HOST: app_db
       WP_URL: 'http://localhost'
       WP_DOMAIN: 'localhost'
-      USING_XDEBUG: $USING_XDEBUG
     networks:
       testing:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       ADMIN_EMAIL: admin@example.com
       ADMIN_USERNAME: admin
       ADMIN_PASSWORD: password
+      USING_XDEBUG: $USING_XDEBUG
     ports:
       - '8091:80'
     networks:
@@ -47,10 +48,10 @@ services:
       - './codeception.dist.yml:/var/www/html/wp-content/plugins/wp-graphql/codeception.yml'
     env_file: .env.dist
     environment:
-      XDEBUG_CONFIG: remote_host=host.docker.internal remote_port=9000 remote_enable=1
       DB_HOST: app_db
       WP_URL: 'http://localhost'
       WP_DOMAIN: 'localhost'
+      USING_XDEBUG: $USING_XDEBUG
     networks:
       testing:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,9 +19,6 @@ services:
       ADMIN_EMAIL: admin@example.com
       ADMIN_USERNAME: admin
       ADMIN_PASSWORD: password
-      INCLUDE_WPGRAPHIQL: 1
-      IMPORT_WC_PRODUCTS: 1
-      STRIPE_GATEWAY: 1
     ports:
       - '8091:80'
     networks:
@@ -54,7 +51,6 @@ services:
       DB_HOST: app_db
       WP_URL: 'http://localhost'
       WP_DOMAIN: 'localhost'
-      STRIPE_GATEWAY: 1
     networks:
       testing:
 

--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -52,6 +52,18 @@ RUN sed -i '$d' /usr/local/bin/docker-entrypoint.sh
 # Set up Apache
 RUN echo 'ServerName localhost' >> /etc/apache2/apache2.conf
 
+# Install XDebug 3
+RUN if [ "$USING_XDEBUG" ]; then \
+        pecl install xdebug \
+        && docker-php-ext-enable xdebug \
+        && echo "zend_extension=xdebug" > /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
+        && echo "xdebug.mode=develop,debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
+        && echo "xdebug.start_with_request=yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
+        && echo "xdebug.client_host=host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
+        && echo "xdebug.client_port=9003" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
+        ; \
+    fi
+
 # Set up entrypoint
 WORKDIR    /var/www/html
 COPY       docker/app.entrypoint.sh /usr/local/bin/app-entrypoint.sh

--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -57,7 +57,7 @@ RUN echo "Installing XDebug 3 (in disabled state)" \
     && pecl install xdebug \
     && mkdir -p /usr/local/etc/php/conf.d/disabled \
     && echo "zend_extension=xdebug" > /usr/local/etc/php/conf.d/disabled/docker-php-ext-xdebug.ini \
-    && echo "xdebug.mode=develop,debug" >> /usr/local/etc/php/conf.d/disabled/docker-php-ext-xdebug.ini \
+    && echo "xdebug.mode=develop,debug,coverage" >> /usr/local/etc/php/conf.d/disabled/docker-php-ext-xdebug.ini \
     && echo "xdebug.start_with_request=yes" >> /usr/local/etc/php/conf.d/disabled/docker-php-ext-xdebug.ini \
     && echo "xdebug.client_host=host.docker.internal" >> /usr/local/etc/php/conf.d/disabled/docker-php-ext-xdebug.ini \
     && echo "xdebug.client_port=9003" >> /usr/local/etc/php/conf.d/disabled/docker-php-ext-xdebug.ini \

--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -53,16 +53,18 @@ RUN sed -i '$d' /usr/local/bin/docker-entrypoint.sh
 RUN echo 'ServerName localhost' >> /etc/apache2/apache2.conf
 
 # Install XDebug 3
-RUN if [ "$USING_XDEBUG" ]; then \
-        pecl install xdebug \
-        && docker-php-ext-enable xdebug \
-        && echo "zend_extension=xdebug" > /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
-        && echo "xdebug.mode=develop,debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
-        && echo "xdebug.start_with_request=yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
-        && echo "xdebug.client_host=host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
-        && echo "xdebug.client_port=9003" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
-        ; \
-    fi
+RUN echo "Installing XDebug 3 (in disabled state)" \
+    && pecl install xdebug \
+    && mkdir -p /usr/local/etc/php/conf.d/disabled \
+    && echo "zend_extension=xdebug" > /usr/local/etc/php/conf.d/disabled/docker-php-ext-xdebug.ini \
+    && echo "xdebug.mode=develop,debug" >> /usr/local/etc/php/conf.d/disabled/docker-php-ext-xdebug.ini \
+    && echo "xdebug.start_with_request=yes" >> /usr/local/etc/php/conf.d/disabled/docker-php-ext-xdebug.ini \
+    && echo "xdebug.client_host=host.docker.internal" >> /usr/local/etc/php/conf.d/disabled/docker-php-ext-xdebug.ini \
+    && echo "xdebug.client_port=9003" >> /usr/local/etc/php/conf.d/disabled/docker-php-ext-xdebug.ini \
+    ;
+
+# Set xdebug configuration off by default. See the entrypoint.sh.
+ENV USING_XDEBUG=0
 
 # Set up entrypoint
 WORKDIR    /var/www/html

--- a/docker/app.entrypoint.sh
+++ b/docker/app.entrypoint.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [ "$USING_XDEBUG" == "1"  ]; then
+    echo "Enabling XDebug 3"
+    mv /usr/local/etc/php/conf.d/disabled/docker-php-ext-xdebug.ini /usr/local/etc/php/conf.d/
+fi
+
 # Run WordPress docker entrypoint.
 . docker-entrypoint.sh 'apache2'
 

--- a/docker/testing.Dockerfile
+++ b/docker/testing.Dockerfile
@@ -10,14 +10,12 @@ LABEL author_uri=https://github.com/jasonbahl
 
 SHELL [ "/bin/bash", "-c" ]
 
-# Redeclare ARGs and set as environmental variables for reuse.
-ARG USE_CODE_COVERAGE
-
 # Install php extensions
 RUN docker-php-ext-install pdo_mysql
 
 # Install PCOV
 # This is needed for Codeception / PHPUnit to track code coverage
+ARG USE_CODE_COVERAGE=0
 RUN if [ "$USE_CODE_COVERAGE" ]; then \
         apt-get install zip unzip -y \
         && pecl install pcov \

--- a/docker/testing.Dockerfile
+++ b/docker/testing.Dockerfile
@@ -11,26 +11,18 @@ LABEL author_uri=https://github.com/jasonbahl
 SHELL [ "/bin/bash", "-c" ]
 
 # Redeclare ARGs and set as environmental variables for reuse.
-ARG USE_XDEBUG
-ENV USING_XDEBUG=${USE_XDEBUG}
+ARG USE_CODE_COVERAGE
 
 # Install php extensions
 RUN docker-php-ext-install pdo_mysql
 
-# Install PCOV and XDebug 3
+# Install PCOV
 # This is needed for Codeception / PHPUnit to track code coverage
-RUN if [ "$USING_XDEBUG" ]; then \
+RUN if [ "$USE_CODE_COVERAGE" ]; then \
         apt-get install zip unzip -y \
         && pecl install pcov \
         && docker-php-ext-enable pcov \
         && echo "pcov.enabled=1" >> /usr/local/etc/php/php.ini \
-        && pecl install -f xdebug \
-        && docker-php-ext-enable xdebug \
-        && echo "zend_extension=xdebug" > /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
-        && echo "xdebug.mode=develop,debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
-        && echo "xdebug.start_with_request=yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
-        && echo "xdebug.client_host=host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
-        && echo "xdebug.client_port=9003" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
         ; \
     fi
 

--- a/docker/testing.Dockerfile
+++ b/docker/testing.Dockerfile
@@ -17,19 +17,22 @@ ENV USING_XDEBUG=${USE_XDEBUG}
 # Install php extensions
 RUN docker-php-ext-install pdo_mysql
 
-# Install PCOV and XDebug
+# Install PCOV and XDebug 3
 # This is needed for Codeception / PHPUnit to track code coverage
-RUN if [[ "$USING_XDEBUG" ]]; then \
-    apt-get install zip unzip -y && \
-    pecl install pcov && \
-    docker-php-ext-enable pcov && \
-    rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && \
-    echo "pcov.enabled=1" >> /usr/local/etc/php/php.ini ;\
-    yes | pecl install xdebug \
-    && echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" > /usr/local/etc/php/conf.d/xdebug.ini \
-    && echo "xdebug.remote_enable=on" >> /usr/local/etc/php/conf.d/xdebug.ini \
-    && echo "xdebug.remote_autostart=off" >> /usr/local/etc/php/conf.d/xdebug.ini; \
-fi
+RUN if [ "$USING_XDEBUG" ]; then \
+        apt-get install zip unzip -y \
+        && pecl install pcov \
+        && docker-php-ext-enable pcov \
+        && echo "pcov.enabled=1" >> /usr/local/etc/php/php.ini \
+        && pecl install -f xdebug \
+        && docker-php-ext-enable xdebug \
+        && echo "zend_extension=xdebug" > /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
+        && echo "xdebug.mode=develop,debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
+        && echo "xdebug.start_with_request=yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
+        && echo "xdebug.client_host=host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
+        && echo "xdebug.client_port=9003" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
+        ; \
+    fi
 
 # Install composer
 ENV COMPOSER_ALLOW_SUPERUSER=1

--- a/docker/testing.Dockerfile
+++ b/docker/testing.Dockerfile
@@ -16,7 +16,7 @@ RUN docker-php-ext-install pdo_mysql
 # Install PCOV
 # This is needed for Codeception / PHPUnit to track code coverage
 RUN apt-get install zip unzip -y \
-    && pecl install pcov \
+    && pecl install pcov
 
 ENV COVERAGE=0
 

--- a/docker/testing.Dockerfile
+++ b/docker/testing.Dockerfile
@@ -15,14 +15,10 @@ RUN docker-php-ext-install pdo_mysql
 
 # Install PCOV
 # This is needed for Codeception / PHPUnit to track code coverage
-ARG USE_CODE_COVERAGE=0
-RUN if [ "$USE_CODE_COVERAGE" ]; then \
-        apt-get install zip unzip -y \
-        && pecl install pcov \
-        && docker-php-ext-enable pcov \
-        && echo "pcov.enabled=1" >> /usr/local/etc/php/php.ini \
-        ; \
-    fi
+RUN apt-get install zip unzip -y \
+    && pecl install pcov \
+
+ENV COVERAGE=0
 
 # Install composer
 ENV COMPOSER_ALLOW_SUPERUSER=1

--- a/docker/testing.entrypoint.sh
+++ b/docker/testing.entrypoint.sh
@@ -73,10 +73,13 @@ COMPOSER_MEMORY_LIMIT=-1 composer install --prefer-source --no-interaction
 
 # Install pcov/clobber if PHP7.1+
 if version_gt $PHP_VERSION 7.0 && [[ -n "$COVERAGE" ]] && [[ -z "$USING_XDEBUG" ]]; then
-    echo "Installing pcov/clobber"
-    COMPOSER_MEMORY_LIMIT=-1 composer require --dev pcov/clobber
+    echo "Using pcov/clobber for codecoverage"
+    docker-php-ext-enable pcov
+    echo "pcov.enabled=1" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini
+    echo "pcov.directory = /var/www/html/wp-content/plugins/wp-graphql" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini
+    COMPOSER_MEMORY_LIMIT=-1 composer require pcov/clobber --dev
     vendor/bin/pcov clobber
-elif [[ -n "$COVERAGE" ]]; then
+elif [[ -n "$COVERAGE" ]] && [[ -z "$USING_XDEBUG" ]]; then
     echo "Using XDebug for codecoverage"
 fi
 
@@ -104,6 +107,7 @@ if [ -f "${TESTS_OUTPUT}/coverage.xml" ] && [[ -n "$COVERAGE" ]]; then
         echo 'Removing pcov/clobber.'
         vendor/bin/pcov unclobber
         COMPOSER_MEMORY_LIMIT=-1 composer remove --dev pcov/clobber
+        rm /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini
     fi
 
 fi


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Allow building docker app and testing images with xdebub 3 installed and configured on port 9003. 


Does this close any currently open issues?
------------------------------------------
Fixes #1737 using xdebug in a docker with this repo.


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
Here is how I'd document this.
# Using Docker For Local Development

## WordPress Site

The `app` docker image starts a running WordPress site with the local wp-graphql directory installed and activated. Local changes to the source code is immediately reflects in the app.

1. Build the plugin. 
1.1 `composer install` or `docker run -v $PWD:/app composer --ignore-platform-reqs install`
1. Run `composer build-app` to build the `app` docker image.
1. Run `composer build-test` to build the `testing` docker image.
1. Run `composer run-app` to start the WordPress site.
1. Browse to http://localhost:8091/ to access the running WordPress app.
1. Browse to http://localhost:8091/wp-admin/ to access the admin dashboard. Username is 'admin'. Password is 'password'.

## Testing Suite

The `testing` docker image starts a running WordPress and runs the codeception test suites.

1. Run `composer build-test` to build the `testing` docker image.
1. Run `composer run-tests` to start the `testing` image and run the codeception tests.

# Using XDebug

## Local WordPress Site With XDebug
Use an environment variable USING_XDEBUG to start the docker image and WordPress with xdebug configured to use port 9003 to communicated with your IDE. 

```
export USING_XDEBUG=1
composer run-app
```

Start the debugger in your IDE. Set breakpoints. 

Load the app in http://localhost:8091/.

## Using XDebug With Tests

Use the environment variable USING_XDEBUG to run tests with xdebug configured to use port 9003 to communicated with your IDE. 

```
export USING_XDEBUG=1
composer run-tests
```

Start the debugger in your IDE. Set breakpoints.

## Configure VSCode IDE Launch File

Create or add the following configuration to your .vscode/launch.json in the root directory. Restart VSCode. Start the debug listener before running the app or testing images.

If you have WordPress core files in a directory for local development, you can add the location to the `pathMappings` for debug step through.

```
{
    "version": "0.2.0",
    "configurations": [
		{
			"name": "Listen for Xdebug",
			"type": "php",
			"request": "launch",
			"port": 9003,
			"xdebugSettings": {
				"max_children": 128,
				"max_data": 1024,
				"max_depth": 3,
				"show_hidden": 1
			},
			"pathMappings": {
				"/var/www/html/wp-content/plugins/wp-graphql": "${workspaceFolder}",
				"/var/www/html": "${workspaceFolder}/wordpress",
			}
		}
    ]
}
```


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
