### PR TITLE
chore: add `allow-plugins` to composer.json config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,11 @@
   },
   "config": {
     "optimize-autoloader": true,
-    "process-timeout": 0
+    "process-timeout": 0,
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true,
+      "phpstan/extension-installer": true
+    }
   },
   "autoload": {
     "files": [


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR adds the `allow-plugins` config to `composer.json`, so users running Composer v2.2.0+ can run `composer install` without the annoying prompts (pictured):

![image](https://user-images.githubusercontent.com/29322304/157736059-f4fffa09-7f16-4349-baa6-1d4ee881eded.png)



Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 + PHP 8.0.15, Composer v2.2.5

**WordPress Version:** 5.9.1
