### PR TITLE
Bugfix: Provide correctly-formatted modified date

### DIFF
--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -639,7 +639,7 @@ class Post extends Model {
 					return ! empty( $punged ) ? implode( ',', (array) $punged ) : null;
 				},
 				'modified'                  => function() {
-					return ! empty( $this->data->post_modified ) && '0000-00-00 00:00:00' !== $this->data->post_modified ? $this->data->post_modified : null;
+					return ! empty( $this->data->post_modified ) && '0000-00-00 00:00:00' !== $this->data->post_modified ? Utils::prepare_date_response( $this->data->post_modified ) : null;
 				},
 				'modifiedGmt'               => function() {
 					return ! empty( $this->data->post_modified_gmt ) ? Utils::prepare_date_response( $this->data->post_modified_gmt ) : null;


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Currently, the modified date is passed straight from the model layer (MySQL `DATETIME`). Wrap in `Utils::prepare_date_response` to make it consistent with other date fields.

Does this close any currently open issues?
------------------------------------------
Fixes #1696.


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
https://wp-graphql.slack.com/archives/C3NM1M291/p1619813145455500


Any other comments?
-------------------



Where has this been tested?
---------------------------
**Operating System:** Debian

**WordPress Version:** 5.7.1
