### PR TITLE
feat: allow global/db ids in comment mutation ID inputs

### DIFF
--- a/src/Data/CommentMutation.php
+++ b/src/Data/CommentMutation.php
@@ -6,6 +6,7 @@ use Exception;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
+use WPGraphQL\Utils\Utils;
 
 /**
  * Class CommentMutation
@@ -85,7 +86,7 @@ class CommentMutation {
 		}
 
 		if ( ! empty( $input['parent'] ) ) {
-			$output_args['comment_parent'] = $input['parent'];
+			$output_args['comment_parent'] = Utils::get_database_id_from_id( $input['parent'] );
 		}
 
 		if ( ! empty( $input['type'] ) ) {

--- a/src/Mutation/CommentCreate.php
+++ b/src/Mutation/CommentCreate.php
@@ -36,7 +36,7 @@ class CommentCreate {
 		return [
 			'commentOn'   => [
 				'type'        => 'Int',
-				'description' => __( 'The ID of the post object the comment belongs to.', 'wp-graphql' ),
+				'description' => __( 'The database ID of the post object the comment belongs to.', 'wp-graphql' ),
 			],
 			'author'      => [
 				'type'        => 'String',
@@ -60,7 +60,7 @@ class CommentCreate {
 			],
 			'parent'      => [
 				'type'        => 'ID',
-				'description' => __( 'Parent comment of current comment.', 'wp-graphql' ),
+				'description' => __( 'Parent comment ID of current comment.', 'wp-graphql' ),
 			],
 			'date'        => [
 				'type'        => 'String',

--- a/src/Mutation/CommentDelete.php
+++ b/src/Mutation/CommentDelete.php
@@ -8,6 +8,7 @@ use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
 use WPGraphQL\Model\Comment;
+use WPGraphQL\Utils\Utils;
 
 class CommentDelete {
 	/**
@@ -80,16 +81,11 @@ class CommentDelete {
 	 */
 	public static function mutate_and_get_payload() {
 		return function ( $input ) {
-			/**
-			 * Get the ID from the global ID
-			 */
-			$id_parts = Relay::fromGlobalId( $input['id'] );
+			// Get the database ID for the comment.
+			$comment_id = Utils::get_database_id_from_id( $input['id'] );
 
-			/**
-			 * Get the post object before deleting it
-			 */
-			$comment_id            = absint( $id_parts['id'] );
-			$comment_before_delete = get_comment( $comment_id );
+			// Get the post object before deleting it.
+			$comment_before_delete = ! empty( $comment_id ) ? get_comment( $comment_id ) : false;
 
 			if ( empty( $comment_before_delete ) ) {
 				throw new UserError( __( 'The Comment could not be deleted', 'wp-graphql' ) );
@@ -133,7 +129,7 @@ class CommentDelete {
 			/**
 			 * Delete the comment
 			 */
-			wp_delete_comment( $id_parts['id'], $force_delete );
+			wp_delete_comment( (int) $comment_id, $force_delete );
 
 			return [
 				'commentObject' => $comment_before_delete,

--- a/src/Mutation/CommentRestore.php
+++ b/src/Mutation/CommentRestore.php
@@ -7,6 +7,7 @@ use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
 use WPGraphQL\Data\DataSource;
+use WPGraphQL\Utils\Utils;
 
 /**
  * Class CommentRestore
@@ -82,27 +83,20 @@ class CommentRestore {
 	 */
 	public static function mutate_and_get_payload() {
 		return function ( $input ) {
-			/**
-			 * Get the ID from the global ID
-			 */
-			$id_parts = Relay::fromGlobalId( $input['id'] );
-
-			/**
-			 * Get the post object before deleting it
-			 */
-			$comment_id = absint( $id_parts['id'] );
-
-			/**
-			 * Stop now if a user isn't allowed to delete the comment
-			 */
+			// Stop now if a user isn't allowed to delete the comment.
 			if ( ! current_user_can( 'moderate_comments' ) ) {
 				throw new UserError( __( 'Sorry, you are not allowed to restore this comment.', 'wp-graphql' ) );
 			}
 
-			/**
-			 * Delete the comment
-			 */
-			wp_untrash_comment( $id_parts['id'] );
+			// Get the database ID for the comment.
+			$comment_id = Utils::get_database_id_from_id( $input['id'] );
+
+			if ( false === $comment_id ) {
+				throw new UserError( __( 'Sorry, you are not allowed to restore this comment.', 'wp-graphql' ) );
+			}
+
+			// Delete the comment.
+			wp_untrash_comment( $comment_id );
 
 			$comment = get_comment( $comment_id );
 

--- a/src/Mutation/CommentUpdate.php
+++ b/src/Mutation/CommentUpdate.php
@@ -8,6 +8,7 @@ use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
 use WPGraphQL\Data\CommentMutation;
+use WPGraphQL\Utils\Utils;
 
 /**
  * Class CommentUpdate
@@ -67,15 +68,10 @@ class CommentUpdate {
 	 */
 	public static function mutate_and_get_payload() {
 		return function ( $input, AppContext $context, ResolveInfo $info ) {
-			/**
-			 * Throw an exception if there's no input
-			 */
-			if ( ( empty( $input ) || ! is_array( $input ) ) ) {
-				throw new UserError( __( 'Mutation not processed. There was no input for the mutation or the comment_object was invalid', 'wp-graphql' ) );
-			}
+			// Get the database ID for the comment.
+			$comment_id = ! empty( $input['id'] ) ? Utils::get_database_id_from_id( $input['id'] ) : null;
 
-			$id_parts     = ! empty( $input['id'] ) ? Relay::fromGlobalId( $input['id'] ) : null;
-			$comment_id   = isset( $id_parts['id'] ) && absint( $id_parts['id'] ) ? absint( $id_parts['id'] ) : null;
+			// Get the args from the existing comment.
 			$comment_args = ! empty( $comment_id ) ? get_comment( $comment_id, ARRAY_A ) : null;
 
 			if ( empty( $comment_id ) || empty( $comment_args ) ) {

--- a/tests/wpunit/CommentMutationsTest.php
+++ b/tests/wpunit/CommentMutationsTest.php
@@ -411,8 +411,6 @@ class CommentMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		}
 		';
 
-		wp_set_current_user( $this->admin );
-
 		// Test database ID
 		$variables = [
 			'id' => $comment_id,
@@ -429,6 +427,14 @@ class CommentMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 			],
 		];
 
+		// Test without permissions
+		wp_set_current_user( 0 );
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+		$this->assertArrayHasKey( 'errors', $actual );
+
+		// Test with permissions
+		wp_set_current_user( $this->admin );
+
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
 		$this->assertEquals( $expected, $actual['data'] );
@@ -441,6 +447,11 @@ class CommentMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
 		$this->assertEquals( $expected, $actual['data'] );
+
+		// Test bad ID
+		$variables['id'] = '3ab21';
+		$actual          = $this->graphql( compact( 'query', 'variables' ) );
+		$this->assertArrayHasKey( 'errors', $actual );
 	}
 
 	/**


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR enables users to supply _either_ a database ID or a global ID to comment mutation inputs of `type` ID. Part of #998 .
The description of `commentOn` was changed to specify it only takes a database ID  (until #532 can be handled).
Also a new test was added for creating child comments.


Does this close any currently open issues?
------------------------------------------
Invalidates #2195 

Any other comments?
-------------------
- I'm intentionally handling the different parts of #998 in separate PRs to make merging easier. 
- I removed the empty input `UserError` from `CommentUpdate`, since `id` is non-null and its exclusion will already throw a GraphQL error.


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (Wsl2 + devilbox + PHP 8.0.15)

**WordPress Version:** 5.9.2
