### PR TITLE
Release/v1.5.0

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -7,7 +7,7 @@ WP_URL=http://localhost
 WP_DOMAIN=localhost
 ADMIN_EMAIL=admin@example.com
 ADMIN_USERNAME=admin
-ADMIN_PASSWORD=root
+ADMIN_PASSWORD=password
 ADMIN_PATH=/wp-admin
 
 TEST_DB_NAME=wptests

--- a/.github/workflows/deploy-docker-image.yml
+++ b/.github/workflows/deploy-docker-image.yml
@@ -1,11 +1,10 @@
 name: Deploy Docker Image
 
-# Note: testing image push process. On merge to develop branch, push the image.
-# TODO: Deploy when release is tagged. Add release version to image name.
+# On release/tag, use "v#.#.#' tag version number. Also push 'latest' image.
 on:
   push:
-    branches:
-      - develop
+    tags:
+      - 'v*'
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
@@ -22,6 +21,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      # Use magic to get the tag number from /ref/heads/v0.1.2 in GITHUB_REF
+      - name: Get the version
+        id: vars
+        run: echo ::set-output name=tag::$(echo ${GITHUB_REF:11})
+
       - name: Log in to the Container registry
         uses: docker/login-action@v1
         with:
@@ -34,7 +38,9 @@ jobs:
         with:
           context: .
           push: true
-          tags: ghcr.io/wp-graphql/wp-graphql:latest-wp${{ matrix.wordpress }}-php${{ matrix.php }}
+          tags: |
+            ghcr.io/wp-graphql/wp-graphql:latest-wp${{ matrix.wordpress }}-php${{ matrix.php }}
+            ghcr.io/wp-graphql/wp-graphql:${{ steps.vars.outputs.tag }}-wp${{ matrix.wordpress }}-php${{ matrix.php }}
           file: docker/app.Dockerfile
           build-args: |
             PHP_VERSION=${{ matrix.php }}

