### PR TITLE
feat: add where args to plugin connections

### DIFF
--- a/src/Data/Connection/PluginConnectionResolver.php
+++ b/src/Data/Connection/PluginConnectionResolver.php
@@ -45,14 +45,14 @@ class PluginConnectionResolver extends AbstractConnectionResolver {
 	 */
 	public function get_ids() {
 		$ids     = [];
-		$queried = $this->get_query();
+		$queried = ! empty( $this->query ) ? $this->query : [];
 
 		if ( empty( $queried ) ) {
 			return $ids;
 		}
 
 		foreach ( $queried as $key => $item ) {
-			$ids[ $key ] = $item;
+			$ids[ $key ] = $key;
 		}
 
 		return $ids;
@@ -62,17 +62,169 @@ class PluginConnectionResolver extends AbstractConnectionResolver {
 	 * @return array|void
 	 */
 	public function get_query_args() {
+		if ( ! empty( $this->args['where']['status'] ) ) {
+			$this->args['where']['stati'] = [ $this->args['where']['status'] ];
+		} elseif ( ! empty( $this->args['where']['stati'] ) && is_string( $this->args['where']['stati'] ) ) {
+			$this->args['where']['stati'] = [ $this->args['where']['stati'] ];
+		}
 
+		return $this->args;
 	}
 
 	/**
 	 * @return array|mixed
 	 */
 	public function get_query() {
-		require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
-		// This is missing "must use" and "drop-in" plugins.
-		$plugins = apply_filters( 'all_plugins', get_plugins() );
-		return array_keys( $plugins );
+		// File has not loaded.
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		// This is missing must use and drop in plugins, so we need to fetch and merge them separately.
+		$site_plugins   = apply_filters( 'all_plugins', get_plugins() );
+		$mu_plugins     = apply_filters( 'show_advanced_plugins', true, 'mustuse' ) ? get_mu_plugins() : [];
+		$dropin_plugins = apply_filters( 'show_advanced_plugins', true, 'dropins' ) ? get_dropins() : [];
+
+		$all_plugins = array_merge( $site_plugins, $mu_plugins, $dropin_plugins );
+
+		// Bail early if no plugins.
+		if ( empty( $all_plugins ) ) {
+			return [];
+		}
+
+		// Holds the plugin names sorted by status. The other ` status =>  [ plugin_names ] ` will be added later.
+		$plugins_by_status = [
+			'mustuse' => array_flip( array_keys( $mu_plugins ) ),
+			'dropins' => array_flip( array_keys( $dropin_plugins ) ),
+		];
+
+		// Permissions.
+		$can_update           = current_user_can( 'update_plugins' );
+		$can_view_autoupdates = $can_update && function_exists( 'wp_is_auto_update_enabled_for_type' ) && wp_is_auto_update_enabled_for_type( 'plugin' );
+		$show_network_plugins = apply_filters( 'show_network_active_plugins', current_user_can( 'manage_network_plugins' ) );
+
+		// Store the plugin stati as array keys for performance.
+		$active_stati = ! empty( $this->args['where']['stati'] ) ? array_flip( $this->args['where']['stati'] ) : [];
+
+		// Get additional plugin info.
+		$upgradable_list         = $can_update && isset( $active_stati['upgrade'] ) ? get_site_transient( 'update_plugins' ) : [];
+		$recently_activated_list = isset( $active_stati['recently_activated'] ) ? get_site_option( 'recently_activated', [] ) : [];
+
+		// Loop through the plugins, add additional data, and store them in $plugins_by_status.
+		foreach ( (array) $all_plugins as $plugin_file => $plugin_data ) {
+			// Handle multisite plugins.
+			if ( is_multisite() && is_network_only_plugin( $plugin_file ) && ! is_plugin_active( $plugin_file ) ) {
+				// Check for inactive network plugins.
+				if ( $show_network_plugins ) {
+					$plugins_by_status['network_inactive'][ $plugin_file ] = $plugin_file;
+				} else {
+					// Unset and skip to next plugin.
+					unset( $all_plugins[ $plugin_file ] );
+					continue;
+				}
+			} elseif ( is_plugin_active_for_network( $plugin_file ) ) {
+				// Check for active network plugins.
+				if ( $show_network_plugins ) {
+					$plugins_by_status['network_activated'][ $plugin_file ] = $plugin_file;
+				} else {
+					// Unset and skip to next plugin.
+					unset( $all_plugins[ $plugin_file ] );
+					continue;
+				}
+			}
+
+			// Populate active/inactive lists.
+			// @todo should this include MU/Dropins?
+			if ( is_plugin_active( $plugin_file ) ) {
+				$plugins_by_status['active'][ $plugin_file ] = $plugin_file;
+			} else {
+				$plugins_by_status['inactive'][ $plugin_file ] = $plugin_file;
+			}
+
+			// Populate recently activated list.
+			if ( isset( $recently_activated_list[ $plugin_file ] ) ) {
+				$plugins_by_status['recently_activated'][ $plugin_file ] = $plugin_file;
+			}
+
+			// Populate paused list.
+			if ( is_plugin_paused( $plugin_file ) ) {
+				$plugins_by_status['paused'][ $plugin_file ] = $plugin_file;
+			}
+
+			// Get update information.
+			if ( $can_update && isset( $upgradable_list->response[ $plugin_file ] ) ) {
+				// An update is available.
+				$plugin_data['update'] = true;
+				// Exra info if known.
+				$plugin_data = array_merge( (array) $upgradable_list->response[ $plugin_file ], [ 'update-supported' => true ], $plugin_data );
+
+				// Populate upgradable list.
+				$plugins_by_status['upgrade'][ $plugin_file ] = $plugin_file;
+			} elseif ( isset( $upgradable_list->no_update[ $plugin_file ] ) ) {
+				$plugin_data = array_merge( (array) $upgradable_list->no_update[ $plugin_file ], [ 'update-supported' => true ], $plugin_data );
+			} elseif ( empty( $plugin_data['update-supported'] ) ) {
+				$plugin_data['update-supported'] = false;
+			}
+
+			// Get autoupdate information.
+			if ( $can_view_autoupdates ) {
+				/*
+				* Create the payload that's used for the auto_update_plugin filter.
+				* This is the same data contained within $upgradable_list->(response|no_update) however
+				* not all plugins will be contained in those keys, this avoids unexpected warnings.
+				*/
+				$filter_payload = [
+					'id'            => $plugin_file,
+					'slug'          => '',
+					'plugin'        => $plugin_file,
+					'new_version'   => '',
+					'url'           => '',
+					'package'       => '',
+					'icons'         => [],
+					'banners'       => [],
+					'banners_rtl'   => [],
+					'tested'        => '',
+					'requires_php'  => '',
+					'compatibility' => new \stdClass(),
+				];
+				$filter_payload = (object) wp_parse_args( $plugin_data, $filter_payload );
+
+				if ( function_exists( 'wp_is_auto_update_forced_for_item' ) ) {
+					$auto_update_forced                = wp_is_auto_update_forced_for_item( 'plugin', null, $filter_payload );
+					$plugin_data['auto-update-forced'] = $auto_update_forced;
+				}
+			}
+
+			// Save any changes to the plugin data.
+			$all_plugins[ $plugin_file ] = $plugin_data;
+		}
+
+		$plugins_by_status['all'] = array_flip( array_keys( $all_plugins ) );
+
+		// Filter the plugins by stati.
+		$filtered_plugins = ! empty( $active_stati ) ? array_merge( ... array_values( array_intersect_key( $plugins_by_status, $active_stati ) ) ) : $plugins_by_status['all'];
+
+		if ( ! empty( $this->args['where']['search'] ) ) {
+			// Filter by search args.
+			$s       = sanitize_text_field( $this->args['where']['search'] );
+			$matches = array_keys(
+				array_filter(
+					$all_plugins,
+					function ( $plugin ) use ( $s ) {
+						foreach ( $plugin as $value ) {
+							if ( is_string( $value ) && false !== stripos( strip_tags( $value ), $s ) ) {
+								return true;
+							}
+						}
+
+						return false;
+					},
+				)
+			);
+			if ( ! empty( $matches ) ) {
+				$filtered_plugins = array_intersect_key( $filtered_plugins, array_flip( $matches ) );
+			}
+		}
+
+		// Return plugin data filtered by args.
+		return ! empty( $filtered_plugins ) ? array_intersect_key( $all_plugins, $filtered_plugins ) : [];
 	}
 
 	/**
@@ -131,5 +283,4 @@ class PluginConnectionResolver extends AbstractConnectionResolver {
 	public function should_execute() {
 		return current_user_can( 'update_plugins' );
 	}
-
 }

--- a/src/Data/Loader/PluginLoader.php
+++ b/src/Data/Loader/PluginLoader.php
@@ -32,9 +32,16 @@ class PluginLoader extends AbstractDataLoader {
 	 * @throws Exception
 	 */
 	public function loadKeys( array $keys ) {
+		if ( empty( $keys ) ) {
+			return $keys;
+		}
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		// This is missing must use and drop in plugins, so we need to fetch and merge them separately.
+		$site_plugins   = apply_filters( 'all_plugins', get_plugins() );
+		$mu_plugins     = apply_filters( 'show_advanced_plugins', true, 'mustuse' ) ? get_mu_plugins() : [];
+		$dropin_plugins = apply_filters( 'show_advanced_plugins', true, 'dropins' ) ? get_dropins() : [];
 
-		require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
-		$plugins = apply_filters( 'all_plugins', get_plugins() );
+		$plugins = array_merge( $site_plugins, $mu_plugins, $dropin_plugins );
 
 		$loaded = [];
 		if ( ! empty( $plugins ) && is_array( $plugins ) ) {
@@ -50,6 +57,5 @@ class PluginLoader extends AbstractDataLoader {
 		}
 
 		return $loaded;
-
 	}
 }

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -83,6 +83,7 @@ use WPGraphQL\Type\Enum\PostObjectsConnectionDateColumnEnum;
 use WPGraphQL\Type\Enum\PostObjectsConnectionOrderbyEnum;
 use WPGraphQL\Type\Enum\PostStatusEnum;
 use WPGraphQL\Type\Enum\ContentTypeEnum;
+use WPGraphQL\Type\Enum\PluginStatusEnum;
 use WPGraphQL\Type\Enum\RelationEnum;
 use WPGraphQL\Type\Enum\TaxonomyEnum;
 use WPGraphQL\Type\Enum\TermObjectsConnectionOrderbyEnum;
@@ -310,6 +311,7 @@ class TypeRegistry {
 		MenuNodeIdTypeEnum::register_type();
 		MimeTypeEnum::register_type();
 		OrderEnum::register_type();
+		PluginStatusEnum::register_type();
 		PostObjectFieldFormatEnum::register_type();
 		PostObjectsConnectionDateColumnEnum::register_type();
 		PostObjectsConnectionOrderbyEnum::register_type();

--- a/src/Type/Enum/PluginStatusEnum.php
+++ b/src/Type/Enum/PluginStatusEnum.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace WPGraphQL\Type\Enum;
+
+class PluginStatusEnum {
+
+	/**
+	 * Register the PluginStatusEnum Type to the Schema
+	 *
+	 * @return void
+	 */
+	public static function register_type() {
+		register_graphql_enum_type(
+			'PluginStatusEnum',
+			[
+				'description'  => __( 'The status of the WordPress plugin.', 'wp-graphql' ),
+				'values'       => self::get_enum_values(),
+				'defaultValue' => 'ACTIVE',
+			]
+		);
+	}
+
+	/**
+	 * Returns the array configuration for the GraphQL enum values.
+	 *
+	 * @return array
+	 */
+	protected static function get_enum_values() {
+		$values = [
+			'ACTIVE'          => [
+				'value'       => 'active',
+				'description' => __( 'The plugin is currently active.', 'wp-graphql' ),
+			],
+			'DROP_IN'         => [
+				'value'       => 'dropins',
+				'description' => __( 'The plugin is a drop-in plugin.', 'wp-graphql' ),
+
+			],
+			'INACTIVE'        => [
+				'value'       => 'inactive',
+				'description' => __( 'The plugin is currently inactive.', 'wp-graphql' ),
+			],
+			'MUST_USE'        => [
+				'value'       => 'mustuse',
+				'description' => __( 'The plugin is a Must-use plugin.', 'wp-graphql' ),
+			],
+			'PAUSED'          => [
+				'value'       => 'paused',
+				'description' => __( 'The plugin is technically active but was paused while loading.' ),
+			],
+			'RECENTLY_ACTIVE' => [
+				'value'       => 'recently_activated',
+				'description' => __( 'The plugin was active recently.', 'wp-graphql' ),
+			],
+			'UPGRADE'         => [
+				'value'       => 'upgrade',
+				'description' => __( 'The plugin has an upgrade available.' ),
+			],
+		];
+
+		// Multisite enums
+		if ( is_multisite() ) {
+			$values['NETWORK_ACTIVATED'] = [
+				'value'       => 'network_activated',
+				'description' => __( 'The plugin is activated on the multisite network.', 'wp-graphql' ),
+			];
+			$values['NETWORK_INACTIVE']  = [
+				'value'       => 'network_inactive',
+				'description' => __( 'The plugin is installed on the multisite network, but is currently inactive.', 'wp-graphql' ),
+			];
+		}
+
+		return $values;
+	}
+}

--- a/src/Type/Enum/PluginStatusEnum.php
+++ b/src/Type/Enum/PluginStatusEnum.php
@@ -42,7 +42,7 @@ class PluginStatusEnum {
 			],
 			'MUST_USE'        => [
 				'value'       => 'mustuse',
-				'description' => __( 'The plugin is a Must-use plugin.', 'wp-graphql' ),
+				'description' => __( 'The plugin is a must-use plugin.', 'wp-graphql' ),
 			],
 			'PAUSED'          => [
 				'value'       => 'paused',

--- a/src/Type/ObjectType/RootQuery.php
+++ b/src/Type/ObjectType/RootQuery.php
@@ -65,8 +65,23 @@ class RootQuery {
 						},
 					],
 					'plugins'               => [
-						'toType'  => 'Plugin',
-						'resolve' => function ( $root, $args, $context, $info ) {
+						'toType'         => 'Plugin',
+						'connectionArgs' => [
+							'search' => [
+								'name'        => 'search',
+								'type'        => 'String',
+								'description' => __( 'Show plugin based on a keyword search.', 'wp-graphql' ),
+							],
+							'status' => [
+								'type'        => 'PluginStatusEnum',
+								'description' => __( 'Show plugins with a specific status.', 'wp-graphql' ),
+							],
+							'stati'  => [
+								'type'        => [ 'list_of' => 'PluginStatusEnum' ],
+								'description' => __( 'Retrieve plugins where plugin status is in an array.', 'wp-graphql' ),
+							],
+						],
+						'resolve'        => function ( $root, $args, $context, $info ) {
 							return DataSource::resolve_plugins_connection( $root, $args, $context, $info );
 						},
 					],


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR adds the ability to filter plugin connections. It builds off #895 and loosely mimics [`WP_Plugins_List_Table::prepare_items()`](https://github.com/WordPress/wordpress-develop/blob/0b800e21c311e302824e4a025946a6fdb4f6c794/src/wp-admin/includes/class-wp-plugins-list-table.php#L92)

It adds the following where args to `RootQueryToPluginConnection`:
- `search`: a keyword search across all plugin data.
- `status`:  filters by a single `PluginStatusEnum`.
- `stati`: filters by _any_ `PluginStatusEnum` in the given array.

The possible plugin stati that can be filtered are: `ACTIVE`, `DROP_IN`, `INACTIVE`, `MUST_USE`, `PAUSED`, `RECENTLY_ACTIVE`, and `UPGRADE`. On MU, we also get `NETWORK_ACTIVATED` and `NETWORK_INACTIVE`.

When no where args are set, the query will return _all_ plugins (including drop-in and MU, which were previously missing ).


Does this close any currently open issues?
------------------------------------------
#178


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
![image](https://user-images.githubusercontent.com/29322304/158097319-79cca198-ab9a-4bfa-8448-77a11b6d0073.png)


Any other comments?
-------------------
**Needs Decision**:
- I think `PluginConnectionResolver::should_execute()` _should_ be checking `current_user_can( 'activate_plugins' )` and not the current `update_plugins` cap. `PluginConnectionResolver::get_query()` is written under the assumption it will be changed. Was checking `update_plugins` intentional or an oversight?

- The existing schema pattern is to have separate where args for a ` 'type' => 'SomeType'` and `'type' => [ 'list_of' => 'SomeType' ]` ( e.g. `status` and `stati`) even though the latter:
  - Can take a single value sans the array wrapper,
  - Almost always needs to be type checked, to convert a single value to an array, and
  - That same check + conversion is often done on a single `status` to keep the rest of the resolver DRY.
  
  IMO all those single-value args are unnecessary, can be removed without any loss of functionality, improving the WPGraphiQL DX and a resulting in leaner codebase + schema. Assuming you agree (I'd open a separate issue/PR) should this PR still add both args?

**Notes**:
- Filtering by `ACTIVE | INACTIVE` doesn't include network plugins (you can get both with `where : { stati : [ACTIVE, NETWORK_ACTIVATED] }` ). This differs from the backend, where network activated plugins are included in the `Active`/`Inactive` tabs. The alternative would be  a `(bool) includeNetworkPlugins` connection arg, which is bad DX.

- `NETWORK_INACTIVE` doesn't have a WP backend counterpart. It's here for DX.

- `PluginConnectionResolver::get_query()` strays from the pattern of other resolver query methods, to reduce cognitive complexity and keep things performant (ternaries over if/else, splatting to avoid multiple loops, and keeping array operations to a minimum). IDK if the existing patterns are a relic of the WP ecosystem in 2017 or style preference, but if it's the latter, a second set of eyes might be able to change the style without compromising on performance.

- Following `WP_Plugins_List_Table::prepare_items()`, `get_query()` builds the plugin data from a few sources, which means there's more fields that can be surfaced by the Plugin model. Separation of concerns stopped me from adding those fields to the schema in this PR. (The data is in this PR for simplicity, and this way devs can add the fields themselves in the interim).

- WPUnit tests *have not * been added to the PR. Its a waste of time before #2293 and #2294 are merged.

- Every time I tried to `git rebase` the original PR, my PC crashed from 3 years of commit history. Props to @t0lya should be added to the release.

Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (Wsl2 + devilbox) + PHP v8.0.15

**WordPress Version:** 5.9.2
