### PR TITLE
Release/v1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.6.2
+
+### Chores / Bugfixes
+
+- ([#2051](https://github.com/wp-graphql/wp-graphql/pull/2051)): Fixes a bug where Types that share the same name as a PHP function (ex: `Header` / `header()`) would try and call the function when loading the Type. See ([Issue #2047](https://github.com/wp-graphql/wp-graphql/issues/2047))
+- ([#2055](https://github.com/wp-graphql/wp-graphql/pull/2055)): Fixes a bug where Connections registered from Types were adding connections to the registry too late causing some queries to fail. See Issue ([Issue #2054](https://github.com/wp-graphql/wp-graphql/issues/2054))
+
 ## 1.6.1
 
 ### Chores / Bugfixes

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, API, Gatsby, Headless, Decoupled, React, Nextjs, Vue, Apollo, RES
 Requires at least: 5.0
 Tested up to: 5.8
 Requires PHP: 7.1
-Stable tag: 1.6.1
+Stable tag: 1.6.2
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -90,6 +90,14 @@ The `uri` field was non-null on some Types in the Schema but has been changed to
 Composer dependencies are no longer versioned in Github. Recommended install source is WordPress.org or using Composer to get the code from Packagist.org or WPackagist.org.
 
 == Changelog ==
+
+= 1.6.2 =
+
+**Chores / Bugfixes**
+
+- ([#2051](https://github.com/wp-graphql/wp-graphql/pull/2051)): Fixes a bug where Types that share the same name as a PHP function (ex: `Header` / `header()`) would try and call the function when loading the Type. See ([Issue #2047](https://github.com/wp-graphql/wp-graphql/issues/2047))
+- ([#2055](https://github.com/wp-graphql/wp-graphql/pull/2055)): Fixes a bug where Connections registered from Types were adding connections to the registry too late causing some queries to fail. See Issue ([Issue #2054](https://github.com/wp-graphql/wp-graphql/issues/2054))
+
 
 = 1.6.1 =
 

--- a/src/Data/Connection/UserRoleConnectionResolver.php
+++ b/src/Data/Connection/UserRoleConnectionResolver.php
@@ -71,7 +71,7 @@ class UserRoleConnectionResolver extends AbstractConnectionResolver {
 	 * @return array
 	 */
 	public function get_query_args() {
-		return $this->query_args;
+		return is_array( $this->query_args ) && ! empty( $this->query_args ) ? $this->query_args : [];
 	}
 
 	/**

--- a/src/Type/WPConnectionType.php
+++ b/src/Type/WPConnectionType.php
@@ -233,7 +233,7 @@ class WPConnectionType {
 
 		$input_name = $this->connection_name . 'WhereArgs';
 
-		if ( $this->type_registry->get_type( $input_name ) ) {
+		if ( $this->type_registry->has_type( $input_name ) ) {
 			return;
 		}
 

--- a/src/Type/WPInterfaceTrait.php
+++ b/src/Type/WPInterfaceTrait.php
@@ -70,35 +70,4 @@ trait WPInterfaceTrait {
 
 	}
 
-	/**
-	 * Registers connections that were passed through the Type registration config
-	 *
-	 * @param TypeRegistry $type_registry The WPGraphQL Type Registry
-	 *
-	 * @return void
-	 *
-	 * @throws Exception
-	 */
-	protected function register_connections_from_config( TypeRegistry $type_registry ) {
-
-		$connections = $this->config['connections'] ?? null;
-
-		if ( null === $connections || ! is_array( $connections ) ) {
-			return;
-		}
-
-		foreach ( $connections as $field_name => $connection_config ) {
-
-			if ( ! is_array( $connection_config ) ) {
-				continue;
-			}
-
-			$connection_config['fromType']      = $this->config['name'];
-			$connection_config['fromFieldName'] = $field_name;
-			$type_registry->register_connection( $connection_config );
-
-		}
-
-	}
-
 }

--- a/src/Type/WPInterfaceType.php
+++ b/src/Type/WPInterfaceType.php
@@ -87,8 +87,6 @@ class WPInterfaceType extends InterfaceType {
 			return $fields;
 		};
 
-		$this->register_connections_from_config( $this->type_registry );
-
 		$config['resolveType'] = function ( $object ) use ( $config ) {
 			$type = null;
 			if ( is_callable( $config['resolveType'] ) ) {

--- a/src/Type/WPObjectType.php
+++ b/src/Type/WPObjectType.php
@@ -129,8 +129,6 @@ class WPObjectType extends ObjectType {
 			return $fields;
 		};
 
-		$this->register_connections_from_config( $this->type_registry );
-
 		/**
 		 * Run an action when the WPObjectType is instantiating
 		 *

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -130,7 +130,7 @@ final class WPGraphQL {
 
 		// Plugin version.
 		if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-			define( 'WPGRAPHQL_VERSION', '1.6.1' );
+			define( 'WPGRAPHQL_VERSION', '1.6.2' );
 		}
 
 		// Plugin Folder Path.

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.6.1
+ * Version: 1.6.2
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.6.1
+ * @version  1.6.2
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
# Release Notes

## Chores / Bugfixes

- ([#2051](https://github.com/wp-graphql/wp-graphql/pull/2051)): Fixes a bug where Types that share the same name as a PHP function (ex: `Header` / `header()`) would try and call the function when loading the Type. See ([Issue #2047](https://github.com/wp-graphql/wp-graphql/issues/2047))
- ([#2055](https://github.com/wp-graphql/wp-graphql/pull/2055)): Fixes a bug where Connections registered from Types were adding connections to the registry too late causing some queries to fail. See Issue ([Issue #2054](https://github.com/wp-graphql/wp-graphql/issues/2054))
