### PR TITLE
Fixes bug with Comment Authors not always returning

### DIFF
--- a/src/Type/ObjectType/Comment.php
+++ b/src/Type/ObjectType/Comment.php
@@ -31,13 +31,18 @@ class Comment {
 						'oneToOne'             => true,
 						'resolve'              => function ( $comment, $args, AppContext $context, ResolveInfo $info ) {
 
-							/**
-							 * If the comment has a user associated, use it to populate the author, otherwise return
-							 * the $comment and the Union will use that to hydrate the CommentAuthor Type
-							 */
-							if ( ! empty( $comment->userId ) ) {
+							$node = null;
+
+							// if the request is authenticated
+							// and the comment is from a user, try and load
+							// the user node
+							if ( ! empty( $comment->userId ) && is_user_logged_in() ) {
 								$node = $context->get_loader( 'user' )->load( absint( $comment->userId ) );
-							} else {
+							}
+
+							// If no node is loaded, fallback to the
+							// public comment author data
+							if ( ! $node ) {
 								$node = ! empty( $comment->commentId ) ? $context->get_loader( 'comment_author' )->load( $comment->commentId ) : null;
 							}
 

--- a/tests/wpunit/CommentObjectQueriesTest.php
+++ b/tests/wpunit/CommentObjectQueriesTest.php
@@ -663,7 +663,7 @@ class CommentObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 	/**
 	 * @throws Exception
 	 */
-	public function testQueryingAvatarOnUserAuthorsIsValid() {
+	public function testQueryingAvatarOnUserAuthorsIsValidForPublicAndAuthenticagedRequests() {
 
 		// create a comment with a guest author as the author
 		$comment_id = $this->createCommentObject();
@@ -686,6 +686,22 @@ class CommentObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 		';
 
 		$global_id = \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_id );
+
+		$actual = graphql( [
+			'query' => $query,
+			'variables' => [
+				'id' => $global_id
+			]
+		] );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		codecept_debug( $actual );
+
+		$typename = $actual['data']['comment']['author']['node']['__typename'];
+
+		$this->assertSame( 'CommentAuthor', $typename );
+		$this->assertNotEmpty( $actual['data']['comment']['author']['node']['avatar']['url'] );
+
+		wp_set_current_user( $this->admin );
 
 		$actual = graphql( [
 			'query' => $query,


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

This fixes a bug where Comment Authors are not always returned if the author is a user, and the user is not considered a public node. 

- update resolver for Comment->author connection to load the CommentAuthor (public) by default, and only use the User node if it's publicly visible
- update test to query publicly and authenticated

Does this close any currently open issues?
------------------------------------------
closes #2348 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

## Scenario:

Given a user (in my case with `databaseId: 4`) that has no published content in any public post type, have that user post a comment and approve the comment. 

### Before:

This comment will return `null` for the author (because the User Model Layer prevents the User from being returned):

![CleanShot 2022-04-22 at 11 54 55](https://user-images.githubusercontent.com/1260765/164768750-59b9e35b-aa59-4ff3-bbc1-19224be65268.png)

### After:

The author is returned as a public `CommentAuthor` Type:

![CleanShot 2022-04-22 at 11 53 50](https://user-images.githubusercontent.com/1260765/164768622-989727db-b3e2-4894-861d-0221181996d0.png)

Any other comments?
-------------------
Authenticated users would get a `User` Type returned instead of the `CommentAuthor` type. This would be useful for things like administrative UIs where more information about the User might be used in the UI:

![CleanShot 2022-04-22 at 11 55 43](https://user-images.githubusercontent.com/1260765/164768844-85bea6c8-5a66-4240-9c24-df520e18e326.png)

