### PR TITLE
Use mariadb instead of mysql for tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       local:
 
   app_db:
-    image: mysql:5.7
+    image: mariadb:10.2
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE:      wordpress


### PR DESCRIPTION
Use `mariadb` instead `mysql` image in Docker environment. The `mariadb` image provides images for ARM platforms (including M1 / "Apple Silicon" Macs) without the need for additional Docker configuration.

Where has this been tested?
---------------------------
**Operating System:** macOS on M1 chip
