### PR TITLE
Bug/fail fast for batch queries

### DIFF
--- a/src/Admin/Settings/Settings.php
+++ b/src/Admin/Settings/Settings.php
@@ -129,6 +129,13 @@ class Settings {
 				'default' => 'on',
 			],
 			[
+				'name'    => 'batch_limit',
+				'label'   => __( 'Batch Query Limit', 'wp-graphql' ),
+				'desc'    => __( 'If Batch Queries are enabled, this value sets the max number of batch operations to allow per request. Requests containing more batch operations than allowed will be rejected before execution.', 'wp-graphql' ),
+				'type'    => 'number',
+				'default' => 10,
+			],
+			[
 				'name'    => 'query_depth_enabled',
 				'label'   => __( 'Enable Query Depth Limiting', 'wp-graphql' ),
 				'desc'    => __( 'Enabling this will limit the depth of queries WPGraphQL will execute using the value of the Max Depth setting.', 'wp-graphql' ),

--- a/src/Request.php
+++ b/src/Request.php
@@ -4,6 +4,8 @@ namespace WPGraphQL;
 
 use Exception;
 use GraphQL\Error\DebugFlag;
+use GraphQL\Error\Error;
+use GraphQL\Error\UserError;
 use GraphQL\GraphQL;
 use GraphQL\Server\OperationParams;
 use GraphQL\Server\ServerConfig;
@@ -216,6 +218,7 @@ class Request {
 	 * Apply filters and do actions before GraphQL execution
 	 *
 	 * @return void
+	 * @throws Error
 	 */
 	private function before_execute() {
 
@@ -243,6 +246,9 @@ class Request {
 		 * If the request is a batch request it will come back as an array
 		 */
 		if ( is_array( $this->params ) ) {
+			if ( ! $this->is_batch_queries_enabled() ) {
+				throw new Error( __( 'Batch Queries are not supported', 'wp-graphql' ) );
+			}
 			array_walk( $this->params, [ $this, 'do_action' ] );
 		} else {
 			$this->do_action( $this->params );

--- a/src/Request.php
+++ b/src/Request.php
@@ -5,7 +5,6 @@ namespace WPGraphQL;
 use Exception;
 use GraphQL\Error\DebugFlag;
 use GraphQL\Error\Error;
-use GraphQL\Error\UserError;
 use GraphQL\GraphQL;
 use GraphQL\Server\OperationParams;
 use GraphQL\Server\ServerConfig;
@@ -182,9 +181,9 @@ class Request {
 
 		$validation_rules = GraphQL::getStandardValidationRules();
 
-		$validation_rules[] = new RequireAuthentication();
-		$validation_rules[] = new DisableIntrospection();
-		$validation_rules[] = new QueryDepth();
+		$validation_rules['require_authentication'] = new RequireAuthentication();
+		$validation_rules['disable_introspection']  = new DisableIntrospection();
+		$validation_rules['query_depth']            = new QueryDepth();
 
 		/**
 		 * Return the validation rules to use in the request
@@ -246,10 +245,33 @@ class Request {
 		 * If the request is a batch request it will come back as an array
 		 */
 		if ( is_array( $this->params ) ) {
+
+			// If the request is a batch request, but batch requests are disabled,
+			// bail early
 			if ( ! $this->is_batch_queries_enabled() ) {
 				throw new Error( __( 'Batch Queries are not supported', 'wp-graphql' ) );
 			}
+
+			$batch_limit = get_graphql_setting( 'batch_limit', 10 );
+			$batch_limit = absint( $batch_limit ) ? absint( $batch_limit ) : 10;
+
+			// If batch requests are enabled, but a limit is set and the request exceeds the limit
+			// fail now
+			if ( $batch_limit < count( $this->params ) ) {
+				// translators: First placeholder is the max number of batch operations allowed in a GraphQL request. The 2nd placeholder is the number of operations requested in the current request.
+				throw new Error( sprintf( __( 'Batch requests are limited to %1$d operations. This request contained %2$d', 'wp-graphql' ), absint( $batch_limit ), count( $this->params ) ) );
+			}
+
+			/**
+			 * Execute batch queries
+			 *
+			 * @param OperationParams[] $params The operation params of the batch request
+			 */
+			do_action( 'graphql_execute_batch_queries', $this->params );
+
+			// Process the batched requests
 			array_walk( $this->params, [ $this, 'do_action' ] );
+
 		} else {
 			$this->do_action( $this->params );
 		}
@@ -462,7 +484,7 @@ class Request {
 			if ( is_array( $response ) ) {
 				$response['extensions']['debug'] = $this->debug_log->get_logs();
 			} else {
-				$response->extensions = [ 'debug' => $this->debug_log->get_logs() ];
+				$response->extensions['debug'] = $this->debug_log->get_logs();
 			}
 		}
 

--- a/tests/functional/BatchQueriesDisabledCept.php
+++ b/tests/functional/BatchQueriesDisabledCept.php
@@ -22,7 +22,7 @@ $I->sendPost( 'http://localhost/graphql', json_encode([
 	]
 ]));
 
-$I->seeResponseCodeIs( 200 );
+$I->seeResponseCodeIs( 500 );
 $I->seeResponseIsJson();
 $response       = $I->grabResponse();
 $response_array = json_decode( $response, true );


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This adds a setting to let WordPress administrators set the max limit of batch operations to allow when Batch Queries are enabled. 

![Screen Shot 2021-05-05 at 2 31 01 PM](https://user-images.githubusercontent.com/1260765/117205197-86a7f100-adae-11eb-95e7-3418e4a6241c.png)

This also adjusts batch queries to fail fast if batch queries are disabled or the request contains more batch operations than allowed. 

Previously the batch would attempt to execute and each request within the batch would need to be validated and failed, now the entire request fails early.


Does this close any currently open issues?
------------------------------------------
Closes #1894 
Closes $1895


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

**BEFORE:**
Each operation in the request would be validated for failure:

![Screen Shot 2021-05-05 at 2 33 02 PM](https://user-images.githubusercontent.com/1260765/117205512-f4541d00-adae-11eb-9b65-47189d16b7c1.png)


**AFTER:**

The request fails early, before each operation is validated:

![Screen Shot 2021-05-05 at 2 33 08 PM](https://user-images.githubusercontent.com/1260765/117205399-d1c20400-adae-11eb-8dc1-382840de4d1a.png)