--- a/.github/workflows/deploy-docker-image.yml
+++ b/.github/workflows/deploy-docker-image.yml
@@ -1,0 +1,41 @@
+name: Deploy Docker Image
+
+# Note: testing image push process. On merge to develop branch, push the image.
+# TODO: Deploy when release is tagged. Add release version to image name.
+on:
+  push:
+    branches:
+      - develop
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        php: [ '7.3', '7.4' ]
+        wordpress: [ '5.6', '5.5.3', '5.4.2' ]
+      fail-fast: false
+    name: WordPress ${{ matrix.wordpress }} on PHP ${{ matrix.php }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2.5.0
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/wp-graphql/wp-graphql:latest-wp${{ matrix.wordpress }}-php${{ matrix.php }}
+          file: docker/app.Dockerfile
+          build-args: |
+            PHP_VERSION=${{ matrix.php }}
+            WP_VERSION=${{ matrix.wordpress }}

--- a/.github/workflows/testing-integration.yml
+++ b/.github/workflows/testing-integration.yml
@@ -64,6 +64,8 @@ jobs:
           DEBUG: ${{ matrix.debug }}
           SKIP_TESTS_CLEANUP: ${{ matrix.coverage }}
           SUITES: wpunit
+          PHP_VERSION: ${{ matrix.php }}
+          WP_VERSION: ${{ matrix.wordpress }}
         run: composer run-test
 
       - name: Push Codecoverage to Coveralls.io

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 1.5.0
+
+## Chores / Bugfixes
+
+- ([#1865](https://github.com/wp-graphql/wp-graphql/pull/1865)): Change `MenuItem.path` field from `nonNull` to nullable as the value can be null in WordPress. Thanks @furedal!
+- ([#1978](https://github.com/wp-graphql/wp-graphql/pull/1978)): Use "docker compose" instead of docker-compose in the run-docker.sh script. Thanks @markkelnar!
+- ([#1974](https://github.com/wp-graphql/wp-graphql/pull/1974)): Separates app setup and app-post-setup scripts for use in the Docker/test environment setup. Thanks @markkelnar!
+- ([#1972](https://github.com/wp-graphql/wp-graphql/pull/1972)): Pushes Docker images when new releases are tagged. Thanks @markkelnar!
+- ([#1970](https://github.com/wp-graphql/wp-graphql/pull/1970)): Change Docker Image names specific to the WP and PHP versions. Thanks @markkelnar!
+- ([#1967](https://github.com/wp-graphql/wp-graphql/pull/1967)): Update xdebug max nesting level to allow coverage to pass with resolver instrumentation active. Thanks @markkelnar!
+
+
+## New Features
+
+- ([#1977](https://github.com/wp-graphql/wp-graphql/pull/1977)): Allow same string to be passed for "graphql_single_name" and "graphql_plural_name" (ex: "deer" and "deer") when registering Post Types and Taxonomies. Same strings will be prefixed with "all" for plurals. Thanks @apmatthews!
+- ([#1787](https://github.com/wp-graphql/wp-graphql/pull/1787)): Adds a new "ContentTypesOf. Thanks @plong0!
+
+
 ## 1.4.3
 
 - See previous release. This was a version bump to fix a missed deploy.

--- a/access-functions.php
+++ b/access-functions.php
@@ -141,14 +141,12 @@ function register_graphql_interfaces_to_types( $interface_names, $type_names ) {
 			// Filter the GraphQL Object Type Interface to apply the interface
 			add_filter(
 				'graphql_type_interfaces',
-				function( $interfaces, $config ) use ( $type_name, $interface_names ) {
+				function ( $interfaces, $config ) use ( $type_name, $interface_names ) {
 
 					$interfaces = is_array( $interfaces ) ? $interfaces : [];
 
 					if ( strtolower( $type_name ) === strtolower( $config['name'] ) ) {
 						$interfaces = array_unique( array_merge( $interfaces, $interface_names ) );
-
-
 					}
 
 					return $interfaces;
@@ -173,7 +171,7 @@ function register_graphql_interfaces_to_types( $interface_names, $type_names ) {
 function register_graphql_type( string $type_name, array $config ) {
 	add_action(
 		get_graphql_register_action(),
-		function( TypeRegistry $type_registry ) use ( $type_name, $config ) {
+		function ( TypeRegistry $type_registry ) use ( $type_name, $config ) {
 			$type_registry->register_type( $type_name, $config );
 		},
 		10
@@ -192,7 +190,7 @@ function register_graphql_type( string $type_name, array $config ) {
 function register_graphql_interface_type( string $type_name, array $config ) {
 	add_action(
 		get_graphql_register_action(),
-		function( TypeRegistry $type_registry ) use ( $type_name, $config ) {
+		function ( TypeRegistry $type_registry ) use ( $type_name, $config ) {
 			$type_registry->register_interface_type( $type_name, $config );
 		},
 		10
@@ -239,7 +237,7 @@ function register_graphql_union_type( string $type_name, array $config ) {
 
 	add_action(
 		get_graphql_register_action(),
-		function( TypeRegistry $type_registry ) use ( $type_name, $config ) {
+		function ( TypeRegistry $type_registry ) use ( $type_name, $config ) {
 			$config['kind'] = 'union';
 			$type_registry->register_type( $type_name, $config );
 		},
@@ -273,7 +271,7 @@ function register_graphql_enum_type( string $type_name, array $config ) {
 function register_graphql_field( string $type_name, string $field_name, array $config ) {
 	add_action(
 		get_graphql_register_action(),
-		function( TypeRegistry $type_registry ) use ( $type_name, $field_name, $config ) {
+		function ( TypeRegistry $type_registry ) use ( $type_name, $field_name, $config ) {
 			$type_registry->register_field( $type_name, $field_name, $config );
 		},
 		10
@@ -292,7 +290,7 @@ function register_graphql_field( string $type_name, string $field_name, array $c
 function register_graphql_fields( string $type_name, array $fields ) {
 	add_action(
 		get_graphql_register_action(),
-		function( TypeRegistry $type_registry ) use ( $type_name, $fields ) {
+		function ( TypeRegistry $type_registry ) use ( $type_name, $fields ) {
 			$type_registry->register_fields( $type_name, $fields );
 		},
 		10
@@ -312,7 +310,7 @@ function register_graphql_fields( string $type_name, array $fields ) {
 function rename_graphql_field( string $type_name, string $field_name, string $new_field_name ) {
 	add_filter(
 		"graphql_{$type_name}_fields",
-		function( $fields ) use ( $field_name, $new_field_name ) {
+		function ( $fields ) use ( $field_name, $new_field_name ) {
 			$fields[ $new_field_name ] = $fields[ $field_name ];
 			unset( $fields[ $field_name ] );
 
@@ -333,7 +331,7 @@ function rename_graphql_field( string $type_name, string $field_name, string $ne
 function rename_graphql_type( string $type_name, string $new_type_name ) {
 	add_filter(
 		'graphql_type_name',
-		function( $name ) use ( $type_name, $new_type_name ) {
+		function ( $name ) use ( $type_name, $new_type_name ) {
 			if ( $name === $type_name ) {
 				return $new_type_name;
 			}
@@ -346,7 +344,7 @@ function rename_graphql_type( string $type_name, string $new_type_name ) {
 	// referenced as the type when registering fields.
 	add_action(
 		'graphql_register_types_late',
-		function( TypeRegistry $type_registry ) use ( $type_name, $new_type_name ) {
+		function ( TypeRegistry $type_registry ) use ( $type_name, $new_type_name ) {
 			$type = $type_registry->get_type( $type_name );
 			if ( ! $type instanceof Type ) {
 				return;
@@ -368,7 +366,7 @@ function rename_graphql_type( string $type_name, string $new_type_name ) {
 function register_graphql_connection( array $config ) {
 	add_action(
 		get_graphql_register_action(),
-		function( TypeRegistry $type_registry ) use ( $config ) {
+		function ( TypeRegistry $type_registry ) use ( $config ) {
 			$type_registry->register_connection( $config );
 		},
 		10
@@ -387,7 +385,7 @@ function register_graphql_connection( array $config ) {
 function register_graphql_scalar( string $type_name, array $config ) {
 	add_action(
 		get_graphql_register_action(),
-		function( TypeRegistry $type_registry ) use ( $type_name, $config ) {
+		function ( TypeRegistry $type_registry ) use ( $type_name, $config ) {
 			$type_registry->register_scalar( $type_name, $config );
 		},
 		10
@@ -405,7 +403,7 @@ function register_graphql_scalar( string $type_name, array $config ) {
 function deregister_graphql_field( string $type_name, string $field_name ) {
 	add_action(
 		get_graphql_register_action(),
-		function( TypeRegistry $type_registry ) use ( $type_name, $field_name ) {
+		function ( TypeRegistry $type_registry ) use ( $type_name, $field_name ) {
 			$type_registry->deregister_field( $type_name, $field_name );
 		},
 		10
@@ -425,7 +423,7 @@ function deregister_graphql_field( string $type_name, string $field_name ) {
 function register_graphql_mutation( string $mutation_name, array $config ) {
 	add_action(
 		get_graphql_register_action(),
-		function( TypeRegistry $type_registry ) use ( $mutation_name, $config ) {
+		function ( TypeRegistry $type_registry ) use ( $mutation_name, $config ) {
 			$type_registry->register_mutation( $mutation_name, $config );
 		},
 		10
@@ -477,7 +475,7 @@ function is_graphql_http_request() {
 function register_graphql_settings_section( string $slug, array $config ) {
 	add_action(
 		'graphql_init_settings',
-		function( \WPGraphQL\Admin\Settings\SettingsRegistry $registry ) use ( $slug, $config ) {
+		function ( \WPGraphQL\Admin\Settings\SettingsRegistry $registry ) use ( $slug, $config ) {
 			$registry->register_section( $slug, $config );
 		}
 	);
@@ -494,7 +492,7 @@ function register_graphql_settings_section( string $slug, array $config ) {
 function register_graphql_settings_field( string $group, array $config ) {
 	add_action(
 		'graphql_init_settings',
-		function( \WPGraphQL\Admin\Settings\SettingsRegistry $registry ) use ( $group, $config ) {
+		function ( \WPGraphQL\Admin\Settings\SettingsRegistry $registry ) use ( $group, $config ) {
 			$registry->register_field( $group, $config );
 		}
 	);
@@ -518,7 +516,7 @@ function graphql_debug( $message, $config = [] ) {
 		? array_column(
 			array_filter( // Filter out steps without files
 				$debug_backtrace,
-				function( $step ) {
+				function ( $step ) {
 					return ! empty( $step['file'] );
 				}
 			),
@@ -528,7 +526,7 @@ function graphql_debug( $message, $config = [] ) {
 
 	add_action(
 		'graphql_get_debug_log',
-		function( \WPGraphQL\Utils\DebugLog $debug_log ) use ( $message, $config ) {
+		function ( \WPGraphQL\Utils\DebugLog $debug_log ) use ( $message, $config ) {
 			return $debug_log->add_log_entry( $message, $config );
 		}
 	);
@@ -560,7 +558,7 @@ function is_valid_graphql_name( string $type_name ) {
 function register_graphql_settings_fields( string $group, array $fields ) {
 	add_action(
 		'graphql_init_settings',
-		function( \WPGraphQL\Admin\Settings\SettingsRegistry $registry ) use ( $group, $fields ) {
+		function ( \WPGraphQL\Admin\Settings\SettingsRegistry $registry ) use ( $group, $fields ) {
 			$registry->register_fields( $group, $fields );
 		}
 	);

--- a/bin/install-test-env.sh
+++ b/bin/install-test-env.sh
@@ -9,9 +9,8 @@ fi
 source .env
 
 print_usage_instruction() {
-  echo "ERROR!"
-  echo "Values in the .env file are missing or incorrect."
-  echo "Open the .env file at the root of this plugin and enter values to match your local environment settings"
+	echo "Ensure that .env file exist in project root directory exists."
+	echo "And run the following 'composer build-test' in the project root directory"
 	exit 1
 }
 
@@ -169,7 +168,7 @@ setup_plugin() {
 
 	cd $WP_CORE_DIR
 
-  wp plugin list
+	wp plugin list
 
 	# activate the plugin
 	wp plugin activate wp-graphql

--- a/bin/run-docker.sh
+++ b/bin/run-docker.sh
@@ -79,7 +79,7 @@ case "$subcommand" in
         while getopts "e:at" opt; do
             case ${opt} in
                 a )
-                docker-compose up --scale testing=0 \
+                docker compose up app \
                     -e WP_VERSION=${WP_VERSION} \
                     -e PHP_VERSION=${PHP_VERSION} \
                     ;;

--- a/bin/run-docker.sh
+++ b/bin/run-docker.sh
@@ -79,7 +79,7 @@ case "$subcommand" in
         while getopts "e:at" opt; do
             case ${opt} in
                 a )
-                docker-compose up --scale testing=0
+                docker-compose up --scale testing=0 \
                     -e WP_VERSION=${WP_VERSION} \
                     -e PHP_VERSION=${PHP_VERSION} \
                     ;;

--- a/bin/run-docker.sh
+++ b/bin/run-docker.sh
@@ -19,28 +19,34 @@ if [ -z "$1" ]; then
 	print_usage_instructions
 fi
 
+BUILD_NO_CACHE=
+
 env_file=".env.dist";
 
 subcommand=$1; shift
 case "$subcommand" in
     "build" )
-        while getopts ":at" opt; do
+        while getopts ":cat" opt; do
             case ${opt} in
+                c )
+                    echo "Build without cache"
+                    BUILD_NO_CACHE=--no-cache
+                    ;;
                 a )
-                docker build -f docker/app.Dockerfile \
+                docker build $BUILD_NO_CACHE -f docker/app.Dockerfile \
                     -t wpgraphql-app:latest \
                     --build-arg WP_VERSION=${WP_VERSION-5.4} \
                     --build-arg PHP_VERSION=${PHP_VERSION-7.4} \
                     .
                     ;;
                 t )
-                docker build -f docker/app.Dockerfile \
+                docker build $BUILD_NO_CACHE -f docker/app.Dockerfile \
                     -t wpgraphql-app:latest \
                     --build-arg WP_VERSION=${WP_VERSION-5.4} \
                     --build-arg PHP_VERSION=${PHP_VERSION-7.4} \
                     .
 
-                docker build -f docker/testing.Dockerfile \
+                docker build $BUILD_NO_CACHE -f docker/testing.Dockerfile \
                     -t wpgraphql-testing:latest \
                     .
                     ;;

--- a/bin/run-docker.sh
+++ b/bin/run-docker.sh
@@ -9,19 +9,36 @@ set -eu
 # flag for what you need.
 ##
 print_usage_instructions() {
-	echo "Usage: composer build-and-run -- [-a|-t]";
-	echo "       -a  Spin up a WordPress installation.";
-	echo "       -t  Run the automated tests.";
-	exit 1
+    echo "Usage: composer build-and-run -- [-a|-t]";
+    echo "       -a  Spin up a WordPress installation.";
+    echo "       -t  Run the automated tests.";
+    echo "Example use:";
+    echo "  composer build-app";
+    echo "  composer run-app";
+    echo "";
+    echo "  WP_VERSION=5.5.3 PHP_VERSION=7.4 composer build-app";
+    echo "  WP_VERSION=5.5.3 PHP_VERSION=7.4 composer run-app";
+    echo "";
+    echo "  WP_VERSION=5.5.3 PHP_VERSION=7.4  bin/run-docker.sh build -a";
+    echo "  WP_VERSION=5.5.3 PHP_VERSION=7.4  bin/run-docker.sh run -a";
+    exit 1
 }
 
-if [ -z "$1" ]; then
-	print_usage_instructions
+if [ $# -eq 0 ]; then
+    print_usage_instructions
 fi
 
-BUILD_NO_CACHE=
+TAG=${TAG-latest}
+WP_VERSION=${WP_VERSION-5.6}
+PHP_VERSION=${PHP_VERSION-7.4}
 
-env_file=".env.dist";
+BUILD_NO_CACHE=${BUILD_NO_CACHE-}
+
+if [[ ! -f ".env" ]]; then
+  echo "No .env file was detected. .env.dist has been copied to .env"
+  echo "Open the .env file and enter values to match your local environment"
+  cp .env.dist .env
+fi
 
 subcommand=$1; shift
 case "$subcommand" in
@@ -34,20 +51,22 @@ case "$subcommand" in
                     ;;
                 a )
                 docker build $BUILD_NO_CACHE -f docker/app.Dockerfile \
-                    -t wpgraphql-app:latest \
-                    --build-arg WP_VERSION=${WP_VERSION-5.4} \
-                    --build-arg PHP_VERSION=${PHP_VERSION-7.4} \
+                    -t wp-graphql:${TAG}-wp${WP_VERSION}-php${PHP_VERSION} \
+                    --build-arg WP_VERSION=${WP_VERSION} \
+                    --build-arg PHP_VERSION=${PHP_VERSION} \
                     .
                     ;;
                 t )
                 docker build $BUILD_NO_CACHE -f docker/app.Dockerfile \
-                    -t wpgraphql-app:latest \
-                    --build-arg WP_VERSION=${WP_VERSION-5.4} \
-                    --build-arg PHP_VERSION=${PHP_VERSION-7.4} \
+                    -t wp-graphql:${TAG}-wp${WP_VERSION}-php${PHP_VERSION} \
+                    --build-arg WP_VERSION=${WP_VERSION} \
+                    --build-arg PHP_VERSION=${PHP_VERSION} \
                     .
 
                 docker build $BUILD_NO_CACHE -f docker/testing.Dockerfile \
-                    -t wpgraphql-testing:latest \
+                    -t wp-graphql-testing:${TAG}-wp${WP_VERSION}-php${PHP_VERSION} \
+                    --build-arg WP_VERSION=${WP_VERSION} \
+                    --build-arg PHP_VERSION=${PHP_VERSION} \
                     .
                     ;;
                 \? ) print_usage_instructions;;
@@ -59,18 +78,18 @@ case "$subcommand" in
     "run" )
         while getopts "e:at" opt; do
             case ${opt} in
-				e )
-				env_file=${OPTARG};
-				if [ ! -f $env_file ]; then
-					echo "No file found at $env_file"
-				fi
-				;;
-                a ) docker-compose up --scale testing=0;;
+                a )
+                docker-compose up --scale testing=0
+                    -e WP_VERSION=${WP_VERSION} \
+                    -e PHP_VERSION=${PHP_VERSION} \
+                    ;;
                 t )
                 docker-compose run --rm \
                     -e COVERAGE=${COVERAGE-} \
                     -e USING_XDEBUG=${USING_XDEBUG-} \
                     -e DEBUG=${DEBUG-} \
+                    -e WP_VERSION=${WP_VERSION} \
+                    -e PHP_VERSION=${PHP_VERSION} \
                     testing --scale app=0
                     ;;
                 \? ) print_usage_instructions;;

--- a/codeception.dist.yml
+++ b/codeception.dist.yml
@@ -6,7 +6,7 @@ paths:
   envs: '%TESTS_ENVS%'
 params:
   - env
-  - .env.dist
+  - .env
 actor_suffix: Tester
 settings:
   colors: true

--- a/composer.json
+++ b/composer.json
@@ -80,10 +80,10 @@
       "php ./vendor/bin/phpcs -i"
     ],
     "check-cs": [
-      "php ./vendor/bin/phpcs src"
+      "php ./vendor/bin/phpcs"
     ],
     "fix-cs": [
-      "php ./vendor/bin/phpcbf src"
+      "php ./vendor/bin/phpcbf"
     ],
     "phpstan": ["phpstan analyze --ansi --memory-limit=1G"]
   },

--- a/composer.lock
+++ b/composer.lock
@@ -2130,7 +2130,7 @@
         },
         {
             "name": "illuminate/collections",
-            "version": "v8.46.0",
+            "version": "v8.47.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
@@ -2184,7 +2184,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v8.46.0",
+            "version": "v8.47.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
@@ -2232,7 +2232,7 @@
         },
         {
             "name": "illuminate/macroable",
-            "version": "v8.46.0",
+            "version": "v8.47.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
@@ -2278,16 +2278,16 @@
         },
         {
             "name": "illuminate/support",
-            "version": "v8.46.0",
+            "version": "v8.47.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
-                "reference": "79e1ec26d58426e4f06e5b548712a8a6dc1ffdca"
+                "reference": "a8f90b73ccfd4b37aceafc2e17bcca9ed96cb4e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/support/zipball/79e1ec26d58426e4f06e5b548712a8a6dc1ffdca",
-                "reference": "79e1ec26d58426e4f06e5b548712a8a6dc1ffdca",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/a8f90b73ccfd4b37aceafc2e17bcca9ed96cb4e4",
+                "reference": "a8f90b73ccfd4b37aceafc2e17bcca9ed96cb4e4",
                 "shasum": ""
             },
             "require": {
@@ -2342,7 +2342,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2021-06-08T13:14:36+00:00"
+            "time": "2021-06-10T13:13:44+00:00"
         },
         {
             "name": "justinrainbow/json-schema",
@@ -2982,16 +2982,16 @@
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v5.7.1",
+            "version": "v5.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "9705d1d0ac8e5000fdcdc96b4d5fd12e429c125d"
+                "reference": "beda02c58f1c4689d42c8dde6a84f7f0c9c93f42"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/9705d1d0ac8e5000fdcdc96b4d5fd12e429c125d",
-                "reference": "9705d1d0ac8e5000fdcdc96b4d5fd12e429c125d",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/beda02c58f1c4689d42c8dde6a84f7f0c9c93f42",
+                "reference": "beda02c58f1c4689d42c8dde6a84f7f0c9c93f42",
                 "shasum": ""
             },
             "replace": {
@@ -3020,9 +3020,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v5.7.1"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v5.7.2"
             },
-            "time": "2021-04-15T14:47:11+00:00"
+            "time": "2021-05-13T07:54:04+00:00"
         },
         {
             "name": "php-webdriver/webdriver",
@@ -5489,16 +5489,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v5.3.0",
+            "version": "v5.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "9f4a448c2d7fd2c90882dfff930b627ddbe16810"
+                "reference": "9c307728cfacbd50914f0db28aee1e0ecd82b99f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/9f4a448c2d7fd2c90882dfff930b627ddbe16810",
-                "reference": "9f4a448c2d7fd2c90882dfff930b627ddbe16810",
+                "url": "https://api.github.com/repos/symfony/config/zipball/9c307728cfacbd50914f0db28aee1e0ecd82b99f",
+                "reference": "9c307728cfacbd50914f0db28aee1e0ecd82b99f",
                 "shasum": ""
             },
             "require": {
@@ -5548,7 +5548,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v5.3.0"
+                "source": "https://github.com/symfony/config/tree/v5.3.2"
             },
             "funding": [
                 {
@@ -5564,20 +5564,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-26T17:43:10+00:00"
+            "time": "2021-06-12T10:15:17+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v5.3.0",
+            "version": "v5.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "058553870f7809087fa80fa734704a21b9bcaeb2"
+                "reference": "649730483885ff2ca99ca0560ef0e5f6b03f2ac1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/058553870f7809087fa80fa734704a21b9bcaeb2",
-                "reference": "058553870f7809087fa80fa734704a21b9bcaeb2",
+                "url": "https://api.github.com/repos/symfony/console/zipball/649730483885ff2ca99ca0560ef0e5f6b03f2ac1",
+                "reference": "649730483885ff2ca99ca0560ef0e5f6b03f2ac1",
                 "shasum": ""
             },
             "require": {
@@ -5646,7 +5646,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.3.0"
+                "source": "https://github.com/symfony/console/tree/v5.3.2"
             },
             "funding": [
                 {
@@ -5662,7 +5662,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-26T17:43:10+00:00"
+            "time": "2021-06-12T09:42:48+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -7090,16 +7090,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v5.3.0",
+            "version": "v5.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "a9a0f8b6aafc5d2d1c116dcccd1573a95153515b"
+                "reference": "0732e97e41c0a590f77e231afc16a327375d50b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/a9a0f8b6aafc5d2d1c116dcccd1573a95153515b",
-                "reference": "a9a0f8b6aafc5d2d1c116dcccd1573a95153515b",
+                "url": "https://api.github.com/repos/symfony/string/zipball/0732e97e41c0a590f77e231afc16a327375d50b0",
+                "reference": "0732e97e41c0a590f77e231afc16a327375d50b0",
                 "shasum": ""
             },
             "require": {
@@ -7153,7 +7153,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.3.0"
+                "source": "https://github.com/symfony/string/tree/v5.3.2"
             },
             "funding": [
                 {
@@ -7169,20 +7169,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-26T17:43:10+00:00"
+            "time": "2021-06-06T09:51:56+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v5.3.0",
+            "version": "v5.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "251de0d921c42ef0a81494d8f37405421deefdf6"
+                "reference": "7e2603bcc598e14804c4d2359d8dc4ee3c40391b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/251de0d921c42ef0a81494d8f37405421deefdf6",
-                "reference": "251de0d921c42ef0a81494d8f37405421deefdf6",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/7e2603bcc598e14804c4d2359d8dc4ee3c40391b",
+                "reference": "7e2603bcc598e14804c4d2359d8dc4ee3c40391b",
                 "shasum": ""
             },
             "require": {
@@ -7248,7 +7248,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v5.3.0"
+                "source": "https://github.com/symfony/translation/tree/v5.3.2"
             },
             "funding": [
                 {
@@ -7264,7 +7264,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-29T22:28:28+00:00"
+            "time": "2021-06-06T09:51:56+00:00"
         },
         {
             "name": "symfony/translation-contracts",
@@ -7346,16 +7346,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v5.3.0",
+            "version": "v5.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "3bbcf262fceb3d8f48175302e6ba0ac96e3a5a11"
+                "reference": "71719ab2409401711d619765aa255f9d352a59b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/3bbcf262fceb3d8f48175302e6ba0ac96e3a5a11",
-                "reference": "3bbcf262fceb3d8f48175302e6ba0ac96e3a5a11",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/71719ab2409401711d619765aa255f9d352a59b2",
+                "reference": "71719ab2409401711d619765aa255f9d352a59b2",
                 "shasum": ""
             },
             "require": {
@@ -7401,7 +7401,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v5.3.0"
+                "source": "https://github.com/symfony/yaml/tree/v5.3.2"
             },
             "funding": [
                 {
@@ -7417,7 +7417,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-26T17:43:10+00:00"
+            "time": "2021-06-06T09:51:56+00:00"
         },
         {
             "name": "szepeviktor/phpstan-wordpress",

--- a/composer.lock
+++ b/composer.lock
@@ -3534,16 +3534,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.89",
+            "version": "0.12.90",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "54c0f5a6c30511b77128d58b6369f718df250542"
+                "reference": "f0e4b56630fc3d4eb5be86606d07212ac212ede4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/54c0f5a6c30511b77128d58b6369f718df250542",
-                "reference": "54c0f5a6c30511b77128d58b6369f718df250542",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/f0e4b56630fc3d4eb5be86606d07212ac212ede4",
+                "reference": "f0e4b56630fc3d4eb5be86606d07212ac212ede4",
                 "shasum": ""
             },
             "require": {
@@ -3574,7 +3574,7 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/0.12.89"
+                "source": "https://github.com/phpstan/phpstan/tree/0.12.90"
             },
             "funding": [
                 {
@@ -3594,7 +3594,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-06-09T20:23:49+00:00"
+            "time": "2021-06-18T07:15:38+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -5244,16 +5244,16 @@
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",
-            "version": "v2.11.0",
+            "version": "v2.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
-                "reference": "e76e816236f401458dd8e16beecab905861b5867"
+                "reference": "9df9ade5961a3505d0d24b0e6be2ab82e335f753"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/e76e816236f401458dd8e16beecab905861b5867",
-                "reference": "e76e816236f401458dd8e16beecab905861b5867",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/9df9ade5961a3505d0d24b0e6be2ab82e335f753",
+                "reference": "9df9ade5961a3505d0d24b0e6be2ab82e335f753",
                 "shasum": ""
             },
             "require": {
@@ -5293,7 +5293,7 @@
                 "source": "https://github.com/sirbrillig/phpcs-variable-analysis",
                 "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
             },
-            "time": "2021-03-09T22:32:14+00:00"
+            "time": "2021-06-18T20:54:59+00:00"
         },
         {
             "name": "softcreatr/jsonpath",
@@ -7421,16 +7421,16 @@
         },
         {
             "name": "szepeviktor/phpstan-wordpress",
-            "version": "v0.7.5",
+            "version": "v0.7.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/szepeviktor/phpstan-wordpress.git",
-                "reference": "90cf3c6a225a633889b1b3a556816911f42de4f7"
+                "reference": "3721127a9ddc62c8dc14fc8726cbfb3e47529bbe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/szepeviktor/phpstan-wordpress/zipball/90cf3c6a225a633889b1b3a556816911f42de4f7",
-                "reference": "90cf3c6a225a633889b1b3a556816911f42de4f7",
+                "url": "https://api.github.com/repos/szepeviktor/phpstan-wordpress/zipball/3721127a9ddc62c8dc14fc8726cbfb3e47529bbe",
+                "reference": "3721127a9ddc62c8dc14fc8726cbfb3e47529bbe",
                 "shasum": ""
             },
             "require": {
@@ -7440,7 +7440,7 @@
                 "symfony/polyfill-php73": "^1.12.0"
             },
             "require-dev": {
-                "composer/composer": "^1.8.6",
+                "composer/composer": "^1.10.22",
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
                 "php-parallel-lint/php-parallel-lint": "^1.1",
                 "phpstan/phpstan-strict-rules": "^0.12",
@@ -7473,7 +7473,7 @@
             ],
             "support": {
                 "issues": "https://github.com/szepeviktor/phpstan-wordpress/issues",
-                "source": "https://github.com/szepeviktor/phpstan-wordpress/tree/v0.7.5"
+                "source": "https://github.com/szepeviktor/phpstan-wordpress/tree/v0.7.6"
             },
             "funding": [
                 {
@@ -7481,7 +7481,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2021-03-19T21:23:23+00:00"
+            "time": "2021-06-19T15:51:50+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/deactivation.php
+++ b/deactivation.php
@@ -25,7 +25,7 @@ function delete_graphql_data() {
 	$delete_data = get_graphql_setting( 'delete_data_on_deactivate' );
 
 	// If data is not set to delete, stop now
-	if ( "on" !== $delete_data ) {
+	if ( 'on' !== $delete_data ) {
 		return;
 	}
 
@@ -42,7 +42,7 @@ function delete_graphql_data() {
 
 	// Loop over the registered settings fields and delete the options
 	if ( ! empty( $fields ) && is_array( $fields ) ) {
-		foreach( $fields as $group => $fields ) {
+		foreach ( $fields as $group => $fields ) {
 			delete_option( $group );
 		}
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,21 +4,14 @@ services:
   app:
     depends_on:
       - app_db
-    image: wpgraphql-app:latest
+    image: wp-graphql:latest-wp${WP_VERSION-5.6}-php${PHP_VERSION-7.4}
     volumes:
       - '.:/var/www/html/wp-content/plugins/wp-graphql'
       - './.log/app:/var/log/apache2'
+    env_file:
+      - .env
     environment:
-      WP_URL: 'http://localhost:8091'
-      WP_DOMAIN: 'localhost:8091'
-      DB_HOST: app_db
-      DB_NAME: wordpress
-      DB_USER: wordpress
-      DB_PASSWORD: wordpress
-      WP_DOMAIN: localhost
-      ADMIN_EMAIL: admin@example.com
-      ADMIN_USERNAME: admin
-      ADMIN_PASSWORD: password
+      WP_URL: http://localhost:8091
       USING_XDEBUG: ${USING_XDEBUG:-}
     ports:
       - '8091:80'
@@ -41,16 +34,14 @@ services:
   testing:
     depends_on:
       - app_db
-    image: wpgraphql-testing:latest
+    image: wp-graphql-testing:latest-wp${WP_VERSION-5.6}-php${PHP_VERSION-7.4}
     volumes:
       - '.:/var/www/html/wp-content/plugins/wp-graphql'
       - './.log/testing:/var/log/apache2'
       - './codeception.dist.yml:/var/www/html/wp-content/plugins/wp-graphql/codeception.yml'
-    env_file: .env.dist
+    env_file:
+      - .env
     environment:
-      DB_HOST: app_db
-      WP_URL: 'http://localhost'
-      WP_DOMAIN: 'localhost'
       SUITES: ${SUITES:-}
     networks:
       testing:

--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -65,6 +65,7 @@ RUN echo "Installing XDebug 3 (in disabled state)" \
     && echo "xdebug.start_with_request=yes" >> /usr/local/etc/php/conf.d/disabled/docker-php-ext-xdebug.ini \
     && echo "xdebug.client_host=host.docker.internal" >> /usr/local/etc/php/conf.d/disabled/docker-php-ext-xdebug.ini \
     && echo "xdebug.client_port=9003" >> /usr/local/etc/php/conf.d/disabled/docker-php-ext-xdebug.ini \
+    && echo "xdebug.max_nesting_level=512" >> /usr/local/etc/php/conf.d/disabled/docker-php-ext-xdebug.ini \
     ;
 
 # Set xdebug configuration off by default. See the entrypoint.sh.

--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -52,6 +52,7 @@ ENV WORDPRESS_DB_PASSWORD=${DB_PASSWORD}
 ENV WORDPRESS_DB_NAME=${DB_NAME}
 ENV PLUGINS_DIR="${WP_ROOT_FOLDER}/wp-content/plugins"
 ENV PROJECT_DIR="${PLUGINS_DIR}/wp-graphql"
+ENV DATA_DUMP_DIR="${PROJECT_DIR}/tests/_data"
 
 # Remove exec statement from base entrypoint script.
 RUN sed -i '$d' /usr/local/bin/docker-entrypoint.sh
@@ -80,6 +81,8 @@ ENV USING_XDEBUG=0
 
 # Set up entrypoint
 WORKDIR    /var/www/html
+COPY       docker/app.setup.sh /usr/local/bin/app-setup.sh
+COPY       docker/app.post-setup.sh /usr/local/bin/app-post-setup.sh
 COPY       docker/app.entrypoint.sh /usr/local/bin/app-entrypoint.sh
 RUN        chmod 755 /usr/local/bin/app-entrypoint.sh
 ENTRYPOINT ["app-entrypoint.sh"]

--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -2,11 +2,18 @@
 # Pre-configured WordPress Installation w/ WPGraphQL, WPGatsby #
 # For testing only, use in production not recommended. #
 ###############################################################################
+
+# Use build args to get the right wordpress + php image
 ARG WP_VERSION
 ARG PHP_VERSION
 
 FROM wordpress:${WP_VERSION}-php${PHP_VERSION}-apache
 
+# Needed to specify the build args again after the FROM command.
+ARG WP_VERSION
+ARG PHP_VERSION
+
+# Save the build args for use by the runtime environment
 ENV WP_VERSION=${WP_VERSION}
 ENV PHP_VERSION=${PHP_VERSION}
 

--- a/docker/app.entrypoint.sh
+++ b/docker/app.entrypoint.sh
@@ -1,52 +1,7 @@
 #!/bin/bash
 
-if [ "$USING_XDEBUG" == "1"  ]; then
-    echo "Enabling XDebug 3"
-    mv /usr/local/etc/php/conf.d/disabled/docker-php-ext-xdebug.ini /usr/local/etc/php/conf.d/
-fi
-
-# Run WordPress docker entrypoint.
-. docker-entrypoint.sh 'apache2'
-
-set +u
-
-# Ensure mysql is loaded
-dockerize -wait tcp://${DB_HOST}:${DB_HOST_PORT:-3306} -timeout 1m
-
-# Config WordPress
-if [ ! -f "${WP_ROOT_FOLDER}/wp-config.php" ]; then
-    wp config create \
-        --path="${WP_ROOT_FOLDER}" \
-        --dbname="${DB_NAME}" \
-        --dbuser="${DB_USER}" \
-        --dbpass="${DB_PASSWORD}" \
-        --dbhost="${DB_HOST}" \
-        --dbprefix="${WP_TABLE_PREFIX}" \
-        --skip-check \
-        --quiet \
-        --allow-root
-fi
-
-# Install WP if not yet installed
-if ! $( wp core is-installed --allow-root ); then
-	wp core install \
-		--path="${WP_ROOT_FOLDER}" \
-		--url="${WP_URL}" \
-		--title='Test' \
-		--admin_user="${ADMIN_USERNAME}" \
-		--admin_password="${ADMIN_PASSWORD}" \
-		--admin_email="${ADMIN_EMAIL}" \
-		--allow-root
-fi
-
-echo "Running WordPress version: $(wp core version --allow-root) at $(wp option get home --allow-root)"
-
-# Activate wp-graphql
-wp plugin activate wp-graphql --allow-root
-
-# Set pretty permalinks.
-wp rewrite structure '/%year%/%monthnum%/%postname%/' --allow-root
-
-wp db export "${PROJECT_DIR}/tests/_data/dump.sql" --allow-root
+# Run app setup script.
+. app-setup.sh
+. app-post-setup.sh
 
 exec "$@"

--- a/docker/app.entrypoint.sh
+++ b/docker/app.entrypoint.sh
@@ -39,7 +39,9 @@ if ! $( wp core is-installed --allow-root ); then
 		--allow-root
 fi
 
-# Install and activate WPGatsby
+echo "Running WordPress version: $(wp core version --allow-root) at $(wp option get home --allow-root)"
+
+# Activate wp-graphql
 wp plugin activate wp-graphql --allow-root
 
 # Set pretty permalinks.

--- a/docker/app.post-setup.sh
+++ b/docker/app.post-setup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Activate wp-graphql
+wp plugin activate wp-graphql --allow-root
+
+# Set pretty permalinks.
+wp rewrite structure '/%year%/%monthnum%/%postname%/' --allow-root
+
+wp db export "${DATA_DUMP_DIR}/dump.sql" --allow-root

--- a/docker/app.setup.sh
+++ b/docker/app.setup.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+if [ "$USING_XDEBUG" == "1"  ]; then
+    echo "Enabling XDebug 3"
+    mv /usr/local/etc/php/conf.d/disabled/docker-php-ext-xdebug.ini /usr/local/etc/php/conf.d/
+fi
+
+# Run WordPress docker entrypoint.
+. docker-entrypoint.sh 'apache2'
+
+set +u
+
+# Ensure mysql is loaded
+dockerize -wait tcp://${DB_HOST}:${DB_HOST_PORT:-3306} -timeout 1m
+
+# Config WordPress
+if [ ! -f "${WP_ROOT_FOLDER}/wp-config.php" ]; then
+    wp config create \
+        --path="${WP_ROOT_FOLDER}" \
+        --dbname="${DB_NAME}" \
+        --dbuser="${DB_USER}" \
+        --dbpass="${DB_PASSWORD}" \
+        --dbhost="${DB_HOST}" \
+        --dbprefix="${WP_TABLE_PREFIX}" \
+        --skip-check \
+        --quiet \
+        --allow-root
+fi
+
+# Install WP if not yet installed
+if ! $( wp core is-installed --allow-root ); then
+	wp core install \
+		--path="${WP_ROOT_FOLDER}" \
+		--url="${WP_URL}" \
+		--title='Test' \
+		--admin_user="${ADMIN_USERNAME}" \
+		--admin_password="${ADMIN_PASSWORD}" \
+		--admin_email="${ADMIN_EMAIL}" \
+		--allow-root
+fi
+
+echo "Running WordPress version: $(wp core version --allow-root) at $(wp option get home --allow-root)"

--- a/docker/testing.Dockerfile
+++ b/docker/testing.Dockerfile
@@ -36,9 +36,6 @@ ENV PATH "$PATH:~/.composer/vendor/bin"
 # Configure php
 RUN echo "date.timezone = UTC" >> /usr/local/etc/php/php.ini
 
-# Remove exec statement from base entrypoint script.
-RUN sed -i '$d' /usr/local/bin/app-entrypoint.sh
-
 # Set up entrypoint
 WORKDIR    /var/www/html/wp-content/plugins/wp-graphql
 COPY       docker/testing.entrypoint.sh /usr/local/bin/testing-entrypoint.sh

--- a/docker/testing.Dockerfile
+++ b/docker/testing.Dockerfile
@@ -2,8 +2,10 @@
 # Container for running Codeception tests on a WPGraphQL Docker instance. #
 ############################################################################
 
-# Using the 'DESIRED_' prefix to avoid confusion with environment variables of the same name.
-FROM wpgraphql-app:latest
+ARG WP_VERSION
+ARG PHP_VERSION
+
+FROM wp-graphql:latest-wp${WP_VERSION}-php${PHP_VERSION}
 
 LABEL author=jasonbahl
 LABEL author_uri=https://github.com/jasonbahl
@@ -30,8 +32,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- \
 
 # Add composer global binaries to PATH
 ENV PATH "$PATH:~/.composer/vendor/bin"
-
-
 
 # Configure php
 RUN echo "date.timezone = UTC" >> /usr/local/etc/php/php.ini

--- a/docker/testing.entrypoint.sh
+++ b/docker/testing.entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+echo "WordPress: ${WP_VERSION} PHP: ${PHP_VERSION}"
+
 # Processes parameters and runs Codeception.
 run_tests() {
     if [[ -n "$COVERAGE" ]]; then

--- a/docker/testing.entrypoint.sh
+++ b/docker/testing.entrypoint.sh
@@ -137,7 +137,7 @@ fi
 
 # Check results and exit accordingly.
 if [ -f "${TESTS_OUTPUT}/failed" ]; then
-    echo "Uh oh, some went wrong."
+    echo "Uh oh, something went wrong."
     exit 1
 else
     echo "Woohoo! It's working!"

--- a/docker/testing.entrypoint.sh
+++ b/docker/testing.entrypoint.sh
@@ -46,7 +46,8 @@ echo "Moving to WordPress root directory."
 cd ${WP_ROOT_FOLDER}
 
 # Run app entrypoint script.
-. app-entrypoint.sh
+. app-setup.sh
+. app-post-setup.sh
 
 write_htaccess
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, API, Gatsby, Headless, Decoupled, React, Nextjs, Vue, Apollo, RES
 Requires at least: 5.0
 Tested up to: 5.6
 Requires PHP: 7.1
-Stable tag: 1.4.3
+Stable tag: 1.5.0
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -77,6 +77,10 @@ Gatsby and WP Engine both believe that a strong GraphQL API for WordPress is a b
 
 == Upgrade Notice ==
 
+= 1.5.0 =
+
+The `MenuItem.path` field was changed from `non-null` to nullable and some clients may need to make adjustments to support this.
+
 = 1.4.0 =
 
 The `uri` field was non-null on some Types in the Schema but has been changed to be nullable on all types that have it. This might require clients to update code to expect possible null values.
@@ -86,6 +90,24 @@ The `uri` field was non-null on some Types in the Schema but has been changed to
 Composer dependencies are no longer versioned in Github. Recommended install source is WordPress.org or using Composer to get the code from Packagist.org or WPackagist.org.
 
 == Changelog ==
+
+= 1.5.0 =
+
+**Chores / Bugfixes**
+
+- ([#1865](https://github.com/wp-graphql/wp-graphql/pull/1865)): Change `MenuItem.path` field from `nonNull` to nullable as the value can be null in WordPress. Thanks @furedal!
+- ([#1978](https://github.com/wp-graphql/wp-graphql/pull/1978)): Use "docker compose" instead of docker-compose in the run-docker.sh script. Thanks @markkelnar!
+- ([#1974](https://github.com/wp-graphql/wp-graphql/pull/1974)): Separates app setup and app-post-setup scripts for use in the Docker/test environment setup. Thanks @markkelnar!
+- ([#1972](https://github.com/wp-graphql/wp-graphql/pull/1972)): Pushes Docker images when new releases are tagged. Thanks @markkelnar!
+- ([#1970](https://github.com/wp-graphql/wp-graphql/pull/1970)): Change Docker Image names specific to the WP and PHP versions. Thanks @markkelnar!
+- ([#1967](https://github.com/wp-graphql/wp-graphql/pull/1967)): Update xdebug max nesting level to allow coverage to pass with resolver instrumentation active. Thanks @markkelnar!
+
+
+**New Features**
+
+- ([#1977](https://github.com/wp-graphql/wp-graphql/pull/1977)): Allow same string to be passed for "graphql_single_name" and "graphql_plural_name" (ex: "deer" and "deer") when registering Post Types and Taxonomies. Same strings will be prefixed with "all" for plurals. Thanks @apmatthews!
+- ([#1787](https://github.com/wp-graphql/wp-graphql/pull/1787)): Adds a new "ContentTypesOf. Thanks @plong0!
+
 
 = 1.4.3 =
 

--- a/src/Connection/PostObjects.php
+++ b/src/Connection/PostObjects.php
@@ -91,16 +91,8 @@ class PostObjects {
 				'toType'         => 'ContentNode',
 				'queryClass'     => 'WP_Query',
 				'fromFieldName'  => 'contentNodes',
-				'connectionArgs' => self::get_connection_args(
-					[
-						'contentTypes' => [
-							'type'        => [ 'list_of' => 'ContentTypeEnum' ],
-							'description' => __( 'The Types of content to filter', 'wp-graphql' ),
-						],
-					],
-					null
-				),
-				'resolve'        => function ( $source, $args, $context, $info ) {
+				'connectionArgs' => self::get_connection_args(),
+				'resolve'        => function( $source, $args, $context, $info ) {
 					$post_types = isset( $args['where']['contentTypes'] ) && is_array( $args['where']['contentTypes'] ) ? $args['where']['contentTypes'] : \WPGraphQL::get_allowed_post_types();
 
 					return DataSource::resolve_post_objects_connection( $source, $args, $context, $info, $post_types );
@@ -696,6 +688,30 @@ class PostObjects {
 					'description' => __( 'Array of tag slugs, used to exclude objects in specified tags', 'wp-graphql' ),
 				];
 			}
+		} else if ( isset( $post_type_object ) && $post_type_object instanceof WP_Taxonomy ) {
+			/**
+			 * Taxonomy-specific Content Type $args
+			 *
+			 * @see   : https://developer.wordpress.org/reference/classes/wp_query/#post-type-parameters
+			 */
+			$args['contentTypes'] = [
+				'type'        => [ 'list_of' => 'ContentTypesOf' . \WPGraphQL\Utils\Utils::format_type_name( $post_type_object->graphql_single_name ) . 'Enum' ],
+				'description' => __( 'The Types of content to filter', 'wp-graphql' ),
+			];
+		} else {
+			/**
+			 * Handle cases when the connection is for many post types
+			 */
+
+			/**
+			 * Content Type $args
+			 *
+			 * @see   : https://developer.wordpress.org/reference/classes/wp_query/#post-type-parameters
+			 */
+			$args['contentTypes'] = [
+				'type'        => [ 'list_of' => 'ContentTypeEnum' ],
+				'description' => __( 'The Types of content to filter', 'wp-graphql' ),
+			];
 		}
 
 		return array_merge( $fields, $args );

--- a/src/Connection/PostObjects.php
+++ b/src/Connection/PostObjects.php
@@ -195,7 +195,21 @@ class PostObjects {
 				 * Registers the RootQuery connection for each post_type
 				 */
 				if ( 'revision' !== $post_type ) {
-					register_graphql_connection( self::get_connection_config( $post_type_object ) );
+					$root_query_from_field_name = lcfirst( $post_type_object->graphql_plural_name );
+
+					// Prevent field name conflicts with the singular PostObject type.
+					if ( $post_type_object->graphql_single_name === $post_type_object->graphql_plural_name ) {
+						$root_query_from_field_name = 'all' . ucfirst( $post_type_object->graphql_single_name );
+					}
+
+					register_graphql_connection(
+						self::get_connection_config(
+							$post_type_object,
+							[
+								'fromFieldName' => $root_query_from_field_name,
+							]
+						)
+					);
 				}
 
 				if ( ! in_array( $post_type, [ 'attachment', 'revision' ], true ) ) {

--- a/src/Connection/PostObjects.php
+++ b/src/Connection/PostObjects.php
@@ -387,7 +387,7 @@ class PostObjects {
 	 * Given an optional array of args, this returns the args to be used in the connection
 	 *
 	 * @param array         $args             The args to modify the defaults
-	 * @param WP_Post_Type $post_type_object The post type the connection is going to
+	 * @param mixed|WP_Post_Type|WP_Taxonomy $post_type_object The post type the connection is going to
 	 *
 	 * @return array
 	 */
@@ -688,7 +688,7 @@ class PostObjects {
 					'description' => __( 'Array of tag slugs, used to exclude objects in specified tags', 'wp-graphql' ),
 				];
 			}
-		} elseif ( isset( $post_type_object ) && $post_type_object instanceof WP_Taxonomy ) {
+		} elseif ( $post_type_object instanceof WP_Taxonomy ) {
 			/**
 			 * Taxonomy-specific Content Type $args
 			 *

--- a/src/Connection/PostObjects.php
+++ b/src/Connection/PostObjects.php
@@ -92,7 +92,7 @@ class PostObjects {
 				'queryClass'     => 'WP_Query',
 				'fromFieldName'  => 'contentNodes',
 				'connectionArgs' => self::get_connection_args(),
-				'resolve'        => function( $source, $args, $context, $info ) {
+				'resolve'        => function ( $source, $args, $context, $info ) {
 					$post_types = isset( $args['where']['contentTypes'] ) && is_array( $args['where']['contentTypes'] ) ? $args['where']['contentTypes'] : \WPGraphQL::get_allowed_post_types();
 
 					return DataSource::resolve_post_objects_connection( $source, $args, $context, $info, $post_types );
@@ -688,7 +688,7 @@ class PostObjects {
 					'description' => __( 'Array of tag slugs, used to exclude objects in specified tags', 'wp-graphql' ),
 				];
 			}
-		} else if ( isset( $post_type_object ) && $post_type_object instanceof WP_Taxonomy ) {
+		} elseif ( isset( $post_type_object ) && $post_type_object instanceof WP_Taxonomy ) {
 			/**
 			 * Taxonomy-specific Content Type $args
 			 *

--- a/src/Connection/TermObjects.php
+++ b/src/Connection/TermObjects.php
@@ -61,10 +61,24 @@ class TermObjects {
 
 				if ( $tax_object instanceof \WP_Taxonomy ) {
 
+					$root_query_from_field_name = $tax_object->graphql_plural_name;
+
+					// Prevent field name conflicts with the singular TermObject type.
+					if ( $tax_object->graphql_single_name === $tax_object->graphql_plural_name ) {
+						$root_query_from_field_name = 'all' . ucfirst( $tax_object->graphql_single_name );
+					}
+
 					/**
 					 * Registers the RootQuery connection for each allowed taxonomy's TermObjects
 					 */
-					register_graphql_connection( self::get_connection_config( $tax_object ) );
+					register_graphql_connection(
+						self::get_connection_config(
+							$tax_object,
+							[
+								'fromFieldName' => $root_query_from_field_name,
+							]
+						)
+					);
 
 					/**
 					 * Registers the connections between each allowed PostObjectType and it's TermObjects

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -419,6 +419,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 			'status'        => 'post_status',
 			'stati'         => 'post_status',
 			'dateQuery'     => 'date_query',
+			'contentTypes'  => 'post_type',
 		];
 
 		/**

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -407,16 +407,6 @@ class TypeRegistry {
 					return;
 				}
 
-				if ( $post_type_object->graphql_single_name === $post_type_object->graphql_plural_name ) {
-					throw new \GraphQL\Error\InvariantViolation(
-						sprintf(
-						/* translators: %s will replaced with the registered type */
-							__( 'The %s post_type cannot declare the same value for "graphql_single_name" and "graphql_plural_name".', 'wp-graphql' ),
-							$post_type_object->name
-						)
-					);
-				}
-
 				PostObject::register_post_object_types( $post_type_object, $type_registry );
 
 				/**
@@ -450,16 +440,6 @@ class TypeRegistry {
 								/* translators: %s will replaced with the registered type */
 									__( 'The %s taxonomy cannot be found.', 'wp-graphql' ),
 									$taxonomy
-								)
-							);
-						}
-
-						if ( $tax_object->graphql_single_name === $tax_object->graphql_plural_name ) {
-							throw new \GraphQL\Error\InvariantViolation(
-								sprintf(
-								/* translators: %s will replaced with the registered type */
-									__( 'The %s taxonomy cannot declare the same value for "graphql_single_name" and "graphql_plural_name".', 'wp-graphql' ),
-									$tax_object->name
 								)
 							);
 						}

--- a/src/Type/Enum/ContentTypeEnum.php
+++ b/src/Type/Enum/ContentTypeEnum.php
@@ -3,6 +3,7 @@
 namespace WPGraphQL\Type\Enum;
 
 use WPGraphQL\Type\WPEnumType;
+use WPGraphQL\Utils\Utils;
 
 class ContentTypeEnum {
 
@@ -46,5 +47,43 @@ class ContentTypeEnum {
 				'values'      => $values,
 			]
 		);
+
+		/**
+		 * Register a ContentTypesOf${taxonomyName}Enum for each taxonomy
+		 */
+		$allowed_taxonomies = \WPGraphQL::get_allowed_taxonomies();
+		if ( ! empty( $allowed_taxonomies ) && is_array( $allowed_taxonomies ) ) {
+			foreach ( $allowed_taxonomies as $taxonomy ) {
+				/** @var \WP_Taxonomy $taxonomy_object */
+				$taxonomy_object = get_taxonomy( $taxonomy );
+
+				/**
+				 * Loop through the taxonomy's object type and create an array
+				 * of values for use in the enum type.
+				 */
+				$taxonomy_values = [];
+				foreach ( $taxonomy_object->object_type as $taxonomy_object_type ) {
+					// Skip object types that are not allowed by WPGraphQL
+					if ( !array_key_exists( $taxonomy_object_type, $allowed_post_types ) ) {
+						continue;
+					}
+
+					$taxonomy_values[ WPEnumType::get_safe_name( $taxonomy_object_type ) ] = [
+						'value'       => $taxonomy_object_type,
+						'description' => __( 'The Type of Content object', 'wp-graphql' ),
+					];
+				}
+
+				register_graphql_enum_type(
+					'ContentTypesOf' . Utils::format_type_name( $taxonomy_object->graphql_single_name ) . 'Enum',
+					[
+						'description' => __( 'Allowed Content Types of the ' . Utils::format_type_name( $taxonomy_object->graphql_single_name ) . ' taxonomy.', 'wp-graphql' ),
+						'values'      => $taxonomy_values,
+					]
+				);
+
+			}
+		}
+
 	}
 }

--- a/src/Type/Enum/ContentTypeEnum.php
+++ b/src/Type/Enum/ContentTypeEnum.php
@@ -64,7 +64,7 @@ class ContentTypeEnum {
 				$taxonomy_values = [];
 				foreach ( $taxonomy_object->object_type as $taxonomy_object_type ) {
 					// Skip object types that are not allowed by WPGraphQL
-					if ( !array_key_exists( $taxonomy_object_type, $allowed_post_types ) ) {
+					if ( ! array_key_exists( $taxonomy_object_type, $allowed_post_types ) ) {
 						continue;
 					}
 
@@ -77,7 +77,7 @@ class ContentTypeEnum {
 				register_graphql_enum_type(
 					'ContentTypesOf' . Utils::format_type_name( $taxonomy_object->graphql_single_name ) . 'Enum',
 					[
-						'description' => __( 'Allowed Content Types of the ' . Utils::format_type_name( $taxonomy_object->graphql_single_name ) . ' taxonomy.', 'wp-graphql' ),
+						'description' => sprintf( __( 'Allowed Content Types of the %s taxonomy.', 'wp-graphql' ), Utils::format_type_name( $taxonomy_object->graphql_single_name ) ),
 						'values'      => $taxonomy_values,
 					]
 				);

--- a/src/Type/ObjectType/MenuItem.php
+++ b/src/Type/ObjectType/MenuItem.php
@@ -66,7 +66,7 @@ class MenuItem {
 						'description' => __( 'URL or destination of the menu item.', 'wp-graphql' ),
 					],
 					'path'             => [
-						'type'        => [ 'non_null' => 'String' ],
+						'type'        => 'String',
 						'description' => __( 'Path for the resource. Relative path for internal resources. Absolute path for external resources.', 'wp-graphql' ),
 					],
 					'isRestricted'     => [

--- a/src/Utils/InstrumentSchema.php
+++ b/src/Utils/InstrumentSchema.php
@@ -28,7 +28,7 @@ class InstrumentSchema {
 
 		$types = $schema->getTypeMap();
 
-		$schema->config->types = array_map( static function( $type_object ) {
+		$schema->config->types = array_map( function ( $type_object ) {
 
 			if ( ! method_exists( $type_object, 'getFields' ) ) {
 				return $type_object;
@@ -105,7 +105,7 @@ class InstrumentSchema {
 			 * @throws Exception
 			 * @since 0.0.1
 			 */
-			$field->resolveFn = static function ( $source, array $args, AppContext $context, ResolveInfo $info ) use ( $field_resolver, $type_name, $field_key, $field ) {
+			$field->resolveFn = function ( $source, array $args, AppContext $context, ResolveInfo $info ) use ( $field_resolver, $type_name, $field_key, $field ) {
 
 				/**
 				 * Fire an action BEFORE the field resolves

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -127,7 +127,7 @@ final class WPGraphQL {
 
 		// Plugin version.
 		if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-			define( 'WPGRAPHQL_VERSION', '1.4.3' );
+			define( 'WPGRAPHQL_VERSION', '1.5.0' );
 		}
 
 		// Plugin Folder Path.

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -383,7 +383,7 @@ final class WPGraphQL {
 		 *
 		 * @deprecated
 		 */
-		add_filter( 'graphql_type_interfaces', function( $interfaces, $config, $type ) {
+		add_filter( 'graphql_type_interfaces', function ( $interfaces, $config, $type ) {
 
 			if ( $type instanceof \WPGraphQL\Type\WPObjectType ) {
 				/**

--- a/tests/wpunit/AssertValidSchemaTest.php
+++ b/tests/wpunit/AssertValidSchemaTest.php
@@ -16,8 +16,6 @@ class AssertValidSchemaTest extends \Codeception\TestCase\WPTestCase {
 
 		// then
 		parent::tearDown();
-		unregister_post_type( 'test_aaa' );
-		unregister_taxonomy( 'test_tax_aaa' );
 		WPGraphQL::clear_schema();
 	}
 
@@ -40,78 +38,6 @@ class AssertValidSchemaTest extends \Codeception\TestCase\WPTestCase {
 			// Fail upon throwing
 			$this->assertTrue( false );
 		}
-	}
-
-	public function testPostTypeWithSameValueForGraphqlSingleNameAndGraphqlPluralNameThrowsException() {
-
-		WPGraphQL::clear_schema();
-
-		register_post_type( 'test_aaa', [
-			'show_in_graphql' => true,
-			'graphql_single_name' => 'testName',
-			'graphql_plural_name' => 'testName',
-		] );
-
-
-		$this->expectException( '\GraphQL\Error\InvariantViolation' );
-
-		$actual = graphql([
-			'query' => '
-			{
-			  __type(name: "RootQuery") {
-			    name
-			  }
-			  __schema {
-			    queryType {
-			      name
-			    }
-			  }
-			}
-			'
-		]);
-
-		codecept_debug( $actual );
-
-		$this->assertArrayHasKey( 'errors', $actual );
-
-		WPGraphQL::clear_schema();
-
-	}
-
-	public function testTaxonomyWithSameValueForGraphqlSingleNameAndGraphqlPluralNameThrowsException() {
-
-		WPGraphQL::clear_schema();
-
-		register_taxonomy( 'test_tax_aaa', 'post', [
-			'show_in_graphql' => true,
-			'graphql_single_name' => 'testTaxName',
-			'graphql_plural_name' => 'testTaxName',
-		] );
-
-
-		$this->expectException( '\GraphQL\Error\InvariantViolation' );
-
-		$actual = graphql([
-			'query' => '
-			{
-			  __type(name: "RootQuery") {
-			    name
-			  }
-			  __schema {
-			    queryType {
-			      name
-			    }
-			  }
-			}
-			'
-		]);
-
-		codecept_debug( $actual );
-
-		$this->assertArrayHasKey( 'errors', $actual );
-
-		WPGraphQL::clear_schema();
-
 	}
 
 	public function testIntrospectionQueriesDisabledForPublicRequests() {

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.4.3
+ * Version: 1.5.0
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.4.3
+ * @version  1.5.0
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
# Release Notes

## Chores / Bugfixes

- ([#1865](https://github.com/wp-graphql/wp-graphql/pull/1865)): Change `MenuItem.path` field from `nonNull` to nullable as the value can be null in WordPress. Thanks @furedal!
- ([#1978](https://github.com/wp-graphql/wp-graphql/pull/1978)): Use "docker compose" instead of docker-compose in the run-docker.sh script. Thanks @markkelnar!
- ([#1974](https://github.com/wp-graphql/wp-graphql/pull/1974)): Separates app setup and app-post-setup scripts for use in the Docker/test environment setup. Thanks @markkelnar!
- ([#1972](https://github.com/wp-graphql/wp-graphql/pull/1972)): Pushes Docker images when new releases are tagged. Thanks @markkelnar!
- ([#1970](https://github.com/wp-graphql/wp-graphql/pull/1970)): Change Docker Image names specific to the WP and PHP versions. Thanks @markkelnar!
- ([#1967](https://github.com/wp-graphql/wp-graphql/pull/1967)): Update xdebug max nesting level to allow coverage to pass with resolver instrumentation active. Thanks @markkelnar!


## New Features

- ([#1977](https://github.com/wp-graphql/wp-graphql/pull/1977)): Allow same string to be passed for "graphql_single_name" and "graphql_plural_name" (ex: "deer" and "deer") when registering Post Types and Taxonomies. Same strings will be prefixed with "all" for plurals. Thanks @apmatthews!
- ([#1787](https://github.com/wp-graphql/wp-graphql/pull/1787)): Adds a new "ContentTypesOf. Thanks @plong0!
