### PR TITLE
Fix link in WPGraphQL vs. REST docs page

### DIFF
--- a/docs/wpgraphql-vs-wp-rest-api.md
+++ b/docs/wpgraphql-vs-wp-rest-api.md
@@ -11,7 +11,7 @@ RESTful APIs, including the WP REST API have no official specification. REST is 
 
 This means that as a developer interacting with an API, each REST API you interact with requires you to learn entire new paradigms, use different tooling, etc.
 
-GraphQL on the other hand, is a [specification](https://spec.graphql.org/June2018/) for building APIs that all behave the same. This means that interacting with the [Github GraphQL API](https://developer.github.com/v4/explorer/, [Yelp's GraphQL API](https://www.yelp.com/developers/graphql/guides/intro) or GraphQL for WordPress via WPGraphQL, or any other GraphQL API that follows the specification, things work the same.
+GraphQL on the other hand, is a [specification](https://spec.graphql.org/June2018/) for building APIs that all behave the same. This means that interacting with the [Github GraphQL API](https://developer.github.com/v4/explorer/), [Yelp's GraphQL API](https://www.yelp.com/developers/graphql/guides/intro) or GraphQL for WordPress via WPGraphQL, or any other GraphQL API that follows the specification, things work the same.
 
 ### Improved Tooling
 


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This fixes a link in the WPGraphQL vs. REST docs page.


Does this close any currently open issues?
------------------------------------------
No.


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
No.


Any other comments?
-------------------
No.


Where has this been tested?
---------------------------
n/a