### PR TITLE
Add php8 for docker image build/deploy

### DIFF
--- a/.github/workflows/deploy-docker-image.yml
+++ b/.github/workflows/deploy-docker-image.yml
@@ -13,8 +13,11 @@ jobs:
       packages: write
     strategy:
       matrix:
-        php: [ '7.3', '7.4' ]
-        wordpress: [ '5.6', '5.5.3', '5.4.2' ]
+        php: [ '8.0', '7.4', '7.3' ]
+        wordpress: [ '5.7.2', '5.6', '5.5.3' ]
+        exclude:
+          - php: '8.0'
+            wordpress: '5.5.3'
       fail-fast: false
     name: WordPress ${{ matrix.wordpress }} on PHP ${{ matrix.php }}
     steps:


### PR DESCRIPTION
Build docker images for PHP 8.0 and versions of WP 5.7.2.  This matches what was recently added to the testing integration workflow.