### PR TITLE
feat: Add `taxonomyName` field

### DIFF
--- a/src/Type/InterfaceType/TermNode.php
+++ b/src/Type/InterfaceType/TermNode.php
@@ -97,6 +97,10 @@ class TermNode {
 						'type'        => 'Int',
 						'description' => __( 'The taxonomy ID that the object is associated with', 'wp-graphql' ),
 					],
+					'taxonomyName' => [
+						'type'        => 'String',
+						'description' => __( 'The name of the taxonomy that the object is associated with', 'wp-graphql' ),
+					],
 					'isRestricted'   => [
 						'type'        => 'Boolean',
 						'description' => __( 'Whether the object is restricted from the current viewer', 'wp-graphql' ),

--- a/src/Type/InterfaceType/TermNode.php
+++ b/src/Type/InterfaceType/TermNode.php
@@ -97,7 +97,7 @@ class TermNode {
 						'type'        => 'Int',
 						'description' => __( 'The taxonomy ID that the object is associated with', 'wp-graphql' ),
 					],
-					'taxonomyName' => [
+					'taxonomyName'   => [
 						'type'        => 'String',
 						'description' => __( 'The name of the taxonomy that the object is associated with', 'wp-graphql' ),
 					],

--- a/tests/wpunit/TermObjectQueriesTest.php
+++ b/tests/wpunit/TermObjectQueriesTest.php
@@ -188,6 +188,7 @@ class TermObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 				}
 				termGroupId
 				termTaxonomyId
+				taxonomyName
 			}
 		}";
 
@@ -221,6 +222,7 @@ class TermObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 				],
 				'termGroupId'    => null,
 				'termTaxonomyId' => $term_id,
+				'taxonomyName' => 'category',
 			],
 		];
 


### PR DESCRIPTION
This PR adds a `taxonomyName` field to the `TermNode` type, since there’s currently no other way to associate a generic term node to its taxonomy. This is also potentially more performant compared to `taxonomy->name` since the taxonomy doesn’t have to be loaded to get the taxonomy name.