### PR TITLE
fix: refactor AbstractConnectionResolver::get_nodes() to prevent children double slicing

### DIFF
--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -592,27 +592,27 @@ abstract class AbstractConnectionResolver {
 	}
 
 	/**
-	 * Get_nodes
+	 * Get_ids_for_nodes
 	 *
-	 * Get the nodes from the query.
+	 * Gets the IDs from the query.
 	 *
 	 * We slice the array to match the amount of items that was asked for, as we over-fetched
 	 * by 1 item to calculate pageInfo.
 	 *
 	 * For backward pagination, we reverse the order of nodes.
 	 *
+	 * @used-by AbstractConnectionResolver::get_nodes()
+	 *
 	 * @return array
-	 * @throws Exception
 	 */
-	public function get_nodes() {
+	public function get_ids_for_nodes() {
 		if ( empty( $this->ids ) ) {
 			return [];
 		}
 
-		$nodes = [];
-
 		$ids = $this->ids;
-		$ids = array_slice( $ids, 0, $this->query_amount, true );
+
+		$ids = array_slice( $this->ids, 0, $this->query_amount, true );
 
 		// If pagination is going backwards, revers the array of IDs
 		$ids = ! empty( $this->args['last'] ) ? array_reverse( $ids ) : $ids;
@@ -633,6 +633,24 @@ abstract class AbstractConnectionResolver {
 				}
 			}
 		}
