### PR TITLE
Add docs sidebar nav menu

### DIFF
--- a/docs/docs-nav-menu.yaml
+++ b/docs/docs-nav-menu.yaml
@@ -1,5 +1,5 @@
 - section:
-    name: Introduction
+    name: Getting Started
     items:
       -
           uri: /docs/introduction/

--- a/docs/docs-nav-menu.yaml
+++ b/docs/docs-nav-menu.yaml
@@ -1,0 +1,93 @@
+- section:
+    name: Introduction
+    items:
+      -
+          uri: /docs/introduction/
+          label: Introduction
+      -
+          uri: /docs/quick-start/
+- section:
+    name: Beginner Guides
+    items:
+      -
+          uri: /docs/intro-to-graphql/
+      -
+          uri: /docs/intro-to-wordpress/
+      -
+          uri: /docs/interacting-with-wpgraphql/
+      -
+          uri: /docs/build-your-first-wpgraphql-extension/
+      -
+          uri: /docs/wpgraphql-vs-wp-rest-api/
+- section:
+    name: Using WPGraphQL
+    items:
+      -
+          uri: /docs/posts-and-pages/
+      -
+          uri: /docs/custom-post-types/
+      -
+          uri: /docs/categories-and-tags/
+      -
+          uri: /docs/custom-taxonomies/
+      -
+          uri: /docs/media/
+      -
+          uri: /docs/menus/
+      -
+          uri: /docs/settings/
+      -
+          uri: /docs/users/
+      -
+          uri: /docs/comments/
+      -
+          uri: /docs/plugins/
+      -
+          uri: /docs/themes/
+      -
+          uri: /docs/widgets/
+- section:
+    name: Dig Deeper
+    items:
+      -
+          uri: /docs/wpgraphql-concepts/
+      -
+          uri: /docs/wordpress-as-an-application-data-graph/
+      -
+          uri: /docs/wpgraphql-request-lifecycle/
+      -
+          uri: /docs/default-types-and-fields/
+      -
+          uri: /docs/connections/
+      -
+          uri: /docs/interfaces/
+      -
+          uri: /docs/wpgraphql-mutations/
+      -
+          uri: /docs/graphql-resolvers/
+      -
+          uri: /docs/performance/
+      -
+          uri: /docs/security/
+      -
+          uri: /docs/authentication-and-authorization/
+      -
+          uri: /docs/hierarchical-data/
+      -
+          uri: /docs/debugging/
+      -
+          uri: /docs/using-data-from-custom-database-tables/
+      -
+          uri: /docs/use-with-php/
+- section:
+    name: Community
+    items:
+      -
+          uri: /docs/contributing/
+          label: How to Contribute
+      -
+          uri: /docs/testing/
+      -
+          uri: /docs/upgrading/
+      -
+          uri: /docs/faqs/

--- a/docs/docs-nav-menu.yaml
+++ b/docs/docs-nav-menu.yaml
@@ -1,93 +1,55 @@
 - section:
     name: Getting Started
     items:
-      -
-          uri: /docs/introduction/
-          label: Introduction
-      -
-          uri: /docs/quick-start/
+      - uri: /docs/introduction/
+        label: Introduction
+      - uri: /docs/quick-start/
 - section:
     name: Beginner Guides
     items:
-      -
-          uri: /docs/intro-to-graphql/
-      -
-          uri: /docs/intro-to-wordpress/
-      -
-          uri: /docs/interacting-with-wpgraphql/
-      -
-          uri: /docs/build-your-first-wpgraphql-extension/
-      -
-          uri: /docs/wpgraphql-vs-wp-rest-api/
+      - uri: /docs/intro-to-graphql/
+      - uri: /docs/intro-to-wordpress/
+      - uri: /docs/interacting-with-wpgraphql/
+      - uri: /docs/build-your-first-wpgraphql-extension/
+      - uri: /docs/wpgraphql-vs-wp-rest-api/
 - section:
     name: Using WPGraphQL
     items:
-      -
-          uri: /docs/posts-and-pages/
-      -
-          uri: /docs/custom-post-types/
-      -
-          uri: /docs/categories-and-tags/
-      -
-          uri: /docs/custom-taxonomies/
-      -
-          uri: /docs/media/
-      -
-          uri: /docs/menus/
-      -
-          uri: /docs/settings/
-      -
-          uri: /docs/users/
-      -
-          uri: /docs/comments/
-      -
-          uri: /docs/plugins/
-      -
-          uri: /docs/themes/
-      -
-          uri: /docs/widgets/
+      - uri: /docs/posts-and-pages/
+      - uri: /docs/custom-post-types/
+      - uri: /docs/categories-and-tags/
+      - uri: /docs/custom-taxonomies/
+      - uri: /docs/media/
+      - uri: /docs/menus/
+      - uri: /docs/settings/
+      - uri: /docs/users/
+      - uri: /docs/comments/
+      - uri: /docs/plugins/
+      - uri: /docs/themes/
+      - uri: /docs/widgets/
 - section:
     name: Dig Deeper
     items:
-      -
-          uri: /docs/wpgraphql-concepts/
-      -
-          uri: /docs/wordpress-as-an-application-data-graph/
-      -
-          uri: /docs/wpgraphql-request-lifecycle/
-      -
-          uri: /docs/default-types-and-fields/
-      -
-          uri: /docs/connections/
-      -
-          uri: /docs/interfaces/
-      -
-          uri: /docs/wpgraphql-mutations/
-      -
-          uri: /docs/graphql-resolvers/
-      -
-          uri: /docs/performance/
-      -
-          uri: /docs/security/
-      -
-          uri: /docs/authentication-and-authorization/
-      -
-          uri: /docs/hierarchical-data/
-      -
-          uri: /docs/debugging/
-      -
-          uri: /docs/using-data-from-custom-database-tables/
-      -
-          uri: /docs/use-with-php/
+      - uri: /docs/wpgraphql-concepts/
+      - uri: /docs/wordpress-as-an-application-data-graph/
+      - uri: /docs/wpgraphql-request-lifecycle/
+      - uri: /docs/default-types-and-fields/
+      - uri: /docs/connections/
+      - uri: /docs/interfaces/
+      - uri: /docs/wpgraphql-mutations/
+      - uri: /docs/graphql-resolvers/
+      - uri: /docs/performance/
+      - uri: /docs/security/
+      - uri: /docs/authentication-and-authorization/
+      - uri: /docs/hierarchical-data/
+      - uri: /docs/debugging/
+      - uri: /docs/using-data-from-custom-database-tables/
+      - uri: /docs/use-with-php/
 - section:
     name: Community
     items:
-      -
-          uri: /docs/contributing/
-          label: How to Contribute
-      -
-          uri: /docs/testing/
-      -
-          uri: /docs/upgrading/
-      -
-          uri: /docs/faqs/
+      - uri: /docs/contributing/
+        label: How to Contribute
+      - uri: /docs/testing/
+      - uri: /docs/upgrading/
+      - uri: /docs/faqs/


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Sidebar navigation in wpgraphql.com is in the WP content right now. Includes sections, labels/titles, links to docs and order for pagination.  Putting that in this yaml file to specify order of that sidebar name as well as the optional text label.


Does this close any currently open issues?
------------------------------------------
https://github.com/orgs/wp-graphql/projects/8#card-59867799


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
