### PR TITLE
Add avatar field to the CommentAuthor Type and Commenter Interface

### DIFF
--- a/src/Type/InterfaceType/CommenterInterface.php
+++ b/src/Type/InterfaceType/CommenterInterface.php
@@ -39,7 +39,7 @@ class CommenterInterface {
 					],
 					'description' => __( 'The globally unique identifier for the comment author.', 'wp-graphql' ),
 				],
-				'avatar' => [
+				'avatar'       => [
 					'type'        => 'Avatar',
 					'description' => __( 'Avatar object for user. The avatar object can be retrieved in different sizes by specifying the size argument.', 'wp-graphql' ),
 				],

--- a/src/Type/InterfaceType/CommenterInterface.php
+++ b/src/Type/InterfaceType/CommenterInterface.php
@@ -39,6 +39,10 @@ class CommenterInterface {
 					],
 					'description' => __( 'The globally unique identifier for the comment author.', 'wp-graphql' ),
 				],
+				'avatar' => [
+					'type'        => 'Avatar',
+					'description' => __( 'Avatar object for user. The avatar object can be retrieved in different sizes by specifying the size argument.', 'wp-graphql' ),
+				],
 				'databaseId'   => [
 					'type'        => [
 						'non_null' => 'Int',

--- a/src/Type/ObjectType/CommentAuthor.php
+++ b/src/Type/ObjectType/CommentAuthor.php
@@ -38,8 +38,8 @@ class CommentAuthor {
 						'type'        => 'Boolean',
 						'description' => __( 'Whether the object is restricted from the current viewer', 'wp-graphql' ),
 					],
-					'avatar'            => [
-						'args'        => [
+					'avatar'       => [
+						'args'    => [
 							'size'         => [
 								'type'         => 'Int',
 								'description'  => __( 'The size attribute of the avatar field can be used to fetch avatars of different sizes. The value corresponds to the dimension in pixels to fetch. The default is 96 pixels.', 'wp-graphql' ),
@@ -55,7 +55,7 @@ class CommentAuthor {
 							],
 
 						],
-						'resolve'     => function ( $comment_author, $args, $context, $info ) {
+						'resolve' => function ( $comment_author, $args, $context, $info ) {
 
 							if ( ! isset( $comment_author->email ) ) {
 								return null;

--- a/src/Type/ObjectType/CommentAuthor.php
+++ b/src/Type/ObjectType/CommentAuthor.php
@@ -2,6 +2,8 @@
 
 namespace WPGraphQL\Type\ObjectType;
 
+use WPGraphQL\Data\DataSource;
+
 class CommentAuthor {
 
 	/**
@@ -35,6 +37,49 @@ class CommentAuthor {
 					'isRestricted' => [
 						'type'        => 'Boolean',
 						'description' => __( 'Whether the object is restricted from the current viewer', 'wp-graphql' ),
+					],
+					'avatar'            => [
+						'args'        => [
+							'size'         => [
+								'type'         => 'Int',
+								'description'  => __( 'The size attribute of the avatar field can be used to fetch avatars of different sizes. The value corresponds to the dimension in pixels to fetch. The default is 96 pixels.', 'wp-graphql' ),
+								'defaultValue' => 96,
+							],
+							'forceDefault' => [
+								'type'        => 'Boolean',
+								'description' => __( 'Whether to always show the default image, never the Gravatar. Default false' ),
+							],
+							'rating'       => [
+								'type'        => 'AvatarRatingEnum',
+								'description' => __( 'The rating level of the avatar.', 'wp-graphql' ),
+							],
+
+						],
+						'resolve'     => function ( $comment_author, $args, $context, $info ) {
+
+							if ( ! isset( $comment_author->email ) ) {
+								return null;
+							}
+
+							$avatar_args = [];
+							if ( is_numeric( $args['size'] ) ) {
+								$avatar_args['size'] = absint( $args['size'] );
+								if ( ! $avatar_args['size'] ) {
+									$avatar_args['size'] = 96;
+								}
+							}
+
+							if ( ! empty( $args['forceDefault'] ) && true === $args['forceDefault'] ) {
+								$avatar_args['force_default'] = true;
+							}
+
+							if ( ! empty( $args['rating'] ) ) {
+								$avatar_args['rating'] = esc_sql( $args['rating'] );
+							}
+
+							$avatar = get_avatar_data( $comment_author->email, $avatar_args );
+							return ! empty( $avatar ) ? new \WPGraphQL\Model\Avatar( $avatar ) : null;
+						},
 					],
 				],
 			]

--- a/src/Type/ObjectType/User.php
+++ b/src/Type/ObjectType/User.php
@@ -143,8 +143,6 @@ class User {
 						'description' => __( 'Whether the object is restricted from the current viewer', 'wp-graphql' ),
 					],
 					'avatar'            => [
-						'type'        => 'Avatar',
-						'description' => __( 'Avatar object for user. The avatar object can be retrieved in different sizes by specifying the size argument.', 'wp-graphql' ),
 						'args'        => [
 							'size'         => [
 								'type'         => 'Int',

--- a/src/Type/ObjectType/User.php
+++ b/src/Type/ObjectType/User.php
@@ -143,7 +143,7 @@ class User {
 						'description' => __( 'Whether the object is restricted from the current viewer', 'wp-graphql' ),
 					],
 					'avatar'            => [
-						'args'        => [
+						'args'    => [
 							'size'         => [
 								'type'         => 'Int',
 								'description'  => __( 'The size attribute of the avatar field can be used to fetch avatars of different sizes. The value corresponds to the dimension in pixels to fetch. The default is 96 pixels.', 'wp-graphql' ),
@@ -159,7 +159,7 @@ class User {
 							],
 
 						],
-						'resolve'     => function ( $user, $args, $context, $info ) {
+						'resolve' => function ( $user, $args, $context, $info ) {
 
 							$avatar_args = [];
 							if ( is_numeric( $args['size'] ) ) {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

This PR does the following:

- Add the avatar field to the Commenter interface so that User and CommentAuthor can both query for avatar field
- Update resolver in CommentAuthor to properly resolve to the avatar
- remove description for avatar field from User type to let it inherit from the Interface
- add tests to query for avatar on comment from a user and a guest author

This allows for the `avatar` field to be queried from User and CommentAuthor Types. 

Before, the avatar was returned only for the User type, but not the CommentAuthor type, so querying for comment authors meant only getting the avatar field for comments written by authors that are also users. 

Now public "guest" authors also will return an avatar. 

For example:

This is now a valid query:
```graphql
query {
  posts {
    nodes {
      comments {
        edges {
          node {
            author {
              node {
                url
                name
                avatar { # get the avatar whether it's a User or guest author (CommentAuthor)
                   url
                }
              }
            }
          }
        }
      }
    }
  }
}
```

Does this close any currently open issues?
------------------------------------------
closes #2245 