### PR TITLE
fix: checking for route instead of domain+route

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -169,14 +169,18 @@ class Router {
 			// Check the server to determine if the GraphQL endpoint is being requested
 			if ( isset( $_SERVER['HTTP_HOST'] ) && isset( $_SERVER['REQUEST_URI'] ) ) {
 
-				// $host = wp_unslash( $_SERVER['HTTP_HOST'] );
+				$host = wp_unslash( $_SERVER['HTTP_HOST'] );
 				$uri  = wp_unslash( $_SERVER['REQUEST_URI'] );
 
-				if ( ! is_string( $uri ) ) {
+				if ( ! is_string( $host ) ) {
+					return false;
+				} elseif ( ! is_string( $uri ) ) {
 					return false;
 				}
 
 				$len                     = strlen( self::$route );
+
+				// the off by one offset validates it's at /graphql or /graphql/ and not /somepath/graphql
 				$is_graphql_http_request = ( substr( $uri, 1, $len ) === self::$route );
 			}
 		}

--- a/src/Router.php
+++ b/src/Router.php
@@ -177,9 +177,12 @@ class Router {
 				} else if ( ! is_string( $uri ) ) {
 					return false;
 				}
- 
-				$graphql_url = wp_unslash( parse_url( site_url( self::$route ), PHP_URL_PATH ) );
-				$request_url = wp_unslash( parse_url( $uri, PHP_URL_PATH ) );
+
+				$parsed_site_url = parse_url( site_url( self::$route ), PHP_URL_PATH );
+				$graphql_url = ! empty( $parsed_site_url ) ? wp_unslash( $parsed_site_url ) : self::$route;
+
+				$parsed_request_url = parse_url( $uri, PHP_URL_PATH );
+				$request_url = ! empty( $parsed_request_url ) ? wp_unslash( $parsed_request_url ) : null;
 
 				// Determine if the route is indeed a graphql request
 				$is_graphql_http_request = str_replace( '/', '', $request_url ) === str_replace( '/', '', $graphql_url );

--- a/src/Router.php
+++ b/src/Router.php
@@ -178,6 +178,12 @@ class Router {
 					return false;
 				}
 
+				// @todo: check how this behaves in multisite 
+				// Strip query params when evaluating the route
+				$queryParamPosition = strpos( $uri, '?' );
+				$uri                = substr( $uri, 0, $queryParamPosition );
+
+				// Determine if the route is indeed a graphql request
 				$is_graphql_http_request = str_replace( '/', '', $uri ) === wp_unslash( self::$route );
 
 			}

--- a/src/Router.php
+++ b/src/Router.php
@@ -174,21 +174,15 @@ class Router {
 
 				if ( ! is_string( $host ) ) {
 					return false;
-				} elseif ( ! is_string( $uri ) ) {
+				} else if ( ! is_string( $uri ) ) {
 					return false;
 				}
-
-				// @todo: check how this behaves in multisite
-				// Strip query params when evaluating the route
-				$queryParamPosition = strpos( $uri, '?' );
-				if ( false !== $queryParamPosition ) {
-					$uri = substr( $uri, 0, $queryParamPosition );
-				} else {
-					$uri = substr( $uri, 0 );
-				}
+ 
+				$graphql_url = wp_unslash( parse_url( site_url( self::$route ), PHP_URL_PATH ) );
+				$request_url = wp_unslash( parse_url( $uri, PHP_URL_PATH ) );
 
 				// Determine if the route is indeed a graphql request
-				$is_graphql_http_request = str_replace( '/', '', $uri ) === wp_unslash( self::$route );
+				$is_graphql_http_request = str_replace( '/', '', $request_url ) === str_replace( '/', '', $graphql_url );
 
 			}
 		}

--- a/src/Router.php
+++ b/src/Router.php
@@ -178,10 +178,14 @@ class Router {
 					return false;
 				}
 
-				// @todo: check how this behaves in multisite 
+				// @todo: check how this behaves in multisite
 				// Strip query params when evaluating the route
 				$queryParamPosition = strpos( $uri, '?' );
-				$uri                = substr( $uri, 0, $queryParamPosition );
+				if ( false !== $queryParamPosition ) {
+					$uri = substr( $uri, 0, $queryParamPosition );
+				} else {
+					$uri = substr( $uri, 0 );
+				}
 
 				// Determine if the route is indeed a graphql request
 				$is_graphql_http_request = str_replace( '/', '', $uri ) === wp_unslash( self::$route );

