### PR TITLE
Release/v1.7.2

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -30,5 +30,4 @@
 /phpstan.neon.dist export-ignore
 /schema.graphql export-ignore
 /node_modules export-ignore
-/packages export-ignore
 /artifacts export-ignore

--- a/.github/workflows/deploy-to-wordpress.yml
+++ b/.github/workflows/deploy-to-wordpress.yml
@@ -18,12 +18,7 @@ jobs:
       - name: Install PHP dependencies
         run: |
           composer install --no-dev --optimize-autoloader
-      - name: Install NPM Dependencies
-        run: |
-          npm install
-      - name: Build JavaScript App (GraphiQL)
-        run: |
-          npm run build
+
       - name: WordPress Plugin Deploy
         uses: 10up/action-wordpress-plugin-deploy@stable
         env:

--- a/.github/workflows/graphiql-e2e-tests.yml
+++ b/.github/workflows/graphiql-e2e-tests.yml
@@ -38,9 +38,7 @@ jobs:
       - name: Install Composer Dependencies
         run: |
           composer install --no-dev
-      - name: Npm install and build
-        run: |
-          npm ci && npm run build
+
       - name: Install WordPress
         run: |
           npm run wp-env start

--- a/.github/workflows/graphiql-unit-tests.yml
+++ b/.github/workflows/graphiql-unit-tests.yml
@@ -39,9 +39,6 @@ jobs:
         run: |
           composer install --no-dev
 
-      - name: Npm install and build
-        run: |
-          npm install && npm run build
       - name: Install WordPress
         run: |
           npm run wp-env start

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,23 @@
 # Changelog
 
