### PR TITLE
Bug/#2371 auth callback should work for mutations

### DIFF
--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -1070,7 +1070,7 @@ class TypeRegistry {
 		$this->register_field(
 			'rootMutation',
 			$mutation_name,
-			[
+			array_merge( $config, [
 				'description' => sprintf( __( 'The payload for the %s mutation', 'wp-graphql' ), $mutation_name ),
 				'args'        => [
 					'input' => [
@@ -1099,7 +1099,7 @@ class TypeRegistry {
 
 					return $payload;
 				},
-			]
+			])
 		);
 
 	}

--- a/src/Utils/InstrumentSchema.php
+++ b/src/Utils/InstrumentSchema.php
@@ -216,7 +216,7 @@ class InstrumentSchema {
 			return true;
 		}
 
-		if ( ! isset( $field->config['auth'] ) || ! is_array( $field->config['auth'] ) ) {
+		if ( ( ! isset( $field->config['auth'] ) || ! is_array( $field->config['auth'] ) ) && ! isset( $field->config['isPrivate'] ) ) {
 			return true;
 		}
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This updates `register_graphql_mutation` to work with the current `auth` and `isPrivate` methods for restricting resolvers at the Schema level. 


Does this close any currently open issues?
------------------------------------------
related to: #2371 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

Given the following snippet: 

```php
register_graphql_mutation( 'isPrivateMutation', [
	'inputFields' => [],
	'outputFields' => [
		'test' => [
			'type' => 'String'
		]
	],
	'isPrivate' => true,
	'mutateAndGetPayload' => function() use ( $expected ) {
		return [
			'test' => 'test_value';
		];
	}
]);
```

The following query can be executed: 

```php
mutation {
  isPrivateMutation(input:{ clientMutationId: "test" }) {
    test
  }
}
```

### BEFORE

As a public user, I'm able to execute the mutation and get the data back

![CleanShot 2022-05-13 at 15 54 56](https://user-images.githubusercontent.com/1260765/168394394-b54abf73-0088-4952-9d74-9d97195e3946.png)


### AFTER

Now, we can see the mutation is properly restricted, because of the `isPrivate` config is set to true on the mutation

![CleanShot 2022-05-13 at 15 54 11](https://user-images.githubusercontent.com/1260765/168394322-7c800164-f5c7-4fab-9c9c-6f4db69d6437.png)

Any other comments?
-------------------
This doesn't solve/close #2371. It just brings an existing layer of auth restrictions at the Schema level to be supported by mutations, and adds some better tests around this functionality.
