### PR TITLE
Add relative `uri` to MenuItem

### DIFF
--- a/src/Model/MenuItem.php
+++ b/src/Model/MenuItem.php
@@ -146,6 +146,7 @@ class MenuItem extends Model {
 					return ( ! empty( $this->data->attr_title ) ) ? $this->data->attr_title : null;
 				},
 				'uri'              => function () {
+
 					$url = $this->url;
 
 					if ( empty( $url ) ) {
@@ -161,6 +162,7 @@ class MenuItem extends Model {
 					}
 
 					return $url;
+
 				},
 				'url'              => function () {
 					return ! empty( $this->data->url ) ? $this->data->url : null;

--- a/src/Model/MenuItem.php
+++ b/src/Model/MenuItem.php
@@ -145,11 +145,7 @@ class MenuItem extends Model {
 				'title'            => function () {
 					return ( ! empty( $this->data->attr_title ) ) ? $this->data->attr_title : null;
 				},
-				'url'              => function () {
-					return ! empty( $this->data->url ) ? $this->data->url : null;
-				},
-				'path'             => function () {
-
+				'uri'              => function () {
 					$url = $this->url;
 
 					if ( empty( $url ) ) {
@@ -158,15 +154,7 @@ class MenuItem extends Model {
 
 					$parsed = wp_parse_url( $url );
 
-					if ( ! isset( $parsed['host'] ) ) {
-						return $url;
-					}
-
-					if ( ! isset( $parsed['path'] ) ) {
-						return;
-					}
-
-					if ( is_multisite() ) {
+					if ( is_multisite() && isset( $parsed['host'] ) && strpos( home_url(), $parsed['host'] ) ) {
 						$site                = get_site();
 						$subdirectory        = untrailingslashit( $site->path );
 						$path_from_site_root = str_replace( $subdirectory, '', $parsed['path'] );
@@ -174,7 +162,27 @@ class MenuItem extends Model {
 						return $path_from_site_root;
 					}
 
-					return $parsed['path'];
+					return $url;
+				},
+				'url'              => function () {
+					return ! empty( $this->data->url ) ? $this->data->url : null;
+				},
+				'path'             => function () {
+
+					$url = $this->url;
+
+					if ( ! empty( $url ) ) {
+						$parsed = wp_parse_url( $url );
+						if ( isset( $parsed['host'] ) ) {
+							if ( strpos( home_url(), $parsed['host'] ) ) {
+								return $parsed['path'];
+							} elseif ( strpos( home_url(), $parsed['host'] ) ) {
+								return $parsed['path'];
+							}
+						}
+					}
+
+					return $url;
 
 				},
 				'order'            => function () {

--- a/src/Model/MenuItem.php
+++ b/src/Model/MenuItem.php
@@ -155,11 +155,9 @@ class MenuItem extends Model {
 					$parsed = wp_parse_url( $url );
 
 					if ( is_multisite() && isset( $parsed['host'] ) && strpos( home_url(), $parsed['host'] ) ) {
-						$site                = get_site();
-						$subdirectory        = untrailingslashit( $site->path );
-						$path_from_site_root = str_replace( $subdirectory, '', $parsed['path'] );
-
-						return $path_from_site_root;
+						$site         = get_site();
+						$subdirectory = untrailingslashit( $site->path );
+						$url          = str_replace( $subdirectory, '', $parsed['path'] );
 					}
 
 					return $url;

--- a/src/Model/MenuItem.php
+++ b/src/Model/MenuItem.php
@@ -152,18 +152,29 @@ class MenuItem extends Model {
 
 					$url = $this->url;
 
-					if ( ! empty( $url ) ) {
-						$parsed = wp_parse_url( $url );
-						if ( isset( $parsed['host'] ) ) {
-							if ( strpos( home_url(), $parsed['host'] ) ) {
-								return $parsed['path'];
-							} elseif ( strpos( home_url(), $parsed['host'] ) ) {
-								return $parsed['path'];
-							}
-						}
+					if ( empty( $url ) ) {
+						return $url;
 					}
 
-					return $url;
+					$parsed = wp_parse_url( $url );
+
+					if ( ! isset( $parsed['host'] ) ) {
+						return $url;
+					}
+
+					if ( ! isset( $parsed['path'] ) ) {
+						return;
+					}
+
+					if ( is_multisite() ) {
+						$site                = get_site();
+						$subdirectory        = untrailingslashit( $site->path );
+						$path_from_site_root = str_replace( $subdirectory, '', $parsed['path'] );
+
+						return $path_from_site_root;
+					}
+
+					return $parsed['path'];
 
 				},
 				'order'            => function () {

--- a/src/Model/MenuItem.php
+++ b/src/Model/MenuItem.php
@@ -146,23 +146,9 @@ class MenuItem extends Model {
 					return ( ! empty( $this->data->attr_title ) ) ? $this->data->attr_title : null;
 				},
 				'uri'              => function () {
+					$url = $this->data->url;
 
-					$url = $this->url;
-
-					if ( empty( $url ) ) {
-						return $url;
-					}
-
-					$parsed = wp_parse_url( $url );
-
-					if ( is_multisite() && isset( $parsed['host'] ) && strpos( home_url(), $parsed['host'] ) ) {
-						$site         = get_site();
-						$subdirectory = untrailingslashit( $site->path );
-						$url          = str_replace( $subdirectory, '', $parsed['path'] );
-					}
-
-					return $url;
-
+					return ! empty( $url ) ? str_ireplace( home_url(), '', $url ) : null;
 				},
 				'url'              => function () {
 					return ! empty( $this->data->url ) ? $this->data->url : null;

--- a/src/Mutation/MediaItemUpdate.php
+++ b/src/Mutation/MediaItemUpdate.php
@@ -121,15 +121,15 @@ class MediaItemUpdate {
 			 * Check to see if the existing_media_item author matches the current user,
 			 * if not they need to be able to edit others posts to proceed
 			 */
-			if (  get_current_user_id() !== $author_id && ( ! isset( $post_type_object->cap->edit_others_posts ) || ! current_user_can( $post_type_object->cap->edit_others_posts ) ) ) {
+			if ( get_current_user_id() !== $author_id && ( ! isset( $post_type_object->cap->edit_others_posts ) || ! current_user_can( $post_type_object->cap->edit_others_posts ) ) ) {
 				throw new UserError( __( 'Sorry, you are not allowed to update mediaItems as this user.', 'wp-graphql' ) );
 			}
 
 			/**
 			 * Insert the post object and get the ID
 			 */
-			$post_args                = MediaItemMutation::prepare_media_item( $input, $post_type_object, $mutation_name, false );
-			$post_args['ID']          = $media_item_id;
+			$post_args       = MediaItemMutation::prepare_media_item( $input, $post_type_object, $mutation_name, false );
+			$post_args['ID'] = $media_item_id;
 
 			$clean_args = wp_slash( (array) $post_args );
 

--- a/src/Type/ObjectType/MenuItem.php
+++ b/src/Type/ObjectType/MenuItem.php
@@ -118,6 +118,12 @@ class MenuItem {
 						'type'        => 'String',
 						'description' => __( 'URL or destination of the menu item.', 'wp-graphql' ),
 					],
+					// Note: this field is added to the MenuItem type instead of applied by the "UniformResourceIdentifiable" interface
+					// because a MenuItem is not identifiable by a uri, the connected resource is identifiable by the uri.
+					'uri'              => [
+						'type'        => 'String',
+						'description' => __( 'The uri of the resource the menu item links to', 'wp-graphql' ),
+					],
 					'path'             => [
 						'type'        => 'String',
 						'description' => __( 'Path for the resource. Relative path for internal resources. Absolute path for external resources.', 'wp-graphql' ),

--- a/src/Type/ObjectType/MenuItem.php
+++ b/src/Type/ObjectType/MenuItem.php
@@ -21,7 +21,7 @@ class MenuItem {
 			'MenuItem',
 			[
 				'description' => __( 'Navigation menu items are the individual items assigned to a menu. These are rendered as the links in a navigation menu.', 'wp-graphql' ),
-				'interfaces'  => [ 'Node', 'DatabaseIdentifier' ],
+				'interfaces'  => [ 'Node', 'DatabaseIdentifier', 'UniformResourceIdentifiable' ],
 				'connections' => [
 					'connectedNode' => [
 						'toType'               => 'MenuItemLinkable',
@@ -113,10 +113,6 @@ class MenuItem {
 					'title'            => [
 						'type'        => 'String',
 						'description' => __( 'Title attribute for the menu item link', 'wp-graphql' ),
-					],
-					'uri'              => [
-						'type'        => 'String',
-						'description' => __( 'The relative path to the current site.', 'wp-graphql' ),
 					],
 					'url'              => [
 						'type'        => 'String',

--- a/src/Type/ObjectType/MenuItem.php
+++ b/src/Type/ObjectType/MenuItem.php
@@ -21,7 +21,7 @@ class MenuItem {
 			'MenuItem',
 			[
 				'description' => __( 'Navigation menu items are the individual items assigned to a menu. These are rendered as the links in a navigation menu.', 'wp-graphql' ),
-				'interfaces'  => [ 'Node', 'DatabaseIdentifier', 'UniformResourceIdentifiable' ],
+				'interfaces'  => [ 'Node', 'DatabaseIdentifier' ],
 				'connections' => [
 					'connectedNode' => [
 						'toType'               => 'MenuItemLinkable',

--- a/src/Type/ObjectType/MenuItem.php
+++ b/src/Type/ObjectType/MenuItem.php
@@ -114,6 +114,10 @@ class MenuItem {
 						'type'        => 'String',
 						'description' => __( 'Title attribute for the menu item link', 'wp-graphql' ),
 					],
+					'uri'              => [
+						'type'        => 'String',
+						'description' => __( 'The relative path to the current site.', 'wp-graphql' ),
+					],
 					'url'              => [
 						'type'        => 'String',
 						'description' => __( 'URL or destination of the menu item.', 'wp-graphql' ),


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This fixes an issue with using wp-graphql in a WordPress multisite using subdirectories where the individual site subdirectory is included with the menu path.

Does this close any currently open issues?
------------------------------------------
https://github.com/wp-graphql/wp-graphql/issues/2362


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
**Before**
<img width="1385" alt="Screen Shot 2022-05-04 at 3 24 03 PM" src="https://user-images.githubusercontent.com/6676674/166811382-bdc52551-3d6e-463b-aa7f-58cc4a288bee.png">

**After**
<img width="1385" alt="Screen Shot 2022-05-04 at 3 23 49 PM" src="https://user-images.githubusercontent.com/6676674/166811406-e39af925-6619-4c6d-b7a9-9aca2509649f.png">


Where has this been tested?
---------------------------
**Operating System:** macOS 12.3.1
**WordPress Version:** 5.9.2
