### PR TITLE
fix: non-logged in users could not see the tracing or query log

### DIFF
--- a/src/Utils/QueryLog.php
+++ b/src/Utils/QueryLog.php
@@ -73,8 +73,8 @@ class QueryLog {
 			$can_see = false;
 		} else {
 
-			// If "all" is the selected role, anyone can see the logs
-			if ( 'all' === $this->query_log_user_role ) {
+			// If "any" is the selected role, anyone can see the logs
+			if ( 'any' === $this->query_log_user_role ) {
 				$can_see = true;
 			} else {
 				// Get the current users roles

--- a/src/Utils/Tracing.php
+++ b/src/Utils/Tracing.php
@@ -312,8 +312,8 @@ class Tracing {
 		if ( ! $this->tracing_enabled ) {
 			$can_see = false;
 		} else {
-			// If "all" is the selected role, anyone can see the logs
-			if ( 'all' === $this->tracing_user_role ) {
+			// If "any" is the selected role, anyone can see the logs
+			if ( 'any' === $this->tracing_user_role ) {
 				$can_see = true;
 			} else {
 				// Get the current users roles


### PR DESCRIPTION
When the value 'any' is set in the settings of wp graphql both in the Tracing role and in the Query log role none of these are returned.