### PR TITLE
Register post/page templates with get_page_templates()

### DIFF
--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -535,7 +535,7 @@ class Post extends Model {
 				},
 				'template'                  => function () {
 
-					$registered_templates = wp_get_theme()->get_post_templates();
+					$registered_templates = wp_get_theme()->get_page_templates( null, $this->data->post_type );
 
 					$template = [
 						'__typename'   => 'DefaultTemplate',
@@ -550,9 +550,9 @@ class Post extends Model {
 							return $template;
 						}
 
-						$post_type = $parent_post->post_type;
+						$registered_templates = wp_get_theme()->get_page_templates( $parent_post );
 
-						if ( ! isset( $registered_templates[ $post_type ] ) ) {
+						if ( empty( $registered_templates ) ) {
 							return $template;
 						}
 						$set_template  = get_post_meta( $this->parentDatabaseId, '_wp_page_template', true );
@@ -569,7 +569,7 @@ class Post extends Model {
 						$template_name = ! empty( $template_name ) ? $template_name : 'Default';
 
 					} else {
-						if ( ! isset( $registered_templates[ $this->data->post_type ] ) ) {
+						if ( empty( $registered_templates ) ) {
 							return $template;
 						}
 						$post_type     = $this->data->post_type;
@@ -579,8 +579,8 @@ class Post extends Model {
 						$template_name = ! empty( $template_name ) ? $template_name : 'Default';
 					}
 
-					if ( ! empty( $template_name ) && ! empty( $registered_templates[ $post_type ][ $set_template ] ) ) {
-						$name          = ucwords( $registered_templates[ $post_type ][ $set_template ] );
+					if ( ! empty( $template_name ) && ! empty( $registered_templates[ $set_template ] ) ) {
+						$name          = ucwords( $registered_templates[ $set_template ] );
 						$replaced_name = preg_replace( '/[^\w]/', '', $name );
 
 						if ( ! empty( $replaced_name ) ) {
@@ -592,7 +592,7 @@ class Post extends Model {
 
 						$template = [
 							'__typename'   => $name,
-							'templateName' => ucwords( $registered_templates[ $post_type ][ $set_template ] ),
+							'templateName' => ucwords( $registered_templates[ $set_template ] ),
 						];
 					}
 

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -280,6 +280,7 @@ class TypeRegistry {
 		Avatar::register_type();
 		Comment::register_type();
 		CommentAuthor::register_type();
+		ContentTemplate::register_content_template_types();
 		EnqueuedStylesheet::register_type();
 		EnqueuedScript::register_type();
 		MediaDetails::register_type();
@@ -362,56 +363,6 @@ class TypeRegistry {
 		UserUpdate::register_mutation();
 		UserRegister::register_mutation();
 		UpdateSettings::register_mutation( $this );
-
-		$registered_page_templates = wp_get_theme()->get_post_templates();
-
-		$page_templates['default'] = 'DefaultTemplate';
-
-		if ( ! empty( $registered_page_templates ) && is_array( $registered_page_templates ) ) {
-
-			foreach ( $registered_page_templates as $post_type_templates ) {
-				if ( ! empty( $post_type_templates ) && is_array( $post_type_templates ) ) {
-					foreach ( $post_type_templates as $file => $name ) {
-						$page_templates[ $file ] = $name;
-					}
-				}
-			}
-		}
-
-		if ( ! empty( $page_templates ) && is_array( $page_templates ) ) {
-
-			foreach ( $page_templates as $file => $name ) {
-				$name          = ucwords( $name );
-				$replaced_name = preg_replace( '/[^\w]/', '', $name );
-
-				if ( ! empty( $replaced_name ) ) {
-					$name = $replaced_name;
-				}
-
-				if ( preg_match( '/^\d/', $name ) || false === strpos( strtolower( $name ), 'template' ) ) {
-					$name = 'Template_' . $name;
-				}
-				$template_type_name = $name;
-
-				register_graphql_object_type(
-					$template_type_name,
-					[
-						'interfaces'      => [ 'ContentTemplate' ],
-						// Translators: Placeholder is the name of the GraphQL Type in the Schema
-						'description'     => __( 'The template assigned to the node', 'wp-graphql' ),
-						'fields'          => [
-							'templateName' => [
-								'resolve' => function ( $template ) {
-									return isset( $template['templateName'] ) ? $template['templateName'] : null;
-								},
-							],
-						],
-						'eagerlyLoadType' => true,
-					]
-				);
-
-			}
-		}
 
 		/**
 		 * Register PostObject types based on post_types configured to show_in_graphql

--- a/src/Type/InterfaceType/ContentTemplate.php
+++ b/src/Type/InterfaceType/ContentTemplate.php
@@ -26,4 +26,61 @@ class ContentTemplate {
 			]
 		);
 	}
+
+	/**
+	 * Register individual GraphQL objects for supported theme templates.
+	 *
+	 * @return void
+	 */
+	public static function register_content_template_types() {
+		$registered_page_templates = wp_get_theme()->get_post_templates();
+
+		$page_templates['default'] = 'DefaultTemplate';
+
+		if ( ! empty( $registered_page_templates ) && is_array( $registered_page_templates ) ) {
+
+			foreach ( $registered_page_templates as $post_type_templates ) {
+				if ( ! empty( $post_type_templates ) && is_array( $post_type_templates ) ) {
+					foreach ( $post_type_templates as $file => $name ) {
+						$page_templates[ $file ] = $name;
+					}
+				}
+			}
+		}
+
+		if ( ! empty( $page_templates ) && is_array( $page_templates ) ) {
+
+			foreach ( $page_templates as $file => $name ) {
+				$name          = ucwords( $name );
+				$replaced_name = preg_replace( '/[^\w]/', '', $name );
+
+				if ( ! empty( $replaced_name ) ) {
+					$name = $replaced_name;
+				}
+
+				if ( preg_match( '/^\d/', $name ) || false === strpos( strtolower( $name ), 'template' ) ) {
+					$name = 'Template_' . $name;
+				}
+				$template_type_name = $name;
+
+				register_graphql_object_type(
+					$template_type_name,
+					[
+						'interfaces'      => [ 'ContentTemplate' ],
+						// Translators: Placeholder is the name of the GraphQL Type in the Schema
+						'description'     => __( 'The template assigned to the node', 'wp-graphql' ),
+						'fields'          => [
+							'templateName' => [
+								'resolve' => function ( $template ) {
+									return isset( $template['templateName'] ) ? $template['templateName'] : null;
+								},
+							],
+						],
+						'eagerlyLoadType' => true,
+					]
+				);
+
+			}
+		}
+	}
 }

--- a/src/Type/InterfaceType/ContentTemplate.php
+++ b/src/Type/InterfaceType/ContentTemplate.php
@@ -33,23 +33,22 @@ class ContentTemplate {
 	 * @return void
 	 */
 	public static function register_content_template_types() {
-		$registered_page_templates = wp_get_theme()->get_post_templates();
-
 		$page_templates['default'] = 'DefaultTemplate';
 
-		if ( ! empty( $registered_page_templates ) && is_array( $registered_page_templates ) ) {
+		// Cycle through the registered post types and get the template information
+		$allowed_post_types = \WPGraphQL::get_allowed_post_types();
+		foreach ( $allowed_post_types as $post_type ) {
+			$post_type_templates = wp_get_theme()->get_page_templates( null, $post_type );
 
-			foreach ( $registered_page_templates as $post_type_templates ) {
-				if ( ! empty( $post_type_templates ) && is_array( $post_type_templates ) ) {
-					foreach ( $post_type_templates as $file => $name ) {
-						$page_templates[ $file ] = $name;
-					}
+			if ( ! empty( $post_type_templates ) && is_array( $post_type_templates ) ) {
+				foreach ( $post_type_templates as $file => $name ) {
+					$page_templates[ $file ] = $name;
 				}
 			}
 		}
 
 		if ( ! empty( $page_templates ) && is_array( $page_templates ) ) {
-
+			// Register each template to the schema
 			foreach ( $page_templates as $file => $name ) {
 				$name          = ucwords( $name );
 				$replaced_name = preg_replace( '/[^\w]/', '', $name );
@@ -79,7 +78,6 @@ class ContentTemplate {
 						'eagerlyLoadType' => true,
 					]
 				);
-
 			}
 		}
 	}

--- a/src/Type/InterfaceType/ContentTemplate.php
+++ b/src/Type/InterfaceType/ContentTemplate.php
@@ -40,10 +40,6 @@ class ContentTemplate {
 		foreach ( $allowed_post_types as $post_type ) {
 			$post_type_templates = wp_get_theme()->get_page_templates( null, $post_type );
 
-			if ( empty( $post_type_templates ) ) {
-				continue;
-			}
-
 			foreach ( $post_type_templates as $file => $name ) {
 				$page_templates[ $file ] = $name;
 			}

--- a/src/Type/InterfaceType/ContentTemplate.php
+++ b/src/Type/InterfaceType/ContentTemplate.php
@@ -40,45 +40,45 @@ class ContentTemplate {
 		foreach ( $allowed_post_types as $post_type ) {
 			$post_type_templates = wp_get_theme()->get_page_templates( null, $post_type );
 
-			if ( ! empty( $post_type_templates ) && is_array( $post_type_templates ) ) {
-				foreach ( $post_type_templates as $file => $name ) {
-					$page_templates[ $file ] = $name;
-				}
+			if ( empty( $post_type_templates ) ) {
+				continue;
+			}
+
+			foreach ( $post_type_templates as $file => $name ) {
+				$page_templates[ $file ] = $name;
 			}
 		}
 
-		if ( ! empty( $page_templates ) && is_array( $page_templates ) ) {
-			// Register each template to the schema
-			foreach ( $page_templates as $file => $name ) {
-				$name          = ucwords( $name );
-				$replaced_name = preg_replace( '/[^\w]/', '', $name );
+		// Register each template to the schema
+		foreach ( $page_templates as $file => $name ) {
+			$name          = ucwords( $name );
+			$replaced_name = preg_replace( '/[^\w]/', '', $name );
 
-				if ( ! empty( $replaced_name ) ) {
-					$name = $replaced_name;
-				}
-
-				if ( preg_match( '/^\d/', $name ) || false === strpos( strtolower( $name ), 'template' ) ) {
-					$name = 'Template_' . $name;
-				}
-				$template_type_name = $name;
-
-				register_graphql_object_type(
-					$template_type_name,
-					[
-						'interfaces'      => [ 'ContentTemplate' ],
-						// Translators: Placeholder is the name of the GraphQL Type in the Schema
-						'description'     => __( 'The template assigned to the node', 'wp-graphql' ),
-						'fields'          => [
-							'templateName' => [
-								'resolve' => function ( $template ) {
-									return isset( $template['templateName'] ) ? $template['templateName'] : null;
-								},
-							],
-						],
-						'eagerlyLoadType' => true,
-					]
-				);
+			if ( ! empty( $replaced_name ) ) {
+				$name = $replaced_name;
 			}
+
+			if ( preg_match( '/^\d/', $name ) || false === strpos( strtolower( $name ), 'template' ) ) {
+				$name = 'Template_' . $name;
+			}
+			$template_type_name = $name;
+
+			register_graphql_object_type(
+				$template_type_name,
+				[
+					'interfaces'      => [ 'ContentTemplate' ],
+					// Translators: Placeholder is the name of the GraphQL Type in the Schema
+					'description'     => __( 'The template assigned to the node', 'wp-graphql' ),
+					'fields'          => [
+						'templateName' => [
+							'resolve' => function ( $template ) {
+								return isset( $template['templateName'] ) ? $template['templateName'] : null;
+							},
+						],
+					],
+					'eagerlyLoadType' => true,
+				]
+			);
 		}
 	}
 }


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR replaces the use of `wp_get_theme()->get_post_templates()` with the filterable `wp_get_theme()->get_page_templates()`.

For sanity, the `register_graphql_object_type()` loop has been moved from class `TypeRegistry` to class `Type\InterfaceType\ContentTemplate`, following the pattern established in `RootQuery::register_post_object_fields()`, and `RootQuery::register_term_object_fields()`.


Does this close any currently open issues?
------------------------------------------
#1845 


Any other comments?
-------------------
- I would recommend the pattern used here be adopted for the rest of the registration loops in TypeRegistry. Happy to work on a PR.
- From my understanding of the previous code (unconfirmed), _all_ templates were registered to the schema, not just those used by recognized Post Types. As they could only be queried via the `templates` field on a recognized post type, I don't think we should consider this a breaking change.

Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox), PHP 8.0.15

**WordPress Version:** 5.9.2
