### PR TITLE
Edited WPGraphqlQL Endpoint URL

### DIFF
--- a/docs/interacting-with-wpgraphql.md
+++ b/docs/interacting-with-wpgraphql.md
@@ -50,7 +50,7 @@ One of the easiest ways to test a WPGraphQL server is to make a `fetch` request 
 You can open up Chrome Dev Tools and paste the following into your console to fetch data from WPGraphQL. (**Of course, change the URL to the API you want to fetch from.**)
 
 ```js
-fetch('https://www.wpgraphql.com/graphql', {
+fetch('https://content.wpgraphql.com/graphql', {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',


### PR DESCRIPTION
Changed www.wpgraphql.com/graphql to content.wpgraphql.com/graphql as browsers fail to fetch the endpoint due to redirect in the preflight request

<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Changed www.wpgraphql.com/graphql to content.wpgraphql.com/graphql as browsers fail to fetch the endpoint due to redirect in the preflight request


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
