### PR TITLE
feat: Allow global/db IDs in connection where args

### DIFF
--- a/src/Connection/PostObjects.php
+++ b/src/Connection/PostObjects.php
@@ -14,6 +14,7 @@ use WPGraphQL\Model\Post;
 use WPGraphQL\Model\PostType;
 use WPGraphQL\Model\Term;
 use WPGraphQL\Model\User;
+use WPGraphQL\Utils\Utils;
 
 /**
  * Class PostObjects
@@ -412,30 +413,45 @@ class PostObjects {
 			'parent'      => [
 				'type'        => 'ID',
 				'description' => __( 'Use ID to return only children. Use 0 to return only top-level items', 'wp-graphql' ),
+				'parseValue'  => function ( $value ) {
+					return Utils::parse_input_ids( $value );
+				},
 			],
 			'parentIn'    => [
 				'type'        => [
 					'list_of' => 'ID',
 				],
 				'description' => __( 'Specify objects whose parent is in an array', 'wp-graphql' ),
+				'parseValue'  => function ( $value ) {
+					return Utils::parse_input_ids( $value );
+				},
 			],
 			'parentNotIn' => [
 				'type'        => [
 					'list_of' => 'ID',
 				],
 				'description' => __( 'Specify posts whose parent is not in an array', 'wp-graphql' ),
+				'parseValue'  => function ( $value ) {
+					return Utils::parse_input_ids( $value );
+				},
 			],
 			'in'          => [
 				'type'        => [
 					'list_of' => 'ID',
 				],
 				'description' => __( 'Array of IDs for the objects to retrieve', 'wp-graphql' ),
+				'parseValue'  => function ( $value ) {
+					return Utils::parse_input_ids( $value );
+				},
 			],
 			'notIn'       => [
 				'type'        => [
 					'list_of' => 'ID',
 				],
 				'description' => __( 'Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored', 'wp-graphql' ),
+				'parseValue'  => function ( $value ) {
+					return Utils::parse_input_ids( $value );
+				},
 			],
 			'nameIn'      => [
 				'type'        => [
@@ -594,12 +610,18 @@ class PostObjects {
 						'list_of' => 'ID',
 					],
 					'description' => __( 'Find objects connected to author(s) in the array of author\'s userIds', 'wp-graphql' ),
+					'parseValue'  => function ( $value ) {
+						return Utils::parse_input_ids( $value );
+					},
 				];
 				$fields['authorNotIn'] = [
 					'type'        => [
 						'list_of' => 'ID',
 					],
 					'description' => __( 'Find objects NOT connected to author(s) in the array of author\'s userIds', 'wp-graphql' ),
+					'parseValue'  => function ( $value ) {
+						return Utils::parse_input_ids( $value );
+					},
 				];
 			}
 
@@ -624,12 +646,18 @@ class PostObjects {
 						'list_of' => 'ID',
 					],
 					'description' => __( 'Array of category IDs, used to display objects from one category OR another', 'wp-graphql' ),
+					'parseValue'  => function ( $value ) {
+						return Utils::parse_input_ids( $value );
+					},
 				];
 				$fields['categoryNotIn'] = [
 					'type'        => [
 						'list_of' => 'ID',
 					],
 					'description' => __( 'Array of category IDs, used to display objects from one category OR another', 'wp-graphql' ),
+					'parseValue'  => function ( $value ) {
+						return Utils::parse_input_ids( $value );
+					},
 				];
 			}
 
@@ -647,18 +675,27 @@ class PostObjects {
 				$fields['tagId']      = [
 					'type'        => 'String',
 					'description' => __( 'Use Tag ID', 'wp-graphql' ),
+					'parseValue'  => function ( $value ) {
+						return Utils::parse_input_ids( $value );
+					},
 				];
 				$fields['tagIn']      = [
 					'type'        => [
 						'list_of' => 'ID',
 					],
 					'description' => __( 'Array of tag IDs, used to display objects from one tag OR another', 'wp-graphql' ),
+					'parseValue'  => function ( $value ) {
+						return Utils::parse_input_ids( $value );
+					},
 				];
 				$fields['tagNotIn']   = [
 					'type'        => [
 						'list_of' => 'ID',
 					],
 					'description' => __( 'Array of tag IDs, used to display objects from one tag OR another', 'wp-graphql' ),
+					'parseValue'  => function ( $value ) {
+						return Utils::parse_input_ids( $value );
+					},
 				];
 				$fields['tagSlugAnd'] = [
 					'type'        => [

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -144,21 +144,6 @@ abstract class AbstractConnectionResolver {
 		$this->source = $source;
 
 		/**
-		 * Set the args for the resolver
-		 */
-		$this->args = $args;
-
-		/**
-		 *
-		 * Filters the GraphQL args before they are used in get_query_args().
-		 *
-		 * @param array                      $args                   The GraphQL args passed to the resolver.
-		 *
-		 * @since @todo
-		 */
-		$this->args = apply_filters( 'graphql_connection_args', $this->get_args() );
-
-		/**
 		 * Set the context of the resolver
 		 */
 		$this->context = $context;
