### PR TITLE
Release v1.5.5

### DIFF
--- a/.github/workflows/deploy-docker-image.yml
+++ b/.github/workflows/deploy-docker-image.yml
@@ -61,3 +61,4 @@ jobs:
           build-args: |
             PHP_VERSION=${{ matrix.php }}
             WP_VERSION=${{ matrix.wordpress }}
+            DOCKER_REGISTRY=ghcr.io/wp-graphql/

--- a/.github/workflows/testing-integration.yml
+++ b/.github/workflows/testing-integration.yml
@@ -20,12 +20,12 @@ jobs:
     strategy:
       matrix:
         php: [ '7.4', '7.3' ]
-        wordpress: [ '5.7.2', '5.6.2', '5.5.3' ]
+        wordpress: [ 'beta-5.8', '5.7.2', '5.6.2', '5.5.3' ]
         include:
           - php: '8.0'
-            wordpress: '5.7.2'
+            wordpress: 'beta-5.8'
           - php: '7.4'
-            wordpress: '5.7.2'
+            wordpress: 'beta-5.8'
             coverage: 1
       fail-fast: false
     name: WordPress ${{ matrix.wordpress }} on PHP ${{ matrix.php }}
@@ -59,7 +59,7 @@ jobs:
           WP_VERSION: ${{ matrix.wordpress }}
         run: composer build-test
 
-      - name: Run Functional w/ Docker.
+      - name: Run Functional Tests w/ Docker.
         env:
           COVERAGE: ${{ matrix.coverage }}
           USING_XDEBUG: ${{ matrix.coverage }}

--- a/.github/workflows/testing-integration.yml
+++ b/.github/workflows/testing-integration.yml
@@ -20,12 +20,12 @@ jobs:
     strategy:
       matrix:
         php: [ '7.4', '7.3' ]
-        wordpress: [ 'beta-5.8', '5.7.2', '5.6.2', '5.5.3' ]
+        wordpress: [ '5.8', '5.7.2', '5.6.2' ]
         include:
           - php: '8.0'
-            wordpress: 'beta-5.8'
+            wordpress: '5.8'
           - php: '7.4'
