### PR TITLE
Add composer post-install script

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -30,5 +30,4 @@
 /phpstan.neon.dist export-ignore
 /schema.graphql export-ignore
 /node_modules export-ignore
-/packages export-ignore
 /artifacts export-ignore

--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,10 @@
     "fix-cs": [
       "php ./vendor/bin/phpcbf"
     ],
-    "phpstan": ["phpstan analyze --ansi --memory-limit=1G"]
+    "phpstan": ["phpstan analyze --ansi --memory-limit=1G"],
+    "post-install-cmd": [
+      "npm ci && npm run build"
+    ]
   },
   "archive": {
     "exclude": [
@@ -98,7 +101,8 @@
       "!.wordpress-org/",
       "docs/",
       "wp-graphql.zip",
-      "!build"
+      "!build",
+      "packages"
     ]
   }
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR updates the composer scripts to include a post-install script which installs npm dependencies and builds the graphiql app. 

This:

- update .gitattributes, to **_not_** ignore the packages directory, as it includes packages needed to build the JS files
- update `composer.json` to exclude the packages directory for plugin builds. The final result, after building the plugin, does not need the packages directory


Does this close any currently open issues?
------------------------------------------
closes #2273 


Any other comments?
-------------------
We should be able to also remove the `npm install` / `npm run build` scripts from workflows that already run composer install, as this will be redundant now.
