### PR TITLE
For repos that extend the docker testing image and dont have a package.json

### DIFF
--- a/docker/testing.entrypoint.sh
+++ b/docker/testing.entrypoint.sh
@@ -90,12 +90,16 @@ echo "Running composer install"
 COMPOSER_MEMORY_LIMIT=-1 composer install --no-interaction
 
 ## Install JavaScript Dependencies
-echo "Running npm install"
-npm ci
+if [ -f package.json ]; then
+    echo "Running npm install"
+    npm ci
 
-## Build the JavaScript app
-echo "Building the JavaScript app"
-npm build
+    ## Build the JavaScript app
+    echo "Building the JavaScript app"
+    npm build
+else
+    echo "Skipping npm install"
+fi
 
 # Install pcov/clobber if PHP7.1+
 if version_gt $PHP_VERSION 7.0 && [[ -n "$COVERAGE" ]] && [[ -z "$USING_XDEBUG" ]]; then


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
When another repo extends the docker file format of wp-graphql (ex. wp-graphql-labs), but doesn't have a package.json file of it's own, running the testing image fails for that repo.  This fix will not run `npm` commands during docker container run/up if the package.json file does not exist.  Prints/echos a message stating that.


Does this close any currently open issues?
------------------------------------------
No


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
<img width="1189" alt="Screen Shot 2022-03-07 at 2 48 05 PM" src="https://user-images.githubusercontent.com/749603/157115463-e0c11151-915e-4670-b9ee-4e5f9d379314.png">


Any other comments?
-------------------
With the fix, prints "Skipping npm install"

<img width="532" alt="Screen Shot 2022-03-07 at 2 49 00 PM" src="https://user-images.githubusercontent.com/749603/157115592-4ba2ecbb-2bad-453a-94e7-bf72943139e4.png">



Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
