### PR TITLE
Add docker registry for testing docker image

### DIFF
--- a/.github/workflows/deploy-docker-image.yml
+++ b/.github/workflows/deploy-docker-image.yml
@@ -61,3 +61,4 @@ jobs:
           build-args: |
             PHP_VERSION=${{ matrix.php }}
             WP_VERSION=${{ matrix.wordpress }}
+            DOCKER_REGISTRY=ghcr.io/wp-graphql/

--- a/docker/testing.Dockerfile
+++ b/docker/testing.Dockerfile
@@ -4,8 +4,9 @@
 
 ARG WP_VERSION
 ARG PHP_VERSION
+ARG DOCKER_REGISTRY
 
-FROM wp-graphql:latest-wp${WP_VERSION}-php${PHP_VERSION}
+FROM ${DOCKER_REGISTRY:-}wp-graphql:latest-wp${WP_VERSION}-php${PHP_VERSION}
 
 LABEL author=jasonbahl
 LABEL author_uri=https://github.com/jasonbahl


### PR DESCRIPTION
Fix the failing workflow that builds the wp-graphql-testing image and deploys it to the container registry.
This job runs when release is tagged.