### PR TITLE
Release/v1.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.3.7
+
+### Chores / Bugfixes
+
+- ([#1885](https://github.com/wp-graphql/wp-graphql/pull/1885)): Fixes regression to `register_graphql_connection` that was breaking custom connections registered by 3rd party plugins. 
+
 ## 1.3.6
 
 ### Chores / Bugfixes

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, API, Gatsby, Headless, Decoupled, React, Nextjs, Vue, Apollo, RES
 Requires at least: 5.0
 Tested up to: 5.6
 Requires PHP: 7.1
-Stable tag: 1.3.6
+Stable tag: 1.3.7
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -82,6 +82,13 @@ Gatsby and WP Engine both believe that a strong GraphQL API for WordPress is a b
 Composer dependencies are no longer versioned in Github. Recommended install source is WordPress.org or using Composer to get the code from Packagist.org or WPackagist.org.
 
 == Changelog ==
+
+= 1.3.7 =
+
+**Chores / Bugfixes**
+
+- ([#1885](https://github.com/wp-graphql/wp-graphql/pull/1885)): Fixes regression to `register_graphql_connection` that was breaking custom connections registered by 3rd party plugins.
+
 
 = 1.3.6 =
 

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -1091,7 +1091,7 @@ class TypeRegistry {
 		 */
 		if ( ! empty( $connection_args ) ) {
 
-			register_graphql_input_type(
+			$this->register_input_type(
 				$connection_name . 'WhereArgs',
 				[
 					// Translators: Placeholder is the name of the connection
@@ -1112,7 +1112,7 @@ class TypeRegistry {
 
 		if ( true === $one_to_one ) {
 
-			register_graphql_object_type(
+			$this->register_object_type(
 				$connection_name . 'Edge',
 				[
 					'description' => sprintf( __( 'Connection between the %1$s type and the %2$s type', 'wp-graphql' ), $from_type, $to_type ),
@@ -1130,7 +1130,7 @@ class TypeRegistry {
 
 		} else {
 
-			register_graphql_object_type(
+			$this->register_object_type(
 				$connection_name . 'Edge',
 				[
 					'description' => __( 'An edge in a connection', 'wp-graphql' ),
@@ -1158,7 +1158,7 @@ class TypeRegistry {
 				]
 			);
 
-			register_graphql_object_type(
+			$this->register_object_type(
 				$connection_name,
 				[
 					// Translators: the placeholders are the name of the Types the connection is between.
@@ -1227,7 +1227,7 @@ class TypeRegistry {
 			];
 		}
 
-		register_graphql_field(
+		$this->register_field(
 			$from_type,
 			$from_field_name,
 			[

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -125,7 +125,7 @@ final class WPGraphQL {
 
 		// Plugin version.
 		if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-			define( 'WPGRAPHQL_VERSION', '1.3.6' );
+			define( 'WPGRAPHQL_VERSION', '1.3.7' );
 		}
 
 		// Plugin Folder Path.

--- a/tests/wpunit/TypesTest.php
+++ b/tests/wpunit/TypesTest.php
@@ -267,4 +267,52 @@ class TypesTest extends \Codeception\TestCase\WPTestCase {
 
 	}
 
+	/**
+	 * This test ensures that connections registered at `graphql_register_types` action are
+	 * respected in the Schema.
+	 *
+	 * @throws Exception
+	 * @see: https://github.com/wp-graphql/wp-graphql/issues/1882
+	 * @see: https://github.com/wp-graphql/wp-graphql/issues/1883
+	 */
+	public function testRegisterCustomConnection() {
+
+		add_action( 'graphql_register_types', function() {
+			register_graphql_type( 'TestCustomType', [
+				'fields' => [
+					'test' => [
+						'type' => 'String'
+					]
+				]
+			]);
+
+			register_graphql_connection([
+				'fromType' => 'RootQuery',
+				'toType' => 'TestCustomType',
+				'fromFieldName' => 'customTestConnection',
+				'resolve' => function() {
+					return null;
+				}
+			]);
+
+		});
+
+		$query = '
+		{
+		  customTestConnection {
+		    nodes {
+		      test
+		    }
+		  }
+		}
+		';
+
+		$actual = graphql([
+			'query' => $query,
+		]);
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+
+	}
+
 }

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.3.6
+ * Version: 1.3.7
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.3.6
+ * @version  1.3.7
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
# Release Notes

## Chores / Bugfixes

- ([#1885](https://github.com/wp-graphql/wp-graphql/pull/1885)): Fixes regression to `register_graphql_connection` that was breaking custom connections registered by 3rd party plugins. 
