### PR TITLE
fix: pass `WP_Comment` object to `comment_text` filter

### DIFF
--- a/src/Model/Comment.php
+++ b/src/Model/Comment.php
@@ -165,7 +165,7 @@ class Comment extends Model {
 				'contentRendered'    => function () {
 					$content = ! empty( $this->data->comment_content ) ? $this->data->comment_content : null;
 
-					return $this->html_entity_decode( apply_filters( 'comment_text', $content ), 'contentRendered', false );
+					return $this->html_entity_decode( apply_filters( 'comment_text', $content, $this->data ), 'contentRendered', false );
 				},
 				'karma'              => function () {
 					return ! empty( $this->data->comment_karma ) ? $this->data->comment_karma : null;


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR fixes an issue with the Comment model's `contentRendered` field, where the `WP_Comment` object was not passed to the `comment_text` wp filter.


Does this close any currently open issues?
------------------------------------------
closes #2309 


Any other comments?
-------------------
There are no tests to write. The behavior of the plugin hasnt changed, we're just fixing our use of WP's api.


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php8)

**WordPress Version:** 5.9.2
