### PR TITLE
Bug/#2048 user role connection resolver

### DIFF
--- a/src/Data/Connection/UserRoleConnectionResolver.php
+++ b/src/Data/Connection/UserRoleConnectionResolver.php
@@ -71,7 +71,7 @@ class UserRoleConnectionResolver extends AbstractConnectionResolver {
 	 * @return array
 	 */
 	public function get_query_args() {
-		return $this->query_args;
+		return is_array( $this->query_args ) && ! empty( $this->query_args ) ? $this->query_args : [];
 	}
 
 	/**


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

This updates the UserRoleConnectionResolver class to ensure `get_query_args()` always returns an array. 

This also includes a test to prevent a regression to this behavior.


Does this close any currently open issues?
------------------------------------------
closes #2048 

Any other comments?
-------------------

With the filter provided in #2048: 

```php
add_filter( 'graphql_connection_query_args', 'my_custom_filter', 10, 2 );
function my_custom_filter( array $query_args, \WPGraphQL\Data\Connection\AbstractConnectionResolver $resolver ){
	return $query_args;
}
```

### Before

![Screen Shot 2021-08-02 at 10 12 48 AM](https://user-images.githubusercontent.com/1260765/127892114-07f38917-5afd-4528-8368-48af4372afcb.png)

### After

![Screen Shot 2021-08-02 at 10 13 00 AM](https://user-images.githubusercontent.com/1260765/127892119-8747d472-0090-41d0-bb10-c7a54cb937ba.png)
