### PR TITLE
Docker app script for setup without the exec

### DIFF
--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -81,6 +81,7 @@ ENV USING_XDEBUG=0
 # Set up entrypoint
 WORKDIR    /var/www/html
 COPY       docker/app.setup.sh /usr/local/bin/app-setup.sh
+COPY       docker/app.post-setup.sh /usr/local/bin/app-post-setup.sh
 COPY       docker/app.entrypoint.sh /usr/local/bin/app-entrypoint.sh
 RUN        chmod 755 /usr/local/bin/app-entrypoint.sh
 ENTRYPOINT ["app-entrypoint.sh"]

--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -52,6 +52,7 @@ ENV WORDPRESS_DB_PASSWORD=${DB_PASSWORD}
 ENV WORDPRESS_DB_NAME=${DB_NAME}
 ENV PLUGINS_DIR="${WP_ROOT_FOLDER}/wp-content/plugins"
 ENV PROJECT_DIR="${PLUGINS_DIR}/wp-graphql"
+ENV DATA_DUMP_DIR="${PROJECT_DIR}/tests/_data"
 
 # Remove exec statement from base entrypoint script.
 RUN sed -i '$d' /usr/local/bin/docker-entrypoint.sh

--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -80,6 +80,7 @@ ENV USING_XDEBUG=0
 
 # Set up entrypoint
 WORKDIR    /var/www/html
+COPY       docker/app.setup.sh /usr/local/bin/app-setup.sh
 COPY       docker/app.entrypoint.sh /usr/local/bin/app-entrypoint.sh
 RUN        chmod 755 /usr/local/bin/app-entrypoint.sh
 ENTRYPOINT ["app-entrypoint.sh"]

--- a/docker/app.entrypoint.sh
+++ b/docker/app.entrypoint.sh
@@ -2,5 +2,6 @@
 
 # Run app setup script.
 . app-setup.sh
+. app-post-setup.sh
 
 exec "$@"

--- a/docker/app.entrypoint.sh
+++ b/docker/app.entrypoint.sh
@@ -1,52 +1,6 @@
 #!/bin/bash
 
-if [ "$USING_XDEBUG" == "1"  ]; then
-    echo "Enabling XDebug 3"
-    mv /usr/local/etc/php/conf.d/disabled/docker-php-ext-xdebug.ini /usr/local/etc/php/conf.d/
-fi
-
-# Run WordPress docker entrypoint.
-. docker-entrypoint.sh 'apache2'
-
-set +u
-
-# Ensure mysql is loaded
-dockerize -wait tcp://${DB_HOST}:${DB_HOST_PORT:-3306} -timeout 1m
-
-# Config WordPress
-if [ ! -f "${WP_ROOT_FOLDER}/wp-config.php" ]; then
-    wp config create \
-        --path="${WP_ROOT_FOLDER}" \
-        --dbname="${DB_NAME}" \
-        --dbuser="${DB_USER}" \
-        --dbpass="${DB_PASSWORD}" \
-        --dbhost="${DB_HOST}" \
-        --dbprefix="${WP_TABLE_PREFIX}" \
-        --skip-check \
-        --quiet \
-        --allow-root
-fi
-
-# Install WP if not yet installed
-if ! $( wp core is-installed --allow-root ); then
-	wp core install \
-		--path="${WP_ROOT_FOLDER}" \
-		--url="${WP_URL}" \
-		--title='Test' \
-		--admin_user="${ADMIN_USERNAME}" \
-		--admin_password="${ADMIN_PASSWORD}" \
-		--admin_email="${ADMIN_EMAIL}" \
-		--allow-root
-fi
-
-echo "Running WordPress version: $(wp core version --allow-root) at $(wp option get home --allow-root)"
-
-# Activate wp-graphql
-wp plugin activate wp-graphql --allow-root
-
-# Set pretty permalinks.
-wp rewrite structure '/%year%/%monthnum%/%postname%/' --allow-root
-
-wp db export "${PROJECT_DIR}/tests/_data/dump.sql" --allow-root
+# Run app setup script.
+. app-setup.sh
 
 exec "$@"

--- a/docker/app.post-setup.sh
+++ b/docker/app.post-setup.sh
@@ -6,4 +6,4 @@ wp plugin activate wp-graphql --allow-root
 # Set pretty permalinks.
 wp rewrite structure '/%year%/%monthnum%/%postname%/' --allow-root
 
-wp db export "${PROJECT_DIR}/tests/_data/dump.sql" --allow-root
+wp db export "${DATA_DUMP_DIR}/dump.sql" --allow-root

