### PR TITLE
Respect 'publicly_queryable' post type setting.

### DIFF
--- a/docs/custom-post-types.md
+++ b/docs/custom-post-types.md
@@ -56,7 +56,7 @@ Custom Post Type UI is a popular WordPress plugin that enables users to register
 
 ## Public vs Private Data
 
-WPGraphQL respects WordPress access control policies. If a Post Type is registered as `public => true` then WPGraphQL will expose posts of that post type to public queries. If the post type is registered as `public => false` the posts of that post type will be exposed only to authenticated users.
+WPGraphQL respects WordPress access control policies. If a Post Type is registered as `publicly_queryable => true` then WPGraphQL will expose posts of that post type to public queries. If the post type is registered as `publicly_queryable => false` the posts of that post type will be exposed only to authenticated users who have the capability required to access it.
 
 ## Querying Custom Post Types
 

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -328,7 +328,7 @@ class Post extends Model {
 		/**
 		 * Published content is public, not private
 		 */
-		if ( 'publish' === $this->data->post_status && $this->post_type_object->publicly_queryable ) {
+		if ( 'publish' === $this->data->post_status && $this->post_type_object && $this->post_type_object->publicly_queryable ) {
 			return false;
 		}
 

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -328,7 +328,7 @@ class Post extends Model {
 		/**
 		 * Published content is public, not private
 		 */
-		if ( 'publish' === $this->data->post_status ) {
+		if ( 'publish' === $this->data->post_status && $this->post_type_object->publicly_queryable ) {
 			return false;
 		}
 

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -328,7 +328,7 @@ class Post extends Model {
 		/**
 		 * Published content is public, not private
 		 */
-		if ( 'publish' === $this->data->post_status && $this->post_type_object && $this->post_type_object->publicly_queryable ) {
+		if ( 'publish' === $this->data->post_status && $this->post_type_object && ( true === $this->post_type_object->public || true === $this->post_type_object->publicly_queryable ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
Fixes #2134.

What does this implement/fix? Explain your changes.
---------------------------------------------------
Consider a post as private if 'publicly_queryable' is set to false so that only authenticated users with the required capability can access it.


Does this close any currently open issues?
------------------------------------------
Yes, #2134.


Any other comments?
-------------------
Please test this to double-check that it results in the intended behavior.

I also updated the paragraph at the top of the https://www.wpgraphql.com/docs/custom-post-types/#public-vs-private-data section of the docs to reflect this change (wp-admin edit page is here: https://content.wpgraphql.com/wp-admin/post.php?post=5116&action=edit).
