### PR TITLE
Prevent ContentTypesOf* Enum from generating when associated post types are not shown in GraphQL

### DIFF
--- a/src/Type/Enum/ContentTypeEnum.php
+++ b/src/Type/Enum/ContentTypeEnum.php
@@ -69,19 +69,22 @@ class ContentTypeEnum {
 					}
 
 					$taxonomy_values[ WPEnumType::get_safe_name( $taxonomy_object_type ) ] = [
+						'name'        => WPEnumType::get_safe_name( $taxonomy_object_type ),
 						'value'       => $taxonomy_object_type,
 						'description' => __( 'The Type of Content object', 'wp-graphql' ),
 					];
 				}
 
-				register_graphql_enum_type(
-					'ContentTypesOf' . Utils::format_type_name( $taxonomy_object->graphql_single_name ) . 'Enum',
-					[
-						'description' => sprintf( __( 'Allowed Content Types of the %s taxonomy.', 'wp-graphql' ), Utils::format_type_name( $taxonomy_object->graphql_single_name ) ),
-						'values'      => $taxonomy_values,
-					]
-				);
+				if ( ! empty( $taxonomy_values ) ) {
 
+					register_graphql_enum_type(
+						'ContentTypesOf' . Utils::format_type_name( $taxonomy_object->graphql_single_name ) . 'Enum',
+						[
+							'description' => sprintf( __( 'Allowed Content Types of the %s taxonomy.', 'wp-graphql' ), Utils::format_type_name( $taxonomy_object->graphql_single_name ) ),
+							'values'      => $taxonomy_values,
+						]
+					);
+				}
 			}
 		}
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

The WPGraphQL Schema generates a `ContentTypesOf{TaxonomyName}Enum` with the values being the names of the associated post types. 

For example, there's an Enum `ContentTypesOfPostEnum` that has values `POST` out of the box: 

![Screen Shot 2021-07-09 at 9 19 49 AM](https://user-images.githubusercontent.com/1260765/125100891-d77de380-e096-11eb-89cc-081bfc044e47.png)

![Screen Shot 2021-07-09 at 9 19 30 AM](https://user-images.githubusercontent.com/1260765/125100901-db116a80-e096-11eb-8916-ad1669d17588.png)

### BUG:

Currently when a Taxonomy is registered to "show_in_graphql" but is associated with post type(s) that are set to NOT show in GraphQL, a `ContentTypesOf{TaxonomyName}Enum` is Generated with no values. 

For example, we can register a post type that is not shown in GraphQL, like so: 

```php
register_post_type( 'not_in_graphql', [
  'public' => true,
] );
```

And register a taxonomy associated with that post type, that IS shown in GraphQL, like so: 

```php
register_taxonomy( 'test_taxonomy_two', [ 'not_in_graphql' ], [
		'show_in_graphql' => true,
		'graphql_single_name' => 'TestTaxonomyTwo',
		'graphql_plural_name' => 'TestTaxonomieTwos',
		'public' => true,
		'label' => 'Test Taxonomy Two, Yo'
	]);
```

### Current Behavior

This currently generates an `ContentTypesOfTestTaxonomyTwoEnum` Enum with no values:

![Screen Shot 2021-07-09 at 9 07 05 AM](https://user-images.githubusercontent.com/1260765/125101357-5d019380-e097-11eb-8cc8-6f2d6bfc5083.png)

### Fixed Behavior

With this fix, the `ContentTypesOfTestTaxonomyTwoEnum` Enum is no longer generated because there are no GraphQL-ready Post Types associated with the Taxonomy.

![Screen Shot 2021-07-09 at 9 07 19 AM](https://user-images.githubusercontent.com/1260765/125101361-5d9a2a00-e097-11eb-852d-3a412a8607df.png)


Does this close any currently open issues?
------------------------------------------
Closes #1996 