### PR TITLE
Release/v1.4.0

### DIFF
--- a/.github/workflows/deploy-to-wordpress.yml
+++ b/.github/workflows/deploy-to-wordpress.yml
@@ -35,12 +35,8 @@ jobs:
           name: wp-graphql
           path: plugin-build/wp-graphql.zip
       - name: Upload release asset
-        uses: actions/upload-release-asset@v1
+        uses: softprops/action-gh-release@v1
+        with:
+          files: plugin-build/wp-graphql.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: plugin-build/wp-graphql.zip
-          asset_name: wp-graphql.zip
-          asset_content_type: application/zip
-

--- a/.github/workflows/schema-linter.yml
+++ b/.github/workflows/schema-linter.yml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Setup Node.js
         uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
 
       - name: Setup GraphQL Schema Linter
         run: npm install -g graphql-schema-linter
@@ -57,3 +59,24 @@ jobs:
       - name: Display ignored linting errors
         run: |
           graphql-schema-linter /tmp/schema.graphql || true
+
+      - name: Get Latest tag
+        uses: actions-ecosystem/action-get-latest-tag@v1
+        id: get-latest-tag
+
+      - name: Test Schema for breaking changes
+        run: |
+          echo "Previous tagged schema ${{ steps.get-latest-tag.outputs.tag }}"
+
+      - name: Get Previous Released Schema
+        run: curl 'https://github.com/wp-graphql/wp-graphql/releases/download/${{ steps.get-latest-tag.outputs.tag }}/schema.graphql' -L  --output /tmp/${{ steps.get-latest-tag.outputs.tag }}.graphql
+
+      # https://github.com/marketplace/actions/graphql-inspector
+      - name: Install Schema Inspector
+        run: |
+          npm install @graphql-inspector/config @graphql-inspector/cli graphql
+
+      - name: Run Schema Inspector
+        run: |
+          # This schema and previous release schema
+          node_modules/.bin/graphql-inspector diff /tmp/${{ steps.get-latest-tag.outputs.tag }}.graphql /tmp/schema.graphql

--- a/.github/workflows/upload-schema-artifact.yml
+++ b/.github/workflows/upload-schema-artifact.yml
@@ -38,12 +38,10 @@ jobs:
           cd /tmp/wordpress/
           # Output: /tmp/schema.graphql
           wp graphql generate-static-schema
+
       - name: Upload schema as release artifact
-        uses: actions/upload-release-asset@v1
+        uses: softprops/action-gh-release@v1
+        with:
+          files: /tmp/schema.graphql
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: /tmp/schema.graphql
-          asset_name: schema.graphql
-          asset_content_type: text/plain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### New Features
 
