### PR TITLE
feat: allow global/db ids in mediaItem mutation ID inputs

### DIFF
--- a/src/Data/MediaItemMutation.php
+++ b/src/Data/MediaItemMutation.php
@@ -6,6 +6,7 @@ use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
 use WP_Post_Type;
 use WPGraphQL\AppContext;
+use WPGraphQL\Utils\Utils;
 
 /**
  * Class MediaItemMutation
@@ -60,9 +61,8 @@ class MediaItemMutation {
 			$insert_post_args['post_title'] = basename( $file['file'] );
 		}
 
-		$author_id_parts = ! empty( $input['authorId'] ) ? Relay::fromGlobalId( $input['authorId'] ) : null;
-		if ( is_array( $author_id_parts ) && ! empty( $author_id_parts['id'] ) ) {
-			$insert_post_args['post_author'] = absint( $author_id_parts['id'] );
+		if ( ! empty( $input['authorId'] ) ) {
+			$insert_post_args['post_author'] = Utils::get_database_id_from_id( $input['authorId'] );
 		}
 
 		if ( ! empty( $input['commentStatus'] ) ) {
@@ -90,16 +90,7 @@ class MediaItemMutation {
 		}
 
 		if ( ! empty( $input['parentId'] ) ) {
-			if ( absint( $input['parentId'] ) ) {
-				$insert_post_args['post_parent'] = absint( $input['parentId'] );
-			} else {
-
-				$parent_id_parts = ( ! empty( $input['parentId'] ) ? Relay::fromGlobalId( $input['parentId'] ) : null );
-
-				if ( is_array( $parent_id_parts ) && absint( $parent_id_parts['id'] ) ) {
-					$insert_post_args['post_parent'] = absint( $parent_id_parts['id'] );
-				}
-			}
+			$insert_post_args['post_parent'] = Utils::get_database_id_from_id( $input['parentId'] );
 		}
 
 		/**

--- a/src/Mutation/MediaItemCreate.php
+++ b/src/Mutation/MediaItemCreate.php
@@ -8,6 +8,7 @@ use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
 use WPGraphQL\Data\DataSource;
 use WPGraphQL\Data\MediaItemMutation;
+use WPGraphQL\Utils\Utils;
 
 class MediaItemCreate {
 	/**
@@ -39,7 +40,7 @@ class MediaItemCreate {
 				'description' => __( 'Alternative text to display when mediaItem is not displayed', 'wp-graphql' ),
 			],
 			'authorId'      => [
-				'type'        => 'Id',
+				'type'        => 'ID',
 				'description' => __( 'The userId to assign as the author of the mediaItem', 'wp-graphql' ),
 			],
 			'caption'       => [
@@ -87,8 +88,8 @@ class MediaItemCreate {
 				'description' => __( 'The ping status for the mediaItem', 'wp-graphql' ),
 			],
 			'parentId'      => [
-				'type'        => 'Id',
-				'description' => __( 'The WordPress post ID or the graphQL postId of the parent object', 'wp-graphql' ),
+				'type'        => 'ID',
+				'description' => __( 'The ID of the parent object', 'wp-graphql' ),
 			],
 		];
 	}
@@ -125,6 +126,25 @@ class MediaItemCreate {
 			 */
 			if ( ! current_user_can( 'upload_files' ) ) {
 				throw new UserError( __( 'Sorry, you are not allowed to upload mediaItems', 'wp-graphql' ) );
+			}
+
+			$post_type_object = get_post_type_object( 'attachment' );
+			if ( empty( $post_type_object ) ) {
+				throw new UserError( __( 'The Media Item could not be created', 'wp-graphql' ) );
+			}
+
+			/**
+			 * If the mediaItem being created is being assigned to another user that's not the current user, make sure
+			 * the current user has permission to edit others mediaItems
+			 */
+			if ( ! empty( $input['authorId'] ) ) {
+				// Ensure authorId is a valid databaseId.
+				$input['authorId'] = Utils::get_database_id_from_id( $input['authorId'] );
+
+				// Bail if cant edit other users' attachments.
+				if ( get_current_user_id() !== $input['authorId'] && ( ! isset( $post_type_object->cap->edit_others_posts ) || ! current_user_can( $post_type_object->cap->edit_others_posts ) ) ) {
+					throw new UserError( __( 'Sorry, you are not allowed to create mediaItems as this user', 'wp-graphql' ) );
+				}
 			}
 
 			/**
@@ -196,12 +216,6 @@ class MediaItemCreate {
 				throw new UserError( __( 'Sorry, the URL for this file is invalid, it must be a path to the mediaItem file', 'wp-graphql' ) );
 			}
 
-			$post_type_object = get_post_type_object( 'attachment' );
-
-			if ( empty( $post_type_object ) ) {
-				return null;
-			}
-
 			/**
 			 * Insert the mediaItem object and get the ID
 			 */
