### PR TITLE
Release v1.3.10

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches:
       - develop
+      - master
 
 jobs:
   run:

--- a/.github/workflows/schema-linter.yml
+++ b/.github/workflows/schema-linter.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     branches:
       - develop
-
+      - master
 jobs:
   run:
     runs-on: ubuntu-latest

--- a/.github/workflows/testing-integration.yml
+++ b/.github/workflows/testing-integration.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches:
       - develop
+      - master
     paths:
       - '**.php'
       - '.github/workflows/*.yml'

--- a/.github/workflows/wordpress-coding-standards.yml
+++ b/.github/workflows/wordpress-coding-standards.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     branches:
       - develop
-
+      - master
 jobs:
   run:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 1.3.10
+
+### Chores / Bugfixes
+
+- ([#1940](https://github.com/wp-graphql/wp-graphql/pull/1940)): Adds Breaking Change inspector to run on new Pull Requests. Thanks @markkelnar!
+- ([#1937](https://github.com/wp-graphql/wp-graphql/pull/1937)): Fixed typo in documentation. Thanks @LeonardoDB!
+- ([#1923](https://github.com/wp-graphql/wp-graphql/issues/1923)): Fixed bug where User Model didn't support the databaseId field
+
+## New Features
+
+- ([#1938](https://github.com/wp-graphql/wp-graphql/pull/1938)): Adds new functionality to the `register_graphql_connection()` API. Thanks @kidunot89!
+
+
 ## 1.3.9
 
 ### Chores / Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - ([#1937](https://github.com/wp-graphql/wp-graphql/pull/1937)): Fixed typo in documentation. Thanks @LeonardoDB!
 - ([#1923](https://github.com/wp-graphql/wp-graphql/issues/1923)): Fixed bug where User Model didn't support the databaseId field
 
-## New Features
+### New Features
 
 - ([#1938](https://github.com/wp-graphql/wp-graphql/pull/1938)): Adds new functionality to the `register_graphql_connection()` API. Thanks @kidunot89!
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, API, Gatsby, Headless, Decoupled, React, Nextjs, Vue, Apollo, RES
 Requires at least: 5.0
 Tested up to: 5.6
 Requires PHP: 7.1
-Stable tag: 1.3.9
+Stable tag: 1.3.10
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -82,6 +82,18 @@ Gatsby and WP Engine both believe that a strong GraphQL API for WordPress is a b
 Composer dependencies are no longer versioned in Github. Recommended install source is WordPress.org or using Composer to get the code from Packagist.org or WPackagist.org.
 
 == Changelog ==
+
+= 1.3.10 =
+
+**Chores / Bugfixes**
+
+- ([#1940](https://github.com/wp-graphql/wp-graphql/pull/1940)): Adds Breaking Change inspector to run on new Pull Requests. Thanks @markkelnar!
+- ([#1937](https://github.com/wp-graphql/wp-graphql/pull/1937)): Fixed typo in documentation. Thanks @LeonardoDB!
+- ([#1923](https://github.com/wp-graphql/wp-graphql/issues/1923)): Fixed bug where User Model didn't support the databaseId field
+
+**New Features**
+
+- ([#1938](https://github.com/wp-graphql/wp-graphql/pull/1938)): Adds new functionality to the `register_graphql_connection()` API. Thanks @kidunot89!
 
 = 1.3.9 =
 

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -12,6 +12,7 @@ use WPGraphQL;
  * Class User - Models the data for the User object type
  *
  * @property string $id
+ * @property int    $databaseId
  * @property array  $capabilities
  * @property string $capKey
  * @property array  $roles
@@ -76,6 +77,7 @@ class User extends Model {
 			'isRestricted',
 			'id',
 			'userId',
+			'databaseId',
 			'name',
 			'firstName',
 			'lastName',
@@ -172,6 +174,9 @@ class User extends Model {
 			$this->fields = [
 				'id'                       => function() {
 					return ( ! empty( $this->data->ID ) ) ? Relay::toGlobalId( 'user', (string) $this->data->ID ) : null;
+				},
+				'databaseId'               => function() {
+					return $this->userId;
 				},
 				'capabilities'             => function() {
 					if ( ! empty( $this->data->allcaps ) ) {

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -125,7 +125,7 @@ final class WPGraphQL {
 
 		// Plugin version.
 		if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-			define( 'WPGRAPHQL_VERSION', '1.3.9' );
+			define( 'WPGRAPHQL_VERSION', '1.3.10' );
 		}
 
 		// Plugin Folder Path.

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.3.9
+ * Version: 1.3.10
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.3.9
+ * @version  1.3.10
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
## Chores / Bugfixes

- ([#1940](https://github.com/wp-graphql/wp-graphql/pull/1940)): Adds Breaking Change inspector to run on new Pull Requests. Thanks @markkelnar!
- ([#1937](https://github.com/wp-graphql/wp-graphql/pull/1937)): Fixed typo in documentation. Thanks @LeonardoDB!
- ([#1923](https://github.com/wp-graphql/wp-graphql/issues/1923)): Fixed bug where User Model didn't support the databaseId field

## New Features

- ([#1938](https://github.com/wp-graphql/wp-graphql/pull/1938)): Adds new functionality to the `register_graphql_connection()` API. Thanks @kidunot89!