-- ([#1951](https://github.com/wp-graphql/wp-graphql/pull/1951)): Introduces the ability for Interfaces to implement other Interfaces!
+- ([#1951](https://github.com/wp-graphql/wp-graphql/pull/1951)): Updates GraphQL-PHP to v14.8.0 (from 14.4.0) and Introduces the ability for Interfaces to implement other Interfaces!
 
 ## 1.3.10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.4.0
+
+### Chores / Bugfixes
+
+- ([#1953](https://github.com/wp-graphql/wp-graphql/pull/1953)): Fixes bug with Settings groups with underscores not showing in the Schema properly. Thanks @markkelnar!
+
+### New Features
+
+- ([#1951](https://github.com/wp-graphql/wp-graphql/pull/1951)): Introduces the ability for Interfaces to implement other Interfaces!
+
 ## 1.3.10
 
 ### Chores / Bugfixes

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   ],
   "require": {
     "php": ">=7.1.0",
-    "webonyx/graphql-php": "14.4.0",
+    "webonyx/graphql-php": "14.8.0",
     "ivome/graphql-relay-php": "0.5.0"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e110e1060dba00e11e541b5dd84764d4",
+    "content-hash": "8d2e6d476e0705d26cdbbd2ba3154891",
     "packages": [
         {
             "name": "ivome/graphql-relay-php",
@@ -53,16 +53,16 @@
         },
         {
             "name": "webonyx/graphql-php",
-            "version": "v14.4.0",
+            "version": "v14.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webonyx/graphql-php.git",
-                "reference": "aab3d49181467db064b41429cde117a7589625fc"
+                "reference": "7149ebfb0ba4132ca3cc5ef943b8e2ece58a5d5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/aab3d49181467db064b41429cde117a7589625fc",
-                "reference": "aab3d49181467db064b41429cde117a7589625fc",
+                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/7149ebfb0ba4132ca3cc5ef943b8e2ece58a5d5b",
+                "reference": "7149ebfb0ba4132ca3cc5ef943b8e2ece58a5d5b",
                 "shasum": ""
             },
             "require": {
@@ -76,9 +76,9 @@
                 "nyholm/psr7": "^1.2",
                 "phpbench/phpbench": "^0.16.10",
                 "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "0.12.32",
-                "phpstan/phpstan-phpunit": "0.12.11",
-                "phpstan/phpstan-strict-rules": "0.12.2",
+                "phpstan/phpstan": "0.12.82",
+                "phpstan/phpstan-phpunit": "0.12.18",
+                "phpstan/phpstan-strict-rules": "0.12.9",
                 "phpunit/phpunit": "^7.2|^8.5",
                 "psr/http-message": "^1.0",
                 "react/promise": "2.*",
@@ -107,7 +107,7 @@
             ],
             "support": {
                 "issues": "https://github.com/webonyx/graphql-php/issues",
-                "source": "https://github.com/webonyx/graphql-php/tree/v14.4.0"
+                "source": "https://github.com/webonyx/graphql-php/tree/v14.8.0"
             },
             "funding": [
                 {
@@ -115,7 +115,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2020-12-03T16:05:21+00:00"
+            "time": "2021-06-01T10:24:56+00:00"
         }
     ],
     "packages-dev": [
@@ -285,16 +285,16 @@
         },
         {
             "name": "codeception/codeception",
-            "version": "4.1.20",
+            "version": "4.1.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeception/Codeception.git",
-                "reference": "d8b16e13e1781dbc3a7ae8292117d520c89a9c5a"
+                "reference": "c25f20d842a7e3fa0a8e6abf0828f102c914d419"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeception/Codeception/zipball/d8b16e13e1781dbc3a7ae8292117d520c89a9c5a",
-                "reference": "d8b16e13e1781dbc3a7ae8292117d520c89a9c5a",
+                "url": "https://api.github.com/repos/Codeception/Codeception/zipball/c25f20d842a7e3fa0a8e6abf0828f102c914d419",
+                "reference": "c25f20d842a7e3fa0a8e6abf0828f102c914d419",
                 "shasum": ""
             },
             "require": {
@@ -314,11 +314,11 @@
                 "symfony/yaml": ">=2.7 <6.0"
             },
             "require-dev": {
-                "codeception/module-asserts": "*@dev",
-                "codeception/module-cli": "*@dev",
-                "codeception/module-db": "*@dev",
-                "codeception/module-filesystem": "*@dev",
-                "codeception/module-phpbrowser": "*@dev",
+                "codeception/module-asserts": "1.*@dev",
+                "codeception/module-cli": "1.*@dev",
+                "codeception/module-db": "1.*@dev",
+                "codeception/module-filesystem": "1.*@dev",
+                "codeception/module-phpbrowser": "1.*@dev",
                 "codeception/specify": "~0.3",
                 "codeception/util-universalframework": "*@dev",
                 "monolog/monolog": "~1.8",
@@ -368,7 +368,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Codeception/Codeception/issues",
-                "source": "https://github.com/Codeception/Codeception/tree/4.1.20"
+                "source": "https://github.com/Codeception/Codeception/tree/4.1.21"
             },
             "funding": [
                 {
@@ -376,7 +376,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2021-04-02T16:41:51+00:00"
+            "time": "2021-05-28T17:43:39+00:00"
         },
         {
             "name": "codeception/lib-asserts",
@@ -991,16 +991,16 @@
         },
         {
             "name": "composer/ca-bundle",
-            "version": "1.2.9",
+            "version": "1.2.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "78a0e288fdcebf92aa2318a8d3656168da6ac1a5"
+                "reference": "9fdb22c2e97a614657716178093cd1da90a64aa8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/78a0e288fdcebf92aa2318a8d3656168da6ac1a5",
-                "reference": "78a0e288fdcebf92aa2318a8d3656168da6ac1a5",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/9fdb22c2e97a614657716178093cd1da90a64aa8",
+                "reference": "9fdb22c2e97a614657716178093cd1da90a64aa8",
                 "shasum": ""
             },
             "require": {
@@ -1047,7 +1047,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/ca-bundle/issues",
-                "source": "https://github.com/composer/ca-bundle/tree/1.2.9"
+                "source": "https://github.com/composer/ca-bundle/tree/1.2.10"
             },
             "funding": [
                 {
@@ -1063,20 +1063,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-12T12:10:35+00:00"
+            "time": "2021-06-07T13:58:28+00:00"
         },
         {
             "name": "composer/composer",
-            "version": "2.0.14",
+            "version": "2.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "92b2ccbef65292ba9f2004271ef47c7231e2eed5"
+                "reference": "fc5c4573aafce3a018eb7f1f8f91cea423970f2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/92b2ccbef65292ba9f2004271ef47c7231e2eed5",
-                "reference": "92b2ccbef65292ba9f2004271ef47c7231e2eed5",
+                "url": "https://api.github.com/repos/composer/composer/zipball/fc5c4573aafce3a018eb7f1f8f91cea423970f2e",
+                "reference": "fc5c4573aafce3a018eb7f1f8f91cea423970f2e",
                 "shasum": ""
             },
             "require": {
@@ -1111,7 +1111,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "2.1-dev"
                 }
             },
             "autoload": {
@@ -1145,7 +1145,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/composer/issues",
-                "source": "https://github.com/composer/composer/tree/2.0.14"
+                "source": "https://github.com/composer/composer/tree/2.1.3"
             },
             "funding": [
                 {
@@ -1161,7 +1161,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-21T15:03:37+00:00"
+            "time": "2021-06-09T14:31:20+00:00"
         },
         {
             "name": "composer/metadata-minifier",
@@ -2130,7 +2130,7 @@
         },
         {
             "name": "illuminate/collections",
-            "version": "v8.43.0",
+            "version": "v8.46.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
@@ -2184,16 +2184,16 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v8.43.0",
+            "version": "v8.46.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
-                "reference": "b9a7cf6acf1d05d863b6ef67c00cdb0e4ccea097"
+                "reference": "199fcedc161ba4a0b83feaddc4629f395dbf1641"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/contracts/zipball/b9a7cf6acf1d05d863b6ef67c00cdb0e4ccea097",
-                "reference": "b9a7cf6acf1d05d863b6ef67c00cdb0e4ccea097",
+                "url": "https://api.github.com/repos/illuminate/contracts/zipball/199fcedc161ba4a0b83feaddc4629f395dbf1641",
+                "reference": "199fcedc161ba4a0b83feaddc4629f395dbf1641",
                 "shasum": ""
             },
             "require": {
@@ -2228,11 +2228,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2021-05-21T19:16:29+00:00"
+            "time": "2021-06-01T14:53:38+00:00"
         },
         {
             "name": "illuminate/macroable",
-            "version": "v8.43.0",
+            "version": "v8.46.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
@@ -2278,16 +2278,16 @@
         },
         {
             "name": "illuminate/support",
-            "version": "v8.43.0",
+            "version": "v8.46.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
-                "reference": "8a2db3cb7e76fdbd28c6172492a79ab540a9b8e5"
+                "reference": "79e1ec26d58426e4f06e5b548712a8a6dc1ffdca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/support/zipball/8a2db3cb7e76fdbd28c6172492a79ab540a9b8e5",
-                "reference": "8a2db3cb7e76fdbd28c6172492a79ab540a9b8e5",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/79e1ec26d58426e4f06e5b548712a8a6dc1ffdca",
+                "reference": "79e1ec26d58426e4f06e5b548712a8a6dc1ffdca",
                 "shasum": ""
             },
             "require": {
@@ -2342,7 +2342,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2021-05-20T18:46:23+00:00"
+            "time": "2021-06-08T13:14:36+00:00"
         },
         {
             "name": "justinrainbow/json-schema",
@@ -2779,16 +2779,16 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "2.48.0",
+            "version": "2.49.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/briannesbitt/Carbon.git",
-                "reference": "d3c447f21072766cddec3522f9468a5849a76147"
+                "reference": "93d9db91c0235c486875d22f1e08b50bdf3e6eee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/d3c447f21072766cddec3522f9468a5849a76147",
-                "reference": "d3c447f21072766cddec3522f9468a5849a76147",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/93d9db91c0235c486875d22f1e08b50bdf3e6eee",
+                "reference": "93d9db91c0235c486875d22f1e08b50bdf3e6eee",
                 "shasum": ""
             },
             "require": {
@@ -2868,7 +2868,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-07T10:08:30+00:00"
+            "time": "2021-06-02T07:31:40+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -3534,16 +3534,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.88",
+            "version": "0.12.89",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "464d1a81af49409c41074aa6640ed0c4cbd9bb68"
+                "reference": "54c0f5a6c30511b77128d58b6369f718df250542"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/464d1a81af49409c41074aa6640ed0c4cbd9bb68",
-                "reference": "464d1a81af49409c41074aa6640ed0c4cbd9bb68",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/54c0f5a6c30511b77128d58b6369f718df250542",
+                "reference": "54c0f5a6c30511b77128d58b6369f718df250542",
                 "shasum": ""
             },
             "require": {
@@ -3574,11 +3574,15 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/0.12.88"
+                "source": "https://github.com/phpstan/phpstan/tree/0.12.89"
             },
             "funding": [
                 {
                     "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
                     "type": "github"
                 },
                 {
@@ -3590,7 +3594,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-17T12:24:49+00:00"
+            "time": "2021-06-09T20:23:49+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -4319,16 +4323,16 @@
         },
         {
             "name": "rmccue/requests",
-            "version": "v1.8.0",
+            "version": "v1.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/Requests.git",
-                "reference": "afbe4790e4def03581c4a0963a1e8aa01f6030f1"
+                "reference": "82e6936366eac3af4d836c18b9d8c31028fe4cd5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/Requests/zipball/afbe4790e4def03581c4a0963a1e8aa01f6030f1",
-                "reference": "afbe4790e4def03581c4a0963a1e8aa01f6030f1",
+                "url": "https://api.github.com/repos/WordPress/Requests/zipball/82e6936366eac3af4d836c18b9d8c31028fe4cd5",
+                "reference": "82e6936366eac3af4d836c18b9d8c31028fe4cd5",
                 "shasum": ""
             },
             "require": {
@@ -4373,9 +4377,9 @@
             ],
             "support": {
                 "issues": "https://github.com/WordPress/Requests/issues",
-                "source": "https://github.com/WordPress/Requests/tree/v1.8.0"
+                "source": "https://github.com/WordPress/Requests/tree/v1.8.1"
             },
-            "time": "2021-04-27T11:05:25+00:00"
+            "time": "2021-06-04T09:56:25+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -5293,16 +5297,16 @@
         },
         {
             "name": "softcreatr/jsonpath",
-            "version": "0.7.4",
+            "version": "0.7.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/SoftCreatR/JSONPath.git",
-                "reference": "e01ff3eae8d0b94648354cb02b614968e83d56a2"
+                "reference": "008569bf80aa3584834f7890781576bc7b65afa7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/SoftCreatR/JSONPath/zipball/e01ff3eae8d0b94648354cb02b614968e83d56a2",
-                "reference": "e01ff3eae8d0b94648354cb02b614968e83d56a2",
+                "url": "https://api.github.com/repos/SoftCreatR/JSONPath/zipball/008569bf80aa3584834f7890781576bc7b65afa7",
+                "reference": "008569bf80aa3584834f7890781576bc7b65afa7",
                 "shasum": ""
             },
             "require": {
@@ -5354,7 +5358,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-05-07T14:31:33+00:00"
+            "time": "2021-06-02T22:15:26+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -5414,16 +5418,16 @@
         },
         {
             "name": "symfony/browser-kit",
-            "version": "v5.2.9",
+            "version": "v5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/browser-kit.git",
-                "reference": "38e16b426f1a4cd663b2583111f213e0c9d9d4fe"
+                "reference": "379984e25eee9811b0a25a2105e1a2b3b8d9b734"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/38e16b426f1a4cd663b2583111f213e0c9d9d4fe",
-                "reference": "38e16b426f1a4cd663b2583111f213e0c9d9d4fe",
+                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/379984e25eee9811b0a25a2105e1a2b3b8d9b734",
+                "reference": "379984e25eee9811b0a25a2105e1a2b3b8d9b734",
                 "shasum": ""
             },
             "require": {
@@ -5465,7 +5469,7 @@
             "description": "Simulates the behavior of a web browser, allowing you to make requests, click on links and submit forms programmatically",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/browser-kit/tree/v5.2.9"
+                "source": "https://github.com/symfony/browser-kit/tree/v5.3.0"
             },
             "funding": [
                 {
@@ -5481,20 +5485,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-16T13:07:46+00:00"
+            "time": "2021-05-26T17:43:10+00:00"
         },
         {
             "name": "symfony/config",
-            "version": "v5.2.8",
+            "version": "v5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "8dfa5f8adea9cd5155920069224beb04f11d6b7e"
+                "reference": "9f4a448c2d7fd2c90882dfff930b627ddbe16810"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/8dfa5f8adea9cd5155920069224beb04f11d6b7e",
-                "reference": "8dfa5f8adea9cd5155920069224beb04f11d6b7e",
+                "url": "https://api.github.com/repos/symfony/config/zipball/9f4a448c2d7fd2c90882dfff930b627ddbe16810",
+                "reference": "9f4a448c2d7fd2c90882dfff930b627ddbe16810",
                 "shasum": ""
             },
             "require": {
@@ -5502,7 +5506,8 @@
                 "symfony/deprecation-contracts": "^2.1",
                 "symfony/filesystem": "^4.4|^5.0",
                 "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-php80": "^1.15"
+                "symfony/polyfill-php80": "^1.15",
+                "symfony/polyfill-php81": "^1.22"
             },
             "conflict": {
                 "symfony/finder": "<4.4"
@@ -5543,7 +5548,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v5.2.8"
+                "source": "https://github.com/symfony/config/tree/v5.3.0"
             },
             "funding": [
                 {
@@ -5559,24 +5564,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-07T13:41:16+00:00"
+            "time": "2021-05-26T17:43:10+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v5.2.8",
+            "version": "v5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "864568fdc0208b3eba3638b6000b69d2386e6768"
+                "reference": "058553870f7809087fa80fa734704a21b9bcaeb2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/864568fdc0208b3eba3638b6000b69d2386e6768",
-                "reference": "864568fdc0208b3eba3638b6000b69d2386e6768",
+                "url": "https://api.github.com/repos/symfony/console/zipball/058553870f7809087fa80fa734704a21b9bcaeb2",
+                "reference": "058553870f7809087fa80fa734704a21b9bcaeb2",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/polyfill-php73": "^1.8",
                 "symfony/polyfill-php80": "^1.15",
@@ -5640,7 +5646,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.2.8"
+                "source": "https://github.com/symfony/console/tree/v5.3.0"
             },
             "funding": [
                 {
@@ -5656,20 +5662,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-11T15:45:21+00:00"
+            "time": "2021-05-26T17:43:10+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v5.2.9",
+            "version": "v5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "5d5f97809015102116208b976eb2edb44b689560"
+                "reference": "fcd0b29a7a0b1bb5bfbedc6231583d77fea04814"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/5d5f97809015102116208b976eb2edb44b689560",
-                "reference": "5d5f97809015102116208b976eb2edb44b689560",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/fcd0b29a7a0b1bb5bfbedc6231583d77fea04814",
+                "reference": "fcd0b29a7a0b1bb5bfbedc6231583d77fea04814",
                 "shasum": ""
             },
             "require": {
@@ -5705,7 +5711,7 @@
             "description": "Converts CSS selectors to XPath expressions",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/css-selector/tree/v5.2.9"
+                "source": "https://github.com/symfony/css-selector/tree/v5.3.0"
             },
             "funding": [
                 {
@@ -5721,7 +5727,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-16T13:07:46+00:00"
+            "time": "2021-05-26T17:40:38+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -5792,20 +5798,21 @@
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v5.2.9",
+            "version": "v5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dom-crawler.git",
-                "reference": "8d5201206ded6f37de475b041a11bfaf3ac73d5e"
+                "reference": "55fff62b19f413f897a752488ade1bc9c8a19cdd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/8d5201206ded6f37de475b041a11bfaf3ac73d5e",
-                "reference": "8d5201206ded6f37de475b041a11bfaf3ac73d5e",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/55fff62b19f413f897a752488ade1bc9c8a19cdd",
+                "reference": "55fff62b19f413f897a752488ade1bc9c8a19cdd",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/polyfill-php80": "^1.15"
@@ -5846,7 +5853,7 @@
             "description": "Eases DOM navigation for HTML and XML documents",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dom-crawler/tree/v5.2.9"
+                "source": "https://github.com/symfony/dom-crawler/tree/v5.3.0"
             },
             "funding": [
                 {
@@ -5862,20 +5869,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-16T13:07:46+00:00"
+            "time": "2021-05-26T17:43:10+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v5.2.4",
+            "version": "v5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "d08d6ec121a425897951900ab692b612a61d6240"
+                "reference": "67a5f354afa8e2f231081b3fa11a5912f933c3ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/d08d6ec121a425897951900ab692b612a61d6240",
-                "reference": "d08d6ec121a425897951900ab692b612a61d6240",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/67a5f354afa8e2f231081b3fa11a5912f933c3ce",
+                "reference": "67a5f354afa8e2f231081b3fa11a5912f933c3ce",
                 "shasum": ""
             },
             "require": {
@@ -5931,7 +5938,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v5.2.4"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v5.3.0"
             },
             "funding": [
                 {
@@ -5947,7 +5954,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-18T17:12:37+00:00"
+            "time": "2021-05-26T17:43:10+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -6030,16 +6037,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.2.7",
+            "version": "v5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "056e92acc21d977c37e6ea8e97374b2a6c8551b0"
+                "reference": "348116319d7fb7d1faa781d26a48922428013eb2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/056e92acc21d977c37e6ea8e97374b2a6c8551b0",
-                "reference": "056e92acc21d977c37e6ea8e97374b2a6c8551b0",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/348116319d7fb7d1faa781d26a48922428013eb2",
+                "reference": "348116319d7fb7d1faa781d26a48922428013eb2",
                 "shasum": ""
             },
             "require": {
@@ -6072,7 +6079,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.2.7"
+                "source": "https://github.com/symfony/filesystem/tree/v5.3.0"
             },
             "funding": [
                 {
@@ -6088,20 +6095,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-04-01T10:42:13+00:00"
+            "time": "2021-05-26T17:43:10+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v5.2.9",
+            "version": "v5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "ccccb9d48ca42757dd12f2ca4bf857a4e217d90d"
+                "reference": "0ae3f047bed4edff6fd35b26a9a6bfdc92c953c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/ccccb9d48ca42757dd12f2ca4bf857a4e217d90d",
-                "reference": "ccccb9d48ca42757dd12f2ca4bf857a4e217d90d",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/0ae3f047bed4edff6fd35b26a9a6bfdc92c953c6",
+                "reference": "0ae3f047bed4edff6fd35b26a9a6bfdc92c953c6",
                 "shasum": ""
             },
             "require": {
@@ -6133,7 +6140,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v5.2.9"
+                "source": "https://github.com/symfony/finder/tree/v5.3.0"
             },
             "funding": [
                 {
@@ -6149,20 +6156,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-16T13:07:46+00:00"
+            "time": "2021-05-26T12:52:38+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.22.1",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e"
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/c6c942b1ac76c82448322025e084cadc56048b4e",
-                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/46cd95797e9df938fdd2b03693b5fca5e64b01ce",
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce",
                 "shasum": ""
             },
             "require": {
@@ -6174,7 +6181,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -6212,7 +6219,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -6228,20 +6235,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-02-19T12:13:01+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.22.1",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "5601e09b69f26c1828b13b6bb87cb07cddba3170"
+                "reference": "24b72c6baa32c746a4d0840147c9715e42bb68ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/5601e09b69f26c1828b13b6bb87cb07cddba3170",
-                "reference": "5601e09b69f26c1828b13b6bb87cb07cddba3170",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/24b72c6baa32c746a4d0840147c9715e42bb68ab",
+                "reference": "24b72c6baa32c746a4d0840147c9715e42bb68ab",
                 "shasum": ""
             },
             "require": {
@@ -6253,7 +6260,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -6293,7 +6300,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -6309,20 +6316,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-22T09:19:47+00:00"
+            "time": "2021-05-27T09:17:38+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.22.1",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "2d63434d922daf7da8dd863e7907e67ee3031483"
+                "reference": "65bd267525e82759e7d8c4e8ceea44f398838e65"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/2d63434d922daf7da8dd863e7907e67ee3031483",
-                "reference": "2d63434d922daf7da8dd863e7907e67ee3031483",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/65bd267525e82759e7d8c4e8ceea44f398838e65",
+                "reference": "65bd267525e82759e7d8c4e8ceea44f398838e65",
                 "shasum": ""
             },
             "require": {
@@ -6336,7 +6343,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -6380,7 +6387,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -6396,20 +6403,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-22T09:19:47+00:00"
+            "time": "2021-05-27T09:27:20+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.22.1",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "43a0283138253ed1d48d352ab6d0bdb3f809f248"
+                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/43a0283138253ed1d48d352ab6d0bdb3f809f248",
-                "reference": "43a0283138253ed1d48d352ab6d0bdb3f809f248",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8590a5f561694770bdcd3f9b5c69dde6945028e8",
+                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8",
                 "shasum": ""
             },
             "require": {
@@ -6421,7 +6428,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -6464,7 +6471,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -6480,20 +6487,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-22T09:19:47+00:00"
+            "time": "2021-02-19T12:13:01+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.22.1",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "5232de97ee3b75b0360528dae24e73db49566ab1"
+                "reference": "2df51500adbaebdc4c38dea4c89a2e131c45c8a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/5232de97ee3b75b0360528dae24e73db49566ab1",
-                "reference": "5232de97ee3b75b0360528dae24e73db49566ab1",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/2df51500adbaebdc4c38dea4c89a2e131c45c8a1",
+                "reference": "2df51500adbaebdc4c38dea4c89a2e131c45c8a1",
                 "shasum": ""
             },
             "require": {
@@ -6505,7 +6512,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -6544,7 +6551,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -6560,20 +6567,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-22T09:19:47+00:00"
+            "time": "2021-05-27T09:27:20+00:00"
         },
         {
             "name": "symfony/polyfill-php72",
-            "version": "v1.22.1",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php72.git",
-                "reference": "cc6e6f9b39fe8075b3dabfbaf5b5f645ae1340c9"
+                "reference": "9a142215a36a3888e30d0a9eeea9766764e96976"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/cc6e6f9b39fe8075b3dabfbaf5b5f645ae1340c9",
-                "reference": "cc6e6f9b39fe8075b3dabfbaf5b5f645ae1340c9",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/9a142215a36a3888e30d0a9eeea9766764e96976",
+                "reference": "9a142215a36a3888e30d0a9eeea9766764e96976",
                 "shasum": ""
             },
             "require": {
@@ -6582,7 +6589,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -6620,7 +6627,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php72/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-php72/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -6636,20 +6643,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-05-27T09:17:38+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.22.1",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "a678b42e92f86eca04b7fa4c0f6f19d097fb69e2"
+                "reference": "fba8933c384d6476ab14fb7b8526e5287ca7e010"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/a678b42e92f86eca04b7fa4c0f6f19d097fb69e2",
-                "reference": "a678b42e92f86eca04b7fa4c0f6f19d097fb69e2",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/fba8933c384d6476ab14fb7b8526e5287ca7e010",
+                "reference": "fba8933c384d6476ab14fb7b8526e5287ca7e010",
                 "shasum": ""
             },
             "require": {
@@ -6658,7 +6665,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -6699,7 +6706,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -6715,20 +6722,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-02-19T12:13:01+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.22.1",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "dc3063ba22c2a1fd2f45ed856374d79114998f91"
+                "reference": "eca0bf41ed421bed1b57c4958bab16aa86b757d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dc3063ba22c2a1fd2f45ed856374d79114998f91",
-                "reference": "dc3063ba22c2a1fd2f45ed856374d79114998f91",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/eca0bf41ed421bed1b57c4958bab16aa86b757d0",
+                "reference": "eca0bf41ed421bed1b57c4958bab16aa86b757d0",
                 "shasum": ""
             },
             "require": {
@@ -6737,7 +6744,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -6782,7 +6789,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -6798,20 +6805,99 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-02-19T12:13:01+00:00"
         },
         {
-            "name": "symfony/process",
-            "version": "v4.4.22",
+            "name": "symfony/polyfill-php81",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/process.git",
-                "reference": "f5481b22729d465acb1cea3455fc04ce84b0148b"
+                "url": "https://github.com/symfony/polyfill-php81.git",
+                "reference": "e66119f3de95efc359483f810c4c3e6436279436"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/f5481b22729d465acb1cea3455fc04ce84b0148b",
-                "reference": "f5481b22729d465acb1cea3455fc04ce84b0148b",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/e66119f3de95efc359483f810c4c3e6436279436",
+                "reference": "e66119f3de95efc359483f810c4c3e6436279436",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php81\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.1+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.23.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-21T13:25:03+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v4.4.25",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "cd61e6dd273975c6625316de9d141ebd197f93c9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/cd61e6dd273975c6625316de9d141ebd197f93c9",
+                "reference": "cd61e6dd273975c6625316de9d141ebd197f93c9",
                 "shasum": ""
             },
             "require": {
@@ -6843,7 +6929,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v4.4.22"
+                "source": "https://github.com/symfony/process/tree/v4.4.25"
             },
             "funding": [
                 {
@@ -6859,7 +6945,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-04-07T16:22:29+00:00"
+            "time": "2021-05-26T11:20:16+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -6942,16 +7028,16 @@
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v5.2.7",
+            "version": "v5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "d99310c33e833def36419c284f60e8027d359678"
+                "reference": "313d02f59d6543311865007e5ff4ace05b35ee65"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/d99310c33e833def36419c284f60e8027d359678",
-                "reference": "d99310c33e833def36419c284f60e8027d359678",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/313d02f59d6543311865007e5ff4ace05b35ee65",
+                "reference": "313d02f59d6543311865007e5ff4ace05b35ee65",
                 "shasum": ""
             },
             "require": {
@@ -6984,7 +7070,7 @@
             "description": "Provides a way to profile code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/stopwatch/tree/v5.3.0-BETA1"
+                "source": "https://github.com/symfony/stopwatch/tree/v5.3.0"
             },
             "funding": [
                 {
@@ -7000,20 +7086,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-03-29T15:28:41+00:00"
+            "time": "2021-05-26T17:43:10+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v5.2.8",
+            "version": "v5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "01b35eb64cac8467c3f94cd0ce2d0d376bb7d1db"
+                "reference": "a9a0f8b6aafc5d2d1c116dcccd1573a95153515b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/01b35eb64cac8467c3f94cd0ce2d0d376bb7d1db",
-                "reference": "01b35eb64cac8467c3f94cd0ce2d0d376bb7d1db",
+                "url": "https://api.github.com/repos/symfony/string/zipball/a9a0f8b6aafc5d2d1c116dcccd1573a95153515b",
+                "reference": "a9a0f8b6aafc5d2d1c116dcccd1573a95153515b",
                 "shasum": ""
             },
             "require": {
@@ -7067,7 +7153,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.2.8"
+                "source": "https://github.com/symfony/string/tree/v5.3.0"
             },
             "funding": [
                 {
@@ -7083,24 +7169,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-10T14:56:10+00:00"
+            "time": "2021-05-26T17:43:10+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v5.2.9",
+            "version": "v5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "61af68dba333e2d376a325a29c2a3f2a605b4876"
+                "reference": "251de0d921c42ef0a81494d8f37405421deefdf6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/61af68dba333e2d376a325a29c2a3f2a605b4876",
-                "reference": "61af68dba333e2d376a325a29c2a3f2a605b4876",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/251de0d921c42ef0a81494d8f37405421deefdf6",
+                "reference": "251de0d921c42ef0a81494d8f37405421deefdf6",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/polyfill-php80": "^1.15",
                 "symfony/translation-contracts": "^2.3"
@@ -7123,6 +7210,7 @@
                 "symfony/finder": "^4.4|^5.0",
                 "symfony/http-kernel": "^5.0",
                 "symfony/intl": "^4.4|^5.0",
+                "symfony/polyfill-intl-icu": "^1.21",
                 "symfony/service-contracts": "^1.1.2|^2",
                 "symfony/yaml": "^4.4|^5.0"
             },
@@ -7160,7 +7248,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v5.2.9"
+                "source": "https://github.com/symfony/translation/tree/v5.3.0"
             },
             "funding": [
                 {
@@ -7176,7 +7264,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-16T13:07:46+00:00"
+            "time": "2021-05-29T22:28:28+00:00"
         },
         {
             "name": "symfony/translation-contracts",
@@ -7258,16 +7346,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v5.2.9",
+            "version": "v5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "d23115e4a3d50520abddccdbec9514baab1084c8"
+                "reference": "3bbcf262fceb3d8f48175302e6ba0ac96e3a5a11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/d23115e4a3d50520abddccdbec9514baab1084c8",
-                "reference": "d23115e4a3d50520abddccdbec9514baab1084c8",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/3bbcf262fceb3d8f48175302e6ba0ac96e3a5a11",
+                "reference": "3bbcf262fceb3d8f48175302e6ba0ac96e3a5a11",
                 "shasum": ""
             },
             "require": {
@@ -7313,7 +7401,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v5.2.9"
+                "source": "https://github.com/symfony/yaml/tree/v5.3.0"
             },
             "funding": [
                 {
@@ -7329,7 +7417,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-16T13:07:46+00:00"
+            "time": "2021-05-26T17:43:10+00:00"
         },
         {
             "name": "szepeviktor/phpstan-wordpress",
@@ -9772,21 +9860,22 @@
         },
         {
             "name": "wp-graphql/wp-graphql-testcase",
-            "version": "v1.1.1",
+            "version": "v1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-graphql/wp-graphql-testcase.git",
-                "reference": "9650e0c4e7bc60d97aafbb69b4c457e314b46390"
+                "reference": "466e157582f2ad8c8c55c4de81509da6f3ef1a14"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-graphql/wp-graphql-testcase/zipball/9650e0c4e7bc60d97aafbb69b4c457e314b46390",
-                "reference": "9650e0c4e7bc60d97aafbb69b4c457e314b46390",
+                "url": "https://api.github.com/repos/wp-graphql/wp-graphql-testcase/zipball/466e157582f2ad8c8c55c4de81509da6f3ef1a14",
+                "reference": "466e157582f2ad8c8c55c4de81509da6f3ef1a14",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1",
-                "phpunit/phpunit": "^7.5"
+                "phpunit/phpunit": "^7.5",
+                "wp-phpunit/wp-phpunit": "^5.7"
             },
             "require-dev": {
                 "automattic/vipwpcs": "^2.2",
@@ -9833,9 +9922,57 @@
             "description": "Codeception module for WPGraphQL API testing",
             "support": {
                 "issues": "https://github.com/wp-graphql/wp-graphql-testcase/issues",
-                "source": "https://github.com/wp-graphql/wp-graphql-testcase/tree/v1.1.1"
+                "source": "https://github.com/wp-graphql/wp-graphql-testcase/tree/v1.1.3"
             },
-            "time": "2021-05-19T21:43:27+00:00"
+            "time": "2021-06-02T23:47:27+00:00"
+        },
+        {
+            "name": "wp-phpunit/wp-phpunit",
+            "version": "5.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wp-phpunit/wp-phpunit.git",
+                "reference": "5ab77c1e1328e9bee65f60c246e33b13fc202375"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wp-phpunit/wp-phpunit/zipball/5ab77c1e1328e9bee65f60c246e33b13fc202375",
+                "reference": "5ab77c1e1328e9bee65f60c246e33b13fc202375",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "__loaded.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Evan Mattson",
+                    "email": "me@aaemnnost.tv"
+                },
+                {
+                    "name": "WordPress Community",
+                    "homepage": "https://wordpress.org/about/"
+                }
+            ],
+            "description": "WordPress core PHPUnit library",
+            "homepage": "https://github.com/wp-phpunit",
+            "keywords": [
+                "phpunit",
+                "test",
+                "wordpress"
+            ],
+            "support": {
+                "docs": "https://github.com/wp-phpunit/docs",
+                "issues": "https://github.com/wp-phpunit/issues",
+                "source": "https://github.com/wp-phpunit/wp-phpunit"
+            },
+            "time": "2021-03-10T17:57:07+00:00"
         },
         {
             "name": "zordius/lightncandy",
@@ -9903,5 +10040,5 @@
         "php": ">=7.1.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/docs/intro-to-graphql.md
+++ b/docs/intro-to-graphql.md
@@ -315,7 +315,7 @@ query GetPersonById($id:Int!) {
 
 Here, we've added `($id:Int!)` to the operation name, declaring the variable `$id` and telling GraphQL that the input will be a required `Integer` value.
 
-Then, we replaced `id: 123` with `id: $id`, which tells the query to use the `$id variable when fulfillin`g the request for the `person` field.
+Then, we replaced `id: 123` with `id: $id`, which tells the query to use the `$id` variable when fulfilling the request for the `person` field.
 
 Below is an example of using variables with the `graphql()` function provided by WPGraphQL:
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, API, Gatsby, Headless, Decoupled, React, Nextjs, Vue, Apollo, RES
 Requires at least: 5.0
 Tested up to: 5.6
 Requires PHP: 7.1
-Stable tag: 1.3.10
+Stable tag: 1.4.0
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -82,6 +82,17 @@ Gatsby and WP Engine both believe that a strong GraphQL API for WordPress is a b
 Composer dependencies are no longer versioned in Github. Recommended install source is WordPress.org or using Composer to get the code from Packagist.org or WPackagist.org.
 
 == Changelog ==
+
+= 1.4.0 =
+
+**Chores / Bugfixes**
+
+- ([#1953](https://github.com/wp-graphql/wp-graphql/pull/1953)): Fixes bug with Settings groups with underscores not showing in the Schema properly. Thanks @markkelnar!
+
+**New Features**
+
+- ([#1951](https://github.com/wp-graphql/wp-graphql/pull/1951)): Introduces the ability for Interfaces to implement other Interfaces!
+
 
 = 1.3.10 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -91,8 +91,7 @@ Composer dependencies are no longer versioned in Github. Recommended install sou
 
 **New Features**
 
-- ([#1951](https://github.com/wp-graphql/wp-graphql/pull/1951)): Introduces the ability for Interfaces to implement other Interfaces!
-
+- ([#1951](https://github.com/wp-graphql/wp-graphql/pull/1951)): Updates GraphQL-PHP to v14.8.0 (from 14.4.0) and Introduces the ability for Interfaces to implement other Interfaces!
 
 = 1.3.10 =
 

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -86,8 +86,12 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	 * @throws Exception
 	 */
 	public function get_query() {
+		// Get query class.
+		$queryClass = ! empty( $this->context->queryClass )
+			? $this->context->queryClass
+			: '\WP_Query';
 
-		$query = new \WP_Query( $this->query_args );
+		$query = new $queryClass( $this->query_args );
 
 		if ( isset( $query->query_vars['suppress_filters'] ) && true === $query->query_vars['suppress_filters'] ) {
 			throw new InvariantViolation( __( 'WP_Query has been modified by a plugin or theme to suppress_filters, which will cause issues with WPGraphQL Execution. If you need to suppress filters for a specific reason within GraphQL, consider registering a custom field to the WPGraphQL Schema with a custom resolver.', 'wp-graphql' ) );

--- a/src/Data/Connection/UserConnectionResolver.php
+++ b/src/Data/Connection/UserConnectionResolver.php
@@ -176,7 +176,12 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 	 * @throws \Exception
 	 */
 	public function get_query() {
-		return new \WP_User_Query( $this->query_args );
+		// Get query class.
+		$queryClass = ! empty( $this->context->queryClass )
+			? $this->context->queryClass
+			: '\WP_User_Query';
+
+		return new $queryClass( $this->query_args );
 	}
 
 	/**

--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -376,6 +376,27 @@ class DataSource {
 	}
 
 	/**
+	 * Format the setting group name to our standard.
+	 *
+	 * @param string $group
+	 *
+	 * @return string $group
+	 */
+	public static function format_group_name( string $group ) {
+		$replaced_group = preg_replace( '[^a-zA-Z0-9 -]', ' ', $group );
+
+		if ( ! empty( $replaced_group ) ) {
+			$group = $replaced_group;
+		}
+
+		$group = lcfirst( str_replace( '_', ' ', ucwords( $group, '_' ) ) );
+		$group = lcfirst( str_replace( '-', ' ', ucwords( $group, '_' ) ) );
+		$group = lcfirst( str_replace( ' ', '', ucwords( $group, ' ' ) ) );
+
+		return $group;
+	}
+
+	/**
 	 * Get all of the allowed settings by group and return the
 	 * settings group that matches the group param
 	 *
@@ -413,14 +434,16 @@ class DataSource {
 		 */
 		$allowed_settings_by_group = [];
 		foreach ( $registered_settings as $key => $setting ) {
+			$group = self::format_group_name( $setting['group'] );
+
 			if ( ! isset( $setting['show_in_graphql'] ) ) {
 				if ( isset( $setting['show_in_rest'] ) && false !== $setting['show_in_rest'] ) {
-					$setting['key'] = $key;
-					$allowed_settings_by_group[ $setting['group'] ][ $key ] = $setting;
+					$setting['key']                              = $key;
+					$allowed_settings_by_group[ $group ][ $key ] = $setting;
 				}
 			} elseif ( true === $setting['show_in_graphql'] ) {
-				$setting['key'] = $key;
-				$allowed_settings_by_group[ $setting['group'] ][ $key ] = $setting;
+				$setting['key']                              = $key;
+				$allowed_settings_by_group[ $group ][ $key ] = $setting;
 			}
 		};
 

--- a/src/Model/Term.php
+++ b/src/Model/Term.php
@@ -13,6 +13,7 @@ use WP_Term;
  *
  * @property string $id
  * @property int    $term_id
+ * @property int    $databaseId
  * @property int    $count
  * @property string $description
  * @property string $name
@@ -136,6 +137,9 @@ class Term extends Model {
 					return ( ! empty( $this->data->taxonomy ) && ! empty( $this->data->term_id ) ) ? Relay::toGlobalId( 'term', (string) $this->data->term_id ) : null;
 				},
 				'term_id'                  => function() {
+					return ( ! empty( $this->data->term_id ) ) ? absint( $this->data->term_id ) : null;
+				},
+				'databaseId'               => function() {
 					return ( ! empty( $this->data->term_id ) ) ? absint( $this->data->term_id ) : null;
 				},
 				'count'                    => function() {

--- a/src/Mutation/UpdateSettings.php
+++ b/src/Mutation/UpdateSettings.php
@@ -100,16 +100,7 @@ class UpdateSettings {
 		if ( ! empty( $allowed_setting_groups ) && is_array( $allowed_setting_groups ) ) {
 			foreach ( $allowed_setting_groups as $group => $setting_type ) {
 
-				$replaced_group = preg_replace( '[^a-zA-Z0-9 -]', ' ', $group );
-
-				if ( ! empty( $replaced_group ) ) {
-					$group = $replaced_group;
-				}
-
-				$setting_type = lcfirst( $group );
-				$setting_type = lcfirst( str_replace( '_', ' ', ucwords( $setting_type, '_' ) ) );
-				$setting_type = lcfirst( str_replace( '-', ' ', ucwords( $setting_type, '_' ) ) );
-				$setting_type = lcfirst( str_replace( ' ', '', ucwords( $setting_type, ' ' ) ) );
+				$setting_type = DataSource::format_group_name( $group );
 
 				$output_fields[ $setting_type . 'Settings' ] = [
 					'type'        => $setting_type . 'Settings',

--- a/src/Type/InterfaceType/ContentNode.php
+++ b/src/Type/InterfaceType/ContentNode.php
@@ -117,7 +117,7 @@ class ContentNode {
 						'description' => __( 'The permalink of the post', 'wp-graphql' ),
 					],
 					'uri'                       => [
-						'type'        => [ 'non_null' => 'String' ],
+						'type'        => 'String',
 						'description' => __( 'URI path for the resource', 'wp-graphql' ),
 					],
 					'isRestricted'              => [

--- a/src/Type/InterfaceType/MenuItemLinkable.php
+++ b/src/Type/InterfaceType/MenuItemLinkable.php
@@ -22,7 +22,7 @@ class MenuItemLinkable {
 			'description' => __( 'Nodes that can be linked to as Menu Items', 'wp-graphql' ),
 			'fields'      => [
 				'uri'        => [
-					'type'        => [ 'non_null' => 'String' ],
+					'type'        => 'String',
 					'description' => __( 'The unique resource identifier path', 'wp-graphql' ),
 				],
 				'id'         => [

--- a/src/Type/InterfaceType/TermNode.php
+++ b/src/Type/InterfaceType/TermNode.php
@@ -88,7 +88,7 @@ class TermNode {
 						'description' => __( 'The link to the term', 'wp-graphql' ),
 					],
 					'uri'            => [
-						'type'        => [ 'non_null' => 'String' ],
+						'type'        => 'String',
 						'description' => __( 'The unique resource identifier path', 'wp-graphql' ),
 					],
 				],

--- a/src/Type/ObjectType/Settings.php
+++ b/src/Type/ObjectType/Settings.php
@@ -59,10 +59,7 @@ class Settings {
 					$field_key = $key;
 				}
 
-				$group = lcfirst( preg_replace( '[^a-zA-Z0-9 -]', ' ', $setting_field['group'] ) );
-				$group = lcfirst( str_replace( '_', ' ', ucwords( $group, '_' ) ) );
-				$group = lcfirst( str_replace( '-', ' ', ucwords( $group, '_' ) ) );
-				$group = lcfirst( str_replace( ' ', '', ucwords( $group, ' ' ) ) );
+				$group = DataSource::format_group_name( $setting_field['group'] );
 
 				$field_key = lcfirst( preg_replace( '[^a-zA-Z0-9 -]', ' ', $field_key ) );
 				$field_key = lcfirst( str_replace( '_', ' ', ucwords( $field_key, '_' ) ) );

--- a/src/Type/WPInterfaceTrait.php
+++ b/src/Type/WPInterfaceTrait.php
@@ -1,0 +1,58 @@
+<?php
+namespace WPGraphQL\Type;
+
+use GraphQL\Type\Definition\InterfaceType;
+
+/**
+ * Trait WPInterfaceTrait
+ *
+ * This Trait includes methods to help Interfaces and ObjectTypes ensure they implement
+ * the proper inherited interfaces
+ *
+ * @package WPGraphQL\Type
+ */
+trait WPInterfaceTrait {
+
+	/**
+	 * Given an array of interfaces, this gets the Interfaces the Type should implement including
+	 * inherited interfaces.
+	 *
+	 * @param array $interfaces Array of interfaces the type implements
+	 *
+	 * @return array
+	 */
+	protected function get_implemented_interfaces( array $interfaces ) {
+
+		$new_interfaces = [];
+
+		foreach ( $interfaces as $interface ) {
+			if ( ! is_string( $interface ) ) {
+				continue;
+			}
+
+			$interface_type = $this->type_registry->get_type( $interface );
+			if ( ! $interface_type instanceof InterfaceType ) {
+				continue;
+			}
+
+			$new_interfaces[ $interface ] = $interface_type;
+			$interface_interfaces         = $interface_type->getInterfaces();
+
+			if ( ! is_array( $interface_interfaces ) || empty( $interface_interfaces ) ) {
+				continue;
+			}
+
+			foreach ( $interface_interfaces as $interface_interface_name => $interface_interface ) {
+				if ( ! $interface_interface instanceof InterfaceType ) {
+					continue;
+				}
+
+				$new_interfaces[ $interface_interface_name ] = $interface_interface;
+			}
+		}
+
+		return array_unique( $new_interfaces );
+
+	}
+
+}

--- a/src/Type/WPInterfaceType.php
+++ b/src/Type/WPInterfaceType.php
@@ -2,10 +2,14 @@
 
 namespace WPGraphQL\Type;
 
+use Exception;
+use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\InterfaceType;
 use WPGraphQL\Registry\TypeRegistry;
 
 class WPInterfaceType extends InterfaceType {
+
+	use WPInterfaceTrait;
 
 	/**
 	 * Instance of the TypeRegistry as an Interface needs knowledge of available Types
@@ -19,6 +23,8 @@ class WPInterfaceType extends InterfaceType {
 	 *
 	 * @param array        $config
 	 * @param TypeRegistry $type_registry
+	 *
+	 * @throws Exception
 	 */
 	public function __construct( array $config, TypeRegistry $type_registry ) {
 
@@ -27,7 +33,45 @@ class WPInterfaceType extends InterfaceType {
 		$name             = ucfirst( $config['name'] );
 		$config['name']   = apply_filters( 'graphql_type_name', $name, $config, $this );
 		$config['fields'] = function() use ( $config ) {
-			$fields = $this->prepare_fields( $config['fields'], $config['name'] );
+
+			$fields = $config['fields'];
+
+			/**
+			 * Get the fields of interfaces and ensure they exist as fields of this type.
+			 *
+			 * Types are still responsible for ensuring the fields resolve properly.
+			 */
+			if ( ! empty( $this->getInterfaces() ) && is_array( $this->getInterfaces() ) ) {
+
+				foreach ( $this->getInterfaces() as $interface_name => $interface_type ) {
+
+					if ( is_string( $interface_name ) && ! $interface_type instanceof InterfaceType ) {
+						$interface_type = $this->type_registry->get_type( $interface_name );
+					}
+
+					if ( ! $interface_type instanceof InterfaceType ) {
+						continue;
+					}
+
+					$interface_config_fields = $interface_type->getFields();
+
+					if ( empty( $interface_config_fields ) || ! is_array( $interface_config_fields ) ) {
+						continue;
+					}
+
+					foreach ( $interface_config_fields as $interface_field ) {
+						if ( ! isset( $interface_field->name ) || isset( $fields[ $interface_field->name ] ) ) {
+							continue;
+						}
+
+						if ( ! isset( $fields[ $interface_field->name ] ) && isset( $interface_field->config ) && is_array( $interface_field->config ) ) {
+							$fields[ $interface_field->name ] = $interface_field->config;
+						}
+					}
+				}
+			}
+
+			$fields = $this->prepare_fields( $fields, $config['name'] );
 			$fields = $this->type_registry->prepare_fields( $fields, $config['name'] );
 
 			return $fields;
@@ -58,6 +102,20 @@ class WPInterfaceType extends InterfaceType {
 		$config = apply_filters( 'graphql_wp_interface_type_config', $config, $this );
 
 		parent::__construct( $config );
+	}
+
+	/**
+	 * Get interfaces implemented by this Interface
+	 *
+	 * @return array
+	 */
+	public function getInterfaces(): array {
+
+		if ( ! isset( $this->config['interfaces'] ) || ! is_array( $this->config['interfaces'] ) || empty( $this->config['interfaces'] ) ) {
+			return [];
+		}
+
+		return $this->get_implemented_interfaces( $this->config['interfaces'] );
 	}
 
 	/**

--- a/src/Type/WPObjectType.php
+++ b/src/Type/WPObjectType.php
@@ -3,6 +3,7 @@
 namespace WPGraphQL\Type;
 
 use GraphQL\Error\UserError;
+use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\ObjectType;
 use WPGraphQL\Data\DataSource;
 use WPGraphQL\Registry\TypeRegistry;
@@ -18,6 +19,8 @@ use WPGraphQL\Type\InterfaceType\Node;
  * @since   0.0.5
  */
 class WPObjectType extends ObjectType {
+
+	use WPInterfaceTrait;
 
 	/**
 	 * Holds the node_interface definition allowing WPObjectTypes
@@ -42,6 +45,7 @@ class WPObjectType extends ObjectType {
 	 * @param array        $config
 	 * @param TypeRegistry $type_registry
 	 *
+	 * @throws \Exception
 	 * @since 0.0.5
 	 */
 	public function __construct( $config, TypeRegistry $type_registry ) {
@@ -65,41 +69,6 @@ class WPObjectType extends ObjectType {
 		$name           = ucfirst( $config['name'] );
 		$config['name'] = apply_filters( 'graphql_type_name', $name, $config, $this );
 
-		$interfaces = isset( $config['interfaces'] ) ? $config['interfaces'] : [];
-
-		/**
-		 * Filters the interfaces applied to an object type
-		 *
-		 * @param array        $interfaces     List of interfaces applied to the Object Type
-		 * @param array        $config         The config for the Object Type
-		 * @param WPObjectType $wp_object_type The WPObjectType instance
-		 */
-		$interfaces               = apply_filters( 'graphql_object_type_interfaces', $interfaces, $config, $this );
-		$config['interfaceNames'] = $interfaces;
-
-		/**
-		 * Convert Interfaces from Strings to Types
-		 */
-		$config['interfaces'] = function() use ( $interfaces ) {
-			$new_interfaces = [];
-			if ( ! is_array( $interfaces ) ) {
-				// TODO Throw an error.
-				return $new_interfaces;
-			}
-
-			foreach ( $interfaces as $interface ) {
-				if ( is_string( $interface ) ) {
-					$new_interfaces[ $interface ] = $this->type_registry->get_type( $interface );
-					continue;
-				}
-				if ( $interface instanceof WPInterfaceType ) {
-					$new_interfaces[ get_class( $interface ) ] = $interface;
-				}
-			}
-
-			return $new_interfaces;
-		};
-
 		/**
 		 * Setup the fields
 		 *
@@ -114,34 +83,31 @@ class WPObjectType extends ObjectType {
 			 *
 			 * Types are still responsible for ensuring the fields resolve properly.
 			 */
-			if ( ! empty( $config['interfaceNames'] ) ) {
-				// Throw if "interfaceNames" invalid.
-				if ( ! is_array( $config['interfaceNames'] ) ) {
-					throw new UserError(
-						sprintf(
-						/* translators: %s: type name */
-							__( 'Invalid value provided as "interfaceNames" on %s.', 'wp-graphql' ),
-							$config['name']
-						)
-					);
-				}
+			if ( ! empty( $this->getInterfaces() ) && is_array( $this->getInterfaces() ) ) {
 
-				foreach ( $config['interfaceNames'] as $interface_name ) {
-					$interface_type = null;
-					if ( is_string( $interface_name ) ) {
-						$interface_type = $this->type_registry->get_type( $interface_name );
-					} elseif ( $interface_name instanceof WPInterfaceType ) {
-						$interface_type = $interface_name;
+				foreach ( $this->getInterfaces() as $interface_type ) {
+
+					if ( ! $interface_type instanceof InterfaceType ) {
+						$interface_type = $this->type_registry->get_type( $interface_type );
 					}
-					$interface_fields = [];
-					if ( ! empty( $interface_type ) && $interface_type instanceof WPInterfaceType ) {
-						$interface_config_fields = $interface_type->getFields();
-						foreach ( $interface_config_fields as $interface_field ) {
-							$interface_fields[ $interface_field->name ] = $interface_field->config;
+
+					if ( ! $interface_type instanceof InterfaceType ) {
+						continue;
+					}
+
+					$interface_config_fields = $interface_type->getFields();
+
+					if ( empty( $interface_config_fields ) || ! is_array( $interface_config_fields ) ) {
+						continue;
+					}
+
+					foreach ( $interface_config_fields as $interface_field_name => $interface_field ) {
+						if ( ! isset( $interface_field->config ) ) {
+							continue;
 						}
-					}
 
-					$fields = array_replace_recursive( $interface_fields, $fields );
+						$fields[ $interface_field_name ] = $interface_field->config;
+					}
 				}
 			}
 
@@ -160,6 +126,20 @@ class WPObjectType extends ObjectType {
 		do_action( 'graphql_wp_object_type', $config, $this );
 
 		parent::__construct( $config );
+	}
+
+	/**
+	 * Get the interfaces implemented by the ObjectType
+	 *
+	 * @return array
+	 */
+	public function getInterfaces(): array {
+
+		if ( ! isset( $this->config['interfaces'] ) || ! is_array( $this->config['interfaces'] ) || empty( $this->config['interfaces'] ) ) {
+			return parent::getInterfaces();
+		}
+
+		return $this->get_implemented_interfaces( $this->config['interfaces'] );
 	}
 
 	/**

--- a/src/Utils/InstrumentSchema.php
+++ b/src/Utils/InstrumentSchema.php
@@ -6,6 +6,7 @@ use Exception;
 use GraphQL\Error\UserError;
 use GraphQL\Executor\Executor;
 use GraphQL\Type\Definition\FieldDefinition;
+use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
@@ -31,14 +32,14 @@ class InstrumentSchema {
 	 *
 	 * @return WPSchema
 	 */
-	public static function instrument_schema( WPSchema $schema ) {
+	public static function instrument_schema( WPSchema $schema ): WPSchema {
 
 		$new_types = [];
 		$types     = $schema->getTypeMap();
 
 		if ( ! empty( $types ) && is_array( $types ) ) {
 			foreach ( $types as $type_name => $type_object ) {
-				if ( $type_object instanceof ObjectType ) {
+				if ( $type_object instanceof ObjectType || $type_object instanceof InterfaceType ) {
 					$fields                            = $type_object->getFields();
 					$new_fields                        = self::wrap_fields( $fields, $type_name );
 					$new_type_object                   = $type_object;
@@ -51,7 +52,7 @@ class InstrumentSchema {
 		}
 
 		if ( ! empty( $new_types ) && is_array( $new_types ) ) {
-			$schema->config->types = $new_types;
+			$schema->config->types = array_merge( $types, $new_types );
 		}
 
 		return $schema;
@@ -69,149 +70,150 @@ class InstrumentSchema {
 	 *
 	 * @return mixed
 	 */
-	protected static function wrap_fields( $fields, $type_name ) {
+	protected static function wrap_fields( array $fields, string $type_name ) {
 
-		if ( ! empty( $fields ) && is_array( $fields ) ) {
+		if ( empty( $fields ) || ! is_array( $fields ) ) {
+			return $fields;
+		}
 
-			foreach ( $fields as $field_key => $field ) {
+		foreach ( $fields as $field_key => $field ) {
 
-				if ( $field instanceof FieldDefinition ) {
+			/**
+			 * Filter the field definition
+			 *
+			 * @param FieldDefinition $field     The field definition
+			 * @param string                                   $type_name The name of the Type the field belongs to
+			 */
+			$field = apply_filters( 'graphql_field_definition', $field, $type_name );
 
-					/**
-					 * Filter the field definition
-					 *
-					 * @param \GraphQL\Type\Definition\FieldDefinition $field     The field definition
-					 * @param string                                   $type_name The name of the Type the field belongs to
-					 */
-					$field = apply_filters( 'graphql_field_definition', $field, $type_name );
-
-					/**
-					 * Get the fields resolve function
-					 *
-					 * @since 0.0.1
-					 */
-					$field_resolver = ! empty( $field->resolveFn ) ? $field->resolveFn : null;
-
-					/**
-					 * Sanitize the description and deprecation reason
-					 */
-					$field->description       = ! empty( $field->description ) && is_string( $field->description ) ? esc_html( $field->description ) : '';
-					$field->deprecationReason = ! empty( $field->deprecationReason ) && is_string( $field->description ) ? esc_html( $field->deprecationReason ) : null;
-
-					/**
-					 * Replace the existing field resolve method with a new function that captures data about
-					 * the resolver to be stored in the resolver_report
-					 *
-					 * @param mixed       $source  The source passed down the Resolve Tree
-					 * @param array       $args    The args for the field
-					 * @param AppContext  $context The AppContext passed down the ResolveTree
-					 * @param ResolveInfo $info    The ResolveInfo passed down the ResolveTree
-					 *
-					 * @return mixed
-					 * @throws Exception
-					 * @since 0.0.1
-					 */
-					$field->resolveFn = function( $source, array $args, AppContext $context, ResolveInfo $info ) use ( $field_resolver, $type_name, $field_key, $field ) {
-
-						/**
-						 * Setup the global post to the current post (if a post)
-						 * This ensures that functions like get_the_content() work correctly
-						 * so graphql queries can be used in the loop without issues.
-						 */
-						if ( is_a( $source, 'WP_Post' ) && self::$cached_post !== $source ) {
-							self::$cached_post = $source;
-							$GLOBALS['post']   = $source;
-							setup_postdata( $source );
-						}
-
-						/**
-						 * Fire an action BEFORE the field resolves
-						 *
-						 * @param mixed           $source         The source passed down the Resolve Tree
-						 * @param array           $args           The args for the field
-						 * @param AppContext      $context        The AppContext passed down the ResolveTree
-						 * @param ResolveInfo     $info           The ResolveInfo passed down the ResolveTree
-						 * @param callable        $field_resolver The Resolve function for the field
-						 * @param string          $type_name      The name of the type the fields belong to
-						 * @param string          $field_key      The name of the field
-						 * @param FieldDefinition $field          The Field Definition for the resolving field
-						 */
-						do_action( 'graphql_before_resolve_field', $source, $args, $context, $info, $field_resolver, $type_name, $field_key, $field );
-
-						/**
-						 * Create unique custom "nil" value which is different from the build-in PHP null, false etc.
-						 * When this custom "nil" is returned we can know that the filter did not try to preresolve
-						 * the field because it does not equal with anything but itself.
-						 */
-						$nil = new \stdClass();
-
-						/**
-						 * When this filter return anything other than the $nil it will be used as the resolved value
-						 * and the execution of the actual resolved is skipped. This filter can be used to implement
-						 * field level caches or for efficiently hiding data by returning null.
-						 *
-						 * @param mixed           $nil            Unique nil value
-						 * @param mixed           $source         The source passed down the Resolve Tree
-						 * @param array           $args           The args for the field
-						 * @param AppContext      $context        The AppContext passed down the ResolveTree
-						 * @param ResolveInfo     $info           The ResolveInfo passed down the ResolveTree
-						 * @param string          $type_name      The name of the type the fields belong to
-						 * @param string          $field_key      The name of the field
-						 * @param FieldDefinition $field          The Field Definition for the resolving field
-						 * @param mixed           $field_resolver The default field resolver
-						 */
-						$result = apply_filters( 'graphql_pre_resolve_field', $nil, $source, $args, $context, $info, $type_name, $field_key, $field, $field_resolver );
-
-						/**
-						 * Check if the field preresolved
-						 */
-						if ( $nil === $result ) {
-							/**
-							 * If the current field doesn't have a resolve function, use the defaultFieldResolver,
-							 * otherwise use the $field_resolver
-							 */
-							if ( null === $field_resolver || ! is_callable( $field_resolver ) ) {
-								$result = Executor::defaultFieldResolver( $source, $args, $context, $info );
-							} else {
-								$result = call_user_func( $field_resolver, $source, $args, $context, $info );
-							}
-						}
-
-						/**
-						 * Fire an action before the field resolves
-						 *
-						 * @param mixed           $result         The result of the field resolution
-						 * @param mixed           $source         The source passed down the Resolve Tree
-						 * @param array           $args           The args for the field
-						 * @param AppContext      $context        The AppContext passed down the ResolveTree
-						 * @param ResolveInfo     $info           The ResolveInfo passed down the ResolveTree
-						 * @param string          $type_name      The name of the type the fields belong to
-						 * @param string          $field_key      The name of the field
-						 * @param FieldDefinition $field          The Field Definition for the resolving field
-						 * @param mixed           $field_resolver The default field resolver
-						 */
-						$result = apply_filters( 'graphql_resolve_field', $result, $source, $args, $context, $info, $type_name, $field_key, $field, $field_resolver );
-
-						/**
-						 * Fire an action AFTER the field resolves
-						 *
-						 * @param mixed           $source    The source passed down the Resolve Tree
-						 * @param array           $args      The args for the field
-						 * @param AppContext      $context   The AppContext passed down the ResolveTree
-						 * @param ResolveInfo     $info      The ResolveInfo passed down the ResolveTree
-						 * @param string          $type_name The name of the type the fields belong to
-						 * @param string          $field_key The name of the field
-						 * @param FieldDefinition $field     The Field Definition for the resolving field
-						 * @param mixed           $result    The result of the field resolver
-						 */
-						do_action( 'graphql_after_resolve_field', $source, $args, $context, $info, $field_resolver, $type_name, $field_key, $field, $result );
-
-						return $result;
-
-					};
-
-				}
+			if ( ! $field instanceof FieldDefinition ) {
+				return $field;
 			}
+
+			/**
+			 * Get the fields resolve function
+			 *
+			 * @since 0.0.1
+			 */
+			$field_resolver = is_callable( $field->resolveFn ) ? $field->resolveFn : null;
+
+			/**
+			 * Sanitize the description and deprecation reason
+			 */
+			$field->description       = ! empty( $field->description ) && is_string( $field->description ) ? esc_html( $field->description ) : '';
+			$field->deprecationReason = ! empty( $field->deprecationReason ) && is_string( $field->description ) ? esc_html( $field->deprecationReason ) : null;
+
+			/**
+			 * Replace the existing field resolve method with a new function that captures data about
+			 * the resolver to be stored in the resolver_report
+			 *
+			 * @param mixed       $source  The source passed down the Resolve Tree
+			 * @param array       $args    The args for the field
+			 * @param AppContext  $context The AppContext passed down the ResolveTree
+			 * @param ResolveInfo $info    The ResolveInfo passed down the ResolveTree
+			 *
+			 * @return mixed
+			 * @throws Exception
+			 * @since 0.0.1
+			 */
+			$field->resolveFn = static function( $source, array $args, AppContext $context, ResolveInfo $info ) use ( $field_resolver, $type_name, $field_key, $field ) {
+
+				/**
+				 * Setup the global post to the current post (if a post)
+				 * This ensures that functions like get_the_content() work correctly
+				 * so graphql queries can be used in the loop without issues.
+				 */
+				if ( is_a( $source, 'WP_Post' ) && self::$cached_post !== $source ) {
+					self::$cached_post = $source;
+					$GLOBALS['post']   = $source;
+					setup_postdata( $source );
+				}
+
+				/**
+				 * Fire an action BEFORE the field resolves
+				 *
+				 * @param mixed           $source         The source passed down the Resolve Tree
+				 * @param array           $args           The args for the field
+				 * @param AppContext      $context        The AppContext passed down the ResolveTree
+				 * @param ResolveInfo     $info           The ResolveInfo passed down the ResolveTree
+				 * @param callable        $field_resolver The Resolve function for the field
+				 * @param string          $type_name      The name of the type the fields belong to
+				 * @param string          $field_key      The name of the field
+				 * @param FieldDefinition $field          The Field Definition for the resolving field
+				 */
+				do_action( 'graphql_before_resolve_field', $source, $args, $context, $info, $field_resolver, $type_name, $field_key, $field );
+
+				/**
+				 * Create unique custom "nil" value which is different from the build-in PHP null, false etc.
+				 * When this custom "nil" is returned we can know that the filter did not try to preresolve
+				 * the field because it does not equal with anything but itself.
+				 */
+				$nil = new \stdClass();
+
+				/**
+				 * When this filter return anything other than the $nil it will be used as the resolved value
+				 * and the execution of the actual resolved is skipped. This filter can be used to implement
+				 * field level caches or for efficiently hiding data by returning null.
+				 *
+				 * @param mixed           $nil            Unique nil value
+				 * @param mixed           $source         The source passed down the Resolve Tree
+				 * @param array           $args           The args for the field
+				 * @param AppContext      $context        The AppContext passed down the ResolveTree
+				 * @param ResolveInfo     $info           The ResolveInfo passed down the ResolveTree
+				 * @param string          $type_name      The name of the type the fields belong to
+				 * @param string          $field_key      The name of the field
+				 * @param FieldDefinition $field          The Field Definition for the resolving field
+				 * @param mixed           $field_resolver The default field resolver
+				 */
+				$result = apply_filters( 'graphql_pre_resolve_field', $nil, $source, $args, $context, $info, $type_name, $field_key, $field, $field_resolver );
+
+				/**
+				 * Check if the field pre-resolved
+				 */
+				if ( $nil === $result ) {
+					/**
+					 * If the current field doesn't have a resolve function, use the defaultFieldResolver,
+					 * otherwise use the $field_resolver
+					 */
+					if ( null === $field_resolver || ! is_callable( $field_resolver ) ) {
+						$result = Executor::defaultFieldResolver( $source, $args, $context, $info );
+					} else {
+						$result = $field_resolver( $source, $args, $context, $info );
+					}
+				}
+
+				/**
+				 * Fire an action before the field resolves
+				 *
+				 * @param mixed           $result         The result of the field resolution
+				 * @param mixed           $source         The source passed down the Resolve Tree
+				 * @param array           $args           The args for the field
+				 * @param AppContext      $context        The AppContext passed down the ResolveTree
+				 * @param ResolveInfo     $info           The ResolveInfo passed down the ResolveTree
+				 * @param string          $type_name      The name of the type the fields belong to
+				 * @param string          $field_key      The name of the field
+				 * @param FieldDefinition $field          The Field Definition for the resolving field
+				 * @param mixed           $field_resolver The default field resolver
+				 */
+				$result = apply_filters( 'graphql_resolve_field', $result, $source, $args, $context, $info, $type_name, $field_key, $field, $field_resolver );
+
+				/**
+				 * Fire an action AFTER the field resolves
+				 *
+				 * @param mixed           $source    The source passed down the Resolve Tree
+				 * @param array           $args      The args for the field
+				 * @param AppContext      $context   The AppContext passed down the ResolveTree
+				 * @param ResolveInfo     $info      The ResolveInfo passed down the ResolveTree
+				 * @param string          $type_name The name of the type the fields belong to
+				 * @param string          $field_key The name of the field
+				 * @param FieldDefinition $field     The Field Definition for the resolving field
+				 * @param mixed           $result    The result of the field resolver
+				 */
+				do_action( 'graphql_after_resolve_field', $source, $args, $context, $info, $field_resolver, $type_name, $field_key, $field, $result );
+
+				return $result;
+
+			};
 		}
 
 		/**
@@ -239,62 +241,71 @@ class InstrumentSchema {
 	 */
 	public static function check_field_permissions( $source, array $args, AppContext $context, ResolveInfo $info, $field_resolver, string $type_name, string $field_key, FieldDefinition $field ) {
 
+		if ( ! $field instanceof FieldDefinition ) {
+			return true;
+		}
+
+		if ( ! isset( $field->config['auth'] ) || ! is_array( $field->config['auth'] ) ) {
+			return true;
+		}
+
 		/**
 		 * Set the default auth error message
 		 */
 		$default_auth_error_message = __( 'You do not have permission to view this', 'wp-graphql' );
+		$default_auth_error_message = apply_filters( 'graphql_field_resolver_auth_error_message', $default_auth_error_message, $field );
 
 		/**
-		 * Filter the $auth_error
+		 * Retrieve permissions error message.
 		 */
-		$auth_error = apply_filters( 'graphql_field_resolver_auth_error_message', $default_auth_error_message, $field );
+		$auth_error = isset( $field->config['auth']['errorMessage'] ) && ! empty( $field->config['auth']['errorMessage'] )
+			? $field->config['auth']['errorMessage']
+			: $default_auth_error_message;
 
 		/**
-		 * Check to see if
+		 * If the user is authenticated, and the field has a custom auth callback configured
+		 * execute the callback before continuing resolution
 		 */
-		if ( $field instanceof FieldDefinition && (
-				isset( $field->config['isPrivate'] ) ||
-				( ! empty( $field->config['auth'] ) && is_array( $field->config['auth'] ) ) )
-		) {
+		if ( isset( $field->config['auth']['callback'] ) && is_callable( $field->config['auth']['callback'] ) ) {
 
-			/**
-			 * If the schema for the field is configured to "isPrivate" or has "auth" configured,
-			 * make sure the user is authenticated before resolving the field
-			 */
-			if ( empty( get_current_user_id() ) ) {
+			$authorized = call_user_func( $field->config['auth']['callback'], $field, $field_key, $source, $args, $context, $info, $field_resolver );
+
+			// If callback returns explicit false throw.
+			if ( false === $authorized ) {
 				throw new UserError( $auth_error );
 			}
 
-			/**
-			 * If the user is authenticated, and the field has a custom auth callback configured,
-			 * execute the callback before continuing resolution
-			 */
-			if ( ! empty( $field->config['auth']['callback'] ) && is_callable( $field->config['auth']['callback'] ) ) {
+			return $authorized;
+		}
 
-				return call_user_func( $field->config['auth']['callback'], $field, $field_key, $source, $args, $context, $info, $field_resolver );
+		/**
+		 * If the schema for the field is configured to "isPrivate" or has "auth" configured,
+		 * make sure the user is authenticated before resolving the field
+		 */
+		if ( isset( $field->config['isPrivate'] ) && true === $field->config['isPrivate'] && empty( get_current_user_id() ) ) {
+			throw new UserError( $auth_error );
+		}
+
+		/**
+		 * If the user is authenticated and the field has "allowedCaps" configured,
+		 * ensure the user has at least one of the allowedCaps before resolving
+		 */
+		if ( isset( $field->config['auth']['allowedCaps'] ) && is_array( $field->config['auth']['allowedCaps'] ) ) {
+			$caps = ! empty( wp_get_current_user()->allcaps ) ? wp_get_current_user()->allcaps : [];
+			if ( empty( array_intersect( array_keys( $caps ), array_values( $field->config['auth']['allowedCaps'] ) ) ) ) {
+				throw new UserError( $auth_error );
 			}
+		}
 
-			/**
-			 * If the user is authenticated and the field has "allowedCaps" configured,
-			 * ensure the user has at least one of the allowedCaps before resolving
-			 */
-			if ( ! empty( $field->config['auth']['allowedCaps'] ) && is_array( $field->config['auth']['allowedCaps'] ) ) {
-				$caps = ! empty( wp_get_current_user()->allcaps ) ? wp_get_current_user()->allcaps : [];
-				if ( empty( array_intersect( array_keys( $caps ), array_values( $field->config['auth']['allowedCaps'] ) ) ) ) {
-					throw new UserError( $auth_error );
-				}
-			}
-
-			/**
-			 * If the user is authenticated and the field has "allowedRoles" configured,
-			 * ensure the user has at least one of the allowedRoles before resolving
-			 */
-			if ( ! empty( $field->config['auth']['allowedRoles'] ) && is_array( $field->config['auth']['allowedRoles'] ) ) {
-				$roles         = ! empty( wp_get_current_user()->roles ) ? wp_get_current_user()->roles : [];
-				$allowed_roles = array_values( $field->config['auth']['allowedRoles'] );
-				if ( empty( array_intersect( array_values( $roles ), array_values( $allowed_roles ) ) ) ) {
-					throw new UserError( $auth_error );
-				}
+		/**
+		 * If the user is authenticated and the field has "allowedRoles" configured,
+		 * ensure the user has at least one of the allowedRoles before resolving
+		 */
+		if ( isset( $field->config['auth']['allowedRoles'] ) && is_array( $field->config['auth']['allowedRoles'] ) ) {
+			$roles         = ! empty( wp_get_current_user()->roles ) ? wp_get_current_user()->roles : [];
+			$allowed_roles = array_values( $field->config['auth']['allowedRoles'] );
+			if ( empty( array_intersect( array_values( $roles ), array_values( $allowed_roles ) ) ) ) {
+				throw new UserError( $auth_error );
 			}
 		}
 

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -125,7 +125,7 @@ final class WPGraphQL {
 
 		// Plugin version.
 		if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-			define( 'WPGRAPHQL_VERSION', '1.3.10' );
+			define( 'WPGRAPHQL_VERSION', '1.4.0' );
 		}
 
 		// Plugin Folder Path.

--- a/tests/wpunit/SettingsQueriesTest.php
+++ b/tests/wpunit/SettingsQueriesTest.php
@@ -4,19 +4,6 @@ class WP_GraphQL_Test_Settings_Queries extends \Codeception\TestCase\WPTestCase 
 
 	public function setUp(): void {
 
-		/**
-		 * Manually Register a setting for testing
-		 *
-		 * This registers a setting as a number to see if it gets the correct type
-		 * associated with it and returned through WPGraphQL
-		 */
-		register_setting( 'Zool', 'points', array(
-			'type'         => 'number',
-			'description'  => __( 'Test how many points we have in Zool.' ),
-			'show_in_graphql' => true,
-			'default' => 4.5,
-		) );
-
 		$this->admin = $this->factory->user->create( [
 			'role' => 'administrator',
 		] );
@@ -27,10 +14,12 @@ class WP_GraphQL_Test_Settings_Queries extends \Codeception\TestCase\WPTestCase 
 
 		parent::setUp();
 
+		WPGraphQL::clear_schema();
 	}
 
 	public function tearDown(): void {
 		parent::tearDown();
+		WPGraphQL::clear_schema();
 	}
 
 	/**

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.3.10
+ * Version: 1.4.0
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.3.10
+ * @version  1.4.0
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
# Release Notes

## Chores / Bugfixes

- ([#1951](https://github.com/wp-graphql/wp-graphql/pull/1951)): Fixes bug with the `uri` field. Some Types in the Schema had the `uri` field as nullable field and some as a non-null field. This fixes it and makes the field consistently nullable as some Nodes with a URI might have a `null` value if the node is private.
- ([#1953](https://github.com/wp-graphql/wp-graphql/pull/1953)): Fixes bug with Settings groups with underscores not showing in the Schema properly. Thanks @markkelnar!

## New Features

- ([#1951](https://github.com/wp-graphql/wp-graphql/pull/1951)): Updates GraphQL-PHP to v14.8.0 (from 14.4.0) and Introduces the ability for Interfaces to implement other Interfaces!
