### PR TITLE
Add WP 5.8 to the matrix of docker images built

### DIFF
--- a/.github/workflows/deploy-docker-image.yml
+++ b/.github/workflows/deploy-docker-image.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         php: [ '8.0', '7.4', '7.3' ]
-        wordpress: [ '5.7.2', '5.6', '5.5.3' ]
+        wordpress: [ '5.8', '5.7.2', '5.6', '5.5.3' ]
         exclude:
           - php: '8.0'
             wordpress: '5.5.3'


### PR DESCRIPTION
Add WP version 5.8 to the matrix list of versions built and deployed for available docker images.  
This version is already included in the 'Testing Integration' action.