### PR TITLE
(bugfix): #2377 - fixes bug where Wp class wasn't being properly passed as reference to parse_request filter

### DIFF
--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -347,7 +347,7 @@ class NodeResolver {
 
 		unset( $this->wp->query_vars['graphql'] );
 
-		do_action_ref_array( 'parse_request', [ $this->wp ] );
+		do_action_ref_array( 'parse_request', [ &$this->wp ] );
 
 		// If the request is for the homepage, determine
 		if ( '/' === $uri ) {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- fixes bug in NodeResolver where the instance of Wp class wasn't being passed properly as a reference
- adds test to ensure filter runs and properly returns the $wp instance


Does this close any currently open issues?
------------------------------------------
closes #2377 
