### PR TITLE
Feature/#2179 content type name

### DIFF
--- a/src/Type/InterfaceType/ContentNode.php
+++ b/src/Type/InterfaceType/ContentNode.php
@@ -2,15 +2,10 @@
 namespace WPGraphQL\Type\InterfaceType;
 
 use Exception;
-use GraphQL\Deferred;
-use GraphQL\Type\Definition\ResolveInfo;
-use WPGraphQL\AppContext;
 use WPGraphQL\Data\Connection\ContentTypeConnectionResolver;
 use WPGraphQL\Data\Connection\EnqueuedScriptsConnectionResolver;
 use WPGraphQL\Data\Connection\EnqueuedStylesheetConnectionResolver;
-use WPGraphQL\Data\DataSource;
 use WPGraphQL\Model\Post;
-use WPGraphQL\Model\Term;
 use WPGraphQL\Registry\TypeRegistry;
 
 class ContentNode {
@@ -102,6 +97,13 @@ class ContentNode {
 
 				},
 				'fields'      => [
+					'contentTypeName'           => [
+						'type'        => [ 'non_null' => 'String' ],
+						'description' => __( 'The name of the Content Type the node belongs to', 'wp-graphql' ),
+						'resolve'     => function ( $node ) {
+							return $node->post_type;
+						},
+					],
 					'template'                  => [
 						'type'        => 'ContentTemplate',
 						'description' => __( 'The template assigned to a node of content', 'wp-graphql' ),

--- a/tests/wpunit/ContentNodeInterfaceTest.php
+++ b/tests/wpunit/ContentNodeInterfaceTest.php
@@ -73,6 +73,7 @@ class ContentNodeInterfaceTest extends \Codeception\TestCase\WPTestCase {
 		      __typename
 		      id
 		      databaseId
+		      contentTypeName
 		      ...on NodeWithTitle {
 		        title
 		      }
@@ -96,10 +97,12 @@ class ContentNodeInterfaceTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertArrayNotHasKey( 'errors', $actual );
 
 		$this->assertEquals( 'Post', $actual['data']['contentNodes']['nodes'][0]['__typename'] );
+		$this->assertEquals( 'post', $actual['data']['contentNodes']['nodes'][0]['contentTypeName'] );
 		$this->assertEquals( $post_id, $actual['data']['contentNodes']['nodes'][0]['databaseId'] );
 		$this->assertEquals( $post_id, $actual['data']['contentNodes']['nodes'][0]['postId'] );
 
 		$this->assertEquals( 'Page', $actual['data']['contentNodes']['nodes'][1]['__typename'] );
+		$this->assertEquals( 'page', $actual['data']['contentNodes']['nodes'][1]['contentTypeName'] );
 		$this->assertEquals( $page_id, $actual['data']['contentNodes']['nodes'][1]['databaseId'] );
 		$this->assertEquals( $page_id, $actual['data']['contentNodes']['nodes'][1]['pageId'] );
 	}


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This adds a `contentTypeName` to the ContentNode interface. 

Users can now query the `contentTypeName` field on any Node that implements the `ContentNode` Interface. 

ex: 

```
{
  posts {
    nodes {
      __typename
      contentTypeName
      id
      title
    }
  }
}
```
![Screen Shot 2021-12-20 at 12 24 44 PM](https://user-images.githubusercontent.com/1260765/146821526-4dc53405-fe96-4cf2-9ba4-71e2adfe6ca6.png)

Does this close any currently open issues?
------------------------------------------
closes #2179 

Any other comments?
-------------------
In many cases `__typename` would be recommended, but there are some cases where the underlying WordPress type is needed, and this exposes it.

