### PR TITLE
Simplify use of env variable SUITES to run specific tests.

### DIFF
--- a/.github/workflows/testing-integration.yml
+++ b/.github/workflows/testing-integration.yml
@@ -69,4 +69,4 @@ jobs:
         env:
           COVERALLS_RUN_LOCALLY: 1
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: vendor/bin/php-coveralls -v
+        run: ls -l tests/_output/ ; vendor/bin/php-coveralls -v

--- a/.github/workflows/testing-integration.yml
+++ b/.github/workflows/testing-integration.yml
@@ -62,7 +62,6 @@ jobs:
           USING_XDEBUG: ${{ matrix.coverage }}
           DEBUG: ${{ matrix.debug }}
           SKIP_TESTS_CLEANUP: ${{ matrix.coverage }}
-          LOWEST: ${{ matrix.lowest }}
         run: composer run-test
 
       - name: Push Codecoverage to Coveralls.io

--- a/.github/workflows/testing-integration.yml
+++ b/.github/workflows/testing-integration.yml
@@ -62,6 +62,7 @@ jobs:
           USING_XDEBUG: ${{ matrix.coverage }}
           DEBUG: ${{ matrix.debug }}
           SKIP_TESTS_CLEANUP: ${{ matrix.coverage }}
+          SUITES: wpunit
         run: composer run-test
 
       - name: Push Codecoverage to Coveralls.io

--- a/.github/workflows/testing-integration.yml
+++ b/.github/workflows/testing-integration.yml
@@ -62,11 +62,11 @@ jobs:
           USING_XDEBUG: ${{ matrix.coverage }}
           DEBUG: ${{ matrix.debug }}
           SKIP_TESTS_CLEANUP: ${{ matrix.coverage }}
-        run: composer run-test ; ls -l tests/_output/
+        run: composer run-test
 
       - name: Push Codecoverage to Coveralls.io
         if: ${{ matrix.coverage == 1 }}
         env:
           COVERALLS_RUN_LOCALLY: 1
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ls -l tests/_output/ ; vendor/bin/php-coveralls -v
+        run: vendor/bin/php-coveralls -v

--- a/.github/workflows/testing-integration.yml
+++ b/.github/workflows/testing-integration.yml
@@ -62,7 +62,7 @@ jobs:
           USING_XDEBUG: ${{ matrix.coverage }}
           DEBUG: ${{ matrix.debug }}
           SKIP_TESTS_CLEANUP: ${{ matrix.coverage }}
-        run: composer run-test
+        run: composer run-test ; ls -l tests/_output/
 
       - name: Push Codecoverage to Coveralls.io
         if: ${{ matrix.coverage == 1 }}

--- a/bin/run-docker.sh
+++ b/bin/run-docker.sh
@@ -61,14 +61,10 @@ case "$subcommand" in
 				;;
                 a ) docker-compose up --scale testing=0;;
                 t )
-				source ${env_file}
                 docker-compose run --rm \
-                    -e SUITES=${SUITES-} \
                     -e COVERAGE=${COVERAGE-} \
                     -e USING_XDEBUG=${USING_XDEBUG-} \
                     -e DEBUG=${DEBUG-} \
-                    -e SKIP_TESTS_CLEANUP=${SKIP_TESTS_CLEANUP-} \
-					-e LOWEST=${LOWEST-} \
                     testing --scale app=0
                     ;;
                 \? ) print_usage_instructions;;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,7 @@ services:
       DB_HOST: app_db
       WP_URL: 'http://localhost'
       WP_DOMAIN: 'localhost'
+      SUITES: $SUITES
     networks:
       testing:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       ADMIN_EMAIL: admin@example.com
       ADMIN_USERNAME: admin
       ADMIN_PASSWORD: password
-      USING_XDEBUG: $USING_XDEBUG
+      USING_XDEBUG: ${USING_XDEBUG:-}
     ports:
       - '8091:80'
     networks:
@@ -51,7 +51,7 @@ services:
       DB_HOST: app_db
       WP_URL: 'http://localhost'
       WP_DOMAIN: 'localhost'
-      SUITES: $SUITES
+      SUITES: ${SUITES:-}
     networks:
       testing:
 

--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -52,6 +52,10 @@ RUN sed -i '$d' /usr/local/bin/docker-entrypoint.sh
 # Set up Apache
 RUN echo 'ServerName localhost' >> /etc/apache2/apache2.conf
 
+# Custom PHP settings
+RUN echo "upload_max_filesize = 50M" >> /usr/local/etc/php/conf.d/custom.ini \
+    ;
+
 # Install XDebug 3
 RUN echo "Installing XDebug 3 (in disabled state)" \
     && pecl install xdebug \

--- a/docker/testing.Dockerfile
+++ b/docker/testing.Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get install zip unzip -y \
     && pecl install pcov
 
 ENV COVERAGE=0
-ENV SUITES=${SUITES:-SPECIFY-TEST-SUITE}
+ENV SUITES=${SUITES:-}
 
 # Install composer
 ENV COMPOSER_ALLOW_SUPERUSER=1