--- a/docker/app.post-setup.sh
+++ b/docker/app.post-setup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Activate wp-graphql
+wp plugin activate wp-graphql --allow-root
+
+# Set pretty permalinks.
+wp rewrite structure '/%year%/%monthnum%/%postname%/' --allow-root
+
+wp db export "${PROJECT_DIR}/tests/_data/dump.sql" --allow-root

--- a/docker/app.setup.sh
+++ b/docker/app.setup.sh
@@ -40,11 +40,3 @@ if ! $( wp core is-installed --allow-root ); then
 fi
 
 echo "Running WordPress version: $(wp core version --allow-root) at $(wp option get home --allow-root)"
-
-# Activate wp-graphql
-wp plugin activate wp-graphql --allow-root
-
-# Set pretty permalinks.
-wp rewrite structure '/%year%/%monthnum%/%postname%/' --allow-root
-
-wp db export "${PROJECT_DIR}/tests/_data/dump.sql" --allow-root

--- a/docker/app.setup.sh
+++ b/docker/app.setup.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+if [ "$USING_XDEBUG" == "1"  ]; then
+    echo "Enabling XDebug 3"
+    mv /usr/local/etc/php/conf.d/disabled/docker-php-ext-xdebug.ini /usr/local/etc/php/conf.d/
+fi
+
+# Run WordPress docker entrypoint.
+. docker-entrypoint.sh 'apache2'
+
+set +u
+
+# Ensure mysql is loaded
+dockerize -wait tcp://${DB_HOST}:${DB_HOST_PORT:-3306} -timeout 1m
+
+# Config WordPress
+if [ ! -f "${WP_ROOT_FOLDER}/wp-config.php" ]; then
+    wp config create \
+        --path="${WP_ROOT_FOLDER}" \
+        --dbname="${DB_NAME}" \
+        --dbuser="${DB_USER}" \
+        --dbpass="${DB_PASSWORD}" \
+        --dbhost="${DB_HOST}" \
+        --dbprefix="${WP_TABLE_PREFIX}" \
+        --skip-check \
+        --quiet \
+        --allow-root
+fi
+
+# Install WP if not yet installed
+if ! $( wp core is-installed --allow-root ); then
+	wp core install \
+		--path="${WP_ROOT_FOLDER}" \
+		--url="${WP_URL}" \
+		--title='Test' \
+		--admin_user="${ADMIN_USERNAME}" \
+		--admin_password="${ADMIN_PASSWORD}" \
+		--admin_email="${ADMIN_EMAIL}" \
+		--allow-root
+fi
+
+echo "Running WordPress version: $(wp core version --allow-root) at $(wp option get home --allow-root)"
+
+# Activate wp-graphql
+wp plugin activate wp-graphql --allow-root
+
+# Set pretty permalinks.
+wp rewrite structure '/%year%/%monthnum%/%postname%/' --allow-root
+
+wp db export "${PROJECT_DIR}/tests/_data/dump.sql" --allow-root

--- a/docker/testing.Dockerfile
+++ b/docker/testing.Dockerfile
@@ -36,9 +36,6 @@ ENV PATH "$PATH:~/.composer/vendor/bin"
 # Configure php
 RUN echo "date.timezone = UTC" >> /usr/local/etc/php/php.ini
 
-# Remove exec statement from base entrypoint script.
-RUN sed -i '$d' /usr/local/bin/app-entrypoint.sh
-
 # Set up entrypoint
 WORKDIR    /var/www/html/wp-content/plugins/wp-graphql
 COPY       docker/testing.entrypoint.sh /usr/local/bin/testing-entrypoint.sh

--- a/docker/testing.entrypoint.sh
+++ b/docker/testing.entrypoint.sh
@@ -47,6 +47,7 @@ cd ${WP_ROOT_FOLDER}
 
 # Run app entrypoint script.
 . app-setup.sh
+. app-post-setup.sh
 
 write_htaccess
 

--- a/docker/testing.entrypoint.sh
+++ b/docker/testing.entrypoint.sh
@@ -46,7 +46,7 @@ echo "Moving to WordPress root directory."
 cd ${WP_ROOT_FOLDER}
 
 # Run app entrypoint script.
-. app-entrypoint.sh
+. app-setup.sh
 
 write_htaccess
 


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
The app entrypoint sh script is invoked by the testing script. But also invokes the exec CMD, which starts apache. For the testing image, we don't want to do that, we have a different exec CMD to run.  So it has a 'sed' command to modify the apo entrypoint script.  Kinda gross. We want to invoke the app setup for testing and potentially for other docker image.

Right now, don't really change any behavior. Just make it more useable for the next script that wants to invoke it.


Does this close any currently open issues?
------------------------------------------
Part of https://github.com/wp-graphql/wp-graphql-persisted-queries/issues/1


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
