### PR TITLE
Release/v1.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.3.5
+
+### Chores / Bugfixes
+
+- ([#1846](https://github.com/wp-graphql/wp-graphql/pull/1846)): Fixes bug where sites with no menu locations can throw a php error in the MenuItemConnectionResolver. Thanks @markkelnar!
+
 ## 1.3.4
 
 ### New Features

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, API, Gatsby, Headless, Decoupled, React, Nextjs, Vue, Apollo, RES
 Requires at least: 5.0
 Tested up to: 5.6
 Requires PHP: 7.1
-Stable tag: 1.3.4
+Stable tag: 1.3.5
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -82,6 +82,12 @@ Gatsby and WP Engine both believe that a strong GraphQL API for WordPress is a b
 Composer dependencies are no longer versioned in Github. Recommended install source is WordPress.org or using Composer to get the code from Packagist.org or WPackagist.org.
 
 == Changelog ==
+
+= 1.3.5 =
+
+**Chores / Bugfixes**
+
+- ([#1846](https://github.com/wp-graphql/wp-graphql/pull/1846)): Fixes bug where sites with no menu locations can throw a php error in the MenuItemConnectionResolver. Thanks @markkelnar!
 
 = 1.3.4 =
 

--- a/src/Data/Connection/MenuItemConnectionResolver.php
+++ b/src/Data/Connection/MenuItemConnectionResolver.php
@@ -58,7 +58,7 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 		// locations to allow public queries for.
 		// Public queries should only be allowed to query for
 		// Menu Items assigned to a Menu Location
-		$locations = array_unique( array_values( $menu_locations ) );
+		$locations = is_array( $menu_locations ) && ! empty( $menu_locations ) ? array_unique( array_values( $menu_locations ) ) : [];
 
 		// If the location argument is set, set the argument to the input argument
 		if ( isset( $this->args['where']['location'] ) && isset( $menu_locations[ $this->args['where']['location'] ] ) ) {

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -125,7 +125,7 @@ final class WPGraphQL {
 
 		// Plugin version.
 		if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-			define( 'WPGRAPHQL_VERSION', '1.3.4' );
+			define( 'WPGRAPHQL_VERSION', '1.3.5' );
 		}
 
 		// Plugin Folder Path.

--- a/tests/wpunit/MenuItemConnectionResolverTest.php
+++ b/tests/wpunit/MenuItemConnectionResolverTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use WPGraphQL\Data\Connection\MenuItemConnectionResolver;
+
+class MenuItemConnectionResolverTest extends \Codeception\TestCase\WPTestCase {
+
+	public function setUp(): void {
+		// before
+		WPGraphQL::clear_schema();
+		parent::setUp();
+		// your set up methods here
+	}
+
+	public function tearDown(): void {
+		// your tear down methods here
+		WPGraphQL::clear_schema();
+		// then
+		parent::tearDown();
+	}
+
+	public function testMenuItemConnectionResolverWithNoMenuItem() {
+
+		$query = '
+		{
+			menuItems {
+			  nodes {
+				id
+			  }
+			}
+		  }
+		';
+
+		$actual = do_graphql_request( $query );
+		$this->assertEmpty( $actual['data']['menuItems']['nodes'] );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+	}
+}

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.3.4
+ * Version: 1.3.5
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.3.4
+ * @version  1.3.5
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
# Release Notes

## Chores / Bugfixes

- ([#1846](https://github.com/wp-graphql/wp-graphql/pull/1846)): Fixes bug where sites with no menu locations can throw a php error in the MenuItemConnectionResolver. Thanks @markkelnar!
