### PR TITLE
Allowing extensions to support `nodeByUri`

### DIFF
--- a/access-functions.php
+++ b/access-functions.php
@@ -332,9 +332,9 @@ function rename_graphql_type( string $type_name, string $new_type_name ) {
 	add_filter(
 		'graphql_type_name',
 		function( $name ) use ( $type_name, $new_type_name ) {
-            if ( $name === $type_name ) {
-                return $new_type_name;
-            }
+			if ( $name === $type_name ) {
+				return $new_type_name;
+			}
 			return $name;
 		}
 	);

--- a/src/AppContext.php
+++ b/src/AppContext.php
@@ -176,9 +176,8 @@ class AppContext {
 	/**
 	 * Returns the $args for the connection the field is a part of
 	 *
-	 * @return array|mixed
-	 *
 	 * @deprecated use get_connection_args() instead
+	 * @return array|mixed
 	 */
 	public function getConnectionArgs() {
 		return $this->get_connection_args();

--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -305,10 +305,10 @@ class NodeResolver {
 		/**
 		 * When this filter return anything other than null, it will be used as a resolved node
 		 * and the execution will be skipped.
-		 * 
-		 * This is to be used in extensions to resolve their own nodes which might not use 
+		 *
+		 * This is to be used in extensions to resolve their own nodes which might not use
 		 * WordPress permalink structure.
-		 * 
+		 *
 		 * @param null $node The node, defaults to nothing.
 		 * @param string $uri The uri being searched.
 		 * @param AppContext $content The app context.

--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -302,7 +302,23 @@ class NodeResolver {
 
 		do_action_ref_array( 'parse_request', [ &$this ] );
 
-		$node = null;
+		/**
+		 * When this filter return anything other than null, it will be used as a resolved node
+		 * and the execution will be skipped.
+		 * 
+		 * This is to be used in extensions to resolve their own nodes which might not use 
+		 * WordPress permalink structure.
+		 * 
+		 * @param null $node The node, defaults to nothing.
+		 * @param string $uri The uri being searched.
+		 * @param AppContext $content The app context.
+		 * @param WP $wo WP object.
+		 */
+		$node = apply_filters( 'graphql_pre_resolve_uri', null, $uri, $this->context, $this->wp );
+
+		if ( ! empty( $node ) && ! is_null( $node ) ) {
+			return $node;
+		}
 
 		// If the request is for the homepage, determine
 		if ( '/' === $uri ) {
@@ -418,7 +434,5 @@ class NodeResolver {
 		}
 
 		return $node;
-
 	}
-
 }

--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -45,6 +45,24 @@ class NodeResolver {
 	 */
 	public function resolve_uri( string $uri, $extra_query_vars = '' ) {
 
+		/**
+		 * When this filter return anything other than null, it will be used as a resolved node
+		 * and the execution will be skipped.
+		 *
+		 * This is to be used in extensions to resolve their own nodes which might not use
+		 * WordPress permalink structure.
+		 *
+		 * @param null $node The node, defaults to nothing.
+		 * @param string $uri The uri being searched.
+		 * @param AppContext $content The app context.
+		 * @param WP $wp WP object.
+		 */
+		$node = apply_filters( 'graphql_pre_resolve_uri', null, $uri, $this->context, $this->wp );
+
+		if ( ! empty( $node ) ) {
+			return $node;
+		}
+
 		global $wp_rewrite;
 
 		$parsed_url = wp_parse_url( $uri );
@@ -301,24 +319,6 @@ class NodeResolver {
 		unset( $this->wp->query_vars['graphql'] );
 
 		do_action_ref_array( 'parse_request', [ &$this ] );
-
-		/**
-		 * When this filter return anything other than null, it will be used as a resolved node
-		 * and the execution will be skipped.
-		 *
-		 * This is to be used in extensions to resolve their own nodes which might not use
-		 * WordPress permalink structure.
-		 *
-		 * @param null $node The node, defaults to nothing.
-		 * @param string $uri The uri being searched.
-		 * @param AppContext $content The app context.
-		 * @param WP $wo WP object.
-		 */
-		$node = apply_filters( 'graphql_pre_resolve_uri', null, $uri, $this->context, $this->wp );
-
-		if ( ! empty( $node ) && ! is_null( $node ) ) {
-			return $node;
-		}
 
 		// If the request is for the homepage, determine
 		if ( '/' === $uri ) {

--- a/src/Mutation/MediaItemCreate.php
+++ b/src/Mutation/MediaItemCreate.php
@@ -3,7 +3,6 @@
 namespace WPGraphQL\Mutation;
 
 use Exception;
-use GraphQL\Deferred;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -220,8 +220,8 @@ class TypeRegistry {
 		Node::register_type();
 		CommenterInterface::register_type( $type_registry );
 		ContentNode::register_type( $type_registry );
-		ContentTemplate::register_type( $type_registry );
-		DatabaseIdentifier::register_type( $type_registry );
+		ContentTemplate::register_type();
+		DatabaseIdentifier::register_type();
 		EnqueuedAsset::register_type( $type_registry );
 		HierarchicalTermNode::register_type( $type_registry );
 		HierarchicalContentNode::register_type( $type_registry );

--- a/src/Type/InterfaceType/ContentTemplate.php
+++ b/src/Type/InterfaceType/ContentTemplate.php
@@ -2,18 +2,14 @@
 
 namespace WPGraphQL\Type\InterfaceType;
 
-use WPGraphQL\Registry\TypeRegistry;
-
 class ContentTemplate {
 
 	/**
 	 * Register the ContentTemplate Interface
 	 *
-	 * @param TypeRegistry $type_registry
-	 *
 	 * @return void
 	 */
-	public static function register_type( TypeRegistry $type_registry ) {
+	public static function register_type() {
 		register_graphql_interface_type(
 			'ContentTemplate',
 			[

--- a/src/Type/InterfaceType/DatabaseIdentifier.php
+++ b/src/Type/InterfaceType/DatabaseIdentifier.php
@@ -1,7 +1,6 @@
 <?php
 
 namespace WPGraphQL\Type\InterfaceType;
-use WPGraphQL\Registry\TypeRegistry;
 
 /**
  * Class DatabaseIdentifier
@@ -11,13 +10,11 @@ use WPGraphQL\Registry\TypeRegistry;
 class DatabaseIdentifier {
 
 	/**
-	 * Register the DatabaseIdentifier Interface
-	 *
-	 * @param TypeRegistry $type_registry
+	 * Register the DatabaseIdentifier Interface.
 	 *
 	 * @return void
 	 */
-	public static function register_type( TypeRegistry $type_registry ) {
+	public static function register_type() {
 
 		register_graphql_interface_type( 'DatabaseIdentifier', [
 			'description' => __( 'Object that can be identified with a Database ID', 'wp-graphql' ),
@@ -28,7 +25,5 @@ class DatabaseIdentifier {
 				],
 			],
 		]);
-
 	}
-
 }

--- a/src/Type/InterfaceType/Node.php
+++ b/src/Type/InterfaceType/Node.php
@@ -17,9 +17,7 @@ class Node {
 				'description' => __( 'An object with an ID', 'wp-graphql' ),
 				'fields'      => [
 					'id' => [
-						'type'        => [
-							'non_null' => 'ID',
-						],
+						'type'        => [ 'non_null' => 'ID' ],
 						'description' => __( 'The globally unique ID for the object', 'wp-graphql' ),
 					],
 				],

--- a/src/Type/InterfaceType/UniformResourceIdentifiable.php
+++ b/src/Type/InterfaceType/UniformResourceIdentifiable.php
@@ -16,7 +16,6 @@ class UniformResourceIdentifiable {
 	 * Registers the UniformResourceIdentifiable Interface to the Schema.
 	 *
 	 * @param TypeRegistry $type_registry
-	 *
 	 * @return void
 	 */
 	public static function register_type( TypeRegistry $type_registry ) {
@@ -57,8 +56,14 @@ class UniformResourceIdentifiable {
 							$type = null;
 					}
 
-					return $type;
-
+					/**
+					 * Filter the UniformResourceIdentifiable node type.
+					 *
+					 * @param null|string $type The type definition the node should resolve to.
+					 * @param object $node The $node that is being resolved.
+					 * @param TypeRegistry $type_registry The type registry.
+					 */
+					return apply_filters( 'graphql_resolve_uniform_resource_identifiable_node_type', $type, $node, $type_registry );
 				},
 			]
 		);

--- a/src/Type/InterfaceType/UniformResourceIdentifiable.php
+++ b/src/Type/InterfaceType/UniformResourceIdentifiable.php
@@ -56,14 +56,7 @@ class UniformResourceIdentifiable {
 							$type = null;
 					}
 
-					/**
-					 * Filter the UniformResourceIdentifiable node type.
-					 *
-					 * @param null|string $type The type definition the node should resolve to.
-					 * @param object $node The $node that is being resolved.
-					 * @param TypeRegistry $type_registry The type registry.
-					 */
-					return apply_filters( 'graphql_resolve_uniform_resource_identifiable_node_type', $type, $node, $type_registry );
+					return $type;
 				},
 			]
 		);

--- a/src/Type/ObjectType/RootQuery.php
+++ b/src/Type/ObjectType/RootQuery.php
@@ -266,8 +266,7 @@ class RootQuery {
 								'description' => __( 'Type of unique identifier to fetch a menu item by. Default is Global ID', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function( $source, array $args, AppContext $context) {
-
+						'resolve'     => function( $source, array $args, AppContext $context ) {
 							$id_type = isset( $args['idType'] ) ? $args['idType'] : 'id';
 
 							switch ( $id_type ) {

--- a/src/Type/ObjectType/RootQuery.php
+++ b/src/Type/ObjectType/RootQuery.php
@@ -199,7 +199,7 @@ class RootQuery {
 								'description' => __( 'Unique Resource Identifier in the form of a path or permalink for a node. Ex: "/hello-world"', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function( $root, $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => function( $root, $args, AppContext $context ) {
 							return ! empty( $args['uri'] ) ? $context->node_resolver->resolve_uri( $args['uri'] ) : null;
 						},
 					],
@@ -218,7 +218,7 @@ class RootQuery {
 								'description' => __( 'Type of unique identifier to fetch a menu by. Default is Global ID', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function( $source, array $args, AppContext $context, $info ) {
+						'resolve'     => function( $source, array $args, AppContext $context ) {
 
 							$id_type = isset( $args['idType'] ) ? $args['idType'] : 'id';
 
@@ -266,7 +266,7 @@ class RootQuery {
 								'description' => __( 'Type of unique identifier to fetch a menu item by. Default is Global ID', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function( $source, array $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => function( $source, array $args, AppContext $context) {
 
 							$id_type = isset( $args['idType'] ) ? $args['idType'] : 'id';
 
@@ -298,7 +298,7 @@ class RootQuery {
 								'description' => __( 'The globally unique identifier of the plugin.', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function( $source, array $args, AppContext $context, $info ) {
+						'resolve'     => function( $source, array $args, AppContext $context ) {
 							$id_components = Relay::fromGlobalId( $args['id'] );
 
 							return ! empty( $id_components['id'] ) ? $context->get_loader( 'plugin' )->load_deferred( $id_components['id'] ) : null;
@@ -323,7 +323,7 @@ class RootQuery {
 								'description' => __( 'The taxonomy of the tern node. Required when idType is set to "name" or "slug"', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function( $root, $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => function( $root, $args, AppContext $context ) {
 
 							$idType  = isset( $args['idType'] ) ? $args['idType'] : 'global_id';
 							$term_id = null;
@@ -379,7 +379,7 @@ class RootQuery {
 								'description' => __( 'The globally unique identifier of the theme.', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function( $source, array $args, $context, $info ) {
+						'resolve'     => function( $source, array $args ) {
 							$id_components = Relay::fromGlobalId( $args['id'] );
 
 							return DataSource::resolve_theme( $id_components['id'] );
@@ -400,7 +400,7 @@ class RootQuery {
 								'description' => __( 'Type of unique identifier to fetch a user by. Default is Global ID', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function( $source, array $args, $context, $info ) {
+						'resolve'     => function( $source, array $args, $context ) {
 
 							$idType = isset( $args['idType'] ) ? $args['idType'] : 'id';
 
@@ -457,7 +457,7 @@ class RootQuery {
 								'description' => __( 'The globally unique identifier of the user object.', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function( $source, array $args, $context, $info ) {
+						'resolve'     => function( $source, array $args ) {
 
 							$id_components = Relay::fromGlobalId( $args['id'] );
 
@@ -468,7 +468,7 @@ class RootQuery {
 					'viewer'      => [
 						'type'        => 'User',
 						'description' => __( 'Returns the current user', 'wp-graphql' ),
-						'resolve'     => function( $source, array $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => function( $source, array $args, AppContext $context ) {
 							return isset( $context->viewer->ID ) && ! empty( $context->viewer->ID ) ? DataSource::resolve_user( $context->viewer->ID, $context ) : null;
 						},
 					],
@@ -515,7 +515,7 @@ class RootQuery {
 								'description' => __( 'Whether to return the node as a preview instance', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function( $source, array $args, AppContext $context, ResolveInfo $info ) use ( $post_type_object ) {
+						'resolve'     => function( $source, array $args, AppContext $context ) use ( $post_type_object ) {
 
 							$idType  = isset( $args['idType'] ) ? $args['idType'] : 'global_id';
 							$post_id = null;
@@ -617,7 +617,7 @@ class RootQuery {
 						'deprecationReason' => __( 'Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: "" ), use post(id: "" idType: "")', 'wp-graphql' ),
 						'description'       => sprintf( __( 'A %s object', 'wp-graphql' ), $post_type_object->graphql_single_name ),
 						'args'              => $post_by_args,
-						'resolve'           => function( $source, array $args, $context, $info ) use ( $post_type_object ) {
+						'resolve'           => function( $source, array $args, $context ) use ( $post_type_object ) {
 							$post_object = null;
 							$post_id     = 0;
 							if ( ! empty( $args['id'] ) ) {

--- a/src/Type/Union/PostObjectUnion.php
+++ b/src/Type/Union/PostObjectUnion.php
@@ -10,7 +10,6 @@ class PostObjectUnion {
 	 * Registers the Type
 	 *
 	 * @param TypeRegistry $type_registry
-	 *
 	 * @return void
 	 */
 	public static function register_type( TypeRegistry $type_registry ) {
@@ -41,7 +40,7 @@ class PostObjectUnion {
 	 *
 	 * @return array
 	 */
-	public static function get_possible_types() {
+	public static function get_possible_types(): array {
 		$possible_types     = [];
 		$allowed_post_types = \WPGraphQL::get_allowed_post_types();
 
@@ -58,5 +57,4 @@ class PostObjectUnion {
 
 		return $possible_types;
 	}
-
 }

--- a/src/Type/Union/PostObjectUnion.php
+++ b/src/Type/Union/PostObjectUnion.php
@@ -40,7 +40,7 @@ class PostObjectUnion {
 	 *
 	 * @return array
 	 */
-	public static function get_possible_types(): array {
+	public static function get_possible_types() {
 		$possible_types     = [];
 		$allowed_post_types = \WPGraphQL::get_allowed_post_types();
 

--- a/src/Utils/InstrumentSchema.php
+++ b/src/Utils/InstrumentSchema.php
@@ -9,7 +9,6 @@ use GraphQL\Type\Definition\FieldDefinition;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
-use WPGraphQL\Type\WPObjectType;
 use WPGraphQL\WPSchema;
 
 /**

--- a/src/WPSchema.php
+++ b/src/WPSchema.php
@@ -5,7 +5,6 @@ namespace WPGraphQL;
 use GraphQL\Type\Schema;
 use GraphQL\Type\SchemaConfig;
 
-
 /**
  * Class WPSchema
  *


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This adds two hooks allowing extensions to resolve their nodes when using `nodeByUri`.


Does this close any currently open issues?
------------------------------------------
no!

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

![Screen Shot 2021-05-09 at 19 58 19](https://user-images.githubusercontent.com/19148962/117589598-eaa91d00-b100-11eb-98d8-bb5fc9b42bad.png)


Any other comments?
-------------------
I also did a minor cleanup while I was browsing around the codebase.

Just for reference, here is where I'm using it: https://github.com/wp-graphql/wp-graphql-buddypress/issues/77


Where has this been tested?
---------------------------
**Operating System:** MacOS Big Sur 11.3

**WordPress Version:** Version 5.7.1
