### PR TITLE
ci: WP environment vars for testing image

### DIFF
--- a/docker/testing.Dockerfile
+++ b/docker/testing.Dockerfile
@@ -37,7 +37,7 @@ ENV PATH "$PATH:~/.composer/vendor/bin"
 RUN echo "date.timezone = UTC" >> /usr/local/etc/php/php.ini
 
 # Set up entrypoint
-WORKDIR    /var/www/html/wp-content/plugins/wp-graphql
+WORKDIR    /var/www/html
 COPY       docker/testing.entrypoint.sh /usr/local/bin/testing-entrypoint.sh
 RUN        chmod 755 /usr/local/bin/testing-entrypoint.sh
 ENTRYPOINT ["testing-entrypoint.sh"]

--- a/docker/testing.entrypoint.sh
+++ b/docker/testing.entrypoint.sh
@@ -42,8 +42,15 @@ RewriteRule . /index.php [L]
 
 # Move to WordPress root folder
 workdir="$PWD"
-echo "Moving to WordPress root directory."
+echo "Moving to WordPress root directory ${WP_ROOT_FOLDER}."
 cd ${WP_ROOT_FOLDER}
+
+# Because we are starting apache independetly of the docker image,
+# we set WORDPRESS environment variables so apache see them and used in the wp-config.php
+echo "export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST}" >> /etc/apache2/envvars
+echo "export WORDPRESS_DB_USER=${WORDPRESS_DB_USER}" >> /etc/apache2/envvars
+echo "export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD}" >> /etc/apache2/envvars
+echo "export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME}" >> /etc/apache2/envvars
 
 # Run app entrypoint script.
 . app-setup.sh
@@ -53,7 +60,7 @@ write_htaccess
 
 # Return to PWD.
 echo "Moving back to project working directory."
-cd ${workdir}
+cd ${WP_ROOT_FOLDER}/wp-content/plugins/wp-graphql
 
 # Ensure Apache is running
 service apache2 start


### PR DESCRIPTION
Because we are starting apache independently of the docker image in the testing image, we need to set WORDPRESS environment variables so apache sees them and they are used in the wp-config.php