### PR TITLE
Update tests to use WordPress 5.8

### DIFF
--- a/.github/workflows/testing-integration.yml
+++ b/.github/workflows/testing-integration.yml
@@ -20,12 +20,12 @@ jobs:
     strategy:
       matrix:
         php: [ '7.4', '7.3' ]
-        wordpress: [ '5.7.2', '5.6.2', '5.5.3' ]
+        wordpress: [ 'beta-5.8', '5.7.2', '5.6.2', '5.5.3' ]
         include:
           - php: '8.0'
-            wordpress: '5.7.2'
+            wordpress: 'beta-5.8'
           - php: '7.4'
-            wordpress: '5.7.2'
+            wordpress: 'beta-5.8'
             coverage: 1
       fail-fast: false
     name: WordPress ${{ matrix.wordpress }} on PHP ${{ matrix.php }}
@@ -59,7 +59,7 @@ jobs:
           WP_VERSION: ${{ matrix.wordpress }}
         run: composer build-test
 
-      - name: Run Functional w/ Docker.
+      - name: Run Functional Tests w/ Docker.
         env:
           COVERAGE: ${{ matrix.coverage }}
           USING_XDEBUG: ${{ matrix.coverage }}

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: jasonbahl, tylerbarnes1, ryankanner, hughdevore, chopinbach, kidunot89
 Tags: GraphQL, API, Gatsby, Headless, Decoupled, React, Nextjs, Vue, Apollo, REST, JSON,  HTTP, Remote, Query Language
 Requires at least: 5.0
-Tested up to: 5.7.2
+Tested up to: 5.8
 Requires PHP: 7.1
 Stable tag: 1.5.4
 License: GPL-3


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

This PR updates the Github test integration workflow to run with WordPress 5.8 (using beta-5.8 as [Docker Hub](https://hub.docker.com/_/wordpress) doesn't have 5.8 images yet)


Does this close any currently open issues?
------------------------------------------
closes #2024 
