### PR TITLE
Ingore docs in deployed code

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -8,6 +8,7 @@
 /github
 /plugin-build
 /documentation
+/docs
 /img
 /phpstan
 /tests

--- a/composer.json
+++ b/composer.json
@@ -94,7 +94,9 @@
       "plugin-build/",
       "!src/Admin/GraphiQL/app/",
       "node_modules/",
-      "!.wordpress-org/"
+      "!.wordpress-org/",
+      "docs/",
+      "wp-graphql.zip"
     ]
   }
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

- Update .distignore and composer.json to ignore the /docs directory when creating an archive to deploy to WordPress.org


Does this close any currently open issues?
------------------------------------------
closes #2034