### PR TITLE
Use correct variable for pre execure request filter

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -605,9 +605,9 @@ class Request {
 			 */
 			$this->before_execute();
 
-			$result = apply_filters( 'pre_graphql_execute_request', null, $this );
+			$response = apply_filters( 'pre_graphql_execute_request', null, $this );
 
-			if ( null === $result ) {
+			if ( null === $response ) {
 				$result = \GraphQL\GraphQL::executeQuery(
 					$this->schema,
 					isset( $this->params->query ) ? $this->params->query : '',


### PR DESCRIPTION

What does this implement/fix? Explain your changes.
---------------------------------------------------
Wrong variable which caused $response to always be empty and throw error, when filter returned results.


Does this close any currently open issues?
------------------------------------------
Related to persisted queries and caching [work](https://github.com/wp-graphql/wp-graphql-persisted-queries/issues/18).


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
