### PR TITLE
Tag and deploy testing image for use from the registry

### DIFF
--- a/.github/workflows/deploy-docker-image.yml
+++ b/.github/workflows/deploy-docker-image.yml
@@ -48,3 +48,16 @@ jobs:
           build-args: |
             PHP_VERSION=${{ matrix.php }}
             WP_VERSION=${{ matrix.wordpress }}
+
+      - name: Build and push Docker testing image
+        uses: docker/build-push-action@v2.5.0
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/wp-graphql/wp-graphql-testing:latest-wp${{ matrix.wordpress }}-php${{ matrix.php }}
+            ghcr.io/wp-graphql/wp-graphql-testing:${{ steps.vars.outputs.tag }}-wp${{ matrix.wordpress }}-php${{ matrix.php }}
+          file: docker/testing.Dockerfile
+          build-args: |
+            PHP_VERSION=${{ matrix.php }}
+            WP_VERSION=${{ matrix.wordpress }}


### PR DESCRIPTION
Similar to how we push the built docker image for the app, let's also push the testing built image to the github container registry.  This will help with other plugins that want to reuse that testing image/container flow instead of rebuilding all the pieces.  

First use case as part of https://github.com/wp-graphql/wp-graphql-persisted-queries/issues/2.
