### PR TITLE
Fix type of parent ID when creating a response to a parent comment

### DIFF
--- a/src/Mutation/CommentCreate.php
+++ b/src/Mutation/CommentCreate.php
@@ -59,7 +59,7 @@ class CommentCreate {
 				'description' => __( 'Type of comment.', 'wp-graphql' ),
 			],
 			'parent'      => [
-				'type'        => 'ID',
+				'type'        => 'Int',
 				'description' => __( 'Parent comment of current comment.', 'wp-graphql' ),
 			],
 			'date'        => [


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
I was trying to create a comment under another comment (i.e. reply to a comment), but it looks like setting `parent` in `createComment`'s input field does not work at all, the comment is posted directly under the post, not a response to another comment.
Changed the type of `parent` to `Int` and the issue was gone.
According to https://developer.wordpress.org/reference/functions/wp_new_comment/, when creating a new comment with parent ID, `comment_parent` field should be integer, not ID/string. Currently we're taking `parent` argument as ID.

Does this close any currently open issues?
------------------------------------------
No


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
There's no error message for this bug.
The following command would post the comment directly under post 3538 (`parent` does not work):
```
mutation CREATE_COMMENT {
  createComment(
    input: {commentOn: 3538 (Post ID), content: "This is a test comment, yo", author: "Jason", authorEmail: "xyz@gmail.com", parent: "Y29tbWVudDoxMDQ1"  (Parent Comment ID)}
  ) {
    success
  }
}
```
The following command would post a response under comment "Y29tbWVudDoxMDQ1" / 1045 after I changed type of `parent` to `Int`:
```
mutation CREATE_COMMENT {
  createComment(
    input: {commentOn: 3538 (Post ID), content: "This is a test comment, yo", author: "Jason", authorEmail: "xyz@gmail.com", parent: 1045  (Parent Comment ID)}
  ) {
    success
  }
}
```

Any other comments?
-------------------
First time creating a PR to an open source project, please let me know if I need to change anything, thanks!


Where has this been tested?
---------------------------
**Operating System:** Windows 11

**WordPress Version:** 5.8.2
