### PR TITLE
Feat/term object mutation id inputs

### DIFF
--- a/src/Mutation/TermObjectCreate.php
+++ b/src/Mutation/TermObjectCreate.php
@@ -70,7 +70,7 @@ class TermObjectCreate {
 		 */
 		if ( true === $taxonomy->hierarchical ) {
 			$fields['parentId'] = [
-				'type'        => 'Id',
+				'type'        => 'ID',
 				// Translators: The placeholder is the name of the taxonomy for the object being mutated
 				'description' => sprintf( __( 'The ID of the %1$s that should be set as the parent', 'wp-graphql' ), $taxonomy->name ),
 			];

--- a/src/Mutation/TermObjectDelete.php
+++ b/src/Mutation/TermObjectDelete.php
@@ -6,6 +6,7 @@ use GraphQL\Error\UserError;
 use GraphQLRelay\Relay;
 use WP_Taxonomy;
 use WPGraphQL\Model\Term;
+use WPGraphQL\Utils\Utils;
 
 /**
  * Class TermObjectDelete
@@ -90,12 +91,10 @@ class TermObjectDelete {
 	 */
 	public static function mutate_and_get_payload( WP_Taxonomy $taxonomy, string $mutation_name ) {
 		return function ( $input ) use ( $taxonomy ) {
+			// Get the database ID for the comment.
+			$term_id = Utils::get_database_id_from_id( $input['id'] );
 
-			$id_parts = Relay::fromGlobalId( $input['id'] );
-
-			if ( ! empty( $id_parts['id'] ) && absint( $id_parts['id'] ) ) {
-				$term_id = absint( $id_parts['id'] );
-			} else {
+			if ( empty( $term_id ) ) {
 				// Translators: The placeholder is the name of the taxonomy for the term being deleted
 				throw new UserError( sprintf( __( 'The ID for the %1$s was not valid', 'wp-graphql' ), $taxonomy->graphql_single_name ) );
 			}

--- a/tests/wpunit/TermObjectMutationsTest.php
+++ b/tests/wpunit/TermObjectMutationsTest.php
@@ -43,7 +43,7 @@ class TermObjectMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCas
 	public function createCategoryMutation() {
 
 		$query = '
-		mutation createCategory( $name:String!, $description:String, $parentId: ID ) {
+		mutation createCategory( $name:String!, $description:String ) {
 			createCategory(
 				input: {
 					name: $name

--- a/tests/wpunit/TermObjectMutationsTest.php
+++ b/tests/wpunit/TermObjectMutationsTest.php
@@ -656,13 +656,25 @@ class TermObjectMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCas
 		}
 		';
 
-		// Test with database ID
+		// Test with bad parent ID
 		$variables = [
 			'input' => [
 				'name'     => 'Child Category 1',
-				'parentId' => $parent_term_id,
+				'parentId' => 'notarealid',
 			],
 		];
+
+		$actual = graphql( compact( 'query', 'variables' ) );
+		$this->assertArrayHasKey( 'errors', $actual );
+
+		// Test with non-existent parent ID
+		$variables['input']['parentId'] = 999999;
+
+		$actual = graphql( compact( 'query', 'variables' ) );
+		$this->assertArrayHasKey( 'errors', $actual );
+
+		// Test with database ID
+		$variables['input']['parentId'] = $parent_term_id;
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 

--- a/tests/wpunit/TermObjectMutationsTest.php
+++ b/tests/wpunit/TermObjectMutationsTest.php
@@ -591,6 +591,45 @@ class TermObjectMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCas
 
 	}
 
+	/**
+	 * Tests updating a category with bad id.
+	 */
+	public function testUpdateCategoryWithBadId() {
+		$query =
+		'mutation updateCategory( $id:ID! $description:String ) {
+			updateCategory(
+				input: {
+					description: $description
+					id: $id
+				}
+			) {
+				category {
+					databaseId
+					id
+					name
+					description
+				}
+			}
+		}
+		';
+
+		// Test no id.
+		$variables = [
+			'id'          => '',
+			'description' => 'Some description',
+		];
+		$actual    = graphql( compact( 'query', 'variables' ) );
+		$this->assertArrayHasKey( 'errors', $actual );
+
+		// Test non-existent id.
+		$variables['id'] = 99999999;
+		$actual          = $this->graphql( compact( 'query', 'variables' ) );
+		$this->assertArrayHasKey( 'errors', $actual );
+	}
+
+	/**
+	 * Tests category mutations with a parent category.
+	 */
 	public function testCategoryParent() {
 
 		wp_set_current_user( $this->admin );


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR enables users to supply either a database ID or a global ID to term object mutation inputs of type ID. Part of #998 


Does this close any currently open issues?
------------------------------------------
…


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php8.0.15)

**WordPress Version:** 5.9.2
