### PR TITLE
fix: MediaItemUpdate mutation comparing string author ID with number returned from get_current_user_id

### DIFF
--- a/src/Mutation/MediaItemUpdate.php
+++ b/src/Mutation/MediaItemUpdate.php
@@ -82,7 +82,7 @@ class MediaItemUpdate {
 			if ( null === $existing_media_item ) {
 				throw new UserError( __( 'No mediaItem with that ID could be found to update', 'wp-graphql' ) );
 			} else {
-				$author_id = $existing_media_item->post_author;
+				$author_id = absint( $existing_media_item->post_author );
 			}
 
 			/**
@@ -106,7 +106,7 @@ class MediaItemUpdate {
 			 */
 			if ( ! empty( $input['authorId'] ) ) {
 				$author_id_parts = Relay::fromGlobalId( $input['authorId'] );
-				$author_id       = $author_id_parts['id'];
+				$author_id       = absint( $author_id_parts['id'] );
 			}
 
 			/**

--- a/src/Mutation/MediaItemUpdate.php
+++ b/src/Mutation/MediaItemUpdate.php
@@ -81,8 +81,6 @@ class MediaItemUpdate {
 			 */
 			if ( null === $existing_media_item ) {
 				throw new UserError( __( 'No mediaItem with that ID could be found to update', 'wp-graphql' ) );
-			} else {
-				$author_id = absint( $existing_media_item->post_author );
 			}
 
 			/**
@@ -99,6 +97,8 @@ class MediaItemUpdate {
 			if ( ! isset( $post_type_object->cap->edit_posts ) || ! current_user_can( $post_type_object->cap->edit_posts ) ) {
 				throw new UserError( __( 'Sorry, you are not allowed to update mediaItems', 'wp-graphql' ) );
 			}
+
+			$author_id = absint( $existing_media_item->post_author );
 
 			/**
 			 * If the mutation is setting the author to be someone other than the user making the request

--- a/tests/wpunit/MediaItemMutationsTest.php
+++ b/tests/wpunit/MediaItemMutationsTest.php
@@ -1166,4 +1166,23 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 		$this->assertArrayHasKey( 'errors', $actual );
 
 	}
+
+	public function testUpdateMediaItemOwnedByAnotherUser() {
+
+		$media_item_1 = $this->factory()->attachment->create( ['post_mime_type' => 'image/gif', 'post_author' => $this->subscriber ] );
+
+		wp_set_current_user( $this->admin );
+
+		$this->update_variables = [
+			'input' => [
+				'id' => \GraphQLRelay\Relay::toGlobalId( 'post', $media_item_1 ),
+				'title' => 'Test update title...'
+			]
+		];
+
+		$actual =  $this->updateMediaItemMutation();
+
+		codecept_debug( $actual );
+
+	}
 }

--- a/tests/wpunit/MediaItemMutationsTest.php
+++ b/tests/wpunit/MediaItemMutationsTest.php
@@ -1167,11 +1167,14 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 
 	}
 
-	public function testUpdateMediaItemOwnedByAnotherUser() {
+	public function testUpdateMediaItemOwnedByUserUpdatingIt() {
 
-		$media_item_1 = $this->factory()->attachment->create( ['post_mime_type' => 'image/gif', 'post_author' => $this->subscriber ] );
+		$media_item_1 = $this->factory()->attachment->create( [
+			'post_mime_type' => 'image/gif',
+			'post_author' => $this->author
+		] );
 
-		wp_set_current_user( $this->admin );
+		wp_set_current_user( $this->author );
 
 		$this->update_variables = [
 			'input' => [
@@ -1182,7 +1185,9 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 
 		$actual =  $this->updateMediaItemMutation();
 
-		codecept_debug( $actual );
+//		codecept_debug( $actual );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
 
 	}
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

When running a `updateMediaItem` mutation as a user who can't edit another users' posts, a `UserError` gets thrown, even if this should go through for users who can update their post and are trying to do that. 

The `$author_id` variable was always a string. Both in the initial assignment when pulling it out of the media item post [here](https://github.com/wp-graphql/wp-graphql/blob/develop/src/Mutation/MediaItemUpdate.php#L85), and for the case where a different user ID is provided [here](https://github.com/wp-graphql/wp-graphql/blob/develop/src/Mutation/MediaItemUpdate.php#L109).

This PR should cast the variable to int, and make sure that the comparison with the `get_current_user_id` function call is valid [here](https://github.com/wp-graphql/wp-graphql/blob/develop/src/Mutation/MediaItemUpdate.php#L116).

Does this close any currently open issues?
------------------------------------------

I have searched around, but it seems there isn't an open issue regarding this.

Where has this been tested?
---------------------------
**Operating System:** macOS Monterey 12.2.1 (21D62)

**WordPress Version:** 5.9.2
