### PR TITLE
Feat/post object mutation id inputs

### DIFF
--- a/src/Data/PostObjectMutation.php
+++ b/src/Data/PostObjectMutation.php
@@ -6,6 +6,7 @@ use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
 use WP_Post_Type;
 use WPGraphQL\AppContext;
+use WPGraphQL\Utils\Utils;
 
 /**
  * Class PostObjectMutation
@@ -36,9 +37,8 @@ class PostObjectMutation {
 		 * Prepare the data for inserting the post
 		 * NOTE: These are organized in the same order as: https://developer.wordpress.org/reference/functions/wp_insert_post/
 		 */
-		$author_id_parts = ! empty( $input['authorId'] ) ? Relay::fromGlobalId( $input['authorId'] ) : null;
-		if ( is_array( $author_id_parts ) && ! empty( $author_id_parts['id'] ) && absint( $author_id_parts['id'] ) ) {
-			$insert_post_args['post_author'] = absint( $author_id_parts['id'] );
+		if ( ! empty( $input['authorId'] ) ) {
+			$insert_post_args['post_author'] = Utils::get_database_id_from_id( $input['authorId'] );
 		}
 
 		if ( ! empty( $input['date'] ) && false !== strtotime( $input['date'] ) ) {
@@ -85,9 +85,8 @@ class PostObjectMutation {
 			$insert_post_args['pinged'] = $input['pinged'];
 		}
 
-		$parent_id_parts = ! empty( $input['parentId'] ) ? Relay::fromGlobalId( $input['parentId'] ) : null;
-		if ( is_array( $parent_id_parts ) && ! empty( $parent_id_parts['id'] ) && absint( $parent_id_parts['id'] ) ) {
-			$insert_post_args['post_parent'] = absint( $parent_id_parts['id'] );
+		if ( ! empty( $input['parentId'] ) ) {
+			$insert_post_args['post_parent'] = Utils::get_database_id_from_id( $input['parentId'] );
 		}
 
 		if ( ! empty( $input['menuOrder'] ) ) {

--- a/src/Mutation/PostObjectCreate.php
+++ b/src/Mutation/PostObjectCreate.php
@@ -7,6 +7,7 @@ use GraphQL\Type\Definition\ResolveInfo;
 use WP_Post_Type;
 use WPGraphQL\AppContext;
 use WPGraphQL\Data\PostObjectMutation;
+use WPGraphQL\Utils\Utils;
 
 /**
  * Class PostObjectCreate
@@ -127,7 +128,7 @@ class PostObjectCreate {
 			'revision',
 		], true ) ) {
 			$fields['parentId'] = [
-				'type'        => 'Id',
+				'type'        => 'ID',
 				'description' => __( 'The ID of the parent object', 'wp-graphql' ),
 			];
 		}
@@ -213,9 +214,20 @@ class PostObjectCreate {
 			 * If the post being created is being assigned to another user that's not the current user, make sure
 			 * the current user has permission to edit others posts for this post_type
 			 */
-			if ( ( isset( $input['authorId'] ) && get_current_user_id() !== $input['authorId'] ) && ( ! isset( $post_type_object->cap->edit_others_posts ) || ! current_user_can( $post_type_object->cap->edit_others_posts ) ) ) {
-				// translators: the $post_type_object->graphql_plural_name placeholder is the name of the object being mutated
-				throw new UserError( sprintf( __( 'Sorry, you are not allowed to create %1$s as this user', 'wp-graphql' ), $post_type_object->graphql_plural_name ) );
+			if ( ! empty( $input['authorId'] ) ) {
+				// Ensure authorId is a valid databaseId.
+				$input['authorId'] = Utils::get_database_id_from_id( $input['authorId'] );
+
+				$author = ! empty( $input['authorId'] ) ? get_user_by( 'ID', $input['authorId'] ) : false;
+
+				if ( false === $author ) {
+					throw new UserError( __( 'The provided `authorId` is not a valid user', 'wp-graphql' ) );
+				}
+
+				if ( get_current_user_id() !== $input['authorId'] && ( ! isset( $post_type_object->cap->edit_others_posts ) || ! current_user_can( $post_type_object->cap->edit_others_posts ) ) ) {
+					// translators: the $post_type_object->graphql_plural_name placeholder is the name of the object being mutated
+					throw new UserError( sprintf( __( 'Sorry, you are not allowed to create %1$s as this user', 'wp-graphql' ), $post_type_object->graphql_plural_name ) );
+				}
 			}
 
 			/**

--- a/src/Mutation/PostObjectDelete.php
+++ b/src/Mutation/PostObjectDelete.php
@@ -7,6 +7,7 @@ use GraphQL\Error\UserError;
 use GraphQLRelay\Relay;
 use WP_Post_Type;
 use WPGraphQL\Model\Post;
+use WPGraphQL\Utils\Utils;
 
 class PostObjectDelete {
 	/**
@@ -63,7 +64,7 @@ class PostObjectDelete {
 	public static function get_output_fields( WP_Post_Type $post_type_object ) {
 		return [
 			'deletedId'                            => [
-				'type'        => 'Id',
+				'type'        => 'ID',
 				'description' => __( 'The ID of the deleted object', 'wp-graphql' ),
 				'resolve'     => function ( $payload ) {
 					$deleted = (object) $payload['postObject'];
@@ -93,16 +94,13 @@ class PostObjectDelete {
 	 */
 	public static function mutate_and_get_payload( WP_Post_Type $post_type_object, string $mutation_name ) {
 		return function ( $input ) use ( $post_type_object ) {
-
-			/**
-			 * Get the ID from the global ID
-			 */
-			$id_parts = Relay::fromGlobalId( $input['id'] );
+			// Get the database ID for the post.
+			$post_id = Utils::get_database_id_from_id( $input['id'] );
 
 			/**
 			 * Stop now if a user isn't allowed to delete a post
 			 */
-			if ( ! isset( $post_type_object->cap->delete_post ) || ! current_user_can( $post_type_object->cap->delete_post, absint( $id_parts['id'] ) ) ) {
+			if ( ! isset( $post_type_object->cap->delete_post ) || ! current_user_can( $post_type_object->cap->delete_post, $post_id ) ) {
 				// translators: the $post_type_object->graphql_plural_name placeholder is the name of the object being mutated
 				throw new UserError( sprintf( __( 'Sorry, you are not allowed to delete %1$s', 'wp-graphql' ), $post_type_object->graphql_plural_name ) );
 			}
@@ -115,7 +113,7 @@ class PostObjectDelete {
 			/**
 			 * Get the post object before deleting it
 			 */
-			$post_before_delete = get_post( absint( $id_parts['id'] ) );
+			$post_before_delete = ! empty( $post_id ) ? get_post( $post_id ) : null;
 
 			if ( empty( $post_before_delete ) ) {
 				throw new UserError( __( 'The post could not be deleted', 'wp-graphql' ) );
@@ -127,17 +125,15 @@ class PostObjectDelete {
 			 * If the post is already in the trash, and the forceDelete input was not passed,
 			 * don't remove from the trash
 			 */
-			if ( 'trash' === $post_before_delete->post_status ) {
-				if ( true !== $force_delete ) {
-					// Translators: the first placeholder is the post_type of the object being deleted and the second placeholder is the unique ID of that object
-					throw new UserError( sprintf( __( 'The %1$s with id %2$s is already in the trash. To remove from the trash, use the forceDelete input', 'wp-graphql' ), $post_type_object->graphql_single_name, $input['id'] ) );
-				}
+			if ( 'trash' === $post_before_delete->post_status && true !== $force_delete ) {
+				// Translators: the first placeholder is the post_type of the object being deleted and the second placeholder is the unique ID of that object
+				throw new UserError( sprintf( __( 'The %1$s with id %2$s is already in the trash. To remove from the trash, use the forceDelete input', 'wp-graphql' ), $post_type_object->graphql_single_name, $post_id ) );
 			}
 
 			/**
 			 * Delete the post
 			 */
-			$deleted = wp_delete_post( $id_parts['id'], $force_delete );
+			$deleted = wp_delete_post( (int) $post_id, $force_delete );
 
 			/**
 			 * If the post was moved to the trash, spoof the object's status before returning it

--- a/src/Mutation/PostObjectUpdate.php
+++ b/src/Mutation/PostObjectUpdate.php
@@ -8,6 +8,7 @@ use GraphQLRelay\Relay;
 use WP_Post_Type;
 use WPGraphQL\AppContext;
 use WPGraphQL\Data\PostObjectMutation;
+use WPGraphQL\Utils\Utils;
 
 class PostObjectUpdate {
 	/**
@@ -74,21 +75,21 @@ class PostObjectUpdate {
 	 */
 	public static function mutate_and_get_payload( $post_type_object, $mutation_name ) {
 		return function ( $input, AppContext $context, ResolveInfo $info ) use ( $post_type_object, $mutation_name ) {
-
-			$id_parts      = ! empty( $input['id'] ) ? Relay::fromGlobalId( $input['id'] ) : null;
-			$existing_post = isset( $id_parts['id'] ) && absint( $id_parts['id'] ) ? get_post( absint( $id_parts['id'] ) ) : null;
+			// Get the database ID for the comment.
+			$post_id       = Utils::get_database_id_from_id( $input['id'] );
+			$existing_post = ! empty( $post_id ) ? get_post( $post_id ) : null;
 
 			/**
 			 * If there's no existing post, throw an exception
 			 */
-			if ( ! isset( $id_parts['id'] ) || empty( $existing_post ) ) {
+			if ( null === $existing_post ) {
 				// translators: the placeholder is the name of the type of post being updated
 				throw new UserError( sprintf( __( 'No %1$s could be found to update', 'wp-graphql' ), $post_type_object->graphql_single_name ) );
 			}
 
 			if ( $post_type_object->name !== $existing_post->post_type ) {
 				// translators: The first placeholder is an ID and the second placeholder is the name of the post type being edited
-				throw new UserError( sprintf( __( 'The id %1$d is not of the type "%2$s"', 'wp-graphql' ), $id_parts['id'], $post_type_object->name ) );
+				throw new UserError( sprintf( __( 'The id %1$d is not of the type "%2$s"', 'wp-graphql' ), $post_id, $post_type_object->name ) );
 			}
 
 			/**
@@ -107,12 +108,24 @@ class PostObjectUpdate {
 				throw new UserError( sprintf( __( 'Sorry, you are not allowed to update another author\'s %1$s', 'wp-graphql' ), $post_type_object->graphql_single_name ) );
 			}
 
+			$author_id = absint( $existing_post->post_author );
+
 			/**
 			 * If the mutation is setting the author to be someone other than the user making the request
 			 * make sure they have permission to edit others posts
 			 */
-			$author_id_parts = ! empty( $input['authorId'] ) ? Relay::fromGlobalId( $input['authorId'] ) : null;
-			if ( ! empty( $author_id_parts['id'] ) && get_current_user_id() !== $author_id_parts['id'] && ( ! isset( $post_type_object->cap->edit_others_posts ) || ! current_user_can( $post_type_object->cap->edit_others_posts ) ) ) {
+			if ( ! empty( $input['authorId'] ) ) {
+				// Ensure authorId is a valid databaseId.
+				$input['authorId'] = Utils::get_database_id_from_id( $input['authorId'] );
+				// Use the new author for checks.
+				$author_id = $input['authorId'];
+			}
+
+			/**
+			 * Check to see if the existing_media_item author matches the current user,
+			 * if not they need to be able to edit others posts to proceed
+			 */
+			if ( get_current_user_id() !== $author_id && ( ! isset( $post_type_object->cap->edit_others_posts ) || ! current_user_can( $post_type_object->cap->edit_others_posts ) ) ) {
 				// translators: the $post_type_object->graphql_single_name placeholder is the name of the object being mutated
 				throw new UserError( sprintf( __( 'Sorry, you are not allowed to update %1$s as this user.', 'wp-graphql' ), $post_type_object->graphql_plural_name ) );
 			}
@@ -131,7 +144,7 @@ class PostObjectUpdate {
 			 * Insert the post object and get the ID
 			 */
 			$post_args       = PostObjectMutation::prepare_post_object( $input, $post_type_object, $mutation_name );
-			$post_args['ID'] = absint( $id_parts['id'] );
+			$post_args['ID'] = $post_id;
 
 			$clean_args = wp_slash( (array) $post_args );
 
@@ -142,12 +155,12 @@ class PostObjectUpdate {
 			/**
 			 * Insert the post and retrieve the ID
 			 */
-			$post_id = wp_update_post( $clean_args, true );
+			$updated_post_id = wp_update_post( $clean_args, true );
 
 			/**
 			 * Throw an exception if the post failed to update
 			 */
-			if ( is_wp_error( $post_id ) ) {
+			if ( 0 === $post_id || is_wp_error( $updated_post_id ) ) {
 				throw new UserError( __( 'The object failed to update', 'wp-graphql' ) );
 			}
 
@@ -180,7 +193,7 @@ class PostObjectUpdate {
 			 * The input for the postObjectMutation will be passed, along with the $new_post_id for the
 			 * postObject that was updated so that relations can be set, meta can be updated, etc.
 			 */
-			PostObjectMutation::update_additional_post_object_data( $post_id, $input, $post_type_object, $mutation_name, $context, $info );
+			PostObjectMutation::update_additional_post_object_data( (int) $post_id, $input, $post_type_object, $mutation_name, $context, $info );
 
 			/**
 			 * Return the payload

--- a/tests/wpunit/PostObjectMutationsTest.php
+++ b/tests/wpunit/PostObjectMutationsTest.php
@@ -1,10 +1,9 @@
 <?php
 
-class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
+class PostObjectMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 	public $title;
 	public $content;
-	public $client_mutation_id;
 	public $admin;
 	public $subscriber;
 	public $author;
@@ -14,9 +13,8 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 		// before
 		parent::setUp();
 
-		$this->title              = 'some title';
-		$this->content            = 'some content';
-		$this->client_mutation_id = 'someUniqueId';
+		$this->title   = 'some title';
+		$this->content = 'some content';
 
 		$this->author = $this->factory()->user->create( [
 			'role' => 'author',
@@ -52,432 +50,54 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 	 */
 	public function createPostMutation() {
 
-		$mutation = '
-		mutation createPost( $clientMutationId:String!, $title:String!, $content:String! ){
-		  createPost(
-		    input:{
-		      clientMutationId:$clientMutationId,
-		      title:$title
-		      content:$content
-		    }
-		  ){
-		    clientMutationId
-		    post{
-		      title
-		      content
-		    }
-		  }
-		}
-		';
-
-		$variables = wp_json_encode( [
-			'clientMutationId' => $this->client_mutation_id,
-			'title'            => $this->title,
-			'content'          => $this->content,
-		] );
-
-		$actual = do_graphql_request( $mutation, 'createPost', $variables );
-
-		return $actual;
-
-	}
-
-	public function createPageMutation() {
-
-		$mutation = '
-		mutation createPage( $clientMutationId:String!, $title:String!, $content:String! ){
-		  createPage(
-		    input:{
-		      clientMutationId:$clientMutationId,
-		      title:$title
-		      content:$content
-		    }
-		  ){
-		    clientMutationId
-		    page{
-		      title
-		      content
-		    }
-		  }
-		}
-		';
-
-		$variables = wp_json_encode( [
-			'clientMutationId' => $this->client_mutation_id,
-			'title'            => $this->title,
-			'content'          => $this->content,
-		] );
-
-		$actual = do_graphql_request( $mutation, 'createPage', $variables );
-
-		return $actual;
-
-	}
-
-	public function testUpdatePageMutation() {
-
-		$args = [
-			'post_type'    => 'page',
-			'post_status'  => 'publish',
-			'post_title'   => 'Original Title',
-			'post_content' => 'Original Content',
-		];
-
-		/**
-		 * Create a page to test against
-		 */
-		$page_id = $this->factory()->post->create( $args );
-
-		/**
-		 * Get the new page object
-		 */
-		$new_page = get_post( $page_id );
-
-		/**
-		 * Verify the page was created with the original content as expected
-		 */
-		$this->assertEquals( $new_page->post_type, 'page' );
-		$this->assertEquals( $new_page->post_title, 'Original Title' );
-		$this->assertEquals( $new_page->post_content, 'Original Content' );
-
-		/**
-		 * Prepare the mutation
-		 */
-		$mutation = '
-		mutation updatePageTest( $clientMutationId:String! $id:ID! $title:String $content:String ){
-		  updatePage(
-		    input: {
-		        clientMutationId:$clientMutationId
-		        id:$id,
-		        title:$title,
-		        content:$content,
-		    }
-		  ) {
-		    clientMutationId
-		    page{
-		      id
-		      title
-		      content
-		      pageId
-		    }
-		  }
-		}';
-
-		/**
-		 * Set the variables to use with the mutation
-		 */
-		$variables = wp_json_encode( [
-			'id'               => \GraphQLRelay\Relay::toGlobalId( 'post', $page_id ),
-			'title'            => 'Some updated title',
-			'content'          => 'Some updated content',
-			'clientMutationId' => 'someId',
-		] );
-
-		/**
-		 * Set the current user as the subscriber so we can test, and expect to fail
-		 */
-		wp_set_current_user( $this->subscriber );
-
-		/**
-		 * Execute the request
-		 */
-		$actual = do_graphql_request( $mutation, 'updatePageTest', $variables );
-
-		/**
-		 * We should get an error because the user is a subscriber and can't edit posts
-		 */
-		$this->assertArrayHasKey( 'errors', $actual );
-
-		/**
-		 * Set the current user to a user with permission to edit posts, but NOT permission to edit OTHERS posts
-		 */
-		wp_set_current_user( $this->author );
-
-		/**
-		 * Execute the request
-		 */
-		$actual = do_graphql_request( $mutation, 'updatePageTest', $variables );
-
-		/**
-		 * We should get an error because the user is an and can't edit others posts
-		 */
-		$this->assertArrayHasKey( 'errors', $actual );
-
-		/**
-		 * Set the current user as the admin role so we
-		 * successfully run the mutation
-		 */
-		wp_set_current_user( $this->admin );
-
-		/**
-		 * Execute the request
-		 */
-		$actual = do_graphql_request( $mutation, 'updatePageTest', $variables );
-
-		/**
-		 * Define the expected output.
-		 *
-		 * The mutation should've updated the article to contain the updated content
-		 */
-		$expected = [
-			'updatePage' => [
-				'clientMutationId' => 'someId',
-				'page'             => [
-					'id'      => \GraphQLRelay\Relay::toGlobalId( 'post', $page_id ),
-					'title'   => apply_filters( 'the_title', 'Some updated title' ),
-					'content' => apply_filters( 'the_content', 'Some updated content' ),
-					'pageId'  => $page_id,
-				],
-			],
-		];
-
-		/**
-		 * Compare the actual output vs the expected output
-		 */
-		$this->assertEquals( $expected, $actual['data'] );
-
-		/**
-		 * Make sure the edit lock is removed after the mutation has finished
-		 */
-		$this->assertFalse( get_post_meta( '_edit_lock', $page_id, true ) );
-
-	}
-
-	public function testDeletePageMutation() {
-
-		/**
-		 * Set the current user as the subscriber role so we
-		 * can test the mutation and assert that it failed
-		 */
-		wp_set_current_user( $this->subscriber );
-
-		$args = [
-			'post_type'    => 'page',
-			'post_status'  => 'publish',
-			'post_title'   => 'Original Title',
-			'post_content' => 'Original Content',
-		];
-
-		/**
-		 * Create a page to test against
-		 */
-		$page_id = $this->factory()->post->create( $args );
-
-		/**
-		 * Get the new page object
-		 */
-		$new_page = get_post( $page_id );
-
-		/**
-		 * Verify the page was created with the original content as expected
-		 */
-		$this->assertEquals( $new_page->post_type, 'page' );
-		$this->assertEquals( $new_page->post_title, 'Original Title' );
-		$this->assertEquals( $new_page->post_content, 'Original Content' );
-
-		/**
-		 * Prepare the mutation
-		 */
-		$mutation = '
-		mutation deletePageTest($input:DeletePageInput!){
-		  deletePage(input:$input){
-		    clientMutationId
-		    deletedId
-		    page{
-		      id
-		      title
-		      content
-		      pageId
-		    }
-		  }
-		}';
-
-		/**
-		 * Set the variables to use with the mutation
-		 */
-		$variables = [
-			'input' => [
-				'id'               => \GraphQLRelay\Relay::toGlobalId( 'post', $page_id ),
-				'clientMutationId' => 'someId',
-			],
-		];
-
-
-		/**
-		 * Execute the request
-		 */
-		$actual = do_graphql_request( $mutation, 'deletePageTest', $variables );
-
-		/**
-		 * The deletion should fail because we're a subscriber
-		 */
-		$this->assertArrayHasKey( 'errors', $actual );
-
-		/**
-		 * Set the user to an admin and try again
-		 */
-		wp_set_current_user( $this->admin );
-
-		/**
-		 * Execute the request
-		 */
-		$actual = do_graphql_request( $mutation, 'deletePageTest', $variables );
-
-		/**
-		 * Define the expected output.
-		 *
-		 * The mutation should've updated the article to contain the updated content
-		 */
-		$expected = [
-			'deletePage' => [
-				'clientMutationId' => 'someId',
-				'deletedId'        => \GraphQLRelay\Relay::toGlobalId( 'post', $page_id ),
-				'page'             => [
-					'id'      => \GraphQLRelay\Relay::toGlobalId( 'post', $page_id ),
-					'title'   => apply_filters( 'the_title', 'Original Title' ),
-					'content' => apply_filters( 'the_content', 'Original Content' ),
-					'pageId'  => $page_id,
-				],
-			],
-		];
-
-		/**
-		 * Compare the actual output vs the expected output
-		 */
-		$this->assertEquals( $expected, $actual['data'] );
-
-		/**
-		 * Try to delete again
-		 */
-		$actual = do_graphql_request( $mutation, 'deletePageTest', $variables );
-
-		/**
-		 * We should get an error because we're not using forceDelete
-		 */
-		$this->assertArrayHasKey( 'errors', $actual );
-
-		/**
-		 * Try to delete again, this time with forceDelete
-		 */
-		$variables = [
-			'input' => [
-				'id'               => \GraphQLRelay\Relay::toGlobalId( 'post', $page_id ),
-				'clientMutationId' => 'someId',
-				'forceDelete'      => true,
-			],
-		];
-		$actual    = do_graphql_request( $mutation, 'deletePageTest', $variables );
-
-
-		/**
-		 * This time, we used forceDelete so the mutation should have succeeded
-		 */
-		$this->assertArrayNotHasKey( 'errors', $actual );
-		$this->assertEquals( 'someId', $actual['data']['deletePage']['clientMutationId'] );
-		$this->assertEquals( \GraphQLRelay\Relay::toGlobalId( 'post', $page_id ), $actual['data']['deletePage']['deletedId'] );
-
-		/**
-		 * Try to delete the page one more time, and now there's nothing to delete, not even from the trash
-		 */
-		$actual = do_graphql_request( $mutation, 'deletePageTest', $variables );
-
-		/**
-		 * Now we should have errors again, because there's nothing to be deleted
-		 */
-		$this->assertArrayHasKey( 'errors', $actual );
-
-
-	}
-
-	public function testUpdatePostWithInvalidId() {
-
-		$mutation = '
-		mutation updatePostWithInvalidId($input:UpdatePostInput!) {
-			updatePost(input:$input) {
-				clientMutationId
+		$query = '
+		mutation createPost( $title:String!, $content:String! ){
+			createPost(
+				input:{
+					title:$title
+					content:$content
+				}
+			){
+				post{
+					title
+					content
+				}
 			}
 		}
 		';
 
 		$variables = [
-			'input' => [
-				'clientMutationId' => 'someId',
-				'id'               => 'invalidIdThatShouldThrowAnError',
-			],
+			'title'   => $this->title,
+			'content' => $this->content,
 		];
 
-		$actual = do_graphql_request( $mutation, 'updatePostWithInvalidId', $variables );
-
-		codecept_debug( $actual );
-
-		/**
-		 * We should get an error thrown if we try and update a post with an invalid id
-		 */
-		$this->assertArrayHasKey( 'errors', $actual );
-
-		$page_id   = $this->factory()->post->create( [
-			'post_type' => 'page',
-		] );
-		$global_id = \GraphQLRelay\Relay::toGlobalId( 'post', $page_id );
-
-		$variables = [
-			'input' => [
-				'clientMutationId' => 'someId',
-				'id'               => $global_id,
-			],
-		];
-
-		/**
-		 * Try to update a post, with a valid ID of a page
-		 */
-		$actual = do_graphql_request( $mutation, 'updatePostWithInvalidId', $variables );
-
-		/**
-		 * We should get an error here because the updatePost mutation should only be able to update "post" objects
-		 */
-		$this->assertArrayHasKey( 'errors', $actual );
-
+		return graphql( compact( 'query', 'variables' ) );
 	}
 
-	public function testDeletePostOfAnotherType() {
+	public function createPageMutation() {
 
-		$args = [
-			'post_type'    => 'page',
-			'post_status'  => 'publish',
-			'post_title'   => 'Original Title',
-			'post_content' => 'Original Content',
-		];
-
-		/**
-		 * Create a page to test against
-		 */
-		$page_id = $this->factory()->post->create( $args );
-
-		$mutation = '
-		mutation deletePostWithPageIdShouldFail{
-		  deletePost( $clientMutationId:String! $id:ID! ){
-		    post{
-		      id
-		    }
-		  }
+		$query = '
+		mutation createPage( $title:String!, $content:String! ){
+			createPage(
+				input:{
+					title:$title
+					content:$content
+				}
+			){
+				page{
+					title
+					content
+				}
+			}
 		}
 		';
 
-		$variables = wp_json_encode( [
-			'id'               => \GraphQLRelay\Relay::toGlobalId( 'post', $page_id ),
-			'clientMutationId' => 'someId',
-		] );
+		$variables = [
+			'title'   => $this->title,
+			'content' => $this->content,
+		];
 
-		/**
-		 * Run the mutation
-		 */
-		$actual = do_graphql_request( $mutation, 'deletePostWithPageIdShouldFail', $variables );
-
-		/**
-		 * The mutation should fail because the ID is for a page, but we're trying to delete a post
-		 */
-		$this->assertArrayHasKey( 'errors', $actual );
-
+		return graphql( compact( 'query', 'variables' ) );
 	}
 
 	/**
@@ -522,15 +142,11 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 		 * Run the mutation
 		 */
 		$actual = $this->createPageMutation();
+		codecept_debug( $actual );
 
-		/**
-		 * We're expecting to have createPage returned with a nested clientMutationId matching the
-		 * clientMutationId we sent through, as well as the title and content we passed through in the mutation
-		 */
 		$expected = [
 			'createPage' => [
-				'clientMutationId' => $this->client_mutation_id,
-				'page'             => [
+				'page' => [
 					'title'   => apply_filters( 'the_title', $this->title ),
 					'content' => apply_filters( 'the_content', $this->content ),
 				],
@@ -543,17 +159,17 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 
 	public function testCreatePostWithNoInput() {
 
-		$mutation = '
+		$query = '
 		mutation {
-		  createPost{
-		    post{
-		      id
-		    }
-		  }
+			createPost{
+				post{
+					id
+				}
+			}
 		}
 		';
 
-		$actual = do_graphql_request( $mutation );
+		$actual = graphql( compact( 'query' ) );
 
 		/**
 		 * Make sure we're throwing an error if there's no $input with the mutation
@@ -564,35 +180,28 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 
 	public function testCreatePostByAuthorCanHavePublishStatus() {
 
-		$mutation = '
+		$query = '
 		mutation createPost($input:CreatePostInput!){
-		  createPost(input:$input){
-		    clientMutationId
-		    post{
-		      id
-		      title
-		      status
-		    }
-		  }
+			createPost(input:$input){
+				post{
+					id
+					title
+					status
+				}
+			}
 		}
 		';
 
 		$variables = [
 			'input' => [
-				'clientMutationId' => 'CreatePost',
-				'title' => 'Test Post as Contributor',
+				'title'  => 'Test Post as Contributor',
 				'status' => 'PUBLISH',
 			],
 		];
 
 		wp_set_current_user( $this->author );
 
-		$actual = graphql([
-			'query' => $mutation,
-			'variables' => $variables
-		]);
-
-		codecept_debug( $actual );
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
 		/**
 		 * Make sure we're throwing an error if there's no $input with the mutation
@@ -600,41 +209,33 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertSame( 'publish', $actual['data']['createPost']['post']['status'] );
 		$this->assertSame( $variables['input']['title'], $actual['data']['createPost']['post']['title'] );
-		$this->assertSame( $variables['input']['clientMutationId'], $actual['data']['createPost']['clientMutationId'] );
 
 	}
 
 	public function testCreatePostByContributorCannotHavePublishStatus() {
 
-		$mutation = '
+		$query = '
 		mutation createPost($input:CreatePostInput!){
-		  createPost(input:$input){
-		    clientMutationId
-		    post{
-		      id
-		      title
-		      status
-		    }
-		  }
+			createPost(input:$input){
+				post{
+					id
+					title
+					status
+				}
+			}
 		}
 		';
 
 		$variables = [
 			'input' => [
-				'clientMutationId' => 'CreatePost',
-				'title' => 'Test Post as Contributor',
+				'title'  => 'Test Post as Contributor',
 				'status' => 'PUBLISH',
 			],
 		];
 
 		wp_set_current_user( $this->contributor );
 
-		$actual = graphql([
-			'query' => $mutation,
-			'variables' => $variables
-		]);
-
-		codecept_debug( $actual );
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
 		/**
 		 * Make sure we're throwing an error if there's no $input with the mutation
@@ -642,295 +243,639 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertSame( 'pending', $actual['data']['createPost']['post']['status'] );
 		$this->assertSame( $variables['input']['title'], $actual['data']['createPost']['post']['title'] );
-		$this->assertSame( $variables['input']['clientMutationId'], $actual['data']['createPost']['clientMutationId'] );
 
 	}
 
 	public function createPostWithDatesMutation( $input ) {
 
-        wp_set_current_user( $this->admin );
+		wp_set_current_user( $this->admin );
 
-        $mutation = 'mutation createPost( $input:CreatePostInput! ) {
-          createPost(input: $input) {
-            post {
-              id
-              postId
-              title
-              date
-              dateGmt
-              modified
-              modifiedGmt
-            }
-          }
+		$query = 'mutation createPost( $input:CreatePostInput! ) {
+			createPost(input: $input) {
+				post {
+					id
+					postId
+					title
+					date
+					dateGmt
+					modified
+					modifiedGmt
+				}
+			}
 		}
-        ';
+		';
 
-        $defaults = [
-            'clientMutationId' => uniqid(),
-            'title' => 'New Post',
-            'status' => 'PUBLISH',
-        ];
+		$defaults = [
+			'title'  => 'New Post',
+			'status' => 'PUBLISH',
+		];
 
-        $input = array_merge( $defaults, $input );
+		$input = array_merge( $defaults, $input );
 
-        $variables = [
-            'input' => $input,
-        ];
+		$variables = [
+			'input' => $input,
+		];
 
-        /**
-         * Run the mutation.
-         */
+		/**
+		 * Run the mutation.
+		 */
 
-        $results = do_graphql_request( $mutation, 'createPost', $variables );
-
-	    return $results;
+		return graphql( compact( 'query', 'variables' ) );
 	}
 
-    public function testDateInputsForCreatePost() {
+	public function testDateInputsForCreatePost() {
 
-        /**
-         * Set the current user as the admin role so we
-         * can test the mutation
-         */
+		/**
+		 * Set the current user as the admin role so we
+		 * can test the mutation
+		 */
 
-        wp_set_current_user( $this->admin );
+		wp_set_current_user( $this->admin );
 
-        /**
-         * Set the expected date outcome
-         */
+		/**
+		 * Set the expected date outcome
+		 */
 
-        $dateExpected = '2017-01-03T00:00:00';
-        $dateGmtExpected = '2017-01-03T00:00:00';
+		$dateExpected    = '2017-01-03T00:00:00';
+		$dateGmtExpected = '2017-01-03T00:00:00';
 
-        $results = $this->createPostWithDatesMutation([
-            'date' => '1/3/2017',
-            'status' => 'PUBLISH'
-        ]);
-
-        /**
-         * Make sure there are no errors
-         */
-        $this->assertArrayNotHasKey( 'errors', $results );
-
-        /**
-         * We're expecting the date variable to match the date entry regardless of the way user enters it
-         */
-
-        $this->assertEquals( $dateExpected, $results['data']['createPost']['post']['date'] );
-        $this->assertEquals( $dateGmtExpected, $results['data']['createPost']['post']['dateGmt'] );
-        $this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modified'] );
-        $this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modifiedGmt'] );
-
-    }
-
-    public function testDateInputsWithSlashFormattingForCreatePost() {
-
-        /**
-         * Set the current user as the admin role so we
-         * can test the mutation
-         */
-
-        wp_set_current_user( $this->admin );
-
-        /**
-         * Set the input and expected date outcome
-         */
-
-        $dateExpected = '2017-01-03T00:00:00';
-        $dateGmtExpected = '2017-01-03T00:00:00';
-
-        $results = $this->createPostWithDatesMutation([
-            'date' => '2017/01/03',
-        ]);
-
-        /**
-         * Make sure there are no errors
-         */
-
-        $this->assertArrayNotHasKey( 'errors', $results );
-
-        /**
-         * We're expecting the date variable to match the date entry regardless of the way user enters it
-         */
-
-        $this->assertEquals( $dateExpected, $results['data']['createPost']['post']['date'] );
-        $this->assertEquals( $dateGmtExpected, $results['data']['createPost']['post']['dateGmt'] );
-	    $this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modified'] );
-	    $this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modifiedGmt'] );
-
-    }
-
-    public function testDateInputsWithStatusPendingAndDashesCreatePost() {
-
-        /**
-         * Set the current user as the admin role so we
-         * can test the mutation
-         */
-
-        wp_set_current_user( $this->admin );
-
-        /**
-         * Set the input and expected date outcome
-         */
-
-        $dateExpected = '2017-01-03T00:00:00';
-        $dateGmtExpected = null;
-
-        $results = $this->createPostWithDatesMutation([
-            'date' => '3-1-2017',
-            'status' => 'PENDING'
-        ]);
-
-        /**
-         * Make sure there are no errors
-         */
-
-        $this->assertArrayNotHasKey( 'errors', $results );
-
-        /**
-         * We're expecting the date variable to match the date entry regardless of the way user enters it
-         */
-
-        $this->assertEquals( $dateExpected, $results['data']['createPost']['post']['date'] );
-        $this->assertEquals( $dateGmtExpected, $results['data']['createPost']['post']['dateGmt'] );
-	    $this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modified'] );
-	    $this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modifiedGmt'] );
-
-    }
-
-    public function testDateInputsWithDraftAndPublishUpdatePost() {
-
-        /**
-         * Set the current user as the admin role so we
-         * can test the mutation
-         */
-        wp_set_current_user( $this->admin );
-
-        /**
-         * Create a post to test against and set global ID
-         */
-        $test_post = $this->factory()->post->create( [
-            'post_title' => 'My Test Post',
-            'post_status' => 'draft',
-        ] );
-
-        $global_id = \GraphQLRelay\Relay::toGlobalId( 'post', $test_post );
-
-        /**
-         * Prepare mutation for GQL request
-         */
-        $request = '
-        {
-            post( id: "'. $global_id . '" ) {
-              id
-              postId
-              title
-              date
-              dateGmt
-              modified
-              modifiedGmt
-            }
-        }
-        ';
-
-        /**
-         * Run GQl request
-         */
-        $results = do_graphql_request( $request );
-
-        /**
-         * Set the expected dateGmt outcome
-         */
-        $dateGmtExpected = null;
-
-        /**
-         * Assert results dateGmt equals the expected outcome
-         */
-        $this->assertEquals( $dateGmtExpected, $results['data']['post']['dateGmt'] );
-
-        /**
-         * Update post to test against status: published
-         */
-        wp_update_post( [
-            'ID'          => $test_post,
-            'post_status' => 'publish',
-        ] );
-
-        /**
-         * Run GQl request
-         */
-        $results = do_graphql_request( $request );
-
-        /**
-         * Assert timestamp is not null
-         */
-        $this->assertNotNull( $results['data']['post']['dateGmt'] );
-
-        /**
-         * Update post back to draft
-         */
-        wp_update_post( [
-            'ID' => $test_post,
-            'post_status' => 'draft'
-        ] );
-
-        /**
-         * Run GQl request
-         */
-        $results = do_graphql_request( $request );
-
-        /**
-         * Assert timestamp is STILL not null
-         */
-        $this->assertNotNull( $results['data']['post']['dateGmt'] );
-    }
-
-	/**
-	 * @throws Exception
-	 */
-    public function testUserWithoutProperCapabilityCannotUpdateOthersPosts() {
-
-		$admin_created_post_id = $this->factory()->post->create([
-			'post_type' => 'post',
-			'post_status' => 'publish',
-			'post_title' => 'Test Post from Admin, Edit by Contributor',
-			'post_author' => $this->admin
+		$results = $this->createPostWithDatesMutation([
+			'date'   => '1/3/2017',
+			'status' => 'PUBLISH',
 		]);
+		codecept_debug( $results );
 
-		$global_id = \GraphQLRelay\Relay::toGlobalId( 'post', $admin_created_post_id );
+		/**
+		 * Make sure there are no errors
+		 */
+		$this->assertArrayNotHasKey( 'errors', $results );
 
-		$mutation = '
-		mutation UpdatePost($input: UpdatePostInput! ) {
-		  updatePost(input:$input) {
-		    post {
-		      id
-		      title
-		      content
-		    }
-		  }
+		/**
+		 * We're expecting the date variable to match the date entry regardless of the way user enters it
+		 */
+
+		$this->assertEquals( $dateExpected, $results['data']['createPost']['post']['date'] );
+		$this->assertEquals( $dateGmtExpected, $results['data']['createPost']['post']['dateGmt'] );
+		$this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modified'] );
+		$this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modifiedGmt'] );
+
+	}
+
+	public function testDateInputsWithSlashFormattingForCreatePost() {
+
+		/**
+		 * Set the current user as the admin role so we
+		 * can test the mutation
+		 */
+
+		wp_set_current_user( $this->admin );
+
+		/**
+		 * Set the input and expected date outcome
+		 */
+
+		$dateExpected    = '2017-01-03T00:00:00';
+		$dateGmtExpected = '2017-01-03T00:00:00';
+
+		$results = $this->createPostWithDatesMutation([
+			'date' => '2017/01/03',
+		]);
+		codecept_debug( $results );
+
+		/**
+		 * Make sure there are no errors
+		 */
+
+		$this->assertArrayNotHasKey( 'errors', $results );
+
+		/**
+		 * We're expecting the date variable to match the date entry regardless of the way user enters it
+		 */
+
+		$this->assertEquals( $dateExpected, $results['data']['createPost']['post']['date'] );
+		$this->assertEquals( $dateGmtExpected, $results['data']['createPost']['post']['dateGmt'] );
+		$this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modified'] );
+		$this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modifiedGmt'] );
+
+	}
+
+	public function testDateInputsWithStatusPendingAndDashesCreatePost() {
+
+		/**
+		 * Set the current user as the admin role so we
+		 * can test the mutation
+		 */
+
+		wp_set_current_user( $this->admin );
+
+		/**
+		 * Set the input and expected date outcome
+		 */
+
+		$dateExpected    = '2017-01-03T00:00:00';
+		$dateGmtExpected = null;
+
+		$results = $this->createPostWithDatesMutation([
+			'date'   => '3-1-2017',
+			'status' => 'PENDING',
+		]);
+		codecept_debug( $results );
+
+		/**
+		 * Make sure there are no errors
+		 */
+
+		$this->assertArrayNotHasKey( 'errors', $results );
+
+		/**
+		 * We're expecting the date variable to match the date entry regardless of the way user enters it
+		 */
+
+		$this->assertEquals( $dateExpected, $results['data']['createPost']['post']['date'] );
+		$this->assertEquals( $dateGmtExpected, $results['data']['createPost']['post']['dateGmt'] );
+		$this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modified'] );
+		$this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modifiedGmt'] );
+
+	}
+
+	public function testDateInputsWithDraftAndPublishUpdatePost() {
+
+		/**
+		 * Set the current user as the admin role so we
+		 * can test the mutation
+		 */
+		wp_set_current_user( $this->admin );
+
+		/**
+		 * Create a post to test against and set global ID
+		 */
+		$test_post = $this->factory()->post->create( [
+			'post_title'  => 'My Test Post',
+			'post_status' => 'draft',
+		] );
+
+		$global_id = \GraphQLRelay\Relay::toGlobalId( 'post', $test_post );
+
+		/**
+		 * Prepare mutation for GQL request
+		 */
+		$query = '
+		{
+			post( id: "' . $global_id . '" ) {
+				id
+				postId
+				title
+				date
+				dateGmt
+				modified
+				modifiedGmt
+			}
+		}
+		';
+
+		/**
+		 * Run GQl request
+		 */
+		$results = $this->graphql( compact( 'query' ) );
+
+		/**
+		 * Set the expected dateGmt outcome
+		 */
+		$dateGmtExpected = null;
+
+		/**
+		 * Assert results dateGmt equals the expected outcome
+		 */
+		$this->assertEquals( $dateGmtExpected, $results['data']['post']['dateGmt'] );
+
+		/**
+		 * Update post to test against status: published
+		 */
+		wp_update_post( [
+			'ID'          => $test_post,
+			'post_status' => 'publish',
+		] );
+
+		/**
+		 * Run GQl request
+		 */
+		$results = $this->graphql( compact( 'query' ) );
+
+		/**
+		 * Assert timestamp is not null
+		 */
+		$this->assertNotNull( $results['data']['post']['dateGmt'] );
+
+		/**
+		 * Update post back to draft
+		 */
+		wp_update_post( [
+			'ID'          => $test_post,
+			'post_status' => 'draft',
+		] );
+
+		/**
+		 * Run GQl request
+		 */
+		$results = $this->graphql( compact( 'query' ) );
+
+		/**
+		 * Assert timestamp is STILL not null
+		 */
+		$this->assertNotNull( $results['data']['post']['dateGmt'] );
+	}
+
+	public function testDeletePageMutation() {
+
+		/**
+		 * Set the current user as the subscriber role so we
+		 * can test the mutation and assert that it failed
+		 */
+		wp_set_current_user( $this->subscriber );
+
+		$args = [
+			'post_type'    => 'page',
+			'post_status'  => 'publish',
+			'post_title'   => 'Original Title',
+			'post_content' => 'Original Content',
+		];
+
+		/**
+		 * Create a page to test against
+		 */
+		$page_id = $this->factory()->post->create( $args );
+
+		/**
+		 * Get the new page object
+		 */
+		$new_page = get_post( $page_id );
+
+		/**
+		 * Verify the page was created with the original content as expected
+		 */
+		$this->assertEquals( $new_page->post_type, 'page' );
+		$this->assertEquals( $new_page->post_title, 'Original Title' );
+		$this->assertEquals( $new_page->post_content, 'Original Content' );
+
+		/**
+		 * Prepare the mutation
+		 */
+		$query = '
+		mutation deletePageTest($input:DeletePageInput!){
+			deletePage(input:$input){
+				deletedId
+				page{
+					id
+					title
+					content
+					pageId
+				}
+			}
+		}';
+
+		/**
+		 * Set the variables to use with the mutation
+		 */
+		$variables = [
+			'input' => [
+				'id' => \GraphQLRelay\Relay::toGlobalId( 'post', $page_id ),
+			],
+		];
+
+		/**
+		 * Execute the request
+		 */
+		$actual = graphql( compact( 'query', 'variables' ) );
+
+		/**
+		 * The deletion should fail because we're a subscriber
+		 */
+		$this->assertArrayHasKey( 'errors', $actual );
+
+		/**
+		 * Set the user to an admin and try again
+		 */
+		wp_set_current_user( $this->admin );
+
+		/**
+		 * Execute the request
+		 */
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		/**
+		 * Define the expected output.
+		 *
+		 * The mutation should've updated the article to contain the updated content
+		 */
+		$expected = [
+			'deletePage' => [
+				'deletedId' => \GraphQLRelay\Relay::toGlobalId( 'post', $page_id ),
+				'page'      => [
+					'id'      => \GraphQLRelay\Relay::toGlobalId( 'post', $page_id ),
+					'title'   => apply_filters( 'the_title', 'Original Title' ),
+					'content' => apply_filters( 'the_content', 'Original Content' ),
+					'pageId'  => $page_id,
+				],
+			],
+		];
+
+		/**
+		 * Compare the actual output vs the expected output
+		 */
+		$this->assertEquals( $expected, $actual['data'] );
+
+		/**
+		 * Try to delete again
+		 */
+		$actual = graphql( compact( 'query', 'variables' ) );
+
+		/**
+		 * We should get an error because we're not using forceDelete
+		 */
+		$this->assertArrayHasKey( 'errors', $actual );
+
+		/**
+		 * Try to delete again, this time with forceDelete
+		 */
+		$variables = [
+			'input' => [
+				'id'          => \GraphQLRelay\Relay::toGlobalId( 'post', $page_id ),
+				'forceDelete' => true,
+			],
+		];
+		$actual    = $this->graphql( compact( 'query', 'variables' ) );
+
+		/**
+		 * This time, we used forceDelete so the mutation should have succeeded
+		 */
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEquals( \GraphQLRelay\Relay::toGlobalId( 'post', $page_id ), $actual['data']['deletePage']['deletedId'] );
+
+		/**
+		 * Try to delete the page one more time, and now there's nothing to delete, not even from the trash
+		 */
+		$actual = graphql( compact( 'query', 'variables' ) );
+
+		/**
+		 * Now we should have errors again, because there's nothing to be deleted
+		 */
+		$this->assertArrayHasKey( 'errors', $actual );
+
+	}
+
+	public function testDeletePostOfAnotherType() {
+
+		$args = [
+			'post_type'    => 'page',
+			'post_status'  => 'publish',
+			'post_title'   => 'Original Title',
+			'post_content' => 'Original Content',
+		];
+
+		/**
+		 * Create a page to test against
+		 */
+		$page_id = $this->factory()->post->create( $args );
+
+		$query = '
+		mutation deletePostWithPageIdShouldFail{
+			deletePost( $id:ID! ){
+				post{
+					id
+				}
+			}
+		}
+		';
+
+		$variables = [
+			'id' => \GraphQLRelay\Relay::toGlobalId( 'post', $page_id ),
+		];
+
+		/**
+		 * Run the mutation
+		 */
+		$actual = graphql( compact( 'query', 'variables' ) );
+
+		/**
+		 * The mutation should fail because the ID is for a page, but we're trying to delete a post
+		 */
+		$this->assertArrayHasKey( 'errors', $actual );
+
+	}
+
+	public function testUpdatePageMutation() {
+
+		$args = [
+			'post_type'    => 'page',
+			'post_status'  => 'publish',
+			'post_title'   => 'Original Title',
+			'post_content' => 'Original Content',
+		];
+
+		/**
+		 * Create a page to test against
+		 */
+		$page_id = $this->factory()->post->create( $args );
+
+		/**
+		 * Get the new page object
+		 */
+		$new_page = get_post( $page_id );
+
+		/**
+		 * Verify the page was created with the original content as expected
+		 */
+		$this->assertEquals( $new_page->post_type, 'page' );
+		$this->assertEquals( $new_page->post_title, 'Original Title' );
+		$this->assertEquals( $new_page->post_content, 'Original Content' );
+
+		/**
+		 * Prepare the mutation
+		 */
+		$query = '
+		mutation updatePageTest( $id:ID! $title:String $content:String ){
+			updatePage(
+				input: {
+					id:$id,
+					title:$title,
+					content:$content,
+				}
+			) {
+				page{
+					id
+					title
+					content
+					pageId
+				}
+			}
+		}';
+
+		/**
+		 * Set the variables to use with the mutation
+		 */
+		$variables = [
+			'id'      => \GraphQLRelay\Relay::toGlobalId( 'post', $page_id ),
+			'title'   => 'Some updated title',
+			'content' => 'Some updated content',
+		];
+
+		/**
+		 * Set the current user as the subscriber so we can test, and expect to fail
+		 */
+		wp_set_current_user( $this->subscriber );
+
+		/**
+		 * Execute the request
+		 */
+		$actual = graphql( compact( 'query', 'variables' ) );
+
+		/**
+		 * We should get an error because the user is a subscriber and can't edit posts
+		 */
+		$this->assertArrayHasKey( 'errors', $actual );
+
+		/**
+		 * Set the current user to a user with permission to edit posts, but NOT permission to edit OTHERS posts
+		 */
+		wp_set_current_user( $this->author );
+
+		/**
+		 * Execute the request
+		 */
+		$actual = graphql( compact( 'query', 'variables' ) );
+
+		/**
+		 * We should get an error because the user is an and can't edit others posts
+		 */
+		$this->assertArrayHasKey( 'errors', $actual );
+
+		/**
+		 * Set the current user as the admin role so we
+		 * successfully run the mutation
+		 */
+		wp_set_current_user( $this->admin );
+
+		/**
+		 * Execute the request
+		 */
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		/**
+		 * Define the expected output.
+		 *
+		 * The mutation should've updated the article to contain the updated content
+		 */
+		$expected = [
+			'updatePage' => [
+				'page' => [
+					'id'      => \GraphQLRelay\Relay::toGlobalId( 'post', $page_id ),
+					'title'   => apply_filters( 'the_title', 'Some updated title' ),
+					'content' => apply_filters( 'the_content', 'Some updated content' ),
+					'pageId'  => $page_id,
+				],
+			],
+		];
+
+		/**
+		 * Compare the actual output vs the expected output
+		 */
+		$this->assertEquals( $expected, $actual['data'] );
+
+		/**
+		 * Make sure the edit lock is removed after the mutation has finished
+		 */
+		$this->assertFalse( get_post_meta( '_edit_lock', $page_id, true ) );
+
+	}
+
+	public function testUpdatePostWithInvalidId() {
+
+		$query = '
+		mutation updatePostWithInvalidId($input:UpdatePostInput!) {
+			updatePost(input:$input) {
+				post {
+					databaseId
+				}
+			}
 		}
 		';
 
 		$variables = [
 			'input' => [
-				'clientMutationId' => 'UpdatePost',
+				'id' => 'invalidIdThatShouldThrowAnError',
+			],
+		];
+
+		$actual = graphql( compact( 'query', 'variables' ) );
+
+		/**
+		 * We should get an error thrown if we try and update a post with an invalid id
+		 */
+		$this->assertArrayHasKey( 'errors', $actual );
+
+		$page_id   = $this->factory()->post->create( [
+			'post_type' => 'page',
+		] );
+		$global_id = \GraphQLRelay\Relay::toGlobalId( 'post', $page_id );
+
+		$variables = [
+			'input' => [
 				'id' => $global_id,
-				'title' => 'New Title'
-			]
+			],
+		];
+
+		/**
+		 * Try to update a post, with a valid ID of a page
+		 */
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		/**
+		 * We should get an error here because the updatePost mutation should only be able to update "post" objects
+		 */
+		$this->assertArrayHasKey( 'errors', $actual );
+
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function testUserWithoutProperCapabilityCannotUpdateOthersPosts() {
+
+		$admin_created_post_id = $this->factory()->post->create([
+			'post_type'   => 'post',
+			'post_status' => 'publish',
+			'post_title'  => 'Test Post from Admin, Edit by Contributor',
+			'post_author' => $this->admin,
+		]);
+
+		$global_id = \GraphQLRelay\Relay::toGlobalId( 'post', $admin_created_post_id );
+
+		$query = '
+		mutation UpdatePost($input: UpdatePostInput! ) {
+			updatePost(input:$input) {
+				post {
+					id
+					title
+					content
+				}
+			}
+		}
+		';
+
+		$variables = [
+			'input' => [
+				'id'    => $global_id,
+				'title' => 'New Title',
+			],
 		];
 
 		wp_set_current_user( $this->contributor );
 
-		$actual = graphql([
-			'query' => $mutation,
-			'variables' => $variables,
-		]);
-
-		codecept_debug( $actual );
+		$actual = graphql( compact( 'query', 'variables' ) );
 
 		$this->assertArrayHasKey( 'errors', $actual );
 
-    }
+	}
 
 	/**
 	 * @throws Exception
@@ -941,39 +886,33 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 			'post_type'   => 'page',
 			'post_status' => 'publish',
 			'post_title'  => 'Test Page from Admin, Edit by Contributor',
-			'post_author' => $this->admin
+			'post_author' => $this->admin,
 		] );
 
 		$global_id = \GraphQLRelay\Relay::toGlobalId( 'post', $admin_created_page_id );
 
-		$mutation = '
+		$query = '
 		mutation UpdatePage($input: UpdatePageInput! ) {
-		  updatePage(input:$input) {
-		    page {
-		      id
-		      title
-		      content
-		    }
-		  }
+			updatePage(input:$input) {
+				page {
+					id
+					title
+					content
+				}
+			}
 		}
 		';
 
 		$variables = [
 			'input' => [
-				'clientMutationId' => 'UpdatePage',
-				'id'               => $global_id,
-				'title'            => 'New Title'
-			]
+				'id'    => $global_id,
+				'title' => 'New Title',
+			],
 		];
 
 		wp_set_current_user( $this->contributor );
 
-		$actual = graphql( [
-			'query'     => $mutation,
-			'variables' => $variables,
-		] );
-
-		codecept_debug( $actual );
+		$actual = graphql( compact( 'query', 'variables' ) );
 
 		$this->assertArrayHasKey( 'errors', $actual );
 
@@ -982,35 +921,33 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 	public function testUpdatingPostByOtherAuthorRequiresEditOtherPostCapability() {
 
 		$post_id = $this->factory()->post->create([
-			'post_type' => 'post',
+			'post_type'   => 'post',
 			'post_status' => 'publish',
-			'post_author' => $this->author
+			'post_author' => $this->author,
 		]);
 
 		wp_set_current_user( $this->contributor );
 
-		$mutation = '
+		$query = '
 		mutation updatePost( $input: UpdatePostInput! ) {
-		  updatePost( input: $input ) {
-		    post {
-		      id
-		      title
-		    }
-		  }
+			updatePost( input: $input ) {
+				post {
+					id
+					title
+				}
+			}
 		}
 		';
 
 		$actual = graphql([
-			'query' => $mutation,
+			'query'     => $query,
 			'variables' => [
 				'input' => [
-					'id' => \GraphQLRelay\Relay::toGlobalId( 'post', $post_id ),
+					'id'    => \GraphQLRelay\Relay::toGlobalId( 'post', $post_id ),
 					'title' => 'Test Update',
-					'clientMutationId' => 'test...'
 				],
 			],
 		]);
-
 
 		// A contributor cannot edit another authors posts
 		$this->assertArrayHasKey( 'errors', $actual );
@@ -1019,18 +956,15 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 
 		$updated_title = uniqid();
 
-		$actual = graphql([
-			'query' => $mutation,
+		$actual = $this->graphql([
+			'query'     => $query,
 			'variables' => [
 				'input' => [
-					'id' => \GraphQLRelay\Relay::toGlobalId( 'post', $post_id ),
+					'id'    => \GraphQLRelay\Relay::toGlobalId( 'post', $post_id ),
 					'title' => $updated_title,
-					'clientMutationId' => 'test...'
 				],
 			],
 		]);
-
-		codecept_debug( $actual );
 
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertSame( $updated_title, $actual['data']['updatePost']['post']['title'] );


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR enables users to supply either a database ID or a global ID to postObject mutation inputs of type ID. Part of #998 


Does this close any currently open issues?
------------------------------------------
…


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php8.0.15)
**WordPress Version:** 5.9.2
