### PR TITLE
Bugfix/#2378 fix slashes in term mutations

### DIFF
--- a/src/Data/TermObjectMutation.php
+++ b/src/Data/TermObjectMutation.php
@@ -2,24 +2,26 @@
 
 namespace WPGraphQL\Data;
 
+use Exception;
 use GraphQL\Error\UserError;
 use GraphQLRelay\Relay;
+use WP_Taxonomy;
 
 class TermObjectMutation {
 
 	/**
-	 * This prepares the object to be mutated – ensures data is safe to be saved,
+	 * This prepares the object to be mutated - ensures data is safe to be saved,
 	 * and mapped from input args to WordPress $args
 	 *
 	 * @param array        $input         The input from the GraphQL Request
-	 * @param \WP_Taxonomy $taxonomy      The Taxonomy object for the type of term being mutated
+	 * @param WP_Taxonomy  $taxonomy      The Taxonomy object for the type of term being mutated
 	 * @param string       $mutation_name The name of the mutation (create, update, etc)
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 *
 	 * @return mixed
 	 */
-	public static function prepare_object( $input, \WP_Taxonomy $taxonomy, $mutation_name ) {
+	public static function prepare_object( array $input, WP_Taxonomy $taxonomy, string $mutation_name ) {
 
 		/**
 		 * Set the taxonomy for insert
@@ -34,15 +36,15 @@ class TermObjectMutation {
 		}
 
 		if ( ! empty( $input['name'] ) ) {
-			$insert_args['name'] = esc_sql( $input['name'] );
+			$insert_args['name'] = $input['name'];
 		}
 
 		if ( ! empty( $input['description'] ) ) {
-			$insert_args['description'] = esc_sql( $input['description'] );
+			$insert_args['description'] = $input['description'];
 		}
 
 		if ( ! empty( $input['slug'] ) ) {
-			$insert_args['slug'] = esc_sql( $input['slug'] );
+			$insert_args['slug'] = $input['slug'];
 		}
 
 		/**
@@ -54,7 +56,7 @@ class TermObjectMutation {
 			/**
 			 * Convert parent ID to WordPress ID
 			 */
-			$parent_id_parts = ! empty( $input['parentId'] ) ? Relay::fromGlobalId( $input['parentId'] ) : null;
+			$parent_id_parts = Relay::fromGlobalId( $input['parentId'] );
 
 			/**
 			 * Ensure that the ID passed in is a valid GlobalID
@@ -72,7 +74,7 @@ class TermObjectMutation {
 				$parent_term = get_term( absint( $parent_id ), $taxonomy->name );
 
 				if ( $parent_term instanceof \WP_Term ) {
-					// Otherwise set the parent as the parent term's ID
+					// Otherwise, set the parent as the parent term's ID
 					$insert_args['parent'] = $parent_term->term_id;
 				} else {
 					throw new UserError( __( 'The parent does not exist', 'wp-graphql' ) );
@@ -87,15 +89,10 @@ class TermObjectMutation {
 		 *
 		 * @param array $insert_args The array of input args that will be passed to the functions that insert terms
 		 * @param array $input The data that was entered as input for the mutation
-		 * @param \WP_Taxonomy $taxonomy The taxonomy object of the term being mutated
+		 * @param WP_Taxonomy $taxonomy The taxonomy object of the term being mutated
 		 * @param string $mutation_name The name of the mutation being performed (create, edit, etc)
 		 */
-		$insert_args = apply_filters( 'graphql_term_object_insert_term_args', $insert_args, $input, $taxonomy, $mutation_name );
-
-		/**
-		 * Return the $args
-		 */
-		return $insert_args;
+		return apply_filters( 'graphql_term_object_insert_term_args', $insert_args, $input, $taxonomy, $mutation_name );
 
 	}
 

--- a/src/Mutation/MediaItemUpdate.php
+++ b/src/Mutation/MediaItemUpdate.php
@@ -121,15 +121,15 @@ class MediaItemUpdate {
 			 * Check to see if the existing_media_item author matches the current user,
 			 * if not they need to be able to edit others posts to proceed
 			 */
-			if (  get_current_user_id() !== $author_id && ( ! isset( $post_type_object->cap->edit_others_posts ) || ! current_user_can( $post_type_object->cap->edit_others_posts ) ) ) {
+			if ( get_current_user_id() !== $author_id && ( ! isset( $post_type_object->cap->edit_others_posts ) || ! current_user_can( $post_type_object->cap->edit_others_posts ) ) ) {
 				throw new UserError( __( 'Sorry, you are not allowed to update mediaItems as this user.', 'wp-graphql' ) );
 			}
 
 			/**
 			 * Insert the post object and get the ID
 			 */
-			$post_args                = MediaItemMutation::prepare_media_item( $input, $post_type_object, $mutation_name, false );
-			$post_args['ID']          = $media_item_id;
+			$post_args       = MediaItemMutation::prepare_media_item( $input, $post_type_object, $mutation_name, false );
+			$post_args['ID'] = $media_item_id;
 
 			$clean_args = wp_slash( (array) $post_args );
 

--- a/tests/wpunit/TermObjectMutationsTest.php
+++ b/tests/wpunit/TermObjectMutationsTest.php
@@ -649,7 +649,8 @@ class TermObjectMutationsTest extends \Codeception\TestCase\WPTestCase
 		';
 
 		$expected_name = "what's up";
-		$expected_slug = "what's-up";
+		$slug_input = "what's-up"; // includes apostrophe
+		$expected_slug = "whats-up"; // wp should strip it on save
 		$expected_description = "what's up, description";
 
 		wp_set_current_user( $this->admin );
@@ -659,7 +660,7 @@ class TermObjectMutationsTest extends \Codeception\TestCase\WPTestCase
 			'variables' => [
 				'input' => [
 					'name' => $expected_name,
-					'slug' => $expected_slug,
+					'slug' => $slug_input,
 					'description' => $expected_description,
 				]
 			]

--- a/tests/wpunit/TermObjectMutationsTest.php
+++ b/tests/wpunit/TermObjectMutationsTest.php
@@ -739,7 +739,7 @@ class TermObjectMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCas
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertEquals( $parent_id, $actual['data']['updateCategory']['category']['parent']['node']['id'] );
 	}
-  
+
   /**
 	 * @see: https://github.com/wp-graphql/wp-graphql/issues/2378
 	 * @return void
@@ -762,7 +762,7 @@ class TermObjectMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCas
 
 		$expected_name = "what's up";
 		$slug_input = "what's-up"; // includes apostrophe
-		$expected_slug = "whats-up"; // wp should strip it on save
+		$expected_slug = sanitize_title( $slug_input ); // wp should strip it on save
 		$expected_description = "what's up, description";
 
 		wp_set_current_user( $this->admin );


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This fixes a bug where creating or updating terms with a WPGraphQL Mutation would save slashes in the database if the term had an apostrophe. 

For example "What's up" would become "What\'s up" in the database and "What\\'s up" when being returned in the response.


Does this close any currently open issues?
------------------------------------------
Closes #2378 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

**BEFORE**

We can see that a mutation that includes apostrophes in the name and description leads to slashes being output in the response, and a slash stored raw in the database:

![CleanShot 2022-05-16 at 10 11 36](https://user-images.githubusercontent.com/1260765/168637079-e141ccc0-bc6a-4cb4-868f-03002568dbab.png)

![CleanShot 2022-05-16 at 10 12 17](https://user-images.githubusercontent.com/1260765/168637215-f197646d-17b8-4a8e-a082-f8a9e110dcaa.png)


**AFTER**

Now we can see the slashes are not returned in the response, and the database stores the data as expected:

![CleanShot 2022-05-16 at 10 13 26](https://user-images.githubusercontent.com/1260765/168637379-2a7c044b-2bb7-443a-b9b9-25bef412b3fb.png)

![CleanShot 2022-05-16 at 10 14 04](https://user-images.githubusercontent.com/1260765/168637483-05593eb4-389b-43ff-91f6-a6f8ea98c61f.png)

Any other comments?
-------------------
This now more closely matches the behavior of the WP REST API: https://github.com/WordPress/WordPress/blob/aeb3b7530af57db885dfa8f377a7c6aa22e309bd/wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php#L613

And core edit-tags.php page: https://github.com/WordPress/WordPress/blob/master/wp-admin/edit-tags.php#L183
