### PR TITLE
Add a note to the GraphQL Introspection setting when Debug mode is enabled

### DIFF
--- a/src/Admin/Settings/Settings.php
+++ b/src/Admin/Settings/Settings.php
@@ -202,7 +202,7 @@ class Settings {
 			[
 				'name'     => 'public_introspection_enabled',
 				'label'    => __( 'Enable Public Introspection', 'wp-graphql' ),
-				'desc'     => __( 'GraphQL Introspection is a feature that allows the GraphQL Schema to be queried. For Production and Staging environments, WPGraphQL will by default limit introspection queries to authenticated requests. Checking this enables Introspection for public requests, regardless of environment.', 'wp-graphql' ),
+				'desc'     => sprintf( __( 'GraphQL Introspection is a feature that allows the GraphQL Schema to be queried. For Production and Staging environments, WPGraphQL will by default limit introspection queries to authenticated requests. Checking this enables Introspection for public requests, regardless of environment. %s ', 'wp-graphql' ), true === \WPGraphQL::debug() ? '<strong>' . __( 'NOTE: This setting is force enabled because GraphQL Debug Mode is enabled. ', 'wp-graphql' ) . '</strong>' : null ),
 				'type'     => 'checkbox',
 				'default'  => ( 'local' === $this->get_wp_environment() || 'development' === $this->get_wp_environment() ) ? 'on' : 'off',
 				'value'    => true === \WPGraphQL::debug() ? 'on' : get_graphql_setting( 'public_introspection_enabled', 'off' ),


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This adds a note to the GraphQL Introspection setting, that it is force-enabled when GraphQL Debug mode is enabled

![Screen Shot 2022-01-14 at 7 57 30 AM](https://user-images.githubusercontent.com/1260765/149536261-ee64f5c1-de37-4e22-bf25-0699f706b547.png)

Does this close any currently open issues?
------------------------------------------
closes #2217 
