### PR TITLE
(bugfix): #2381 register field to setting group not working

### DIFF
--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -485,7 +485,7 @@ class TypeRegistry {
 				$group_name = DataSource::format_group_name( $group_name );
 				$type_name  = SettingGroup::register_settings_group( $group_name, $group_name, $this );
 
-				if ( ! $type_name || ! $this->get_type( $type_name ) ) {
+				if ( ! $type_name ) {
 					continue;
 				}
 

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -485,7 +485,7 @@ class TypeRegistry {
 				$group_name = DataSource::format_group_name( $group_name );
 				$type_name  = SettingGroup::register_settings_group( $group_name, $group_name, $this );
 
-				if ( ! $type_name ) {
+				if ( ! $type_name || ! $this->get_type( $type_name ) ) {
 					continue;
 				}
 

--- a/src/Type/ObjectType/SettingGroup.php
+++ b/src/Type/ObjectType/SettingGroup.php
@@ -30,7 +30,7 @@ class SettingGroup {
 			return null;
 		}
 
-		$type_registry->register_object_type(
+		register_graphql_object_type(
 			ucfirst( $group_name ) . 'Settings',
 			[
 				'description' => sprintf( __( 'The %s setting type', 'wp-graphql' ), $group_name ),

--- a/src/Type/ObjectType/SettingGroup.php
+++ b/src/Type/ObjectType/SettingGroup.php
@@ -30,7 +30,7 @@ class SettingGroup {
 			return null;
 		}
 
-		register_graphql_object_type(
+		$type_registry->register_object_type(
 			ucfirst( $group_name ) . 'Settings',
 			[
 				'description' => sprintf( __( 'The %s setting type', 'wp-graphql' ), $group_name ),


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This fixes a bug where fields could not be registered to GraphQL Types that are added to the Schema from the register_settings API. 

Does this close any currently open issues?
------------------------------------------
closes #2381 

Pushed it up with a failing test: https://github.com/wp-graphql/wp-graphql/runs/6459066904?check_suite_focus=true#step:9:463

Then the code that gets the tests to all pass: https://github.com/wp-graphql/wp-graphql/runs/6459071170?check_suite_focus=true#step:9:462