### PR TITLE
#2274 - fix bug with the generalSettings.url field being removed 

### DIFF
--- a/src/Mutation/UpdateSettings.php
+++ b/src/Mutation/UpdateSettings.php
@@ -119,23 +119,6 @@ class UpdateSettings {
 		 */
 		$allowed_setting_groups = DataSource::get_allowed_settings_by_group( $type_registry );
 
-		if ( ! empty( $allowed_setting_groups ) && is_array( $allowed_setting_groups ) ) {
-			foreach ( $allowed_setting_groups as $group => $setting_type ) {
-
-				$setting_type      = DataSource::format_group_name( $group );
-				$setting_type_name = Utils::format_type_name( $setting_type . 'Settings' );
-
-				$output_fields[ $setting_type_name ] = [
-					'type'        => $setting_type_name,
-					'description' => sprintf( __( 'Update the %s setting.', 'wp-graphql' ), $setting_type_name ),
-					'resolve'     => function () use ( $setting_type_name ) {
-						return $setting_type_name;
-					},
-				];
-
-			}
-		}
-
 		/**
 		 * Get all of the settings, regardless of group
 		 */
@@ -147,6 +130,22 @@ class UpdateSettings {
 			},
 		];
 
+		if ( ! empty( $allowed_setting_groups ) && is_array( $allowed_setting_groups ) ) {
+			foreach ( $allowed_setting_groups as $group => $setting_type ) {
+
+				$setting_type      = DataSource::format_group_name( $group );
+				$setting_type_name = Utils::format_type_name( $setting_type . 'Settings' );
+
+				$output_fields[ Utils::format_field_name( $setting_type_name ) ] = [
+					'type'        => $setting_type_name,
+					'description' => sprintf( __( 'Update the %s setting.', 'wp-graphql' ), $setting_type_name ),
+					'resolve'     => function () use ( $setting_type_name ) {
+						return $setting_type_name;
+					},
+				];
+
+			}
+		}
 		return $output_fields;
 	}
 

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -536,21 +536,21 @@ class TypeRegistry {
 		 */
 		$allowed_setting_types = DataSource::get_allowed_settings_by_group( $this );
 
-		if ( ! empty( $allowed_setting_types ) && is_array( $allowed_setting_types ) ) {
+		/**
+		 * The url is not a registered setting for multisite, so this is a polyfill
+		 * to expose the URL to the Schema for multisite sites
+		 */
+		if ( is_multisite() ) {
+			$this->register_field( 'GeneralSettings', 'url', [
+				'type'        => 'String',
+				'description' => __( 'Site URL.', 'wp-graphql' ),
+				'resolve'     => function () {
+					return get_site_url();
+				},
+			] );
+		}
 
-			/**
-			 * The url is not a registered setting for multisite, so this is a polyfill
-			 * to expose the URL to the Schema for multisite sites
-			 */
-			if ( is_multisite() ) {
-				register_graphql_field( 'GeneralSettings', 'url', [
-					'type'        => 'String',
-					'description' => __( 'Site URL.', 'wp-graphql' ),
-					'resolve'     => function () {
-						return get_site_url();
-					},
-				] );
-			}
+		if ( ! empty( $allowed_setting_types ) && is_array( $allowed_setting_types ) ) {
 
 			foreach ( $allowed_setting_types as $group_name => $setting_type ) {
 

--- a/src/Type/ObjectType/SettingGroup.php
+++ b/src/Type/ObjectType/SettingGroup.php
@@ -30,7 +30,7 @@ class SettingGroup {
 			return null;
 		}
 
-		register_graphql_object_type(
+		$type_registry->register_object_type(
 			ucfirst( $group_name ) . 'Settings',
 			[
 				'description' => sprintf( __( 'The %s setting type', 'wp-graphql' ), $group_name ),
@@ -95,8 +95,10 @@ class SettingGroup {
 							 * Check to see if the user querying the email field has the 'manage_options' capability
 							 * All other options should be public by default
 							 */
-							if ( ( 'admin_email' === $setting_field['key'] ) && ! current_user_can( 'manage_options' ) ) {
-								throw new UserError( __( 'Sorry, you do not have permission to view this setting.', 'wp-graphql' ) );
+							if ( 'admin_email' === $setting_field['key'] ) {
+								if ( ! current_user_can( 'manage_options' ) ) {
+									throw new UserError( __( 'Sorry, you do not have permission to view this setting.', 'wp-graphql' ) );
+								}
 							}
 
 							$option = ! empty( $setting_field['key'] ) ? get_option( $setting_field['key'] ) : null;

--- a/src/Type/ObjectType/SettingGroup.php
+++ b/src/Type/ObjectType/SettingGroup.php
@@ -30,7 +30,7 @@ class SettingGroup {
 			return null;
 		}
 
-		$type_registry->register_object_type(
+		register_graphql_object_type(
 			ucfirst( $group_name ) . 'Settings',
 			[
 				'description' => sprintf( __( 'The %s setting type', 'wp-graphql' ), $group_name ),
@@ -95,10 +95,8 @@ class SettingGroup {
 							 * Check to see if the user querying the email field has the 'manage_options' capability
 							 * All other options should be public by default
 							 */
-							if ( 'admin_email' === $setting_field['key'] ) {
-								if ( ! current_user_can( 'manage_options' ) ) {
-									throw new UserError( __( 'Sorry, you do not have permission to view this setting.', 'wp-graphql' ) );
-								}
+							if ( ( 'admin_email' === $setting_field['key'] ) && ! current_user_can( 'manage_options' ) ) {
+								throw new UserError( __( 'Sorry, you do not have permission to view this setting.', 'wp-graphql' ) );
 							}
 
 							$option = ! empty( $setting_field['key'] ) ? get_option( $setting_field['key'] ) : null;


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This updates the call to `register_graphql_field` to use `$this->register_field()` for the multisite `generalSettings.url` field

Does this close any currently open issues?
------------------------------------------
closes #2274 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

## Before (v1.6.12)

In v1.6.12, we can see that we can succesfully query for:

```graphql
{
  generalSettings {
    dateFormat
    url
  }
}
```

![CleanShot 2022-03-07 at 10 01 11](https://user-images.githubusercontent.com/1260765/157081767-1ae296a8-12d3-4b55-a4ec-2419f036c72d.png)

## Regression (v1.7.1)

In v1.7.1 we can see that the same leads to an error, as the field `generalSettings.url` is not in the Schema

![CleanShot 2022-03-07 at 09 59 33](https://user-images.githubusercontent.com/1260765/157081422-f03ae916-47ce-4f82-94da-f9ad197ca1a1.png)

## After (current PR)

With this change, we can query the field again:

![CleanShot 2022-03-07 at 09 59 05](https://user-images.githubusercontent.com/1260765/157081343-8ac2feef-a898-4ccc-94db-ec5f8b236682.png)


Any other comments?
-------------------

This PR doesn't have a test for this, as we don't have the test environment properly setup to run tests in multisite. 

I created this issue (https://github.com/wp-graphql/wp-graphql/issues/2275) to follow-up.