@@ -210,7 +224,7 @@ class MediaItemCreate {
 			/**
 			 * Get the post parent and if it's not set, set it to 0
 			 */
-			$attachment_parent_id = ! empty( $media_item_args['post_parent'] ) ? absint( $media_item_args['post_parent'] ) : 0;
+			$attachment_parent_id = ! empty( $media_item_args['post_parent'] ) ? $media_item_args['post_parent'] : 0;
 
 			/**
 			 * Stop now if a user isn't allowed to edit the parent post
@@ -229,16 +243,6 @@ class MediaItemCreate {
 				}
 			}
 
-			$post_type_object = get_post_type_object( 'attachment' );
-
-			/**
-			 * If the mediaItem being created is being assigned to another user that's not the current user, make sure
-			 * the current user has permission to edit others mediaItems
-			 */
-			if ( ! empty( $input['authorId'] ) && get_current_user_id() !== $input['authorId'] && ( ! isset( $post_type_object->cap->edit_others_posts ) || ! current_user_can( $post_type_object->cap->edit_others_posts ) ) ) {
-				throw new UserError( __( 'Sorry, you are not allowed to create mediaItems as this user', 'wp-graphql' ) );
-			}
-
 			/**
 			 * Insert the mediaItem
 			 *
@@ -251,7 +255,7 @@ class MediaItemCreate {
 			 */
 			$attachment_id = wp_insert_attachment( $media_item_args, $file['file'], $attachment_parent_id );
 
-			if ( is_wp_error( $attachment_id ) ) {
+			if ( 0 === $attachment_id || is_wp_error( $attachment_id ) ) {
 				throw new UserError( __( 'The Media Item failed to create', 'wp-graphql' ) );
 			}
 
@@ -267,12 +271,6 @@ class MediaItemCreate {
 			 */
 			$attachment_data = wp_generate_attachment_metadata( $attachment_id, $file['file'] );
 			wp_update_attachment_metadata( $attachment_id, $attachment_data );
-
-			$post_type_object = get_post_type_object( 'attachment' );
-
-			if ( empty( $post_type_object ) ) {
-				throw new UserError( __( 'The Media Item could not be created', 'wp-graphql' ) );
-			}
 
 			/**
 			 * Update alt text postmeta for mediaItem

--- a/src/Mutation/MediaItemDelete.php
+++ b/src/Mutation/MediaItemDelete.php
@@ -5,6 +5,7 @@ use Exception;
 use GraphQL\Error\UserError;
 use GraphQLRelay\Relay;
 use WPGraphQL\Model\Post;
+use WPGraphQL\Utils\Utils;
 
 class MediaItemDelete {
 	/**
@@ -79,25 +80,30 @@ class MediaItemDelete {
 	 */
 	public static function mutate_and_get_payload() {
 		return function ( $input ) {
-			$post_type_object = get_post_type_object( 'attachment' );
+			// Get the database ID for the comment.
+			$media_item_id = Utils::get_database_id_from_id( $input['id'] );
 
 			/**
-			 * Get the ID from the global ID
+			 * Get the mediaItem object before deleting it
 			 */
-			$id_parts            = Relay::fromGlobalId( $input['id'] );
-			$existing_media_item = get_post( absint( $id_parts['id'] ) );
+			$existing_media_item = ! empty( $media_item_id ) ? get_post( $media_item_id ) : null;
 
-			/**
-			 * If there's no existing mediaItem, throw an exception
-			 */
-			if ( empty( $existing_media_item ) ) {
-				throw new UserError( __( 'No mediaItem could be found to delete', 'wp-graphql' ) );
+			// If there's no existing mediaItem, throw an exception.
+			if ( null === $existing_media_item ) {
+				throw new UserError( __( 'No mediaItem with that ID could be found to delete', 'wp-graphql' ) );
+			}
+
+			// Stop now if the post isn't a mediaItem.
+			if ( 'attachment' !== $existing_media_item->post_type ) {
+				throw new UserError( sprintf( __( 'Sorry, the item you are trying to delete is a %1%s, not a mediaItem', 'wp-graphql' ), $existing_media_item->post_type ) );
 			}
 
 			/**
 			 * Stop now if a user isn't allowed to delete a mediaItem
 			 */
-			if ( ! isset( $post_type_object->cap->delete_post ) || ! current_user_can( $post_type_object->cap->delete_post, absint( $id_parts['id'] ) ) ) {
+			$post_type_object = get_post_type_object( 'attachment' );
+
+			if ( ! isset( $post_type_object->cap->delete_post ) || ! current_user_can( $post_type_object->cap->delete_post, $media_item_id ) ) {
 				throw new UserError( __( 'Sorry, you are not allowed to delete mediaItems', 'wp-graphql' ) );
 			}
 
@@ -107,43 +113,26 @@ class MediaItemDelete {
 			$force_delete = ! empty( $input['forceDelete'] ) && true === $input['forceDelete'];
 
 			/**
-			 * Get the mediaItem object before deleting it
-			 */
-			$media_item_before_delete = get_post( absint( $id_parts['id'] ) );
-			$media_item_before_delete = isset( $media_item_before_delete->ID ) && absint( $media_item_before_delete->ID ) ? new Post( $media_item_before_delete ) : $media_item_before_delete;
-
-			if ( empty( $media_item_before_delete ) ) {
-				throw new UserError( __( 'The Media Item could not be deleted', 'wp-graphql' ) );
-			}
-
-			/**
-			 * If the mediaItem isn't of the attachment post type, throw an error
-			 */
-			if ( 'attachment' !== $media_item_before_delete->post_type ) {
-				throw new UserError( sprintf( __( 'Sorry, the item you are trying to delete is a %1%s, not a mediaItem', 'wp-graphql' ), $media_item_before_delete->post_type ) );
-			}
-
-			/**
 			 * If the mediaItem is already in the trash, and the forceDelete input was not passed,
 			 * don't remove from the trash
 			 */
-			if ( 'trash' === $media_item_before_delete->post_status ) {
-				if ( true !== $force_delete ) {
-					// Translators: the first placeholder is the post_type of the object being deleted and the second placeholder is the unique ID of that object
-					throw new UserError( sprintf( __( 'The mediaItem with id %1$s is already in the trash. To remove from the trash, use the forceDelete input', 'wp-graphql' ), $input['id'] ) );
-				}
+			if ( 'trash' === $existing_media_item->post_status && true !== $force_delete ) {
+				// Translators: the first placeholder is the post_type of the object being deleted and the second placeholder is the unique ID of that object
+				throw new UserError( sprintf( __( 'The mediaItem with id %1$s is already in the trash. To remove from the trash, use the forceDelete input', 'wp-graphql' ), $input['id'] ) );
 			}
 
 			/**
 			 * Delete the mediaItem. This will not throw false thanks to
 			 * all of the above validation
 			 */
-			$deleted = wp_delete_attachment( $id_parts['id'], $force_delete );
+			$deleted = wp_delete_attachment( (int) $media_item_id, $force_delete );
 
 			/**
 			 * If the post was moved to the trash, spoof the object's status before returning it
 			 */
-			$media_item_before_delete->post_status = ( false !== $deleted && true !== $force_delete ) ? 'trash' : $media_item_before_delete->post_status;
+			$existing_media_item->post_status = ( false !== $deleted && true !== $force_delete ) ? 'trash' : $existing_media_item->post_status;
+
+			$media_item_before_delete = new Post( $existing_media_item );
 
 			/**
 			 * Return the deletedId and the mediaItem before it was deleted
@@ -151,7 +140,6 @@ class MediaItemDelete {
 			return [
 				'mediaItemObject' => $media_item_before_delete,
 			];
-
 		};
 	}
 }

--- a/tests/wpunit/MediaItemMutationsTest.php
+++ b/tests/wpunit/MediaItemMutationsTest.php
@@ -1,13 +1,13 @@
 <?php
 
-class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
-{
+class MediaItemMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
+
 
 	public $altText;
 	public $authorId;
 	public $caption;
 	public $commentStatus;
-    public $current_date_gmt;
+	public $current_date_gmt;
 	public $date;
 	public $dateGmt;
 	public $description;
@@ -17,7 +17,6 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	public $status;
 	public $title;
 	public $parentId;
-	public $clientMutationId;
 	public $updated_title;
 	public $updated_description;
 	public $updated_altText;
@@ -27,7 +26,6 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	public $updated_dateGmt;
 	public $updated_slug;
 	public $updated_status;
-	public $updated_clientMutationId;
 
 	public $create_variables;
 	public $update_variables;
@@ -43,132 +41,128 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	public $attachment_id;
 	public $media_item_id;
 
-    public function setUp(): void
-    {
-        // before
-        parent::setUp();
+	public function setUp(): void {
+		// before
+		parent::setUp();
 
-        // We don't want this funking with our tests
-	    remove_image_size( 'twentyseventeen-thumbnail-avatar' );
+		// We don't want this funking with our tests
+		remove_image_size( 'twentyseventeen-thumbnail-avatar' );
 
-	    /**
-	     * Set up different user roles for permissions testing
-	     */
-	    $this->subscriber = $this->factory()->user->create( [
-		    'role' => 'subscriber',
-	    ] );
-	    $this->subscriber_name = 'User ' . $this->subscriber;
+		/**
+		 * Set up different user roles for permissions testing
+		 */
+		$this->subscriber      = $this->factory()->user->create( [
+			'role' => 'subscriber',
+		] );
+		$this->subscriber_name = 'User ' . $this->subscriber;
 
-	    $this->author = $this->factory()->user->create( [
-		    'role' => 'author',
-	    ] );
-	    $this->author_name = 'User ' . $this->author;
+		$this->author      = $this->factory()->user->create( [
+			'role' => 'author',
+		] );
+		$this->author_name = 'User ' . $this->author;
 
-	    $this->admin = $this->factory()->user->create( [
-		    'role' => 'administrator',
-	    ] );
-	    $this->admin_name = 'User ' . $this->admin;
+		$this->admin      = $this->factory()->user->create( [
+			'role' => 'administrator',
+		] );
+		$this->admin_name = 'User ' . $this->admin;
 
-	    /**
-	     * Populate the mediaItem input fields
-	     */
-	    $this->altText          = 'A gif of Shia doing Magic.';
-	    $this->authorId         = \GraphQLRelay\Relay::toGlobalId( 'user', $this->admin );
-	    $this->caption          = 'Shia shows off some magic in this caption.';
-	    $this->commentStatus    = 'closed';
-	    $this->date             = '2017-08-01T15:00:00';
-	    $this->dateGmt          = '2017-08-01T21:00:00';
-	    $this->description      = 'This is a magic description.';
-	    $this->filePath         = 'https://content.wpgraphql.com/wp-content/uploads/2020/12/mgc.gif';
-	    $this->fileType         = 'IMAGE_GIF';
-	    $this->slug             = 'magic-shia';
-	    $this->status           = 'INHERIT';
-	    $this->title            = 'Magic Shia Gif';
-	    $this->parentId         = null;
-	    $this->clientMutationId = 'someUniqueId';
+		/**
+		 * Populate the mediaItem input fields
+		 */
+		$this->altText       = 'A gif of Shia doing Magic.';
+		$this->authorId      = \GraphQLRelay\Relay::toGlobalId( 'user', $this->admin );
+		$this->caption       = 'Shia shows off some magic in this caption.';
+		$this->commentStatus = 'closed';
+		$this->date          = '2017-08-01T15:00:00';
+		$this->dateGmt       = '2017-08-01T21:00:00';
+		$this->description   = 'This is a magic description.';
+		$this->filePath      = 'https://content.wpgraphql.com/wp-content/uploads/2020/12/mgc.gif';
+		$this->fileType      = 'IMAGE_GIF';
+		$this->slug          = 'magic-shia';
+		$this->status        = 'INHERIT';
+		$this->title         = 'Magic Shia Gif';
+		$this->parentId      = null;
 
-	    /**
-	     * Set up the updateMediaItem variables
-	     */
-	    $this->updated_title = 'Updated Magic Shia Gif';
-	    $this->updated_description = 'This is an updated magic description.';
-	    $this->updated_altText = 'Some updated alt text';
-	    $this->updated_caption = 'Shia shows off some magic in this updated caption.';
-	    $this->updated_commentStatus = 'open';
-	    $this->updated_date = '2017-08-01T16:00:00';
-	    $this->updated_dateGmt = '2017-08-01T22:00:00';
-	    $this->updated_slug = 'updated-shia-magic';
-	    $this->updated_status = 'INHERIT';
-	    $this->updated_clientMutationId = 'someUpdatedUniqueId';
+		/**
+		 * Set up the updateMediaItem variables
+		 */
+		$this->updated_title         = 'Updated Magic Shia Gif';
+		$this->updated_description   = 'This is an updated magic description.';
+		$this->updated_altText       = 'Some updated alt text';
+		$this->updated_caption       = 'Shia shows off some magic in this updated caption.';
+		$this->updated_commentStatus = 'open';
+		$this->updated_date          = '2017-08-01T16:00:00';
+		$this->updated_dateGmt       = '2017-08-01T22:00:00';
+		$this->updated_slug          = 'updated-shia-magic';
+		$this->updated_status        = 'INHERIT';
 
-	    /**
-	     * Create a mediaItem to update and store it's WordPress post ID
-	     * and it's WPGraphQL ID for using in our updateMediaItem mutation
-	     */
-	    $this->attachment_id = $this->factory()->attachment->create( ['post_mime_type' => 'image/gif', 'post_author' => $this->admin] );
-	    $this->media_item_id = \GraphQLRelay\Relay::toGlobalId( 'post', $this->attachment_id );
+		/**
+		 * Create a mediaItem to update and store it's WordPress post ID
+		 * and it's WPGraphQL ID for using in our updateMediaItem mutation
+		 */
+		$this->attachment_id = $this->factory()->attachment->create( [
+			'post_mime_type' => 'image/gif',
+			'post_author'    => $this->admin,
+		] );
+		$this->media_item_id = \GraphQLRelay\Relay::toGlobalId( 'post', $this->attachment_id );
 
-	    /**
-	     * Set the createMediaItem mutation input variables
-	     */
-	    $this->create_variables = [
-		    'input' => [
-			    'filePath'         => $this->filePath,
-			    'fileType'         => $this->fileType,
-			    'clientMutationId' => $this->clientMutationId,
-			    'title'            => $this->title,
-			    'description'      => $this->description,
-			    'altText'          => $this->altText,
-			    'parentId'         => $this->parentId,
-			    'caption'          => $this->caption,
-			    'commentStatus'    => $this->commentStatus,
-			    'date'             => $this->date,
-			    'dateGmt'          => $this->dateGmt,
-			    'slug'             => $this->slug,
-			    'status'           => $this->status,
-			    'authorId'         => $this->authorId,
-		    ],
-	    ];
+		/**
+		 * Set the createMediaItem mutation input variables
+		 */
+		$this->create_variables = [
+			'input' => [
+				'filePath'      => $this->filePath,
+				'fileType'      => $this->fileType,
+				'title'         => $this->title,
+				'description'   => $this->description,
+				'altText'       => $this->altText,
+				'parentId'      => $this->parentId,
+				'caption'       => $this->caption,
+				'commentStatus' => $this->commentStatus,
+				'date'          => $this->date,
+				'dateGmt'       => $this->dateGmt,
+				'slug'          => $this->slug,
+				'status'        => $this->status,
+				'authorId'      => $this->authorId,
+			],
+		];
 
-	    /**
-	     * Set the updateMediaItem mutation input variables
-	     */
-	    $this->update_variables = [
-		    'input' => [
-			    'id'               => $this->media_item_id,
-			    'clientMutationId' => $this->updated_clientMutationId,
-			    'title'            => $this->updated_title,
-			    'description'      => $this->updated_description,
-			    'altText'          => $this->updated_altText,
-			    'caption'          => $this->updated_caption,
-			    'commentStatus'    => $this->updated_commentStatus,
-			    'date'             => $this->updated_date,
-			    'dateGmt'          => $this->updated_dateGmt,
-			    'slug'             => $this->updated_slug,
-			    'status'           => $this->updated_status,
-			    'fileType'         => $this->fileType,
-		    ]
-	    ];
+		/**
+		 * Set the updateMediaItem mutation input variables
+		 */
+		$this->update_variables = [
+			'input' => [
+				'id'            => $this->media_item_id,
+				'title'         => $this->updated_title,
+				'description'   => $this->updated_description,
+				'altText'       => $this->updated_altText,
+				'caption'       => $this->updated_caption,
+				'commentStatus' => $this->updated_commentStatus,
+				'date'          => $this->updated_date,
+				'dateGmt'       => $this->updated_dateGmt,
+				'slug'          => $this->updated_slug,
+				'status'        => $this->updated_status,
+				'fileType'      => $this->fileType,
+			],
+		];
 
-	    /**
-	     * Set the deleteMediaItem input variables
-	     */
-	    $this->delete_variables = [
-		    'input' => [
-			    'id'               => $this->media_item_id,
-			    'clientMutationId' => $this->clientMutationId,
-			    'forceDelete'      => true,
-		    ]
-	    ];
-    }
+		/**
+		 * Set the deleteMediaItem input variables
+		 */
+		$this->delete_variables = [
+			'input' => [
+				'id'          => $this->media_item_id,
+				'forceDelete' => true,
+			],
+		];
+	}
 
-    public function tearDown(): void
-    {
-        // your tear down methods here
+	public function tearDown(): void {
+		// your tear down methods here
 
-        // then
-        parent::tearDown();
-    }
+		// then
+		parent::tearDown();
+	}
 
 	/**
 	 * This function tests the createMediaItem mutation
@@ -178,70 +172,69 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	 * @return array $actual
 	 */
 	public function createMediaItemMutation() {
-
 		/**
 		 * Set up the createMediaItem mutation
 		 */
-		$mutation = '
+		$query = '
 			mutation createMediaItem( $input: CreateMediaItemInput! ){
-			  createMediaItem(input: $input){
-			    clientMutationId
-			    mediaItem{
-			      id
-			      mediaItemId
-			      mediaType
-			      date
-			      dateGmt
-			      slug
-			      status
-			      title
-			      commentStatus
-			      altText
-			      caption
-			      description
-			      mimeType
-			      parent {
-			        node {
-				      ... on Post {
-				        id
-				      }
-			        }
-			      }
-			      sourceUrl
-			      mediaDetails {
-			          file
-			          height
-			          meta {
-			            aperture
-			            credit
-			            camera
-			            caption
-			            createdTimestamp
-			            copyright
-			            focalLength
-			            iso
-			            shutterSpeed
-			            title
-			            orientation
-			          }
-			          width
-			          sizes {
-			            name
-			            file
-			            width
-			            height
-			            mimeType
-			            sourceUrl
-			          }
-			        }
-			    }
-			  }
+				createMediaItem(input: $input){
+					mediaItem{
+						id
+						databaseId
+						mediaType
+						date
+						dateGmt
+						slug
+						status
+						title
+						commentStatus
+						altText
+						caption
+						description
+						mimeType
+						parent {
+							node {
+							... on Post {
+								id
+							}
+							}
+						}
+						sourceUrl
+						mediaDetails {
+								file
+								height
+								meta {
+									aperture
+									credit
+									camera
+									caption
+									createdTimestamp
+									copyright
+									focalLength
+									iso
+									shutterSpeed
+									title
+									orientation
+								}
+								width
+								sizes {
+									name
+									file
+									width
+									height
+									mimeType
+									sourceUrl
+								}
+							}
+					}
+				}
 			}
 		';
 
-		$actual = do_graphql_request( $mutation, 'createMediaItem', $this->create_variables );
-
-		return $actual;
+		return $this->graphql( [
+			'query'     => $query,
+			'variables' => $this->create_variables,
+		]);
 	}
 
 	/**
@@ -267,7 +260,7 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	public function testCreateMediaItemFilePath() {
 		wp_set_current_user( $this->admin );
 		$this->create_variables['input']['filePath'] = 'file:///Users/hdevore/Desktop/Current/colorado_lake.jpeg';
-		$actual = $this->createMediaItemMutation();
+		$actual                                      = $this->createMediaItemMutation();
 		$this->assertArrayHasKey( 'errors', $actual );
 		$this->create_variables['input']['filePath'] = $this->filePath;
 	}
@@ -285,19 +278,20 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 		/**
 		 * Set up the createMediaItem mutation
 		 */
-		$mutation = '
+		$query = '
 		mutation createMediaItem( $input: CreateMediaItemInput! ){
-		  createMediaItem(input: $input){
-		    clientMutationId
-		    mediaItem{
-		      id
-		    }
-		  }
+			createMediaItem(input: $input){
+				mediaItem{
+					id
+				}
+			}
 		}
 		';
 
-		$empty_variables = '';
-		$actual = do_graphql_request( $mutation, 'createMediaItem', $empty_variables );
+		$actual = $this->graphql([
+			'query'     => $query,
+			'variables' => '',
+		]);
 		$this->assertArrayHasKey( 'errors', $actual );
 	}
 
@@ -313,14 +307,13 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 		/**
 		 * Set up the createMediaItem mutation
 		 */
-		$mutation = '
+		$query = '
 		mutation createMediaItem( $input: CreateMediaItemInput! ){
-		  createMediaItem(input: $input){
-		    clientMutationId
-		    mediaItem{
-		      id
-		    }
-		  }
+			createMediaItem(input: $input){
+				mediaItem{
+					id
+				}
+			}
 		}
 		';
 
@@ -329,25 +322,24 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 		 */
 		$variables = [
 			'input' => [
-				'filePath'         => $this->filePath,
-				'fileType'         => $this->fileType,
-				'clientMutationId' => $this->clientMutationId,
-				'title'            => $this->title,
-				'description'      => $this->description,
-				'altText'          => $this->altText,
-				'parentId'         => $this->parentId,
-				'caption'          => $this->caption,
-				'commentStatus'    => $this->commentStatus,
-				'date'             => $this->date,
-				'dateGmt'          => $this->dateGmt,
-				'slug'             => $this->slug,
-				'status'           => $this->status,
-				'authorId'         => $this->admin,
+				'filePath'      => $this->filePath,
+				'fileType'      => $this->fileType,
+				'title'         => $this->title,
+				'description'   => $this->description,
+				'altText'       => $this->altText,
+				'parentId'      => $this->parentId,
+				'caption'       => $this->caption,
+				'commentStatus' => $this->commentStatus,
+				'date'          => $this->date,
+				'dateGmt'       => $this->dateGmt,
+				'slug'          => $this->slug,
+				'status'        => $this->status,
+				'authorId'      => $this->admin,
 			],
 		];
 
 		wp_set_current_user( $this->author );
-		$actual = do_graphql_request( $mutation, 'createMediaItem', $variables );
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
 		$this->assertArrayHasKey( 'errors', $actual );
 	}
 
@@ -361,7 +353,7 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	public function testCreateMediaItemWithInvalidUrl() {
 		wp_set_current_user( $this->author );
 		$this->create_variables['input']['filePath'] = 'htt://vice.co.um/images/2016/09/16/bill-murray-has-a-couple-of-shifts-at-a-brooklyn-bar-this-weekend-body-image-1473999364.jpg?crop=1xw:1xh;center,center&resize=1440:*';
-		$actual = $this->createMediaItemMutation();
+		$actual                                      = $this->createMediaItemMutation();
 		$this->assertArrayHasKey( 'errors', $actual );
 		$this->create_variables['input']['filePath'] = $this->filePath;
 	}
@@ -376,7 +368,7 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	public function testCreateMediaItemWithNoFile() {
 		wp_set_current_user( $this->author );
 		$this->create_variables['input']['filePath'] = 'https://i-d-images.vice.com/images/2016/09/16/bill-murray-has-a-couple-of-shifts-at-a-brooklyn-bar-this-weekend-body-image-1473999364.jpg?crop=1xw:1xh;center,center&resize=1440:*';
-		$actual = $this->createMediaItemMutation();
+		$actual                                      = $this->createMediaItemMutation();
 		$this->assertArrayHasKey( 'errors', $actual );
 		$this->create_variables['input']['filePath'] = $this->filePath;
 	}
@@ -392,7 +384,7 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	public function testCreateMediaItemAttachToParentAsAuthor() {
 		$post                                        = $this->factory()->post->create( [
 			'post_author' => $this->admin,
-			'post_status' => 'publish'
+			'post_status' => 'publish',
 		] );
 		$this->create_variables['input']['parentId'] = absint( $post );
 
@@ -403,8 +395,6 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 		wp_set_current_user( $this->author );
 		$actual = $this->createMediaItemMutation();
 
-		codecept_debug( $actual );
-
 		$this->assertArrayHasKey( 'errors', $actual );
 
 	}
@@ -413,67 +403,64 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 
 		$post                                        = $this->factory()->post->create( [
 			'post_author' => $this->admin,
-			'post_status' => 'publish'
+			'post_status' => 'publish',
 		] );
 		$this->create_variables['input']['parentId'] = absint( $post );
 
 		wp_set_current_user( $this->admin );
 		$actual = $this->createMediaItemMutation();
 
-		codecept_debug( $actual );
-
-		$media_item_id = $actual["data"]["createMediaItem"]["mediaItem"]["id"];
-		$attachment_id = $actual["data"]["createMediaItem"]["mediaItem"]["mediaItemId"];
-		$attachment_url = wp_get_attachment_url( $attachment_id );
+		$media_item_id      = $actual['data']['createMediaItem']['mediaItem']['id'];
+		$attachment_id      = $actual['data']['createMediaItem']['mediaItem']['databaseId'];
+		$attachment_url     = wp_get_attachment_url( $attachment_id );
 		$attachment_details = wp_get_attachment_metadata( $attachment_id );
 
 		$expected = [
 			'createMediaItem' => [
-				'clientMutationId' => $this->clientMutationId,
 				'mediaItem' => [
-					'id'               => $media_item_id,
-					'mediaItemId'      => $attachment_id,
-					'title'            => $this->title,
-					'description'      => apply_filters( 'the_content', $this->description ),
-					'altText'          => $this->altText,
-					'caption'          => apply_filters( 'the_content', $this->caption ),
-					'commentStatus'    => $this->commentStatus,
-					'date'             => $this->date,
-					'dateGmt'          => $this->dateGmt,
-					'slug'             => $this->slug,
-					'status'           => strtolower( $this->status ),
-					'mimeType'         => 'image/gif',
-					'parent'           => [
+					'id'            => $media_item_id,
+					'databaseId'    => $attachment_id,
+					'title'         => $this->title,
+					'description'   => apply_filters( 'the_content', $this->description ),
+					'altText'       => $this->altText,
+					'caption'       => apply_filters( 'the_content', $this->caption ),
+					'commentStatus' => $this->commentStatus,
+					'date'          => $this->date,
+					'dateGmt'       => $this->dateGmt,
+					'slug'          => $this->slug,
+					'status'        => strtolower( $this->status ),
+					'mimeType'      => 'image/gif',
+					'parent'        => [
 						'node' => [
 							'id' => \GraphQLRelay\Relay::toGlobalId( 'post', $post ),
 						],
 					],
-					'mediaType'        => 'image',
-					'sourceUrl'        => $attachment_url,
-					'mediaDetails'     => [
+					'mediaType'     => 'image',
+					'sourceUrl'     => $attachment_url,
+					'mediaDetails'  => [
 						'file'   => $attachment_details['file'],
 						'height' => $attachment_details['height'],
 						'meta'   => [
-							'aperture' => 0.0,
-							'credit'   => '',
-							'camera'   => '',
-							'caption'  => '',
+							'aperture'         => 0.0,
+							'credit'           => '',
+							'camera'           => '',
+							'caption'          => '',
 							'createdTimestamp' => null,
-							'copyright' => '',
-							'focalLength' => null,
-							'iso' => 0,
-							'shutterSpeed' => null,
-							'title' => '',
-							'orientation' => '0',
+							'copyright'        => '',
+							'focalLength'      => null,
+							'iso'              => 0,
+							'shutterSpeed'     => null,
+							'title'            => '',
+							'orientation'      => '0',
 						],
-						'width' => $attachment_details['width'],
-						'sizes' => [
+						'width'  => $attachment_details['width'],
+						'sizes'  => [
 							0 => [
-								'name' => 'thumbnail',
-								'file' => $attachment_details['sizes']['thumbnail']['file'],
-								'width' => (int) $attachment_details['sizes']['thumbnail']['width'],
-								'height' => (int) $attachment_details['sizes']['thumbnail']['height'],
-								'mimeType' => $attachment_details['sizes']['thumbnail']['mime-type'],
+								'name'      => 'thumbnail',
+								'file'      => $attachment_details['sizes']['thumbnail']['file'],
+								'width'     => (int) $attachment_details['sizes']['thumbnail']['width'],
+								'height'    => (int) $attachment_details['sizes']['thumbnail']['height'],
+								'mimeType'  => $attachment_details['sizes']['thumbnail']['mime-type'],
 								'sourceUrl' => wp_get_attachment_image_src( $attachment_id, 'thumbnail' )[0],
 							],
 						],
@@ -501,7 +488,7 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 		] );
 		wp_set_current_user( $this->author );
 		$this->create_variables['input']['parentId'] = $post;
-		$actual = $this->createMediaItemMutation();
+		$actual                                      = $this->createMediaItemMutation();
 		$this->assertArrayHasKey( 'errors', $actual );
 		$this->create_variables['input']['parentId'] = $this->parentId;
 	}
@@ -510,6 +497,7 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	 * Test the MediaItemMutation by setting the default values:
 	 *
 	 * post_status
+	 *
 	 * @source wp-content/plugins/wp-graphql/src/Type/MediaItem/Mutation/MediaItemMutation.php:136
 	 *
 	 * post_title
@@ -536,124 +524,122 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 		/**
 		 * Set up the createMediaItem mutation
 		 */
-		$default_mutation = '
+		$query = '
 		mutation createMediaItem( $input: CreateMediaItemInput! ){
-		  createMediaItem(input: $input){
-		    clientMutationId
-		    mediaItem{
-		      id
-		      mediaItemId
-		      status
-		      title
-		      author {
-		        node {
-		          id
-		        }
-		      }
-		      description
-		      mimeType
-		      parent {
-		        node {
-  		          ... on Post {
-  		            id
-		          }
-		        }
-		      }
-		      sourceUrl
-		      mediaDetails {
-	            file
-	            height
-	            meta {
-	              aperture
-	              credit
-	              camera
-	              caption
-	              createdTimestamp
-	              copyright
-	              focalLength
-	              iso
-	              shutterSpeed
-	              title
-	              orientation
-	            }
-	            width
-	            sizes {
-	              name
-	              file
-	              width
-	              height
-	              mimeType
-	              sourceUrl
-	            }
-	          }
-		    }
-		  }
+			createMediaItem(input: $input){
+				mediaItem{
+					id
+					databaseId
+					status
+					title
+					author {
+						node {
+							id
+						}
+					}
+					description
+					mimeType
+					parent {
+						node {
+								... on Post {
+									id
+							}
+						}
+					}
+					sourceUrl
+					mediaDetails {
+							file
+							height
+							meta {
+								aperture
+								credit
+								camera
+								caption
+								createdTimestamp
+								copyright
+								focalLength
+								iso
+								shutterSpeed
+								title
+								orientation
+							}
+							width
+							sizes {
+								name
+								file
+								width
+								height
+								mimeType
+								sourceUrl
+							}
+						}
+				}
+			}
 		}
 		';
 
 		/**
 		 * Set new input variables without changing defaults
 		 */
-		$default_variables = [
+		$variables = [
 			'input' => [
-				'filePath'         => $this->filePath,
-				'clientMutationId' => $this->clientMutationId,
+				'filePath' => $this->filePath,
 			],
 		];
 
 		/**
 		 * Do the graphQL request using the above variables for input in the above mutation
 		 */
-		$actual = do_graphql_request( $default_mutation, 'createMediaItem', $default_variables );
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+		$this->assertArrayNotHasKey( 'errors', $actual );
 
-		$media_item_id = $actual["data"]["createMediaItem"]["mediaItem"]["id"];
-		$attachment_id = $actual["data"]["createMediaItem"]["mediaItem"]["mediaItemId"];
-		$attachment_data = get_post( $attachment_id );
-		$attachment_title = $attachment_data->post_title;
-		$attachment_url = wp_get_attachment_url( $attachment_id );
+		$media_item_id      = $actual['data']['createMediaItem']['mediaItem']['id'];
+		$attachment_id      = $actual['data']['createMediaItem']['mediaItem']['databaseId'];
+		$attachment_data    = get_post( $attachment_id );
+		$attachment_title   = $attachment_data->post_title;
+		$attachment_url     = wp_get_attachment_url( $attachment_id );
 		$attachment_details = wp_get_attachment_metadata( $attachment_id );
 
 		$expected = [
 			'createMediaItem' => [
-				'clientMutationId' => $this->clientMutationId,
 				'mediaItem' => [
-					'id'               => $media_item_id,
-					'mediaItemId'      => $attachment_id,
-					'status'           => strtolower( $this->status ),
-					'title'            => $attachment_title,
-					'description'      => '',
-					'mimeType'         => 'image/gif',
-					'author'           => [
+					'id'           => $media_item_id,
+					'databaseId'   => $attachment_id,
+					'status'       => strtolower( $this->status ),
+					'title'        => $attachment_title,
+					'description'  => '',
+					'mimeType'     => 'image/gif',
+					'author'       => [
 						'node' => [
 							'id' => \GraphQLRelay\Relay::toGlobalId( 'user', $this->admin ),
 						],
 					],
-					'parent'           => null,
-					'sourceUrl'        => $attachment_url,
-					'mediaDetails'     => [
+					'parent'       => null,
+					'sourceUrl'    => $attachment_url,
+					'mediaDetails' => [
 						'file'   => $attachment_details['file'],
 						'height' => $attachment_details['height'],
 						'meta'   => [
-							'aperture' => 0.0,
-							'credit'   => '',
-							'camera'   => '',
-							'caption'  => '',
+							'aperture'         => 0.0,
+							'credit'           => '',
+							'camera'           => '',
+							'caption'          => '',
 							'createdTimestamp' => null,
-							'copyright' => '',
-							'focalLength' => null,
-							'iso' => 0,
-							'shutterSpeed' => null,
-							'title' => '',
-							'orientation' => '0',
+							'copyright'        => '',
+							'focalLength'      => null,
+							'iso'              => 0,
+							'shutterSpeed'     => null,
+							'title'            => '',
+							'orientation'      => '0',
 						],
-						'width' => $attachment_details['width'],
-						'sizes' => [
+						'width'  => $attachment_details['width'],
+						'sizes'  => [
 							0 => [
-								'name' => 'thumbnail',
-								'file' => $attachment_details['sizes']['thumbnail']['file'],
-								'width' => (int) $attachment_details['sizes']['thumbnail']['width'],
-								'height' => (int) $attachment_details['sizes']['thumbnail']['height'],
-								'mimeType' => $attachment_details['sizes']['thumbnail']['mime-type'],
+								'name'      => 'thumbnail',
+								'file'      => $attachment_details['sizes']['thumbnail']['file'],
+								'width'     => (int) $attachment_details['sizes']['thumbnail']['width'],
+								'height'    => (int) $attachment_details['sizes']['thumbnail']['height'],
+								'mimeType'  => $attachment_details['sizes']['thumbnail']['mime-type'],
 								'sourceUrl' => wp_get_attachment_image_src( $attachment_id, 'thumbnail' )[0],
 							],
 						],
@@ -685,54 +671,53 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 		 */
 		$actual = $this->createMediaItemMutation();
 
-		$media_item_id = $actual["data"]["createMediaItem"]["mediaItem"]["id"];
-		$attachment_id = $actual["data"]["createMediaItem"]["mediaItem"]["mediaItemId"];
-		$attachment_url = wp_get_attachment_url( $attachment_id );
+		$media_item_id      = $actual['data']['createMediaItem']['mediaItem']['id'];
+		$attachment_id      = $actual['data']['createMediaItem']['mediaItem']['databaseId'];
+		$attachment_url     = wp_get_attachment_url( $attachment_id );
 		$attachment_details = wp_get_attachment_metadata( $attachment_id );
 
 		$expected = [
 			'createMediaItem' => [
-				'clientMutationId' => $this->clientMutationId,
 				'mediaItem' => [
-					'id'               => $media_item_id,
-					'mediaItemId'      => $attachment_id,
-					'title'            => $this->title,
-					'description'      => apply_filters( 'the_content', $this->description ),
-					'altText'          => $this->altText,
-					'caption'          => apply_filters( 'the_content', $this->caption ),
-					'commentStatus'    => $this->commentStatus,
-					'date'             => $this->date,
-					'dateGmt'          => $this->dateGmt,
-					'slug'             => $this->slug,
-					'status'           => strtolower( $this->status ),
-					'mimeType'         => 'image/gif',
-					'parent'           => null,
-					'mediaType'        => 'image',
-					'sourceUrl'        => $attachment_url,
-					'mediaDetails'     => [
+					'id'            => $media_item_id,
+					'databaseId'    => $attachment_id,
+					'title'         => $this->title,
+					'description'   => apply_filters( 'the_content', $this->description ),
+					'altText'       => $this->altText,
+					'caption'       => apply_filters( 'the_content', $this->caption ),
+					'commentStatus' => $this->commentStatus,
+					'date'          => $this->date,
+					'dateGmt'       => $this->dateGmt,
+					'slug'          => $this->slug,
+					'status'        => strtolower( $this->status ),
+					'mimeType'      => 'image/gif',
+					'parent'        => null,
+					'mediaType'     => 'image',
+					'sourceUrl'     => $attachment_url,
+					'mediaDetails'  => [
 						'file'   => $attachment_details['file'],
 						'height' => $attachment_details['height'],
 						'meta'   => [
-							'aperture' => 0.0,
-							'credit'   => '',
-							'camera'   => '',
-							'caption'  => '',
+							'aperture'         => 0.0,
+							'credit'           => '',
+							'camera'           => '',
+							'caption'          => '',
 							'createdTimestamp' => null,
-							'copyright' => '',
-							'focalLength' => null,
-							'iso' => 0,
-							'shutterSpeed' => null,
-							'title' => '',
-							'orientation' => '0',
+							'copyright'        => '',
+							'focalLength'      => null,
+							'iso'              => 0,
+							'shutterSpeed'     => null,
+							'title'            => '',
+							'orientation'      => '0',
 						],
-						'width' => $attachment_details['width'],
-						'sizes' => [
+						'width'  => $attachment_details['width'],
+						'sizes'  => [
 							0 => [
-								'name' => 'thumbnail',
-								'file' => $attachment_details['sizes']['thumbnail']['file'],
-								'width' => (int) $attachment_details['sizes']['thumbnail']['width'],
-								'height' => (int) $attachment_details['sizes']['thumbnail']['height'],
-								'mimeType' => $attachment_details['sizes']['thumbnail']['mime-type'],
+								'name'      => 'thumbnail',
+								'file'      => $attachment_details['sizes']['thumbnail']['file'],
+								'width'     => (int) $attachment_details['sizes']['thumbnail']['width'],
+								'height'    => (int) $attachment_details['sizes']['thumbnail']['height'],
+								'mimeType'  => $attachment_details['sizes']['thumbnail']['mime-type'],
 								'sourceUrl' => wp_get_attachment_image_src( $attachment_id, 'thumbnail' )[0],
 							],
 						],
@@ -742,7 +727,6 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 		];
 
 		$this->assertEquals( $expected, $actual['data'] );
-
 	}
 
 	/**
@@ -758,28 +742,27 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 		 */
 		$mutation = '
 		mutation updateMediaItem( $input: UpdateMediaItemInput! ){
-		  updateMediaItem (input: $input){
-		    clientMutationId
-		    mediaItem {
-		      id
-		      mediaItemId
-		      date
-		      dateGmt
-		      slug
-		      status
-		      title
-		      commentStatus
-		      altText
-		      caption
-		      description
-		      mimeType
-		      author {
-		        node {
-		          id
-		        }
-		      }
-		    }
-		  }
+			updateMediaItem (input: $input){
+				mediaItem {
+					id
+					databaseId
+					date
+					dateGmt
+					slug
+					status
+					title
+					commentStatus
+					altText
+					caption
+					description
+					mimeType
+					author {
+						node {
+							id
+						}
+					}
+				}
+			}
 		}
 		';
 
@@ -798,7 +781,7 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testUpdateMediaItemInvalidId() {
 		$this->update_variables['input']['id'] = \GraphQLRelay\Relay::toGlobalId( 'post', 123456 );
-		$actual = $this->updateMediaItemMutation();
+		$actual                                = $this->updateMediaItemMutation();
 		$this->assertArrayHasKey( 'errors', $actual );
 		$this->update_variables['input']['id'] = $this->media_item_id;
 	}
@@ -810,9 +793,9 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	 * @return void
 	 */
 	public function testUpdateMediaItemUpdatePost() {
-		$test_post = $this->factory()->post->create();
+		$test_post                             = $this->factory()->post->create();
 		$this->update_variables['input']['id'] = \GraphQLRelay\Relay::toGlobalId( 'post', $test_post );
-		$actual = $this->updateMediaItemMutation();
+		$actual                                = $this->updateMediaItemMutation();
 		$this->assertArrayHasKey( 'errors', $actual );
 		$this->update_variables['input']['id'] = $this->media_item_id;
 	}
@@ -844,7 +827,7 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 		] );
 		wp_set_current_user( $this->author );
 		$this->update_variables['input']['parentId'] = $post;
-		$actual = $this->updateMediaItemMutation();
+		$actual                                      = $this->updateMediaItemMutation();
 		$this->assertArrayHasKey( 'errors', $actual );
 		$this->update_variables['input']['parentId'] = $this->parentId;
 	}
@@ -860,7 +843,7 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	public function testUpdateMediaItemAddOtherAuthorsAsAuthor() {
 		wp_set_current_user( $this->author );
 		$this->update_variables['input']['authorId'] = \GraphQLRelay\Relay::toGlobalId( 'user', $this->admin );
-		$actual = $this->updateMediaItemMutation();
+		$actual                                      = $this->updateMediaItemMutation();
 		$this->assertArrayHasKey( 'errors', $actual );
 		$this->update_variables['input']['authorId'] = false;
 	}
@@ -875,7 +858,7 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	public function testUpdateMediaItemAddOtherAuthorsAsAdmin() {
 		wp_set_current_user( $this->admin );
 		$this->update_variables['input']['authorId'] = \GraphQLRelay\Relay::toGlobalId( 'user', $this->author );
-		$actual = $this->updateMediaItemMutation();
+		$actual                                      = $this->updateMediaItemMutation();
 
 		$actual_created = $actual['data']['updateMediaItem']['mediaItem'];
 		$this->assertArrayHasKey( 'id', $actual_created );
@@ -898,29 +881,27 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 
 		$actual = $this->updateMediaItemMutation();
 
-
 		/**
 		 * Define the expected output.
 		 */
 		$expected = [
 			'updateMediaItem' => [
-				'clientMutationId' => $this->updated_clientMutationId,
-				'mediaItem'             => [
-					'id'               => $this->media_item_id,
-					'title'            => $this->updated_title,
-					'description'      => apply_filters( 'the_content', $this->updated_description ),
-					'mediaItemId'      => $this->attachment_id,
-					'altText'          => $this->updated_altText,
-					'caption'          => apply_filters( 'the_content', $this->updated_caption ),
-					'commentStatus'    => $this->updated_commentStatus,
-					'date'             => $this->updated_date,
-					'dateGmt'          => $this->updated_dateGmt,
-					'slug'             => $this->updated_slug,
-					'status'           => strtolower( $this->updated_status ),
-					'mimeType'         => 'image/gif',
-					'author'           => [
+				'mediaItem' => [
+					'id'            => $this->media_item_id,
+					'title'         => $this->updated_title,
+					'description'   => apply_filters( 'the_content', $this->updated_description ),
+					'databaseId'    => $this->attachment_id,
+					'altText'       => $this->updated_altText,
+					'caption'       => apply_filters( 'the_content', $this->updated_caption ),
+					'commentStatus' => $this->updated_commentStatus,
+					'date'          => $this->updated_date,
+					'dateGmt'       => $this->updated_dateGmt,
+					'slug'          => $this->updated_slug,
+					'status'        => strtolower( $this->updated_status ),
+					'mimeType'      => 'image/gif',
+					'author'        => [
 						'node' => [
-							'id'       => \GraphQLRelay\Relay::toGlobalId( 'user', $this->admin ),
+							'id' => \GraphQLRelay\Relay::toGlobalId( 'user', $this->admin ),
 						],
 					],
 				],
@@ -949,14 +930,13 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 		 */
 		$mutation = '
 		mutation deleteMediaItem( $input: DeleteMediaItemInput! ){
-		  deleteMediaItem(input: $input) {
-		    clientMutationId
-		    deletedId
-		    mediaItem{
-		      id
-		      mediaItemId
-		    }
-		  }
+			deleteMediaItem(input: $input) {
+				deletedId
+				mediaItem{
+					id
+					databaseId
+				}
+			}
 		}
 		';
 
@@ -973,7 +953,7 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testDeleteMediaItemInvalidId() {
 		$this->delete_variables['input']['id'] = 12345;
-		$actual = $this->deleteMediaItemMutation();
+		$actual                                = $this->deleteMediaItemMutation();
 		$this->assertArrayHasKey( 'errors', $actual );
 		$this->delete_variables['input']['id'] = $this->media_item_id;
 	}
@@ -1007,14 +987,13 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 		 */
 		$mutation = '
 		mutation deleteMediaItem( $input: DeleteMediaItemInput! ){
-		  deleteMediaItem(input: $input) {
-		    clientMutationId
-		    deletedId
-		    mediaItem {
-		      id
-		      mediaItemId
-		    }
-		  }
+			deleteMediaItem(input: $input) {
+				deletedId
+				mediaItem {
+					id
+					databaseId
+				}
+			}
 		}
 		';
 
@@ -1023,15 +1002,13 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 		 */
 		$delete_trash_variables = [
 			'input' => [
-				'id'               => \GraphQLRelay\Relay::toGlobalId( 'post', $deleted_media_item ),
-				'clientMutationId' => $this->clientMutationId,
-				'forceDelete'      => false,
-			]
+				'id'          => \GraphQLRelay\Relay::toGlobalId( 'post', $deleted_media_item ),
+				'forceDelete' => false,
+			],
 		];
 
 		wp_set_current_user( $this->admin );
 		$actual = do_graphql_request( $mutation, 'deleteMediaItem', $delete_trash_variables );
-
 
 		$this->assertArrayHasKey( 'errors', $actual );
 	}
@@ -1052,14 +1029,13 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 		 */
 		$mutation = '
 		mutation deleteMediaItem( $input: DeleteMediaItemInput! ){
-		  deleteMediaItem(input: $input) {
-		    clientMutationId
-		    deletedId
-		    mediaItem {
-		      id
-		      mediaItemId
-		    }
-		  }
+			deleteMediaItem(input: $input) {
+				deletedId
+				mediaItem {
+					id
+					databaseId
+				}
+			}
 		}
 		';
 
@@ -1068,16 +1044,15 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 		 */
 		$delete_trash_variables = [
 			'input' => [
-				'id'               => \GraphQLRelay\Relay::toGlobalId( 'post', $deleted_media_item ),
-				'clientMutationId' => $this->clientMutationId,
-				'forceDelete'      => false,
-			]
+				'id'          => \GraphQLRelay\Relay::toGlobalId( 'post', $deleted_media_item ),
+				'forceDelete' => false,
+			],
 		];
 
 		wp_set_current_user( $this->admin );
 
 		$delete_trash_variables['input']['forceDelete'] = true;
-		$actual = do_graphql_request( $mutation, 'deleteMediaItem', $delete_trash_variables );
+		$actual              = do_graphql_request( $mutation, 'deleteMediaItem', $delete_trash_variables );
 		$actual_deleted_item = $actual['data']['deleteMediaItem'];
 		$this->assertArrayHasKey( 'deletedId', $actual_deleted_item );
 
@@ -1110,7 +1085,7 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 		/**
 		 * Create a page to test against and set the post id in the mutation variables
 		 */
-		$post_to_delete = $this->factory->post->create( $args );
+		$post_to_delete                        = $this->factory->post->create( $args );
 		$this->delete_variables['input']['id'] = \GraphQLRelay\Relay::toGlobalId( 'post', $post_to_delete );
 
 		/**
@@ -1145,11 +1120,10 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 		 */
 		$expected = [
 			'deleteMediaItem' => [
-				'clientMutationId' => $this->clientMutationId,
 				'deletedId' => $this->media_item_id,
 				'mediaItem' => [
-					'id'               => $this->media_item_id,
-					'mediaItemId'      => $this->attachment_id,
+					'id'         => $this->media_item_id,
+					'databaseId' => $this->attachment_id,
 				],
 			],
 		];
@@ -1157,7 +1131,7 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 		/**
 		 * Compare the actual output vs the expected output
 		 */
-		$this->assertEquals( $expected,  $actual['data'] );
+		$this->assertEquals( $expected, $actual['data'] );
 
 		/**
 		 * Try to delete again but we should have errors, because there's nothing to be deleted
@@ -1171,21 +1145,21 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 
 		$media_item_1 = $this->factory()->attachment->create( [
 			'post_mime_type' => 'image/gif',
-			'post_author' => $this->author
+			'post_author'    => $this->author,
 		] );
 
 		wp_set_current_user( $this->author );
 
 		$this->update_variables = [
 			'input' => [
-				'id' => \GraphQLRelay\Relay::toGlobalId( 'post', $media_item_1 ),
-				'title' => 'Test update title...'
-			]
+				'id'    => \GraphQLRelay\Relay::toGlobalId( 'post', $media_item_1 ),
+				'title' => 'Test update title...',
+			],
 		];
 
-		$actual =  $this->updateMediaItemMutation();
+		$actual = $this->updateMediaItemMutation();
 
-//		codecept_debug( $actual );
+		//			codecept_debug( $actual );
 
 		$this->assertArrayNotHasKey( 'errors', $actual );
 


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR enables users to supply either a database ID or a global ID to mediaItem mutation inputs of type ID. Part of https://github.com/wp-graphql/wp-graphql/issues/998 .


Does this close any currently open issues?
------------------------------------------
…



Any other comments?
-------------------
The `mutate_and_get_payload` methods were also refactored to bail earlier on failure and to remove some code duplication. 


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php8.0.15)

**WordPress Version:** 5.9.2
