### PR TITLE
Add pre_graphql_execute_request filter to allow cache to be queried first

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -605,21 +605,25 @@ class Request {
 			 */
 			$this->before_execute();
 
-			$result = \GraphQL\GraphQL::executeQuery(
-				$this->schema,
-				isset( $this->params->query ) ? $this->params->query : '',
-				$this->root_value,
-				$this->app_context,
-				isset( $this->params->variables ) ? $this->params->variables : null,
-				isset( $this->params->operation ) ? $this->params->operation : null,
-				$this->field_resolver,
-				$this->validation_rules
-			);
+			$result = apply_filters( 'pre_graphql_execute_request', null, $this );
 
-			/**
-			 * Return the result of the request
-			 */
-			$response = $result->toArray( $this->get_debug_flag() );
+			if ( null === $result ) {
+				$result = \GraphQL\GraphQL::executeQuery(
+					$this->schema,
+					isset( $this->params->query ) ? $this->params->query : '',
+					$this->root_value,
+					$this->app_context,
+					isset( $this->params->variables ) ? $this->params->variables : null,
+					isset( $this->params->operation ) ? $this->params->operation : null,
+					$this->field_resolver,
+					$this->validation_rules
+				);
+
+				/**
+				 * Return the result of the request
+				 */
+				$response = $result->toArray( $this->get_debug_flag() );
+			}
 
 			/**
 			 * Ensure the response is returned as a proper, populated array. Otherwise add an error.
@@ -662,8 +666,15 @@ class Request {
 		/**
 		 * Get the response.
 		 */
-		$server   = $this->get_server();
-		$response = $server->executeRequest( $this->params );
+		$response = apply_filters( 'pre_graphql_execute_request', null, $this );
+
+		/**
+		 * If no cached response, execute the query
+		 */
+		if ( null === $response ) {
+			$server   = $this->get_server();
+			$response = $server->executeRequest( $this->params );
+		}
 
 		return $this->after_execute( $response );
 	}


### PR DESCRIPTION

What does this implement/fix? Explain your changes.
---------------------------------------------------
Add new filters during processing of the request to invoke filter before execution of the query. If results are returned from the filter, do not run the full execution of the query.


Does this close any currently open issues?
------------------------------------------
Related to persisted queries and caching [work](https://github.com/wp-graphql/wp-graphql-persisted-queries/issues/18).


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