--- a/docker/testing.Dockerfile
+++ b/docker/testing.Dockerfile
@@ -1,5 +1,5 @@
 ############################################################################
-# Container for running Codeception tests on a WooGraphQL Docker instance. #
+# Container for running Codeception tests on a WPGraphQL Docker instance. #
 ############################################################################
 
 # Using the 'DESIRED_' prefix to avoid confusion with environment variables of the same name.

--- a/docker/testing.Dockerfile
+++ b/docker/testing.Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get install zip unzip -y \
     && pecl install pcov
 
 ENV COVERAGE=0
+ENV SUITES=${SUITES:-SPECIFY-TEST-SUITE}
 
 # Install composer
 ENV COMPOSER_ALLOW_SUPERUSER=1

--- a/docker/testing.entrypoint.sh
+++ b/docker/testing.entrypoint.sh
@@ -76,7 +76,7 @@ if version_gt $PHP_VERSION 7.0 && [[ -n "$COVERAGE" ]] && [[ -z "$USING_XDEBUG" 
     echo "pcov.directory = /var/www/html/wp-content/plugins/wp-graphql" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini
     COMPOSER_MEMORY_LIMIT=-1 composer require pcov/clobber --dev
     vendor/bin/pcov clobber
-elif [[ -n "$COVERAGE" ]] && [[ -z "$USING_XDEBUG" ]]; then
+elif [[ -n "$COVERAGE" ]] && [[ -n "$USING_XDEBUG" ]]; then
     echo "Using XDebug for codecoverage"
 fi
 

--- a/docker/testing.entrypoint.sh
+++ b/docker/testing.entrypoint.sh
@@ -2,7 +2,6 @@
 
 # Processes parameters and runs Codeception.
 run_tests() {
-    echo "Running Tests"
     if [[ -n "$COVERAGE" ]]; then
         local coverage="--coverage --coverage-xml"
     fi
@@ -10,9 +9,9 @@ run_tests() {
         local debug="--debug"
     fi
 
-    local suites=${1:-" ;"}
-    IFS=';' read -ra target_suites <<< "$suites"
-    for suite in "${target_suites[@]}"; do
+    local suites=${1:-" "}
+    for suite in $suites ; do
+        echo "Running Test Suite $suite"
         vendor/bin/codecept run -c codeception.dist.yml ${suite} ${coverage:-} ${debug:-} --no-exit
     done
 }
@@ -63,13 +62,11 @@ if [ ! -f "$PROJECT_DIR/c3.php" ]; then
     curl -L 'https://raw.github.com/Codeception/c3/2.0/c3.php' > "$PROJECT_DIR/c3.php"
 fi
 
-if [[ -n "$LOWEST" ]]; then
-    PREFER_LOWEST="--prefer-source"
-fi
-
 # Install dependencies
-COMPOSER_MEMORY_LIMIT=-1 composer update --prefer-source ${PREFER_LOWEST}
-COMPOSER_MEMORY_LIMIT=-1 composer install --prefer-source --no-interaction
+echo "Running composer update"
+COMPOSER_MEMORY_LIMIT=-1 composer update
+echo "Running composer install"
+COMPOSER_MEMORY_LIMIT=-1 composer install --no-interaction
 
 # Install pcov/clobber if PHP7.1+
 if version_gt $PHP_VERSION 7.0 && [[ -n "$COVERAGE" ]] && [[ -z "$USING_XDEBUG" ]]; then
@@ -88,7 +85,7 @@ echo "Setting Codeception output directory permissions"
 chmod 777 ${TESTS_OUTPUT}
 
 # Run tests
-run_tests ${SUITES}
+run_tests "${SUITES}"
 
 # Remove c3.php
 if [ -f "$PROJECT_DIR/c3.php" ] && [ "$SKIP_TESTS_CLEANUP" != "1" ]; then
@@ -136,5 +133,4 @@ if [ -f "${TESTS_OUTPUT}/failed" ]; then
     exit 1
 else
     echo "Woohoo! It's working!"
-    exit 0
 fi

--- a/docker/testing.entrypoint.sh
+++ b/docker/testing.entrypoint.sh
@@ -9,7 +9,12 @@ run_tests() {
         local debug="--debug"
     fi
 
-    local suites=${1:-" "}
+    local suites=$1
+    if [[ -z "$suites" ]]; then
+        echo "No test suites specified. Must specify variable SUITES."
+        exit 1
+    fi
+
     for suite in $suites ; do
         echo "Running Test Suite $suite"
         vendor/bin/codecept run -c codeception.dist.yml ${suite} ${coverage:-} ${debug:-} --no-exit


### PR DESCRIPTION
Follow up work to issue #1737 

Allow environment variable SUITES to pass into `composter run-test` command.
Use composer packages from dist, not source to speed up update and install commands. As this pulls package versions and caches them instead of pulling from github .git repo.
Increase php file upload limit.

Updates to documentation at https://www.wpgraphql.com/docs/testing/ to come soon.