### PR TITLE
allow argument 4 to be null in filter_post_meta_for_previews()

### DIFF
--- a/src/Utils/Preview.php
+++ b/src/Utils/Preview.php
@@ -16,7 +16,7 @@ class Preview {
 	 * @param mixed       $default_value The default value of the meta
 	 * @param int         $object_id     The ID of the object the meta is for
 	 * @param string|null $meta_key      The meta key
-	 * @param bool        $single        Whether the meta is a single value
+	 * @param bool|null   $single        Whether the meta is a single value
 	 *
 	 * @return mixed
 	 */
@@ -50,6 +50,7 @@ class Preview {
 		if ( 'revision' === $post->post_type ) {
 			$parent   = get_post( $post->post_parent );
 			$meta_key = ! empty( $meta_key ) ? $meta_key : '';
+
 			return isset( $parent->ID ) && absint( $parent->ID ) ? get_post_meta( $parent->ID, $meta_key, $single ) : $default_value;
 
 		}

--- a/src/Utils/Preview.php
+++ b/src/Utils/Preview.php
@@ -20,7 +20,7 @@ class Preview {
 	 *
 	 * @return mixed
 	 */
-	public static function filter_post_meta_for_previews( $default_value, int $object_id, ?string $meta_key, ?bool $single = false ) {
+	public static function filter_post_meta_for_previews( $default_value, int $object_id, ?string $meta_key = null, ?bool $single = false ) {
 
 		if ( ! is_graphql_request() ) {
 			return $default_value;
@@ -51,7 +51,7 @@ class Preview {
 			$parent   = get_post( $post->post_parent );
 			$meta_key = ! empty( $meta_key ) ? $meta_key : '';
 
-			return isset( $parent->ID ) && absint( $parent->ID ) ? get_post_meta( $parent->ID, $meta_key, $single ) : $default_value;
+			return isset( $parent->ID ) && absint( $parent->ID ) ? get_post_meta( $parent->ID, $meta_key, (bool) $single ) : $default_value;
 
 		}
 

--- a/src/Utils/Preview.php
+++ b/src/Utils/Preview.php
@@ -20,7 +20,7 @@ class Preview {
 	 *
 	 * @return mixed
 	 */
-	public static function filter_post_meta_for_previews( $default_value, int $object_id, ?string $meta_key, bool $single = false ) {
+	public static function filter_post_meta_for_previews( $default_value, int $object_id, ?string $meta_key, ?bool $single = false ) {
 
 		if ( ! is_graphql_request() ) {
 			return $default_value;

--- a/tests/wpunit/PreviewTest.php
+++ b/tests/wpunit/PreviewTest.php
@@ -156,6 +156,42 @@ class PreviewTest extends \Codeception\TestCase\WPTestCase {
 
 	}
 
+	public function testGetPostMetaWithNullAsSingleDoesNotBreakPreview() {
+
+		wp_set_current_user( $this->admin );
+
+		$actual = graphql([ 'query' => $this->get_query(), 'variables' => [
+			'id' => $this->post,
+		] ]);
+
+		codecept_debug( $actual );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertNotNull( $actual['data']['post']['preview'] );
+
+		add_filter( 'wp_revisions_to_keep', function() {
+			return 0;
+		} );
+
+		$actual = graphql([ 'query' => $this->get_query(), 'variables' => [
+			'id' => $this->post,
+		] ]);
+
+		// Tests #1864
+		// Getting the post meta with a null key should not fail requests.
+		// Previously this would cause errors
+		get_post_meta( $this->post, null, null );
+
+		codecept_debug( $actual );
+
+		add_filter( 'wp_revisions_to_keep', function( $default ) {
+			return $default;
+		} );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertNotNull( $actual['data']['post']['preview'] );
+	}
+
 	public function testGetPostMetaWithNullMetaKeyDoesNotBreakPreviews() {
 
 		wp_set_current_user( $this->admin );


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
--------------------------------------------------

Allows for null to be passed in argument 4 (bool) in filter_post_meta_for_previews.


Does this close any currently open issues?
------------------------------------------
No


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)
`[04-Aug-2021 19:15:35 UTC] PHP Fatal error:  Uncaught TypeError: Argument 4 passed to WPGraphQL\Utils\Preview::filter_post_meta_for_previews() must be of the type bool, null given, called in /nas/content/live/devcasa/wp-includes/class-wp-hook.php on line 305 and defined in /nas/content/live/devcasa/wp-content/plugins/wp-graphql/src/Utils/Preview.php:23`

Where has this been tested?
---------------------------
**Operating System:** …
Mac OS 11.4
**WordPress Version:** … 5.8
