### PR TITLE
Bug/#2183 duplicate type debug message regression

### DIFF
--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -669,7 +669,7 @@ class TypeRegistry {
 			return;
 		}
 
-		if ( isset( $this->types[ $this->format_key( $type_name ) ] ) ) {
+		if ( isset( $this->types[ $this->format_key( $type_name ) ] ) || isset( $this->type_loaders[ $this->format_key( $type_name ) ] ) ) {
 			graphql_debug(
 				sprintf( __( 'You cannot register duplicate Types to the Schema. The Type \'%1$s\' already exists in the Schema. Make sure to give new Types a unique name.', 'wp-graphql' ), $type_name ),
 				[

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -669,7 +669,7 @@ class TypeRegistry {
 			return;
 		}
 
-		if ( isset( $this->types[ $this->format_key( $type_name ) ] ) || isset( $this->type_loaders[ $this->format_key( $type_name ) ] ) ) {
+		if ( isset( $this->types[ $this->format_key( $type_name ) ] ) ) {
 			graphql_debug(
 				sprintf( __( 'You cannot register duplicate Types to the Schema. The Type \'%1$s\' already exists in the Schema. Make sure to give new Types a unique name.', 'wp-graphql' ), $type_name ),
 				[

--- a/tests/wpunit/TypesTest.php
+++ b/tests/wpunit/TypesTest.php
@@ -446,4 +446,78 @@ class TypesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$this->assertQueryError( $response, $expected );
 	}
+
+	// A regular query shouldn't have a duplicate type debug message
+	public function testQueryDoesntHaveDuplicateTypesDebugMessage() {
+		$actual = graphql([
+			'query' => '{posts{nodes{id}}}'
+		]);
+
+		// There should be no debug messages by default
+		$this->assertTrue( isset( $actual['extensions']['debug'] ) );
+		$this->assertEmpty( $actual['extensions']['debug'] );
+	}
+
+	public function testRegisterDuplicateTypesOutputsDebugMessage() {
+
+		// register duplicate types
+		register_graphql_object_type( 'NewType', [
+			'fields' => [
+				'one' => [
+					'type' => 'String'
+				]
+			]
+		]);
+		register_graphql_object_type( 'NewType', [
+			'fields' => [
+				'two' => [
+					'type' => 'String'
+				]
+			]
+		]);
+
+		$actual = graphql([
+			'query' => '{posts{nodes{id}}}'
+		]);
+
+		codecept_debug( $actual );
+
+		// There should be no debug messages by default
+		$this->assertTrue( isset( $actual['extensions']['debug'] ), 'query has debug in the extensions payload' );
+		$this->assertNotEmpty( $actual['extensions']['debug'], 'query has a debug message' );
+		$this->assertNotFalse( strpos( $actual['extensions']['debug'][0]['message'], 'duplicate'), 'debug message contains the word duplicate' );
+
+//		// clear the schema
+//		$this->clearSchema();
+//
+//		// register duplicate types
+//		register_graphql_object_type( 'NewType', [
+//			'fields' => [
+//				'one' => [
+//					'type' => 'String'
+//				]
+//			]
+//		]);
+//		register_graphql_object_type( 'NewType', [
+//			'fields' => [
+//				'two' => [
+//					'type' => 'String'
+//				]
+//			]
+//		]);
+//
+//		// query again
+//		$actual = graphql([
+//			'query' => '{posts{nodes{id}}}'
+//		]);
+//
+//		codecept_debug( $actual );
+//
+//		// There should be a debug message now!
+//		$this->assertTrue( isset( $actual['extensions']['debug'] ) );
+//		$this->assertNotEmpty( $actual['extensions']['debug'] );
+
+
+
+	}
 }


### PR DESCRIPTION

What does this implement/fix? Explain your changes.
---------------------------------------------------
This fixes the `graphql_debug()` message about Duplicate Types to work with the new lazy type loading (introduced in v1.6)

Does this close any currently open issues?
------------------------------------------
closes #2183 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

With duplicate types registered like so: 

```php
add_action( 'graphql_register_types', function() {

	register_graphql_object_type( 'NewType', [
		'fields' => [
			'one' => [
				'type' => 'String'
			]
		]
	]);
	register_graphql_object_type( 'NewType', [
		'fields' => [
			'two' => [
				'type' => 'String'
			]
		]
	]);
	register_graphql_field( 'RootQuery', 'newType', [
		'type' => 'NewType'
	]);
});
```

**Before (no debug message)**

![Screen Shot 2021-12-17 at 12 56 53 PM](https://user-images.githubusercontent.com/1260765/146600744-1c38fb7b-5830-42c3-b231-d7b02e5453eb.png)


**After (debug message shows)**

![Screen Shot 2021-12-17 at 12 57 14 PM](https://user-images.githubusercontent.com/1260765/146600722-dc0c0c73-2b3d-4ecb-ba18-f072684adffb.png)