### PR TITLE
fix: various issues on createComment Mutation

### DIFF
--- a/src/Mutation/CommentCreate.php
+++ b/src/Mutation/CommentCreate.php
@@ -41,11 +41,11 @@ class CommentCreate {
 				'description' => __( 'The ID of the post object the comment belongs to.', 'wp-graphql' ),
 			],
 			'author'      => [
-				'type'        => 'String',
+				'type'        => boolval( get_option( 'require_name_email' ) ) ? [ 'non_null' => 'String' ] : 'String',
 				'description' => __( 'The name of the comment\'s author.', 'wp-graphql' ),
 			],
 			'authorEmail' => [
-				'type'        => 'String',
+				'type'        => boolval( get_option( 'require_name_email' ) ) ? [ 'non_null' => 'String' ] : 'String',
 				'description' => __( 'The email of the comment\'s author.', 'wp-graphql' ),
 			],
 			'authorUrl'   => [
@@ -146,8 +146,8 @@ class CommentCreate {
 			}
 
 			if ( '1' === get_option( 'require_name_email' ) && ( empty( $input['author'] ) || empty( $input['authorEmail'] ) ) ) {
-				throw new UserError( __( "This site requires you to provide a name and email address leave a comment", 'wp-graphql' ) );
-			} 
+				throw new UserError( __( 'This site requires you to provide a name and email address leave a comment', 'wp-graphql' ) );
+			}
 
 			/**
 			 * Map all of the args from GraphQL to WordPress friendly args array

--- a/src/Mutation/CommentCreate.php
+++ b/src/Mutation/CommentCreate.php
@@ -143,6 +143,10 @@ class CommentCreate {
 				throw new UserError( __( 'This site requires you to be logged in to leave a comment', 'wp-graphql' ) );
 			}
 
+			if ( '1' === get_option( 'require_name_email' ) && ( empty( $input['author'] ) || empty( $input['authorEmail'] ) ) ) {
+				throw new UserError( __( "This site requires you to provide a name and email address leave a comment", 'wp-graphql' ) );
+			} 
+
 			/**
 			 * Map all of the args from GraphQL to WordPress friendly args array
 			 */

--- a/src/Mutation/CommentCreate.php
+++ b/src/Mutation/CommentCreate.php
@@ -35,7 +35,9 @@ class CommentCreate {
 	public static function get_input_fields() {
 		return [
 			'commentOn'   => [
-				'type'        => 'Int',
+				'type'        => [
+					'non_null' => 'ID',
+				],
 				'description' => __( 'The ID of the post object the comment belongs to.', 'wp-graphql' ),
 			],
 			'author'      => [


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
1. Changed the `commentOn` type to by ID as it seems it should be. Given this is potentially a breaking change I can revert it if needed. 
2. Modified the Schema to correctly reflect what fields are required. 
3. Check for name/email when they are required in the discussion settings.

Does this close any currently open issues?
------------------------------------------

1 addresses #997

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …
Windows 10 /WSL
**WordPress Version:** …

5.7

I'll try my hand at tests here soon. I'll also see if I should modify related mutations to match.