+## 1.7.2
+
+### Chores / Bugfixes
+
+- ([#2276](https://github.com/wp-graphql/wp-graphql/pull/2276)): Fixes a bug where `generalSettings.url` field was not in the Schema for multisite installs. 
+- ([#2278](https://github.com/wp-graphql/wp-graphql/pull/2278)): Adds a composer post-install script that installs JS dependencies and builds the JS app when `composer install` is run
+- ([#2277](https://github.com/wp-graphql/wp-graphql/pull/2277)): Adds a condition to the docker image to only run `npm` scripts if the project has a package.json. Thanks @markkelnar!
+
 ## 1.7.1
 
-## Chores / Bugfixes
+### Chores / Bugfixes
 
 - ([#2268](https://github.com/wp-graphql/wp-graphql/pull/2268)): Fixes a bug in GraphiQL that would update browser history with every change to a query param. 
 
 
 ## 1.7.0
 
-## Chores / Bugfixes
+### Chores / Bugfixes
 
 - ([#2228](https://github.com/wp-graphql/wp-graphql/pull/2228)): Allows optional fields to be set to empty values in the `updateUser` mutation. Thanks @victormattosvm!
 - ([#2247](https://github.com/wp-graphql/wp-graphql/pull/2247)): Add WordPress 5.9 to the automated testing matrix. Thanks @markkelnar!
@@ -18,7 +26,7 @@
 - ([#2263](https://github.com/wp-graphql/wp-graphql/pull/2263)): Adds documentation entry for WordPress Application Passwords guide. Thanks @abhisekmazumdar!
 - ([#2262](https://github.com/wp-graphql/wp-graphql/pull/2262)): Fixes a bug where settings registered via the core `register_setting()` API would cause Schema Introspection failures, causing GraphiQL and other tools to not work properly.
 
-## New Features
+### New Features
 
 - ([#2248](https://github.com/wp-graphql/wp-graphql/pull/2248)): WPGraphiQL (the GraphiQL IDE in the WordPress dashboard) has been re-built to have an extension architecture and some updated user interfaces. Thanks for contributing to this effort @scottyzen!
 - ([#2246](https://github.com/wp-graphql/wp-graphql/pull/2246)): Adds support for querying the `avatar` for the CommentAuthor Type and the Commenter Interface type.

--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,10 @@
     "fix-cs": [
       "php ./vendor/bin/phpcbf"
     ],
-    "phpstan": ["phpstan analyze --ansi --memory-limit=1G"]
+    "phpstan": ["phpstan analyze --ansi --memory-limit=1G"],
+    "post-install-cmd": [
+      "npm ci && npm run build"
+    ]
   },
   "archive": {
     "exclude": [
@@ -98,7 +101,8 @@
       "!.wordpress-org/",
       "docs/",
       "wp-graphql.zip",
-      "!build"
+      "!build",
+      "packages"
     ]
   }
 }

--- a/docker/app.post-setup.sh
+++ b/docker/app.post-setup.sh
@@ -13,3 +13,5 @@ if $( wp maintenance-mode is-active --allow-root ); then
   echo "Deactivating maintenance mode"
   wp maintenance-mode deactivate --allow-root
 fi
+
+

--- a/docker/testing.entrypoint.sh
+++ b/docker/testing.entrypoint.sh
@@ -83,23 +83,13 @@ if [ ! -f "$PROJECT_DIR/c3.php" ]; then
     curl -L 'https://raw.github.com/Codeception/c3/2.0/c3.php' > "$PROJECT_DIR/c3.php"
 fi
 
-# Install PHP dependencies
+
+# Install the PHP dependencies
 echo "Running composer update"
 COMPOSER_MEMORY_LIMIT=-1 composer update
 echo "Running composer install"
 COMPOSER_MEMORY_LIMIT=-1 composer install --no-interaction
 
-## Install JavaScript Dependencies
-if [ -f package.json ]; then
-    echo "Running npm install"
-    npm ci
-
-    ## Build the JavaScript app
-    echo "Building the JavaScript app"
-    npm build
-else
-    echo "Skipping npm install"
-fi
 
 # Install pcov/clobber if PHP7.1+
 if version_gt $PHP_VERSION 7.0 && [[ -n "$COVERAGE" ]] && [[ -z "$USING_XDEBUG" ]]; then

--- a/docker/testing.entrypoint.sh
+++ b/docker/testing.entrypoint.sh
@@ -90,12 +90,16 @@ echo "Running composer install"
 COMPOSER_MEMORY_LIMIT=-1 composer install --no-interaction
 
 ## Install JavaScript Dependencies
-echo "Running npm install"
-npm ci
+if [ -f package.json ]; then
+    echo "Running npm install"
+    npm ci
 
-## Build the JavaScript app
-echo "Building the JavaScript app"
-npm build
+    ## Build the JavaScript app
+    echo "Building the JavaScript app"
+    npm build
+else
+    echo "Skipping npm install"
+fi
 
 # Install pcov/clobber if PHP7.1+
 if version_gt $PHP_VERSION 7.0 && [[ -n "$COVERAGE" ]] && [[ -z "$USING_XDEBUG" ]]; then

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-graphql",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "GraphQL API for WordPress",
   "homepage": "https://github.com/wp-graphql/wp-graphql#readme",
   "author": "WPGraphQL <info@wpgraphql.com> (https://www.wpgraphql.com)",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, API, Gatsby, Headless, Decoupled, React, Nextjs, Vue, Apollo, RES
 Requires at least: 5.0
 Tested up to: 5.9.1
 Requires PHP: 7.1
-Stable tag: 1.7.1
+Stable tag: 1.7.2
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -130,6 +130,15 @@ The `uri` field was non-null on some Types in the Schema but has been changed to
 Composer dependencies are no longer versioned in Github. Recommended install source is WordPress.org or using Composer to get the code from Packagist.org or WPackagist.org.
 
 == Changelog ==
+
+= 1.7.2 =
+
+**Chores / Bugfixes**
+
+- ([#2276](https://github.com/wp-graphql/wp-graphql/pull/2276)): Fixes a bug where `generalSettings.url` field was not in the Schema for multisite installs.
+- ([#2278](https://github.com/wp-graphql/wp-graphql/pull/2278)): Adds a composer post-install script that installs JS dependencies and builds the JS app when `composer install` is run
+- ([#2277](https://github.com/wp-graphql/wp-graphql/pull/2277)): Adds a condition to the docker image to only run `npm` scripts if the project has a package.json. Thanks @markkelnar!
+
 
 = 1.7.1 =
 

--- a/src/Mutation/UpdateSettings.php
+++ b/src/Mutation/UpdateSettings.php
@@ -119,23 +119,6 @@ class UpdateSettings {
 		 */
 		$allowed_setting_groups = DataSource::get_allowed_settings_by_group( $type_registry );
 
-		if ( ! empty( $allowed_setting_groups ) && is_array( $allowed_setting_groups ) ) {
-			foreach ( $allowed_setting_groups as $group => $setting_type ) {
-
-				$setting_type      = DataSource::format_group_name( $group );
-				$setting_type_name = Utils::format_type_name( $setting_type . 'Settings' );
-
-				$output_fields[ $setting_type_name ] = [
-					'type'        => $setting_type_name,
-					'description' => sprintf( __( 'Update the %s setting.', 'wp-graphql' ), $setting_type_name ),
-					'resolve'     => function () use ( $setting_type_name ) {
-						return $setting_type_name;
-					},
-				];
-
-			}
-		}
-
 		/**
 		 * Get all of the settings, regardless of group
 		 */
@@ -147,6 +130,22 @@ class UpdateSettings {
 			},
 		];
 
+		if ( ! empty( $allowed_setting_groups ) && is_array( $allowed_setting_groups ) ) {
+			foreach ( $allowed_setting_groups as $group => $setting_type ) {
+
+				$setting_type      = DataSource::format_group_name( $group );
+				$setting_type_name = Utils::format_type_name( $setting_type . 'Settings' );
+
+				$output_fields[ Utils::format_field_name( $setting_type_name ) ] = [
+					'type'        => $setting_type_name,
+					'description' => sprintf( __( 'Update the %s setting.', 'wp-graphql' ), $setting_type_name ),
+					'resolve'     => function () use ( $setting_type_name ) {
+						return $setting_type_name;
+					},
+				];
+
+			}
+		}
 		return $output_fields;
 	}
 

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -536,21 +536,21 @@ class TypeRegistry {
 		 */
 		$allowed_setting_types = DataSource::get_allowed_settings_by_group( $this );
 
-		if ( ! empty( $allowed_setting_types ) && is_array( $allowed_setting_types ) ) {
+		/**
+		 * The url is not a registered setting for multisite, so this is a polyfill
+		 * to expose the URL to the Schema for multisite sites
+		 */
+		if ( is_multisite() ) {
+			$this->register_field( 'GeneralSettings', 'url', [
+				'type'        => 'String',
+				'description' => __( 'Site URL.', 'wp-graphql' ),
+				'resolve'     => function () {
+					return get_site_url();
+				},
+			] );
+		}
 
-			/**
-			 * The url is not a registered setting for multisite, so this is a polyfill
-			 * to expose the URL to the Schema for multisite sites
-			 */
-			if ( is_multisite() ) {
-				register_graphql_field( 'GeneralSettings', 'url', [
-					'type'        => 'String',
-					'description' => __( 'Site URL.', 'wp-graphql' ),
-					'resolve'     => function () {
-						return get_site_url();
-					},
-				] );
-			}
+		if ( ! empty( $allowed_setting_types ) && is_array( $allowed_setting_types ) ) {
 
 			foreach ( $allowed_setting_types as $group_name => $setting_type ) {
 

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -130,7 +130,7 @@ final class WPGraphQL {
 
 		// Plugin version.
 		if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-			define( 'WPGRAPHQL_VERSION', '1.7.1' );
+			define( 'WPGRAPHQL_VERSION', '1.7.2' );
 		}
 
 		// Plugin Folder Path.

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.7.1
+ * Version: 1.7.2
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.7.1
+ * @version  1.7.2
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
# Release Notes

## Chores / Bugfixes

- ([#2276](https://github.com/wp-graphql/wp-graphql/pull/2276)): Fixes a bug where `generalSettings.url` field was not in the Schema for multisite installs. 
- ([#2278](https://github.com/wp-graphql/wp-graphql/pull/2278)): Adds a composer post-install script that installs JS dependencies and builds the JS app when `composer install` is run
- ([#2277](https://github.com/wp-graphql/wp-graphql/pull/2277)): Adds a condition to the docker image to only run `npm` scripts if the project has a package.json. Thanks @markkelnar!
