### PR TITLE
Bug/#2268 graphiql changes overwhelms browser history

### DIFF
--- a/packages/wpgraphiql/components/App/App.js
+++ b/packages/wpgraphiql/components/App/App.js
@@ -72,17 +72,8 @@ export const AppWithContext = () => {
       <QueryParams config={filteredQueryParamsConfig}>
         {(renderProps) => {
           const { query, setQuery } = renderProps;
-
-          const updateQuery = (query) => {
-            console.log( {
-              current: history.state,
-              updateQuery: query
-            })
-            setQuery(query);
-          }
-
           return (
-            <AppContextProvider queryParams={query} setQueryParams={updateQuery}>
+            <AppContextProvider queryParams={query} setQueryParams={setQuery}>
               <ApolloProvider client={client(getEndpoint())}>
                 <FilteredApp />
               </ApolloProvider>

--- a/packages/wpgraphiql/components/App/App.js
+++ b/packages/wpgraphiql/components/App/App.js
@@ -21,6 +21,23 @@ const FilteredApp = () => {
   return hooks.applyFilters("graphiql_app", <Router />, { appContext });
 };
 
+
+/**
+ * QueryParamHistory object, used to define how
+ * the UseQueryParams hook should modify browser history
+ */
+const queryParamHistory = {
+  push: args => {
+    // we replace the state to not
+    // constantly add to the history for every
+    // character change
+    history.replaceState(null, null, args.href);
+  },
+  replace: args => {
+    history.replaceState(null, null, args.href);
+  }
+}
+
 /**
  * Return the app
  *
@@ -48,13 +65,24 @@ export const AppWithContext = () => {
     }
   }, []);
 
+
+
   return render ? (
-    <QueryParamProvider>
+    <QueryParamProvider history={queryParamHistory}>
       <QueryParams config={filteredQueryParamsConfig}>
         {(renderProps) => {
           const { query, setQuery } = renderProps;
+
+          const updateQuery = (query) => {
+            console.log( {
+              current: history.state,
+              updateQuery: query
+            })
+            setQuery(query);
+          }
+
           return (
-            <AppContextProvider queryParams={query} setQueryParams={setQuery}>
+            <AppContextProvider queryParams={query} setQueryParams={updateQuery}>
               <ApolloProvider client={client(getEndpoint())}>
                 <FilteredApp />
               </ApolloProvider>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This provides a custom history object to the QueryParamProvider which configures the history to be replaced, instead of pushed. 

This allows queries to be typed / changed in GraphiQL without adding a history entry in the browser for each individual change.


Does this close any currently open issues?
------------------------------------------
closes #2268 
