### PR TITLE
Feature/#2202 pass root value to request

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -207,7 +207,10 @@ class Request {
 	 */
 	protected function get_root_value() {
 
-		$root_value = null;
+		/**
+		 * Set the root value based on what was passed to the request
+		 */
+		$root_value = isset( $this->data['root_value'] ) && ! empty( $this->data['root_value'] ) ? $this->data['root_value'] : null;
 
 		/**
 		 * Return the filtered root value

--- a/tests/wpunit/AccessFunctionsTest.php
+++ b/tests/wpunit/AccessFunctionsTest.php
@@ -470,4 +470,27 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		codecept_debug( $actual );
 
 	}
+
+	public function testSettingRootValueWhenCallingGraphqlFunction() {
+
+		$value = uniqid( 'test-', true );
+
+		register_graphql_field( 'RootQuery', 'someRootField', [
+			'type' => 'String',
+			'resolve' => function( $root ) {
+				return isset ( $root['someRootField' ] ) ? $root['someRootField' ] : null;
+			}
+		] );
+
+		$actual = graphql([
+			'query' => '{someRootField}',
+			'root_value' => [
+				'someRootField' => $value
+			]
+		]);
+
+		$this->assertSame( $value, $actual['data']['someRootField'] );
+
+
+	}
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This allows a `root_value` to be passed to the `graphql()` function as well as the underlying Request class, to be used as the default root value, which is typically null. 


Does this close any currently open issues?
------------------------------------------
closes #2202 
