### PR TITLE
Bug/#2054 input args on type connections not loading

### DIFF
--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -608,6 +608,37 @@ class TypeRegistry {
 	}
 
 	/**
+	 * Registers connections that were passed through the Type registration config
+	 *
+	 * @param array $config Type config
+	 *
+	 * @return void
+	 *
+	 * @throws Exception
+	 */
+	protected function register_connections_from_config( array $config ) {
+
+		$connections = $config['connections'] ?? null;
+
+		if ( null === $connections || ! is_array( $connections ) ) {
+			return;
+		}
+
+		foreach ( $connections as $field_name => $connection_config ) {
+
+			if ( ! is_array( $connection_config ) ) {
+				continue;
+			}
+
+			$connection_config['fromType']      = $config['name'];
+			$connection_config['fromFieldName'] = $field_name;
+			register_graphql_connection( $connection_config );
+
+		}
+
+	}
+
+	/**
 	 * Add a Type to the Registry
 	 *
 	 * @param string $type_name The name of the type to register
@@ -618,6 +649,11 @@ class TypeRegistry {
 	 * @return void
 	 */
 	public function register_type( string $type_name, $config ) {
+
+		if ( is_array( $config ) && isset( $config['connections'] ) ) {
+			$config['name'] = ucfirst( $type_name );
+			$this->register_connections_from_config( $config );
+		}
 
 		/**
 		 * If the Type Name starts with a number, prefix it with an underscore to make it valid

--- a/src/Type/WPConnectionType.php
+++ b/src/Type/WPConnectionType.php
@@ -233,7 +233,7 @@ class WPConnectionType {
 
 		$input_name = $this->connection_name . 'WhereArgs';
 
-		if ( $this->type_registry->get_type( $input_name ) ) {
+		if ( $this->type_registry->has_type( $input_name ) ) {
 			return;
 		}
 

--- a/src/Type/WPInterfaceTrait.php
+++ b/src/Type/WPInterfaceTrait.php
@@ -70,35 +70,4 @@ trait WPInterfaceTrait {
 
 	}
 
-	/**
-	 * Registers connections that were passed through the Type registration config
-	 *
-	 * @param TypeRegistry $type_registry The WPGraphQL Type Registry
-	 *
-	 * @return void
-	 *
-	 * @throws Exception
-	 */
-	protected function register_connections_from_config( TypeRegistry $type_registry ) {
-
-		$connections = $this->config['connections'] ?? null;
-
-		if ( null === $connections || ! is_array( $connections ) ) {
-			return;
-		}
-
-		foreach ( $connections as $field_name => $connection_config ) {
-
-			if ( ! is_array( $connection_config ) ) {
-				continue;
-			}
-
-			$connection_config['fromType']      = $this->config['name'];
-			$connection_config['fromFieldName'] = $field_name;
-			$type_registry->register_connection( $connection_config );
-
-		}
-
-	}
-
 }

--- a/src/Type/WPInterfaceType.php
+++ b/src/Type/WPInterfaceType.php
@@ -87,8 +87,6 @@ class WPInterfaceType extends InterfaceType {
 			return $fields;
 		};
 
-		$this->register_connections_from_config( $this->type_registry );
-
 		$config['resolveType'] = function ( $object ) use ( $config ) {
 			$type = null;
 			if ( is_callable( $config['resolveType'] ) ) {

--- a/src/Type/WPObjectType.php
+++ b/src/Type/WPObjectType.php
@@ -129,8 +129,6 @@ class WPObjectType extends ObjectType {
 			return $fields;
 		};
 
-		$this->register_connections_from_config( $this->type_registry );
-
 		/**
 		 * Run an action when the WPObjectType is instantiating
 		 *


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

This moves the registration of connections defined by Type/Interface registrations to the root of the TypeRegistry instead of happening from the Type/Interface object instantiation. 

Does this close any currently open issues?
------------------------------------------
Closes #2054 


Any other comments?
-------------------
Given the following registration of a Type with a connection defined: 

```php
add_action( 'graphql_register_types', function() {

	register_graphql_object_type( 'TestTypeWithConnections', [
		'fields' => [
			'test' => [
				'type' => 'String',
				'resolve' => function() {
					return true;
				}
			]
		],
		'connections' => [
			'testPostConnection' => [
				'toType' => 'Post',
				'connectionArgs' => [
					'testInput' => [
						'type' => 'String'
					],
				],
				'resolve' => function() {
					return [
						'nodes' => [
							[
								'id' => 'goo'
							]
						]
					];
				},
			],
		],
	]);

	register_graphql_field( 'RootQuery', 'test', [
		'type' => 'TestTypeWithConnections',
		'resolve' => function() {
			return true;
		}
	]);

} );
```

The following query:

```graphql
query Test($where: TestTypeWithConnectionsToPostConnectionWhereArgs) {
  test {
    test
    testPostConnection(where: $where) {
      nodes {
        id
      }
    }
  }
}

```

With the following variables: 

```json
{
  "where": {
    "testInput": "test"
  }
}
```

### BEFORE

Would lead to this error: 

```json
{
      "debugMessage": "Type loader is expected to return a callable or valid type \"TestTypeWithConnectionsToPostConnectionWhereArgs\", but it returned null",
      "message": "Internal server error",
      "extensions": {
        "category": "internal"
      }
}
```

![Screen Shot 2021-08-03 at 2 06 47 PM](https://user-images.githubusercontent.com/1260765/128079042-f03e9db3-9690-40b5-ba5f-a6b61e55c141.png)

### After:

I get the expected data and no errors:

![Screen Shot 2021-08-03 at 2 08 08 PM](https://user-images.githubusercontent.com/1260765/128079173-63ecf9a3-e721-405b-bbe7-03667e1c771a.png)
