### PR TITLE
Feat: Refactor get_allowed_post_types() and get_allowed_taxonomies()

### DIFF
--- a/src/Connection/Taxonomies.php
+++ b/src/Connection/Taxonomies.php
@@ -27,7 +27,7 @@ class Taxonomies {
 			]
 		);
 
-		$taxonomies = get_taxonomies( [ 'show_in_graphql' => true ], 'objects' );
+		$taxonomies = \WPGraphQL::get_allowed_taxonomies( 'objects' );
 
 		if ( is_array( $taxonomies ) && ! empty( $taxonomies ) ) {
 			foreach ( $taxonomies as $taxonomy ) {

--- a/src/Connection/TermObjects.php
+++ b/src/Connection/TermObjects.php
@@ -210,7 +210,7 @@ class TermObjects {
 						]
 					),
 					'resolve'        => function ( Post $post, $args, AppContext $context, ResolveInfo $info ) {
-						$taxonomies = get_taxonomies( [ 'show_in_graphql' => true ] );
+						$taxonomies = \WPGraphQL::get_allowed_taxonomies();
 						$terms      = wp_get_post_terms( $post->ID, $taxonomies, [ 'fields' => 'ids' ] );
 						if ( empty( $terms ) || is_wp_error( $terms ) ) {
 							return null;

--- a/src/Data/Connection/ContentTypeConnectionResolver.php
+++ b/src/Data/Connection/ContentTypeConnectionResolver.php
@@ -91,7 +91,7 @@ class ContentTypeConnectionResolver extends AbstractConnectionResolver {
 		}
 
 		$query_args = $this->get_query_args();
-		return array_values( get_post_types( $query_args ) );
+		return array_values( \WPGraphQL::get_allowed_post_types( 'names', $query_args ) );
 	}
 
 	/**

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -53,7 +53,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		if ( 'revision' === $post_type || 'attachment' === $post_type ) {
 			$this->post_type = $post_type;
 		} elseif ( 'any' === $post_type ) {
-			$post_types      = get_post_types( [ 'show_in_graphql' => true ] );
+			$post_types      = \WPGraphQL::get_allowed_post_types();
 			$this->post_type = ! empty( $post_types ) ? array_values( $post_types ) : [];
 		} else {
 			$post_type = is_array( $post_type ) ? $post_type : [ $post_type ];

--- a/src/Data/Connection/TermObjectConnectionResolver.php
+++ b/src/Data/Connection/TermObjectConnectionResolver.php
@@ -48,7 +48,7 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 		/**
 		 * Set the taxonomy for the $args
 		 */
-		$all_taxonomies = get_taxonomies( [ 'show_in_graphql' => true ] );
+		$all_taxonomies = \WPGraphQL::get_allowed_taxonomies();
 		$query_args     = [
 			'taxonomy' => ! empty( $this->taxonomy ) ? $this->taxonomy : $all_taxonomies,
 		];

--- a/src/Data/Loader/PostTypeLoader.php
+++ b/src/Data/Loader/PostTypeLoader.php
@@ -29,7 +29,7 @@ class PostTypeLoader extends AbstractDataLoader {
 	 * @throws Exception
 	 */
 	public function loadKeys( array $keys ) {
-		$post_types = get_post_types( [ 'show_in_graphql' => true ], 'objects' );
+		$post_types = \WPGraphQL::get_allowed_post_types( 'objects' );
 
 		$loaded = [];
 		if ( ! empty( $post_types ) && is_array( $post_types ) ) {

--- a/src/Data/Loader/TaxonomyLoader.php
+++ b/src/Data/Loader/TaxonomyLoader.php
@@ -29,7 +29,7 @@ class TaxonomyLoader extends AbstractDataLoader {
 	 * @throws Exception
 	 */
 	public function loadKeys( array $keys ) {
-		$taxonomies = get_taxonomies( [ 'show_in_graphql' => true ], 'objects' );
+		$taxonomies = \WPGraphQL::get_allowed_taxonomies( 'objects' );
 
 		$loaded = [];
 		if ( ! empty( $taxonomies ) && is_array( $taxonomies ) ) {

--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -475,7 +475,7 @@ class NodeResolver {
 
 			return ! empty( $post_type_object ) ? $this->context->get_loader( 'post_type' )->load_deferred( $post_type_object->name ) : null;
 		} else {
-			$taxonomies = get_taxonomies( [ 'show_in_graphql' => true ], 'objects' );
+			$taxonomies = \WPGraphQL::get_allowed_taxonomies( 'objects' );
 			foreach ( $taxonomies as $taxonomy ) {
 				if ( isset( $this->wp->query_vars[ $taxonomy->query_var ] ) ) {
 					$node = get_term_by( 'slug', $this->wp->query_vars[ $taxonomy->query_var ], $taxonomy->name );

--- a/src/Type/Enum/ContentTypeEnum.php
+++ b/src/Type/Enum/ContentTypeEnum.php
@@ -16,14 +16,12 @@ class ContentTypeEnum {
 		$values = [];
 
 		/**
-		 * Get the allowed taxonomies
+		 * Get the allowed post types
 		 */
-		$allowed_post_types = get_post_types( [
-			'show_in_graphql' => true,
-		] );
+		$allowed_post_types = \WPGraphQL::get_allowed_post_types();
 
 		/**
-		 * Loop through the taxonomies and create an array
+		 * Loop through the post types and create an array
 		 * of values for use in the enum type.
 		 */
 		if ( ! empty( $allowed_post_types ) && is_array( $allowed_post_types ) ) {

--- a/src/Type/ObjectType/RootQuery.php
+++ b/src/Type/ObjectType/RootQuery.php
@@ -215,7 +215,7 @@ class RootQuery {
 								$post_id   = ! empty( $revisions ) ? array_values( $revisions )[0] : $post_id;
 							}
 
-							$allowed_post_types   = get_post_types( [ 'show_in_graphql' => true ] );
+							$allowed_post_types   = \WPGraphQL::get_allowed_post_types();
 							$allowed_post_types[] = 'revision';
 
 							return absint( $post_id ) ? $context->get_loader( 'post' )->load_deferred( $post_id )->then(

--- a/src/Type/Union/MenuItemObjectUnion.php
+++ b/src/Type/Union/MenuItemObjectUnion.php
@@ -79,8 +79,7 @@ class MenuItemObjectUnion {
 		}
 
 		// Add taxonomies that are allowed in WPGraphQL.
-		foreach ( get_taxonomies( $args ) as $type ) {
-			$tax_object = get_taxonomy( $type );
+		foreach ( \WPGraphQL::get_allowed_taxonomies( 'objects', $args ) as $tax_object ) {
 			if ( isset( $tax_object->graphql_single_name ) ) {
 				$possible_types[] = $tax_object->graphql_single_name;
 			}

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -48,22 +48,18 @@ final class WPGraphQL {
 	/**
 	 * Stores an array of allowed post types
 	 *
-	 * @todo make protected
-	 *
 	 * @var ?\WP_Post_Type[] allowed_post_types
 	 * @since  0.0.5
 	 */
-	public static $allowed_post_types;
+	protected static $allowed_post_types;
 
 	/**
 	 * Stores an array of allowed taxonomies
 	 *
-	 * @todo make protected
-	 *
 	 * @var ?\WP_Taxonomy[] allowed_taxonomies
 	 * @since  0.0.5
 	 */
-	public static $allowed_taxonomies;
+	protected static $allowed_taxonomies;
 
 	/**
 	 * @var boolean

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -48,7 +48,9 @@ final class WPGraphQL {
 	/**
 	 * Stores an array of allowed post types
 	 *
-	 * @var array allowed_post_types
+	 * @todo make protected
+	 *
+	 * @var ?\WP_Post_Type[] allowed_post_types
 	 * @since  0.0.5
 	 */
 	public static $allowed_post_types;
@@ -56,7 +58,9 @@ final class WPGraphQL {
 	/**
 	 * Stores an array of allowed taxonomies
 	 *
-	 * @var array allowed_taxonomies
+	 * @todo make protected
+	 *
+	 * @var ?\WP_Taxonomy[] allowed_taxonomies
 	 * @since  0.0.5
 	 */
 	public static $allowed_taxonomies;
@@ -466,94 +470,134 @@ final class WPGraphQL {
 	}
 
 	/**
-	 * Get the post types that are allowed to be used in GraphQL. This gets all post_types that
-	 * are set to show_in_graphql, but allows for external code (plugins/theme) to filter the
-	 * list of allowed_post_types to add/remove additional post_types
+	 * Get the post types that are allowed to be used in GraphQL.
+	 * This gets all post_types that are set to show_in_graphql, but allows for external code (plugins/theme) to
+	 * filter the list of allowed_post_types to add/remove additional post_types
 	 *
-	 * @param array $args Arguments to filter allowed post types
+	 * @param string|array $output Optional. The type of output to return. Accepts post type 'names' or 'objects'. Default 'names'.
+	 * @param array $args Optional. Arguments to filter allowed post types
 	 *
 	 * @return array
 	 * @since  0.0.4
+	 * @since  @todo adds $output as first param, and stores post type objects in class property.
 	 */
-	public static function get_allowed_post_types( $args = [] ) {
+	public static function get_allowed_post_types( $output = 'names', $args = [] ) {
+		// Support deprecated param order.
+		if ( is_array( $output ) ) {
+			// @todo enable once core usage has been refactored.
+			// _doing_it_wrong( __FUNCTION__, '$args should be passed as the second parameter.', '@todo' );
+			$args   = $output;
+			$output = 'names';
+		}
 
-		/**
-		 * Get all post_types
-		 */
-		$post_types = get_post_types( array_merge( [ 'show_in_graphql' => true ], $args ) );
+		// Initialize array of allowed post type objects.
+		if ( empty( self::$allowed_post_types ) ) {
+			/**
+			 * Get all post types objects.
+			 *
+			 * @var \WP_Post_Type[] $post_type_objects
+			 */
+			$post_type_objects = get_post_types(
+				[ 'show_in_graphql' => true ],
+				'objects'
+			);
 
-		/**
-		 * Validate that the post_types have a graphql_single_name and graphql_plural_name
-		 */
-		array_map(
-			function ( $post_type ) {
-				/** @var string $post_type */
-				$post_type_object = get_post_type_object( $post_type );
+			$post_type_names = [];
 
-				if ( ! $post_type_object instanceof WP_Post_Type ) {
-					return;
-				}
-
-				if ( empty( $post_type_object ) || empty( $post_type_object->graphql_single_name ) || empty( $post_type_object->graphql_plural_name ) ) {
+			foreach ( $post_type_objects as $post_type_object ) {
+				/**
+				 * Validate that the post_types have a graphql_single_name and graphql_plural_name
+				 */
+				if ( empty( $post_type_object->graphql_single_name ) || empty( $post_type_object->graphql_plural_name ) ) {
 					throw new UserError(
 						sprintf(
 						/* translators: %s will replaced with the registered type */
-							__( 'The %s post_type isn\'t configured properly to show in GraphQL. It needs a "graphql_single_name" and a "graphql_plural_name"', 'wp-graphql' ),
+							__( 'The %s post_type isn\'t configured properly to show in GraphQL. It needs a "graphql_single_name" and a "graphql_plural_name"', 'wp-graphql-plugin-name' ),
 							$post_type_object->name
 						)
 					);
 				}
-			},
-			$post_types
-		);
+
+				// Save allowed post type names so they can be filtered by the user.
+				$post_type_names[] = $post_type_object->name;
+			}
+
+			/**
+			 * Pass through a filter to allow the post_types to be modified.
+			 * For example if a certain post_type should not be exposed to the GraphQL API.
+			 *
+			 * @since 0.0.2
+			 * @since @todo add $post_type_objects parameter.
+			 *
+			 * @param array $post_type_names Array of post type names.
+			 * @param array $post_type_objects Array of post type objects.
+			 *
+			 * @return array
+			 */
+			$allowed_post_type_names = apply_filters( 'graphql_post_entities_allowed_post_types', $post_type_names, $post_type_objects );
+
+			// Filter the post type objects if the list of allowed types have changed.
+			if ( $post_type_names !== $allowed_post_type_names ) {
+				// Maybe they're just out of order.
+				sort( $post_type_names );
+				sort( $allowed_post_type_names );
+
+				if ( $post_type_names !== $allowed_post_type_names ) {
+					$post_type_objects = array_filter( $post_type_objects, function ( $obj ) use ( $allowed_post_type_names ) {
+						return in_array( $obj->name, $allowed_post_type_names, true );
+					} );
+				}
+			}
+
+			self::$allowed_post_types = $post_type_objects;
+		}
+
+		$post_types = self::$allowed_post_types;
 
 		/**
-		 * Define the $allowed_post_types to be exposed by GraphQL Queries Pass through a filter
-		 * to allow the post_types to be modified (for example if a certain post_type should
-		 * not be exposed to the GraphQL API)
-		 *
-		 * @since 0.0.2
-		 *
-		 * @param array $post_types Array of post types
-		 *
-		 * @return array
+		 * Filter the list of allowed post types either by the provided args or to only return an array of names.
 		 */
-		return apply_filters( 'graphql_post_entities_allowed_post_types', $post_types );
+		if ( ! empty( $args ) || 'names' === $output ) {
+			$field = 'names' === $output ? 'name' : false;
 
+			$post_types = wp_filter_object_list( $post_types, $args, 'and', $field );
+		}
+
+		return $post_types;
 	}
 
 	/**
-	 * Get the taxonomies that are allowed to be used in GraphQL/This gets all taxonomies that
-	 * are set to "show_in_graphql" but allows for external code (plugins/themes) to filter
-	 * the list of allowed_taxonomies to add/remove additional taxonomies
+	 * Get the taxonomies that are allowed to be used in GraphQL.
+	 * This gets all taxonomies that are set to "show_in_graphql" but allows for external code (plugins/themes) to
+	 * filter the list of allowed_taxonomies to add/remove additional taxonomies
+	 *
+	 * @param string $output Optional. The type of output to return. Accepts taxonomy 'names' or 'objects'. Default 'names'.
+	 * @param array $args Optional. Arguments to filter allowed taxonomies.
 	 *
 	 * @since  0.0.4
 	 * @return array
 	 */
-	public static function get_allowed_taxonomies() {
+	public static function get_allowed_taxonomies( $output = 'names', $args = [] ) {
 
-		/**
-		 * Get all taxonomies
-		 */
-		$taxonomies = get_taxonomies(
-			[
-				'show_in_graphql' => true,
-			]
-		);
+		// Initialize array of allowed post type objects.
+		if ( empty( self::$allowed_taxonomies ) ) {
+			/**
+			 * Get all post types objects.
+			 *
+			 * @var \WP_Taxonomy[] $tax_objects
+			 */
+			$tax_objects = get_taxonomies(
+				[ 'show_in_graphql' => true ],
+				'objects'
+			);
 
-		/**
-		 * Validate that the taxonomies have a graphql_single_name and graphql_plural_name
-		 */
-		array_map(
-			function ( $taxonomy ) {
+			$tax_names = [];
 
-				$tax_object = get_taxonomy( $taxonomy );
-
-				if ( ! $tax_object instanceof WP_Taxonomy ) {
-					return;
-				}
-
-				if ( ! isset( $tax_object->graphql_single_name ) || ! isset( $tax_object->graphql_plural_name ) ) {
+			foreach ( $tax_objects as $tax_object ) {
+				/**
+				 * Validate that the taxonomies have a graphql_single_name and graphql_plural_name
+				 */
+				if ( empty( $tax_object->graphql_single_name ) || empty( $tax_object->graphql_plural_name ) ) {
 					throw new UserError(
 						sprintf(
 						/* translators: %s will replaced with the registered taxonomty */
@@ -561,17 +605,53 @@ final class WPGraphQL {
 							$tax_object->name
 						)
 					);
-
 				}
-			},
-			$taxonomies
-		);
 
+				// Save allowed taxonomy names so they can be filtered by the user.
+				$tax_names[] = $tax_object->name;
+			}
+
+			/**
+			 * Pass through a filter to allow the taxonomies to be modified.
+			 * For example if a certain taxonomy should not be exposed to the GraphQL API.
+			 *
+			 * @since 0.0.2
+			 * @since @todo add $tax_names and $tax_objects parameters.
+			 *
+			 * @param array $tax_names Array of taxonomy names
+			 * @param array $tax_objects Array of taxonomy objects.
+			 *
+			 * @return array
+			 */
+			$allowed_tax_names = apply_filters( 'graphql_term_entities_allowed_taxonomies', $tax_names, $tax_objects );
+
+			// Filter the taxonomy objects if the list of allowed types have changed.
+			if ( $tax_names !== $allowed_tax_names ) {
+				// Maybe they're just out of order.
+				sort( $tax_names );
+				sort( $allowed_tax_names );
+
+				if ( $tax_names !== $allowed_tax_names ) {
+					$tax_objects = array_filter( $tax_objects, function ( $obj ) use ( $allowed_tax_names ) {
+						return in_array( $obj->name, $allowed_tax_names, true );
+					} );
+				}
+			}
+
+			self::$allowed_taxonomies = $tax_objects;
+		}
+
+		$taxonomies = self::$allowed_taxonomies;
 		/**
-		 * Returns the array of $allowed_taxonomies
+		 * Filter the list of allowed taxonomies either by the provided args or to only return an array of names.
 		 */
-		return apply_filters( 'graphql_term_entities_allowed_taxonomies', $taxonomies );
+		if ( ! empty( $args ) || 'names' === $output ) {
+			$field = 'names' === $output ? 'name' : false;
 
+			$taxonomies = wp_filter_object_list( $taxonomies, $args, 'and', $field );
+		}
+
+		return $taxonomies;
 	}
 
 	/**
@@ -580,8 +660,10 @@ final class WPGraphQL {
 	 * @return void
 	 */
 	public static function clear_schema() {
-		self::$type_registry = null;
-		self::$schema        = null;
+		self::$type_registry      = null;
+		self::$schema             = null;
+		self::$allowed_post_types = null;
+		self::$allowed_taxonomies = null;
 	}
 
 	/**

--- a/tests/wpunit/WPGraphQLTest.php
+++ b/tests/wpunit/WPGraphQLTest.php
@@ -112,37 +112,37 @@ class WPGraphQLTest extends \Codeception\TestCase\WPTestCase {
 		// Test filter.
 		$expected = 'post';
 
-		// add_filter( 'graphql_post_entities_allowed_post_types', function ( $names, $objects ) use ( $expected ) {
-		// 	$this->assertContains( $expected, $names );
-		// 	$this->assertInstanceOf( \WP_Post_Type::class, $objects[ $expected ] );
+		add_filter( 'graphql_post_entities_allowed_post_types', function ( $names, $objects ) use ( $expected ) {
+			$this->assertContains( $expected, $names );
+			$this->assertInstanceOf( \WP_Post_Type::class, $objects[ $expected ] );
 
-		// 	return [ $expected => $expected ];
-		// }, 10, 2 );
+			return [ $expected => $expected ];
+		}, 10, 2 );
 
-		// // Clear cached types.
-		// WPGraphQL::$allowed_post_types = null;
+		// Clear cached types.
+		WPGraphQL::$allowed_post_types = null;
 
-		// $actual = WPGraphQL::get_allowed_post_types();
+		$actual = WPGraphQL::get_allowed_post_types();
 
-		// codecept_debug( $actual );
+		codecept_debug( $actual );
 
-		// $this->assertEquals( [ $expected => $expected ], $actual );
+		$this->assertEquals( [ $expected => $expected ], $actual );
 
-		// // Test query.
-		// $query = '
-		// 	query contentTypes {
-		// 		contentTypes {
-		// 			nodes {
-		// 				name
-		// 			}
-		// 		}
-		// 	}
-		// ';
+		// Test query.
+		$query = '
+			query contentTypes {
+				contentTypes {
+					nodes {
+						name
+					}
+				}
+			}
+		';
 
-		// $actual = graphql( [ 'query' => $query ] );
-		// codecept_debug( $actual );
+		$actual = graphql( [ 'query' => $query ] );
+		codecept_debug( $actual );
 
-		// $this->assertEquals( [ $expected ], array_column( $actual['data']['contentTypes']['nodes'], 'name' ) );
+		$this->assertEquals( [ $expected ], array_column( $actual['data']['contentTypes']['nodes'], 'name' ) );
 	}
 
 	/**
@@ -182,33 +182,33 @@ class WPGraphQLTest extends \Codeception\TestCase\WPTestCase {
 		// Test filter.
 		$expected = 'category';
 
-		// add_filter( 'graphql_term_entities_allowed_taxonomies', function ( $names = null, $objects = null ) use ( $expected ) {
-		// 	$this->assertContains( $expected, $names );
-		// 	$this->assertInstanceOf( \WP_Taxonomy::class, $objects[ $expected ] );
+		add_filter( 'graphql_term_entities_allowed_taxonomies', function ( $names = null, $objects = null ) use ( $expected ) {
+			$this->assertContains( $expected, $names );
+			$this->assertInstanceOf( \WP_Taxonomy::class, $objects[ $expected ] );
 
-		// 	return [ $expected => $expected ];
-		// }, 10, 2 );
+			return [ $expected => $expected ];
+		}, 10, 2 );
 
-		// // Clear cached types.
-		// WPGraphQL::$allowed_taxonomies = null;
-		// $actual                        = WPGraphQL::get_allowed_taxonomies();
-		// $this->assertEquals( [ $expected => $expected ], $actual, 'filter not equal' );
+		// Clear cached types.
+		WPGraphQL::$allowed_taxonomies = null;
+		$actual                        = WPGraphQL::get_allowed_taxonomies();
+		$this->assertEquals( [ $expected => $expected ], $actual, 'filter not equal' );
 
-		// // Test query.
-		// $query = '
-		// 	query taxonomies {
-		// 		taxonomies {
-		// 			nodes {
-		// 				name
-		// 			}
-		// 		}
-		// 	}
-		// ';
+		// Test query.
+		$query = '
+			query taxonomies {
+				taxonomies {
+					nodes {
+						name
+					}
+				}
+			}
+		';
 
-		// $actual = graphql( [ 'query' => $query ] );
-		// codecept_debug( $actual );
+		$actual = graphql( [ 'query' => $query ] );
+		codecept_debug( $actual );
 
-		// $this->assertEquals( [ $expected ], array_column( $actual['data']['taxonomies']['nodes'], 'name' ) );
+		$this->assertEquals( [ $expected ], array_column( $actual['data']['taxonomies']['nodes'], 'name' ) );
 	}
 
 }

--- a/tests/wpunit/WPGraphQLTest.php
+++ b/tests/wpunit/WPGraphQLTest.php
@@ -120,7 +120,7 @@ class WPGraphQLTest extends \Codeception\TestCase\WPTestCase {
 		}, 10, 2 );
 
 		// Clear cached types.
-		WPGraphQL::$allowed_post_types = null;
+		WPGraphQL::clear_schema();
 
 		$actual = WPGraphQL::get_allowed_post_types();
 
@@ -190,8 +190,8 @@ class WPGraphQLTest extends \Codeception\TestCase\WPTestCase {
 		}, 10, 2 );
 
 		// Clear cached types.
-		WPGraphQL::$allowed_taxonomies = null;
-		$actual                        = WPGraphQL::get_allowed_taxonomies();
+		WPGraphQL::clear_schema();
+		$actual = WPGraphQL::get_allowed_taxonomies();
 		$this->assertEquals( [ $expected => $expected ], $actual, 'filter not equal' );
 
 		// Test query.

--- a/tests/wpunit/WPGraphQLTest.php
+++ b/tests/wpunit/WPGraphQLTest.php
@@ -75,4 +75,140 @@ class WPGraphQLTest extends \Codeception\TestCase\WPTestCase {
 
 	}
 
+	/**
+	 * Tests WPGraphQL::get_allowed_post_types()
+	 */
+	public function testGetAllowedPostTypes() {
+		// Test names.
+		$expected = get_post_types( [ 'show_in_graphql' => true ] );
+
+		$actual = WPGraphQL::get_allowed_post_types();
+
+		codecept_debug( $actual );
+
+		$this->assertEqualSets( $expected, $actual );
+
+		// Test objects.
+		$expected = get_post_types( [ 'show_in_graphql' => true ], 'objects' );
+
+		$actual = WPGraphQL::get_allowed_post_types( 'objects' );
+
+		$this->assertEqualSets( $expected, $actual );
+
+		// Test args.
+		$expected = get_post_types(
+			[
+				'name' => 'page',
+			],
+		);
+
+		codecept_debug( $expected );
+
+		$actual = WPGraphQL::get_allowed_post_types( 'names', [ 'name' => 'page' ] );
+		codecept_debug( $actual );
+
+		$this->assertEqualSets( $expected, $actual );
+
+		// Test filter.
+		$expected = 'post';
+
+		// add_filter( 'graphql_post_entities_allowed_post_types', function ( $names, $objects ) use ( $expected ) {
+		// 	$this->assertContains( $expected, $names );
+		// 	$this->assertInstanceOf( \WP_Post_Type::class, $objects[ $expected ] );
+
+		// 	return [ $expected => $expected ];
+		// }, 10, 2 );
+
+		// // Clear cached types.
+		// WPGraphQL::$allowed_post_types = null;
+
+		// $actual = WPGraphQL::get_allowed_post_types();
+
+		// codecept_debug( $actual );
+
+		// $this->assertEquals( [ $expected => $expected ], $actual );
+
+		// // Test query.
+		// $query = '
+		// 	query contentTypes {
+		// 		contentTypes {
+		// 			nodes {
+		// 				name
+		// 			}
+		// 		}
+		// 	}
+		// ';
+
+		// $actual = graphql( [ 'query' => $query ] );
+		// codecept_debug( $actual );
+
+		// $this->assertEquals( [ $expected ], array_column( $actual['data']['contentTypes']['nodes'], 'name' ) );
+	}
+
+	/**
+	 * Tests WPGraphQL::get_allowed_taxonomies()
+	 */
+	public function testGetAllowedTaxonomies() {
+		// Test names.
+		$expected = get_taxonomies( [ 'show_in_graphql' => true ] );
+
+		$actual = WPGraphQL::get_allowed_taxonomies();
+
+		codecept_debug( $actual );
+
+		$this->assertEqualSets( $expected, $actual );
+
+		// Test objects.
+		$expected = get_taxonomies( [ 'show_in_graphql' => true ], 'objects' );
+
+		$actual = WPGraphQL::get_allowed_taxonomies( 'objects' );
+
+		$this->assertEqualSets( $expected, $actual, 'objects not equal' );
+
+		// Test args.
+		$expected = get_taxonomies(
+			[
+				'name' => 'category',
+			],
+		);
+
+		codecept_debug( $expected );
+
+		$actual = WPGraphQL::get_allowed_taxonomies( 'names', [ 'name' => 'category' ] );
+		codecept_debug( $actual );
+
+		$this->assertEqualSets( $expected, $actual );
+
+		// Test filter.
+		$expected = 'category';
+
+		// add_filter( 'graphql_term_entities_allowed_taxonomies', function ( $names = null, $objects = null ) use ( $expected ) {
+		// 	$this->assertContains( $expected, $names );
+		// 	$this->assertInstanceOf( \WP_Taxonomy::class, $objects[ $expected ] );
+
+		// 	return [ $expected => $expected ];
+		// }, 10, 2 );
+
+		// // Clear cached types.
+		// WPGraphQL::$allowed_taxonomies = null;
+		// $actual                        = WPGraphQL::get_allowed_taxonomies();
+		// $this->assertEquals( [ $expected => $expected ], $actual, 'filter not equal' );
+
+		// // Test query.
+		// $query = '
+		// 	query taxonomies {
+		// 		taxonomies {
+		// 			nodes {
+		// 				name
+		// 			}
+		// 		}
+		// 	}
+		// ';
+
+		// $actual = graphql( [ 'query' => $query ] );
+		// codecept_debug( $actual );
+
+		// $this->assertEquals( [ $expected ], array_column( $actual['data']['taxonomies']['nodes'], 'name' ) );
+	}
+
 }


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes
---------------------------------------------------

This PR refactors `WPGraphQL::get_allowed_post_types()` and `WPGraphQL::get_allowed_taxonomies()` to correctly store data in the `WPGraphQL::$allowed_post_types` and `WPGraphQL::$allowed_taxonomies` class properties.

Additionally, it stores the `WP_Post_Type` and `WP_Taxonomy` objects, allowing the user to retrieve _either_.

This will ensure that the list of possible post types / taxonomies is the same throughout the schema, and will also let us significantly clean up the codebase by removing now-extraneous rehydration calls ( e.g. `get_post_type( \WPGraphQL::allowed_post_type( )[ $n ] )` ) in a future PR.

### Details

* The array of `WP_Post_Type`s and `WP_Taxonomies` are stored to their respective parameters _after_ any `...entities_allowed_{type}` filters have been applied, but before any args passed to the methods.
* `WPGraphQL::get_allowed_post_types()` now takes an `$output` argument _as the first parameter_ that lets a user decide if they need the `names` or the `objects, and relocates the`$args` to the second parameter. This is _backwards compatible_ and if an array is passed as the first arg, it will automatically reassign it.
* `WPGraphQL::get_allowed_taxonomies()` accepts those same two parameters. There's no need to worry about back-compat, since it currently doesnt accept any.
* Numerous calls to `get_post_types()` and `get_taxonomies()` have been replaced with the respective `get_allowed...()` methods. This fixes a handful of bugs where the list of "allowed" types was different throughout the plugin, which would break the schema (e.g. querying `contentTypes` after deregistering a core type ).

* The `WPGraphQL::$allowed_post_types` and `WPGraphQL::$allowed_taxonomies` properties are now `protected`, to enforce the static getter pattern.

Does this close any currently open issues?
------------------------------------------

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

Any other comments?
-------------------

* As mentioned, this PR intentionally doesnt refactor the _usage_ of these methods (e.g rehydrating the post object by first getting the names and then looping through them and calling `get_post_type()` ). That's a separate improvement deserving of its own PR.
* I also didnt change many of the calls in `NodeByUri`, since that's already a finicky piece of code, and ideally we'd first get #2342 and better test how using a cached list of post/tax types might affect filters on the stored query vars.
* Relatedly: the deprecation notice is currently commented out until we're no longer `_doing_it_wrong()` ourselves.
* Storing an array of _objects_ in `WPGraphQL::$allowed_post_types` and `WPGraphQL::$allowed_taxonomies` is _non-breaking_ since theyre still array types, and they weren't actually holding anything beforehand. That said, while changing those properties to `protected` is ideal and wouldn't affect any users, ~since it's technically a breaking change, I'll leave it to @jasonbahl to decide.~ (edit: added by Jason).
* The rationale behind the change in argument order for `WPGraphQL::get_allowed_post_types()` is to conform with PHP best practices, since it's significantly more likely to toggle between `names`/`objects` outputs than it is to pass args. Technically we don't even need to deprecate passing _just_ the `$args` as shorthand for `WPGraphQL::get_allowed_post_types( 'names', $args )` , and can just remove the commented out `_doing_it_wrong`. Again, I'll let @jasonbahl  decide 😎.

Where has this been tested?
---------------------------

**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php 8.0.15)

**WordPress Version:** 5.9.3