@@ -172,6 +157,22 @@ abstract class AbstractConnectionResolver {
 		 * Get the loader for the Connection
 		 */
 		$this->loader = $this->getLoader();
+
+		/**
+		 * Set the args for the resolver
+		 */
+		$this->args = $args;
+
+		/**
+		 *
+		 * Filters the GraphQL args before they are used in get_query_args().
+		 *
+		 * @param array                      $args                The GraphQL args passed to the resolver.
+		 * @param AbstractConnectionResolver $connection_resolver Instance of the ConnectionResolver
+		 *
+		 * @since @todo
+		 */
+		$this->args = apply_filters( 'graphql_connection_args', $this->get_args(), $this );
 
 		/**
 		 * Determine the query amount for the resolver.

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -149,6 +149,16 @@ abstract class AbstractConnectionResolver {
 		$this->args = $args;
 
 		/**
+		 *
+		 * Filters the GraphQL args before they are used in get_query_args().
+		 *
+		 * @param array                      $args                   The GraphQL args passed to the resolver.
+		 *
+		 * @since @todo
+		 */
+		$this->args = apply_filters( 'graphql_connection_args', $this->get_args() );
+
+		/**
 		 * Set the context of the resolver
 		 */
 		$this->context = $context;
@@ -216,9 +226,26 @@ abstract class AbstractConnectionResolver {
 	/**
 	 * Returns the $args passed to the connection
 	 *
+	 * Deprecated in favor of $this->get_args();
+	 *
+	 * @deprecated @todo
+	 *
 	 * @return array
 	 */
 	public function getArgs(): array {
+		_deprecated_function( __FUNCTION__, '@todo', 'get_args' );
+		return $this->get_args();
+	}
+
+
+	/**
+	 * Returns the $args passed to the connection.
+	 *
+	 * Useful for modifying the $args before they are passed to $this->get_query_args().
+	 *
+	 * @return array
+	 */
+	public function get_args() {
 		return $this->args;
 	}
 

--- a/src/Data/Connection/CommentConnectionResolver.php
+++ b/src/Data/Connection/CommentConnectionResolver.php
@@ -260,11 +260,12 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 		 *
 		 * Filters the GraphQL args before they are used in get_query_args().
 		 *
-		 * @param array                      $args                   The GraphQL args passed to the resolver.
+		 * @param array                     $args                The GraphQL args passed to the resolver.
+		 * @param CommentConnectionResolver $connection_resolver Instance of the ConnectionResolver
 		 *
 		 * @since @todo
 		 */
-		$args = apply_filters( 'graphql_comment_connection_args', $args );
+		$args = apply_filters( 'graphql_comment_connection_args', $args, $this );
 
 		return $args;
 

--- a/src/Data/Connection/CommentConnectionResolver.php
+++ b/src/Data/Connection/CommentConnectionResolver.php
@@ -7,7 +7,7 @@ use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use WP_Comment_Query;
 use WPGraphQL\AppContext;
-use WPGraphQL\Types;
+use WPGraphQL\Utils\Utils;
 
 /**
  * Class CommentConnectionResolver

--- a/src/Data/Connection/MenuItemConnectionResolver.php
+++ b/src/Data/Connection/MenuItemConnectionResolver.php
@@ -123,11 +123,12 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 		 *
 		 * Filters the GraphQL args before they are used in get_query_args().
 		 *
-		 * @param array $args The GraphQL args passed to the resolver.
+		 * @param array                      $args                The GraphQL args passed to the resolver.
+		 * @param MenuItemConnectionResolver $connection_resolver Instance of the ConnectionResolver
 		 *
 		 * @since @todo
 		 */
-		$args = apply_filters( 'graphql_menu_item_connection_args', $args );
+		$args = apply_filters( 'graphql_menu_item_connection_args', $args, $this );
 
 		return $args;
 

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -207,4 +207,18 @@ class Utils {
 
 		return ! empty( $id_parts['id'] ) && is_numeric( $id_parts['id'] ) ? absint( $id_parts['id'] ) : false;
 	}
+
+	/**
+	 * Parses a single or list of GraphQL ID types into a list of database IDs.
+	 *
+	 * @param int|string|array<int|string> $ids
+	 */
+	public static function parse_input_ids( $ids ) {
+		// If the value is an array, we need to map each item to a database ID.
+		if ( is_array( $ids ) ) {
+			return array_map( [ __CLASS__, 'get_database_id_from_id' ], $ids );
+		}
+
+		return self::get_database_id_from_id( $ids );
+	}
 }

--- a/tests/wpunit/CommentConnectionQueriesTest.php
+++ b/tests/wpunit/CommentConnectionQueriesTest.php
@@ -27,6 +27,10 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 	}
 
 	public function tearDown(): void {
+		foreach ( $this->created_comment_ids as $comment ) {
+			wp_delete_comment( $comment, true );
+		}
+		wp_delete_post( $this->post_id, true );
 		// then
 		parent::tearDown();
 	}
