### PR TITLE
"select" and "option" added to allowed HTML for settings.

### DIFF
--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -154,6 +154,8 @@ class Utils {
 			'textarea' => $allowed_atts,
 			'iframe'   => $allowed_atts,
 			'script'   => $allowed_atts,
+			'select'   => $allowed_atts,
+            		'option'   => $allowed_atts,
 			'style'    => $allowed_atts,
 			'strong'   => $allowed_atts,
 			'small'    => $allowed_atts,

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -155,7 +155,7 @@ class Utils {
 			'iframe'   => $allowed_atts,
 			'script'   => $allowed_atts,
 			'select'   => $allowed_atts,
-            		'option'   => $allowed_atts,
+			'option'   => $allowed_atts,
 			'style'    => $allowed_atts,
 			'strong'   => $allowed_atts,
 			'small'    => $allowed_atts,


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
The get_allowed_wp_kses_html function was missing "select" and "option" which stripped the HTML when trying to add settings fields.

I noticed this when making an update I'm working on for the wpgraphql-cors repo which has its own tab of settings. Without this change, its not possible to create settings of the "select" type.


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Apache on php 7.4 in Docker

**WordPress Version:** 5.9
