### PR TITLE
Release/v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.4.1
+
+### Chores / Bugfixes 
+
+- ([#1958](https://github.com/wp-graphql/wp-graphql/pull/1958)): Fixes a regression in 1.4.0 where `register_graphql_interfaces_to_types` was broken. 
+
 ## 1.4.0
 
 ### Chores / Bugfixes

--- a/access-functions.php
+++ b/access-functions.php
@@ -140,13 +140,15 @@ function register_graphql_interfaces_to_types( $interface_names, $type_names ) {
 
 			// Filter the GraphQL Object Type Interface to apply the interface
 			add_filter(
-				'graphql_object_type_interfaces',
+				'graphql_type_interfaces',
 				function( $interfaces, $config ) use ( $type_name, $interface_names ) {
 
 					$interfaces = is_array( $interfaces ) ? $interfaces : [];
 
 					if ( strtolower( $type_name ) === strtolower( $config['name'] ) ) {
 						$interfaces = array_unique( array_merge( $interfaces, $interface_names ) );
+
+
 					}
 
 					return $interfaces;

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, API, Gatsby, Headless, Decoupled, React, Nextjs, Vue, Apollo, RES
 Requires at least: 5.0
 Tested up to: 5.6
 Requires PHP: 7.1
-Stable tag: 1.4.0
+Stable tag: 1.4.1
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -82,6 +82,13 @@ Gatsby and WP Engine both believe that a strong GraphQL API for WordPress is a b
 Composer dependencies are no longer versioned in Github. Recommended install source is WordPress.org or using Composer to get the code from Packagist.org or WPackagist.org.
 
 == Changelog ==
+
+= 1.4.1 =
+
+**Chores / Bugfixes**
+
+- ([#1958](https://github.com/wp-graphql/wp-graphql/pull/1958)): Fixes a regression in 1.4.0 where `register_graphql_interfaces_to_types` was broken.
+
 
 = 1.4.0 =
 

--- a/src/Type/WPInterfaceTrait.php
+++ b/src/Type/WPInterfaceTrait.php
@@ -17,13 +17,26 @@ trait WPInterfaceTrait {
 	 * Given an array of interfaces, this gets the Interfaces the Type should implement including
 	 * inherited interfaces.
 	 *
-	 * @param array $interfaces Array of interfaces the type implements
-	 *
 	 * @return array
 	 */
-	protected function get_implemented_interfaces( array $interfaces ) {
+	protected function get_implemented_interfaces() {
 
 		$new_interfaces = [];
+
+		if ( ! isset( $this->config['interfaces'] ) || ! is_array( $this->config['interfaces'] ) || empty( $this->config['interfaces'] ) ) {
+			$interfaces = parent::getInterfaces();
+		} else {
+			$interfaces = $this->config['interfaces'];
+		}
+
+		/**
+		 * Filters the interfaces applied to an object type
+		 *
+		 * @param array        $interfaces     List of interfaces applied to the Object Type
+		 * @param array        $config         The config for the Object Type
+		 * @param mixed|WPInterfaceType|WPObjectType $type The Type instance
+		 */
+		$interfaces = apply_filters( 'graphql_type_interfaces', $interfaces, $this->config, $this );
 
 		foreach ( $interfaces as $interface ) {
 			if ( ! is_string( $interface ) ) {

--- a/src/Type/WPInterfaceType.php
+++ b/src/Type/WPInterfaceType.php
@@ -110,12 +110,7 @@ class WPInterfaceType extends InterfaceType {
 	 * @return array
 	 */
 	public function getInterfaces(): array {
-
-		if ( ! isset( $this->config['interfaces'] ) || ! is_array( $this->config['interfaces'] ) || empty( $this->config['interfaces'] ) ) {
-			return [];
-		}
-
-		return $this->get_implemented_interfaces( $this->config['interfaces'] );
+		return $this->get_implemented_interfaces();
 	}
 
 	/**

--- a/src/Type/WPObjectType.php
+++ b/src/Type/WPObjectType.php
@@ -134,12 +134,7 @@ class WPObjectType extends ObjectType {
 	 * @return array
 	 */
 	public function getInterfaces(): array {
-
-		if ( ! isset( $this->config['interfaces'] ) || ! is_array( $this->config['interfaces'] ) || empty( $this->config['interfaces'] ) ) {
-			return parent::getInterfaces();
-		}
-
-		return $this->get_implemented_interfaces( $this->config['interfaces'] );
+		return $this->get_implemented_interfaces();
 	}
 
 	/**

--- a/src/Utils/InstrumentSchema.php
+++ b/src/Utils/InstrumentSchema.php
@@ -20,40 +20,29 @@ use WPGraphQL\WPSchema;
 class InstrumentSchema {
 
 	/**
-	 * Cache post for the resolvers so we can call the setup_postdata only when the actual
-	 * source post changes
-	 *
-	 * @var mixed The WP_Post object, or null
-	 */
-	private static $cached_post = null;
-
-	/**
 	 * @param WPSchema $schema Instance of the Schema.
 	 *
 	 * @return WPSchema
 	 */
 	public static function instrument_schema( WPSchema $schema ): WPSchema {
 
-		$new_types = [];
-		$types     = $schema->getTypeMap();
+		$types = $schema->getTypeMap();
 
-		if ( ! empty( $types ) && is_array( $types ) ) {
-			foreach ( $types as $type_name => $type_object ) {
-				if ( $type_object instanceof ObjectType || $type_object instanceof InterfaceType ) {
-					$fields                            = $type_object->getFields();
-					$new_fields                        = self::wrap_fields( $fields, $type_name );
-					$new_type_object                   = $type_object;
-					$new_type_object->name             = ucfirst( esc_html( $type_object->name ) );
-					$new_type_object->description      = ! empty( $type_object->description ) ? esc_html( $type_object->description ) : '';
-					$new_type_object->config['fields'] = $new_fields;
-					$new_types[ $type_name ]           = $new_type_object;
-				}
+		$schema->config->types = array_map( static function( $type_object ) {
+
+			if ( ! method_exists( $type_object, 'getFields' ) ) {
+				return $type_object;
 			}
-		}
 
-		if ( ! empty( $new_types ) && is_array( $new_types ) ) {
-			$schema->config->types = array_merge( $types, $new_types );
-		}
+			$fields                        = $type_object->getFields();
+			$fields                        = ! empty( $fields ) ? self::wrap_fields( $fields, $type_object->name ) : [];
+			$type_object->name             = ucfirst( esc_html( $type_object->name ) );
+			$type_object->description      = ! empty( $type_object->description ) ? esc_html( $type_object->description ) : '';
+			$type_object->config['fields'] = $fields;
+
+			return $type_object;
+
+		}, $types );
 
 		return $schema;
 
@@ -117,17 +106,6 @@ class InstrumentSchema {
 			 * @since 0.0.1
 			 */
 			$field->resolveFn = static function( $source, array $args, AppContext $context, ResolveInfo $info ) use ( $field_resolver, $type_name, $field_key, $field ) {
-
-				/**
-				 * Setup the global post to the current post (if a post)
-				 * This ensures that functions like get_the_content() work correctly
-				 * so graphql queries can be used in the loop without issues.
-				 */
-				if ( is_a( $source, 'WP_Post' ) && self::$cached_post !== $source ) {
-					self::$cached_post = $source;
-					$GLOBALS['post']   = $source;
-					setup_postdata( $source );
-				}
 
 				/**
 				 * Fire an action BEFORE the field resolves

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -7,6 +7,8 @@ use WPGraphQL\Admin\Admin;
 use WPGraphQL\AppContext;
 use WPGraphQL\Registry\SchemaRegistry;
 use WPGraphQL\Registry\TypeRegistry;
+use WPGraphQL\Type\WPInterfaceType;
+use WPGraphQL\Type\WPObjectType;
 use WPGraphQL\WPSchema;
 
 /**
@@ -374,6 +376,28 @@ final class WPGraphQL {
 
 		// Filter how metadata is retrieved during GraphQL requests
 		add_filter( 'get_post_metadata', [ '\WPGraphQL\Utils\Preview', 'filter_post_meta_for_previews' ], 10, 4 );
+
+		/**
+		 * Adds back compat support for the `graphql_object_type_interfaces` filter which was renamed
+		 * to support both ObjectTypes and InterfaceTypes
+		 *
+		 * @deprecated
+		 */
+		add_filter( 'graphql_type_interfaces', function( $interfaces, $config, $type ) {
+
+			if ( $type instanceof \WPGraphQL\Type\WPObjectType ) {
+				/**
+				 * Filters the interfaces applied to an object type
+				 *
+				 * @param array        $interfaces     List of interfaces applied to the Object Type
+				 * @param array        $config         The config for the Object Type
+				 * @param mixed|WPInterfaceType|WPObjectType $type The Type instance
+				 */
+				return apply_filters( 'graphql_object_type_interfaces', $interfaces, $config, $type );
+			}
+			return $interfaces;
+
+		}, 10, 3 );
 
 	}
 

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -125,7 +125,7 @@ final class WPGraphQL {
 
 		// Plugin version.
 		if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-			define( 'WPGRAPHQL_VERSION', '1.4.0' );
+			define( 'WPGRAPHQL_VERSION', '1.4.1' );
 		}
 
 		// Plugin Folder Path.

--- a/tests/wpunit/RegisterInterfaceToTypeTest.php
+++ b/tests/wpunit/RegisterInterfaceToTypeTest.php
@@ -1,0 +1,165 @@
+<?php
+
+class RegisterInterfaceToTypeTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
+
+	public function setUp(): void {
+		// before
+		$this->clearSchema();
+		parent::setUp();
+		// your set up methods here
+	}
+
+	public function tearDown(): void {
+		// your tear down methods here
+		$this->clearSchema();
+		// then
+		parent::tearDown();
+	}
+
+	/**
+	 * This test ensures that the `register_graphql_interfaces_to_types()` method
+	 * works as expected.
+	 *
+	 * @throws Exception
+	 */
+	public function testRegisterInterfaceToTypesAddsInterfacesToTypes() {
+
+		register_graphql_object_type( 'TestType', [
+			'fields' => [
+				'a' => [
+					'type' => 'String'
+				]
+			]
+		]);
+
+		register_graphql_interface_type( 'TestInterface', [
+			'fields' => [
+				'b' => [
+					'type' => 'String',
+				],
+			],
+		]);
+
+		register_graphql_interfaces_to_types( [ 'TestInterface' ], [ 'TestType' ] );
+
+		$type_name = 'TestType';
+
+		$query = '
+		query GetType($name:String!) {
+		  __type(name: $name) {
+		    name
+		    kind
+		    interfaces {
+		      name
+		    }
+		    fields {
+		      name
+		    }
+		  }
+		}
+		';
+
+		$actual = graphql([
+			'query' => $query,
+			'variables' => [
+				'name' => $type_name,
+			]
+		]);
+
+		codecept_debug( $actual );
+
+		$this->assertQuerySuccessful( $actual, [
+			$this->expectedNode( '__type.interfaces', [ 'name' => 'TestInterface' ] ),
+			$this->expectedNode( '__type.fields', [ 'name' => 'a' ] ),
+			$this->expectedNode( '__type.fields', [ 'name' => 'b' ] )
+		] );
+
+	}
+
+	/**
+	 * This test ensures that the `register_graphql_interfaces_to_types()` method
+	 * works as expected.
+	 *
+	 * @throws Exception
+	 */
+	public function testRegisterInterfaceToInterfaceAddsInterfacesToTypes() {
+
+		register_graphql_object_type( 'TestType', [
+			'fields' => [
+				'a' => [
+					'type' => 'String'
+				]
+			]
+		]);
+
+		register_graphql_interface_type( 'TestInterface', [
+			'fields' => [
+				'b' => [
+					'type' => 'String',
+				],
+			],
+		]);
+
+		register_graphql_interface_type( 'TestInterfaceTwo', [
+			'fields' => [
+				'c' => [
+					'type' => 'String',
+				],
+			],
+		]);
+
+
+		register_graphql_interfaces_to_types( [ 'TestInterfaceTwo' ], [ 'TestInterface' ] );
+		register_graphql_interfaces_to_types( [ 'TestInterfaceTwo', 'TestInterface' ], [ 'TestType' ] );
+
+		$type_name = 'TestType';
+
+		$query = '
+		query GetType($name:String!) {
+		  __type(name: $name) {
+		    name
+		    kind
+		    interfaces {
+		      name
+		    }
+		    fields {
+		      name
+		    }
+		  }
+		}
+		';
+
+		$actual = graphql([
+			'query' => $query,
+			'variables' => [
+				'name' => $type_name,
+			]
+		]);
+
+		codecept_debug( $actual );
+
+		$this->assertQuerySuccessful( $actual, [
+			$this->expectedNode( '__type.interfaces', [ 'name' => 'TestInterface' ] ),
+			$this->expectedNode( '__type.fields', [ 'name' => 'a' ] ),
+			$this->expectedNode( '__type.fields', [ 'name' => 'b' ] ),
+			$this->expectedNode( '__type.fields', [ 'name' => 'c' ] )
+		] );
+
+		$actual = graphql([
+			'query' => $query,
+			'variables' => [
+				'name' => 'TestInterface',
+			]
+		]);
+
+		codecept_debug( $actual );
+
+		$this->assertQuerySuccessful( $actual, [
+			$this->expectedNode( '__type.interfaces', [ 'name' => 'TestInterfaceTwo' ] ),
+			$this->expectedNode( '__type.fields', [ 'name' => 'b' ] ),
+			$this->expectedNode( '__type.fields', [ 'name' => 'c' ] )
+		] );
+
+	}
+
+}

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.4.0
+ * Version: 1.4.1
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.4.0
+ * @version  1.4.1
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
# Release Notes

## Chores / Bugfixes 

- ([#1958](https://github.com/wp-graphql/wp-graphql/pull/1958)): Fixes a regression in 1.4.0 where `register_graphql_interfaces_to_types` was broken. This was affecting extensions such as WPGraphQL for Gutenberg, WooGraphQL and others. 