### PR TITLE
Model.php: Don't call `prepare_fields()` statically

### DIFF
--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -98,7 +98,7 @@ abstract class Model {
 		}
 
 		$this->init();
-		self::prepare_fields();
+		$this->prepare_fields();
 
 	}
 


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
The Model constructor should call `prepare_fields()` statically, since A) the method isnt `static`, and B) the method relies on other non-static methods, so it cannot be made `static`.



Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
Screenshot of the issue:
![image](https://user-images.githubusercontent.com/29322304/147838071-0651b9e1-0d30-4fd0-a6f5-60ea5e784b68.png)


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2).

**WordPress Version:** 5.8.2
