### PR TITLE
Release/v1.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.6.3
+
+### Chores / Bugfixes
+
+- ([#2064](https://github.com/wp-graphql/wp-graphql/pull/2064)): Fixes bug where using `asQuery` argument could return an error instead of a null when the ID passed could not be previewed. 
+- ([#2072](https://github.com/wp-graphql/wp-graphql/pull/2072)): Fixes bug (regression with 1.6) where Object Types for page templates were not properly loading in the Schema after Lazy Loading was introduced in 1.6. 
+- ([#2059](https://github.com/wp-graphql/wp-graphql/pull/2059)): Update typos and links in docs. Thanks @nicolnt!
+- ([#2058](https://github.com/wp-graphql/wp-graphql/pull/2058)): Fixes bug in the filter_post_meta_for_previews was causing PHP warnings. Thanks @zolon4!
+
+
 ## 1.6.2
 
 ### Chores / Bugfixes

--- a/docs/intro-to-graphql.md
+++ b/docs/intro-to-graphql.md
@@ -100,7 +100,7 @@ The following sections will introduce some concepts of GraphQL and provide resou
 
 GraphQL can be implemented in many programming languages as an API for *any* back-end. WPGraphQL is just one implementation of GraphQL using WordPress as the application and data layer.
 
-There are many things that the GraphQL specification doesn't prescribe, such as Schema design, fetching data behind the scenes, and more. These decisions are made by each individual implementation of a GraphQL server. To learn more about specific concepts of the WPGraphQL implementation, you can read about [](/docs/wpgraphql-concepts/">WPGraphQL Concepts page.
+There are many things that the GraphQL specification doesn't prescribe, such as Schema design, fetching data behind the scenes, and more. These decisions are made by each individual implementation of a GraphQL server. To learn more about specific concepts of the WPGraphQL implementation, you can read about [WPGraphQL Concepts page](/docs/wpgraphql-concepts/).
 
 Because GraphQL can be implemented in many ways, the following sections will attempt to speak to general GraphQL concepts that apply to *any* GraphQL implementation.
 
@@ -561,7 +561,7 @@ Above, we saw the `String` Scalar type, but GraphQL has a few built-in Scalar ty
 
 #### Custom Scalars
 
-Most GraphQL implementations ([including WPGraphQL](/functions/register_graphql_scalar/" data-type="functions" data-id="1730">) provide ways to register custom Scalar types.
+Most GraphQL implementations ([including WPGraphQL](/functions/register_graphql_scalar/)) provide ways to register custom Scalar types.
 
 For example, you may want to register a `Date` Scalar that behaves similar to a String, but enforces different validation rules.
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, API, Gatsby, Headless, Decoupled, React, Nextjs, Vue, Apollo, RES
 Requires at least: 5.0
 Tested up to: 5.8
 Requires PHP: 7.1
-Stable tag: 1.6.2
+Stable tag: 1.6.3
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -90,6 +90,16 @@ The `uri` field was non-null on some Types in the Schema but has been changed to
 Composer dependencies are no longer versioned in Github. Recommended install source is WordPress.org or using Composer to get the code from Packagist.org or WPackagist.org.
 
 == Changelog ==
+
+= 1.6.3
+
+**Chores / Bugfixes**
+
+- ([#2064](https://github.com/wp-graphql/wp-graphql/pull/2064)): Fixes bug where using `asQuery` argument could return an error instead of a null when the ID passed could not be previewed.
+- ([#2072](https://github.com/wp-graphql/wp-graphql/pull/2072)): Fixes bug (regression with 1.6) where Object Types for page templates were not properly loading in the Schema after Lazy Loading was introduced in 1.6.
+- ([#2059](https://github.com/wp-graphql/wp-graphql/pull/2059)): Update typos and links in docs. Thanks @nicolnt!
+- ([#2058](https://github.com/wp-graphql/wp-graphql/pull/2058)): Fixes bug in the filter_post_meta_for_previews was causing PHP warnings. Thanks @zolon4!
+
 
 = 1.6.2 =
 

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -409,7 +409,7 @@ class TypeRegistry {
 								},
 							],
 						],
-						'eagerlyLoadType' => 'DefaultTemplate' === $template_type_name,
+						'eagerlyLoadType' => true,
 					]
 				);
 

--- a/src/Type/ObjectType/RootQuery.php
+++ b/src/Type/ObjectType/RootQuery.php
@@ -664,7 +664,7 @@ class RootQuery {
 								$post_id   = ! empty( $revisions ) ? array_values( $revisions )[0] : null;
 							}
 
-							return $context->get_loader( 'post' )->load_deferred( $post_id )->then(
+							return absint( $post_id ) ? $context->get_loader( 'post' )->load_deferred( $post_id )->then(
 								function ( $post ) use ( $post_type_object ) {
 									if ( ! isset( $post->post_type ) || ! in_array( $post->post_type, [
 										'revision',
@@ -675,7 +675,7 @@ class RootQuery {
 
 									return $post;
 								}
-							);
+							) : null;
 						},
 					]
 				);

--- a/src/Utils/Preview.php
+++ b/src/Utils/Preview.php
@@ -16,11 +16,11 @@ class Preview {
 	 * @param mixed       $default_value The default value of the meta
 	 * @param int         $object_id     The ID of the object the meta is for
 	 * @param string|null $meta_key      The meta key
-	 * @param bool        $single        Whether the meta is a single value
+	 * @param bool|null   $single        Whether the meta is a single value
 	 *
 	 * @return mixed
 	 */
-	public static function filter_post_meta_for_previews( $default_value, int $object_id, ?string $meta_key, bool $single = false ) {
+	public static function filter_post_meta_for_previews( $default_value, int $object_id, ?string $meta_key = null, ?bool $single = false ) {
 
 		if ( ! is_graphql_request() ) {
 			return $default_value;
@@ -50,7 +50,8 @@ class Preview {
 		if ( 'revision' === $post->post_type ) {
 			$parent   = get_post( $post->post_parent );
 			$meta_key = ! empty( $meta_key ) ? $meta_key : '';
-			return isset( $parent->ID ) && absint( $parent->ID ) ? get_post_meta( $parent->ID, $meta_key, $single ) : $default_value;
+
+			return isset( $parent->ID ) && absint( $parent->ID ) ? get_post_meta( $parent->ID, $meta_key, (bool) $single ) : $default_value;
 
 		}
 

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -130,7 +130,7 @@ final class WPGraphQL {
 
 		// Plugin version.
 		if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-			define( 'WPGRAPHQL_VERSION', '1.6.2' );
+			define( 'WPGRAPHQL_VERSION', '1.6.3' );
 		}
 
 		// Plugin Folder Path.

--- a/tests/wpunit/PreviewTest.php
+++ b/tests/wpunit/PreviewTest.php
@@ -156,6 +156,42 @@ class PreviewTest extends \Codeception\TestCase\WPTestCase {
 
 	}
 
+	public function testGetPostMetaWithNullAsSingleDoesNotBreakPreview() {
+
+		wp_set_current_user( $this->admin );
+
+		$actual = graphql([ 'query' => $this->get_query(), 'variables' => [
+			'id' => $this->post,
+		] ]);
+
+		codecept_debug( $actual );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertNotNull( $actual['data']['post']['preview'] );
+
+		add_filter( 'wp_revisions_to_keep', function() {
+			return 0;
+		} );
+
+		$actual = graphql([ 'query' => $this->get_query(), 'variables' => [
+			'id' => $this->post,
+		] ]);
+
+		// Tests #1864
+		// Getting the post meta with a null key should not fail requests.
+		// Previously this would cause errors
+		get_post_meta( $this->post, null, null );
+
+		codecept_debug( $actual );
+
+		add_filter( 'wp_revisions_to_keep', function( $default ) {
+			return $default;
+		} );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertNotNull( $actual['data']['post']['preview'] );
+	}
+
 	public function testGetPostMetaWithNullMetaKeyDoesNotBreakPreviews() {
 
 		wp_set_current_user( $this->admin );

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.6.2
+ * Version: 1.6.3
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.6.2
+ * @version  1.6.3
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
# Release Notes

## Chores / Bugfixes

- ([#2064](https://github.com/wp-graphql/wp-graphql/pull/2064)): Fixes bug where using `asQuery` argument could return an error instead of a null when the ID passed could not be previewed. 
- ([#2072](https://github.com/wp-graphql/wp-graphql/pull/2072)): Fixes bug (regression with 1.6) where Object Types for page templates were not properly loading in the Schema after Lazy Loading was introduced in 1.6. 
- ([#2059](https://github.com/wp-graphql/wp-graphql/pull/2059)): Update typos and links in docs. Thanks @nicolnt!
- ([#2058](https://github.com/wp-graphql/wp-graphql/pull/2058)): Fixes bug in the filter_post_meta_for_previews was causing PHP warnings. Thanks @zolon4!