-            wordpress: 'beta-5.8'
+            wordpress: '5.8'
             coverage: 1
       fail-fast: false
     name: WordPress ${{ matrix.wordpress }} on PHP ${{ matrix.php }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - ([#2023](https://github.com/wp-graphql/wp-graphql/pull/2023)): Fixes issue with deploying Docker Testing Images. Thanks @markkelnar!
 - ([#2025](https://github.com/wp-graphql/wp-graphql/pull/2025)): Update test workflow to test against WordPress 5.8 (released today) and updates the readme.txt to reflect the plugin has been tested up to 5.8
+- ([#2028](https://github.com/wp-graphql/wp-graphql/pull/2028)): Update Codeception test environment to prevent WordPress from entering maintenance mode during tests.
 
 ## 1.5.4 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.5.5
+
+### Chores / Bugfixes
+
+- ([#2023](https://github.com/wp-graphql/wp-graphql/pull/2023)): Fixes issue with deploying Docker Testing Images. Thanks @markkelnar!
+- ([#2025](https://github.com/wp-graphql/wp-graphql/pull/2025)): Update test workflow to test against WordPress 5.8 (released today) and updates the readme.txt to reflect the plugin has been tested up to 5.8
+
 ## 1.5.4 
 
 ### Chores / Bugfixes

--- a/docker/app.setup.sh
+++ b/docker/app.setup.sh
@@ -27,6 +27,9 @@ if [ ! -f "${WP_ROOT_FOLDER}/wp-config.php" ]; then
         --allow-root
 fi
 
+wp config set WP_AUTO_UPDATE_CORE false --allow-root
+wp config set AUTOMATIC_UPDATER_DISABLED true --allow-root
+
 # Install WP if not yet installed
 if ! $( wp core is-installed --allow-root ); then
 	wp core install \

--- a/docker/testing.Dockerfile
+++ b/docker/testing.Dockerfile
@@ -4,8 +4,9 @@
 
 ARG WP_VERSION
 ARG PHP_VERSION
+ARG DOCKER_REGISTRY
 
-FROM wp-graphql:latest-wp${WP_VERSION}-php${PHP_VERSION}
+FROM ${DOCKER_REGISTRY:-}wp-graphql:latest-wp${WP_VERSION}-php${PHP_VERSION}
 
 LABEL author=jasonbahl
 LABEL author_uri=https://github.com/jasonbahl

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: jasonbahl, tylerbarnes1, ryankanner, hughdevore, chopinbach, kidunot89
 Tags: GraphQL, API, Gatsby, Headless, Decoupled, React, Nextjs, Vue, Apollo, REST, JSON,  HTTP, Remote, Query Language
 Requires at least: 5.0
-Tested up to: 5.7.2
+Tested up to: 5.8
 Requires PHP: 7.1
 Stable tag: 1.5.4
 License: GPL-3

--- a/readme.txt
+++ b/readme.txt
@@ -97,7 +97,7 @@ Composer dependencies are no longer versioned in Github. Recommended install sou
 
 - ([#2023](https://github.com/wp-graphql/wp-graphql/pull/2023)): Fixes issue with deploying Docker Testing Images. Thanks @markkelnar!
 - ([#2025](https://github.com/wp-graphql/wp-graphql/pull/2025)): Update test workflow to test against WordPress 5.8 (released today) and updates the readme.txt to reflect the plugin has been tested up to 5.8
-
+- ([#2028](https://github.com/wp-graphql/wp-graphql/pull/2028)): Update Codeception test environment to prevent WordPress from entering maintenance mode during tests.
 
 = 1.5.4 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, API, Gatsby, Headless, Decoupled, React, Nextjs, Vue, Apollo, RES
 Requires at least: 5.0
 Tested up to: 5.8
 Requires PHP: 7.1
-Stable tag: 1.5.4
+Stable tag: 1.5.5
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -90,6 +90,14 @@ The `uri` field was non-null on some Types in the Schema but has been changed to
 Composer dependencies are no longer versioned in Github. Recommended install source is WordPress.org or using Composer to get the code from Packagist.org or WPackagist.org.
 
 == Changelog ==
+
+= 1.5.5 =
+
+**Chores / Bugfixes**
+
+- ([#2023](https://github.com/wp-graphql/wp-graphql/pull/2023)): Fixes issue with deploying Docker Testing Images. Thanks @markkelnar!
+- ([#2025](https://github.com/wp-graphql/wp-graphql/pull/2025)): Update test workflow to test against WordPress 5.8 (released today) and updates the readme.txt to reflect the plugin has been tested up to 5.8
+
 
 = 1.5.4 =
 

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -127,7 +127,7 @@ final class WPGraphQL {
 
 		// Plugin version.
 		if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-			define( 'WPGRAPHQL_VERSION', '1.5.4' );
+			define( 'WPGRAPHQL_VERSION', '1.5.5' );
 		}
 
 		// Plugin Folder Path.

--- a/tests/_bootstrap/bootstrap.php
+++ b/tests/_bootstrap/bootstrap.php
@@ -1,4 +1,10 @@
 <?php
+
+// Disable updates to prevent WP from going into maintenance mode while tests run
+add_filter( 'enable_maintenance_mode', '__return_false' );
+add_filter( 'wp_auto_update_core', '__return_false' );
+add_filter( 'auto_update_plugin', '__return_false' );
+add_filter( 'auto_update_theme', '__return_false' );
 /**
  * This registers custom Post Type and Taxomomy for use in query tests to make sure
  * APIs for Custom Taxonomies and Custom Post Types work as expected.

--- a/tests/_data/config.php
+++ b/tests/_data/config.php
@@ -6,3 +6,5 @@
  */
 define( 'GRAPHQL_DEBUG', true );
 define( 'WPGRAPHQL_AUTOLOAD', false );
+define( 'WP_AUTO_UPDATE_CORE', false );
+define( 'AUTOMATIC_UPDATER_DISABLED', true );

--- a/tests/functional.suite.dist.yml
+++ b/tests/functional.suite.dist.yml
@@ -14,3 +14,4 @@ modules:
   config:
     WPDb:
       cleanup: false
+bootstrap: bootstrap.php

--- a/tests/functional/ApolloPreflightRequestCept.php
+++ b/tests/functional/ApolloPreflightRequestCept.php
@@ -1,10 +1,5 @@
 <?php
 
-// There's a funky issue where WordPress is trying to update during tests
-// and goes into maintenance mode and fails the tests.
-// This is an attempt to wait for it to pass.
-sleep( 2 );
-
 $I = new FunctionalTester( $scenario );
 $I->wantTo( 'Send a preflight Options request like Apollo and check the response' );
 

--- a/tests/functional/BasicPostListCept.php
+++ b/tests/functional/BasicPostListCept.php
@@ -1,10 +1,5 @@
 <?php
 
-// There's a funky issue where WordPress is trying to update during tests
-// and goes into maintenance mode and fails the tests.
-// This is an attempt to wait for it to pass.
-sleep( 2 );
-
 $I = new FunctionalTester( $scenario );
 $I->wantTo('Get public data without passing authentication headers');
 

--- a/tests/functional/BatchQueriesCept.php
+++ b/tests/functional/BatchQueriesCept.php
@@ -1,10 +1,5 @@
 <?php
 
-// There's a funky issue where WordPress is trying to update during tests
-// and goes into maintenance mode and fails the tests.
-// This is an attempt to wait for it to pass.
-sleep( 2 );
-
 $I = new FunctionalTester( $scenario );
 $I->wantTo( 'Test batch queries' );
 

--- a/tests/functional/BatchQueriesDisabledCept.php
+++ b/tests/functional/BatchQueriesDisabledCept.php
@@ -1,10 +1,5 @@
 <?php
 
-// There's a funky issue where WordPress is trying to update during tests
-// and goes into maintenance mode and fails the tests.
-// This is an attempt to wait for it to pass.
-sleep( 2 );
-
 $I = new FunctionalTester( $scenario );
 $I->wantTo( 'Test batch queries return errors when batching is disabled' );
 

--- a/tests/functional/MenuWithMenuItemsCept.php
+++ b/tests/functional/MenuWithMenuItemsCept.php
@@ -1,10 +1,5 @@
 <?php
 
-// There's a funky issue where WordPress is trying to update during tests
-// and goes into maintenance mode and fails the tests.
-// This is an attempt to wait for it to pass.
-sleep( 2 );
-
 $I = new FunctionalTester( $scenario );
 $I->wantTo( 'Get nav menu with menu items' );
 

--- a/tests/functional/PostListWithDifferentStatusCept.php
+++ b/tests/functional/PostListWithDifferentStatusCept.php
@@ -1,10 +1,5 @@
 <?php
 
-// There's a funky issue where WordPress is trying to update during tests
-// and goes into maintenance mode and fails the tests.
-// This is an attempt to wait for it to pass.
-sleep( 2 );
-
 $I = new FunctionalTester( $scenario );
 $I->wantTo( 'Get posts with different post_status' );
 

--- a/tests/functional/QueryDepthRuleCept.php
+++ b/tests/functional/QueryDepthRuleCept.php
@@ -1,10 +1,5 @@
 <?php
 
-// There's a funky issue where WordPress is trying to update during tests
-// and goes into maintenance mode and fails the tests.
-// This is an attempt to wait for it to pass.
-sleep( 2 );
-
 $I = new FunctionalTester( $scenario );
 $I->wantTo( 'Test query depth rules' );
 

--- a/tests/functional/RestrictedQueriesCept.php
+++ b/tests/functional/RestrictedQueriesCept.php
@@ -1,10 +1,5 @@
 <?php
 
-// There's a funky issue where WordPress is trying to update during tests
-// and goes into maintenance mode and fails the tests.
-// This is an attempt to wait for it to pass.
-sleep( 2 );
-
 $I = new FunctionalTester( $scenario );
 $I->wantTo( 'Test restricting the API prevents unauthorized queries' );
 

--- a/tests/functional/bootstrap.php
+++ b/tests/functional/bootstrap.php
@@ -1,0 +1,7 @@
+<?php
+
+// Disable updates to prevent WP from going into maintenance mode while tests run
+add_filter( 'enable_maintenance_mode', '__return_false' );
+add_filter( 'wp_auto_update_core', '__return_false' );
+add_filter( 'auto_update_plugin', '__return_false' );
+add_filter( 'auto_update_theme', '__return_false' );

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,11 +6,11 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.5.4
+ * Version: 1.5.5
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
- * Tested up to: 5.4
+ * Tested up to: 5.8
  * Requires PHP: 7.1
  * License: GPL-3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.5.4
+ * @version  1.5.5
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
# Release Notes

## Chores / Bugfixes

- ([#2023](https://github.com/wp-graphql/wp-graphql/pull/2023)): Fixes issue with deploying Docker Testing Images. Thanks @markkelnar!
- ([#2025](https://github.com/wp-graphql/wp-graphql/pull/2025)): Update test workflow to test against WordPress 5.8 (released today) and updates the readme.txt to reflect the plugin has been tested up to 5.8
- ([#2028](https://github.com/wp-graphql/wp-graphql/pull/2028)): Update Codeception test environment to prevent WordPress from entering maintenance mode during tests.
