### PR TITLE
Bugfix: Remove non-null from MenuItem path

### DIFF
--- a/src/Type/ObjectType/MenuItem.php
+++ b/src/Type/ObjectType/MenuItem.php
@@ -66,7 +66,7 @@ class MenuItem {
 						'description' => __( 'URL or destination of the menu item.', 'wp-graphql' ),
 					],
 					'path'             => [
-						'type'        => [ 'non_null' => 'String' ],
+						'type'        => 'String',
 						'description' => __( 'Path for the resource. Relative path for internal resources. Absolute path for external resources.', 'wp-graphql' ),
 					],
 					'isRestricted'     => [


### PR DESCRIPTION
From Wordpress it is possible to add a custom link without an URL.
When that happens GraphQL will throw `Cannot return null for non-nullable field \"MenuItem.path\".`.

<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [X] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [X] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
From Wordpress it is possible to add a custom link without an URL.
When that happens GraphQL will throw `Cannot return null for non-nullable field \"MenuItem.path\".`.


Does this close any currently open issues?
------------------------------------------


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
Cannot return null for non-nullable field "MenuItem.path".


Any other comments?
-------------------


Where has this been tested?
---------------------------
**Operating System: Linux

**WordPress Version: 5.7.1