+
+		return $ids;
+	}
+
+	/**
+	 * Get_nodes
+	 *
+	 * Get the nodes from the query.
+	 *
+	 * @uses AbstractConnectionResolver::get_ids_for_nodes()
+	 *
+	 * @return array
+	 * @throws Exception
+	 */
+	public function get_nodes() {
+		$nodes = [];
+
+		$ids = $this->get_ids_for_nodes();
 
 		foreach ( $ids as $id ) {
 			$model = $this->get_node_by_id( $id );

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -623,11 +623,11 @@ abstract class AbstractConnectionResolver {
 			// If the offset is in the array
 			if ( false !== $key ) {
 				$key = absint( $key );
-				// Slice the array from the back
 				if ( ! empty( $this->args['before'] ) ) {
+					// Slice the array from the back
 					$ids = array_slice( $ids, 0, $key, true );
-					// Slice the array from the front
 				} else {
+					// Slice the array from the front
 					$key ++;
 					$ids = array_slice( $ids, $key, null, true );
 				}

--- a/src/Data/Connection/ContentTypeConnectionResolver.php
+++ b/src/Data/Connection/ContentTypeConnectionResolver.php
@@ -111,6 +111,7 @@ class ContentTypeConnectionResolver extends AbstractConnectionResolver {
 			// Determine if the offset is in the array
 			$key = array_search( $this->get_offset(), $ids, true );
 			if ( false !== $key ) {
+				$key = absint( $key );
 				if ( ! empty( $this->args['before'] ) ) {
 					// Slice the array from the back.
 					$ids = array_slice( $ids, 0, $key, true );

--- a/src/Data/Connection/ContentTypeConnectionResolver.php
+++ b/src/Data/Connection/ContentTypeConnectionResolver.php
@@ -95,35 +95,36 @@ class ContentTypeConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * Get the nodes from the query.
-	 *
-	 * We slice the array to match the amount of items that was asked for, as we over-fetched
-	 * by 1 item to calculate pageInfo.
-	 *
-	 * For backward pagination, we reverse the order of nodes.
-	 *
-	 * @return array
-	 * @throws Exception
+	 * {@inheritDoc}
 	 */
-	public function get_nodes() {
-
-		$nodes = parent::get_nodes();
-
-		if ( isset( $this->args['after'] ) ) {
-			$key   = array_search( $this->get_offset(), array_keys( $nodes ), true );
-			$nodes = array_slice( $nodes, $key + 1, null, true );
+	public function get_ids_for_nodes() {
+		if ( empty( $this->ids ) ) {
+			return [];
 		}
 
-		if ( isset( $this->args['before'] ) ) {
-			$nodes = array_reverse( $nodes );
-			$key   = array_search( $this->get_offset(), array_keys( $nodes ), true );
-			$nodes = array_slice( $nodes, $key + 1, null, true );
-			$nodes = array_reverse( $nodes );
+		$ids = $this->ids;
+
+		// If pagination is going backwards, revers the array of IDs
+		$ids = ! empty( $this->args['last'] ) ? array_reverse( $ids ) : $ids;
+
+		if ( ! empty( $this->get_offset() ) ) {
+			// Determine if the offset is in the array
+			$key = array_search( $this->get_offset(), $ids, true );
+			if ( false !== $key ) {
+				if ( ! empty( $this->args['before'] ) ) {
+					// Slice the array from the back.
+					$ids = array_slice( $ids, 0, $key, true );
+				} else {
+					// Slice the array from the front.
+					$key ++;
+					$ids = array_slice( $ids, $key, null, true );
+				}
+			}
 		}
 
-		$nodes = array_slice( $nodes, 0, $this->query_amount, true );
+		$ids = array_slice( $ids, 0, $this->query_amount, true );
 
-		return ! empty( $this->args['last'] ) ? array_filter( array_reverse( $nodes, true ) ) : $nodes;
+		return $ids;
 	}
 
 	/**

--- a/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
@@ -85,35 +85,36 @@ class EnqueuedScriptsConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * Get the nodes from the query.
-	 *
-	 * We slice the array to match the amount of items that was asked for, as we over-fetched
-	 * by 1 item to calculate pageInfo.
-	 *
-	 * For backward pagination, we reverse the order of nodes.
-	 *
-	 * @return array
-	 * @throws Exception
+	 * {@inheritDoc}
 	 */
-	public function get_nodes() {
-
-		$nodes = parent::get_nodes();
-
-		if ( isset( $this->args['after'] ) ) {
-			$key   = array_search( $this->get_offset(), array_keys( $nodes ), true );
-			$nodes = array_slice( $nodes, $key + 1, null, true );
+	public function get_ids_for_nodes() {
+		if ( empty( $this->ids ) ) {
+			return [];
 		}
 
-		if ( isset( $this->args['before'] ) ) {
-			$nodes = array_reverse( $nodes );
-			$key   = array_search( $this->get_offset(), array_keys( $nodes ), true );
-			$nodes = array_slice( $nodes, $key + 1, null, true );
-			$nodes = array_reverse( $nodes );
+		$ids = $this->ids;
+
+		// If pagination is going backwards, revers the array of IDs
+		$ids = ! empty( $this->args['last'] ) ? array_reverse( $ids ) : $ids;
+
+		if ( ! empty( $this->get_offset() ) ) {
+			// Determine if the offset is in the array
+			$key = array_search( $this->get_offset(), $ids, true );
+			if ( false !== $key ) {
+				if ( ! empty( $this->args['before'] ) ) {
+					// Slice the array from the back.
+					$ids = array_slice( $ids, 0, $key, true );
+				} else {
+					// Slice the array from the front.
+					$key ++;
+					$ids = array_slice( $ids, $key, null, true );
+				}
+			}
 		}
 
-		$nodes = array_slice( $nodes, 0, $this->query_amount, true );
+		$ids = array_slice( $ids, 0, $this->query_amount, true );
 
-		return ! empty( $this->args['last'] ) ? array_filter( array_reverse( $nodes, true ) ) : $nodes;
+		return $ids;
 	}
 
 	/**

--- a/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
@@ -101,11 +101,12 @@ class EnqueuedScriptsConnectionResolver extends AbstractConnectionResolver {
 			// Determine if the offset is in the array
 			$key = array_search( $this->get_offset(), $ids, true );
 			if ( false !== $key ) {
+				$key = absint( $key );
 				if ( ! empty( $this->args['before'] ) ) {
-					// Slice the array from the back.
+					// Slice the array from the back
 					$ids = array_slice( $ids, 0, $key, true );
 				} else {
-					// Slice the array from the front.
+					// Slice the array from the front
 					$key ++;
 					$ids = array_slice( $ids, $key, null, true );
 				}

--- a/src/Data/Connection/EnqueuedStylesheetConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedStylesheetConnectionResolver.php
@@ -101,6 +101,7 @@ class EnqueuedStylesheetConnectionResolver extends AbstractConnectionResolver {
 			// Determine if the offset is in the array
 			$key = array_search( $this->get_offset(), $ids, true );
 			if ( false !== $key ) {
+				$key = absint( $key );
 				if ( ! empty( $this->args['before'] ) ) {
 					// Slice the array from the back.
 					$ids = array_slice( $ids, 0, $key, true );

--- a/src/Data/Connection/EnqueuedStylesheetConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedStylesheetConnectionResolver.php
@@ -85,35 +85,36 @@ class EnqueuedStylesheetConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * Get the nodes from the query.
-	 *
-	 * We slice the array to match the amount of items that was asked for, as we over-fetched
-	 * by 1 item to calculate pageInfo.
-	 *
-	 * For backward pagination, we reverse the order of nodes.
-	 *
-	 * @return array
-	 * @throws Exception
+	 * {@inheritDoc}
 	 */
-	public function get_nodes() {
-
-		$nodes = parent::get_nodes();
-
-		if ( isset( $this->args['after'] ) ) {
-			$key   = array_search( $this->get_offset(), array_keys( $nodes ), true );
-			$nodes = array_slice( $nodes, $key + 1, null, true );
+	public function get_ids_for_nodes() {
+		if ( empty( $this->ids ) ) {
+			return [];
 		}
 
-		if ( isset( $this->args['before'] ) ) {
-			$nodes = array_reverse( $nodes );
-			$key   = array_search( $this->get_offset(), array_keys( $nodes ), true );
-			$nodes = array_slice( $nodes, $key + 1, null, true );
-			$nodes = array_reverse( $nodes );
+		$ids = $this->ids;
+
+		// If pagination is going backwards, revers the array of IDs
+		$ids = ! empty( $this->args['last'] ) ? array_reverse( $ids ) : $ids;
+
+		if ( ! empty( $this->get_offset() ) ) {
+			// Determine if the offset is in the array
+			$key = array_search( $this->get_offset(), $ids, true );
+			if ( false !== $key ) {
+				if ( ! empty( $this->args['before'] ) ) {
+					// Slice the array from the back.
+					$ids = array_slice( $ids, 0, $key, true );
+				} else {
+					// Slice the array from the front.
+					$key ++;
+					$ids = array_slice( $ids, $key, null, true );
+				}
+			}
 		}
 
-		$nodes = array_slice( $nodes, 0, $this->query_amount, true );
+		$ids = array_slice( $ids, 0, $this->query_amount, true );
 
-		return ! empty( $this->args['last'] ) ? array_filter( array_reverse( $nodes, true ) ) : $nodes;
+		return $ids;
 	}
 
 	/**

--- a/src/Data/Connection/PluginConnectionResolver.php
+++ b/src/Data/Connection/PluginConnectionResolver.php
@@ -76,26 +76,36 @@ class PluginConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * @return array
-	 * @throws Exception
+	 * {@inheritDoc}
 	 */
-	public function get_nodes() {
-		$nodes = parent::get_nodes();
-		if ( isset( $this->args['after'] ) ) {
-			$key   = array_search( $this->get_offset(), array_keys( $nodes ), true );
-			$nodes = array_slice( $nodes, $key + 1, null, true );
+	public function get_ids_for_nodes() {
+		if ( empty( $this->ids ) ) {
+			return [];
 		}
 
-		if ( isset( $this->args['before'] ) ) {
-			$nodes = array_reverse( $nodes );
-			$key   = array_search( $this->get_offset(), array_keys( $nodes ), true );
-			$nodes = array_slice( $nodes, $key + 1, null, true );
-			$nodes = array_reverse( $nodes );
+		$ids = $this->ids;
+
+		// If pagination is going backwards, revers the array of IDs
+		$ids = ! empty( $this->args['last'] ) ? array_reverse( $ids ) : $ids;
+
+		if ( ! empty( $this->get_offset() ) ) {
+			// Determine if the offset is in the array
+			$key = array_search( $this->get_offset(), $ids, true );
+			if ( false !== $key ) {
+				if ( ! empty( $this->args['before'] ) ) {
+					// Slice the array from the back.
+					$ids = array_slice( $ids, 0, $key, true );
+				} else {
+					// Slice the array from the front.
+					$key ++;
+					$ids = array_slice( $ids, $key, null, true );
+				}
+			}
 		}
 
-		$nodes = array_slice( $nodes, 0, $this->query_amount, true );
+		$ids = array_slice( $ids, 0, $this->query_amount, true );
 
-		return ! empty( $this->args['last'] ) ? array_filter( array_reverse( $nodes, true ) ) : $nodes;
+		return $ids;
 	}
 
 	/**

--- a/src/Data/Connection/PluginConnectionResolver.php
+++ b/src/Data/Connection/PluginConnectionResolver.php
@@ -92,6 +92,7 @@ class PluginConnectionResolver extends AbstractConnectionResolver {
 			// Determine if the offset is in the array
 			$key = array_search( $this->get_offset(), $ids, true );
 			if ( false !== $key ) {
+				$key = absint( $key );
 				if ( ! empty( $this->args['before'] ) ) {
 					// Slice the array from the back.
 					$ids = array_slice( $ids, 0, $key, true );

--- a/src/Data/Connection/TaxonomyConnectionResolver.php
+++ b/src/Data/Connection/TaxonomyConnectionResolver.php
@@ -97,35 +97,36 @@ class TaxonomyConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * Get the nodes from the query.
-	 *
-	 * We slice the array to match the amount of items that was asked for, as we over-fetched
-	 * by 1 item to calculate pageInfo.
-	 *
-	 * For backward pagination, we reverse the order of nodes.
-	 *
-	 * @return array
-	 * @throws Exception
+	 * {@inheritDoc}
 	 */
-	public function get_nodes() {
-
-		$nodes = parent::get_nodes();
-
-		if ( isset( $this->args['after'] ) ) {
-			$key   = array_search( $this->get_offset(), array_keys( $nodes ), true );
-			$nodes = array_slice( $nodes, $key + 1, null, true );
+	public function get_ids_for_nodes() {
+		if ( empty( $this->ids ) ) {
+			return [];
 		}
 
-		if ( isset( $this->args['before'] ) ) {
-			$nodes = array_reverse( $nodes );
-			$key   = array_search( $this->get_offset(), array_keys( $nodes ), true );
-			$nodes = array_slice( $nodes, $key + 1, null, true );
-			$nodes = array_reverse( $nodes );
+		$ids = $this->ids;
+
+		// If pagination is going backwards, revers the array of IDs
+		$ids = ! empty( $this->args['last'] ) ? array_reverse( $ids ) : $ids;
+
+		if ( ! empty( $this->get_offset() ) ) {
+			// Determine if the offset is in the array
+			$key = array_search( $this->get_offset(), $ids, true );
+			if ( false !== $key ) {
+				if ( ! empty( $this->args['before'] ) ) {
+					// Slice the array from the back.
+					$ids = array_slice( $ids, 0, $key, true );
+				} else {
+					// Slice the array from the front.
+					$key ++;
+					$ids = array_slice( $ids, $key, null, true );
+				}
+			}
 		}
 
-		$nodes = array_slice( $nodes, 0, $this->query_amount, true );
+		$ids = array_slice( $ids, 0, $this->query_amount, true );
 
-		return ! empty( $this->args['last'] ) ? array_filter( array_reverse( $nodes, true ) ) : $nodes;
+		return $ids;
 	}
 
 	/**

--- a/src/Data/Connection/TaxonomyConnectionResolver.php
+++ b/src/Data/Connection/TaxonomyConnectionResolver.php
@@ -113,6 +113,7 @@ class TaxonomyConnectionResolver extends AbstractConnectionResolver {
 			// Determine if the offset is in the array
 			$key = array_search( $this->get_offset(), $ids, true );
 			if ( false !== $key ) {
+				$key = absint( $key );
 				if ( ! empty( $this->args['before'] ) ) {
 					// Slice the array from the back.
 					$ids = array_slice( $ids, 0, $key, true );

--- a/src/Data/Connection/ThemeConnectionResolver.php
+++ b/src/Data/Connection/ThemeConnectionResolver.php
@@ -84,6 +84,7 @@ class ThemeConnectionResolver extends AbstractConnectionResolver {
 			// Determine if the offset is in the array
 			$key = array_search( $this->get_offset(), $ids, true );
 			if ( false !== $key ) {
+				$key = absint( $key );
 				if ( ! empty( $this->args['before'] ) ) {
 					// Slice the array from the back.
 					$ids = array_slice( $ids, 0, $key, true );

--- a/src/Data/Connection/ThemeConnectionResolver.php
+++ b/src/Data/Connection/ThemeConnectionResolver.php
@@ -68,35 +68,36 @@ class ThemeConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * Get the nodes from the query.
-	 *
-	 * We slice the array to match the amount of items that was asked for, as we over-fetched
-	 * by 1 item to calculate pageInfo.
-	 *
-	 * For backward pagination, we reverse the order of nodes.
-	 *
-	 * @return array
-	 * @throws \Exception
+	 * {@inheritDoc}
 	 */
-	public function get_nodes() {
-
-		$nodes = parent::get_nodes();
-
-		if ( isset( $this->args['after'] ) ) {
-			$key   = array_search( $this->get_offset(), array_keys( $nodes ), true );
-			$nodes = array_slice( $nodes, $key + 1, null, true );
+	public function get_ids_for_nodes() {
+		if ( empty( $this->ids ) ) {
+			return [];
 		}
 
-		if ( isset( $this->args['before'] ) ) {
-			$nodes = array_reverse( $nodes );
-			$key   = array_search( $this->get_offset(), array_keys( $nodes ), true );
-			$nodes = array_slice( $nodes, $key + 1, null, true );
-			$nodes = array_reverse( $nodes );
+		$ids = $this->ids;
+
+		// If pagination is going backwards, revers the array of IDs
+		$ids = ! empty( $this->args['last'] ) ? array_reverse( $ids ) : $ids;
+
+		if ( ! empty( $this->get_offset() ) ) {
+			// Determine if the offset is in the array
+			$key = array_search( $this->get_offset(), $ids, true );
+			if ( false !== $key ) {
+				if ( ! empty( $this->args['before'] ) ) {
+					// Slice the array from the back.
+					$ids = array_slice( $ids, 0, $key, true );
+				} else {
+					// Slice the array from the front.
+					$key ++;
+					$ids = array_slice( $ids, $key, null, true );
+				}
+			}
 		}
 
-		$nodes = array_slice( $nodes, 0, $this->query_amount, true );
+		$ids = array_slice( $ids, 0, $this->query_amount, true );
 
-		return ! empty( $this->args['last'] ) ? array_filter( array_reverse( $nodes, true ) ) : $nodes;
+		return $ids;
 	}
 
 	/**

--- a/src/Data/Connection/UserRoleConnectionResolver.php
+++ b/src/Data/Connection/UserRoleConnectionResolver.php
@@ -85,27 +85,36 @@ class UserRoleConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * @return array
-	 * @throws Exception
+	 * {@inheritDoc}
 	 */
-	public function get_nodes() {
-		$nodes = parent::get_nodes();
-
-		if ( isset( $this->args['after'] ) ) {
-			$key   = array_search( $this->get_offset(), array_keys( $nodes ), true );
-			$nodes = array_slice( $nodes, $key + 1, null, true );
+	public function get_ids_for_nodes() {
+		if ( empty( $this->ids ) ) {
+			return [];
 		}
 
-		if ( isset( $this->args['before'] ) ) {
-			$nodes = array_reverse( $nodes );
-			$key   = array_search( $this->get_offset(), array_keys( $nodes ), true );
-			$nodes = array_slice( $nodes, $key + 1, null, true );
-			$nodes = array_reverse( $nodes );
+		$ids = $this->ids;
+
+		// If pagination is going backwards, revers the array of IDs
+		$ids = ! empty( $this->args['last'] ) ? array_reverse( $ids ) : $ids;
+
+		if ( ! empty( $this->get_offset() ) ) {
+			// Determine if the offset is in the array
+			$key = array_search( $this->get_offset(), $ids, true );
+			if ( false !== $key ) {
+				if ( ! empty( $this->args['before'] ) ) {
+					// Slice the array from the back.
+					$ids = array_slice( $ids, 0, $key, true );
+				} else {
+					// Slice the array from the front.
+					$key ++;
+					$ids = array_slice( $ids, $key, null, true );
+				}
+			}
 		}
 
-		$nodes = array_slice( $nodes, 0, $this->query_amount, true );
+		$ids = array_slice( $ids, 0, $this->query_amount, true );
 
-		return ! empty( $this->args['last'] ) ? array_filter( array_reverse( $nodes, true ) ) : $nodes;
+		return $ids;
 	}
 
 	/**

--- a/src/Data/Connection/UserRoleConnectionResolver.php
+++ b/src/Data/Connection/UserRoleConnectionResolver.php
@@ -101,6 +101,7 @@ class UserRoleConnectionResolver extends AbstractConnectionResolver {
 			// Determine if the offset is in the array
 			$key = array_search( $this->get_offset(), $ids, true );
 			if ( false !== $key ) {
+				$key = absint( $key );
 				if ( ! empty( $this->args['before'] ) ) {
 					// Slice the array from the back.
 					$ids = array_slice( $ids, 0, $key, true );


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR refactors `AbstractConnectionResolver::get_nodes()` to use a separate function (`AbstractionConnectonResolver::get_ids_for_nodes()` for slicing the query ids by the `query_amount` and `offset`.

This serves three purposes:
1. Improves the performance of child `get_nodes()` methods, since the models are only fetched for the actual nodes to return.
2. Makes extending `AbstractConnectionResolver` more DRY, since for most use cases in core, `get_nodes()` is really only used to change how the offsets are handled.
3. Fixes issues like #2087 , since currently `parent::get_nodes()` slices by `query_amount` _before_ slicing by `offset`, which is the entire reason `get_nodes()` needs to be overwritten to begin with.

Does this close any currently open issues?
------------------------------------------
#2087


Any other comments?
-------------------
 - The underlying issue is that some queries require the ids to be sliced by `query_amount` _before_ slicing by `offest`, while others need it to happen after. I see no solution to this that isn't a breaking change (if it is possible at all).
 - While this PR is _not_ a breaking change, plugins that overwrite `AbstractConnectionResolver::get_nodes()` by relying on `parent::get_nodes()` will still be broken as the latter is still slicing by `query_amount` before `offset.


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (WSL + Devilbox) + PHP 8.0.15

**WordPress Version:** 5.9.1
