### PR TITLE
Scrub registered settings group names

### DIFF
--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -376,6 +376,22 @@ class DataSource {
 	}
 
 	/**
+	 * Format the setting group name to our standard.
+	 *
+	 * @param string $group
+	 *
+	 * @return string $group
+	 */
+	public static function format_group_name( string $group ) {
+		$group = lcfirst( preg_replace( '[^a-zA-Z0-9 -]', ' ', $group ) );
+		$group = lcfirst( str_replace( '_', ' ', ucwords( $group, '_' ) ) );
+		$group = lcfirst( str_replace( '-', ' ', ucwords( $group, '_' ) ) );
+		$group = lcfirst( str_replace( ' ', '', ucwords( $group, ' ' ) ) );
+
+		return $group;
+	}
+
+	/**
 	 * Get all of the allowed settings by group and return the
 	 * settings group that matches the group param
 	 *
@@ -413,14 +429,16 @@ class DataSource {
 		 */
 		$allowed_settings_by_group = [];
 		foreach ( $registered_settings as $key => $setting ) {
+			$group = self::format_group_name( $setting['group'] );
+
 			if ( ! isset( $setting['show_in_graphql'] ) ) {
 				if ( isset( $setting['show_in_rest'] ) && false !== $setting['show_in_rest'] ) {
 					$setting['key'] = $key;
-					$allowed_settings_by_group[ $setting['group'] ][ $key ] = $setting;
+					$allowed_settings_by_group[ $group ][ $key ] = $setting;
 				}
 			} elseif ( true === $setting['show_in_graphql'] ) {
 				$setting['key'] = $key;
-				$allowed_settings_by_group[ $setting['group'] ][ $key ] = $setting;
+				$allowed_settings_by_group[ $group ][ $key ] = $setting;
 			}
 		};
 

