### PR TITLE
Code sniff space after closure function word

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -14,10 +14,14 @@
 
 	<!-- Includes -->
 	<file>./access-functions.php</file>
+	<file>./activation.php</file>
+	<file>./deactivation.php</file>
 	<file>./wp-graphql.php</file>
 	<file>./src</file>
 
 	<!-- Rules -->
+	<rule ref="Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction"/>
+
 	<rule ref="WordPress-Core">
 		<!-- Definitely should not be added back -->
 		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
@@ -29,7 +33,6 @@
 		<exclude name="WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid"/>
 		<exclude name="Squiz.PHP.DisallowMultipleAssignments.FoundInControlStructure"/>
 		<exclude name="WordPress.DateTime.RestrictedFunctions.date_date"/>
-
 
 		<!-- Should maybe Add Back Later -->
 		<exclude name="WordPress.WP.I18n.MissingTranslatorsComment"/>

--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -45,7 +45,7 @@ class Admin {
 
 		// This removes the menu page for WPGraphiQL as it's now built into WPGraphQL
 		if ( $this->graphiql_enabled ) {
-			add_action( 'admin_menu', function() {
+			add_action( 'admin_menu', function () {
 				remove_menu_page( 'wp-graphiql/wp-graphiql.php' );
 			} );
 		}

--- a/src/Admin/Settings/Settings.php
+++ b/src/Admin/Settings/Settings.php
@@ -94,7 +94,7 @@ class Settings {
 				'value'             => ! empty( $custom_endpoint ) ? $custom_endpoint : null,
 				'default'           => ! empty( $custom_endpoint ) ? $custom_endpoint : 'graphql',
 				'disabled'          => ! empty( $custom_endpoint ) ? true : false,
-				'sanitize_callback' => function( $value ) {
+				'sanitize_callback' => function ( $value ) {
 					if ( empty( $value ) ) {
 						add_settings_error( 'graphql_endpoint', 'required', __( 'The "GraphQL Endpoint" field is required and cannot be blank. The default endpoint is "graphql"', 'wp-graphql' ), 'error' );
 

--- a/src/Admin/Settings/SettingsRegistry.php
+++ b/src/Admin/Settings/SettingsRegistry.php
@@ -169,7 +169,7 @@ class SettingsRegistry {
 
 			if ( isset( $section['desc'] ) && ! empty( $section['desc'] ) ) {
 				$section['desc'] = '<div class="inside">' . $section['desc'] . '</div>';
-				$callback        = function() use ( $section ) {
+				$callback        = function () use ( $section ) {
 					echo wp_kses( str_replace( '"', '\"', $section['desc'] ), Utils::get_allowed_wp_kses_html() );
 				};
 			} elseif ( isset( $section['callback'] ) ) {

--- a/src/Connection/Commenter.php
+++ b/src/Connection/Commenter.php
@@ -25,7 +25,7 @@ class Commenter {
 			'description'   => __( 'The author of the comment', 'wp-graphql' ),
 			'fromFieldName' => 'author',
 			'oneToOne'      => true,
-			'resolve'       => function( $comment, $args, AppContext $context, ResolveInfo $info ) {
+			'resolve'       => function ( $comment, $args, AppContext $context, ResolveInfo $info ) {
 
 				/**
 				 * If the comment has a user associated, use it to populate the author, otherwise return

--- a/src/Connection/Comments.php
+++ b/src/Connection/Comments.php
@@ -36,7 +36,7 @@ class Comments {
 		 */
 		register_graphql_connection( self::get_connection_config( [
 			'fromType' => 'User',
-			'resolve'  => function( User $user, $args, $context, $info ) {
+			'resolve'  => function ( User $user, $args, $context, $info ) {
 				$resolver = new CommentConnectionResolver( $user, $args, $context, $info );
 
 				return $resolver->set_query_arg( 'user_id', absint( $user->userId ) )->get_connection();
@@ -50,7 +50,7 @@ class Comments {
 			'fromFieldName'      => 'parent',
 			'connectionTypeName' => 'CommentToParentCommentConnection',
 			'oneToOne'           => true,
-			'resolve'            => function( Comment $comment, $args, $context, $info ) {
+			'resolve'            => function ( Comment $comment, $args, $context, $info ) {
 				$resolver = new CommentConnectionResolver( $comment, $args, $context, $info );
 
 				return ! empty( $comment->comment_parent_id ) ? $resolver->one_to_one()->set_query_arg( 'comment__in', [ $comment->comment_parent_id ] )->get_connection() : null;
@@ -65,7 +65,7 @@ class Comments {
 				[
 					'fromType'      => 'Comment',
 					'fromFieldName' => 'replies',
-					'resolve'       => function( Comment $comment, $args, $context, $info ) {
+					'resolve'       => function ( Comment $comment, $args, $context, $info ) {
 						$resolver = new CommentConnectionResolver( $comment, $args, $context, $info );
 
 						return $resolver->set_query_arg( 'parent', absint( $comment->commentId ) )->get_connection();
@@ -93,7 +93,7 @@ class Comments {
 								'fromType'      => $post_type_object->graphql_single_name,
 								'toType'        => 'Comment',
 								'fromFieldName' => 'comments',
-								'resolve'       => function( Post $post, $args, $context, $info ) {
+								'resolve'       => function ( Post $post, $args, $context, $info ) {
 
 									if ( $post->isRevision ) {
 										$id = $post->parentDatabaseId;
@@ -127,7 +127,7 @@ class Comments {
 			'toType'         => 'Comment',
 			'fromFieldName'  => 'comments',
 			'connectionArgs' => self::get_connection_args(),
-			'resolve'        => function( $root, $args, $context, $info ) {
+			'resolve'        => function ( $root, $args, $context, $info ) {
 				return DataSource::resolve_comments_connection( $root, $args, $context, $info );
 			},
 		];

--- a/src/Connection/ContentTypes.php
+++ b/src/Connection/ContentTypes.php
@@ -24,7 +24,7 @@ class ContentTypes {
 				'fromType'      => 'RootQuery',
 				'toType'        => 'ContentType',
 				'fromFieldName' => 'contentTypes',
-				'resolve'       => function( $source, $args, $context, $info ) {
+				'resolve'       => function ( $source, $args, $context, $info ) {
 					$resolver = new ContentTypeConnectionResolver( $source, $args, $context, $info );
 					return $resolver->get_connection();
 				},
@@ -36,7 +36,7 @@ class ContentTypes {
 				'fromType'      => 'ContentNode',
 				'toType'        => 'ContentType',
 				'fromFieldName' => 'contentType',
-				'resolve'       => function( Post $source, $args, $context, $info ) {
+				'resolve'       => function ( Post $source, $args, $context, $info ) {
 
 					if ( $source->isRevision ) {
 						$parent    = get_post( $source->parentDatabaseId );
@@ -61,7 +61,7 @@ class ContentTypes {
 			'toType'        => 'ContentType',
 			'description'   => __( 'List of Content Types associated with the Taxonomy', 'wp-graphql' ),
 			'fromFieldName' => 'connectedContentTypes',
-			'resolve'       => function( Taxonomy $taxonomy, $args, AppContext $context, ResolveInfo $info ) {
+			'resolve'       => function ( Taxonomy $taxonomy, $args, AppContext $context, ResolveInfo $info ) {
 
 				$connected_post_types = ! empty( $taxonomy->object_type ) ? $taxonomy->object_type : [];
 				$resolver             = new ContentTypeConnectionResolver( $taxonomy, $args, $context, $info );

--- a/src/Connection/EnqueuedScripts.php
+++ b/src/Connection/EnqueuedScripts.php
@@ -21,7 +21,7 @@ class EnqueuedScripts {
 			'fromType'      => 'ContentNode',
 			'toType'        => 'EnqueuedScript',
 			'fromFieldName' => 'enqueuedScripts',
-			'resolve'       => function( $source, $args, $context, $info ) {
+			'resolve'       => function ( $source, $args, $context, $info ) {
 				$resolver = new EnqueuedScriptsConnectionResolver( $source, $args, $context, $info );
 				return $resolver->get_connection();
 			},
@@ -31,7 +31,7 @@ class EnqueuedScripts {
 			'fromType'      => 'TermNode',
 			'toType'        => 'EnqueuedScript',
 			'fromFieldName' => 'enqueuedScripts',
-			'resolve'       => function( $source, $args, $context, $info ) {
+			'resolve'       => function ( $source, $args, $context, $info ) {
 				$resolver = new EnqueuedScriptsConnectionResolver( $source, $args, $context, $info );
 				return $resolver->get_connection();
 			},
@@ -41,7 +41,7 @@ class EnqueuedScripts {
 			'fromType'      => 'RootQuery',
 			'toType'        => 'EnqueuedScript',
 			'fromFieldName' => 'registeredScripts',
-			'resolve'       => function( $source, $args, $context, $info ) {
+			'resolve'       => function ( $source, $args, $context, $info ) {
 
 				// The connection resolver expects the source to include
 				// enqueuedScriptsQueue
@@ -59,7 +59,7 @@ class EnqueuedScripts {
 			'fromType'      => 'User',
 			'toType'        => 'EnqueuedScript',
 			'fromFieldName' => 'enqueuedScripts',
-			'resolve'       => function( $source, $args, $context, $info ) {
+			'resolve'       => function ( $source, $args, $context, $info ) {
 				$resolver = new EnqueuedScriptsConnectionResolver( $source, $args, $context, $info );
 				return $resolver->get_connection();
 			},

--- a/src/Connection/EnqueuedStylesheets.php
+++ b/src/Connection/EnqueuedStylesheets.php
@@ -21,7 +21,7 @@ class EnqueuedStylesheets {
 			'fromType'      => 'ContentNode',
 			'toType'        => 'EnqueuedStylesheet',
 			'fromFieldName' => 'enqueuedStylesheets',
-			'resolve'       => function( $source, $args, $context, $info ) {
+			'resolve'       => function ( $source, $args, $context, $info ) {
 				$resolver = new EnqueuedStylesheetConnectionResolver( $source, $args, $context, $info );
 				return $resolver->get_connection();
 			},
@@ -31,7 +31,7 @@ class EnqueuedStylesheets {
 			'fromType'      => 'TermNode',
 			'toType'        => 'EnqueuedStylesheet',
 			'fromFieldName' => 'enqueuedStylesheets',
-			'resolve'       => function( $source, $args, $context, $info ) {
+			'resolve'       => function ( $source, $args, $context, $info ) {
 				$resolver = new EnqueuedStylesheetConnectionResolver( $source, $args, $context, $info );
 				return $resolver->get_connection();
 			},
@@ -41,7 +41,7 @@ class EnqueuedStylesheets {
 			'fromType'      => 'RootQuery',
 			'toType'        => 'EnqueuedStylesheet',
 			'fromFieldName' => 'registeredStylesheets',
-			'resolve'       => function( $source, $args, $context, $info ) {
+			'resolve'       => function ( $source, $args, $context, $info ) {
 
 				// The connection resolver expects the source to include
 				// enqueuedStylesheetsQueue
@@ -59,7 +59,7 @@ class EnqueuedStylesheets {
 			'fromType'      => 'User',
 			'toType'        => 'EnqueuedStylesheet',
 			'fromFieldName' => 'enqueuedStylesheets',
-			'resolve'       => function( $source, $args, $context, $info ) {
+			'resolve'       => function ( $source, $args, $context, $info ) {
 				$resolver = new EnqueuedStylesheetConnectionResolver( $source, $args, $context, $info );
 				return $resolver->get_connection();
 			},

--- a/src/Connection/MediaItems.php
+++ b/src/Connection/MediaItems.php
@@ -25,7 +25,7 @@ class MediaItems {
 			'toType'        => 'MediaItem',
 			'fromFieldName' => 'featuredImage',
 			'oneToOne'      => true,
-			'resolve'       => function( Post $post, $args, AppContext $context, ResolveInfo $info ) {
+			'resolve'       => function ( Post $post, $args, AppContext $context, ResolveInfo $info ) {
 
 				if ( empty( $post->featuredImageDatabaseId ) ) {
 					return null;

--- a/src/Connection/MenuItemLinkableConnection.php
+++ b/src/Connection/MenuItemLinkableConnection.php
@@ -22,7 +22,7 @@ class MenuItemLinkableConnection {
 			'description'   => __( 'Connection from MenuItem to it\'s connected node', 'wp-graphql' ),
 			'fromFieldName' => 'connectedNode',
 			'oneToOne'      => true,
-			'resolve'       => function( MenuItem $menu_item, $args, AppContext $context, ResolveInfo $info ) {
+			'resolve'       => function ( MenuItem $menu_item, $args, AppContext $context, ResolveInfo $info ) {
 
 				$object_id   = intval( get_post_meta( $menu_item->databaseId, '_menu_item_object_id', true ) );
 				$object_type = get_post_meta( $menu_item->databaseId, '_menu_item_type', true );

--- a/src/Connection/MenuItems.php
+++ b/src/Connection/MenuItems.php
@@ -40,7 +40,7 @@ class MenuItems {
 				[
 					'fromType'      => 'MenuItem',
 					'fromFieldName' => 'childItems',
-					'resolve'       => function( MenuItem $menu_item, $args, AppContext $context, ResolveInfo $info ) {
+					'resolve'       => function ( MenuItem $menu_item, $args, AppContext $context, ResolveInfo $info ) {
 
 						if ( empty( $menu_item->menuId ) || empty( $menu_item->databaseId ) ) {
 							return null;
@@ -65,7 +65,7 @@ class MenuItems {
 				[
 					'fromType' => 'Menu',
 					'toType'   => 'MenuItem',
-					'resolve'  => function( Menu $menu, $args, AppContext $context, ResolveInfo $info ) {
+					'resolve'  => function ( Menu $menu, $args, AppContext $context, ResolveInfo $info ) {
 
 						$resolver = new MenuItemConnectionResolver( $menu, $args, $context, $info );
 						$resolver->set_query_arg( 'tax_query', [
@@ -117,7 +117,7 @@ class MenuItems {
 						'description' => __( 'The menu location for the menu being queried', 'wp-graphql' ),
 					],
 				],
-				'resolve'        => function( $source, $args, $context, $info ) {
+				'resolve'        => function ( $source, $args, $context, $info ) {
 					$resolver   = new MenuItemConnectionResolver( $source, $args, $context, $info );
 					$connection = $resolver->get_connection();
 

--- a/src/Connection/Menus.php
+++ b/src/Connection/Menus.php
@@ -59,7 +59,7 @@ class Menus {
 			'description'   => __( 'The Menu a MenuItem is part of', 'wp-graphql' ),
 			'fromFieldName' => 'menu',
 			'oneToOne'      => true,
-			'resolve'       => function( MenuItem $menu_item, $args, $context, $info ) {
+			'resolve'       => function ( MenuItem $menu_item, $args, $context, $info ) {
 				$resolver = new MenuConnectionResolver( $menu_item, $args, $context, $info );
 				$resolver->set_query_arg( 'include', $menu_item->menuDatabaseId );
 				return $resolver->one_to_one()->get_connection();

--- a/src/Connection/PostObjects.php
+++ b/src/Connection/PostObjects.php
@@ -38,7 +38,7 @@ class PostObjects {
 			'fromFieldName'  => 'contentNodes',
 			'connectionArgs' => self::get_connection_args(),
 			'queryClass'     => 'WP_Query',
-			'resolve'        => function( PostType $post_type, $args, AppContext $context, ResolveInfo $info ) {
+			'resolve'        => function ( PostType $post_type, $args, AppContext $context, ResolveInfo $info ) {
 
 				$resolver = new PostObjectConnectionResolver( $post_type, $args, $context, $info );
 				$resolver->set_query_arg( 'post_type', $post_type->name );
@@ -54,7 +54,7 @@ class PostObjects {
 			'queryClass'    => 'WP_Query',
 			'oneToOne'      => true,
 			'fromFieldName' => 'commentedOn',
-			'resolve'       => function( Comment $comment, $args, AppContext $context, ResolveInfo $info ) {
+			'resolve'       => function ( Comment $comment, $args, AppContext $context, ResolveInfo $info ) {
 				if ( empty( $comment->comment_post_ID ) || ! absint( $comment->comment_post_ID ) ) {
 					return null;
 				}
@@ -71,7 +71,7 @@ class PostObjects {
 			'fromFieldName' => 'revisionOf',
 			'description'   => __( 'If the current node is a revision, this field exposes the node this is a revision of. Returns null if the node is not a revision of another node.', 'wp-graphql' ),
 			'oneToOne'      => true,
-			'resolve'       => function( Post $post, $args, AppContext $context, ResolveInfo $info ) {
+			'resolve'       => function ( Post $post, $args, AppContext $context, ResolveInfo $info ) {
 
 				if ( ! $post->isRevision || ! isset( $post->parentDatabaseId ) || ! absint( $post->parentDatabaseId ) ) {
 					return null;
@@ -100,7 +100,7 @@ class PostObjects {
 					],
 					null
 				),
-				'resolve'        => function( $source, $args, $context, $info ) {
+				'resolve'        => function ( $source, $args, $context, $info ) {
 					$post_types = isset( $args['where']['contentTypes'] ) && is_array( $args['where']['contentTypes'] ) ? $args['where']['contentTypes'] : \WPGraphQL::get_allowed_post_types();
 
 					return DataSource::resolve_post_objects_connection( $source, $args, $context, $info, $post_types );
@@ -115,7 +115,7 @@ class PostObjects {
 			'connectionTypeName' => 'HierarchicalContentNodeToParentContentNodeConnection',
 			'description'        => __( 'The parent of the node. The parent object can be of various types', 'wp-graphql' ),
 			'oneToOne'           => true,
-			'resolve'            => function( Post $post, $args, AppContext $context, ResolveInfo $info ) {
+			'resolve'            => function ( Post $post, $args, AppContext $context, ResolveInfo $info ) {
 
 				if ( ! isset( $post->parentDatabaseId ) || ! absint( $post->parentDatabaseId ) ) {
 					return null;
@@ -136,7 +136,7 @@ class PostObjects {
 			'connectionTypeName' => 'HierarchicalContentNodeToContentNodeChildrenConnection',
 			'connectionArgs'     => self::get_connection_args(),
 			'queryClass'         => 'WP_Query',
-			'resolve'            => function( Post $post, $args, $context, $info ) {
+			'resolve'            => function ( Post $post, $args, $context, $info ) {
 
 				if ( $post->isRevision ) {
 					$id = $post->parentDatabaseId;
@@ -160,7 +160,7 @@ class PostObjects {
 			'connectionTypeName' => 'HierarchicalContentNodeToContentNodeAncestorsConnection',
 			'queryClass'         => 'WP_Query',
 			'description'        => __( 'Returns ancestors of the node. Default ordered as lowest (closest to the child) to highest (closest to the root).', 'wp-graphql' ),
-			'resolve'            => function( Post $post, $args, $context, $info ) {
+			'resolve'            => function ( Post $post, $args, $context, $info ) {
 				$ancestors = get_ancestors( $post->ID, '', 'post_type' );
 				if ( empty( $ancestors ) || ! is_array( $ancestors ) ) {
 					return null;
@@ -205,7 +205,7 @@ class PostObjects {
 						'fromFieldName'      => 'preview',
 						'connectionTypeName' => ucfirst( $post_type_object->graphql_single_name ) . 'ToPreviewConnection',
 						'oneToOne'           => true,
-						'resolve'            => function( Post $post, $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'            => function ( Post $post, $args, AppContext $context, ResolveInfo $info ) {
 
 							if ( $post->isRevision ) {
 								return null;
@@ -236,7 +236,7 @@ class PostObjects {
 							$post_type_object,
 							[
 								'fromType' => 'User',
-								'resolve'  => function( User $user, $args, AppContext $context, ResolveInfo $info ) use ( $post_type_object ) {
+								'resolve'  => function ( User $user, $args, AppContext $context, ResolveInfo $info ) use ( $post_type_object ) {
 									$resolver = new PostObjectConnectionResolver( $user, $args, $context, $info, $post_type_object->name );
 									$resolver->set_query_arg( 'author', $user->userId );
 
@@ -261,7 +261,7 @@ class PostObjects {
 									$post_type_object,
 									[
 										'fromType' => $taxonomy_object->graphql_single_name,
-										'resolve'  => function( Term $term, $args, AppContext $context, ResolveInfo $info ) use ( $post_type_object ) {
+										'resolve'  => function ( Term $term, $args, AppContext $context, ResolveInfo $info ) use ( $post_type_object ) {
 											$resolver = new PostObjectConnectionResolver( $term, $args, $context, $info, $post_type_object->name );
 											$resolver->set_query_arg( 'tax_query', [
 												[
@@ -294,7 +294,7 @@ class PostObjects {
 								'fromType'           => $post_type_object->graphql_single_name,
 								'toType'             => $post_type_object->graphql_single_name,
 								'fromFieldName'      => 'revisions',
-								'resolve'            => function( Post $post, $args, $context, $info ) {
+								'resolve'            => function ( Post $post, $args, $context, $info ) {
 									$resolver = new PostObjectConnectionResolver( $post, $args, $context, $info, 'revision' );
 									$resolver->set_query_arg( 'post_parent', $post->ID );
 
@@ -322,7 +322,7 @@ class PostObjects {
 					'fromType'      => $tax_object->graphql_single_name,
 					'fromFieldName' => 'contentNodes',
 					'toType'        => 'ContentNode',
-					'resolve'       => function( Term $term, $args, $context, $info ) {
+					'resolve'       => function ( Term $term, $args, $context, $info ) {
 
 						$resolver = new PostObjectConnectionResolver( $term, $args, $context, $info, 'any' );
 						$resolver->set_query_arg( 'tax_query', [
@@ -369,7 +369,7 @@ class PostObjects {
 				'queryClass'     => 'WP_Query',
 				'fromFieldName'  => lcfirst( $graphql_object->graphql_plural_name ),
 				'connectionArgs' => $connection_args,
-				'resolve'        => function( $root, $args, $context, $info ) use ( $graphql_object ) {
+				'resolve'        => function ( $root, $args, $context, $info ) use ( $graphql_object ) {
 					return DataSource::resolve_post_objects_connection( $root, $args, $context, $info, $graphql_object->name );
 				},
 			],

--- a/src/Connection/Revisions.php
+++ b/src/Connection/Revisions.php
@@ -25,7 +25,7 @@ class Revisions {
 				'queryClass'     => 'WP_Query',
 				'fromFieldName'  => 'revisions',
 				'connectionArgs' => PostObjects::get_connection_args(),
-				'resolve'        => function( $root, $args, $context, $info ) {
+				'resolve'        => function ( $root, $args, $context, $info ) {
 					return DataSource::resolve_post_objects_connection( $root, $args, $context, $info, 'revision' );
 				},
 			]
@@ -39,7 +39,7 @@ class Revisions {
 				'fromFieldName'  => 'revisions',
 				'description'    => __( 'Connection between the User and Revisions authored by the user', 'wp-graphql' ),
 				'connectionArgs' => PostObjects::get_connection_args(),
-				'resolve'        => function( $root, $args, $context, $info ) {
+				'resolve'        => function ( $root, $args, $context, $info ) {
 					return DataSource::resolve_post_objects_connection( $root, $args, $context, $info, 'revision' );
 				},
 			]

--- a/src/Connection/Taxonomies.php
+++ b/src/Connection/Taxonomies.php
@@ -20,7 +20,7 @@ class Taxonomies {
 				'fromType'      => 'RootQuery',
 				'toType'        => 'Taxonomy',
 				'fromFieldName' => 'taxonomies',
-				'resolve'       => function( $source, $args, $context, $info ) {
+				'resolve'       => function ( $source, $args, $context, $info ) {
 					$resolver = new TaxonomyConnectionResolver( $source, $args, $context, $info );
 					return $resolver->get_connection();
 				},
@@ -37,7 +37,7 @@ class Taxonomies {
 						'toType'        => 'Taxonomy',
 						'fromFieldName' => 'taxonomy',
 						'oneToOne'      => true,
-						'resolve'       => function( Term $source, $args, $context, $info ) {
+						'resolve'       => function ( Term $source, $args, $context, $info ) {
 							if ( empty( $source->taxonomyName ) ) {
 								return null;
 							}
@@ -55,7 +55,7 @@ class Taxonomies {
 				'fromType'      => 'ContentType',
 				'toType'        => 'Taxonomy',
 				'fromFieldName' => 'connectedTaxonomies',
-				'resolve'       => function( PostType $source, $args, $context, $info ) {
+				'resolve'       => function ( PostType $source, $args, $context, $info ) {
 					if ( empty( $source->taxonomies ) ) {
 						return null;
 					}

--- a/src/Connection/TermObjects.php
+++ b/src/Connection/TermObjects.php
@@ -42,7 +42,7 @@ class TermObjects {
 						],
 					]
 				),
-				'resolve'        => function( $source, $args, $context, $info ) {
+				'resolve'        => function ( $source, $args, $context, $info ) {
 					$taxonomies = isset( $args['where']['taxonomies'] ) && is_array( $args['where']['taxonomies'] ) ? $args['where']['taxonomies'] : \WPGraphQL::get_allowed_taxonomies();
 					$resolver   = new TermObjectConnectionResolver( $source, $args, $context, $info, array_values( $taxonomies ) );
 					$connection = $resolver->get_connection();
@@ -81,7 +81,7 @@ class TermObjects {
 											'fromType' => $post_type_object->graphql_single_name,
 											'toType'   => $tax_object->graphql_single_name,
 											'fromFieldName' => $tax_object->graphql_plural_name,
-											'resolve'  => function( Post $post, $args, AppContext $context, $info ) use ( $tax_object ) {
+											'resolve'  => function ( Post $post, $args, AppContext $context, $info ) use ( $tax_object ) {
 
 												$object_id = true === $post->isPreview && ! empty( $post->parentDatabaseId ) ? $post->parentDatabaseId : $post->ID;
 
@@ -110,7 +110,7 @@ class TermObjects {
 								[
 									'fromType'      => $tax_object->graphql_single_name,
 									'fromFieldName' => 'children',
-									'resolve'       => function( Term $term, $args, AppContext $context, $info ) {
+									'resolve'       => function ( Term $term, $args, AppContext $context, $info ) {
 										$resolver = new TermObjectConnectionResolver( $term, $args, $context, $info );
 										$resolver->set_query_arg( 'parent', $term->term_id );
 
@@ -127,7 +127,7 @@ class TermObjects {
 							'fromFieldName'      => 'parent',
 							'connectionTypeName' => ucfirst( $tax_object->graphql_single_name ) . 'ToParent' . ucfirst( $tax_object->graphql_single_name ) . 'Connection',
 							'oneToOne'           => true,
-							'resolve'            => function( Term $term, $args, AppContext $context, $info ) use ( $tax_object ) {
+							'resolve'            => function ( Term $term, $args, AppContext $context, $info ) use ( $tax_object ) {
 
 								if ( ! isset( $term->parentDatabaseId ) || empty( $term->parentDatabaseId ) ) {
 									return null;
@@ -147,7 +147,7 @@ class TermObjects {
 							'fromFieldName'      => 'ancestors',
 							'description'        => __( 'The ancestors of the node. Default ordered as lowest (closest to the child) to highest (closest to the root).', 'wp-graphql' ),
 							'connectionTypeName' => ucfirst( $tax_object->graphql_single_name ) . 'ToAncestors' . ucfirst( $tax_object->graphql_single_name ) . 'Connection',
-							'resolve'            => function( Term $term, $args, AppContext $context, $info ) use ( $tax_object ) {
+							'resolve'            => function ( Term $term, $args, AppContext $context, $info ) use ( $tax_object ) {
 
 								if ( ! $tax_object instanceof \WP_Taxonomy ) {
 									return null;
@@ -195,7 +195,7 @@ class TermObjects {
 							],
 						]
 					),
-					'resolve'        => function( Post $post, $args, AppContext $context, ResolveInfo $info ) {
+					'resolve'        => function ( Post $post, $args, AppContext $context, ResolveInfo $info ) {
 						$taxonomies = get_taxonomies( [ 'show_in_graphql' => true ] );
 						$terms      = wp_get_post_terms( $post->ID, $taxonomies, [ 'fields' => 'ids' ] );
 						if ( empty( $terms ) || is_wp_error( $terms ) ) {
@@ -231,7 +231,7 @@ class TermObjects {
 			'toType'         => $tax_object->graphql_single_name,
 			'fromFieldName'  => $tax_object->graphql_plural_name,
 			'connectionArgs' => self::get_connection_args(),
-			'resolve'        => function( $root, $args, $context, $info ) use ( $tax_object ) {
+			'resolve'        => function ( $root, $args, $context, $info ) use ( $tax_object ) {
 				return DataSource::resolve_term_objects_connection( $root, $args, $context, $info, $tax_object->name );
 			},
 		];

--- a/src/Connection/UserRoles.php
+++ b/src/Connection/UserRoles.php
@@ -31,7 +31,7 @@ class UserRoles {
 					'fromType'      => 'RootQuery',
 					'toType'        => 'UserRole',
 					'fromFieldName' => 'userRoles',
-					'resolve'       => function( $user, $args, $context, $info ) {
+					'resolve'       => function ( $user, $args, $context, $info ) {
 						$resolver = new UserRoleConnectionResolver( $user, $args, $context, $info );
 						return $resolver->get_connection();
 					},
@@ -48,7 +48,7 @@ class UserRoles {
 					'fromType'      => 'User',
 					'toType'        => 'UserRole',
 					'fromFieldName' => 'roles',
-					'resolve'       => function( User $user, $args, $context, $info ) {
+					'resolve'       => function ( User $user, $args, $context, $info ) {
 						$resolver = new UserRoleConnectionResolver( $user, $args, $context, $info );
 						// Only get roles matching the slugs of the roles belonging to the user
 

--- a/src/Connection/Users.php
+++ b/src/Connection/Users.php
@@ -48,7 +48,7 @@ class Users {
 				'lockTimestamp' => [
 					'type'        => 'String',
 					'description' => __( 'The timestamp for when the node was last edited', 'wp-graphql' ),
-					'resolve'     => function( $edge, $args, $context, $info ) {
+					'resolve'     => function ( $edge, $args, $context, $info ) {
 						if ( isset( $edge['source'] ) && ( $edge['source'] instanceof Post ) ) {
 							$edit_lock = $edge['source']->editLock;
 							$time      = ( is_array( $edit_lock ) && ! empty( $edit_lock[0] ) ) ? $edit_lock[0] : null;
@@ -61,7 +61,7 @@ class Users {
 			'fromFieldName'      => 'editingLockedBy',
 			'description'        => __( 'If a user has edited the node within the past 15 seconds, this will return the user that last edited. Null if the edit lock doesn\'t exist or is greater than 15 seconds', 'wp-graphql' ),
 			'oneToOne'           => true,
-			'resolve'            => function( Post $source, $args, $context, $info ) {
+			'resolve'            => function ( Post $source, $args, $context, $info ) {
 
 				if ( ! isset( $source->editLock[1] ) || ! absint( $source->editLock[1] ) ) {
 					return $source->editLock;
@@ -82,7 +82,7 @@ class Users {
 			'connectionTypeName' => 'ContentNodeToEditLastConnection',
 			'description'        => __( 'The user that most recently edited the node', 'wp-graphql' ),
 			'oneToOne'           => true,
-			'resolve'            => function( Post $source, $args, $context, $info ) {
+			'resolve'            => function ( Post $source, $args, $context, $info ) {
 
 				$resolver = new UserConnectionResolver( $source, $args, $context, $info );
 				$resolver->set_query_arg( 'include', [ $source->editLastId ] );
@@ -96,7 +96,7 @@ class Users {
 			'toType'        => 'User',
 			'fromFieldName' => 'author',
 			'oneToOne'      => true,
-			'resolve'       => function( Post $post, $args, AppContext $context, ResolveInfo $info ) {
+			'resolve'       => function ( Post $post, $args, AppContext $context, ResolveInfo $info ) {
 
 				$resolver = new UserConnectionResolver( $post, $args, $context, $info );
 				$resolver->set_query_arg( 'include', [ $post->authorDatabaseId ] );

--- a/src/Data/Config.php
+++ b/src/Data/Config.php
@@ -81,7 +81,7 @@ class Config {
 		 */
 		add_filter(
 			'pre_user_query',
-			function( $query ) {
+			function ( $query ) {
 
 				if ( ! $query->get( 'suppress_filters' ) ) {
 					$query->set( 'suppress_filters', 0 );

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -865,7 +865,7 @@ abstract class AbstractConnectionResolver {
 		 * returning the connection.
 		 */
 		return new Deferred(
-			function() {
+			function () {
 
 				if ( ! empty( $this->ids ) ) {
 					$this->loader->load_many( $this->ids );

--- a/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
@@ -26,7 +26,7 @@ class EnqueuedScriptsConnectionResolver extends AbstractConnectionResolver {
 		/**
 		 * Filter the query amount to be 1000 for
 		 */
-		add_filter( 'graphql_connection_max_query_amount', function( $max, $source, $args, $context, ResolveInfo $info ) {
+		add_filter( 'graphql_connection_max_query_amount', function ( $max, $source, $args, $context, ResolveInfo $info ) {
 			if ( 'enqueuedScripts' === $info->fieldName || 'registeredScripts' === $info->fieldName ) {
 				return 1000;
 			}

--- a/src/Data/Connection/EnqueuedStylesheetConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedStylesheetConnectionResolver.php
@@ -26,7 +26,7 @@ class EnqueuedStylesheetConnectionResolver extends AbstractConnectionResolver {
 		/**
 		 * Filter the query amount to be 1000 for
 		 */
-		add_filter( 'graphql_connection_max_query_amount', function( $max, $source, $args, $context, ResolveInfo $info ) {
+		add_filter( 'graphql_connection_max_query_amount', function ( $max, $source, $args, $context, ResolveInfo $info ) {
 			if ( 'enqueuedStylesheets' === $info->fieldName || 'registeredStylesheets' === $info->fieldName ) {
 				return 1000;
 			}

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -275,7 +275,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 
 				$post_in = $query_args['post__in'];
 				// Make sure the IDs are integers
-				$post_in = array_map( function( $id ) {
+				$post_in = array_map( function ( $id ) {
 					return absint( $id );
 				}, $post_in );
 
@@ -502,7 +502,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		 */
 		$allowed_statuses = array_filter(
 			array_map(
-				function( $status ) use ( $post_type_objects ) {
+				function ( $status ) use ( $post_type_objects ) {
 					foreach ( $post_type_objects as $post_type_object ) {
 						if ( 'publish' === $status ) {
 							return $status;

--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -525,11 +525,11 @@ class DataSource {
 
 			$node_definition = Relay::nodeDefinitions(
 			// The ID fetcher definition
-				function( $global_id, AppContext $context, ResolveInfo $info ) {
+				function ( $global_id, AppContext $context, ResolveInfo $info ) {
 					self::resolve_node( $global_id, $context, $info );
 				},
 				// Type resolver
-				function( $node ) {
+				function ( $node ) {
 					self::resolve_node_type( $node );
 				}
 			);

--- a/src/Data/Loader/AbstractDataLoader.php
+++ b/src/Data/Loader/AbstractDataLoader.php
@@ -76,7 +76,7 @@ abstract class AbstractDataLoader {
 		$this->buffer( [ $database_id ] );
 
 		return new Deferred(
-			function() use ( $database_id ) {
+			function () use ( $database_id ) {
 				return $this->load( $database_id );
 			}
 		);

--- a/src/Data/Loader/PostObjectLoader.php
+++ b/src/Data/Loader/PostObjectLoader.php
@@ -109,7 +109,7 @@ class PostObjectLoader extends AbstractDataLoader {
 		 */
 		add_filter(
 			'split_the_query',
-			function( $split, \WP_Query $query ) {
+			function ( $split, \WP_Query $query ) {
 				if ( false === $query->get( 'split_the_query' ) ) {
 					return false;
 				}

--- a/src/Model/Avatar.php
+++ b/src/Model/Avatar.php
@@ -49,34 +49,34 @@ class Avatar extends Model {
 		if ( empty( $this->fields ) ) {
 
 			$this->fields = [
-				'size'         => function() {
+				'size'         => function () {
 					return ! empty( $this->data['size'] ) ? absint( $this->data['size'] ) : null;
 				},
-				'height'       => function() {
+				'height'       => function () {
 					return ! empty( $this->data['height'] ) ? absint( $this->data['height'] ) : null;
 				},
-				'width'        => function() {
+				'width'        => function () {
 					return ! empty( $this->data['width'] ) ? absint( $this->data['width'] ) : null;
 				},
-				'default'      => function() {
+				'default'      => function () {
 					return ! empty( $this->data['default'] ) ? $this->data['default'] : null;
 				},
-				'forceDefault' => function() {
+				'forceDefault' => function () {
 					return ( ! empty( $this->data['force_default'] ) && true === $this->data['force_default'] ) ? true : false;
 				},
-				'rating'       => function() {
+				'rating'       => function () {
 					return ! empty( $this->data['rating'] ) ? $this->data['rating'] : null;
 				},
-				'scheme'       => function() {
+				'scheme'       => function () {
 					return ! empty( $this->data['scheme'] ) ? $this->data['scheme'] : null;
 				},
-				'extraAttr'    => function() {
+				'extraAttr'    => function () {
 					return ! empty( $this->data['extra_attr'] ) ? $this->data['extra_attr'] : null;
 				},
-				'foundAvatar'  => function() {
+				'foundAvatar'  => function () {
 					return ! empty( $this->data['found_avatar'] && true === $this->data['found_avatar'] ) ? true : false;
 				},
-				'url'          => function() {
+				'url'          => function () {
 					return ! empty( $this->data['url'] ) ? $this->data['url'] : null;
 				},
 			];

--- a/src/Model/Comment.php
+++ b/src/Model/Comment.php
@@ -117,69 +117,69 @@ class Comment extends Model {
 		if ( empty( $this->fields ) ) {
 
 			$this->fields = [
-				'id'                 => function() {
+				'id'                 => function () {
 					return ! empty( $this->data->comment_ID ) ? Relay::toGlobalId( 'comment', $this->data->comment_ID ) : null;
 				},
-				'commentId'          => function() {
+				'commentId'          => function () {
 					return ! empty( $this->data->comment_ID ) ? absint( $this->data->comment_ID ) : 0;
 				},
-				'databaseId'         => function() {
+				'databaseId'         => function () {
 					return ! empty( $this->data->comment_ID ) ? $this->data->comment_ID : 0;
 				},
-				'commentAuthorEmail' => function() {
+				'commentAuthorEmail' => function () {
 					return ! empty( $this->data->comment_author_email ) ? $this->data->comment_author_email : 0;
 				},
-				'comment_ID'         => function() {
+				'comment_ID'         => function () {
 					return ! empty( $this->data->comment_ID ) ? absint( $this->data->comment_ID ) : 0;
 				},
-				'comment_post_ID'    => function() {
+				'comment_post_ID'    => function () {
 					return ! empty( $this->data->comment_post_ID ) ? absint( $this->data->comment_post_ID ) : null;
 				},
-				'comment_parent_id'  => function() {
+				'comment_parent_id'  => function () {
 					return ! empty( $this->data->comment_parent ) ? absint( $this->data->comment_parent ) : 0;
 				},
-				'parentDatabaseId'   => function() {
+				'parentDatabaseId'   => function () {
 					return ! empty( $this->data->comment_parent ) ? absint( $this->data->comment_parent ) : 0;
 				},
-				'parentId'           => function() {
+				'parentId'           => function () {
 					return ! empty( $this->comment_parent_id ) ? Relay::toGlobalId( 'comment', $this->data->comment_parent ) : null;
 				},
-				'comment_author'     => function() {
+				'comment_author'     => function () {
 					return ! empty( $this->data->comment_author ) ? absint( $this->data->comment_author ) : null;
 				},
-				'comment_author_url' => function() {
+				'comment_author_url' => function () {
 					return ! empty( $this->data->comment_author_url ) ? absint( $this->data->comment_author_url ) : null;
 				},
-				'authorIp'           => function() {
+				'authorIp'           => function () {
 					return ! empty( $this->data->comment_author_IP ) ? $this->data->comment_author_IP : null;
 				},
-				'date'               => function() {
+				'date'               => function () {
 					return ! empty( $this->data->comment_date ) ? $this->data->comment_date : null;
 				},
-				'dateGmt'            => function() {
+				'dateGmt'            => function () {
 					return ! empty( $this->data->comment_date_gmt ) ? $this->data->comment_date_gmt : null;
 				},
-				'contentRaw'         => function() {
+				'contentRaw'         => function () {
 					return ! empty( $this->data->comment_content ) ? $this->data->comment_content : null;
 				},
-				'contentRendered'    => function() {
+				'contentRendered'    => function () {
 					$content = ! empty( $this->data->comment_content ) ? $this->data->comment_content : null;
 
 					return $this->html_entity_decode( apply_filters( 'comment_text', $content ), 'contentRendered', false );
 				},
-				'karma'              => function() {
+				'karma'              => function () {
 					return ! empty( $this->data->comment_karma ) ? $this->data->comment_karma : null;
 				},
-				'approved'           => function() {
+				'approved'           => function () {
 					return ! empty( $this->data->comment_approved ) ? $this->data->comment_approved : null;
 				},
-				'agent'              => function() {
+				'agent'              => function () {
 					return ! empty( $this->data->comment_agent ) ? $this->data->comment_agent : null;
 				},
-				'type'               => function() {
+				'type'               => function () {
 					return ! empty( $this->data->comment_type ) ? $this->data->comment_type : null;
 				},
-				'userId'             => function() {
+				'userId'             => function () {
 					return isset( $this->data->user_id ) ? absint( $this->data->user_id ) : null;
 				},
 			];

--- a/src/Model/CommentAuthor.php
+++ b/src/Model/CommentAuthor.php
@@ -48,19 +48,19 @@ class CommentAuthor extends Model {
 		if ( empty( $this->fields ) ) {
 
 			$this->fields = [
-				'id'         => function() {
+				'id'         => function () {
 					return ! empty( $this->data->comment_ID ) ? Relay::toGlobalId( 'comment_author', $this->data->comment_ID ) : null;
 				},
-				'databaseId' => function() {
+				'databaseId' => function () {
 					return ! empty( $this->data->comment_ID ) ? absint( $this->data->comment_ID ) : null;
 				},
-				'name'       => function() {
+				'name'       => function () {
 					return ! empty( $this->data->comment_author ) ? $this->data->comment_author : null;
 				},
-				'email'      => function() {
+				'email'      => function () {
 					return current_user_can( 'moderate_comments' ) && ! empty( $this->data->comment_author_email ) ? $this->data->comment_author_email : null;
 				},
-				'url'        => function() {
+				'url'        => function () {
 					return ! empty( $this->data->comment_author_url ) ? $this->data->comment_author_url : '';
 				},
 			];

--- a/src/Model/Menu.php
+++ b/src/Model/Menu.php
@@ -76,25 +76,25 @@ class Menu extends Model {
 		if ( empty( $this->fields ) ) {
 
 			$this->fields = [
-				'id'         => function() {
+				'id'         => function () {
 					return ! empty( $this->data->term_id ) ? Relay::toGlobalId( 'term', (string) $this->data->term_id ) : null;
 				},
-				'count'      => function() {
+				'count'      => function () {
 					return ! empty( $this->data->count ) ? absint( $this->data->count ) : null;
 				},
-				'menuId'     => function() {
+				'menuId'     => function () {
 					return ! empty( $this->data->term_id ) ? absint( $this->data->term_id ) : null;
 				},
-				'databaseId' => function() {
+				'databaseId' => function () {
 					return ! empty( $this->data->term_id ) ? absint( $this->data->term_id ) : null;
 				},
-				'name'       => function() {
+				'name'       => function () {
 					return ! empty( $this->data->name ) ? $this->data->name : null;
 				},
-				'slug'       => function() {
+				'slug'       => function () {
 					return ! empty( $this->data->slug ) ? $this->data->slug : null;
 				},
-				'locations'  => function() {
+				'locations'  => function () {
 					$menu_locations = get_theme_mod( 'nav_menu_locations' );
 
 					if ( empty( $menu_locations ) || ! is_array( $menu_locations ) ) {

--- a/src/Model/MenuItem.php
+++ b/src/Model/MenuItem.php
@@ -103,16 +103,16 @@ class MenuItem extends Model {
 		if ( empty( $fields ) ) {
 
 			$this->fields = [
-				'id'               => function() {
+				'id'               => function () {
 					return ! empty( $this->data->ID ) ? Relay::toGlobalId( 'post', $this->data->ID ) : null;
 				},
-				'parentId'         => function() {
+				'parentId'         => function () {
 					return ! empty( $this->data->menu_item_parent ) ? Relay::toGlobalId( 'post', $this->data->menu_item_parent ) : null;
 				},
-				'parentDatabaseId' => function() {
+				'parentDatabaseId' => function () {
 					return $this->data->menu_item_parent;
 				},
-				'cssClasses'       => function() {
+				'cssClasses'       => function () {
 					// If all we have is a non-array or an array with one empty
 					// string, return an empty array.
 					if ( ! isset( $this->data->classes ) || ! is_array( $this->data->classes ) || empty( $this->data->classes ) || empty( $this->data->classes[0] ) ) {
@@ -121,34 +121,34 @@ class MenuItem extends Model {
 
 					return $this->data->classes;
 				},
-				'description'      => function() {
+				'description'      => function () {
 					return ( ! empty( $this->data->description ) ) ? $this->data->description : null;
 				},
-				'label'            => function() {
+				'label'            => function () {
 					return ( ! empty( $this->data->title ) ) ? $this->html_entity_decode( $this->data->title, 'label', true ) : null;
 				},
-				'linkRelationship' => function() {
+				'linkRelationship' => function () {
 					return ! empty( $this->data->xfn ) ? $this->data->xfn : null;
 				},
-				'menuItemId'       => function() {
+				'menuItemId'       => function () {
 					return absint( $this->data->ID );
 				},
-				'databaseId'       => function() {
+				'databaseId'       => function () {
 					return absint( $this->data->ID );
 				},
-				'objectId'         => function() {
+				'objectId'         => function () {
 					return ( absint( $this->data->object_id ) );
 				},
-				'target'           => function() {
+				'target'           => function () {
 					return ! empty( $this->data->target ) ? $this->data->target : null;
 				},
-				'title'            => function() {
+				'title'            => function () {
 					return ( ! empty( $this->data->attr_title ) ) ? $this->data->attr_title : null;
 				},
-				'url'              => function() {
+				'url'              => function () {
 					return ! empty( $this->data->url ) ? $this->data->url : null;
 				},
-				'path'             => function() {
+				'path'             => function () {
 
 					$url = $this->url;
 
@@ -166,13 +166,13 @@ class MenuItem extends Model {
 					return $url;
 
 				},
-				'order'            => function() {
+				'order'            => function () {
 					return $this->data->menu_order;
 				},
-				'menuId'           => function() {
+				'menuId'           => function () {
 					return ! empty( $this->menuDatabaseId ) ? Relay::toGlobalId( 'term', (string) $this->menuDatabaseId ) : null;
 				},
-				'menuDatabaseId'   => function() {
+				'menuDatabaseId'   => function () {
 
 					$menus = wp_get_object_terms( $this->data->ID, 'nav_menu' );
 					if ( is_wp_error( $menus ) ) {
@@ -181,7 +181,7 @@ class MenuItem extends Model {
 
 					return isset( $menus[0] ) && isset( $menus[0]->term_id ) ? $menus[0]->term_id : null;
 				},
-				'locations'        => function() {
+				'locations'        => function () {
 
 					if ( empty( $this->menuDatabaseId ) ) {
 						return null;

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -348,7 +348,7 @@ abstract class Model {
 		$self        = $this;
 		foreach ( $this->fields as $key => $data ) {
 
-			$clean_array[ $key ] = function() use ( $key, $data, $self ) {
+			$clean_array[ $key ] = function () use ( $key, $data, $self ) {
 				if ( is_array( $data ) ) {
 					$callback = ( ! empty( $data['callback'] ) ) ? $data['callback'] : null;
 
@@ -449,13 +449,13 @@ abstract class Model {
 		/**
 		 * @TODO: potentially abstract this out into a more central spot
 		 */
-		$this->fields['isPublic']     = function() {
+		$this->fields['isPublic']     = function () {
 			return 'public' === $this->get_visibility();
 		};
-		$this->fields['isRestricted'] = function() {
+		$this->fields['isRestricted'] = function () {
 			return 'restricted' === $this->get_visibility();
 		};
-		$this->fields['isPrivate']    = function() {
+		$this->fields['isPrivate']    = function () {
 			return 'private' === $this->get_visibility();
 		};
 

--- a/src/Model/Plugin.php
+++ b/src/Model/Plugin.php
@@ -64,28 +64,28 @@ class Plugin extends Model {
 		if ( empty( $this->fields ) ) {
 
 			$this->fields = [
-				'id'          => function() {
+				'id'          => function () {
 					return ! empty( $this->data['Path'] ) ? Relay::toGlobalId( 'plugin', $this->data['Path'] ) : null;
 				},
-				'name'        => function() {
+				'name'        => function () {
 					return ! empty( $this->data['Name'] ) ? $this->data['Name'] : null;
 				},
-				'pluginUri'   => function() {
+				'pluginUri'   => function () {
 					return ! empty( $this->data['PluginURI'] ) ? $this->data['PluginURI'] : null;
 				},
-				'description' => function() {
+				'description' => function () {
 					return ! empty( $this->data['Description'] ) ? $this->data['Description'] : null;
 				},
-				'author'      => function() {
+				'author'      => function () {
 					return ! empty( $this->data['Author'] ) ? $this->data['Author'] : null;
 				},
-				'authorUri'   => function() {
+				'authorUri'   => function () {
 					return ! empty( $this->data['AuthorURI'] ) ? $this->data['AuthorURI'] : null;
 				},
-				'version'     => function() {
+				'version'     => function () {
 					return ! empty( $this->data['Version'] ) ? $this->data['Version'] : null;
 				},
-				'path'        => function() {
+				'path'        => function () {
 					return ! empty( $this->data['Path'] ) ? $this->data['Path'] : null;
 				},
 			];

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -420,10 +420,10 @@ class Post extends Model {
 		if ( empty( $this->fields ) ) {
 
 			$this->fields = [
-				'ID'                        => function() {
+				'ID'                        => function () {
 					return $this->data->ID;
 				},
-				'post_author'               => function() {
+				'post_author'               => function () {
 					if ( $this->isPreview ) {
 						$parent_post = get_post( $this->parentDatabaseId );
 						if ( empty( $parent_post ) ) {
@@ -435,16 +435,16 @@ class Post extends Model {
 
 					return ! empty( $this->data->post_author ) ? $this->data->post_author : null;
 				},
-				'id'                        => function() {
+				'id'                        => function () {
 					return ( ! empty( $this->data->post_type ) && ! empty( $this->databaseId ) ) ? Relay::toGlobalId( 'post', (string) $this->databaseId ) : null;
 				},
-				'databaseId'                => function() {
+				'databaseId'                => function () {
 					return isset( $this->data->ID ) ? absint( $this->data->ID ) : null;
 				},
-				'post_type'                 => function() {
+				'post_type'                 => function () {
 					return isset( $this->data->post_type ) ? $this->data->post_type : null;
 				},
-				'authorId'                  => function() {
+				'authorId'                  => function () {
 
 					if ( true === $this->isPreview ) {
 						$parent_post = get_post( $this->data->post_parent );
@@ -459,7 +459,7 @@ class Post extends Model {
 
 					return Relay::toGlobalId( 'user', (string) $id );
 				},
-				'authorDatabaseId'          => function() {
+				'authorDatabaseId'          => function () {
 					if ( true === $this->isPreview ) {
 						$parent_post = get_post( $this->data->post_parent );
 						if ( empty( $parent_post ) ) {
@@ -472,68 +472,68 @@ class Post extends Model {
 					return isset( $this->data->post_author ) ? $this->data->post_author : null;
 
 				},
-				'date'                      => function() {
+				'date'                      => function () {
 					return ! empty( $this->data->post_date ) && '0000-00-00 00:00:00' !== $this->data->post_date ? Utils::prepare_date_response( $this->data->post_date_gmt, $this->data->post_date ) : null;
 				},
-				'dateGmt'                   => function() {
+				'dateGmt'                   => function () {
 					return ! empty( $this->data->post_date_gmt ) ? Utils::prepare_date_response( $this->data->post_date_gmt ) : null;
 				},
-				'contentRendered'           => function() {
+				'contentRendered'           => function () {
 					$content = ! empty( $this->data->post_content ) ? $this->data->post_content : null;
 
 					return ! empty( $content ) ? $this->html_entity_decode( apply_filters( 'the_content', $content ), 'contentRendered', false ) : null;
 				},
-				'pageTemplate'              => function() {
+				'pageTemplate'              => function () {
 					$slug = get_page_template_slug( $this->data->ID );
 
 					return ! empty( $slug ) ? $slug : null;
 				},
 				'contentRaw'                => [
-					'callback'   => function() {
+					'callback'   => function () {
 						return ! empty( $this->data->post_content ) ? $this->data->post_content : null;
 					},
 					'capability' => isset( $this->post_type_object->cap->edit_posts ) ? $this->post_type_object->cap->edit_posts : 'edit_posts',
 				],
-				'titleRendered'             => function() {
+				'titleRendered'             => function () {
 					$id    = ! empty( $this->data->ID ) ? $this->data->ID : null;
 					$title = ! empty( $this->data->post_title ) ? $this->data->post_title : null;
 
 					return $this->html_entity_decode( apply_filters( 'the_title', $title, $id ), 'titleRendered', true );
 				},
 				'titleRaw'                  => [
-					'callback'   => function() {
+					'callback'   => function () {
 						return ! empty( $this->data->post_title ) ? $this->data->post_title : null;
 					},
 					'capability' => isset( $this->post_type_object->cap->edit_posts ) ? $this->post_type_object->cap->edit_posts : 'edit_posts',
 				],
-				'excerptRendered'           => function() {
+				'excerptRendered'           => function () {
 					$excerpt = ! empty( $this->data->post_excerpt ) ? $this->data->post_excerpt : null;
 					$excerpt = apply_filters( 'get_the_excerpt', $excerpt, $this->data );
 
 					return $this->html_entity_decode( apply_filters( 'the_excerpt', $excerpt ), 'excerptRendered' );
 				},
 				'excerptRaw'                => [
-					'callback'   => function() {
+					'callback'   => function () {
 						return ! empty( $this->data->post_excerpt ) ? $this->data->post_excerpt : null;
 					},
 					'capability' => isset( $this->post_type_object->cap->edit_posts ) ? $this->post_type_object->cap->edit_posts : 'edit_posts',
 				],
-				'post_status'               => function() {
+				'post_status'               => function () {
 					return ! empty( $this->data->post_status ) ? $this->data->post_status : null;
 				},
-				'status'                    => function() {
+				'status'                    => function () {
 					return ! empty( $this->data->post_status ) ? $this->data->post_status : null;
 				},
-				'commentStatus'             => function() {
+				'commentStatus'             => function () {
 					return ! empty( $this->data->comment_status ) ? $this->data->comment_status : null;
 				},
-				'pingStatus'                => function() {
+				'pingStatus'                => function () {
 					return ! empty( $this->data->ping_status ) ? $this->data->ping_status : null;
 				},
-				'slug'                      => function() {
+				'slug'                      => function () {
 					return ! empty( $this->data->post_name ) ? $this->data->post_name : null;
 				},
-				'template'                  => function() {
+				'template'                  => function () {
 
 					$registered_templates = wp_get_theme()->get_post_templates();
 
@@ -598,7 +598,7 @@ class Post extends Model {
 
 					return $template;
 				},
-				'isFrontPage'               => function() {
+				'isFrontPage'               => function () {
 					if ( 'page' !== $this->data->post_type || 'page' !== get_option( 'show_on_front' ) ) {
 						return false;
 					}
@@ -608,7 +608,7 @@ class Post extends Model {
 
 					return false;
 				},
-				'isPrivacyPage'             => function() {
+				'isPrivacyPage'             => function () {
 					if ( 'page' !== $this->data->post_type ) {
 						return false;
 					}
@@ -618,7 +618,7 @@ class Post extends Model {
 
 					return false;
 				},
-				'isPostsPage'               => function() {
+				'isPostsPage'               => function () {
 					if ( 'page' !== $this->data->post_type ) {
 						return false;
 					}
@@ -628,34 +628,34 @@ class Post extends Model {
 
 					return false;
 				},
-				'toPing'                    => function() {
+				'toPing'                    => function () {
 					$to_ping = get_to_ping( $this->databaseId );
 
 					return ! empty( $to_ping ) ? implode( ',', (array) $to_ping ) : null;
 				},
-				'pinged'                    => function() {
+				'pinged'                    => function () {
 					$punged = get_pung( $this->databaseId );
 
 					return ! empty( $punged ) ? implode( ',', (array) $punged ) : null;
 				},
-				'modified'                  => function() {
+				'modified'                  => function () {
 					return ! empty( $this->data->post_modified ) && '0000-00-00 00:00:00' !== $this->data->post_modified ? Utils::prepare_date_response( $this->data->post_modified ) : null;
 				},
-				'modifiedGmt'               => function() {
+				'modifiedGmt'               => function () {
 					return ! empty( $this->data->post_modified_gmt ) ? Utils::prepare_date_response( $this->data->post_modified_gmt ) : null;
 				},
-				'parentId'                  => function() {
+				'parentId'                  => function () {
 					return ( ! empty( $this->data->post_type ) && ! empty( $this->data->post_parent ) ) ? Relay::toGlobalId( 'post', (string) $this->data->post_parent ) : null;
 				},
-				'parentDatabaseId'          => function() {
+				'parentDatabaseId'          => function () {
 					return ! empty( $this->data->post_parent ) ? absint( $this->data->post_parent ) : null;
 				},
-				'editLastId'                => function() {
+				'editLastId'                => function () {
 					$edit_last = get_post_meta( $this->data->ID, '_edit_last', true );
 
 					return ! empty( $edit_last ) ? absint( $edit_last ) : null;
 				},
-				'editLock'                  => function() {
+				'editLock'                  => function () {
 
 					require_once ABSPATH . 'wp-admin/includes/post.php';
 					if ( ! wp_check_post_lock( $this->data->ID ) ) {
@@ -667,18 +667,18 @@ class Post extends Model {
 
 					return ! empty( $edit_lock_parts ) ? $edit_lock_parts : null;
 				},
-				'enclosure'                 => function() {
+				'enclosure'                 => function () {
 					$enclosure = get_post_meta( $this->data->ID, 'enclosure', true );
 
 					return ! empty( $enclosure ) ? $enclosure : null;
 				},
-				'guid'                      => function() {
+				'guid'                      => function () {
 					return ! empty( $this->data->guid ) ? $this->data->guid : null;
 				},
-				'menuOrder'                 => function() {
+				'menuOrder'                 => function () {
 					return ! empty( $this->data->menu_order ) ? absint( $this->data->menu_order ) : null;
 				},
-				'link'                      => function() {
+				'link'                      => function () {
 					$link = get_permalink( $this->data->ID );
 
 					if ( $this->isPreview ) {
@@ -689,7 +689,7 @@ class Post extends Model {
 
 					return ! empty( $link ) ? $link : null;
 				},
-				'uri'                       => function() {
+				'uri'                       => function () {
 					$uri = $this->link;
 
 					if ( true === $this->isFrontPage ) {
@@ -698,13 +698,13 @@ class Post extends Model {
 
 					return ! empty( $uri ) ? str_ireplace( home_url(), '', $uri ) : null;
 				},
-				'commentCount'              => function() {
+				'commentCount'              => function () {
 					return ! empty( $this->data->comment_count ) ? absint( $this->data->comment_count ) : null;
 				},
-				'featuredImageId'           => function() {
+				'featuredImageId'           => function () {
 					return ! empty( $this->featuredImageDatabaseId ) ? Relay::toGlobalId( 'post', (string) $this->featuredImageDatabaseId ) : null;
 				},
-				'featuredImageDatabaseId'   => function() {
+				'featuredImageDatabaseId'   => function () {
 
 					if ( $this->isRevision ) {
 						$id = $this->parentDatabaseId;
@@ -717,12 +717,12 @@ class Post extends Model {
 					return ! empty( $thumbnail_id ) ? absint( $thumbnail_id ) : null;
 				},
 				'password'                  => [
-					'callback'   => function() {
+					'callback'   => function () {
 						return ! empty( $this->data->post_password ) ? $this->data->post_password : null;
 					},
 					'capability' => isset( $this->post_type_object->cap->edit_others_posts ) ?: 'edit_others_posts',
 				],
-				'enqueuedScriptsQueue'      => function() {
+				'enqueuedScriptsQueue'      => function () {
 					global $wp_scripts;
 					do_action( 'wp_enqueue_scripts' );
 					$queue = $wp_scripts->queue;
@@ -731,7 +731,7 @@ class Post extends Model {
 
 					return $queue;
 				},
-				'enqueuedStylesheetsQueue'  => function() {
+				'enqueuedStylesheetsQueue'  => function () {
 					global $wp_styles;
 					do_action( 'wp_enqueue_scripts' );
 					$queue = $wp_styles->queue;
@@ -740,11 +740,11 @@ class Post extends Model {
 
 					return $queue;
 				},
-				'isRevision'                => function() {
+				'isRevision'                => function () {
 					return 'revision' === $this->data->post_type;
 				},
 				'previewRevisionDatabaseId' => [
-					'callback'   => function() {
+					'callback'   => function () {
 						$revisions = wp_get_post_revisions(
 							$this->data->ID,
 							[
@@ -758,10 +758,10 @@ class Post extends Model {
 					},
 					'capability' => isset( $this->post_type_object->cap->edit_posts ) ? $this->post_type_object->cap->edit_posts : 'edit_posts',
 				],
-				'previewRevisionId'         => function() {
+				'previewRevisionId'         => function () {
 					return ! empty( $this->previewRevisionDatabaseId ) ? Relay::toGlobalId( 'post', (string) $this->previewRevisionDatabaseId ) : null;
 				},
-				'isPreview'                 => function() {
+				'isPreview'                 => function () {
 					if ( $this->isRevision ) {
 						$revisions = wp_get_post_revisions(
 							$this->parentDatabaseId,
@@ -779,48 +779,48 @@ class Post extends Model {
 
 					return false;
 				},
-				'isSticky'                  => function() {
+				'isSticky'                  => function () {
 					return is_sticky( $this->databaseId );
 				},
 			];
 
 			if ( 'attachment' === $this->data->post_type ) {
 				$attachment_fields = [
-					'captionRendered'     => function() {
+					'captionRendered'     => function () {
 						$caption = apply_filters( 'the_excerpt', apply_filters( 'get_the_excerpt', $this->data->post_excerpt, $this->data ) );
 
 						return ! empty( $caption ) ? $caption : null;
 					},
 					'captionRaw'          => [
-						'callback'   => function() {
+						'callback'   => function () {
 							return ! empty( $this->data->post_excerpt ) ? $this->data->post_excerpt : null;
 						},
 						'capability' => isset( $this->post_type_object->cap->edit_posts ) ? $this->post_type_object->cap->edit_posts : 'edit_posts',
 					],
-					'altText'             => function() {
+					'altText'             => function () {
 						return get_post_meta( $this->data->ID, '_wp_attachment_image_alt', true );
 					},
-					'descriptionRendered' => function() {
+					'descriptionRendered' => function () {
 						return ! empty( $this->data->post_content ) ? apply_filters( 'the_content', $this->data->post_content ) : null;
 					},
 					'descriptionRaw'      => [
-						'callback'   => function() {
+						'callback'   => function () {
 							return ! empty( $this->data->post_content ) ? $this->data->post_content : null;
 						},
 						'capability' => isset( $this->post_type_object->cap->edit_posts ) ? $this->post_type_object->cap->edit_posts : 'edit_posts',
 					],
-					'mediaType'           => function() {
+					'mediaType'           => function () {
 						return wp_attachment_is_image( $this->data->ID ) ? 'image' : 'file';
 					},
-					'mediaItemUrl'        => function() {
+					'mediaItemUrl'        => function () {
 						return wp_get_attachment_url( $this->data->ID );
 					},
-					'sourceUrl'           => function() {
+					'sourceUrl'           => function () {
 						$source_url = wp_get_attachment_image_src( $this->data->ID, 'full' );
 
 						return ! empty( $source_url ) && isset( $source_url[0] ) ? $source_url[0] : null;
 					},
-					'sourceUrlsBySize'    => function() {
+					'sourceUrlsBySize'    => function () {
 						$sizes = get_intermediate_image_sizes();
 						$urls  = [];
 						if ( ! empty( $sizes ) && is_array( $sizes ) ) {
@@ -832,10 +832,10 @@ class Post extends Model {
 
 						return $urls;
 					},
-					'mimeType'            => function() {
+					'mimeType'            => function () {
 						return ! empty( $this->data->post_mime_type ) ? $this->data->post_mime_type : null;
 					},
-					'mediaDetails'        => function() {
+					'mediaDetails'        => function () {
 						$media_details = wp_get_attachment_metadata( $this->data->ID );
 						if ( ! empty( $media_details ) ) {
 							$media_details['ID'] = $this->data->ID;
@@ -855,7 +855,7 @@ class Post extends Model {
 			 */
 			if ( isset( $this->post_type_object ) && isset( $this->post_type_object->graphql_single_name ) ) {
 				$type_id                  = $this->post_type_object->graphql_single_name . 'Id';
-				$this->fields[ $type_id ] = function() {
+				$this->fields[ $type_id ] = function () {
 					return absint( $this->data->ID );
 				};
 			};

--- a/src/Model/PostType.php
+++ b/src/Model/PostType.php
@@ -105,89 +105,89 @@ class PostType extends Model {
 		if ( empty( $this->fields ) ) {
 
 			$this->fields = [
-				'id'                  => function() {
+				'id'                  => function () {
 					return ! empty( $this->data->name ) ? Relay::toGlobalId( 'post_type', $this->data->name ) : null;
 				},
-				'name'                => function() {
+				'name'                => function () {
 					return ! empty( $this->data->name ) ? $this->data->name : null;
 				},
-				'label'               => function() {
+				'label'               => function () {
 					return ! empty( $this->data->label ) ? $this->data->label : null;
 				},
-				'labels'              => function() {
+				'labels'              => function () {
 					return get_post_type_labels( $this->data );
 				},
-				'description'         => function() {
+				'description'         => function () {
 					return ! empty( $this->data->description ) ? $this->data->description : '';
 				},
-				'public'              => function() {
+				'public'              => function () {
 					return ! empty( $this->data->public ) ? (bool) $this->data->public : null;
 				},
-				'hierarchical'        => function() {
+				'hierarchical'        => function () {
 					return ( true === $this->data->hierarchical || ! empty( $this->data->hierarchical ) ) ? true : false;
 				},
-				'excludeFromSearch'   => function() {
+				'excludeFromSearch'   => function () {
 					return ( true === $this->data->exclude_from_search ) ? true : false;
 				},
-				'publiclyQueryable'   => function() {
+				'publiclyQueryable'   => function () {
 					return ( true === $this->data->publicly_queryable ) ? true : false;
 				},
-				'showUi'              => function() {
+				'showUi'              => function () {
 					return ( true === $this->data->show_ui ) ? true : false;
 				},
-				'showInMenu'          => function() {
+				'showInMenu'          => function () {
 					return ( true === $this->data->show_in_menu ) ? true : false;
 				},
-				'showInNavMenus'      => function() {
+				'showInNavMenus'      => function () {
 					return ( true === $this->data->show_in_nav_menus ) ? true : false;
 				},
-				'showInAdminBar'      => function() {
+				'showInAdminBar'      => function () {
 					return ( true === $this->data->show_in_admin_bar ) ? true : false;
 				},
-				'menuPosition'        => function() {
+				'menuPosition'        => function () {
 					return ! empty( $this->data->menu_position ) ? $this->data->menu_position : null;
 				},
-				'menuIcon'            => function() {
+				'menuIcon'            => function () {
 					return ! empty( $this->data->menu_icon ) ? $this->data->menu_icon : null;
 				},
-				'hasArchive'          => function() {
+				'hasArchive'          => function () {
 					return ! empty( $this->uri ) ? true : false;
 				},
-				'canExport'           => function() {
+				'canExport'           => function () {
 					return ( true === $this->data->can_export ) ? true : false;
 				},
-				'deleteWithUser'      => function() {
+				'deleteWithUser'      => function () {
 					return ( true === $this->data->delete_with_user ) ? true : false;
 				},
-				'taxonomies'          => function() {
+				'taxonomies'          => function () {
 					$object_taxonomies = get_object_taxonomies( $this->data->name );
 					return ( ! empty( $object_taxonomies ) ) ? $object_taxonomies : null;
 				},
-				'showInRest'          => function() {
+				'showInRest'          => function () {
 					return ( true === $this->data->show_in_rest ) ? true : false;
 				},
-				'restBase'            => function() {
+				'restBase'            => function () {
 					return ! empty( $this->data->rest_base ) ? $this->data->rest_base : null;
 				},
-				'restControllerClass' => function() {
+				'restControllerClass' => function () {
 					return ! empty( $this->data->rest_controller_class ) ? $this->data->rest_controller_class : null;
 				},
-				'showInGraphql'       => function() {
+				'showInGraphql'       => function () {
 					return ( true === $this->data->show_in_graphql ) ? true : false;
 				},
-				'graphqlSingleName'   => function() {
+				'graphqlSingleName'   => function () {
 					return ! empty( $this->data->graphql_single_name ) ? $this->data->graphql_single_name : null;
 				},
-				'graphql_single_name' => function() {
+				'graphql_single_name' => function () {
 					return ! empty( $this->data->graphql_single_name ) ? $this->data->graphql_single_name : null;
 				},
-				'graphqlPluralName'   => function() {
+				'graphqlPluralName'   => function () {
 					return ! empty( $this->data->graphql_plural_name ) ? $this->data->graphql_plural_name : null;
 				},
-				'graphql_plural_name' => function() {
+				'graphql_plural_name' => function () {
 					return ! empty( $this->data->graphql_plural_name ) ? $this->data->graphql_plural_name : null;
 				},
-				'uri'                 => function() {
+				'uri'                 => function () {
 					$link = get_post_type_archive_link( $this->name );
 					return ! empty( $link ) ? trailingslashit( str_ireplace( home_url(), '', $link ) ) : null;
 				},
@@ -205,7 +205,7 @@ class PostType extends Model {
 
 					return false;
 				},
-				'isFrontPage'         => function() {
+				'isFrontPage'         => function () {
 
 					if (
 						'post' === $this->name &&

--- a/src/Model/Taxonomy.php
+++ b/src/Model/Taxonomy.php
@@ -97,67 +97,67 @@ class Taxonomy extends Model {
 		if ( empty( $this->fields ) ) {
 
 			$this->fields = [
-				'id'                  => function() {
+				'id'                  => function () {
 					return ! empty( $this->data->name ) ? Relay::toGlobalId( 'taxonomy', $this->data->name ) : null;
 				},
-				'object_type'         => function() {
+				'object_type'         => function () {
 					return ! empty( $this->data->object_type ) ? $this->data->object_type : null;
 				},
-				'name'                => function() {
+				'name'                => function () {
 					return ! empty( $this->data->name ) ? $this->data->name : null;
 				},
-				'label'               => function() {
+				'label'               => function () {
 					return ! empty( $this->data->label ) ? $this->data->label : null;
 				},
-				'description'         => function() {
+				'description'         => function () {
 					return ! empty( $this->data->description ) ? $this->data->description : '';
 				},
-				'public'              => function() {
+				'public'              => function () {
 					return ! empty( $this->data->public ) ? (bool) $this->data->public : true;
 				},
-				'hierarchical'        => function() {
+				'hierarchical'        => function () {
 					return ( true === $this->data->hierarchical ) ? true : false;
 				},
-				'showUi'              => function() {
+				'showUi'              => function () {
 					return ( true === $this->data->show_ui ) ? true : false;
 				},
-				'showInMenu'          => function() {
+				'showInMenu'          => function () {
 					return ( true === $this->data->show_in_menu ) ? true : false;
 				},
-				'showInNavMenus'      => function() {
+				'showInNavMenus'      => function () {
 					return ( true === $this->data->show_in_nav_menus ) ? true : false;
 				},
-				'showCloud'           => function() {
+				'showCloud'           => function () {
 					return ( true === $this->data->show_tagcloud ) ? true : false;
 				},
-				'showInQuickEdit'     => function() {
+				'showInQuickEdit'     => function () {
 					return ( true === $this->data->show_in_quick_edit ) ? true : false;
 				},
-				'showInAdminColumn'   => function() {
+				'showInAdminColumn'   => function () {
 					return ( true === $this->data->show_admin_column ) ? true : false;
 				},
-				'showInRest'          => function() {
+				'showInRest'          => function () {
 					return ( true === $this->data->show_in_rest ) ? true : false;
 				},
-				'restBase'            => function() {
+				'restBase'            => function () {
 					return ! empty( $this->data->rest_base ) ? $this->data->rest_base : null;
 				},
-				'restControllerClass' => function() {
+				'restControllerClass' => function () {
 					return ! empty( $this->data->rest_controller_class ) ? $this->data->rest_controller_class : null;
 				},
-				'showInGraphql'       => function() {
+				'showInGraphql'       => function () {
 					return ( true === $this->data->show_in_graphql ) ? true : false;
 				},
-				'graphqlSingleName'   => function() {
+				'graphqlSingleName'   => function () {
 					return ! empty( $this->data->graphql_single_name ) ? $this->data->graphql_single_name : null;
 				},
-				'graphql_single_name' => function() {
+				'graphql_single_name' => function () {
 					return ! empty( $this->data->graphql_single_name ) ? $this->data->graphql_single_name : null;
 				},
-				'graphqlPluralName'   => function() {
+				'graphqlPluralName'   => function () {
 					return ! empty( $this->data->graphql_plural_name ) ? $this->data->graphql_plural_name : null;
 				},
-				'graphql_plural_name' => function() {
+				'graphql_plural_name' => function () {
 					return ! empty( $this->data->graphql_plural_name ) ? $this->data->graphql_plural_name : null;
 				},
 			];

--- a/src/Model/Term.php
+++ b/src/Model/Term.php
@@ -133,48 +133,48 @@ class Term extends Model {
 		if ( empty( $this->fields ) ) {
 
 			$this->fields = [
-				'id'                       => function() {
+				'id'                       => function () {
 					return ( ! empty( $this->data->taxonomy ) && ! empty( $this->data->term_id ) ) ? Relay::toGlobalId( 'term', (string) $this->data->term_id ) : null;
 				},
-				'term_id'                  => function() {
+				'term_id'                  => function () {
 					return ( ! empty( $this->data->term_id ) ) ? absint( $this->data->term_id ) : null;
 				},
-				'databaseId'               => function() {
+				'databaseId'               => function () {
 					return ( ! empty( $this->data->term_id ) ) ? absint( $this->data->term_id ) : null;
 				},
-				'count'                    => function() {
+				'count'                    => function () {
 					return ! empty( $this->data->count ) ? absint( $this->data->count ) : null;
 				},
-				'description'              => function() {
+				'description'              => function () {
 					return ! empty( $this->data->description ) ? $this->html_entity_decode( $this->data->description, 'description' ) : null;
 				},
-				'name'                     => function() {
+				'name'                     => function () {
 					return ! empty( $this->data->name ) ? $this->html_entity_decode( $this->data->name, 'name', true ) : null;
 				},
-				'slug'                     => function() {
+				'slug'                     => function () {
 					return ! empty( $this->data->slug ) ? $this->data->slug : null;
 				},
-				'termGroupId'              => function() {
+				'termGroupId'              => function () {
 					return ! empty( $this->data->term_group ) ? absint( $this->data->term_group ) : null;
 				},
-				'termTaxonomyId'           => function() {
+				'termTaxonomyId'           => function () {
 					return ! empty( $this->data->term_taxonomy_id ) ? absint( $this->data->term_taxonomy_id ) : null;
 				},
-				'taxonomyName'             => function() {
+				'taxonomyName'             => function () {
 					return ! empty( $this->taxonomy_object->name ) ? $this->taxonomy_object->name : null;
 				},
-				'link'                     => function() {
+				'link'                     => function () {
 					$link = get_term_link( $this->data->term_id );
 
 					return ( ! is_wp_error( $link ) ) ? $link : null;
 				},
-				'parentId'                 => function() {
+				'parentId'                 => function () {
 					return ! empty( $this->data->parent ) ? Relay::toGlobalId( 'term', (string) $this->data->parent ) : null;
 				},
-				'parentDatabaseId'         => function() {
+				'parentDatabaseId'         => function () {
 					return ! empty( $this->data->parent ) ? $this->data->parent : null;
 				},
-				'enqueuedScriptsQueue'     => function() {
+				'enqueuedScriptsQueue'     => function () {
 					global $wp_scripts;
 					$wp_scripts->reset();
 					do_action( 'wp_enqueue_scripts' );
@@ -184,7 +184,7 @@ class Term extends Model {
 
 					return $queue;
 				},
-				'enqueuedStylesheetsQueue' => function() {
+				'enqueuedStylesheetsQueue' => function () {
 					global $wp_styles;
 					do_action( 'wp_enqueue_scripts' );
 					$queue = $wp_styles->queue;
@@ -193,7 +193,7 @@ class Term extends Model {
 
 					return $queue;
 				},
-				'uri'                      => function() {
+				'uri'                      => function () {
 					$link = get_term_link( $this->name );
 
 					if ( is_wp_error( $link ) ) {

--- a/src/Model/Theme.php
+++ b/src/Model/Theme.php
@@ -71,40 +71,40 @@ class Theme extends Model {
 		if ( empty( $this->fields ) ) {
 
 			$this->fields = [
-				'id'          => function() {
+				'id'          => function () {
 					$stylesheet = $this->data->get_stylesheet();
 					return ( ! empty( $stylesheet ) ) ? Relay::toGlobalId( 'theme', $stylesheet ) : null;
 				},
-				'slug'        => function() {
+				'slug'        => function () {
 					$stylesheet = $this->data->get_stylesheet();
 					return ! empty( $stylesheet ) ? $stylesheet : null;
 				},
-				'name'        => function() {
+				'name'        => function () {
 					$name = $this->data->get( 'Name' );
 					return ! empty( $name ) ? $name : null;
 				},
-				'screenshot'  => function() {
+				'screenshot'  => function () {
 					$screenshot = $this->data->get_screenshot();
 					return ! empty( $screenshot ) ? $screenshot : null;
 				},
-				'themeUri'    => function() {
+				'themeUri'    => function () {
 					$theme_uri = $this->data->get( 'ThemeURI' );
 					return ! empty( $theme_uri ) ? $theme_uri : null;
 				},
-				'description' => function() {
+				'description' => function () {
 					return ! empty( $this->data->description ) ? $this->data->description : null;
 				},
-				'author'      => function() {
+				'author'      => function () {
 					return ! empty( $this->data->author ) ? $this->data->author : null;
 				},
-				'authorUri'   => function() {
+				'authorUri'   => function () {
 					$author_uri = $this->data->get( 'AuthorURI' );
 					return ! empty( $author_uri ) ? $author_uri : null;
 				},
-				'tags'        => function() {
+				'tags'        => function () {
 					return ! empty( $this->data->tags ) ? $this->data->tags : null;
 				},
-				'version'     => function() {
+				'version'     => function () {
 					return ! empty( $this->data->version ) ? $this->data->version : null;
 				},
 			];

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -172,13 +172,13 @@ class User extends Model {
 
 		if ( empty( $this->fields ) ) {
 			$this->fields = [
-				'id'                       => function() {
+				'id'                       => function () {
 					return ( ! empty( $this->data->ID ) ) ? Relay::toGlobalId( 'user', (string) $this->data->ID ) : null;
 				},
-				'databaseId'               => function() {
+				'databaseId'               => function () {
 					return $this->userId;
 				},
-				'capabilities'             => function() {
+				'capabilities'             => function () {
 					if ( ! empty( $this->data->allcaps ) ) {
 
 						/**
@@ -188,7 +188,7 @@ class User extends Model {
 						$capabilities = array_keys(
 							array_filter(
 								$this->data->allcaps,
-								function( $cap ) {
+								function ( $cap ) {
 									return true === $cap;
 								}
 							)
@@ -199,61 +199,61 @@ class User extends Model {
 					return ! empty( $capabilities ) ? $capabilities : null;
 
 				},
-				'capKey'                   => function() {
+				'capKey'                   => function () {
 					return ! empty( $this->data->cap_key ) ? $this->data->cap_key : null;
 				},
-				'roles'                    => function() {
+				'roles'                    => function () {
 					return ! empty( $this->data->roles ) ? $this->data->roles : null;
 				},
-				'email'                    => function() {
+				'email'                    => function () {
 					return ! empty( $this->data->user_email ) ? $this->data->user_email : null;
 				},
-				'firstName'                => function() {
+				'firstName'                => function () {
 					return ! empty( $this->data->first_name ) ? $this->data->first_name : null;
 				},
-				'lastName'                 => function() {
+				'lastName'                 => function () {
 					return ! empty( $this->data->last_name ) ? $this->data->last_name : null;
 				},
-				'extraCapabilities'        => function() {
+				'extraCapabilities'        => function () {
 					return ! empty( $this->data->allcaps ) ? array_keys( $this->data->allcaps ) : null;
 				},
-				'description'              => function() {
+				'description'              => function () {
 					return ! empty( $this->data->description ) ? $this->data->description : null;
 				},
-				'username'                 => function() {
+				'username'                 => function () {
 					return ! empty( $this->data->user_login ) ? $this->data->user_login : null;
 				},
-				'name'                     => function() {
+				'name'                     => function () {
 					return ! empty( $this->data->display_name ) ? $this->data->display_name : null;
 				},
-				'registeredDate'           => function() {
+				'registeredDate'           => function () {
 					$timestamp = ! empty( $this->data->user_registered ) ? strtotime( $this->data->user_registered ) : null;
 					return ! empty( $timestamp ) ? gmdate( 'c', $timestamp ) : null;
 				},
-				'nickname'                 => function() {
+				'nickname'                 => function () {
 					return ! empty( $this->data->nickname ) ? $this->data->nickname : null;
 				},
-				'url'                      => function() {
+				'url'                      => function () {
 					return ! empty( $this->data->user_url ) ? $this->data->user_url : null;
 				},
-				'slug'                     => function() {
+				'slug'                     => function () {
 					return ! empty( $this->data->user_nicename ) ? $this->data->user_nicename : null;
 				},
-				'nicename'                 => function() {
+				'nicename'                 => function () {
 					return ! empty( $this->data->user_nicename ) ? $this->data->user_nicename : null;
 				},
-				'locale'                   => function() {
+				'locale'                   => function () {
 					$user_locale = get_user_locale( $this->data );
 
 					return ! empty( $user_locale ) ? $user_locale : null;
 				},
 				'userId'                   => ! empty( $this->data->ID ) ? absint( $this->data->ID ) : null,
-				'uri'                      => function() {
+				'uri'                      => function () {
 					$user_profile_url = get_author_posts_url( $this->data->ID );
 
 					return ! empty( $user_profile_url ) ? str_ireplace( home_url(), '', $user_profile_url ) : '';
 				},
-				'enqueuedScriptsQueue'     => function() {
+				'enqueuedScriptsQueue'     => function () {
 					global $wp_scripts;
 					do_action( 'wp_enqueue_scripts' );
 					$queue = $wp_scripts->queue;
@@ -262,7 +262,7 @@ class User extends Model {
 
 					return $queue;
 				},
-				'enqueuedStylesheetsQueue' => function() {
+				'enqueuedStylesheetsQueue' => function () {
 					global $wp_styles;
 					do_action( 'wp_enqueue_scripts' );
 					$queue = $wp_styles->queue;

--- a/src/Model/UserRole.php
+++ b/src/Model/UserRole.php
@@ -65,17 +65,17 @@ class UserRole extends Model {
 
 		if ( empty( $this->fields ) ) {
 			$this->fields = [
-				'id'           => function() {
+				'id'           => function () {
 					$id = Relay::toGlobalId( 'user_role', $this->data['id'] );
 					return $id;
 				},
-				'name'         => function() {
+				'name'         => function () {
 					return ! empty( $this->data['name'] ) ? esc_html( $this->data['name'] ) : null;
 				},
-				'displayName'  => function() {
+				'displayName'  => function () {
 					return ! empty( $this->data['displayName'] ) ? esc_html( $this->data['displayName'] ) : null;
 				},
-				'capabilities' => function() {
+				'capabilities' => function () {
 					if ( empty( $this->data['capabilities'] ) || ! is_array( $this->data['capabilities'] ) ) {
 						return null;
 					} else {

--- a/src/Mutation/CommentCreate.php
+++ b/src/Mutation/CommentCreate.php
@@ -83,7 +83,7 @@ class CommentCreate {
 			'comment' => [
 				'type'        => 'Comment',
 				'description' => __( 'The comment that was created', 'wp-graphql' ),
-				'resolve'     => function( $payload, $args, AppContext $context, ResolveInfo $info ) {
+				'resolve'     => function ( $payload, $args, AppContext $context, ResolveInfo $info ) {
 					if ( ! isset( $payload['id'] ) || ! absint( $payload['id'] ) ) {
 						return null;
 					}
@@ -117,7 +117,7 @@ class CommentCreate {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload() {
-		return function( $input, AppContext $context, ResolveInfo $info ) {
+		return function ( $input, AppContext $context, ResolveInfo $info ) {
 
 			/**
 			 * Throw an exception if there's no input

--- a/src/Mutation/CommentDelete.php
+++ b/src/Mutation/CommentDelete.php
@@ -57,7 +57,7 @@ class CommentDelete {
 			'deletedId' => [
 				'type'        => 'Id',
 				'description' => __( 'The deleted comment ID', 'wp-graphql' ),
-				'resolve'     => function( $payload ) {
+				'resolve'     => function ( $payload ) {
 					$deleted = (object) $payload['commentObject'];
 
 					return ! empty( $deleted->comment_ID ) ? Relay::toGlobalId( 'comment', $deleted->comment_ID ) : null;
@@ -66,7 +66,7 @@ class CommentDelete {
 			'comment'   => [
 				'type'        => 'Comment',
 				'description' => __( 'The deleted comment object', 'wp-graphql' ),
-				'resolve'     => function( $payload, $args, AppContext $context, ResolveInfo $info ) {
+				'resolve'     => function ( $payload, $args, AppContext $context, ResolveInfo $info ) {
 					return $payload['commentObject'] ? $payload['commentObject'] : null;
 				},
 			],
@@ -79,7 +79,7 @@ class CommentDelete {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload() {
-		return function( $input ) {
+		return function ( $input ) {
 			/**
 			 * Get the ID from the global ID
 			 */

--- a/src/Mutation/PostObjectCreate.php
+++ b/src/Mutation/PostObjectCreate.php
@@ -171,7 +171,7 @@ class PostObjectCreate {
 			$post_type_object->graphql_single_name => [
 				'type'        => $post_type_object->graphql_single_name,
 				'description' => __( 'The Post object mutation type.', 'wp-graphql' ),
-				'resolve'     => function( $payload, $args, AppContext $context, ResolveInfo $info ) {
+				'resolve'     => function ( $payload, $args, AppContext $context, ResolveInfo $info ) {
 
 					if ( empty( $payload['postObjectId'] ) || ! absint( $payload['postObjectId'] ) ) {
 						return null;
@@ -192,7 +192,7 @@ class PostObjectCreate {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload( $post_type_object, $mutation_name ) {
-		return function( $input, AppContext $context, ResolveInfo $info ) use ( $post_type_object, $mutation_name ) {
+		return function ( $input, AppContext $context, ResolveInfo $info ) use ( $post_type_object, $mutation_name ) {
 
 			/**
 			 * Throw an exception if there's no input

--- a/src/Mutation/PostObjectDelete.php
+++ b/src/Mutation/PostObjectDelete.php
@@ -65,7 +65,7 @@ class PostObjectDelete {
 			'deletedId'                            => [
 				'type'        => 'Id',
 				'description' => __( 'The ID of the deleted object', 'wp-graphql' ),
-				'resolve'     => function( $payload ) {
+				'resolve'     => function ( $payload ) {
 					$deleted = (object) $payload['postObject'];
 
 					return ! empty( $deleted->ID ) ? Relay::toGlobalId( 'post', $deleted->ID ) : null;
@@ -74,7 +74,7 @@ class PostObjectDelete {
 			$post_type_object->graphql_single_name => [
 				'type'        => $post_type_object->graphql_single_name,
 				'description' => __( 'The object before it was deleted', 'wp-graphql' ),
-				'resolve'     => function( $payload ) {
+				'resolve'     => function ( $payload ) {
 					$deleted = (object) $payload['postObject'];
 
 					return ! empty( $deleted ) ? $deleted : null;
@@ -92,7 +92,7 @@ class PostObjectDelete {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload( WP_Post_Type $post_type_object, string $mutation_name ) {
-		return function( $input ) use ( $post_type_object ) {
+		return function ( $input ) use ( $post_type_object ) {
 
 			/**
 			 * Get the ID from the global ID

--- a/src/Mutation/ResetUserPassword.php
+++ b/src/Mutation/ResetUserPassword.php
@@ -60,7 +60,7 @@ class ResetUserPassword {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload() {
-		return function( $input, AppContext $context, ResolveInfo $info ) {
+		return function ( $input, AppContext $context, ResolveInfo $info ) {
 
 			if ( empty( $input['key'] ) ) {
 				throw new UserError( __( 'A password reset key is required.', 'wp-graphql' ) );

--- a/src/Mutation/TermObjectCreate.php
+++ b/src/Mutation/TermObjectCreate.php
@@ -92,7 +92,7 @@ class TermObjectCreate {
 				'type'        => $taxonomy->graphql_single_name,
 				// translators: Placeholder is the name of the taxonomy
 				'description' => sprintf( __( 'The created %s', 'wp-graphql' ), $taxonomy->name ),
-				'resolve'     => function( $payload, $args, AppContext $context, ResolveInfo $info ) {
+				'resolve'     => function ( $payload, $args, AppContext $context, ResolveInfo $info ) {
 					$id = isset( $payload['termId'] ) ? absint( $payload['termId'] ) : null;
 
 					return $context->get_loader( 'term' )->load_deferred( $id );
@@ -111,7 +111,7 @@ class TermObjectCreate {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload( WP_Taxonomy $taxonomy, string $mutation_name ) {
-		return function( $input, AppContext $context, ResolveInfo $info ) use ( $taxonomy, $mutation_name ) {
+		return function ( $input, AppContext $context, ResolveInfo $info ) use ( $taxonomy, $mutation_name ) {
 
 			/**
 			 * Ensure the user can edit_terms

--- a/src/Mutation/TermObjectDelete.php
+++ b/src/Mutation/TermObjectDelete.php
@@ -64,7 +64,7 @@ class TermObjectDelete {
 			'deletedId'                    => [
 				'type'        => 'ID',
 				'description' => __( 'The ID of the deleted object', 'wp-graphql' ),
-				'resolve'     => function( $payload ) {
+				'resolve'     => function ( $payload ) {
 					$deleted = (object) $payload['termObject'];
 
 					return ! empty( $deleted->term_id ) ? Relay::toGlobalId( 'term', $deleted->term_id ) : null;
@@ -73,7 +73,7 @@ class TermObjectDelete {
 			$taxonomy->graphql_single_name => [
 				'type'        => $taxonomy->graphql_single_name,
 				'description' => __( 'The deteted term object', 'wp-graphql' ),
-				'resolve'     => function( $payload ) {
+				'resolve'     => function ( $payload ) {
 					return new Term( $payload['termObject'] );
 				},
 			],
@@ -89,7 +89,7 @@ class TermObjectDelete {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload( WP_Taxonomy $taxonomy, string $mutation_name ) {
-		return function( $input ) use ( $taxonomy ) {
+		return function ( $input ) use ( $taxonomy ) {
 
 			$id_parts = Relay::fromGlobalId( $input['id'] );
 

--- a/src/Mutation/TermObjectUpdate.php
+++ b/src/Mutation/TermObjectUpdate.php
@@ -80,7 +80,7 @@ class TermObjectUpdate {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload( WP_Taxonomy $taxonomy, $mutation_name ) {
-		return function( $input, AppContext $context, ResolveInfo $info ) use ( $taxonomy, $mutation_name ) {
+		return function ( $input, AppContext $context, ResolveInfo $info ) use ( $taxonomy, $mutation_name ) {
 			/**
 			 * Get the ID parts
 			 */

--- a/src/Mutation/UserCreate.php
+++ b/src/Mutation/UserCreate.php
@@ -127,7 +127,7 @@ class UserCreate {
 			'user' => [
 				'type'        => 'User',
 				'description' => __( 'The User object mutation type.', 'wp-graphql' ),
-				'resolve'     => function( $payload ) {
+				'resolve'     => function ( $payload ) {
 
 					$user = get_user_by( 'ID', (int) $payload['id'] );
 
@@ -147,7 +147,7 @@ class UserCreate {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload() {
-		return function( $input, AppContext $context, ResolveInfo $info ) {
+		return function ( $input, AppContext $context, ResolveInfo $info ) {
 			if ( ! current_user_can( 'create_users' ) ) {
 				throw new UserError( __( 'Sorry, you are not allowed to create a new user.', 'wp-graphql' ) );
 			}

--- a/src/Mutation/UserDelete.php
+++ b/src/Mutation/UserDelete.php
@@ -58,7 +58,7 @@ class UserDelete {
 			'deletedId' => [
 				'type'        => 'ID',
 				'description' => __( 'The ID of the user that you just deleted', 'wp-graphql' ),
-				'resolve'     => function( $payload ) {
+				'resolve'     => function ( $payload ) {
 					$deleted = (object) $payload['userObject'];
 					return ( ! empty( $deleted->ID ) ) ? Relay::toGlobalId( 'user', $deleted->ID ) : null;
 				},
@@ -66,7 +66,7 @@ class UserDelete {
 			'user'      => [
 				'type'        => 'User',
 				'description' => __( 'The deleted user object', 'wp-graphql' ),
-				'resolve'     => function( $payload ) {
+				'resolve'     => function ( $payload ) {
 					return new User( $payload['userObject'] );
 				},
 			],
@@ -79,7 +79,7 @@ class UserDelete {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload() {
-		return function( $input ) {
+		return function ( $input ) {
 			/**
 			 * Get the ID from the global ID
 			 */

--- a/src/Mutation/UserRegister.php
+++ b/src/Mutation/UserRegister.php
@@ -72,7 +72,7 @@ class UserRegister {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload() {
-		return function( $input, AppContext $context, ResolveInfo $info ) {
+		return function ( $input, AppContext $context, ResolveInfo $info ) {
 
 			if ( ! get_option( 'users_can_register' ) ) {
 				throw new UserError( __( 'User registration is currently not allowed.', 'wp-graphql' ) );

--- a/src/Registry/SchemaRegistry.php
+++ b/src/Registry/SchemaRegistry.php
@@ -39,7 +39,7 @@ class SchemaRegistry {
 		$schema_config             = new SchemaConfig();
 		$schema_config->query      = $this->type_registry->get_type( 'RootQuery' );
 		$schema_config->mutation   = $this->type_registry->get_type( 'RootMutation' );
-		$schema_config->typeLoader = function( $type ) {
+		$schema_config->typeLoader = function ( $type ) {
 			return $this->type_registry->get_type( $type );
 		};
 		$schema_config->types      = $this->type_registry->get_types();

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -383,7 +383,7 @@ class TypeRegistry {
 						'description' => __( 'The template assigned to the node', 'wp-graphql' ),
 						'fields'      => [
 							'templateName' => [
-								'resolve' => function( $template ) {
+								'resolve' => function ( $template ) {
 									return isset( $template['templateName'] ) ? $template['templateName'] : null;
 								},
 							],
@@ -547,7 +547,7 @@ class TypeRegistry {
 				register_graphql_field( 'GeneralSettings', 'url', [
 					'type'        => 'String',
 					'description' => __( 'Site URL.', 'wp-graphql' ),
-					'resolve'     => function() {
+					'resolve'     => function () {
 						return get_site_url();
 					},
 				] );
@@ -564,7 +564,7 @@ class TypeRegistry {
 					[
 						'type'        => ucfirst( $group_name ) . 'Settings',
 						'description' => sprintf( __( "Fields of the '%s' settings group", 'wp-graphql' ), ucfirst( $group_name ) . 'Settings' ),
-						'resolve'     => function() use ( $setting_type ) {
+						'resolve'     => function () use ( $setting_type ) {
 							return $setting_type;
 						},
 					]
@@ -748,7 +748,7 @@ class TypeRegistry {
 					break;
 				case 'input':
 					if ( ! empty( $config['fields'] ) && is_array( $config['fields'] ) ) {
-						$config['fields'] = function() use ( $config ) {
+						$config['fields'] = function () use ( $config ) {
 							$fields = WPInputObjectType::prepare_fields( $config['fields'], $config['name'], $config, $this );
 							$fields = $this->prepare_fields( $fields, $config['name'] );
 
@@ -944,7 +944,7 @@ class TypeRegistry {
 
 		add_filter(
 			'graphql_' . $type_name . '_fields',
-			function( $fields ) use ( $type_name, $field_name, $config ) {
+			function ( $fields ) use ( $type_name, $field_name, $config ) {
 
 				$field_name = Utils::format_field_name( $field_name );
 
@@ -1002,7 +1002,7 @@ class TypeRegistry {
 
 		add_filter(
 			'graphql_' . $type_name . '_fields',
-			function( $fields ) use ( $field_name ) {
+			function ( $fields ) use ( $field_name ) {
 
 				if ( isset( $fields[ $field_name ] ) ) {
 					unset( $fields[ $field_name ] );
@@ -1069,7 +1069,7 @@ class TypeRegistry {
 		$edge_fields        = array_key_exists( 'edgeFields', $config ) && is_array( $config['edgeFields'] ) ? $config['edgeFields'] : [];
 		$resolve_node       = array_key_exists( 'resolveNode', $config ) && is_callable( $config['resolve'] ) ? $config['resolveNode'] : null;
 		$resolve_cursor     = array_key_exists( 'resolveCursor', $config ) && is_callable( $config['resolve'] ) ? $config['resolveCursor'] : null;
-		$resolve_connection = array_key_exists( 'resolve', $config ) && is_callable( $config['resolve'] ) ? $config['resolve'] : static function() {
+		$resolve_connection = array_key_exists( 'resolve', $config ) && is_callable( $config['resolve'] ) ? $config['resolve'] : static function () {
 			return null;
 		};
 		$connection_name    = ! empty( $config['connectionTypeName'] ) ? $config['connectionTypeName'] : $this->get_connection_name( $from_type, $to_type, $from_field_name );
@@ -1138,7 +1138,7 @@ class TypeRegistry {
 							'node'   => [
 								'type'        => $to_type,
 								'description' => __( 'The item at the end of the edge', 'wp-graphql' ),
-								'resolve'     => function( $source, $args, $context, ResolveInfo $info ) use ( $resolve_node ) {
+								'resolve'     => function ( $source, $args, $context, ResolveInfo $info ) use ( $resolve_node ) {
 									if ( ! empty( $resolve_node ) && is_callable( $resolve_node ) ) {
 										return ! empty( $source['node'] ) ? $resolve_node( $source['node'], $args, $context, $info ) : null;
 									} else {
@@ -1175,7 +1175,7 @@ class TypeRegistry {
 									'list_of' => $to_type,
 								],
 								'description' => __( 'The nodes of the connection, without the edges', 'wp-graphql' ),
-								'resolve'     => function( $source, $args, $context, $info ) use ( $resolve_node ) {
+								'resolve'     => function ( $source, $args, $context, $info ) use ( $resolve_node ) {
 									$nodes = [];
 									if ( ! empty( $source['nodes'] ) && is_array( $source['nodes'] ) ) {
 										if ( is_callable( $resolve_node ) ) {
@@ -1229,7 +1229,7 @@ class TypeRegistry {
 				'args'        => array_merge( $pagination_args, $where_args ),
 				'auth'        => $auth,
 				'description' => ! empty( $config['description'] ) ? $config['description'] : sprintf( __( 'Connection between the %1$s type and the %2$s type', 'wp-graphql' ), $from_type, $to_type ),
-				'resolve'     => function( $root, $args, $context, $info ) use ( $resolve_connection, $queryClass ) {
+				'resolve'     => function ( $root, $args, $context, $info ) use ( $resolve_connection, $queryClass ) {
 					// Set queryClass on AppContext for use in connection resolver.
 					$context->queryClass = $queryClass;
 
@@ -1308,7 +1308,7 @@ class TypeRegistry {
 					],
 				],
 				'type'        => $mutation_name . 'Payload',
-				'resolve'     => function( $root, $args, $context, ResolveInfo $info ) use ( $mutateAndGetPayload, $mutation_name ) {
+				'resolve'     => function ( $root, $args, $context, ResolveInfo $info ) use ( $mutateAndGetPayload, $mutation_name ) {
 					if ( ! is_callable( $mutateAndGetPayload ) ) {
 						// Translators: The placeholder is the name of the mutation
 						throw new Exception( sprintf( __( 'The resolver for the mutation %s is not callable', 'wp-graphql' ), $mutation_name ) );

--- a/src/Server/ValidationRules/RequireAuthentication.php
+++ b/src/Server/ValidationRules/RequireAuthentication.php
@@ -78,7 +78,7 @@ class RequireAuthentication extends QuerySecurityRule {
 		return $this->invokeIfNeeded(
 			$context,
 			[
-				NodeKind::FIELD => static function( FieldNode $node ) use ( $context, $allowed_root_fields ) {
+				NodeKind::FIELD => static function ( FieldNode $node ) use ( $context, $allowed_root_fields ) {
 
 					$parent_type = $context->getParentType();
 

--- a/src/Type/InterfaceType/CommenterInterface.php
+++ b/src/Type/InterfaceType/CommenterInterface.php
@@ -23,7 +23,7 @@ class CommenterInterface {
 
 		register_graphql_interface_type( 'Commenter', [
 			'description' => __( 'The author of a comment', 'wp-graphql' ),
-			'resolveType' => function( $comment_author ) use ( $type_registry ) {
+			'resolveType' => function ( $comment_author ) use ( $type_registry ) {
 				if ( $comment_author instanceof User ) {
 					$type = $type_registry->get_type( 'User' );
 				} else {

--- a/src/Type/InterfaceType/ContentNode.php
+++ b/src/Type/InterfaceType/ContentNode.php
@@ -30,7 +30,7 @@ class ContentNode {
 			'ContentNode',
 			[
 				'description' => __( 'Nodes used to manage content', 'wp-graphql' ),
-				'resolveType' => function( Post $post ) use ( $type_registry ) {
+				'resolveType' => function ( Post $post ) use ( $type_registry ) {
 
 					/**
 					 * The resolveType callback is used at runtime to determine what Type an object

--- a/src/Type/InterfaceType/ContentTemplate.php
+++ b/src/Type/InterfaceType/ContentTemplate.php
@@ -20,7 +20,7 @@ class ContentTemplate {
 						'description' => __( 'The name of the template', 'wp-graphql' ),
 					],
 				],
-				'resolveType' => function( $value ) {
+				'resolveType' => function ( $value ) {
 					return isset( $value['__typename'] ) ? $value['__typename'] : 'DefaultTemplate';
 				},
 			]

--- a/src/Type/InterfaceType/EnqueuedAsset.php
+++ b/src/Type/InterfaceType/EnqueuedAsset.php
@@ -20,7 +20,7 @@ class EnqueuedAsset {
 
 		register_graphql_interface_type( 'EnqueuedAsset', [
 			'description' => __( 'Asset enqueued by the CMS', 'wp-graphql' ),
-			'resolveType' => function( $asset ) use ( $type_registry ) {
+			'resolveType' => function ( $asset ) use ( $type_registry ) {
 
 				/**
 				 * The resolveType callback is used at runtime to determine what Type an object
@@ -71,7 +71,7 @@ class EnqueuedAsset {
 				'extra'        => [
 					'type'        => 'String',
 					'description' => __( 'Extra information needed for the script', 'wp-graphql' ),
-					'resolve'     => function( $asset ) {
+					'resolve'     => function ( $asset ) {
 						return isset( $asset->extra['data'] ) ? $asset->extra['data'] : null;
 					},
 				],

--- a/src/Type/InterfaceType/MenuItemLinkable.php
+++ b/src/Type/InterfaceType/MenuItemLinkable.php
@@ -36,7 +36,7 @@ class MenuItemLinkable {
 					'description' => __( 'The unique resource identifier path', 'wp-graphql' ),
 				],
 			],
-			'resolveType' => function( $node ) use ( $type_registry ) {
+			'resolveType' => function ( $node ) use ( $type_registry ) {
 
 				switch ( true ) {
 					case $node instanceof Post:

--- a/src/Type/InterfaceType/Node.php
+++ b/src/Type/InterfaceType/Node.php
@@ -21,7 +21,7 @@ class Node {
 						'description' => __( 'The globally unique ID for the object', 'wp-graphql' ),
 					],
 				],
-				'resolveType' => function( $node ) {
+				'resolveType' => function ( $node ) {
 					return DataSource::resolve_node_type( $node );
 				},
 			]

--- a/src/Type/InterfaceType/NodeWithContentEditor.php
+++ b/src/Type/InterfaceType/NodeWithContentEditor.php
@@ -26,7 +26,7 @@ class NodeWithContentEditor {
 								'description' => __( 'Format of the field output', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function( $source, $args ) {
+						'resolve'     => function ( $source, $args ) {
 							if ( isset( $args['format'] ) && 'raw' === $args['format'] ) {
 								// @codingStandardsIgnoreLine.
 								return $source->contentRaw;

--- a/src/Type/InterfaceType/NodeWithExcerpt.php
+++ b/src/Type/InterfaceType/NodeWithExcerpt.php
@@ -27,7 +27,7 @@ class NodeWithExcerpt {
 								'description' => __( 'Format of the field output', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function( $source, $args ) {
+						'resolve'     => function ( $source, $args ) {
 							if ( isset( $args['format'] ) && 'raw' === $args['format'] ) {
 								// @codingStandardsIgnoreLine.
 								return $source->excerptRaw;

--- a/src/Type/InterfaceType/NodeWithTitle.php
+++ b/src/Type/InterfaceType/NodeWithTitle.php
@@ -32,7 +32,7 @@ class NodeWithTitle {
 								'description' => __( 'Format of the field output', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function( $source, $args ) {
+						'resolve'     => function ( $source, $args ) {
 							if ( isset( $args['format'] ) && 'raw' === $args['format'] ) {
 								// @codingStandardsIgnoreLine.
 								return $source->titleRaw;

--- a/src/Type/InterfaceType/TermNode.php
+++ b/src/Type/InterfaceType/TermNode.php
@@ -21,7 +21,7 @@ class TermNode {
 			'TermNode',
 			[
 				'description' => __( 'Terms are nodes within a Taxonomy, used to group and relate other nodes.', 'wp-graphql' ),
-				'resolveType' => function( $term ) use ( $type_registry ) {
+				'resolveType' => function ( $term ) use ( $type_registry ) {
 
 					/**
 					 * The resolveType callback is used at runtime to determine what Type an object
@@ -51,7 +51,7 @@ class TermNode {
 					'databaseId'     => [
 						'type'        => [ 'non_null' => 'Int' ],
 						'description' => __( 'Identifies the primary key from the database.', 'wp-graphql' ),
-						'resolve'     => function( Term $term, $args, $context, $info ) {
+						'resolve'     => function ( Term $term, $args, $context, $info ) {
 							return absint( $term->term_id );
 						},
 					],

--- a/src/Type/InterfaceType/UniformResourceIdentifiable.php
+++ b/src/Type/InterfaceType/UniformResourceIdentifiable.php
@@ -33,7 +33,7 @@ class UniformResourceIdentifiable {
 						'description' => __( 'The unique resource identifier path', 'wp-graphql' ),
 					],
 				],
-				'resolveType' => function( $node ) use ( $type_registry ) {
+				'resolveType' => function ( $node ) use ( $type_registry ) {
 
 					switch ( true ) {
 						case $node instanceof Post:

--- a/src/Type/ObjectType/Comment.php
+++ b/src/Type/ObjectType/Comment.php
@@ -50,7 +50,7 @@ class Comment {
 								'description' => __( 'Format of the field output', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function( \WPGraphQL\Model\Comment $comment, $args ) {
+						'resolve'     => function ( \WPGraphQL\Model\Comment $comment, $args ) {
 							if ( isset( $args['format'] ) && 'raw' === $args['format'] ) {
 								return isset( $comment->contentRaw ) ? $comment->contentRaw : null;
 							} else {

--- a/src/Type/ObjectType/EnqueuedScript.php
+++ b/src/Type/ObjectType/EnqueuedScript.php
@@ -25,12 +25,12 @@ class EnqueuedScript {
 					'type'    => [
 						'non_null' => 'ID',
 					],
-					'resolve' => function( $asset ) {
+					'resolve' => function ( $asset ) {
 						return isset( $asset->handle ) ? Relay::toGlobalId( 'enqueued_script', $asset->handle ) : null;
 					},
 				],
 				'src' => [
-					'resolve' => function( \_WP_Dependency $script ) {
+					'resolve' => function ( \_WP_Dependency $script ) {
 						return isset( $script->src ) && is_string( $script->src ) ? $script->src : null;
 					},
 				],

--- a/src/Type/ObjectType/EnqueuedStylesheet.php
+++ b/src/Type/ObjectType/EnqueuedStylesheet.php
@@ -25,12 +25,12 @@ class EnqueuedStylesheet {
 					'type'    => [
 						'non_null' => 'ID',
 					],
-					'resolve' => function( $asset ) {
+					'resolve' => function ( $asset ) {
 						return isset( $asset->handle ) ? Relay::toGlobalId( 'enqueued_stylesheet', $asset->handle ) : null;
 					},
 				],
 				'src' => [
-					'resolve' => function( \_WP_Dependency $stylesheet ) {
+					'resolve' => function ( \_WP_Dependency $stylesheet ) {
 						return isset( $stylesheet->src ) && is_string( $stylesheet->src ) ? $stylesheet->src : null;
 					},
 				],

--- a/src/Type/ObjectType/MediaDetails.php
+++ b/src/Type/ObjectType/MediaDetails.php
@@ -32,7 +32,7 @@ class MediaDetails {
 							'list_of' => 'MediaSize',
 						],
 						'description' => __( 'The available sizes of the mediaItem', 'wp-graphql' ),
-						'resolve'     => function( $media_details, $args, $context, $info ) {
+						'resolve'     => function ( $media_details, $args, $context, $info ) {
 							if ( ! empty( $media_details['sizes'] ) ) {
 								foreach ( $media_details['sizes'] as $size_name => $size ) {
 									$size['ID']   = $media_details['ID'];
@@ -47,7 +47,7 @@ class MediaDetails {
 					'meta'   => [
 						'type'        => 'MediaItemMeta',
 						'description' => __( 'Meta information associated with the mediaItem', 'wp-graphql' ),
-						'resolve'     => function( $media_details, $args, $context, $info ) {
+						'resolve'     => function ( $media_details, $args, $context, $info ) {
 							return ! empty( $media_details['image_meta'] ) ? $media_details['image_meta'] : null;
 						},
 					],

--- a/src/Type/ObjectType/MediaItemMeta.php
+++ b/src/Type/ObjectType/MediaItemMeta.php
@@ -39,7 +39,7 @@ class MediaItemMeta {
 					'createdTimestamp' => [
 						'type'        => 'Int',
 						'description' => __( 'The date/time when the media was created.', 'wp-graphql' ),
-						'resolve'     => function( $meta, $args, $context, $info ) {
+						'resolve'     => function ( $meta, $args, $context, $info ) {
 							return ! empty( $meta['created_timestamp'] ) ? $meta['created_timestamp'] : null;
 						},
 					],
@@ -50,7 +50,7 @@ class MediaItemMeta {
 					'focalLength'      => [
 						'type'        => 'Float',
 						'description' => __( 'The focal length value of the media item.', 'wp-graphql' ),
-						'resolve'     => function( $meta, $args, $context, $info ) {
+						'resolve'     => function ( $meta, $args, $context, $info ) {
 							return ! empty( $meta['focal_length'] ) ? $meta['focal_length'] : null;
 						},
 					],
@@ -61,7 +61,7 @@ class MediaItemMeta {
 					'shutterSpeed'     => [
 						'type'        => 'Float',
 						'description' => __( 'The shutter speed information of the media item.', 'wp-graphql' ),
-						'resolve'     => function( $meta, $args, $context, $info ) {
+						'resolve'     => function ( $meta, $args, $context, $info ) {
 							return ! empty( $meta['shutter_speed'] ) ? $meta['shutter_speed'] : null;
 						},
 					],

--- a/src/Type/ObjectType/MediaSize.php
+++ b/src/Type/ObjectType/MediaSize.php
@@ -34,14 +34,14 @@ class MediaSize {
 					'mimeType'  => [
 						'type'        => 'String',
 						'description' => __( 'The mime type of the referenced size', 'wp-graphql' ),
-						'resolve'     => function( $image, $args, $context, $info ) {
+						'resolve'     => function ( $image, $args, $context, $info ) {
 							return ! empty( $image['mime-type'] ) ? $image['mime-type'] : null;
 						},
 					],
 					'fileSize'  => [
 						'type'        => 'Int',
 						'description' => __( 'The filesize of the resource', 'wp-graphql' ),
-						'resolve'     => function( $image, $args, $context, $info ) {
+						'resolve'     => function ( $image, $args, $context, $info ) {
 
 							$src_url = null;
 
@@ -58,7 +58,7 @@ class MediaSize {
 					'sourceUrl' => [
 						'type'        => 'String',
 						'description' => __( 'The url of the referenced size', 'wp-graphql' ),
-						'resolve'     => function( $image, $args, $context, $info ) {
+						'resolve'     => function ( $image, $args, $context, $info ) {
 
 							$src_url = null;
 

--- a/src/Type/ObjectType/MenuItem.php
+++ b/src/Type/ObjectType/MenuItem.php
@@ -87,7 +87,7 @@ class MenuItem {
 						'type'              => 'MenuItemObjectUnion',
 						'deprecationReason' => __( 'Deprecated in favor of the connectedNode field', 'wp-graphql' ),
 						'description'       => __( 'The object connected to this menu item.', 'wp-graphql' ),
-						'resolve'           => function( $menu_item, array $args, AppContext $context, $info ) {
+						'resolve'           => function ( $menu_item, array $args, AppContext $context, $info ) {
 
 							$object_id   = intval( get_post_meta( $menu_item->menuItemId, '_menu_item_object_id', true ) );
 							$object_type = get_post_meta( $menu_item->menuItemId, '_menu_item_type', true );

--- a/src/Type/ObjectType/PostObject.php
+++ b/src/Type/ObjectType/PostObject.php
@@ -112,7 +112,7 @@ class PostObject {
 								'description' => __( 'Format of the field output', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function( $source, $args ) {
+						'resolve'     => function ( $source, $args ) {
 							if ( isset( $args['format'] ) && 'raw' === $args['format'] ) {
 								// @codingStandardsIgnoreLine.
 								return $source->captionRaw;
@@ -135,7 +135,7 @@ class PostObject {
 							],
 						],
 						'description' => __( 'The srcset attribute specifies the URL of the image to use in different situations. It is a comma separated string of urls and their widths.', 'wp-graphql' ),
-						'resolve'     => function( $source, $args ) {
+						'resolve'     => function ( $source, $args ) {
 							$size = 'medium';
 							if ( ! empty( $args['size'] ) ) {
 								$size = $args['size'];
@@ -155,7 +155,7 @@ class PostObject {
 							],
 						],
 						'description' => __( 'The sizes attribute value for an image.', 'wp-graphql' ),
-						'resolve'     => function( $source, $args ) {
+						'resolve'     => function ( $source, $args ) {
 							$size = 'medium';
 							if ( ! empty( $args['size'] ) ) {
 								$size = $args['size'];
@@ -180,7 +180,7 @@ class PostObject {
 								'description' => __( 'Format of the field output', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function( $source, $args ) {
+						'resolve'     => function ( $source, $args ) {
 							if ( isset( $args['format'] ) && 'raw' === $args['format'] ) {
 								// @codingStandardsIgnoreLine.
 								return $source->descriptionRaw;
@@ -207,7 +207,7 @@ class PostObject {
 								'description' => __( 'Size of the MediaItem to return', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function( $image, $args, $context, $info ) {
+						'resolve'     => function ( $image, $args, $context, $info ) {
 							// @codingStandardsIgnoreLine.
 							$size = null;
 							if ( isset( $args['size'] ) ) {
@@ -226,7 +226,7 @@ class PostObject {
 								'description' => __( 'Size of the MediaItem to return', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function( $image, $args, $context, $info ) {
+						'resolve'     => function ( $image, $args, $context, $info ) {
 
 							// @codingStandardsIgnoreLine.
 							$size = null;
@@ -280,7 +280,7 @@ class PostObject {
 				],
 				'deprecationReason' => __( 'Deprecated in favor of the databaseId field', 'wp-graphql' ),
 				'description'       => __( 'The id field matches the WP_Post->ID field.', 'wp-graphql' ),
-				'resolve'           => function( Post $post, $args, $context, $info ) {
+				'resolve'           => function ( Post $post, $args, $context, $info ) {
 					return absint( $post->ID );
 				},
 			],

--- a/src/Type/ObjectType/PostTypeLabelDetails.php
+++ b/src/Type/ObjectType/PostTypeLabelDetails.php
@@ -27,84 +27,84 @@ class PostTypeLabelDetails {
 					'singularName'        => [
 						'type'        => 'String',
 						'description' => __( 'Name for one object of this post type.', 'wp-graphql' ),
-						'resolve'     => function( $labels ) {
+						'resolve'     => function ( $labels ) {
 							return ! empty( $labels->singular_name ) ? $labels->singular_name : null;
 						},
 					],
 					'addNew'              => [
 						'type'        => 'String',
 						'description' => __( 'Default is ‘Add New’ for both hierarchical and non-hierarchical types.', 'wp-graphql' ),
-						'resolve'     => function( $labels ) {
+						'resolve'     => function ( $labels ) {
 							return ! empty( $labels->add_new ) ? $labels->add_new : null;
 						},
 					],
 					'addNewItem'          => [
 						'type'        => 'String',
 						'description' => __( 'Label for adding a new singular item.', 'wp-graphql' ),
-						'resolve'     => function( $labels ) {
+						'resolve'     => function ( $labels ) {
 							return ! empty( $labels->add_new_item ) ? $labels->add_new_item : null;
 						},
 					],
 					'editItem'            => [
 						'type'        => 'String',
 						'description' => __( 'Label for editing a singular item.', 'wp-graphql' ),
-						'resolve'     => function( $labels ) {
+						'resolve'     => function ( $labels ) {
 							return ! empty( $labels->edit_item ) ? $labels->edit_item : null;
 						},
 					],
 					'newItem'             => [
 						'type'        => 'String',
 						'description' => __( 'Label for the new item page title.', 'wp-graphql' ),
-						'resolve'     => function( $labels ) {
+						'resolve'     => function ( $labels ) {
 							return ! empty( $labels->new_item ) ? $labels->new_item : null;
 						},
 					],
 					'viewItem'            => [
 						'type'        => 'String',
 						'description' => __( 'Label for viewing a singular item.', 'wp-graphql' ),
-						'resolve'     => function( $labels ) {
+						'resolve'     => function ( $labels ) {
 							return ! empty( $labels->view_item ) ? $labels->view_item : null;
 						},
 					],
 					'viewItems'           => [
 						'type'        => 'String',
 						'description' => __( 'Label for viewing post type archives.', 'wp-graphql' ),
-						'resolve'     => function( $labels ) {
+						'resolve'     => function ( $labels ) {
 							return ! empty( $labels->view_items ) ? $labels->view_items : null;
 						},
 					],
 					'searchItems'         => [
 						'type'        => 'String',
 						'description' => __( 'Label for searching plural items.', 'wp-graphql' ),
-						'resolve'     => function( $labels ) {
+						'resolve'     => function ( $labels ) {
 							return ! empty( $labels->search_items ) ? $labels->search_items : null;
 						},
 					],
 					'notFound'            => [
 						'type'        => 'String',
 						'description' => __( 'Label used when no items are found.', 'wp-graphql' ),
-						'resolve'     => function( $labels ) {
+						'resolve'     => function ( $labels ) {
 							return ! empty( $labels->not_found ) ? $labels->not_found : null;
 						},
 					],
 					'notFoundInTrash'     => [
 						'type'        => 'String',
 						'description' => __( 'Label used when no items are in the trash.', 'wp-graphql' ),
-						'resolve'     => function( $labels ) {
+						'resolve'     => function ( $labels ) {
 							return ! empty( $labels->not_found_in_trash ) ? $labels->not_found_in_trash : null;
 						},
 					],
 					'parentItemColon'     => [
 						'type'        => 'String',
 						'description' => __( 'Label used to prefix parents of hierarchical items.', 'wp-graphql' ),
-						'resolve'     => function( $labels ) {
+						'resolve'     => function ( $labels ) {
 							return ! empty( $labels->parent_item_colon ) ? $labels->parent_item_colon : null;
 						},
 					],
 					'allItems'            => [
 						'type'        => 'String',
 						'description' => __( 'Label to signify all items in a submenu link.', 'wp-graphql' ),
-						'resolve'     => function( $labels ) {
+						'resolve'     => function ( $labels ) {
 							return ! empty( $labels->all_items ) ? $labels->all_items : null;
 						},
 					],
@@ -119,70 +119,70 @@ class PostTypeLabelDetails {
 					'insertIntoItem'      => [
 						'type'        => 'String',
 						'description' => __( 'Label for the media frame button.', 'wp-graphql' ),
-						'resolve'     => function( $labels ) {
+						'resolve'     => function ( $labels ) {
 							return ! empty( $labels->insert_into_item ) ? $labels->insert_into_item : null;
 						},
 					],
 					'uploadedToThisItem'  => [
 						'type'        => 'String',
 						'description' => __( 'Label for the media frame filter.', 'wp-graphql' ),
-						'resolve'     => function( $labels ) {
+						'resolve'     => function ( $labels ) {
 							return ! empty( $labels->uploaded_to_this_item ) ? $labels->uploaded_to_this_item : null;
 						},
 					],
 					'featuredImage'       => [
 						'type'        => 'String',
 						'description' => __( 'Label for the Featured Image meta box title.', 'wp-graphql' ),
-						'resolve'     => function( $labels ) {
+						'resolve'     => function ( $labels ) {
 							return ! empty( $labels->featured_image ) ? $labels->featured_image : null;
 						},
 					],
 					'setFeaturedImage'    => [
 						'type'        => 'String',
 						'description' => __( 'Label for setting the featured image.', 'wp-graphql' ),
-						'resolve'     => function( $labels ) {
+						'resolve'     => function ( $labels ) {
 							return ! empty( $labels->set_featured_image ) ? $labels->set_featured_image : null;
 						},
 					],
 					'removeFeaturedImage' => [
 						'type'        => 'String',
 						'description' => __( 'Label for removing the featured image.', 'wp-graphql' ),
-						'resolve'     => function( $labels ) {
+						'resolve'     => function ( $labels ) {
 							return ! empty( $labels->remove_featured_image ) ? $labels->remove_featured_image : null;
 						},
 					],
 					'useFeaturedImage'    => [
 						'type'        => 'String',
 						'description' => __( 'Label in the media frame for using a featured image.', 'wp-graphql' ),
-						'resolve'     => function( $labels ) {
+						'resolve'     => function ( $labels ) {
 							return ! empty( $labels->use_featured_item ) ? $labels->use_featured_item : null;
 						},
 					],
 					'menuName'            => [
 						'type'        => 'String',
 						'description' => __( 'Label for the menu name.', 'wp-graphql' ),
-						'resolve'     => function( $labels ) {
+						'resolve'     => function ( $labels ) {
 							return ! empty( $labels->menu_name ) ? $labels->menu_name : null;
 						},
 					],
 					'filterItemsList'     => [
 						'type'        => 'String',
 						'description' => __( 'Label for the table views hidden heading.', 'wp-graphql' ),
-						'resolve'     => function( $labels ) {
+						'resolve'     => function ( $labels ) {
 							return ! empty( $labels->filter_items_list ) ? $labels->filter_items_list : null;
 						},
 					],
 					'itemsListNavigation' => [
 						'type'        => 'String',
 						'description' => __( 'Label for the table pagination hidden heading.', 'wp-graphql' ),
-						'resolve'     => function( $labels ) {
+						'resolve'     => function ( $labels ) {
 							return ! empty( $labels->items_list_navigation ) ? $labels->items_list_navigation : null;
 						},
 					],
 					'itemsList'           => [
 						'type'        => 'String',
 						'description' => __( 'Label for the table hidden heading.', 'wp-graphql' ),
-						'resolve'     => function( $labels ) {
+						'resolve'     => function ( $labels ) {
 							return ! empty( $labels->items_list ) ? $labels->items_list : null;
 						},
 					],

--- a/src/Type/ObjectType/RootMutation.php
+++ b/src/Type/ObjectType/RootMutation.php
@@ -25,7 +25,7 @@ class RootMutation {
 								'description' => __( 'The count to increase', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function( $root, $args ) {
+						'resolve'     => function ( $root, $args ) {
 							return isset( $args['count'] ) ? absint( $args['count'] ) + 1 : null;
 						},
 					],

--- a/src/Type/ObjectType/RootQuery.php
+++ b/src/Type/ObjectType/RootQuery.php
@@ -29,7 +29,7 @@ class RootQuery {
 					'allSettings' => [
 						'type'        => 'Settings',
 						'description' => __( 'Entry point to get all settings for the site', 'wp-graphql' ),
-						'resolve'     => function() {
+						'resolve'     => function () {
 							return true;
 						},
 					],
@@ -44,7 +44,7 @@ class RootQuery {
 								'description' => __( 'Unique identifier for the comment node.', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function( $source, array $args, AppContext $context, $info ) {
+						'resolve'     => function ( $source, array $args, AppContext $context, $info ) {
 							$id_components = Relay::fromGlobalId( $args['id'] );
 
 							return DataSource::resolve_comment( $id_components['id'], $context );
@@ -73,7 +73,7 @@ class RootQuery {
 								'description' => __( 'Whether to return the node as a preview instance', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function( $root, $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => function ( $root, $args, AppContext $context, ResolveInfo $info ) {
 
 							$idType  = isset( $args['idType'] ) ? $args['idType'] : 'global_id';
 							$post_id = null;
@@ -122,7 +122,7 @@ class RootQuery {
 								'description' => __( 'Type of unique identifier to fetch a content type by. Default is Global ID', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function( $root, $args, $context, $info ) {
+						'resolve'     => function ( $root, $args, $context, $info ) {
 
 							$id_type = isset( $args['idType'] ) ? $args['idType'] : 'id';
 
@@ -156,7 +156,7 @@ class RootQuery {
 								'description' => __( 'Type of unique identifier to fetch a taxonomy by. Default is Global ID', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function( $root, $args, $context, $info ) {
+						'resolve'     => function ( $root, $args, $context, $info ) {
 
 							$id_type = isset( $args['idType'] ) ? $args['idType'] : 'id';
 
@@ -186,7 +186,7 @@ class RootQuery {
 								'description' => __( 'The unique identifier of the node', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function( $root, $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => function ( $root, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $args['id'] ) ? DataSource::resolve_node( $args['id'], $context, $info ) : null;
 						},
 					],
@@ -199,7 +199,7 @@ class RootQuery {
 								'description' => __( 'Unique Resource Identifier in the form of a path or permalink for a node. Ex: "/hello-world"', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function( $root, $args, AppContext $context ) {
+						'resolve'     => function ( $root, $args, AppContext $context ) {
 							return ! empty( $args['uri'] ) ? $context->node_resolver->resolve_uri( $args['uri'] ) : null;
 						},
 					],
@@ -218,7 +218,7 @@ class RootQuery {
 								'description' => __( 'Type of unique identifier to fetch a menu by. Default is Global ID', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function( $source, array $args, AppContext $context ) {
+						'resolve'     => function ( $source, array $args, AppContext $context ) {
 
 							$id_type = isset( $args['idType'] ) ? $args['idType'] : 'id';
 
@@ -266,7 +266,7 @@ class RootQuery {
 								'description' => __( 'Type of unique identifier to fetch a menu item by. Default is Global ID', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function( $source, array $args, AppContext $context ) {
+						'resolve'     => function ( $source, array $args, AppContext $context ) {
 							$id_type = isset( $args['idType'] ) ? $args['idType'] : 'id';
 
 							switch ( $id_type ) {
@@ -297,7 +297,7 @@ class RootQuery {
 								'description' => __( 'The globally unique identifier of the plugin.', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function( $source, array $args, AppContext $context ) {
+						'resolve'     => function ( $source, array $args, AppContext $context ) {
 							$id_components = Relay::fromGlobalId( $args['id'] );
 
 							return ! empty( $id_components['id'] ) ? $context->get_loader( 'plugin' )->load_deferred( $id_components['id'] ) : null;
@@ -322,7 +322,7 @@ class RootQuery {
 								'description' => __( 'The taxonomy of the tern node. Required when idType is set to "name" or "slug"', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function( $root, $args, AppContext $context ) {
+						'resolve'     => function ( $root, $args, AppContext $context ) {
 
 							$idType  = isset( $args['idType'] ) ? $args['idType'] : 'global_id';
 							$term_id = null;
@@ -378,7 +378,7 @@ class RootQuery {
 								'description' => __( 'The globally unique identifier of the theme.', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function( $source, array $args ) {
+						'resolve'     => function ( $source, array $args ) {
 							$id_components = Relay::fromGlobalId( $args['id'] );
 
 							return DataSource::resolve_theme( $id_components['id'] );
@@ -399,7 +399,7 @@ class RootQuery {
 								'description' => __( 'Type of unique identifier to fetch a user by. Default is Global ID', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function( $source, array $args, $context ) {
+						'resolve'     => function ( $source, array $args, $context ) {
 
 							$idType = isset( $args['idType'] ) ? $args['idType'] : 'id';
 
@@ -456,7 +456,7 @@ class RootQuery {
 								'description' => __( 'The globally unique identifier of the user object.', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function( $source, array $args ) {
+						'resolve'     => function ( $source, array $args ) {
 
 							$id_components = Relay::fromGlobalId( $args['id'] );
 
@@ -467,7 +467,7 @@ class RootQuery {
 					'viewer'      => [
 						'type'        => 'User',
 						'description' => __( 'Returns the current user', 'wp-graphql' ),
-						'resolve'     => function( $source, array $args, AppContext $context ) {
+						'resolve'     => function ( $source, array $args, AppContext $context ) {
 							return isset( $context->viewer->ID ) && ! empty( $context->viewer->ID ) ? DataSource::resolve_user( $context->viewer->ID, $context ) : null;
 						},
 					],
@@ -514,7 +514,7 @@ class RootQuery {
 								'description' => __( 'Whether to return the node as a preview instance', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function( $source, array $args, AppContext $context ) use ( $post_type_object ) {
+						'resolve'     => function ( $source, array $args, AppContext $context ) use ( $post_type_object ) {
 
 							$idType  = isset( $args['idType'] ) ? $args['idType'] : 'global_id';
 							$post_id = null;
@@ -570,7 +570,7 @@ class RootQuery {
 							}
 
 							return $context->get_loader( 'post' )->load_deferred( $post_id )->then(
-								function( $post ) use ( $post_type_object ) {
+								function ( $post ) use ( $post_type_object ) {
 									if ( ! isset( $post->post_type ) || ! in_array( $post->post_type, [
 										'revision',
 										$post_type_object->name,
@@ -616,7 +616,7 @@ class RootQuery {
 						'deprecationReason' => __( 'Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: "" ), use post(id: "" idType: "")', 'wp-graphql' ),
 						'description'       => sprintf( __( 'A %s object', 'wp-graphql' ), $post_type_object->graphql_single_name ),
 						'args'              => $post_by_args,
-						'resolve'           => function( $source, array $args, $context ) use ( $post_type_object ) {
+						'resolve'           => function ( $source, array $args, $context ) use ( $post_type_object ) {
 							$post_object = null;
 							$post_id     = 0;
 							if ( ! empty( $args['id'] ) ) {
@@ -639,7 +639,7 @@ class RootQuery {
 							}
 
 							return $context->get_loader( 'post' )->load_deferred( $post_id )->then(
-								function( $post ) use ( $post_type_object ) {
+								function ( $post ) use ( $post_type_object ) {
 
 									if ( ! $post_type_object instanceof \WP_Post_Type ) {
 										return null;
@@ -694,7 +694,7 @@ class RootQuery {
 								'description' => __( 'Type of unique identifier to fetch by. Default is Global ID', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function( $source, array $args, $context, $info ) use ( $taxonomy_object ) {
+						'resolve'     => function ( $source, array $args, $context, $info ) use ( $taxonomy_object ) {
 
 							$idType  = isset( $args['idType'] ) ? $args['idType'] : 'global_id';
 							$term_id = null;

--- a/src/Type/ObjectType/SettingGroup.php
+++ b/src/Type/ObjectType/SettingGroup.php
@@ -68,7 +68,7 @@ class SettingGroup {
 					$fields[ $field_key ] = [
 						'type'        => $setting_field['type'],
 						'description' => isset( $setting_field['description'] ) && ! empty( $setting_field['description'] ) ? $setting_field['description'] : sprintf( __( 'The %s Settings Group', 'wp-graphql' ), $setting_field['type'] ),
-						'resolve'     => function( $root, array $args, $context, $info ) use ( $setting_field ) {
+						'resolve'     => function ( $root, array $args, $context, $info ) use ( $setting_field ) {
 
 							/**
 							 * Check to see if the user querying the email field has the 'manage_options' capability

--- a/src/Type/ObjectType/Settings.php
+++ b/src/Type/ObjectType/Settings.php
@@ -77,7 +77,7 @@ class Settings {
 					$fields[ $field_key ] = [
 						'type'        => $setting_field['type'],
 						'description' => sprintf( __( 'Settings of the the %s Settings Group', 'wp-graphql' ), $setting_field['type'] ),
-						'resolve'     => function( $root, $args, $context, $info ) use ( $setting_field, $key ) {
+						'resolve'     => function ( $root, $args, $context, $info ) use ( $setting_field, $key ) {
 							/**
 							 * Check to see if the user querying the email field has the 'manage_options' capability
 							 * All other options should be public by default

--- a/src/Type/ObjectType/TermObject.php
+++ b/src/Type/ObjectType/TermObject.php
@@ -46,12 +46,12 @@ class TermObject {
 						'type'              => 'Int',
 						'deprecationReason' => __( 'Deprecated in favor of databaseId', 'wp-graphql' ),
 						'description'       => __( 'The id field matches the WP_Post->ID field.', 'wp-graphql' ),
-						'resolve'           => function( Term $term, $args, $context, $info ) {
+						'resolve'           => function ( Term $term, $args, $context, $info ) {
 							return absint( $term->term_id );
 						},
 					],
 					'uri'               => [
-						'resolve' => function( $term, $args, $context, $info ) {
+						'resolve' => function ( $term, $args, $context, $info ) {
 							return ! empty( $term->link ) ? str_ireplace( home_url(), '', $term->link ) : '';
 						},
 					],

--- a/src/Type/ObjectType/User.php
+++ b/src/Type/ObjectType/User.php
@@ -30,7 +30,7 @@ class User {
 					'databaseId'        => [
 						'type'        => [ 'non_null' => 'Int' ],
 						'description' => __( 'Identifies the primary key from the database.', 'wp-graphql' ),
-						'resolve'     => function( \WPGraphQL\Model\User $user ) {
+						'resolve'     => function ( \WPGraphQL\Model\User $user ) {
 							return absint( $user->userId );
 						},
 					],
@@ -126,7 +126,7 @@ class User {
 							],
 
 						],
-						'resolve'     => function( $user, $args, $context, $info ) {
+						'resolve'     => function ( $user, $args, $context, $info ) {
 
 							$avatar_args = [];
 							if ( is_numeric( $args['size'] ) ) {

--- a/src/Type/Union/ContentRevisionUnion.php
+++ b/src/Type/Union/ContentRevisionUnion.php
@@ -23,7 +23,7 @@ class ContentRevisionUnion {
 		if ( ! empty( $post_types_with_revision_support ) && is_array( $post_types_with_revision_support ) ) {
 
 			$type_names = array_map(
-				function( $post_type ) {
+				function ( $post_type ) {
 					/** @var \WP_Post_Type $post_type_object */
 					$post_type_object = get_post_type_object( $post_type );
 
@@ -37,7 +37,7 @@ class ContentRevisionUnion {
 				[
 					'typeNames'   => $type_names,
 					'description' => __( 'A union of Content Node Types that support revisions', 'wp-graphql' ),
-					'resolveType' => function( Post $object ) use ( $type_registry ) {
+					'resolveType' => function ( Post $object ) use ( $type_registry ) {
 
 						$type   = 'Post';
 						$parent = get_post( (int) $object->parentDatabaseId );

--- a/src/Type/Union/MenuItemObjectUnion.php
+++ b/src/Type/Union/MenuItemObjectUnion.php
@@ -30,7 +30,7 @@ class MenuItemObjectUnion {
 			[
 				'typeNames'   => self::get_possible_types(),
 				'description' => __( 'Deprecated in favor of MenuItemLinkeable Interface', 'wp-graphql' ),
-				'resolveType' => function( $object ) use ( $type_registry ) {
+				'resolveType' => function ( $object ) use ( $type_registry ) {
 					// Post object
 					if ( $object instanceof Post && isset( $object->post_type ) && ! empty( $object->post_type ) ) {
 						/** @var \WP_Post_Type $post_type_object */

--- a/src/Type/Union/PostObjectUnion.php
+++ b/src/Type/Union/PostObjectUnion.php
@@ -19,7 +19,7 @@ class PostObjectUnion {
 				'name'        => 'PostObjectUnion',
 				'typeNames'   => self::get_possible_types(),
 				'description' => __( 'Union between the post, page and media item types', 'wp-graphql' ),
-				'resolveType' => function( $value ) use ( $type_registry ) {
+				'resolveType' => function ( $value ) use ( $type_registry ) {
 
 					$type = null;
 					if ( isset( $value->post_type ) ) {

--- a/src/Type/Union/TermObjectUnion.php
+++ b/src/Type/Union/TermObjectUnion.php
@@ -19,7 +19,7 @@ class TermObjectUnion {
 				'kind'        => 'union',
 				'typeNames'   => self::get_possible_types(),
 				'description' => __( 'Union between the Category, Tag and PostFormatPost types', 'wp-graphql' ),
-				'resolveType' => function( $value ) use ( $type_registry ) {
+				'resolveType' => function ( $value ) use ( $type_registry ) {
 
 					$type = null;
 					if ( isset( $value->taxonomyName ) ) {

--- a/src/Type/WPInterfaceType.php
+++ b/src/Type/WPInterfaceType.php
@@ -32,7 +32,7 @@ class WPInterfaceType extends InterfaceType {
 
 		$name             = ucfirst( $config['name'] );
 		$config['name']   = apply_filters( 'graphql_type_name', $name, $config, $this );
-		$config['fields'] = function() use ( $config ) {
+		$config['fields'] = function () use ( $config ) {
 
 			$fields = $config['fields'];
 
@@ -77,7 +77,7 @@ class WPInterfaceType extends InterfaceType {
 			return $fields;
 		};
 
-		$config['resolveType'] = function( $object ) use ( $config ) {
+		$config['resolveType'] = function ( $object ) use ( $config ) {
 			$type = null;
 			if ( is_callable( $config['resolveType'] ) ) {
 				$type = call_user_func( $config['resolveType'], $object );

--- a/src/Type/WPObjectType.php
+++ b/src/Type/WPObjectType.php
@@ -74,7 +74,7 @@ class WPObjectType extends ObjectType {
 		 *
 		 * @return array|mixed
 		 */
-		$config['fields'] = function() use ( $config ) {
+		$config['fields'] = function () use ( $config ) {
 
 			$fields = $config['fields'];
 

--- a/src/Type/WPUnionType.php
+++ b/src/Type/WPUnionType.php
@@ -39,7 +39,7 @@ class WPUnionType extends UnionType {
 		$name           = ucfirst( $config['name'] );
 		$config['name'] = apply_filters( 'graphql_type_name', $name, $config, $this );
 
-		$config['types'] = function() use ( $config ) {
+		$config['types'] = function () use ( $config ) {
 			$prepared_types = [];
 			if ( ! empty( $config['typeNames'] ) && is_array( $config['typeNames'] ) ) {
 				$prepared_types = [];
@@ -51,7 +51,7 @@ class WPUnionType extends UnionType {
 			return $prepared_types;
 		};
 
-		$config['resolveType'] = function( $object ) use ( $config ) {
+		$config['resolveType'] = function ( $object ) use ( $config ) {
 			$type = null;
 			if ( is_callable( $config['resolveType'] ) ) {
 				$type = call_user_func( $config['resolveType'], $object );

--- a/src/Utils/InstrumentSchema.php
+++ b/src/Utils/InstrumentSchema.php
@@ -116,7 +116,7 @@ class InstrumentSchema {
 			 * @throws Exception
 			 * @since 0.0.1
 			 */
-			$field->resolveFn = static function( $source, array $args, AppContext $context, ResolveInfo $info ) use ( $field_resolver, $type_name, $field_key, $field ) {
+			$field->resolveFn = static function ( $source, array $args, AppContext $context, ResolveInfo $info ) use ( $field_resolver, $type_name, $field_key, $field ) {
 
 				/**
 				 * Setup the global post to the current post (if a post)

--- a/src/Utils/QueryLog.php
+++ b/src/Utils/QueryLog.php
@@ -145,7 +145,7 @@ class QueryLog {
 		$trace = [ $default_message ];
 
 		if ( ! empty( $wpdb->queries ) && is_array( $wpdb->queries ) ) {
-			$queries = array_map( function( $query ) {
+			$queries = array_map( function ( $query ) {
 				return [
 					'sql'   => $query[0],
 					'time'  => $query[1],

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -27,7 +27,7 @@ class Utils {
 
 			if ( is_array( $value ) && ! empty( $value ) ) {
 				$value = array_map(
-					function( $value ) {
+					function ( $value ) {
 						if ( is_string( $value ) ) {
 							$value = sanitize_text_field( $value );
 						}

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -237,7 +237,7 @@ final class WPGraphQL {
 		 */
 		add_action(
 			'after_setup_theme',
-			function() {
+			function () {
 
 				new \WPGraphQL\Data\Config();
 				new \WPGraphQL\Router();
@@ -461,7 +461,7 @@ final class WPGraphQL {
 		 * Validate that the post_types have a graphql_single_name and graphql_plural_name
 		 */
 		array_map(
-			function( $post_type ) {
+			function ( $post_type ) {
 				/** @var string $post_type */
 				$post_type_object = get_post_type_object( $post_type );
 
@@ -520,7 +520,7 @@ final class WPGraphQL {
 		 * Validate that the taxonomies have a graphql_single_name and graphql_plural_name
 		 */
 		array_map(
-			function( $taxonomy ) {
+			function ( $taxonomy ) {
 
 				$tax_object = get_taxonomy( $taxonomy );
 


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
PSR-2 and PSR-12 call for closure functions to have a space after the function keyword and before the opening parenthesis.


Does this close any currently open issues?
------------------------------------------
closes https://github.com/wp-graphql/wp-graphql/issues/1561


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
