### PR TITLE
feat: change min permissions for Plugins from `update` to `activate`

### DIFF
--- a/src/Data/Connection/PluginConnectionResolver.php
+++ b/src/Data/Connection/PluginConnectionResolver.php
@@ -129,7 +129,7 @@ class PluginConnectionResolver extends AbstractConnectionResolver {
 	 * @return bool
 	 */
 	public function should_execute() {
-		return current_user_can( 'update_plugins' );
+		return current_user_can( 'activate_plugins' );
 	}
 
 }

--- a/src/Model/Plugin.php
+++ b/src/Model/Plugin.php
@@ -46,7 +46,7 @@ class Plugin extends Model {
 	 */
 	protected function is_private() {
 
-		if ( ! current_user_can( 'update_plugins' ) ) {
+		if ( ! current_user_can( 'activate_plugins' ) ) {
 			return true;
 		}
 


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR changes the minimum permissions to query plugins from `update_plugins` to `activate_plugins`. 

Any other comments?
-------------------
See conversation in #2298


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php 8.0.15)

**WordPress Version:** 5.9.2
