### PR TITLE
Release/v1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.5.2
+
+### Chores / Bugfixes
+
+- ([#1992](https://github.com/wp-graphql/wp-graphql/pull/1992)): Fixes bug that caused conflict with the AmpWP plugin.
+
+
 ## 1.5.1
 
 ### Chores / Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### Chores / Bugfixes
 
 - ([#1992](https://github.com/wp-graphql/wp-graphql/pull/1992)): Fixes bug that caused conflict with the AmpWP plugin.
-
+- ([#1994](https://github.com/wp-graphql/wp-graphql/pull/1994)): Fixes bug where querying a node by uri could return a node of a different post type.
+- ([#1997](https://github.com/wp-graphql/wp-graphql/pull/1997)): Fixes bug where Enums could be generated with no values when a taxonomy was set to show in GraphQL but it's associated post_type(s) are not shown in graphql.
 
 ## 1.5.1
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, API, Gatsby, Headless, Decoupled, React, Nextjs, Vue, Apollo, RES
 Requires at least: 5.0
 Tested up to: 5.7.2
 Requires PHP: 7.1
-Stable tag: 1.5.1
+Stable tag: 1.5.2
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -90,6 +90,13 @@ The `uri` field was non-null on some Types in the Schema but has been changed to
 Composer dependencies are no longer versioned in Github. Recommended install source is WordPress.org or using Composer to get the code from Packagist.org or WPackagist.org.
 
 == Changelog ==
+
+= 1.5.2 =
+
+**Chores / Bugfixes**
+
+- ([#1992](https://github.com/wp-graphql/wp-graphql/pull/1992)): Fixes bug that caused conflict with the AmpWP plugin.
+
 
 = 1.5.1 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -96,6 +96,8 @@ Composer dependencies are no longer versioned in Github. Recommended install sou
 **Chores / Bugfixes**
 
 - ([#1992](https://github.com/wp-graphql/wp-graphql/pull/1992)): Fixes bug that caused conflict with the AmpWP plugin.
+- ([#1994](https://github.com/wp-graphql/wp-graphql/pull/1994)): Fixes bug where querying a node by uri could return a node of a different post type.
+- ([#1997](https://github.com/wp-graphql/wp-graphql/pull/1997)): Fixes bug where Enums could be generated with no values when a taxonomy was set to show in GraphQL but it's associated post_type(s) are not shown in graphql.
 
 
 = 1.5.1 =

--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -318,7 +318,7 @@ class NodeResolver {
 
 		unset( $this->wp->query_vars['graphql'] );
 
-		do_action_ref_array( 'parse_request', [ &$this ] );
+		do_action_ref_array( 'parse_request', [ $this->wp ] );
 
 		// If the request is for the homepage, determine
 		if ( '/' === $uri ) {

--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -4,6 +4,7 @@ namespace WPGraphQL\Data;
 
 use Exception;
 use WP;
+use WP_Post;
 use WPGraphQL\AppContext;
 use WPGraphQL\Model\Post;
 
@@ -30,6 +31,34 @@ class NodeResolver {
 		global $wp;
 		$this->wp      = $wp;
 		$this->context = $context;
+	}
+
+	/**
+	 * Given a Post object, validates it before returning it.
+	 *
+	 * @param WP_Post $post
+	 *
+	 * @return WP_Post|null
+	 */
+	public function validate_post( WP_Post $post ) {
+
+		if ( isset( $this->wp->query_vars['post_type'] ) && ( $post->post_type !== $this->wp->query_vars['post_type'] ) ) {
+			return null;
+		}
+
+		if ( ! isset( $this->wp->query_vars['uri'] ) ) {
+			return $post;
+		}
+
+		$permalink    = get_permalink( $post );
+		$parsed_path  = $permalink ? parse_url( $permalink, PHP_URL_PATH ) : null;
+		$trimmed_path = $parsed_path ? rtrim( ltrim( $parsed_path, '/' ), '/' ) : null;
+		$uri_path     = rtrim( ltrim( $this->wp->query_vars['uri'], '/' ), '/' );
+		if ( $trimmed_path !== $uri_path ) {
+			return null;
+		}
+
+		return $post;
 	}
 
 	/**
@@ -365,8 +394,12 @@ class NodeResolver {
 			if ( isset( $this->wp->query_vars['post_type'] ) && in_array( $this->wp->query_vars['post_type'], $allowed_post_types, true ) ) {
 				$post_type = $this->wp->query_vars['post_type'];
 			}
+
 			// @phpstan-ignore-next-line
 			$post = get_page_by_path( $this->wp->query_vars['name'], 'OBJECT', $post_type );
+
+			unset( $this->wp->query_vars['uri'] );
+			$post = $post instanceof WP_Post ? $this->validate_post( $post ) : null;
 
 			return isset( $post->ID ) ? $this->context->get_loader( 'post' )->load_deferred( $post->ID ) : null;
 
@@ -381,9 +414,19 @@ class NodeResolver {
 			return isset( $node->term_id ) ? $this->context->get_loader( 'term' )->load_deferred( (int) $node->term_id ) : null;
 		} elseif ( isset( $this->wp->query_vars['pagename'] ) && ! empty( $this->wp->query_vars['pagename'] ) ) {
 
-			$post = get_page_by_path( $this->wp->query_vars['pagename'], 'OBJECT', get_post_types( [ 'show_in_graphql' => true ] ) );
+			unset( $this->wp->query_vars['uri'] );
 
-			if ( ! $post instanceof \WP_Post ) {
+			$post_type = isset( $this->wp->query_vars['post_type'] ) ? $this->wp->query_vars['post_type'] : get_post_types( [ 'show_in_graphql' => true ] );
+
+			$post = get_page_by_path( $this->wp->query_vars['pagename'], 'OBJECT', $post_type );
+
+			if ( ! $post instanceof WP_Post ) {
+				return null;
+			}
+
+			$post = $this->validate_post( $post );
+
+			if ( ! $post ) {
 				return null;
 			}
 
@@ -417,6 +460,15 @@ class NodeResolver {
 				$page_on_front = get_option( 'page_on_front', 0 );
 				$post          = get_post( absint( $page_on_front ) );
 				return ! empty( $post ) ? $this->context->get_loader( 'post' )->load_deferred( $post->ID ) : null;
+			}
+
+			if ( isset( $this->wp->query_vars['page'], $this->wp->query_vars['uri'] ) ) {
+				$post_type = $this->wp->query_vars['post_type'];
+
+				$post = get_page_by_path( $this->wp->query_vars['uri'], 'OBJECT', $post_type );
+
+				$post = isset( $post->ID ) ? $this->validate_post( $post ) : null;
+				return isset( $post->ID ) ? $this->context->get_loader( 'post' )->load_deferred( $post->ID ) : null;
 			}
 
 			$post_type_object = get_post_type_object( $this->wp->query_vars['post_type'] );

--- a/src/Type/Enum/ContentTypeEnum.php
+++ b/src/Type/Enum/ContentTypeEnum.php
@@ -69,19 +69,22 @@ class ContentTypeEnum {
 					}
 
 					$taxonomy_values[ WPEnumType::get_safe_name( $taxonomy_object_type ) ] = [
+						'name'        => WPEnumType::get_safe_name( $taxonomy_object_type ),
 						'value'       => $taxonomy_object_type,
 						'description' => __( 'The Type of Content object', 'wp-graphql' ),
 					];
 				}
 
-				register_graphql_enum_type(
-					'ContentTypesOf' . Utils::format_type_name( $taxonomy_object->graphql_single_name ) . 'Enum',
-					[
-						'description' => sprintf( __( 'Allowed Content Types of the %s taxonomy.', 'wp-graphql' ), Utils::format_type_name( $taxonomy_object->graphql_single_name ) ),
-						'values'      => $taxonomy_values,
-					]
-				);
+				if ( ! empty( $taxonomy_values ) ) {
 
+					register_graphql_enum_type(
+						'ContentTypesOf' . Utils::format_type_name( $taxonomy_object->graphql_single_name ) . 'Enum',
+						[
+							'description' => sprintf( __( 'Allowed Content Types of the %s taxonomy.', 'wp-graphql' ), Utils::format_type_name( $taxonomy_object->graphql_single_name ) ),
+							'values'      => $taxonomy_values,
+						]
+					);
+				}
 			}
 		}
 

--- a/src/Type/ObjectType/RootQuery.php
+++ b/src/Type/ObjectType/RootQuery.php
@@ -629,13 +629,26 @@ class RootQuery {
 								$id      = $args[ lcfirst( $post_type_object->graphql_single_name . 'Id' ) ];
 								$post_id = absint( $id );
 							} elseif ( ! empty( $args['uri'] ) ) {
-								$uri = esc_html( $args['uri'] );
 
-								return $context->node_resolver->resolve_uri( $uri );
+								return $context->node_resolver->resolve_uri(
+									$args['uri'],
+									[
+										'post_type' => $post_type_object->name,
+										'archive'   => false,
+										'nodeType'  => 'Page',
+									]
+								);
 							} elseif ( ! empty( $args['slug'] ) ) {
 								$slug = esc_html( $args['slug'] );
 
-								return $context->node_resolver->resolve_uri( $slug );
+								return $context->node_resolver->resolve_uri(
+									$slug,
+									[
+										'name'      => $slug,
+										'post_type' => $post_type_object->name,
+									]
+								);
+
 							}
 
 							return $context->get_loader( 'post' )->load_deferred( $post_id )->then(

--- a/src/Type/WPInputObjectType.php
+++ b/src/Type/WPInputObjectType.php
@@ -40,7 +40,7 @@ class WPInputObjectType extends InputObjectType {
 	 * @return mixed
 	 * @since 0.0.5
 	 */
-	public static function prepare_fields( array $fields, string $type_name, $config = [], TypeRegistry $type_registry ) {
+	public static function prepare_fields( array $fields, string $type_name, array $config, TypeRegistry $type_registry ) {
 
 		/**
 		 * Filter all object fields, passing the $typename as a param

--- a/src/Type/WPUnionType.php
+++ b/src/Type/WPUnionType.php
@@ -29,7 +29,7 @@ class WPUnionType extends UnionType {
 	 *
 	 * @since 0.0.30
 	 */
-	public function __construct( $config = [], TypeRegistry $type_registry ) {
+	public function __construct( array $config, TypeRegistry $type_registry ) {
 
 		$this->type_registry = $type_registry;
 

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -127,7 +127,7 @@ final class WPGraphQL {
 
 		// Plugin version.
 		if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-			define( 'WPGRAPHQL_VERSION', '1.5.1' );
+			define( 'WPGRAPHQL_VERSION', '1.5.2' );
 		}
 
 		// Plugin Folder Path.

--- a/tests/wpunit/NodeBySlugTest.php
+++ b/tests/wpunit/NodeBySlugTest.php
@@ -224,8 +224,8 @@ class NodeBySlugTest extends \Codeception\TestCase\WPTestCase {
 
 
         $query = '
-        query GET_PAGE_BY_URI( $slug: ID! ) {
-           page(id: $slug, idType: URI) {
+        query GET_PAGE_BY_URI( $uri: ID! ) {
+           page(id: $uri, idType: URI) {
                 databaseId
                 title
            }
@@ -234,13 +234,14 @@ class NodeBySlugTest extends \Codeception\TestCase\WPTestCase {
 
         codecept_debug( get_post( $this->custom_type ) );
 
-        $faqPage = get_post($this->page);
+        $faqPage = get_post( $this->page );
+        $permalink = get_permalink( $faqPage );
 
 
         $actual = graphql([
             'query' => $query,
             'variables' => [
-                'slug' => $faqPage->post_name,
+                'uri' => $permalink,
             ],
         ]);
 

--- a/tests/wpunit/PluginCompatibilityTest.php
+++ b/tests/wpunit/PluginCompatibilityTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Class PluginCompatibilityTest
+ *
+ * Various tests to check for compatibility with other plugins in the ecosystem
+ */
+class PluginCompatibilityTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
+
+	public function setUp(): void {
+		// before
+		parent::setUp();
+
+		$this->admin = $this->factory()->user->create( [
+			'role' => 'administrator'
+		] );
+	}
+
+	public function tearDown(): void {
+
+		// then
+		parent::tearDown();
+	}
+
+	public function testAmpWpCompatibility() {
+
+		add_filter( 'parse_request', function( \WP $wp ) {
+			return $wp;
+		});
+
+		$post_id = $this->factory()->post->create([
+			'post_type' => 'publish'
+		]);
+
+		$slug = get_post( $post_id )->post_name;
+
+		$query = '
+		query PostBySlug( $slug: ID! ) {
+		  post( id: $slug idType: SLUG ) {
+		    databaseId
+		  }
+		}
+		';
+		$actual = graphql([ 'query' => $query, 'variables' => [ 'slug' => $slug ] ]);
+
+		$this->assertQuerySuccessful( $actual, [
+			$this->expectedField( 'post.databaseId', $post_id )
+		]);
+
+	}
+
+}

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.5.1
+ * Version: 1.5.2
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.5.1
+ * @version  1.5.2
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
# Release Notes

## Chores / Bugfixes

- ([#1992](https://github.com/wp-graphql/wp-graphql/pull/1992)): Fixes bug that caused conflict with the AmpWP plugin.
- ([#1994](https://github.com/wp-graphql/wp-graphql/pull/1994)): Fixes bug where querying a node by uri could return a node of a different post type.
- ([#1997](https://github.com/wp-graphql/wp-graphql/pull/1997)): Fixes bug where Enums could be generated with no values when a taxonomy was set to show in GraphQL but it's associated post_type(s) are not shown in graphql.
