### PR TITLE
Fix: Use comment author when admin are creating/updating a different users comment.

### DIFF
--- a/src/Data/CommentMutation.php
+++ b/src/Data/CommentMutation.php
@@ -42,17 +42,15 @@ class CommentMutation {
 		 *    'comment_approved' => 1,
 		 */
 
-		$user = wp_get_current_user();
-		if ( 0 !== $user->ID ) {
-			// This is only ever the ID of the current user.
+		$user = self::get_comment_author( $input['authorEmail'] ?? null );
+
+		if ( false !== $user ) {
+
 			$output_args['user_id'] = $user->ID;
 
-			// Only users with the right permissions should be able to set a different author than themselves.
-			$can_moderate_comments = current_user_can( 'moderate_comments' );
-
-			$input['author']      = $can_moderate_comments && ! empty( $input['author'] ) ? $input['author'] : $user->display_name;
-			$input['authorEmail'] = $can_moderate_comments && ! empty( $input['authorEmail'] ) ? $input['authorEmail'] : $user->user_email;
-			$input['authorUrl']   = $can_moderate_comments && ! empty( $input['authorUrl'] ) ? $input['authorUrl'] : $user->user_url;
+			$input['author']      = ! empty( $input['author'] ) ? $input['author'] : $user->display_name;
+			$input['authorEmail'] = ! empty( $input['authorEmail'] ) ? $input['authorEmail'] : $user->user_email;
+			$input['authorUrl']   = ! empty( $input['authorUrl'] ) ? $input['authorUrl'] : $user->user_url;
 		}
 
 		if ( empty( $input['author'] ) ) {
@@ -130,5 +128,30 @@ class CommentMutation {
 		$default_comment_status  = 0;
 
 		do_action( 'graphql_comment_object_mutation_update_additional_data', $comment_id, $input, $mutation_name, $context, $info, $intended_comment_status, $default_comment_status );
+	}
+
+	/**
+	 * Gets the user object for the comment author.
+	 *
+	 * @param ?string $author_email The authorEmail provided to the mutation input.
+	 *
+	 * @return \WP_User|false
+	 */
+	protected static function get_comment_author( string $author_email = null ) {
+		$user = wp_get_current_user();
+
+		// Fail if no logged in user.
+		if ( 0 === $user->ID ) {
+			return false;
+		}
+
+		// Return the current user if they can only handle their own comments or if there's no specified author.
+		if ( empty( $author_email ) || ! $user->has_cap( 'moderate_comments' ) ) {
+			return $user;
+		}
+
+		$author = get_user_by( 'email', $author_email );
+
+		return ! empty( $author->ID ) ? $author : false;
 	}
 }

--- a/src/Model/Comment.php
+++ b/src/Model/Comment.php
@@ -81,7 +81,7 @@ class Comment extends Model {
 	 * @throws Exception
 	 */
 	protected function is_private() {
-		
+
 		if ( empty( $this->data->comment_post_ID ) ) {
 			return true;
 		}

--- a/src/Model/Comment.php
+++ b/src/Model/Comment.php
@@ -81,9 +81,14 @@ class Comment extends Model {
 	 * @throws Exception
 	 */
 	protected function is_private() {
-
+		
 		if ( empty( $this->data->comment_post_ID ) ) {
 			return true;
+		}
+
+		// if the current user is the author of the comment, the comment should not be private
+		if ( 0 !== wp_get_current_user()->ID && absint( $this->data->user_id ) === absint( wp_get_current_user()->ID ) ) {
+			return false;
 		}
 
 		$commented_on = get_post( (int) $this->data->comment_post_ID );

--- a/src/Mutation/CommentCreate.php
+++ b/src/Mutation/CommentCreate.php
@@ -129,7 +129,7 @@ class CommentCreate {
 			$commented_on = get_post( absint( $input['commentOn'] ) );
 
 			if ( empty( $commented_on ) ) {
-				return new UserError( __( 'The ID of the node to comment on is invalid', 'wp-graphql' ) );
+				throw new UserError( __( 'The ID of the node to comment on is invalid', 'wp-graphql' ) );
 			}
 
 			/**

--- a/tests/wpunit/CommentMutationsTest.php
+++ b/tests/wpunit/CommentMutationsTest.php
@@ -227,7 +227,7 @@ class CommentMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertTrue( $actual['data']['createComment']['success'] );
-		// $this->assertEquals( $this->subscriber->ID, $actual['data']['createComment']['comment']['author']['node']['databaseId'] );
+		$this->assertEquals( $this->subscriber, $actual['data']['createComment']['comment']['author']['node']['databaseId'] );
 
 		// Test logged in user different than author.
 		wp_set_current_user( $this->admin );
@@ -251,7 +251,7 @@ class CommentMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertTrue( $actual['data']['createComment']['success'] );
-		// $this->assertEquals( $this->subscriber->ID, $actual['data']['createComment']['comment']['author']['node']['databaseId'] );
+		$this->assertEquals( $this->subscriber, $actual['data']['createComment']['comment']['author']['node']['databaseId'] );
 	}
 
 	public function testUpdateCommentWithAuthorConnection() {

--- a/tests/wpunit/CommentMutationsTest.php
+++ b/tests/wpunit/CommentMutationsTest.php
@@ -1,6 +1,7 @@
 <?php
 
 class CommentMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
+
 	public $title;
 	public $content;
 	public $client_mutation_id;
@@ -9,6 +10,7 @@ class CommentMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 	public $author;
 
 	public function setUp(): void {
+
 		// before
 		parent::setUp();
 
@@ -37,80 +39,6 @@ class CommentMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		WPGraphQL::clear_schema();
 		// then
 		parent::tearDown();
-	}
-
-	public function testCreateCommentByLoggedInUserShouldSetUserProperly() {
-
-		$post_id = $this->factory()->post->create([
-			'post_type' => 'post',
-			'post_status' => 'publish',
-			'post_title' => 'Test for comments...'
-		]);
-
-		$query = '
-		mutation createComment($input: CreateCommentInput!) {
-		  createComment(input: $input) {
-		    clientMutationId
-		    success
-		    comment {
-		      id
-		      content
-		      author {
-		        node {
-		          name
-		          ... on User {
-		            id
-		            databaseId
-		            username
-		          }
-		        }
-		      }
-		    }
-		  }
-		}
-		';
-
-		$variables = [
-			'input' => [
-				'clientMutationId' => 'Create...',
-				'content' => 'Test comment ' . uniqid(),
-				'commentOn' => $post_id
-			]
-		];
-
-		wp_set_current_user( $this->admin );
-
-		$actual = graphql([
-			'query' => $query,
-			'variables' => $variables,
-		]);
-
-
-		codecept_debug( $actual );
-
-		$this->assertArrayNotHasKey( 'errors', $actual );
-		$this->assertTrue( $actual['data']['createComment']['success'] );
-		$this->assertSame( $this->admin, $actual['data']['createComment']['comment']['author']['node']['databaseId'] );
-
-		add_filter( 'comment_flood_filter', '__return_false' );
-
-		wp_set_current_user( 0 );
-
-		$variables['input']['author'] = 'joe';
-		$variables['input']['authorEmail'] = 'joe@example.com';
-
-		sleep(1);
-		$actual = graphql([
-			'query' => $query,
-			'variables' => $variables,
-		]);
-
-
-		codecept_debug( $actual );
-
-		$this->assertArrayNotHasKey( 'errors', $actual );
-		$this->assertTrue( $actual['data']['createComment']['success'] );
-
 	}
 
 	public function createComment( &$post_id, &$comment_id, $postCreator, $commentCreator ) {

--- a/tests/wpunit/CommentMutationsTest.php
+++ b/tests/wpunit/CommentMutationsTest.php
@@ -39,6 +39,80 @@ class CommentMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		parent::tearDown();
 	}
 
+	public function testCreateCommentByLoggedInUserShouldSetUserProperly() {
+
+		$post_id = $this->factory()->post->create([
+			'post_type' => 'post',
+			'post_status' => 'publish',
+			'post_title' => 'Test for comments...'
+		]);
+
+		$query = '
+		mutation createComment($input: CreateCommentInput!) {
+		  createComment(input: $input) {
+		    clientMutationId
+		    success
+		    comment {
+		      id
+		      content
+		      author {
+		        node {
+		          name
+		          ... on User {
+		            id
+		            databaseId
+		            username
+		          }
+		        }
+		      }
+		    }
+		  }
+		}
+		';
+
+		$variables = [
+			'input' => [
+				'clientMutationId' => 'Create...',
+				'content' => 'Test comment ' . uniqid(),
+				'commentOn' => $post_id
+			]
+		];
+
+		wp_set_current_user( $this->admin );
+
+		$actual = graphql([
+			'query' => $query,
+			'variables' => $variables,
+		]);
+
+
+		codecept_debug( $actual );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertTrue( $actual['data']['createComment']['success'] );
+		$this->assertSame( $this->admin, $actual['data']['createComment']['comment']['author']['node']['databaseId'] );
+
+		add_filter( 'comment_flood_filter', '__return_false' );
+
+		wp_set_current_user( 0 );
+
+		$variables['input']['author'] = 'joe';
+		$variables['input']['authorEmail'] = 'joe@example.com';
+
+		sleep(1);
+		$actual = graphql([
+			'query' => $query,
+			'variables' => $variables,
+		]);
+
+
+		codecept_debug( $actual );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertTrue( $actual['data']['createComment']['success'] );
+
+	}
+
 	public function createComment( &$post_id, &$comment_id, $postCreator, $commentCreator ) {
 		wp_set_current_user( $postCreator );
 		$post_args = [


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR fixes `CommentMutation::prepare_comment_object()` to correctly set a comment's author when it differs from the currently logged-in user.


Does this close any currently open issues?
------------------------------------------
#2131 


Any other comments?
-------------------
- Note the two commented-out asserts in `CommentMutationsTest::testCreateComment()`. For some reason, a subscriber is unable to view their own comment. The resolver creates the model, and the model's visibility is visible, but for some reason `DataSource::resolve_comment()` is coming back null. 
I reverted the changes and tried the asserts, but  `comments` still returns null in the tests (didnt check manually in WPGraphiQL), so I believe it's a pre-existing bug. If so a separate issue should be created.

Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php 8.0.15)

**WordPress Version:** 5.9.2
