### PR TITLE
fix: TermObject uri strips host:port path instead of home_url()

### DIFF
--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -815,7 +815,8 @@ class TypeRegistry {
 	 *
 	 * @param string $type_name The name of the Type to get from the registry
 	 *
-	 * @return mixed|null
+	 * @return mixed
+	 * |null
 	 */
 	public function get_type( string $type_name ) {
 

--- a/src/Type/ObjectType/TermObject.php
+++ b/src/Type/ObjectType/TermObject.php
@@ -52,7 +52,14 @@ class TermObject {
 					],
 					'uri'               => [
 						'resolve' => function ( $term, $args, $context, $info ) {
-							return ! empty( $term->link ) ? str_ireplace( home_url(), '', $term->link ) : '';
+							$url = $term->link;
+							if ( ! empty( $url ) ) {
+								$parsed = wp_parse_url( $url );
+								if ( isset( $parsed ) ) {
+									return $parsed['path'];
+								}
+							}
+							return '';
 						},
 					],
 				],

--- a/src/Type/ObjectType/TermObject.php
+++ b/src/Type/ObjectType/TermObject.php
@@ -56,7 +56,7 @@ class TermObject {
 							if ( ! empty( $url ) ) {
 								$parsed = wp_parse_url( $url );
 								if ( isset( $parsed ) ) {
-									$path = isset( $parsed['path'] ) ? $parsed['path']: '';
+									$path  = isset( $parsed['path'] ) ? $parsed['path'] : '';
 									$query = isset( $parsed['query'] ) ? ( '?' . $parsed['query'] ) : '';
 									return trim( $path . $query );
 								}

--- a/src/Type/ObjectType/TermObject.php
+++ b/src/Type/ObjectType/TermObject.php
@@ -56,8 +56,9 @@ class TermObject {
 							if ( ! empty( $url ) ) {
 								$parsed = wp_parse_url( $url );
 								if ( isset( $parsed ) ) {
+									$path = isset( $parsed['path'] ) ? $parsed['path']: '';
 									$query = isset( $parsed['query'] ) ? ( '?' . $parsed['query'] ) : '';
-									return trim( $parsed['path'] . $query );
+									return trim( $path . $query );
 								}
 							}
 							return '';

--- a/src/Type/ObjectType/TermObject.php
+++ b/src/Type/ObjectType/TermObject.php
@@ -56,7 +56,8 @@ class TermObject {
 							if ( ! empty( $url ) ) {
 								$parsed = wp_parse_url( $url );
 								if ( isset( $parsed ) ) {
-									return $parsed['path'];
+									$query = isset( $parsed['query'] ) ? ( '?' . $parsed['query'] ) : '';
+									return trim( $parsed['path'] . $query );
 								}
 							}
 							return '';

--- a/tests/wpunit/TermNodeTest.php
+++ b/tests/wpunit/TermNodeTest.php
@@ -638,8 +638,9 @@ class TermNodeTest extends \Codeception\TestCase\WPTestCase {
 			'taxonomy' => 'category'
 		]);
 
-		$link = get_term_link( $cat->term_id );
-		$term_uri = str_ireplace( home_url(), '', $link );
+		$link     = get_term_link( $cat->term_id );
+		$parsed   = parse_url( $link );
+		$term_uri = $parsed['path'] . '?' . $parsed['query'];
 
 		$expected = [
 			'__typename' => 'Category',

--- a/tests/wpunit/TermNodeTest.php
+++ b/tests/wpunit/TermNodeTest.php
@@ -638,9 +638,8 @@ class TermNodeTest extends \Codeception\TestCase\WPTestCase {
 			'taxonomy' => 'category'
 		]);
 
-		$link     = get_term_link( $cat->term_id );
-		$parsed   = parse_url( $link );
-		$term_uri = $parsed['path'] . '?' . $parsed['query'];
+		$link = get_term_link( $cat->term_id );
+		$term_uri = str_ireplace( home_url(), '', $link );
 
 		$expected = [
 			'__typename' => 'Category',
@@ -671,6 +670,54 @@ class TermNodeTest extends \Codeception\TestCase\WPTestCase {
 			'variables' => [
 				'id' => get_term_link( $cat->term_id ),
 			]
+		]);
+
+		codecept_debug( $actual );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertSame( $expected, $actual['data']['termNode'] );
+
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function testQueryTermLinkCustomHostPortReplacement() {
+		add_filter( 'term_link', function ( $term_link ) {
+			$frontend_uri = 'http://localhost:3000/';
+			$site_url     = trailingslashit( site_url() );
+
+			$this->assertNotSame( site_url(), $frontend_uri );
+
+			return str_replace( $site_url, $frontend_uri, $term_link );
+		});
+		$cat = $this->factory()->term->create_and_get([
+			'taxonomy' => 'category',
+		]);
+
+		$link     = get_term_link( $cat->term_id );
+		$parsed   = parse_url( $link );
+		$term_uri = $parsed['path'] . '?' . $parsed['query'];
+
+		$expected = [
+			'__typename' => 'Category',
+			'uri'        => $term_uri,
+		];
+
+		$query = '
+		query TermByGlobalId($id:ID!){
+		  termNode(id: $id idType:URI) {
+		    __typename
+		    uri
+		  }
+		}
+		';
+
+		$actual = graphql([
+			'query'     => $query,
+			'variables' => [
+				'id' => get_term_link( $cat->term_id ),
+			],
 		]);
 
 		codecept_debug( $actual );

--- a/tests/wpunit/TermNodeTest.php
+++ b/tests/wpunit/TermNodeTest.php
@@ -683,6 +683,10 @@ class TermNodeTest extends \Codeception\TestCase\WPTestCase {
 	 * @throws Exception
 	 */
 	public function testQueryTermLinkCustomHostPortReplacement() {
+		$cat = $this->factory()->term->create_and_get([
+			'taxonomy' => 'category',
+		]);
+
 		add_filter( 'term_link', function ( $term_link ) {
 			$frontend_uri = 'http://localhost:3000/';
 			$site_url     = trailingslashit( site_url() );
@@ -691,17 +695,15 @@ class TermNodeTest extends \Codeception\TestCase\WPTestCase {
 
 			return str_replace( $site_url, $frontend_uri, $term_link );
 		});
-		$cat = $this->factory()->term->create_and_get([
-			'taxonomy' => 'category',
-		]);
 
 		$link     = get_term_link( $cat->term_id );
 		$parsed   = parse_url( $link );
-		$term_uri = $parsed['path'] . '?' . $parsed['query'];
+		$term_uri = $parsed['path'] ?? '';
+		$term_uri .= isset( $parsed['query'] ) ? ( '?' . $parsed['query'] ) : '';
 
 		$expected = [
 			'__typename' => 'Category',
-			'uri'        => $term_uri,
+			'uri'        => trim( $term_uri ),
 		];
 
 		$query = '
@@ -726,6 +728,5 @@ class TermNodeTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertSame( $expected, $actual['data']['termNode'] );
 
 	}
-
 
 }

--- a/tests/wpunit/TermNodeTest.php
+++ b/tests/wpunit/TermNodeTest.php
@@ -687,7 +687,7 @@ class TermNodeTest extends \Codeception\TestCase\WPTestCase {
 			$frontend_uri = 'http://localhost:3000/';
 			$site_url     = trailingslashit( site_url() );
 
-			$this->assertNotSame( site_url(), $frontend_uri );
+			$this->assertNotSame( $site_url, $frontend_uri );
 
 			return str_replace( $site_url, $frontend_uri, $term_link );
 		});


### PR DESCRIPTION
This way the uri will return a relative path even if the term link does not contain the home_url()

When for example` get_term_link( $this->data->term_id )` returns a term link that contains a `host:port` path different than `home_url()`

`get_term_link( $this->data->term_id)` -> `http://localhost:3000/post/example`
`home_url-> 'http://example.com`

The term uri is not substituted correctly because the `home_url` substring does not exist in the `get_term_link` result

`uri` ->` http://localhost:3000/post/example`

With this fix it will replace any host:port path from the term link

`uri` -> `/post/example`

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Provides a fix for https://github.com/wp-graphql/wp-graphql/issues/2210

Does this close any currently open issues?
------------------------------------------
Yes: https://github.com/wp-graphql/wp-graphql/issues/2210


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------



Where has this been tested?
---------------------------
**Operating System:** …
MacOs BigSur
**WordPress Version:**
5.8.3

