### PR TITLE
Add `$graphiql` global variable

### DIFF
--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -59,6 +59,7 @@ class Admin {
 		$this->settings->init();
 
 		if ( 'on' === $this->graphiql_enabled || true === $this->graphiql_enabled ) {
+			global $graphiql;
 			$graphiql = new GraphiQL();
 			$graphiql->init();
 		}


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This adds the GraphiQL class as a global variable to allow extensions access to it to filter out actions/hooks defined by the 

ex: 

```php
add_action( 'admin_init', function() {
	global $graphiql;

	// prevent normal GraphiQL from loading
	remove_action( 'admin_enqueue_scripts', [ $graphiql, 'enqueue_graphiql' ], 10 );

}, 99 );
```


Does this close any currently open issues?
------------------------------------------
closes #2088
