### PR TITLE
#2065 - Fix bug where settings registered with Types not recognized by WPGraphQL cause errors with Introspection

### DIFF
--- a/src/Mutation/UpdateSettings.php
+++ b/src/Mutation/UpdateSettings.php
@@ -196,7 +196,7 @@ class UpdateSettings {
 			 * Dynamically build the individual setting,
 			 * then add it to $updatable_settings_options
 			 */
-			$updatable_settings_options[ $individual_setting_key ] = [
+			$updatable_settings_options[ Utils::format_field_name( $individual_setting_key ) ] = [
 				'option' => $key,
 				'group'  => $setting['group'],
 			];

--- a/src/Mutation/UpdateSettings.php
+++ b/src/Mutation/UpdateSettings.php
@@ -2,8 +2,11 @@
 
 namespace WPGraphQL\Mutation;
 
+use Exception;
 use GraphQL\Error\UserError;
 use WPGraphQL\Data\DataSource;
+use WPGraphQL\Registry\TypeRegistry;
+use WPGraphQL\Utils\Utils;
 
 /**
  * Class UpdateSettings
@@ -15,16 +18,28 @@ class UpdateSettings {
 	/**
 	 * Registers the CommentCreate mutation.
 	 *
+	 * @param TypeRegistry $type_registry The WPGraphQL TypeRegistry
+	 *
 	 * @return void
-	 * @throws \Exception
+	 * @throws Exception
 	 */
-	public static function register_mutation() {
+	public static function register_mutation( TypeRegistry $type_registry ) {
+
+		$output_fields = self::get_output_fields( $type_registry );
+		$input_fields  = self::get_input_fields( $type_registry );
+
+		if ( empty( $output_fields ) || empty( $input_fields ) ) {
+			return;
+		}
+
 		register_graphql_mutation(
 			'updateSettings',
 			[
-				'inputFields'         => self::get_input_fields(),
-				'outputFields'        => self::get_output_fields(),
-				'mutateAndGetPayload' => self::mutate_and_get_payload(),
+				'inputFields'         => $input_fields,
+				'outputFields'        => $output_fields,
+				'mutateAndGetPayload' => function ( $input ) use ( $type_registry ) {
+					return self::mutate_and_get_payload( $input, $type_registry );
+				},
 			]
 		);
 	}
@@ -32,10 +47,12 @@ class UpdateSettings {
 	/**
 	 * Defines the mutation input field configuration.
 	 *
+	 * @param TypeRegistry $type_registry The WPGraphQL TypeRegistry
+	 *
 	 * @return array
 	 */
-	public static function get_input_fields() {
-		$allowed_settings = DataSource::get_allowed_settings();
+	public static function get_input_fields( TypeRegistry $type_registry ) {
+		$allowed_settings = DataSource::get_allowed_settings( $type_registry );
 
 		$input_fields = [];
 
@@ -46,6 +63,10 @@ class UpdateSettings {
 			 * for the individual settings
 			 */
 			foreach ( $allowed_settings as $key => $setting ) {
+
+				if ( ! isset( $setting['type'] ) || ! $type_registry->get_type( $setting['type'] ) ) {
+					continue;
+				}
 
 				/**
 				 * Determine if the individual setting already has a
@@ -87,26 +108,28 @@ class UpdateSettings {
 	/**
 	 * Defines the mutation output field configuration.
 	 *
+	 * @param TypeRegistry $type_registry The WPGraphQL TypeRegistry
+	 *
 	 * @return array
 	 */
-	public static function get_output_fields() {
-		$output_fields = [];
+	public static function get_output_fields( TypeRegistry $type_registry ) {
 
 		/**
 		 * Get the allowed setting groups and their fields
 		 */
-		$allowed_setting_groups = DataSource::get_allowed_settings_by_group();
+		$allowed_setting_groups = DataSource::get_allowed_settings_by_group( $type_registry );
 
 		if ( ! empty( $allowed_setting_groups ) && is_array( $allowed_setting_groups ) ) {
 			foreach ( $allowed_setting_groups as $group => $setting_type ) {
 
-				$setting_type = DataSource::format_group_name( $group );
+				$setting_type      = DataSource::format_group_name( $group );
+				$setting_type_name = Utils::format_type_name( $setting_type . 'Settings' );
 
-				$output_fields[ $setting_type . 'Settings' ] = [
-					'type'        => $setting_type . 'Settings',
-					'description' => sprintf( __( 'Update the %s setting.', 'wp-graphql' ), $setting_type ),
-					'resolve'     => function () use ( $setting_type ) {
-						return $setting_type;
+				$output_fields[ $setting_type_name ] = [
+					'type'        => $setting_type_name,
+					'description' => sprintf( __( 'Update the %s setting.', 'wp-graphql' ), $setting_type_name ),
+					'resolve'     => function () use ( $setting_type_name ) {
+						return $setting_type_name;
 					},
 				];
 
@@ -130,70 +153,75 @@ class UpdateSettings {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @return callable
+	 * @param array $input The mutation input
+	 * @param TypeRegistry $type_registry The WPGraphQL TypeRegistry
+	 *
+	 * @return array
+	 *
+	 * @throws UserError
 	 */
-	public static function mutate_and_get_payload() {
-		return function ( $input ) {
+	public static function mutate_and_get_payload( array $input, TypeRegistry $type_registry ): array {
+		/**
+		 * Check that the user can manage setting options
+		 */
+		if ( ! current_user_can( 'manage_options' ) ) {
+			throw new UserError( __( 'Sorry, you are not allowed to edit settings as this user.', 'wp-graphql' ) );
+		}
+
+		/**
+		 * The $updatable_settings_options will store all of the allowed
+		 * settings in a WP ready format
+		 */
+		$updatable_settings_options = [];
+
+		$allowed_settings = DataSource::get_allowed_settings( $type_registry );
+
+		/**
+		 * Loop through the $allowed_settings and build the insert options array
+		 */
+		foreach ( $allowed_settings as $key => $setting ) {
+
 			/**
-			 * Check that the user can manage setting options
+			 * Determine if the individual setting already has a
+			 * REST API name, if not use the option name.
+			 * Sanitize the field name to be camelcase
 			 */
-			if ( ! current_user_can( 'manage_options' ) ) {
-				throw new UserError( __( 'Sorry, you are not allowed to edit settings as this user.', 'wp-graphql' ) );
+			if ( isset( $setting['show_in_rest']['name'] ) && ! empty( $setting['show_in_rest']['name'] ) ) {
+				$individual_setting_key = lcfirst( $setting['group'] . 'Settings' . str_replace( '_', '', ucwords( $setting['show_in_rest']['name'], '_' ) ) );
+			} else {
+				$individual_setting_key = lcfirst( $setting['group'] . 'Settings' . str_replace( '_', '', ucwords( $key, '_' ) ) );
 			}
 
 			/**
-			 * The $updatable_settings_options will store all of the allowed
-			 * settings in a WP ready format
+			 * Dynamically build the individual setting,
+			 * then add it to $updatable_settings_options
 			 */
-			$updatable_settings_options = [];
+			$updatable_settings_options[ $individual_setting_key ] = [
+				'option' => $key,
+				'group'  => $setting['group'],
+			];
 
-			$allowed_settings = DataSource::get_allowed_settings();
+		}
+
+		foreach ( $input as $key => $value ) {
+			/**
+			 * Throw an error if the input field is the site url,
+			 * as we do not want users changing it and breaking all
+			 * the things
+			 */
+			if ( 'generalSettingsUrl' === $key ) {
+				throw new UserError( __( 'Sorry, that is not allowed, speak with your site administrator to change the site URL.', 'wp-graphql' ) );
+			}
 
 			/**
-			 * Loop through the $allowed_settings and build the insert options array
+			 * Check to see that the input field exists in settings, if so grab the option
+			 * name and update the option
 			 */
-			foreach ( $allowed_settings as $key => $setting ) {
-
-				/**
-				 * Determine if the individual setting already has a
-				 * REST API name, if not use the option name.
-				 * Sanitize the field name to be camelcase
-				 */
-				if ( isset( $setting['show_in_rest']['name'] ) && ! empty( $setting['show_in_rest']['name'] ) ) {
-					$individual_setting_key = lcfirst( $setting['group'] . 'Settings' . str_replace( '_', '', ucwords( $setting['show_in_rest']['name'], '_' ) ) );
-				} else {
-					$individual_setting_key = lcfirst( $setting['group'] . 'Settings' . str_replace( '_', '', ucwords( $key, '_' ) ) );
-				}
-
-				/**
-				 * Dynamically build the individual setting,
-				 * then add it to $updatable_settings_options
-				 */
-				$updatable_settings_options[ $individual_setting_key ] = [
-					'option' => $key,
-					'group'  => $setting['group'],
-				];
-
+			if ( array_key_exists( $key, $updatable_settings_options ) ) {
+				update_option( $updatable_settings_options[ $key ]['option'], $value );
 			}
+		}
 
-			foreach ( $input as $key => $value ) {
-				/**
-				 * Throw an error if the input field is the site url,
-				 * as we do not want users changing it and breaking all
-				 * the things
-				 */
-				if ( 'generalSettingsUrl' === $key ) {
-					throw new UserError( __( 'Sorry, that is not allowed, speak with your site administrator to change the site URL.', 'wp-graphql' ) );
-				}
-
-				/**
-				 * Check to see that the input field exists in settings, if so grab the option
-				 * name and update the option
-				 */
-				if ( array_key_exists( $key, $updatable_settings_options ) ) {
-					update_option( $updatable_settings_options[ $key ]['option'], $value );
-				}
-			}
-		};
+		return $updatable_settings_options;
 	}
 }

--- a/src/Type/ObjectType/SettingGroup.php
+++ b/src/Type/ObjectType/SettingGroup.php
@@ -2,27 +2,44 @@
 
 namespace WPGraphQL\Type\ObjectType;
 
+use Exception;
 use GraphQL\Error\UserError;
 use WPGraphQL\Data\DataSource;
+use WPGraphQL\Registry\TypeRegistry;
 
 class SettingGroup {
 
 	/**
 	 * Register each settings group to the GraphQL Schema
 	 *
-	 * @param string $group_name The name of the setting group
-	 * @param string $group      The settings group config
+	 * @param string       $group_name    The name of the setting group
+	 * @param string       $group         The settings group config
+	 * @param TypeRegistry $type_registry The WPGraphQL TypeRegistry
 	 *
-	 * @return void
+	 * @return string|null
+	 * @throws Exception
 	 */
-	public static function register_settings_group( string $group_name, string $group ) {
-		register_graphql_object_type(
+	public static function register_settings_group( string $group_name, string $group, TypeRegistry $type_registry ) {
+
+		$fields = self::get_settings_group_fields( $group_name, $group, $type_registry );
+
+		// if the settings group doesn't have any fields that
+		// will map to the WPGraphQL Schema,
+		// don't register the settings group Type to the schema
+		if ( empty( $fields ) ) {
+			return null;
+		}
+
+		$type_registry->register_object_type(
 			ucfirst( $group_name ) . 'Settings',
 			[
 				'description' => sprintf( __( 'The %s setting type', 'wp-graphql' ), $group_name ),
-				'fields'      => self::get_settings_group_fields( $group_name, $group ),
+				'fields'      => $fields,
 			]
 		);
+
+		return ucfirst( $group_name ) . 'Settings';
+
 	}
 
 	/**
@@ -30,18 +47,22 @@ class SettingGroup {
 	 *
 	 * @param string $group_name Name of the settings group to retrieve fields for
 	 * @param string $group      The settings group config
+	 * @param TypeRegistry $type_registry The WPGraphQL TypeRegistry
 	 *
 	 * @return array
 	 */
-	public static function get_settings_group_fields( string $group_name, string $group ) {
+	public static function get_settings_group_fields( string $group_name, string $group, TypeRegistry $type_registry ) {
 
-		$setting_fields = DataSource::get_setting_group_fields( $group );
-
-		$fields = [];
+		$setting_fields = DataSource::get_setting_group_fields( $group, $type_registry );
+		$fields         = [];
 
 		if ( ! empty( $setting_fields ) && is_array( $setting_fields ) ) {
 
 			foreach ( $setting_fields as $key => $setting_field ) {
+
+				if ( ! isset( $setting_field['type'] ) || ! $type_registry->get_type( $setting_field['type'] ) ) {
+					continue;
+				}
 
 				/**
 				 * Determine if the individual setting already has a
@@ -66,7 +87,7 @@ class SettingGroup {
 					 * then add it to the fields array
 					 */
 					$fields[ $field_key ] = [
-						'type'        => $setting_field['type'],
+						'type'        => $type_registry->get_type( $setting_field['type'] ),
 						'description' => isset( $setting_field['description'] ) && ! empty( $setting_field['description'] ) ? $setting_field['description'] : sprintf( __( 'The %s Settings Group', 'wp-graphql' ), $setting_field['type'] ),
 						'resolve'     => function ( $root, array $args, $context, $info ) use ( $setting_field ) {
 

--- a/src/Utils/InstrumentSchema.php
+++ b/src/Utils/InstrumentSchema.php
@@ -149,6 +149,7 @@ class InstrumentSchema {
 						$result = Executor::defaultFieldResolver( $source, $args, $context, $info );
 					} else {
 						$result = $field_resolver( $source, $args, $context, $info );
+
 					}
 				}
 

--- a/tests/wpunit/SettingsMutationsTest.php
+++ b/tests/wpunit/SettingsMutationsTest.php
@@ -430,6 +430,8 @@ class SettingsMutationsTest extends \Codeception\TestCase\WPTestCase  {
 			];
 		}
 
+		codecept_debug( $actual );
+
 		/**
 		 * Compare the actual output vs the expected output
 		 */

--- a/tests/wpunit/SettingsMutationsTest.php
+++ b/tests/wpunit/SettingsMutationsTest.php
@@ -30,6 +30,8 @@ class SettingsMutationsTest extends \Codeception\TestCase\WPTestCase  {
 
 	public function setUp(): void {
 
+		WPGraphQL::clear_schema();
+
 		$this->subscriber = $this->factory->user->create( [
 			'role' => 'subscriber',
 		] );
@@ -467,6 +469,46 @@ class SettingsMutationsTest extends \Codeception\TestCase\WPTestCase  {
 		$start_of_week = $actual['data']['updateSettings']['generalSettings']['startOfWeek'];
 
 		$this->assertEquals( 0, $start_of_week);
+	}
+
+	public function testRegisteringSettingWithUnderscoresAllowsSettingToBeMutated() {
+
+		register_setting( 'my_setting_group', 'my_setting_field', [
+			'show_in_rest' => true,
+			'type'         => 'string',
+		] );
+
+		wp_set_current_user( $this->admin );
+
+		$query = '
+		mutation updateSettings( $input: UpdateSettingsInput! ) {
+		  updateSettings( input: $input ) { 
+		    allSettings {
+		      mySettingGroupSettingsMySettingField
+		    }
+		    mySettingGroupSettings {
+		      mySettingField
+		    }
+		  }
+		}
+		';
+
+		$unique_value = uniqid( 'test', true );
+
+		$actual = graphql([
+			'query' => $query,
+			'variables' => [
+				'input' => [
+					'mySettingGroupSettingsMySettingField' => $unique_value
+				]
+			]
+		]);
+
+		codecept_debug( $actual );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertSame( $unique_value, $actual['data']['updateSettings']['allSettings']['mySettingGroupSettingsMySettingField'] );
+		$this->assertSame( $unique_value, $actual['data']['updateSettings']['mySettingGroupSettings']['mySettingField'] );
 	}
 
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

This PR addresses a bug where settings registered using the `register_setting()` API are mapped to the WPGraphQL Schema, even if the `type` defined is an invalid GraphQL Type.

This fixes the bug by only mapping settings that have a valid type defined (`string`, `integer`, etc). 

Settings that have an arbitrary type such as `array` or `object` are no longer mapped to the Schema. 

for example:

```php
register_setting( 'my_setting_group', 'my_setting_field', [ 
  'show_in_rest' => true, 
  'type' => 'string',
  'sanitize_callback' => 'sanitize_text_field', 
] );
```

Would map to the Schema and be queryable like so: 

```graphql
{
  mySettingGroupSettings {
    mySettingField
  }
}
```

and also queryable like so: 

```graphql
{
  allSettings {
    mySettingGroupSettingsMySettingField
  }
}
```

And the setting could be mutated like so:

```graphql
mutation {
  updateSettings(
    input: {mySettingGroupSettingsMySettingField: "updated value"}
  ) {
    allSettings {
      mySettingGroupSettingsMySettingField
    }
    mySettingGroupSettings {
      mySettingField
    }
  }
}
```

With a response like so: 

```json
{
  "data": {
    "updateSettings": {
      "allSettings": {
        "mySettingGroupSettingsMySettingField": "updated value"
      },
      "mySettingGroupSettings": {
        "mySettingField": "updated value"
      }
    }
  }
}
```

Does this close any currently open issues?
------------------------------------------

I believe this PR closes the following issues:

- closes #2049 
- closes #2234 
- closes #2065 
- closes #2067 
- closes #2104 

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

## Google Web Stories plugin conflict

### BEFORE

Here's a screenshot before this PR, showing that when the Google Web Stories plugin is active alongside WPGraphQL, the schema fails to load and instead returns errors when the Introspection query is executed to load GraphiQL:

![CleanShot 2022-03-02 at 14 12 44](https://user-images.githubusercontent.com/1260765/156450546-c0174524-6faa-49ff-822c-0761d9747e66.png)

### AFTER

Here's a screenshot showing the Schema Loaded and GraphiQL being used with the "Google Web Stories" plugin active

![CleanShot 2022-03-02 at 14 08 00](https://user-images.githubusercontent.com/1260765/156449896-aad784dc-83e9-476a-9533-08a64863e2fa.png)


## Stackable plugin conflict

### BEFORE

Here's a screenshot before this PR, showing that when the Stackable plugin is active alongside WPGraphQL, the schema fails to load and instead returns errors when the Introspection query is executed to load GraphiQL:

![CleanShot 2022-03-02 at 14 12 44](https://user-images.githubusercontent.com/1260765/156450546-c0174524-6faa-49ff-822c-0761d9747e66.png)

### AFTER

Here's a screenshot showing GraphiQL IDE querying settings from Stackable (and Google Web Stories) and showing both of those plugins active in the admin. 

![CleanShot 2022-03-02 at 14 11 12](https://user-images.githubusercontent.com/1260765/156450295-4310da88-1e73-486d-96cb-da20cbf7da38.png)
