### PR TITLE
Ignore relay-connection-types-spec schema linting rule

### DIFF
--- a/.github/workflows/schema-linter.yml
+++ b/.github/workflows/schema-linter.yml
@@ -45,10 +45,9 @@ jobs:
           composer run install-test-env
 
       - name: Generate the Static Schema
-        # 💡 Neutralize for now
         run: |
           cd /tmp/wordpress/
           # Output: /tmp/schema.graphql
           wp graphql generate-static-schema
           cd /tmp/wordpress/wp-content/plugins/wp-graphql/
-          graphql-schema-linter /tmp/schema.graphql || true
+          graphql-schema-linter --except=relay-connection-types-spec /tmp/schema.graphql


### PR DESCRIPTION
There are two problems with it.

1. It disables more than just requiring `PageInfo` return type https://github.com/cjoudrey/graphql-schema-linter#relay-connection-types-spec
2. `--except` is a deprecated option

From https://github.com/wp-graphql/wp-graphql/issues/1790#issuecomment-810358120