### PR TITLE
Release/v1.7.1

### DIFF
--- a/.github/workflows/upload-schema-artifact.yml
+++ b/.github/workflows/upload-schema-artifact.yml
@@ -1,4 +1,4 @@
-name: Schema Linter
+name: Upload Schema Artifact
 
 on:
   release:
@@ -24,7 +24,7 @@ jobs:
       - name: Setup PHP w/ Composer & WP-CLI
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.3
+          php-version: 7.4
           extensions: mbstring, intl, bcmath, exif, gd, mysqli, opcache, zip, pdo_mysql
           coverage: none
           tools: composer, wp-cli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.7.1
+
+## Chores / Bugfixes
+
+- ([#2268](https://github.com/wp-graphql/wp-graphql/pull/2268)): Fixes a bug in GraphiQL that would update browser history with every change to a query param. 
+
+
 ## 1.7.0
 
 ## Chores / Bugfixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-graphql",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "GraphQL API for WordPress",
   "homepage": "https://github.com/wp-graphql/wp-graphql#readme",
   "author": "WPGraphQL <info@wpgraphql.com> (https://www.wpgraphql.com)",

--- a/packages/wpgraphiql/components/App/App.js
+++ b/packages/wpgraphiql/components/App/App.js
@@ -21,6 +21,23 @@ const FilteredApp = () => {
   return hooks.applyFilters("graphiql_app", <Router />, { appContext });
 };
 
+
+/**
+ * QueryParamHistory object, used to define how
+ * the UseQueryParams hook should modify browser history
+ */
+const queryParamHistory = {
+  push: args => {
+    // we replace the state to not
+    // constantly add to the history for every
+    // character change
+    history.replaceState(null, null, args.href);
+  },
+  replace: args => {
+    history.replaceState(null, null, args.href);
+  }
+}
+
 /**
  * Return the app
  *
@@ -48,8 +65,10 @@ export const AppWithContext = () => {
     }
   }, []);
 
+
+
   return render ? (
-    <QueryParamProvider>
+    <QueryParamProvider history={queryParamHistory}>
       <QueryParams config={filteredQueryParamsConfig}>
         {(renderProps) => {
           const { query, setQuery } = renderProps;

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, API, Gatsby, Headless, Decoupled, React, Nextjs, Vue, Apollo, RES
 Requires at least: 5.0
 Tested up to: 5.9.1
 Requires PHP: 7.1
-Stable tag: 1.7.0
+Stable tag: 1.7.1
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -130,6 +130,13 @@ The `uri` field was non-null on some Types in the Schema but has been changed to
 Composer dependencies are no longer versioned in Github. Recommended install source is WordPress.org or using Composer to get the code from Packagist.org or WPackagist.org.
 
 == Changelog ==
+
+= 1.7.1 =
+
+**Chores / Bugfixes**
+
+- ([#2268](https://github.com/wp-graphql/wp-graphql/pull/2268)): Fixes a bug in GraphiQL that would update browser history with every change to a query param.
+
 
 = 1.7.0 =
 

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -130,7 +130,7 @@ final class WPGraphQL {
 
 		// Plugin version.
 		if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-			define( 'WPGRAPHQL_VERSION', '1.7.0' );
+			define( 'WPGRAPHQL_VERSION', '1.7.1' );
 		}
 
 		// Plugin Folder Path.

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.7.0
+ * Version: 1.7.1
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.7.0
+ * @version  1.7.1
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
# Release Notes

## Chores / Bugfixes 

- ([#2268](https://github.com/wp-graphql/wp-graphql/pull/2268)): Fixes a bug in GraphiQL that would update browser history with every change to a query param. 