### PR TITLE
#2199 - pass TypeRegistry to the schema config filter

### DIFF
--- a/src/Registry/SchemaRegistry.php
+++ b/src/Registry/SchemaRegistry.php
@@ -2,6 +2,7 @@
 
 namespace WPGraphQL\Registry;
 
+use Exception;
 use GraphQL\Type\SchemaConfig;
 use WPGraphQL\WPSchema;
 
@@ -20,7 +21,7 @@ class SchemaRegistry {
 	/**
 	 * SchemaRegistry constructor.
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function __construct() {
 		$this->type_registry = \WPGraphQL::get_type_registry();
@@ -30,7 +31,7 @@ class SchemaRegistry {
 	 * Returns the Schema to use for execution of the GraphQL Request
 	 *
 	 * @return WPSchema
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function get_schema() {
 
@@ -47,7 +48,7 @@ class SchemaRegistry {
 		/**
 		 * Create a new instance of the Schema
 		 */
-		$schema = new WPSchema( $schema_config );
+		$schema = new WPSchema( $schema_config, $this->type_registry );
 
 		/**
 		 * Filter the Schema

--- a/src/Router.php
+++ b/src/Router.php
@@ -191,8 +191,7 @@ class Router {
 					$site_url = $replaced_url;
 				}
 
-				$len                     = strlen( $site_url );
-				$is_graphql_http_request = ( substr( $full_path, 0, $len ) === $site_url );
+				$is_graphql_http_request = ( strpos( $full_path, $site_url ) === 0 ) && strlen( $full_path ) === strlen( $site_url );
 			}
 		}
 

--- a/src/Router.php
+++ b/src/Router.php
@@ -174,24 +174,19 @@ class Router {
 
 				if ( ! is_string( $host ) ) {
 					return false;
-				} elseif ( ! is_string( $uri ) ) {
+				}
+
+				if ( ! is_string( $uri ) ) {
 					return false;
 				}
 
-				$full_path = $host . $uri;
-				$site_url  = site_url( self::$route );
+				$parsed_site_url    = parse_url( site_url( self::$route ), PHP_URL_PATH );
+				$graphql_url        = ! empty( $parsed_site_url ) ? wp_unslash( $parsed_site_url ) : self::$route;
+				$parsed_request_url = parse_url( $uri, PHP_URL_PATH );
+				$request_url        = ! empty( $parsed_request_url ) ? wp_unslash( $parsed_request_url ) : '';
 
-				// Strip protocol.
-				$replaced_path = preg_replace( '#^(http(s)?://)#', '', $full_path );
-				if ( ! empty( $replaced_path ) ) {
-					$full_path = $replaced_path;
-				}
-				$replaced_url = preg_replace( '#^(http(s)?://)#', '', $site_url );
-				if ( ! empty( $replaced_url ) ) {
-					$site_url = $replaced_url;
-				}
-
-				$is_graphql_http_request = ( strpos( $full_path, $site_url ) === 0 ) && strlen( $full_path ) === strlen( $site_url );
+				// Determine if the route is indeed a graphql request
+				$is_graphql_http_request = str_replace( '/', '', $request_url ) === str_replace( '/', '', $graphql_url );
 			}
 		}
 

--- a/src/WPSchema.php
+++ b/src/WPSchema.php
@@ -4,6 +4,7 @@ namespace WPGraphQL;
 
 use GraphQL\Type\Schema;
 use GraphQL\Type\SchemaConfig;
+use WPGraphQL\Registry\TypeRegistry;
 
 /**
  * Class WPSchema
@@ -32,10 +33,11 @@ class WPSchema extends Schema {
 	 * WPSchema constructor.
 	 *
 	 * @param SchemaConfig $config The config for the Schema.
+	 * @param TypeRegistry $type_registry
 	 *
 	 * @since 0.0.9
 	 */
-	public function __construct( SchemaConfig $config ) {
+	public function __construct( SchemaConfig $config, TypeRegistry $type_registry ) {
 
 		$this->config = $config;
 
@@ -46,7 +48,7 @@ class WPSchema extends Schema {
 		 *
 		 * @since 0.0.9
 		 */
-		$this->filterable_config = apply_filters( 'graphql_schema_config', $config );
+		$this->filterable_config = apply_filters( 'graphql_schema_config', $config, $type_registry );
 		parent::__construct( $this->filterable_config );
 	}
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This passes the TypeRegistry through the "graphql_schema_config" filter


Does this close any currently open issues?
------------------------------------------
closes #2199 


Any other comments?
-------------------
This also includes a bugfix follow-up to #2182 
