### PR TITLE
Move `taxonomy` field to the `TermNode` interface

### DIFF
--- a/src/Connection/Taxonomies.php
+++ b/src/Connection/Taxonomies.php
@@ -29,27 +29,6 @@ class Taxonomies {
 
 		$taxonomies = get_taxonomies( [ 'show_in_graphql' => true ], 'objects' );
 
-		if ( is_array( $taxonomies ) && ! empty( $taxonomies ) ) {
-			foreach ( $taxonomies as $taxonomy ) {
-				register_graphql_connection(
-					[
-						'fromType'      => $taxonomy->graphql_single_name,
-						'toType'        => 'Taxonomy',
-						'fromFieldName' => 'taxonomy',
-						'oneToOne'      => true,
-						'resolve'       => function ( Term $source, $args, $context, $info ) {
-							if ( empty( $source->taxonomyName ) ) {
-								return null;
-							}
-							$resolver = new TaxonomyConnectionResolver( $source, $args, $context, $info );
-							$resolver->set_query_arg( 'name', $source->taxonomyName );
-							return $resolver->one_to_one()->get_connection();
-						},
-					]
-				);
-			}
-		}
-
 		register_graphql_connection(
 			[
 				'fromType'      => 'ContentType',

--- a/src/Type/InterfaceType/TermNode.php
+++ b/src/Type/InterfaceType/TermNode.php
@@ -5,6 +5,7 @@ namespace WPGraphQL\Type\InterfaceType;
 use Exception;
 use WPGraphQL\Data\Connection\EnqueuedScriptsConnectionResolver;
 use WPGraphQL\Data\Connection\EnqueuedStylesheetConnectionResolver;
+use WPGraphQL\Data\Connection\TaxonomyConnectionResolver;
 use WPGraphQL\Data\DataSource;
 use WPGraphQL\Model\Term;
 use WPGraphQL\Registry\TypeRegistry;
@@ -26,6 +27,18 @@ class TermNode {
 			[
 				'interfaces'  => [ 'Node', 'UniformResourceIdentifiable' ],
 				'connections' => [
+					'taxonomy'         => [
+						'toType'   => 'Taxonomy',
+						'oneToOne' => true,
+						'resolve'  => function ( $source, $args, $context, $info ) {
+							if ( empty( $source->taxonomyName ) ) {
+								return null;
+							}
+							$resolver = new TaxonomyConnectionResolver( $source, $args, $context, $info );
+							$resolver->set_query_arg( 'name', $source->taxonomyName );
+							return $resolver->one_to_one()->get_connection();
+						},
+					],
 					'enqueuedScripts'     => [
 						'toType'  => 'EnqueuedScript',
 						'resolve' => function ( $source, $args, $context, $info ) {


### PR DESCRIPTION
Right now the `taxonomy` field used to get a term’s taxonomy is registered on each individual term type. This PR changes this so that it’s registered on the common `TermNode` interface instead. That means you can now make this query which was not possible before:

```gql
query MyQuery {
  terms {
    nodes {
      taxonomy {
        node {
          name
        }
      }
    }
  }
}
```


Where has this been tested?
---------------------------
**Operating System:** MacOS

**WordPress Version:** 5.5.6
