### PR TITLE
Feat/user object mutation id inputs

### DIFF
--- a/src/Mutation/UserDelete.php
+++ b/src/Mutation/UserDelete.php
@@ -85,7 +85,7 @@ class UserDelete {
 			$user_id = Utils::get_database_id_from_id( $input['id'] );
 
 			if ( empty( $user_id ) ) {
-				throw new UserError( 'The user ID passed is invalid', 'wp-graphql' );
+				throw new UserError( __( 'The user ID passed is invalid', 'wp-graphql' ) );
 			}
 
 			if ( ! current_user_can( 'delete_users', $user_id ) ) {
@@ -112,7 +112,7 @@ class UserDelete {
 				$reassign_id = Utils::get_database_id_from_id( $input['reassignId'] );
 
 				if ( empty( $reassign_id ) ) {
-					throw new UserError( 'The user ID passed to `reassignId` is invalid', 'wp-graphql' );
+					throw new UserError( __( 'The user ID passed to `reassignId` is invalid', 'wp-graphql' ) );
 				}
 				/**
 			 * Retrieve the user object before it's deleted

--- a/src/Mutation/UserDelete.php
+++ b/src/Mutation/UserDelete.php
@@ -124,7 +124,6 @@ class UserDelete {
 				}
 			}
 
-
 			if ( ! function_exists( 'wp_delete_user' ) ) {
 				require_once ABSPATH . 'wp-admin/includes/user.php';
 			}

--- a/src/Mutation/UserDelete.php
+++ b/src/Mutation/UserDelete.php
@@ -107,7 +107,7 @@ class UserDelete {
 			/**
 			 * Get the user to reassign posts to.
 			 */
-			$reassign_id = null;
+			$reassign_id = 0;
 			if ( ! empty( $input['reassignId'] ) ) {
 				$reassign_id = Utils::get_database_id_from_id( $input['reassignId'] );
 
@@ -133,12 +133,22 @@ class UserDelete {
 			if ( ! function_exists( 'wpmu_delete_user' ) ) {
 				require_once ABSPATH . 'wp-admin/includes/ms.php';
 			}
+			if ( ! function_exists( 'remove_user_from_blog' ) ) {
+				require_once ABSPATH . 'wp-admin/includes/ms-functions.php';
+			}
 			if ( ! function_exists( 'wp_delete_user' ) ) {
 				require_once ABSPATH . 'wp-admin/includes/user.php';
 			}
 
 			if ( is_multisite() ) {
+				$blog_id = get_current_blog_id();
+				
+				// remove the user from the blog and reassign their posts
+				remove_user_from_blog( $user_id, $blog_id, $reassign_id );
+
+				// delete the user
 				$deleted_user = wpmu_delete_user( $user_id );
+
 			} else {
 				$deleted_user = wp_delete_user( $user_id, $reassign_id );
 			}

--- a/src/Mutation/UserDelete.php
+++ b/src/Mutation/UserDelete.php
@@ -124,25 +124,30 @@ class UserDelete {
 				}
 			}
 
-			/**
-			 * If wpmu_delete_user() or wp_delete_user() doesn't exist yet,
-			 * load the files in which each is defined. I think we need to
-			 * load this manually here because WordPress only uses this
-			 * function on the user edit screen normally.
-			 */
-			if ( ! function_exists( 'wpmu_delete_user' ) ) {
-				require_once ABSPATH . 'wp-admin/includes/ms.php';
-			}
-			if ( ! function_exists( 'remove_user_from_blog' ) ) {
-				require_once ABSPATH . 'wp-admin/includes/ms-functions.php';
-			}
+
 			if ( ! function_exists( 'wp_delete_user' ) ) {
 				require_once ABSPATH . 'wp-admin/includes/user.php';
 			}
 
 			if ( is_multisite() ) {
+
+				/**
+				 * If wpmu_delete_user() or remove_user_from_blog() doesn't exist yet,
+				 * load the files in which each is defined. I think we need to
+				 * load this manually here because WordPress only uses this
+				 * function on the user edit screen normally.
+				 */
+
+				// only include these files for multisite requests
+				if ( ! function_exists( 'wpmu_delete_user' ) ) {
+					require_once ABSPATH . 'wp-admin/includes/ms.php';
+				}
+				if ( ! function_exists( 'remove_user_from_blog' ) ) {
+					require_once ABSPATH . 'wp-admin/includes/ms-functions.php';
+				}
+
 				$blog_id = get_current_blog_id();
-				
+
 				// remove the user from the blog and reassign their posts
 				remove_user_from_blog( $user_id, $blog_id, $reassign_id );
 

--- a/src/Mutation/UserUpdate.php
+++ b/src/Mutation/UserUpdate.php
@@ -4,9 +4,9 @@ namespace WPGraphQL\Mutation;
 use Exception;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
-use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
 use WPGraphQL\Data\UserMutation;
+use WPGraphQL\Utils\Utils;
 
 class UserUpdate {
 	/**
@@ -62,14 +62,18 @@ class UserUpdate {
 	 */
 	public static function mutate_and_get_payload() {
 		return function ( $input, AppContext $context, ResolveInfo $info ) {
+			// Get the user ID.
+			$user_id = Utils::get_database_id_from_id( $input['id'] );
 
-			$id_parts      = ! empty( $input['id'] ) ? Relay::fromGlobalId( $input['id'] ) : null;
-			$existing_user = isset( $id_parts['id'] ) && absint( $id_parts['id'] ) ? get_user_by( 'ID', absint( $id_parts['id'] ) ) : null;
+			if ( empty( $user_id ) ) {
+				throw new UserError( 'The user ID passed is invalid', 'wp-graphql' );
+			}
+			$existing_user = get_user_by( 'ID', $user_id );
 
 			/**
 			 * If there's no existing user, throw an exception
 			 */
-			if ( ! isset( $id_parts['id'] ) || empty( $existing_user ) ) {
+			if ( false === $existing_user ) {
 				throw new UserError( __( 'A user could not be updated with the provided ID', 'wp-graphql' ) );
 			}
 
@@ -83,18 +87,18 @@ class UserUpdate {
 			}
 
 			$user_args       = UserMutation::prepare_user_object( $input, 'updateUser' );
-			$user_args['ID'] = absint( $id_parts['id'] );
+			$user_args['ID'] = $user_id;
 
 			/**
 			 * Update the user
 			 */
-			$user_id = wp_update_user( $user_args );
+			$updated_user_id = wp_update_user( $user_args );
 
 			/**
 			 * Throw an exception if the post failed to create
 			 */
-			if ( is_wp_error( $user_id ) ) {
-				$error_message = $user_id->get_error_message();
+			if ( is_wp_error( $updated_user_id ) ) {
+				$error_message = $updated_user_id->get_error_message();
 				if ( ! empty( $error_message ) ) {
 					throw new UserError( esc_html( $error_message ) );
 				} else {
@@ -103,23 +107,23 @@ class UserUpdate {
 			}
 
 			/**
-			 * If the $user_id is empty, we should throw an exception
+			 * If the $updated_user_id is empty, we should throw an exception
 			 */
-			if ( empty( $user_id ) ) {
+			if ( empty( $updated_user_id ) ) {
 				throw new UserError( __( 'The user failed to update', 'wp-graphql' ) );
 			}
 
 			/**
 			 * Update additional user data
 			 */
-			UserMutation::update_additional_user_object_data( $user_id, $input, 'updateUser', $context, $info );
+			UserMutation::update_additional_user_object_data( $updated_user_id, $input, 'updateUser', $context, $info );
 
 			/**
 			 * Return the new user ID
 			 */
 			return [
-				'id'   => $user_id,
-				'user' => $context->get_loader( 'user' )->load_deferred( $user_id ),
+				'id'   => $updated_user_id,
+				'user' => $context->get_loader( 'user' )->load_deferred( $updated_user_id ),
 			];
 		};
 	}

--- a/src/Mutation/UserUpdate.php
+++ b/src/Mutation/UserUpdate.php
@@ -66,7 +66,7 @@ class UserUpdate {
 			$user_id = Utils::get_database_id_from_id( $input['id'] );
 
 			if ( empty( $user_id ) ) {
-				throw new UserError( 'The user ID passed is invalid', 'wp-graphql' );
+				throw new UserError( __( 'The user ID passed is invalid', 'wp-graphql' ) );
 			}
 			$existing_user = get_user_by( 'ID', $user_id );
 

--- a/tests/wpunit/UserObjectMutationsTest.php
+++ b/tests/wpunit/UserObjectMutationsTest.php
@@ -539,8 +539,6 @@ class UserObjectMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCas
 
 		$this->assertEquals( $user_id, $actual['data']['deleteUser']['user']['databaseId'] );
 
-		codecept_debug( get_post( $post ) );
-
 		$post_obj_after_delete = get_post( $post );
 
 		// Make sure the user actually got reassigned.
@@ -682,8 +680,6 @@ class UserObjectMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCas
 				],
 			],
 		];
-
-		codecept_debug( $actual );
 
 		$this->assertEquals( $expected, $actual['data'] );
 


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR enables users to supply either a database ID or a global ID to user mutation inputs of type ID. Part of #998 


Does this close any currently open issues?
------------------------------------------
#2194 


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php8.0.15)

**WordPress Version:** 5.9.2
