### PR TITLE
#1882 - Fix regression to register_graphql_connection

### DIFF
--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -1091,7 +1091,7 @@ class TypeRegistry {
 		 */
 		if ( ! empty( $connection_args ) ) {
 
-			register_graphql_input_type(
+			$this->register_input_type(
 				$connection_name . 'WhereArgs',
 				[
 					// Translators: Placeholder is the name of the connection
@@ -1112,7 +1112,7 @@ class TypeRegistry {
 
 		if ( true === $one_to_one ) {
 
-			register_graphql_object_type(
+			$this->register_object_type(
 				$connection_name . 'Edge',
 				[
 					'description' => sprintf( __( 'Connection between the %1$s type and the %2$s type', 'wp-graphql' ), $from_type, $to_type ),
@@ -1130,7 +1130,7 @@ class TypeRegistry {
 
 		} else {
 
-			register_graphql_object_type(
+			$this->register_object_type(
 				$connection_name . 'Edge',
 				[
 					'description' => __( 'An edge in a connection', 'wp-graphql' ),
@@ -1158,7 +1158,7 @@ class TypeRegistry {
 				]
 			);
 
-			register_graphql_object_type(
+			$this->register_object_type(
 				$connection_name,
 				[
 					// Translators: the placeholders are the name of the Types the connection is between.
@@ -1227,7 +1227,7 @@ class TypeRegistry {
 			];
 		}
 
-		register_graphql_field(
+		$this->register_field(
 			$from_type,
 			$from_field_name,
 			[

--- a/tests/wpunit/TypesTest.php
+++ b/tests/wpunit/TypesTest.php
@@ -267,4 +267,44 @@ class TypesTest extends \Codeception\TestCase\WPTestCase {
 
 	}
 
+	public function testRegisterCustomConnection() {
+
+		add_action( 'graphql_register_types', function() {
+			register_graphql_type( 'TestCustomType', [
+				'fields' => [
+					'test' => [
+						'type' => 'String'
+					]
+				]
+			]);
+
+			register_graphql_connection([
+				'fromType' => 'RootQuery',
+				'toType' => 'TestCustomType',
+				'fromFieldName' => 'customTestConnection',
+				'resolve' => function() {
+					return null;
+				}
+			]);
+
+		});
+
+		$query = '
+		{
+		  customTestConnection {
+		    nodes {
+		      test
+		    }
+		  }
+		}
+		';
+
+		$actual = graphql([
+			'query' => $query,
+		]);
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+
+	}
+
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This fixes a regression to the `register_graphql_connection` access function which was causing some custom connections to not be shown in the Schema. 


Does this close any currently open issues?
------------------------------------------
Closes #1882
Closes #1883