### PR TITLE
Bug/#2047 - Allow Types to share the name of a global PHP function

### DIFF
--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -175,11 +175,6 @@ class TypeRegistry {
 	 * @return string
 	 */
 	protected function format_key( string $key ) {
-
-		if ( false === strpos( $key, 'graphql_type_', 0 ) ) {
-			return strtolower( 'graphql_type_' . $key );
-		}
-
 		return strtolower( $key );
 	}
 

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -995,7 +995,7 @@ class TypeRegistry {
 				$field = $this->prepare_field( $field_name, $config, $type_name );
 
 				if ( ! empty( $field ) ) {
-					$fields[ $field_name ] = $this->prepare_field( $field_name, $config, $type_name );
+					$fields[ $field_name ] = $field;
 				}
 
 				return $fields;

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -858,13 +858,6 @@ class TypeRegistry {
 	 */
 	protected function prepare_field( $field_name, $field_config, $type_name ) {
 
-		/**
-		 * If the Field is a Type definition and not a config
-		 */
-		if ( ! is_array( $field_config ) ) {
-			return $field_config;
-		}
-
 		if ( ! isset( $field_config['name'] ) ) {
 			$field_config['name'] = lcfirst( $field_name );
 		}

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -906,6 +906,9 @@ class TypeRegistry {
 	}
 
 	/**
+	 * Processes type modifiers (e.g., "non-null"). Loads types immediately, so do
+	 * not call before types are ready to be loaded.
+	 *
 	 * @param mixed|string|array $type The type definition
 	 *
 	 * @return mixed

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -838,8 +838,6 @@ class TypeRegistry {
 					$prepared_field = $this->prepare_field( $field_name, $field_config, $type_name );
 					if ( ! empty( $prepared_field ) ) {
 						$prepared_fields[ $this->format_key( $field_name ) ] = $prepared_field;
-					} else {
-						unset( $prepared_fields[ $this->format_key( $field_name ) ] );
 					}
 				}
 			}

--- a/tests/wpunit/AssertValidSchemaTest.php
+++ b/tests/wpunit/AssertValidSchemaTest.php
@@ -426,4 +426,56 @@ class AssertValidSchemaTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertArrayNotHasKey( 'errors', $actual );
 
 	}
+
+	/**
+	 * Many moons ago, fields could pass a Type definition instead of an array.
+	 *
+	 * This test ensures older plugins that extend WPGraphQL in this way still work
+	 *
+	 * @throws Exception
+	 */
+	public function testRegisteringFieldWithGraphQLTypeDefinitionAsTypeConfigDoesntThrowErrors() {
+
+		$type = new \GraphQL\Type\Definition\ObjectType([
+			'name' => 'Test',
+			'fields' => [
+				'test' => GraphQL\Type\Definition\Type::string(),
+			],
+		]);
+
+		// New way to register:
+		// register_graphql_object_type( 'Test', [
+		//  'fields' => [
+		//    'test' => [
+		//       'type' => 'String',
+		//    ],
+		//  ],
+		// ] );
+
+		register_graphql_field( 'RootQuery', 'test', [
+			'type' => $type,
+		]);
+
+		// New way to register
+		// register_graphql_field( 'RootQuery', 'test', [
+		//   'type' => 'Test'
+		// ]);
+
+		$query = '
+		{
+		  test {
+		    test
+		  }
+		}
+		';
+
+		$actual = graphql([
+			'query' => $query
+		]);
+
+		codecept_debug( $actual );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+
+	}
 }

--- a/tests/wpunit/AssertValidSchemaTest.php
+++ b/tests/wpunit/AssertValidSchemaTest.php
@@ -284,7 +284,7 @@ class AssertValidSchemaTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	public function testSchemaCallsLazyLoadingTypesWhenNeeded() {
-		$filter_calls = [ 'graphql_get_type' ];
+		$filter_calls = [];
 
 		add_filter( 'graphql_get_type', function ( $type, $type_name ) use ( &$filter_calls ) {
 			if ( 'TestLazyType' === $type_name ) {
@@ -349,12 +349,14 @@ class AssertValidSchemaTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertSame( 'bar', $actual['data']['example']['foo'] );
 
-		$expected_filter_calls = [ 'graphql_wp_object_type_config', 'graphql_object_fields', 'graphql_get_type' ];
-		foreach ( $expected_filter_calls as $expected_filter_call ) {
-			$this->assertTrue( in_array( $expected_filter_call, $filter_calls, true ) );
-		}
+		sort( $filter_calls );
+		$expected_filter_calls = [
+			'graphql_get_type',
+			'graphql_object_fields',
+			'graphql_wp_object_type_config',
+		];
 
-		$this->assertSame( count( $expected_filter_calls ), count( $filter_calls ) );
+		$this->assertSame( $expected_filter_calls, $filter_calls );
 	}
 
 	public function testRegisterTypeWithNameOfExistingPhpFunctionDoesNotCauseErrors() {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
--------------------------------------------------

This fixes a bug where GraphQL Types that shared the name of a global PHP function would try and lazy load by calling that PHP function. 

For example, a GraphQL Type named `Header` would try and call `header()` to lazy load, which is not what should happen.

This PR does the following:

- Update the TypeRegistry to prefix types in the registry with `graphql_type_`
- Update the logic around `is_callable()` in the setup_type_modifiers function
- Adds a test to register a type that shares the name of a global PHP function (header`

Does this close any currently open issues?
------------------------------------------
Closes #2047 


Any other comments?
-------------------

With the following snippet in place:

```php
register_graphql_field( 'RootQuery', 'header', [
	'type' => 'Header',
	'description' => __( 'This field is named after a PHP function to test that it does not cause conflicts', 'wp-graphql' ),
	'resolve' => function() {
		return 'it works!';
	}
]);

register_graphql_object_type( 'Header', [
	'fields' => [
		'test' => [
			'type' => 'String'
		],
	],
]);
```

### Before

The Schema won't load at all 😱 

And trying to query the `header` field of the `Header` type returns a fatal error. 

![Screen Shot 2021-08-03 at 9 14 05 AM](https://user-images.githubusercontent.com/1260765/128040514-158a93cf-f36f-43fc-968f-d11012f0dcdf.png)


### After
The `Header` Type can be seen in the Schema and the `header` field can be queried successfully:

![Screen Shot 2021-08-03 at 9 12 30 AM](https://user-images.githubusercontent.com/1260765/128040248-b50eeb4e-a9fc-4801-a01f-575ccd92e6b4.png)


