### PR TITLE
fix: Add missing `graphql_wp_connection_type_config` filter.

### DIFF
--- a/src/Type/WPConnectionType.php
+++ b/src/Type/WPConnectionType.php
@@ -134,7 +134,7 @@ class WPConnectionType {
 		 * Filter the config of WPConnectionType
 		 *
 		 * @param array        $config         Array of configuration options passed to the WPConnectionType when instantiating a new type
-		 * @param WPConnectionType $wp_connection_type The instance of the WPObjectType class
+		 * @param WPConnectionType $wp_connection_type The instance of the WPConnectionType class
 		 */
 		$config = apply_filters( 'graphql_wp_connection_type_config', $config, $this );
 

--- a/src/Type/WPConnectionType.php
+++ b/src/Type/WPConnectionType.php
@@ -130,6 +130,14 @@ class WPConnectionType {
 	 */
 	public function __construct( array $config, TypeRegistry $type_registry ) {
 
+		/**
+		 * Filter the config of WPConnectionType
+		 *
+		 * @param array        $config         Array of configuration options passed to the WPConnectionType when instantiating a new type
+		 * @param WPConnectionType $wp_connection_type The instance of the WPObjectType class
+		 */
+		$config = apply_filters( 'graphql_wp_connection_type_config', $config, $this );
+
 		$this->validate_config( $config );
 
 		$this->config                = $config;

--- a/tests/wpunit/FiltersTest.php
+++ b/tests/wpunit/FiltersTest.php
@@ -127,4 +127,38 @@ class FiltersTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 	}
 
+	public function testFilterWPConnectionTypeConfigDoesntReturnError() {
+		// Add a filter to the connection type config
+		// This should not throw an error because it's returning the $config untouched
+		add_filter( 
+			'graphql_wp_connection_type_config', function( $config, $wp_connection_type ) {
+				// Ensure the connection instance is passed correctly.
+				$this->assertInstanceOf( '\WPGraphQL\Type\WPConnectionType', $wp_connection_type );
+
+				return $config;
+			}
+			, 10,2);
+
+		$query = '
+		{
+			posts {
+				nodes {
+					id
+					title
+				}
+			}
+		}
+		';
+
+		$actual = graphql( [
+			'query' => $query
+		] );
+
+		codecept_debug( $actual );
+
+		$this->assertQuerySuccessful( $actual, [
+			$this->expectedField( 'posts.nodes[0].title', self::NOT_NULL)
+		]);
+	}
+
 }


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR adds the `graphql_wp_connection_type_config` filter to WPConnectionType, providing basic parity with the other `WP{$}Type` classes, and making it possible to filter existing connections and resolvers.

This is an additive change. There are no unit test regarding other filters, so I'm assuming none are needed here. Also it seems the docs for filters arent in the repo anymore (autogenerated?) but if they do need to go somewhere, let me know.


Does this close any currently open issues?
------------------------------------------
#2140 



Usage Example
-------------------
```php
add_filter( 'graphql_wp_connection_type_config',
  function( array $config ) : array {
    if ( 'RootQuery' !== $config['fromType'] || 'MyPostType' !== $config['toType'] ) {
      return $config;
    }

    $config['resolve'] = function( $source, array $args, AppContext $context, ResolveInfo $info ) {
      return ( new MyPostTypeConnectionResolver( $source, $args, $context, $info ) )->get_connection();
    }
  },
);

```

Where has this been tested?
---------------------------
**Operating System:** WSL2 (Ubuntu 20.04 )

**WordPress Version:** 5.8.1