--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -383,7 +383,12 @@ class DataSource {
 	 * @return string $group
 	 */
 	public static function format_group_name( string $group ) {
-		$group = lcfirst( preg_replace( '[^a-zA-Z0-9 -]', ' ', $group ) );
+		$replaced_group = preg_replace( '[^a-zA-Z0-9 -]', ' ', $group );
+
+		if ( ! empty( $replaced_group ) ) {
+			$group = $replaced_group;
+		}
+
 		$group = lcfirst( str_replace( '_', ' ', ucwords( $group, '_' ) ) );
 		$group = lcfirst( str_replace( '-', ' ', ucwords( $group, '_' ) ) );
 		$group = lcfirst( str_replace( ' ', '', ucwords( $group, ' ' ) ) );
@@ -433,11 +438,11 @@ class DataSource {
 
 			if ( ! isset( $setting['show_in_graphql'] ) ) {
 				if ( isset( $setting['show_in_rest'] ) && false !== $setting['show_in_rest'] ) {
-					$setting['key'] = $key;
+					$setting['key']                              = $key;
 					$allowed_settings_by_group[ $group ][ $key ] = $setting;
 				}
 			} elseif ( true === $setting['show_in_graphql'] ) {
-				$setting['key'] = $key;
+				$setting['key']                              = $key;
 				$allowed_settings_by_group[ $group ][ $key ] = $setting;
 			}
 		};

--- a/src/Mutation/UpdateSettings.php
+++ b/src/Mutation/UpdateSettings.php
@@ -100,16 +100,7 @@ class UpdateSettings {
 		if ( ! empty( $allowed_setting_groups ) && is_array( $allowed_setting_groups ) ) {
 			foreach ( $allowed_setting_groups as $group => $setting_type ) {
 
-				$replaced_group = preg_replace( '[^a-zA-Z0-9 -]', ' ', $group );
-
-				if ( ! empty( $replaced_group ) ) {
-					$group = $replaced_group;
-				}
-
-				$setting_type = lcfirst( $group );
-				$setting_type = lcfirst( str_replace( '_', ' ', ucwords( $setting_type, '_' ) ) );
-				$setting_type = lcfirst( str_replace( '-', ' ', ucwords( $setting_type, '_' ) ) );
-				$setting_type = lcfirst( str_replace( ' ', '', ucwords( $setting_type, ' ' ) ) );
+				$setting_type = DataSource::format_group_name( $group );
 
 				$output_fields[ $setting_type . 'Settings' ] = [
 					'type'        => $setting_type . 'Settings',

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -555,15 +555,7 @@ class TypeRegistry {
 
 			foreach ( $allowed_setting_types as $group_name => $setting_type ) {
 
-				$replaced_group_name = preg_replace( '[^a-zA-Z0-9 -]', '_', $group_name );
-
-				if ( ! empty( $replaced_group_name ) ) {
-					$group_name = lcfirst( $replaced_group_name );
-				}
-
-				$group_name = lcfirst( str_replace( '_', ' ', ucwords( $group_name, '_' ) ) );
-				$group_name = lcfirst( str_replace( '-', ' ', ucwords( $group_name, '_' ) ) );
-				$group_name = lcfirst( str_replace( ' ', '', ucwords( $group_name, ' ' ) ) );
+				$group_name = DataSource::format_group_name( $group_name );
 				SettingGroup::register_settings_group( $group_name, $group_name );
 
 				register_graphql_field(

--- a/src/Type/ObjectType/Settings.php
+++ b/src/Type/ObjectType/Settings.php
@@ -59,10 +59,7 @@ class Settings {
 					$field_key = $key;
 				}
 
-				$group = lcfirst( preg_replace( '[^a-zA-Z0-9 -]', ' ', $setting_field['group'] ) );
-				$group = lcfirst( str_replace( '_', ' ', ucwords( $group, '_' ) ) );
-				$group = lcfirst( str_replace( '-', ' ', ucwords( $group, '_' ) ) );
-				$group = lcfirst( str_replace( ' ', '', ucwords( $group, ' ' ) ) );
+				$group = DataSource::format_group_name( $setting_field['group'] );
 
 				$field_key = lcfirst( preg_replace( '[^a-zA-Z0-9 -]', ' ', $field_key ) );
 				$field_key = lcfirst( str_replace( '_', ' ', ucwords( $field_key, '_' ) ) );

--- a/src/Utils/InstrumentSchema.php
+++ b/src/Utils/InstrumentSchema.php
@@ -266,7 +266,7 @@ class InstrumentSchema {
 			if ( ! empty( $field->config['auth']['callback'] ) && is_callable( $field->config['auth']['callback'] ) ) {
 
 				$authorized = call_user_func( $field->config['auth']['callback'], $field, $field_key, $source, $args, $context, $info, $field_resolver );
-				
+
 				// If callback returns explicit false throw.
 				if ( false === $authorized ) {
 					throw new UserError( $auth_error );

--- a/tests/wpunit/SettingsQueriesTest.php
+++ b/tests/wpunit/SettingsQueriesTest.php
@@ -4,19 +4,6 @@ class WP_GraphQL_Test_Settings_Queries extends \Codeception\TestCase\WPTestCase 
 
 	public function setUp(): void {
 
-		/**
-		 * Manually Register a setting for testing
-		 *
-		 * This registers a setting as a number to see if it gets the correct type
-		 * associated with it and returned through WPGraphQL
-		 */
-		register_setting( 'Zool', 'points', array(
-			'type'         => 'number',
-			'description'  => __( 'Test how many points we have in Zool.' ),
-			'show_in_graphql' => true,
-			'default' => 4.5,
-		) );
-
 		$this->admin = $this->factory->user->create( [
 			'role' => 'administrator',
 		] );
@@ -27,10 +14,12 @@ class WP_GraphQL_Test_Settings_Queries extends \Codeception\TestCase\WPTestCase 
 
 		parent::setUp();
 
+		WPGraphQL::clear_schema();
 	}
 
 	public function tearDown(): void {
 		parent::tearDown();
+		WPGraphQL::clear_schema();
 	}
 
 	/**


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Found a place where we are not scrubbing the group names for WP registered settings consistantly.


Does this close any currently open issues?
------------------------------------------
https://github.com/wp-graphql/wp-graphql/issues/1925


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
