### PR TITLE
Fix: Connections missing nodes when `before` or `after` are empty.

### DIFF
--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -470,7 +470,7 @@ abstract class AbstractConnectionResolver {
 	 * @return int|null
 	 */
 	public function get_after_offset(): ?int {
-		if ( isset( $this->args['after'] ) && ! empty( $this->args['after'] ) ) {
+		if ( ! empty( $this->args['after'] ) ) {
 			return ArrayConnection::cursorToOffset( $this->args['after'] );
 		}
 
@@ -481,7 +481,7 @@ abstract class AbstractConnectionResolver {
 	 * @return int|null
 	 */
 	public function get_before_offset(): ?int {
-		if ( isset( $this->args['before'] ) && ! empty( $this->args['before'] ) ) {
+		if ( ! empty( $this->args['before'] ) ) {
 			return ArrayConnection::cursorToOffset( $this->args['before'] );
 		}
 

--- a/src/Data/Connection/ContentTypeConnectionResolver.php
+++ b/src/Data/Connection/ContentTypeConnectionResolver.php
@@ -109,12 +109,12 @@ class ContentTypeConnectionResolver extends AbstractConnectionResolver {
 
 		$nodes = parent::get_nodes();
 
-		if ( isset( $this->args['after'] ) ) {
+		if ( ! empty( $this->args['after'] ) ) {
 			$key   = array_search( $this->get_offset(), array_keys( $nodes ), true );
 			$nodes = array_slice( $nodes, $key + 1, null, true );
 		}
 
-		if ( isset( $this->args['before'] ) ) {
+		if ( ! empty( $this->args['before'] ) ) {
 			$nodes = array_reverse( $nodes );
 			$key   = array_search( $this->get_offset(), array_keys( $nodes ), true );
 			$nodes = array_slice( $nodes, $key + 1, null, true );

--- a/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
@@ -99,12 +99,12 @@ class EnqueuedScriptsConnectionResolver extends AbstractConnectionResolver {
 
 		$nodes = parent::get_nodes();
 
-		if ( isset( $this->args['after'] ) ) {
+		if ( ! empty( $this->args['after'] ) ) {
 			$key   = array_search( $this->get_offset(), array_keys( $nodes ), true );
 			$nodes = array_slice( $nodes, $key + 1, null, true );
 		}
 
-		if ( isset( $this->args['before'] ) ) {
+		if ( ! empty( $this->args['before'] ) ) {
 			$nodes = array_reverse( $nodes );
 			$key   = array_search( $this->get_offset(), array_keys( $nodes ), true );
 			$nodes = array_slice( $nodes, $key + 1, null, true );

--- a/src/Data/Connection/EnqueuedStylesheetConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedStylesheetConnectionResolver.php
@@ -99,12 +99,12 @@ class EnqueuedStylesheetConnectionResolver extends AbstractConnectionResolver {
 
 		$nodes = parent::get_nodes();
 
-		if ( isset( $this->args['after'] ) ) {
+		if ( ! empty( $this->args['after'] ) ) {
 			$key   = array_search( $this->get_offset(), array_keys( $nodes ), true );
 			$nodes = array_slice( $nodes, $key + 1, null, true );
 		}
 
-		if ( isset( $this->args['before'] ) ) {
+		if ( ! empty( $this->args['before'] ) ) {
 			$nodes = array_reverse( $nodes );
 			$key   = array_search( $this->get_offset(), array_keys( $nodes ), true );
 			$nodes = array_slice( $nodes, $key + 1, null, true );

--- a/src/Data/Connection/PluginConnectionResolver.php
+++ b/src/Data/Connection/PluginConnectionResolver.php
@@ -81,12 +81,12 @@ class PluginConnectionResolver extends AbstractConnectionResolver {
 	 */
 	public function get_nodes() {
 		$nodes = parent::get_nodes();
-		if ( isset( $this->args['after'] ) ) {
+		if ( ! empty( $this->args['after'] ) ) {
 			$key   = array_search( $this->get_offset(), array_keys( $nodes ), true );
 			$nodes = array_slice( $nodes, $key + 1, null, true );
 		}
 
-		if ( isset( $this->args['before'] ) ) {
+		if ( ! empty( $this->args['before'] ) ) {
 			$nodes = array_reverse( $nodes );
 			$key   = array_search( $this->get_offset(), array_keys( $nodes ), true );
 			$nodes = array_slice( $nodes, $key + 1, null, true );

--- a/src/Data/Connection/TaxonomyConnectionResolver.php
+++ b/src/Data/Connection/TaxonomyConnectionResolver.php
@@ -111,12 +111,12 @@ class TaxonomyConnectionResolver extends AbstractConnectionResolver {
 
 		$nodes = parent::get_nodes();
 
-		if ( isset( $this->args['after'] ) ) {
+		if ( ! empty( $this->args['after'] ) ) {
 			$key   = array_search( $this->get_offset(), array_keys( $nodes ), true );
 			$nodes = array_slice( $nodes, $key + 1, null, true );
 		}
 
-		if ( isset( $this->args['before'] ) ) {
+		if ( ! empty( $this->args['before'] ) ) {
 			$nodes = array_reverse( $nodes );
 			$key   = array_search( $this->get_offset(), array_keys( $nodes ), true );
 			$nodes = array_slice( $nodes, $key + 1, null, true );

--- a/src/Data/Connection/ThemeConnectionResolver.php
+++ b/src/Data/Connection/ThemeConnectionResolver.php
@@ -82,12 +82,12 @@ class ThemeConnectionResolver extends AbstractConnectionResolver {
 
 		$nodes = parent::get_nodes();
 
-		if ( isset( $this->args['after'] ) ) {
+		if ( ! empty( $this->args['after'] ) ) {
 			$key   = array_search( $this->get_offset(), array_keys( $nodes ), true );
 			$nodes = array_slice( $nodes, $key + 1, null, true );
 		}
 
-		if ( isset( $this->args['before'] ) ) {
+		if ( ! empty( $this->args['before'] ) ) {
 			$nodes = array_reverse( $nodes );
 			$key   = array_search( $this->get_offset(), array_keys( $nodes ), true );
 			$nodes = array_slice( $nodes, $key + 1, null, true );

--- a/src/Data/Connection/UserConnectionResolver.php
+++ b/src/Data/Connection/UserConnectionResolver.php
@@ -133,7 +133,7 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 				} elseif ( ! empty( $orderby_input['field'] ) ) {
 
 					$order = $orderby_input['order'];
-					if ( isset( $this->args['last'] ) && ! empty( $this->args['last'] ) ) {
+					if ( ! empty( $this->args['last'] ) ) {
 						if ( 'ASC' === $order ) {
 							$order = 'DESC';
 						} else {

--- a/src/Data/Connection/UserRoleConnectionResolver.php
+++ b/src/Data/Connection/UserRoleConnectionResolver.php
@@ -91,12 +91,12 @@ class UserRoleConnectionResolver extends AbstractConnectionResolver {
 	public function get_nodes() {
 		$nodes = parent::get_nodes();
 
-		if ( isset( $this->args['after'] ) ) {
+		if ( ! empty( $this->args['after'] ) ) {
 			$key   = array_search( $this->get_offset(), array_keys( $nodes ), true );
 			$nodes = array_slice( $nodes, $key + 1, null, true );
 		}
 
-		if ( isset( $this->args['before'] ) ) {
+		if ( ! empty( $this->args['before'] ) ) {
 			$nodes = array_reverse( $nodes );
 			$key   = array_search( $this->get_offset(), array_keys( $nodes ), true );
 			$nodes = array_slice( $nodes, $key + 1, null, true );


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR fixes certain connections missing nodes when the `before` or `after` where args are empty.

Issue stems from the fact that `get_nodes()` in several connection resolvers simply checked for `isset( $this->args['{before|after'}])` before slicing the array.

Along those lines, I also got rid of the unnecessary `isset()` checks in a couple of places.

## to test:
Run the following query and confirm `withOffset` and `withoutOffset` are the same:

```graphql
{
  withOffset: taxonomies(first:2, before:""){
    nodes{
      name
    }
  }
  withoutOffset: taxonomies(first:2){
    nodes{
      name
    }
  }
}
```

`taxonomies` should be replaced with the other relevant connection types: `contentTypes`, `registeredScripts`, `registeredStylesheets`, `plugins`, `taxonomies`, `themes`, and `roles`.


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
Without PR (v1.7.2)
![image](https://user-images.githubusercontent.com/29322304/157779866-bf1653b3-a2fe-41e4-9354-aab8ef0762f5.png)


With PR:
![image](https://user-images.githubusercontent.com/29322304/157779814-8921e89c-2d5d-4107-a5f9-ec5354484157.png)




Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2) + Devilbox  + PHP v8.0.15

**WordPress Version:** v5.9.1
