### PR TITLE
Fix conflict with AmpWP plugin

### DIFF
--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -318,7 +318,7 @@ class NodeResolver {
 
 		unset( $this->wp->query_vars['graphql'] );
 
-		do_action_ref_array( 'parse_request', [ &$this ] );
+		do_action_ref_array( 'parse_request', [ $this->wp ] );
 
 		// If the request is for the homepage, determine
 		if ( '/' === $uri ) {

--- a/tests/wpunit/PluginCompatibilityTest.php
+++ b/tests/wpunit/PluginCompatibilityTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Class PluginCompatibilityTest
+ *
+ * Various tests to check for compatibility with other plugins in the ecosystem
+ */
+class PluginCompatibilityTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
+
+	public function setUp(): void {
+		// before
+		parent::setUp();
+
+		$this->admin = $this->factory()->user->create( [
+			'role' => 'administrator'
+		] );
+	}
+
+	public function tearDown(): void {
+
+		// then
+		parent::tearDown();
+	}
+
+	public function testAmpWpCompatibility() {
+
+		add_filter( 'parse_request', function( \WP $wp ) {
+			return $wp;
+		});
+
+		$post_id = $this->factory()->post->create([
+			'post_type' => 'publish'
+		]);
+
+		$slug = get_post( $post_id )->post_name;
+
+		$query = '
+		query PostBySlug( $slug: ID! ) {
+		  post( id: $slug idType: SLUG ) {
+		    databaseId
+		  }
+		}
+		';
+		$actual = graphql([ 'query' => $query, 'variables' => [ 'slug' => $slug ] ]);
+
+		$this->assertQuerySuccessful( $actual, [
+			$this->expectedField( 'post.databaseId', $post_id )
+		]);
+
+	}
+
+}


### PR DESCRIPTION

What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes conflict with AmpWP Plugin (and possibly other plugins) where the callback for `parse_request` in that plugin is expecting an instance of the `WP` class and we were passing the NodeResolver class. 

Also includes test to mimic behavior of AmpWP plugin and prevent regression for this scenario.


Does this close any currently open issues?
------------------------------------------
closes #1979 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

With AMPWP plugin active:

### Before:

![Screen Shot 2021-07-08 at 2 17 56 PM](https://user-images.githubusercontent.com/1260765/124985160-54598080-dff7-11eb-9151-52e664d016f2.png)

### After:

![Screen Shot 2021-07-08 at 2 17 42 PM](https://user-images.githubusercontent.com/1260765/124985171-58859e00-dff7-11eb-8275-d5259cf81321.png)