### PR TITLE
Release/v1.5.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.5.9
+
+### Chores / Bugfixes
+
+- ([#2043](https://github.com/wp-graphql/wp-graphql/pull/2043)): Fixes a regression with GraphQL Request Execution that was causing Gatsby and some other CI tools to fail builds.
+
 ## 1.5.8
 
 ### Chores / Bugfixes
@@ -21,7 +27,6 @@
 ### New Features
 
 - ([#2035](https://github.com/wp-graphql/wp-graphql/pull/2035)): (Yes, same PR as the bugfix above). Adds 2 new actions `graphql_before_execute` and `graphql_after_execute` to allow actions to run before/after the execution of entire Batch requests vs. the hooks that currently run _within_ each the execution of each operation within a request.
-
 
 ## 1.5.5
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, API, Gatsby, Headless, Decoupled, React, Nextjs, Vue, Apollo, RES
 Requires at least: 5.0
 Tested up to: 5.8
 Requires PHP: 7.1
-Stable tag: 1.5.8
+Stable tag: 1.5.9
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -90,6 +90,13 @@ The `uri` field was non-null on some Types in the Schema but has been changed to
 Composer dependencies are no longer versioned in Github. Recommended install source is WordPress.org or using Composer to get the code from Packagist.org or WPackagist.org.
 
 == Changelog ==
+
+= 1.5.9
+
+**Chores / Bugfixes**
+
+- ([#2043](https://github.com/wp-graphql/wp-graphql/pull/2043)): Fixes a regression with GraphQL Request Execution that was causing Gatsby and some other CI tools to fail builds.
+
 
 = 1.5.8 =
 

--- a/src/Utils/QueryLog.php
+++ b/src/Utils/QueryLog.php
@@ -43,7 +43,7 @@ class QueryLog {
 		}
 
 		add_action( 'init', [ $this, 'init_save_queries' ] );
-		add_filter( 'graphql_request_results', [ $this, 'show_results' ], 10, 4 );
+		add_filter( 'graphql_request_results', [ $this, 'show_results' ], 10, 5 );
 	}
 
 	/**
@@ -100,14 +100,15 @@ class QueryLog {
 	/**
 	 * Filter the results of the GraphQL Response to include the Query Log
 	 *
-	 * @param array    $response
+	 * @param mixed    $response
 	 * @param WPSchema $schema         The WPGraphQL Schema
 	 * @param string   $operation_name The operation name being executed
 	 * @param string   $request        The GraphQL Request being made
+	 * @param array    $variables      The variables sent with the request
 	 *
 	 * @return array
 	 */
-	public function show_results( array $response, WPSchema $schema, string $operation_name, string $request ) {
+	public function show_results( $response, $schema, $operation_name, $request, $variables ) {
 
 		$query_log = $this->get_query_log();
 
@@ -117,7 +118,12 @@ class QueryLog {
 		}
 
 		if ( ! empty( $response ) ) {
-			$response['extensions']['queryLog'] = $query_log;
+			if ( is_array( $response ) ) {
+				$response['extensions']['queryLog'] = $query_log;
+			} elseif ( is_object( $response ) ) {
+				// @phpstan-ignore-next-line
+				$response->extensions['queryLog'] = $query_log;
+			}
 		}
 
 		return $response;

--- a/src/Utils/Tracing.php
+++ b/src/Utils/Tracing.php
@@ -4,7 +4,6 @@ namespace WPGraphQL\Utils;
 
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
-use WPGraphQL\WPSchema;
 
 /**
  * Class Tracing
@@ -133,10 +132,10 @@ class Tracing {
 	/**
 	 * Initialize tracing for an individual field
 	 *
-	 * @param mixed       $source  The source passed down the Resolve Tree
-	 * @param array       $args    The args for the field
-	 * @param AppContext  $context The AppContext passed down the ResolveTree
-	 * @param ResolveInfo $info    The ResolveInfo passed down the ResolveTree
+	 * @param mixed               $source         The source passed down the Resolve Tree
+	 * @param array               $args           The args for the field
+	 * @param AppContext          $context        The AppContext passed down the ResolveTree
+	 * @param ResolveInfo         $info           The ResolveInfo passed down the ResolveTree
 	 *
 	 * @return void
 	 */
@@ -263,14 +262,14 @@ class Tracing {
 	/**
 	 * Filter the results of the GraphQL Response to include the Query Log
 	 *
-	 * @param array    $response       The response of the GraphQL Request
-	 * @param WPSchema $schema         The WPGraphQL Schema
-	 * @param string   $operation_name The operation name being executed
-	 * @param string   $request        The GraphQL Request being made
+	 * @param mixed|array|object $response       The response of the GraphQL Request
+	 * @param mixed              $schema         The WPGraphQL Schema
+	 * @param string             $operation_name The operation name being executed
+	 * @param string             $request        The GraphQL Request being made
 	 *
 	 * @return mixed $response
 	 */
-	public function add_tracing_to_response_extensions( array $response, WPSchema $schema, string $operation_name, string $request ) {
+	public function add_tracing_to_response_extensions( $response, $schema, string $operation_name, string $request ) {
 
 		// Get the trace
 		$trace = $this->get_trace();
@@ -281,8 +280,11 @@ class Tracing {
 			return $response;
 		}
 
-		if ( ! empty( $response ) ) {
+		if ( is_array( $response ) ) {
 			$response['extensions']['tracing'] = $trace;
+		} elseif ( is_object( $response ) ) {
+			// @phpstan-ignore-next-line
+			$response->extensions['tracing'] = $trace;
 		}
 
 		return $response;

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -127,7 +127,7 @@ final class WPGraphQL {
 
 		// Plugin version.
 		if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-			define( 'WPGRAPHQL_VERSION', '1.5.8' );
+			define( 'WPGRAPHQL_VERSION', '1.5.9' );
 		}
 
 		// Plugin Folder Path.

--- a/tests/wpunit/FiltersTest.php
+++ b/tests/wpunit/FiltersTest.php
@@ -44,12 +44,15 @@ class FiltersTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 	public function testFilterGraphqlRequestResultsForBatchQuery() {
 
-
 		add_filter( 'graphql_request_results', function( $response, $schema, $operation, $query, $variables, $request ) {
+
 			$this->filter_values[] = [
 				'query' => $query,
 				'variables' => $variables,
 			];
+
+			return $response;
+
 		}, 10, 6 );
 
 		$request = [
@@ -68,8 +71,7 @@ class FiltersTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		codecept_debug( $this->filter_values );
 		codecept_debug( $request );
 
-		$this->assertSame( $this->filter_values, $request  );
-
+		$this->assertSame( $request, $this->filter_values );
 	}
 
 }

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.5.8
+ * Version: 1.5.9
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.5.8
+ * @version  1.5.9
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
# Release Notes

## Chores / Bugfixes

- ([#2043](https://github.com/wp-graphql/wp-graphql/pull/2043)): Fixes a regression with GraphQL Request Execution that was causing Gatsby and some other CI tools to fail builds.