@@ -45,7 +49,7 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 		 */
 		$defaults = [
 			'comment_post_ID'  => $post_id,
-			'comment_author'   => $this->admin,
+			'user_id'          => $this->admin,
 			'comment_content'  => 'Test comment content',
 			'comment_approved' => 1,
 		];
@@ -173,7 +177,7 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-//		$this->markTestIncomplete( 'Comments missing cursor pagination support' );
+		//      $this->markTestIncomplete( 'Comments missing cursor pagination support' );
 		$this->assertValidPagination( $expected, $actual );
 		$this->assertEquals( true, $actual['data']['comments']['pageInfo']['hasPreviousPage'] );
 		$this->assertEquals( true, $actual['data']['comments']['pageInfo']['hasNextPage'] );
@@ -267,7 +271,7 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 		$expected = $wp_query->query( $query_args );
 		$expected = array_reverse( $expected );
 
-		$actual   = $this->graphql( compact( 'query', 'variables' ) );
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
 		$this->assertValidPagination( $expected, $actual );
 		$this->assertEquals( true, $actual['data']['comments']['pageInfo']['hasPreviousPage'] );
@@ -352,8 +356,6 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 		// Using first and last should throw an error.
 		$actual = graphql( compact( 'query', 'variables' ) );
 
-
-
 		$this->assertArrayHasKey( 'errors', $actual );
 
 		unset( $variables['first'] );
@@ -367,7 +369,96 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 
 	}
 
