### PR TITLE
Add filter for post insert type during create

### DIFF
--- a/docs/graphql-resolvers.md
+++ b/docs/graphql-resolvers.md
@@ -9,7 +9,7 @@ On this page you will find information about what GraphQL resolvers are and how 
 
 A GraphQL Schema consists of Types and Fields, which declares what is possible to be asked for. Resolvers are the functions that execute when a field is asked for.
 
-When registering a field to theWPGraphQL Schema defining a resolver is optional.
+When registering a field to the WPGraphQL Schema defining a resolver is optional.
 
 **Registering a field *without* a resolver:**
 

--- a/src/Mutation/PostObjectCreate.php
+++ b/src/Mutation/PostObjectCreate.php
@@ -296,17 +296,6 @@ class PostObjectCreate {
 			}
 
 			/**
-			 * Fires after a single term is created or updated via a GraphQL mutation
-			 *
-			 * The dynamic portion of the hook name, `$taxonomy->name` refers to the taxonomy of the term being mutated
-			 *
-			 * @param int    $post_id       Inserted post ID
-			 * @param array  $args          The args used to insert the term
-			 * @param string $mutation_name The name of the mutation being performed
-			 */
-			do_action( "graphql_insert_{$post_type_object->name}", $post_id, $input, $mutation_name );
-
-			/**
 			 * This updates additional data not part of the posts table (postmeta, terms, other relations, etc)
 			 *
 			 * The input for the postObjectMutation will be passed, along with the $new_post_id for the

--- a/src/Mutation/PostObjectCreate.php
+++ b/src/Mutation/PostObjectCreate.php
@@ -296,6 +296,17 @@ class PostObjectCreate {
 			}
 
 			/**
+			 * Fires after a single term is created or updated via a GraphQL mutation
+			 *
+			 * The dynamic portion of the hook name, `$taxonomy->name` refers to the taxonomy of the term being mutated
+			 *
+			 * @param int    $post_id       Inserted post ID
+			 * @param array  $args          The args used to insert the term
+			 * @param string $mutation_name The name of the mutation being performed
+			 */
+			do_action( "graphql_insert_{$post_type_object->name}", $post_id, $input, $mutation_name );
+
+			/**
 			 * This updates additional data not part of the posts table (postmeta, terms, other relations, etc)
 			 *
 			 * The input for the postObjectMutation will be passed, along with the $new_post_id for the

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -1157,7 +1157,12 @@ class TypeRegistry {
 						// Translators: The placeholder is the name of the mutation
 						throw new Exception( sprintf( __( 'The resolver for the mutation %s is not callable', 'wp-graphql' ), $mutation_name ) );
 					}
-					$payload = call_user_func( $mutateAndGetPayload, $args['input'], $context, $info );
+
+					$filtered_input = apply_filters( 'graphql_mutation_input', $args['input'], $context, $info, $mutation_name );
+
+					$payload = call_user_func( $mutateAndGetPayload, $filtered_input, $context, $info );
+
+					do_action( 'graphql_mutation_response', $payload, $filtered_input, $args['input'], $context, $info, $mutation_name );
 
 					if ( ! empty( $args['input']['clientMutationId'] ) ) {
 						$payload['clientMutationId'] = $args['input']['clientMutationId'];


### PR DESCRIPTION
A filter on the post input args for specific post type when post is created. Allows for args to be filtered, validated, renamed, etc.

Used for [this persisted queries work ](https://github.com/wp-graphql/wp-graphql-persisted-queries/pull/40) to filter input on mutation create/update. 

re: https://github.com/wp-graphql/wp-graphql-persisted-queries/issues/38 