--- a/src/Router.php
+++ b/src/Router.php
@@ -165,7 +165,7 @@ class Router {
 			$is_graphql_http_request = true;
 
 		} else {
-			
+
 			// Check the server to determine if the GraphQL endpoint is being requested
 			if ( isset( $_SERVER['HTTP_HOST'] ) && isset( $_SERVER['REQUEST_URI'] ) ) {
 
@@ -178,7 +178,8 @@ class Router {
 					return false;
 				}
 
-				$is_graphql_http_request = boolval( preg_match('/^\/'. preg_quote(self::$route) .'\/?$/', $uri) );
+				$is_graphql_http_request = str_replace( '/', '', $uri ) === wp_unslash( self::$route );
+
 			}
 		}
 

--- a/src/Router.php
+++ b/src/Router.php
@@ -178,10 +178,7 @@ class Router {
 					return false;
 				}
 
-				$len                     = strlen( self::$route );
-
-				// the off by one offset validates it's at /graphql or /graphql/ and not /somepath/graphql
-				$is_graphql_http_request = ( substr( $uri, 1, $len ) === self::$route );
+				$is_graphql_http_request = boolval( preg_match('/^\/'. preg_quote(self::$route) .'\/?$/', $uri) );
 			}
 		}
 

--- a/src/Router.php
+++ b/src/Router.php
@@ -165,34 +165,19 @@ class Router {
 			$is_graphql_http_request = true;
 
 		} else {
-
+			
 			// Check the server to determine if the GraphQL endpoint is being requested
 			if ( isset( $_SERVER['HTTP_HOST'] ) && isset( $_SERVER['REQUEST_URI'] ) ) {
 
-				$host = wp_unslash( $_SERVER['HTTP_HOST'] );
+				// $host = wp_unslash( $_SERVER['HTTP_HOST'] );
 				$uri  = wp_unslash( $_SERVER['REQUEST_URI'] );
 
-				if ( ! is_string( $host ) ) {
-					return false;
-				} elseif ( ! is_string( $uri ) ) {
+				if ( ! is_string( $uri ) ) {
 					return false;
 				}
 
-				$full_path = $host . $uri;
-				$site_url  = site_url( self::$route );
-
-				// Strip protocol.
-				$replaced_path = preg_replace( '#^(http(s)?://)#', '', $full_path );
-				if ( ! empty( $replaced_path ) ) {
-					$full_path = $replaced_path;
-				}
-				$replaced_url = preg_replace( '#^(http(s)?://)#', '', $site_url );
-				if ( ! empty( $replaced_url ) ) {
-					$site_url = $replaced_url;
-				}
-
-				$len                     = strlen( $site_url );
-				$is_graphql_http_request = ( substr( $full_path, 0, $len ) === $site_url );
+				$len                     = strlen( self::$route );
+				$is_graphql_http_request = ( substr( $uri, 1, $len ) === self::$route );
 			}
 		}
 

--- a/src/Router.php
+++ b/src/Router.php
@@ -174,15 +174,16 @@ class Router {
 
 				if ( ! is_string( $host ) ) {
 					return false;
-				} else if ( ! is_string( $uri ) ) {
+				}
+
+				if ( ! is_string( $uri ) ) {
 					return false;
 				}
 
-				$parsed_site_url = parse_url( site_url( self::$route ), PHP_URL_PATH );
-				$graphql_url = ! empty( $parsed_site_url ) ? wp_unslash( $parsed_site_url ) : self::$route;
-
+				$parsed_site_url    = parse_url( site_url( self::$route ), PHP_URL_PATH );
+				$graphql_url        = ! empty( $parsed_site_url ) ? wp_unslash( $parsed_site_url ) : self::$route;
 				$parsed_request_url = parse_url( $uri, PHP_URL_PATH );
-				$request_url = ! empty( $parsed_request_url ) ? wp_unslash( $parsed_request_url ) : null;
+				$request_url        = ! empty( $parsed_request_url ) ? wp_unslash( $parsed_request_url ) : '';
 
 				// Determine if the route is indeed a graphql request
 				$is_graphql_http_request = str_replace( '/', '', $request_url ) === str_replace( '/', '', $graphql_url );


### PR DESCRIPTION

What does this implement/fix? Explain your changes.
---------------------------------------------------

Ignores the domain and just makes sure the configured graphql path is the root path.

Does this close any currently open issues?
------------------------------------------
fixes #2181
https://wpengine.atlassian.net/browse/NEB-844

Any other comments?
-------------------
Should write from tests, but I'll leave that to the experts. 

Right now `/graphql/this/that/the/other/`  passes. If we wanted we could test the path to make sure it's only `/graphql` or `/graphql/` but I'm not sure if it is an issue. 

Where has this been tested?
---------------------------
Tested it on my local PC as per below and also tested on WPEngine and validated it works. 

**Operating System:** …
macOS 11.16.1

**WordPress Version:** …
5.8.2