-	public function testWhereArgs() {
+	public function testAuthorWhereArgs() {
+		$query = $this->getQuery();
+
+		$author_one_id      = $this->factory()->user->create(
+			[
+				'role'       => 'subscriber',
+				'user_email' => 'subscriber@wpgraphql.test',
+			]
+		);
+		$author_two_id      = $this->factory()->user->create(
+			[
+				'role'       => 'author',
+				'user_email' => 'author@wpgraphql.test',
+			]
+		);
+		$author_three_email = 'guest@wpgraphql.test';
+		$author_four_url    = 'https://myguestsite.test';
+
+		$comment_ids = [
+			$this->createCommentObject( [
+				'user_id'              => $author_one_id,
+				'comment_author_email' => 'subscriber@wpgraphql.test',
+			] ),
+			$this->createCommentObject( [
+				'user_id'              => $author_two_id,
+				'comment_author_email' => 'author@wpgraphql.test',
+				'comment_author_url'   => 'https://myguestsite.test',
+			] ),
+		];
+
+		// test authorEmail.
+		$variables = [
+			'where' => [
+				'authorEmail' => 'subscriber@wpgraphql.test',
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertCount( 1, $actual['data']['comments']['nodes'] );
+		$this->assertEquals( $comment_ids[0], $actual['data']['comments']['nodes'][0]['databaseId'] );
+
+		// test authorUrl.
+		$variables = [
+			'where' => [
+				'authorUrl' => 'https://myguestsite.test',
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertCount( 1, $actual['data']['comments']['nodes'] );
+		$this->assertEquals( $comment_ids[1], $actual['data']['comments']['nodes'][0]['databaseId'] );
+
+		// test authorIn with ID + databaseId
+		$author_one_global_id = GraphQLRelay\Relay::toGlobalId( 'user', $author_one_id );
+
+		$variables = [
+			'where' => [
+				'authorIn' => [ $author_one_global_id, $author_two_id ],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertCount( 2, $actual['data']['comments']['nodes'] );
+		$this->assertEquals( $comment_ids[1], $actual['data']['comments']['nodes'][0]['databaseId'] );
+		$this->assertEquals( $comment_ids[0], $actual['data']['comments']['nodes'][1]['databaseId'] );
+
+		// test authorNotIn with ID + databaseId
+
+		$variables = [
+			'where' => [
+				'authorNotIn' => [ $author_one_global_id, $author_two_id ],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertCount( 6, $actual['data']['comments']['nodes'] );
+		$this->assertNotEquals( $comment_ids[1], $actual['data']['comments']['nodes'][0]['databaseId'] );
+		$this->assertNotEquals( $comment_ids[0], $actual['data']['comments']['nodes'][0]['databaseId'] );
+
+	}
+
+	public function testCommentTypeWhereArgs() {
 		$query = $this->getQuery();
 
 		$comment_type_one = 'custom-type-one';


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR allows GraphQL connection where args with a type `ID` to accept either global IDs or database IDs. 
The method proposed is _non-breaking_, works uniformly across all connections, and is easily extendable both by custom connection resolvers and with WP filters.

It follows the pattern used by `AbstractConnectionResolver::get_query_args()`.

As with other PRs addressing #998 , this can be implemented piece-meal for each connection, but only once the primary change to `AbstractConnectionResolver` has been changed. For this reason, I've also included `CommentsConnectionResolver` in the PR, and can either break that to a separate PR or add the other updated resolvers to this one. :shrug:

## How it works:
1. `AbstractConnectionResolver::$args` is now passed through the `graphql_connection_args` filter.
2. `AbstractConnectionResolver::getArgs()` has been deprecated in favor of `AbstractConnectionResolver::get_args()`, which provides a way for resolvers to modify the connection args _before_ they are passed to `AbstractConnectionResolver::get_query_args()`.
3. [👀] Added `CommentConnectionResolver::get_args()` to map all inputs of type `ID` to their database ID.

## Alternatives considered:
- **Converting the ID value in {Type}ConnectionResolver::get_query_args()**. This adds additional mess and complexity to an already complex method, and requires duplicate logic for each input arg.
- **Using the `parseValues` config callable**.
The theory is that using [`parseValues`](https://webonyx.github.io/graphql-php/type-definitions/inputs/) on the input config, would allow us to improve separation of concerns, at the cost of significant code duplication. However, I either misunderstood the GraphQL-PHP docs, or this isnt currently supported by WPGraphQL. (You can see this approach implemented - and failing! - for `Data\Connection\PostObjects` [here](https://github.com/wp-graphql/wp-graphql/pull/2340/commits/e4683a0f5ec49b1ce153a2b9008c5bb7e30ade13) ).

Does this close any currently open issues?
------------------------------------------
#998 



Any other comments?
-------------------
1. ~The `graphql_connection_args` filter only passes the `$args` parameter, as the class instance is not in a place yet where its public methods can be called consistently.~ Now working.
 
2. Tests are going to be a huge ~PITA~ opportunity to improve coverall scores, since most connections dont currently have many of these where args tested. Could use help implementing these.

3. the version number on the deprecations and new filters will need to be updated before release

Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php 8.0.19)

**WordPress Version:** 6.0.1
