### PR TITLE
Amendment to #2349 to add "selected" attribute to allowed HTML.

### DIFF
--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -145,7 +145,7 @@ class Utils {
 			'title'      => [],
 			'checked'    => [],
 			'disabled'   => [],
-            'selected'   => [],
+			'selected'   => [],
 		];
 
 		return [

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -145,6 +145,7 @@ class Utils {
 			'title'      => [],
 			'checked'    => [],
 			'disabled'   => [],
+            'selected'   => [],
 		];
 
 		return [
@@ -155,7 +156,7 @@ class Utils {
 			'iframe'   => $allowed_atts,
 			'script'   => $allowed_atts,
 			'select'   => $allowed_atts,
-            		'option'   => $allowed_atts,
+            'option'   => $allowed_atts,
 			'style'    => $allowed_atts,
 			'strong'   => $allowed_atts,
 			'small'    => $allowed_atts,


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
The get_allowed_wp_kses_html function was missing the "selected" attribute which stripped the HTML when trying to save a select field in custom wpgraphql settings. This should have been included with #2349 but I didn't realize it wasn't saving until now. Oops =/.

Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Apache2 PHP 7.4 on Docker

**WordPress Version:** 5.9
