### PR TITLE
Set is_graphql_request = true in constructor

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -126,6 +126,11 @@ class Request {
 		}
 
 		/**
+		 * Filter "is_graphql_request" to return true
+		 */
+		\WPGraphQL::set_is_graphql_request( true );
+
+		/**
 		 * Action – intentionally with no context – to indicate a GraphQL Request has started.
 		 * This is a great place for plugins to hook in and modify things that should only
 		 * occur in the context of a GraphQL Request. The base class hooks into this action to
@@ -220,11 +225,6 @@ class Request {
 	 * @throws Error
 	 */
 	private function before_execute() {
-
-		/**
-		 * Filter "is_graphql_request" to return true
-		 */
-		\WPGraphQL::set_is_graphql_request( true );
 
 		/**
 		 * Store the global post so it can be reset after GraphQL execution


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This sets `is_graphql_request` to `true` in the constructor so that `is_graphql_request()` can be more accurate in its return value.


Does this close any currently open issues?
------------------------------------------
This would close #2080 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
See issue for details.


Any other comments?
-------------------
N/A


Where has this been tested?
---------------------------
**Operating System:** Mac OS 11.5.2

**WordPress Version:** 5.8
