### PR TITLE
Bugfix/#1959 - uri returns null on term nodes

### DIFF
--- a/src/Type/WPInterfaceType.php
+++ b/src/Type/WPInterfaceType.php
@@ -43,10 +43,12 @@ class WPInterfaceType extends InterfaceType {
 			 */
 			if ( ! empty( $this->getInterfaces() ) && is_array( $this->getInterfaces() ) ) {
 
-				foreach ( $this->getInterfaces() as $interface_name => $interface_type ) {
+				$interface_fields = [];
 
-					if ( is_string( $interface_name ) && ! $interface_type instanceof InterfaceType ) {
-						$interface_type = $this->type_registry->get_type( $interface_name );
+				foreach ( $this->getInterfaces() as $interface_type ) {
+
+					if ( ! $interface_type instanceof InterfaceType ) {
+						$interface_type = $this->type_registry->get_type( $interface_type );
 					}
 
 					if ( ! $interface_type instanceof InterfaceType ) {
@@ -59,16 +61,18 @@ class WPInterfaceType extends InterfaceType {
 						continue;
 					}
 
-					foreach ( $interface_config_fields as $interface_field ) {
-						if ( ! isset( $interface_field->name ) || isset( $fields[ $interface_field->name ] ) ) {
+					foreach ( $interface_config_fields as $interface_field_name => $interface_field ) {
+						if ( ! isset( $interface_field->config ) ) {
 							continue;
 						}
 
-						if ( ! isset( $fields[ $interface_field->name ] ) && isset( $interface_field->config ) && is_array( $interface_field->config ) ) {
-							$fields[ $interface_field->name ] = $interface_field->config;
-						}
+						$interface_fields[ $interface_field_name ] = $interface_field->config;
 					}
 				}
+			}
+
+			if ( ! empty( $interface_fields ) ) {
+				$fields = array_replace_recursive( $interface_fields, $fields );
 			}
 
 			$fields = $this->prepare_fields( $fields, $config['name'] );

--- a/src/Type/WPObjectType.php
+++ b/src/Type/WPObjectType.php
@@ -85,6 +85,8 @@ class WPObjectType extends ObjectType {
 			 */
 			if ( ! empty( $this->getInterfaces() ) && is_array( $this->getInterfaces() ) ) {
 
+				$interface_fields = [];
+
 				foreach ( $this->getInterfaces() as $interface_type ) {
 
 					if ( ! $interface_type instanceof InterfaceType ) {
@@ -106,9 +108,13 @@ class WPObjectType extends ObjectType {
 							continue;
 						}
 
-						$fields[ $interface_field_name ] = $interface_field->config;
+						$interface_fields[ $interface_field_name ] = $interface_field->config;
 					}
 				}
+			}
+
+			if ( ! empty( $interface_fields ) ) {
+				$fields = array_replace_recursive( $interface_fields, $fields );
 			}
 
 			$fields = $this->prepare_fields( $fields, $config['name'], $config );

--- a/tests/wpunit/TermNodeTest.php
+++ b/tests/wpunit/TermNodeTest.php
@@ -638,12 +638,16 @@ class TermNodeTest extends \Codeception\TestCase\WPTestCase {
 			'taxonomy' => 'category'
 		]);
 
+		$link = get_term_link( $cat->term_id );
+		$term_uri = str_ireplace( home_url(), '', $link );
+
 		$expected = [
 			'__typename' => 'Category',
 			'id' => \GraphQLRelay\Relay::toGlobalId( 'term', $cat->term_id ),
 			'name' => $cat->name,
 			'slug' => $cat->slug,
 			'categoryId' => $cat->term_id,
+			'uri' => $term_uri,
 		];
 
 		$query = '
@@ -656,6 +660,7 @@ class TermNodeTest extends \Codeception\TestCase\WPTestCase {
 		    ...on Category {
 		        categoryId
 		    }
+		    uri
 		  }
 		}
 		';
@@ -673,5 +678,6 @@ class TermNodeTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertSame( $expected, $actual['data']['termNode'] );
 
 	}
+
 
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- This updates the code that merges fields on the WPObjectType with fields from interfaces to properly use resolvers from object definitions. 
- Updates test to ensure URI field on term node matches expected output


Does this close any currently open issues?
------------------------------------------
closes #1959 
