### PR TITLE
Use empty array when no menu locations registered

### DIFF
--- a/src/Data/Connection/MenuItemConnectionResolver.php
+++ b/src/Data/Connection/MenuItemConnectionResolver.php
@@ -58,7 +58,8 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 		// locations to allow public queries for.
 		// Public queries should only be allowed to query for
 		// Menu Items assigned to a Menu Location
-		$locations = array_unique( array_values( $menu_locations ) );
+		$locations = is_array( $menu_locations ) && ! empty( $menu_locations ) ? array_unique( array_values( $menu_locations ) ) : [];
+
 
 		// If the location argument is set, set the argument to the input argument
 		if ( isset( $this->args['where']['location'] ) && isset( $menu_locations[ $this->args['where']['location'] ] ) ) {

--- a/src/Data/Connection/MenuItemConnectionResolver.php
+++ b/src/Data/Connection/MenuItemConnectionResolver.php
@@ -60,7 +60,6 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 		// Menu Items assigned to a Menu Location
 		$locations = is_array( $menu_locations ) && ! empty( $menu_locations ) ? array_unique( array_values( $menu_locations ) ) : [];
 
-
 		// If the location argument is set, set the argument to the input argument
 		if ( isset( $this->args['where']['location'] ) && isset( $menu_locations[ $this->args['where']['location'] ] ) ) {
 

--- a/tests/wpunit/MenuItemConnectionResolverTest.php
+++ b/tests/wpunit/MenuItemConnectionResolverTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use WPGraphQL\Data\Connection\MenuItemConnectionResolver;
+
+class MenuItemConnectionResolverTest extends \Codeception\TestCase\WPTestCase {
+
+	public function setUp(): void {
+		// before
+		WPGraphQL::clear_schema();
+		parent::setUp();
+		// your set up methods here
+	}
+
+	public function tearDown(): void {
+		// your tear down methods here
+		WPGraphQL::clear_schema();
+		// then
+		parent::tearDown();
+	}
+
+	public function testMenuItemConnectionResolverWithNoMenuItem() {
+
+		$query = '
+		{
+			menuItems {
+			  nodes {
+				id
+			  }
+			}
+		  }
+		';
+
+		$actual = do_graphql_request( $query );
+		$this->assertEmpty( $actual['data']['menuItems']['nodes'] );
+	}
+}

--- a/tests/wpunit/MenuItemConnectionResolverTest.php
+++ b/tests/wpunit/MenuItemConnectionResolverTest.php
@@ -32,5 +32,6 @@ class MenuItemConnectionResolverTest extends \Codeception\TestCase\WPTestCase {
 
 		$actual = do_graphql_request( $query );
 		$this->assertEmpty( $actual['data']['menuItems']['nodes'] );
+		$this->assertArrayNotHasKey( 'errors', $actual );
 	}
 }


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
When no location menu items set, use empty array list.


Does this close any currently open issues?
------------------------------------------
#1844 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
