### PR TITLE
Release/v1.6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.6.7
+
+## Chores / Bugfixes
+
+- ([#2135](https://github.com/wp-graphql/wp-graphql/pull/2135)): Fixes permission check in the Post model layer. Posts of a `'publicly_queryable' => true` post_type can be queried publicly (non-authenticated requests) via WPGraphQL, even if the post_type is set to `'public' => false`. Thanks @kellenmace!
+- ([#2093](https://github.com/wp-graphql/wp-graphql/pull/2093)): Fixes `Post.pinged` field to properly return an array. Thanks @justlevine!
+- ([#2132](https://github.com/wp-graphql/wp-graphql/pull/2132)): Fix issue where querying posts by slug could erroneously return null. Thanks @ChrisWiegman!
+- ([#2127](https://github.com/wp-graphql/wp-graphql/pull/2127)): Update endpoint in documentation examples. Thanks @RafidMuhyim!
+
 ## 1.6.6
 
 ### New Features

--- a/docs/custom-post-types.md
+++ b/docs/custom-post-types.md
@@ -58,7 +58,7 @@ Custom Post Type UI is a popular WordPress plugin that enables users to register
 
 ## Public vs Private Data
 
-WPGraphQL respects WordPress access control policies. If a Post Type is registered as `public => true` then WPGraphQL will expose posts of that post type to public queries. If the post type is registered as `public => false` the posts of that post type will be exposed only to authenticated users.
+WPGraphQL respects WordPress access control policies. If a Post Type is registered as `publicly_queryable => true` then WPGraphQL will expose posts of that post type to public queries. If the post type is registered as `publicly_queryable => false` the posts of that post type will be exposed only to authenticated users who have the capability required to access it.
 
 ## Querying Custom Post Types
 

--- a/docs/custom-post-types.md
+++ b/docs/custom-post-types.md
@@ -18,15 +18,17 @@ This is an example of registering a new "docs" post_type and enabling GraphQL Su
 ```php
 add_action( 'init', function() {
    register_post_type( 'docs', [
-      'show_ui' => true,
+      'show_ui' => true, # whether you want the post_type to show in the WP Admin UI. Doesn't affect WPGraphQL Schema.
       'labels'  => [
         //@see https://developer.wordpress.org/themes/functionality/internationalization/
-        'menu_name' => __( 'Docs', 'your-textdomain' ),
+        'menu_name' => __( 'Docs', 'your-textdomain' ), # The label for the WP Admin. Doesn't affect the WPGraphQL Schema.
       ],
-      'show_in_graphql' => true,
-      'hierarchical' => true,
-      'graphql_single_name' => 'document',
-      'graphql_plural_name' => 'documents',
+      'hierarchical' => true, # set to false if you don't want parent/child relationships for the entries
+      'show_in_graphql' => true, # Set to false if you want to exclude this type from the GraphQL Schema
+      'graphql_single_name' => 'document', 
+      'graphql_plural_name' => 'documents', # If not set, will default to `all${graphql_single_name}`, i.e. `allDocument`.
+      'public' => true, # set to false if entries of the post_type should not have public URIs per entry
+      'publicly_queryable' => true, # Set to false if entries should only be queryable in WPGraphQL by authenticated requests
    ] );
 } );
 ```
@@ -42,7 +44,7 @@ add_filter( 'register_post_type_args', function( $args, $post_type ) {
   if ( 'docs' === $post_type ) {
     $args['show_in_graphql'] = true;
     $args['graphql_single_name'] = 'document';
-    $args['graphql_plural_name'] = 'documents';
+    $args['graphql_plural_name'] = 'documents'; # Don't set, and it will default to `all${graphql_single_name}`, i.e. `allDocument`.
   }
 
   return $args;

--- a/docs/interacting-with-wpgraphql.md
+++ b/docs/interacting-with-wpgraphql.md
@@ -43,14 +43,14 @@ When making an HTTP request to a WPGraphQL server, a few things need to be inclu
   - **variables (optional):** JSON object of variables for use in the query
   - **operationName (optional):** The name of the operation to use for the response if multiple operations were sent in the query string
 
-### Browser Console
+### Fetch
 
 One of the easiest ways to test a WPGraphQL server is to make a `fetch` request from the browser console.
 
 You can open up Chrome Dev Tools and paste the following into your console to fetch data from WPGraphQL. (**Of course, change the URL to the API you want to fetch from.**)
 
 ```js
-fetch('https://www.wpgraphql.com/graphql', {
+fetch('https://content.wpgraphql.com/graphql', {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
@@ -70,6 +70,33 @@ fetch('https://www.wpgraphql.com/graphql', {
 ```
 
 ![Screenshot showing the request being made](./interacting-fetch-graphql-from-browser-console-1024x619.gif)
+
+#### Fetch with .htaccess Auth
+
+Many WordPress hosts allow users to password protect their WordPress install using a username and password that covers the entire site, and in order to access the site, including the GraphQL endpoint, the application needs to send the username and password. 
+
+We can use the same code as in the above `fetch` example, but add an `Authorization` header with a base64 encoded username/password. 
+
+```
+fetch('https://content.wpgraphql.com/graphql', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'Authorization': 'Basic ' + btoa('username:password') # Add this if you have .htaccess auth on your WordPress install
+  },
+  body: JSON.stringify({
+    query: `
+        {
+            generalSettings {
+                url
+            }
+        }
+    `,
+  }),
+})
+  .then(res => res.json())
+  .then(res => console.log(res.data))
+```
 
 ### Curl
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, API, Gatsby, Headless, Decoupled, React, Nextjs, Vue, Apollo, RES
 Requires at least: 5.0
 Tested up to: 5.8
 Requires PHP: 7.1
-Stable tag: 1.6.6
+Stable tag: 1.6.7
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -77,6 +77,36 @@ Gatsby and WP Engine both believe that a strong GraphQL API for WordPress is a b
 
 == Upgrade Notice ==
 
+= 1.6.7 =
+
+There's been a bugfix in the Post Model layer which _might_ break existing behaviors.
+
+WordPress Post Type registry allows for a post_type to be registered as `public` (`true` or `false`)
+and `publicly_queryable` (`true` or `false`).
+
+WPGraphQL's Model Layer was allowing published content of any post_type to be exposed publicly. This
+change better respects the `public` and `publicly_queryable` properties of post types better.
+
+Now, if a post_type is `public=>true`, published content of that post_type can be queried by public
+WPGraphQL requests.
+
+If a `post_type` is set to `public=>false`, then we fallback to the `publicly_queryable` property.
+If a post_type is set to `publicly_queryable => true`, then published content of the Post Type can
+be queried in WPGraphQL by public users.
+
+If both `public=>false` and `publicly_queryable` is `false` or not defined, then the content of the
+post_type will only be accessible via authenticated queries by users with proper capabilities to
+access the post_type.
+
+**Possible Action:** You might need to adjust your post_type registration to better reflect your intent.
+
+- `public=>true`: The entries in the post_type will be public in WPGraphQL and will have a public
+URI in WordPress.
+- `public=>false, publicly_queryable=>true`: The entries in the post_type will be public in WPGraphQL,
+but will not have individually respected URI from WordPress, and can not be queried by URI in WPGraphQL.
+- `public=>false,publicly_queryable=>false`: The entries in the post_type will only be accessible in
+WPGraphQL by authenticated requests for users with proper capabilities to interact with the post_type.
+
 = 1.5.0 =
 
 The `MenuItem.path` field was changed from `non-null` to nullable and some clients may need to make adjustments to support this.
@@ -90,6 +120,16 @@ The `uri` field was non-null on some Types in the Schema but has been changed to
 Composer dependencies are no longer versioned in Github. Recommended install source is WordPress.org or using Composer to get the code from Packagist.org or WPackagist.org.
 
 == Changelog ==
+
+= 1.6.7
+
+**Chores / Bugfixes**
+
+- ([#2135](https://github.com/wp-graphql/wp-graphql/pull/2135)): Fixes permission check in the Post model layer. Posts of a `'publicly_queryable' => true` post_type can be queried publicly (non-authenticated requests) via WPGraphQL, even if the post_type is set to `'public' => false`. Thanks @kellenmace!
+- ([#2093](https://github.com/wp-graphql/wp-graphql/pull/2093)): Fixes `Post.pinged` field to properly return an array. Thanks @justlevine!
+- ([#2132](https://github.com/wp-graphql/wp-graphql/pull/2132)): Fix issue where querying posts by slug could erroneously return null. Thanks @ChrisWiegman!
+- ([#2127](https://github.com/wp-graphql/wp-graphql/pull/2127)): Update endpoint in documentation examples. Thanks @RafidMuhyim!
+
 
 = 1.6.6
 

--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -387,7 +387,6 @@ class NodeResolver {
 			// Target post types with a public URI.
 			$allowed_post_types = get_post_types( [
 				'show_in_graphql' => true,
-				'public'          => true,
 			] );
 
 			$post_type = 'post';

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -328,7 +328,7 @@ class Post extends Model {
 		/**
 		 * Published content is public, not private
 		 */
-		if ( 'publish' === $this->data->post_status ) {
+		if ( 'publish' === $this->data->post_status && $this->post_type_object && ( true === $this->post_type_object->public || true === $this->post_type_object->publicly_queryable ) ) {
 			return false;
 		}
 
@@ -636,7 +636,7 @@ class Post extends Model {
 				'pinged'                    => function () {
 					$punged = get_pung( $this->databaseId );
 
-					return ! empty( $punged ) ? implode( ',', (array) $punged ) : null;
+					return ! empty( implode( ',', (array) $punged ) ) ? $punged : null;
 				},
 				'modified'                  => function () {
 					return ! empty( $this->data->post_modified ) && '0000-00-00 00:00:00' !== $this->data->post_modified ? Utils::prepare_date_response( $this->data->post_modified ) : null;

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -130,7 +130,7 @@ final class WPGraphQL {
 
 		// Plugin version.
 		if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-			define( 'WPGRAPHQL_VERSION', '1.6.6' );
+			define( 'WPGRAPHQL_VERSION', '1.6.7' );
 		}
 
 		// Plugin Folder Path.

--- a/tests/wpunit/ContentNodeInterfaceTest.php
+++ b/tests/wpunit/ContentNodeInterfaceTest.php
@@ -117,7 +117,7 @@ class ContentNodeInterfaceTest extends \Codeception\TestCase\WPTestCase {
 		    ...ContentFields
 		  }
 		}
-		
+
 		fragment ContentFields on ContentNode {
 		  __typename
 		  id
@@ -351,5 +351,113 @@ class ContentNodeInterfaceTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertEquals( $page_id, $actual['data']['page']['pageId'] );
 	}
 
+	/**
+	 * @throws Exception
+	 */
+	public function testContentNodeFieldBySlug() {
 
+		$post_types = array(
+			'book' => array(
+				'public'              => false,
+				'show_in_graphql'     => true,
+				'graphql_single_name' => 'book',
+				'graphql_plural_name' => 'books',
+				'label'               => 'Books',
+			),
+			'test' => array(
+				'public'              => false,
+				'publicly_queryable'  => true,
+				'show_in_graphql'     => true,
+				'graphql_single_name' => 'test',
+				'graphql_plural_name' => 'tests',
+				'label'               => 'Tests',
+			),
+			'cat' => array(
+				'public'              => false,
+				'publicly_queryable'  => false,
+				'show_in_graphql'     => true,
+				'graphql_single_name' => 'cat',
+				'graphql_plural_name' => 'cats',
+				'label'               => 'Cats',
+			),
+		);
+
+		foreach ( $post_types as $post_type => $args ) {
+			register_post_type( $post_type, $args );
+		}
+
+		$post_id_book = $this->factory()->post->create( [
+			'post_type'   => 'book',
+			'post_status' => 'publish',
+			'post_title'  => 'Test Post',
+			'post_author' => $this->admin
+		] );
+
+		$post_id_test = $this->factory()->post->create( [
+			'post_type'   => 'test',
+			'post_status' => 'publish',
+			'post_title'  => 'Test Test',
+			'post_author' => $this->admin
+		] );
+
+		$post_id_cat = $this->factory()->post->create( [
+			'post_type'   => 'cat',
+			'post_status' => 'publish',
+			'post_title'  => 'Test Cat',
+			'post_author' => $this->admin
+		] );
+
+		$query = '
+			{
+				book(id: "test-post", idType: SLUG) {
+					__typename
+					bookId
+				},
+				test(id: "test-test", idType: SLUG) {
+					__typename
+					testId
+				},
+				cat(id: "test-cat", idType: SLUG) {
+					__typename
+					catId
+				}
+		    }
+		';
+
+		$actual = graphql( [
+			'query'     => $query
+		] );
+
+		codecept_debug( $actual );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEquals( 'Book', $actual['data']['book']['__typename'] );
+		$this->assertEquals( $post_id_book, $actual['data']['book']['bookId'] );
+		$this->assertEquals( 'Test', $actual['data']['test']['__typename'] );
+		$this->assertEquals( $post_id_test, $actual['data']['test']['testId'] );
+		$this->assertEquals( 'Cat', $actual['data']['cat']['__typename'] );
+		$this->assertEquals( $post_id_cat, $actual['data']['cat']['catId'] );
+
+
+		// Set the user to a public user
+		wp_set_current_user( 0 );
+
+		$actual = graphql( [
+			'query'     => $query
+		] );
+
+		codecept_debug( $actual );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+
+		// The book and cat should be empty, because they're not publicly_queryable post types
+		// and this test is from a public user
+		$this->assertEmpty( $actual['data']['book'] );
+		$this->assertEmpty( $actual['data']['cat'] );
+
+		// The test should return data, because it's a publicly_queryable post type
+		$this->assertEquals( 'Test', $actual['data']['test']['__typename'] );
+		$this->assertEquals( $post_id_test, $actual['data']['test']['testId'] );
+
+	}
 }

--- a/tests/wpunit/CustomPostTypeTest.php
+++ b/tests/wpunit/CustomPostTypeTest.php
@@ -31,8 +31,6 @@ class CustomPostTypeTest extends \Codeception\TestCase\WPTestCase {
 	 */
 	public function testQueryCustomPostType() {
 
-
-
 		codecept_debug( WPGraphQL::get_allowed_post_types() );
 
 		$query = '
@@ -60,10 +58,224 @@ class CustomPostTypeTest extends \Codeception\TestCase\WPTestCase {
 			]
 		]);
 
+		// Since the post type was registered as not-public, a public user should
+		// not be able to query the content.
+		// This asserts that the content is not returned to a public user.
+		$this->assertEmpty( $actual['data']['bootstrapPosts']['nodes'] );
+		$this->assertEmpty( $actual['data']['bootstrapPosts']['edges'] );
+		$this->assertEmpty( $actual['data']['bootstrapPostBy'] );
+
+
+
+		// An authenticated user should be able to access the content
+		wp_set_current_user( $this->admin );
+
+		$actual = graphql([
+			'query' => $query,
+			'variables' => [
+				'id' => $this->post_id
+			]
+		]);
+
 		codecept_debug( $actual );
 		$this->assertEquals( $this->post_id, $actual['data']['bootstrapPostBy']['bootstrapPostId']);
 		$this->assertEquals( $this->post_id, $actual['data']['bootstrapPosts']['nodes'][0]['bootstrapPostId']);
 		$this->assertEquals( $this->post_id, $actual['data']['bootstrapPosts']['edges'][0]['node']['bootstrapPostId']);
+
+	}
+
+	public function testQueryNonPublicPostTypeThatIsPublicyQueryable() {
+
+		register_post_type( 'non_public_cpt', [
+			'show_in_graphql'=> true,
+			'graphql_single_name' => 'notPublic',
+			'graphql_plural_name' => 'notPublics',
+			'public' => false,
+			'publicly_queryable' => true,
+		]);
+
+		$database_id = $this->factory()->post->create([
+			'post_type' => 'non_public_cpt',
+			'post_status' => 'publish',
+			'post_title' => 'Test'
+		]);
+
+		$query = '
+		query GET_CUSTOM_POSTS( $id: ID! ) {
+		  contentNode( id: $id, idType: DATABASE_ID ) {
+		    databaseId
+		  }
+		  notPublics {
+		    nodes {
+		      databaseId
+		    }
+		    edges {
+		      node {
+		        databaseId
+		      }
+		    }
+		  }
+		}
+		';
+
+
+		// make sure the query is from a public user
+		wp_set_current_user( 0 );
+
+		$actual = graphql([
+			'query' => $query,
+			'variables' => [
+				'id' => $database_id
+			]
+		]);
+
+		codecept_debug( $actual );
+
+		$this->assertEquals( $database_id, $actual['data']['contentNode']['databaseId']);
+		$this->assertEquals( $database_id, $actual['data']['notPublics']['nodes'][0]['databaseId']);
+		$this->assertEquals( $database_id, $actual['data']['notPublics']['edges'][0]['node']['databaseId']);
+
+		// make sure the query is from a logged in user
+		wp_set_current_user( $this->admin );
+
+		$actual = graphql([
+			'query' => $query,
+			'variables' => [
+				'id' => $database_id
+			]
+		]);
+
+		codecept_debug( $actual );
+
+		// A logged in user should be able to see the data as well!
+		$this->assertEquals( $database_id, $actual['data']['contentNode']['databaseId']);
+		$this->assertEquals( $database_id, $actual['data']['notPublics']['nodes'][0]['databaseId']);
+		$this->assertEquals( $database_id, $actual['data']['notPublics']['edges'][0]['node']['databaseId']);
+
+	}
+
+	public function testQueryPublicPostTypeThatIsNotPublicyQueryable() {
+
+		register_post_type( 'non_public_cpt', [
+			'show_in_graphql'=> true,
+			'graphql_single_name' => 'notPublic',
+			'graphql_plural_name' => 'notPublics',
+			'public' => true,
+			'publicly_queryable' => false,
+		]);
+
+		$database_id = $this->factory()->post->create([
+			'post_type' => 'non_public_cpt',
+			'post_status' => 'publish',
+			'post_title' => 'Test'
+		]);
+
+		$query = '
+		query GET_CUSTOM_POSTS( $id: ID! ) {
+		  contentNode( id: $id, idType: DATABASE_ID ) {
+		    databaseId
+		  }
+		  notPublics {
+		    nodes {
+		      databaseId
+		    }
+		    edges {
+		      node {
+		        databaseId
+		      }
+		    }
+		  }
+		}
+		';
+
+
+		// make sure the query is from a public user
+		wp_set_current_user( 0 );
+
+		$actual = graphql([
+			'query' => $query,
+			'variables' => [
+				'id' => $database_id
+			]
+		]);
+
+		codecept_debug( $actual );
+
+		// Since the post_type is public we should see data, even if it's set to publicly_queryable=>false, as public=>true should trump publicly_queryable
+		$this->assertEquals( $database_id, $actual['data']['contentNode']['databaseId']);
+		$this->assertEquals( $database_id, $actual['data']['notPublics']['nodes'][0]['databaseId']);
+		$this->assertEquals( $database_id, $actual['data']['notPublics']['edges'][0]['node']['databaseId']);
+
+	}
+
+	public function testQueryNonPublicPostTypeThatIsNotPublicyQueryable() {
+
+		register_post_type( 'non_public_cpt', [
+			'show_in_graphql'=> true,
+			'graphql_single_name' => 'notPublic',
+			'graphql_plural_name' => 'notPublics',
+			'public' => false,
+			'publicly_queryable' => false,
+		]);
+
+		$database_id = $this->factory()->post->create([
+			'post_type' => 'non_public_cpt',
+			'post_status' => 'publish',
+			'post_title' => 'Test'
+		]);
+
+		$query = '
+		query GET_CUSTOM_POSTS( $id: ID! ) {
+		  contentNode( id: $id, idType: DATABASE_ID ) {
+		    databaseId
+		  }
+		  notPublics {
+		    nodes {
+		      databaseId
+		    }
+		    edges {
+		      node {
+		        databaseId
+		      }
+		    }
+		  }
+		}
+		';
+
+
+		// make sure the query is from a public user
+		wp_set_current_user( 0 );
+
+		$actual = graphql([
+			'query' => $query,
+			'variables' => [
+				'id' => $database_id
+			]
+		]);
+
+		codecept_debug( $actual );
+
+		// Since the post_type is public=>false / publicly_queryable=>false, the content should be null for a public user
+		$this->assertEmpty($actual['data']['contentNode']);
+		$this->assertEmpty( $actual['data']['notPublics']['nodes']);
+		$this->assertEmpty( $actual['data']['notPublics']['edges']);
+
+		// Log the user in and do the request again
+		wp_set_current_user( $this->admin );
+
+		$actual = graphql([
+			'query' => $query,
+			'variables' => [
+				'id' => $database_id
+			]
+		]);
+
+		codecept_debug( $actual );
+
+		// The admin user should be able to see the content
+		$this->assertEquals( $database_id, $actual['data']['contentNode']['databaseId']);
+		$this->assertEquals( $database_id, $actual['data']['notPublics']['nodes'][0]['databaseId']);
+		$this->assertEquals( $database_id, $actual['data']['notPublics']['edges'][0]['node']['databaseId']);
 
 	}
 

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.6.6
+ * Version: 1.6.7
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.6.6
+ * @version  1.6.7
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
# Release Notes

## Chores / Bugfixes

- ([#2135](https://github.com/wp-graphql/wp-graphql/pull/2135)): Fixes permission check in the Post model layer. Posts of a `'publicly_queryable' => true` post_type can be queried publicly (non-authenticated requests) via WPGraphQL, even if the post_type is set to `'public' => false`. Thanks @kellenmace!
- ([#2093](https://github.com/wp-graphql/wp-graphql/pull/2093)): Fixes `Post.pinged` field to properly return an array. Thanks @justlevine!
- ([#2132](https://github.com/wp-graphql/wp-graphql/pull/2132)): Fix issue where querying posts by slug could erroneously return null. Thanks @ChrisWiegman!
- ([#2127](https://github.com/wp-graphql/wp-graphql/pull/2127)): Update endpoint in documentation examples. Thanks @RafidMuhyim!
