### PR TITLE
Run tests from PROJECT_DIR var

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,6 @@ services:
     volumes:
       - '.:/var/www/html/wp-content/plugins/wp-graphql'
       - './.log/testing:/var/log/apache2'
-      - './codeception.dist.yml:/var/www/html/wp-content/plugins/wp-graphql/codeception.yml'
     env_file:
       - .env
     environment:

--- a/docker/testing.Dockerfile
+++ b/docker/testing.Dockerfile
@@ -20,7 +20,7 @@ RUN docker-php-ext-install pdo_mysql
 RUN apt-get install zip unzip -y \
     && pecl install pcov
 
-ENV COVERAGE=0
+ENV COVERAGE=
 ENV SUITES=${SUITES:-}
 
 # Install composer

--- a/docker/testing.entrypoint.sh
+++ b/docker/testing.entrypoint.sh
@@ -52,15 +52,15 @@ echo "export WORDPRESS_DB_USER=${WORDPRESS_DB_USER}" >> /etc/apache2/envvars
 echo "export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD}" >> /etc/apache2/envvars
 echo "export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME}" >> /etc/apache2/envvars
 
-# Run app entrypoint script.
+# Run app setup scripts.
 . app-setup.sh
 . app-post-setup.sh
 
 write_htaccess
 
 # Return to PWD.
-echo "Moving back to project working directory."
-cd ${WP_ROOT_FOLDER}/wp-content/plugins/wp-graphql
+echo "Moving back to project working directory ${PROJECT_DIR}"
+cd ${PROJECT_DIR}
 
 # Ensure Apache is running
 service apache2 start
@@ -88,7 +88,7 @@ if version_gt $PHP_VERSION 7.0 && [[ -n "$COVERAGE" ]] && [[ -z "$USING_XDEBUG" 
     echo "Using pcov/clobber for codecoverage"
     docker-php-ext-enable pcov
     echo "pcov.enabled=1" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini
-    echo "pcov.directory = /var/www/html/wp-content/plugins/wp-graphql" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini
+    echo "pcov.directory = ${PROJECT_DIR}" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini
     COMPOSER_MEMORY_LIMIT=-1 composer require pcov/clobber --dev
     vendor/bin/pcov clobber
 elif [[ -n "$COVERAGE" ]] && [[ -n "$USING_XDEBUG" ]]; then


### PR DESCRIPTION
Use the $PROJECT_DIR from the .env file instead of the hardcoded directory in the script. This will allow other docker images to resuse this docker file to base their tests on and run codeception tests from their own PROJECT_DIR.

Related to work for persisted queries plugin tests.

Should not change behavior for this repo.