### PR TITLE
Release/v1.8.2

### DIFF
--- a/.github/workflows/schema-linter.yml
+++ b/.github/workflows/schema-linter.yml
@@ -39,7 +39,7 @@ jobs:
           node-version: 12.x
 
       - name: Setup GraphQL Schema Linter
-        run: npm install -g graphql-schema-linter
+        run: npm install -g graphql-schema-linter@^3.0 graphql@^16
 
       - name: Setup WordPress
         run: |

--- a/.github/workflows/testing-integration.yml
+++ b/.github/workflows/testing-integration.yml
@@ -25,12 +25,15 @@ jobs:
           - php: '8.0'
             wordpress: '5.9'
           - php: '8.0'
+            wordpress: '5.9'
+            multisite: 1
+          - php: '8.0'
             wordpress: '5.8'
           - php: '7.4'
             wordpress: '5.8'
             coverage: 1
       fail-fast: false
-    name: WordPress ${{ matrix.wordpress }} on PHP ${{ matrix.php }}
+    name: WordPress ${{ matrix.wordpress }} on PHP ${{ matrix.php }} ${{ matrix.multisite && 'Multisite' || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -80,6 +83,7 @@ jobs:
           SKIP_TESTS_CLEANUP: ${{ matrix.coverage }}
           PHP_VERSION: ${{ matrix.php }}
           WP_VERSION: ${{ matrix.wordpress }}
+          MULTISITE: ${{ matrix.multisite }}
         run: composer run-test
 
       - name: Push Codecoverage to Coveralls.io

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,21 @@
 
 ### New Features
 
+- ([#2363](https://github.com/wp-graphql/wp-graphql/pull/2363)): Adds "uri" field to MenuItem type which resolves the path of the node which can then be used in a `nodeByUri` query to get the linked node. The path is relative and does not contain subdirectory path in a subdirectory multisite. the `path` field does include the multisite subdirectory path, still. Thanks @josephfusco and @justlevine!\
+
+
 ### Chores / Bugfixes
+
+- ([#2368](https://github.com/wp-graphql/wp-graphql/pull/2368)): Updates dependencies for Schema Linter workflow. 
+- ([#2369](https://github.com/wp-graphql/wp-graphql/pull/2369)): Replaces the Codecov badge in the README with Coveralls badge. Thanks @justlevine!
+- ([#2374](https://github.com/wp-graphql/wp-graphql/pull/2374)): Updates descriptions for PostObjectFieldFormatEnum. Thanks @justlevine!
+- ([#2375](https://github.com/wp-graphql/wp-graphql/pull/2375)): Sets up the testing integration workflow to be able to run in multisite. Adds one workflow that runs in multisite. Fixes tests related to multisite.
+- ([#2376](https://github.com/wp-graphql/wp-graphql/pull/2276)): Adds support for `['auth']['callback']` and `isPrivate` for the `register_graphql_mutation()` API. 
+- ([#2379](https://github.com/wp-graphql/wp-graphql/pull/2379)): Fixes a bug where term mutations were adding slashes when being stored in the database.
+- ([#2380](https://github.com/wp-graphql/wp-graphql/pull/2380)): Fixes a bug where WPGraphQL wasn't sending the Wp class to the `parse_request` filter as a reference. 
+- ([#2382](https://github.com/wp-graphql/wp-graphql/pull/2382)): Fixes a bug where `register_graphql_field()` was not being respected by GraphQL Types added to the schema to represent Setting Groups of the core WordPress `register_setting()` API.
+
+
 
 ## 1.8.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - ([#2363](https://github.com/wp-graphql/wp-graphql/pull/2363)): Adds "uri" field to MenuItem type which resolves the path of the node which can then be used in a `nodeByUri` query to get the linked node. The path is relative and does not contain subdirectory path in a subdirectory multisite. the `path` field does include the multisite subdirectory path, still. Thanks @josephfusco and @justlevine!
 - ([#2337](https://github.com/wp-graphql/wp-graphql/pull/2337)): Allows for either global ID or databaseId to be supplied in the ID field for user mutations. Thanks @justlevine!
 - ([#2338](https://github.com/wp-graphql/wp-graphql/pull/2338)): Allows either global "relay" ID or databaseId for post object mutations. Thanks @justlevine!
+- ([#2336](https://github.com/wp-graphql/wp-graphql/pull/2336)): Allows either global "relay" ID or databaseId for term object mutations. Thanks @justlevine!
+- ([#2331](https://github.com/wp-graphql/wp-graphql/pull/2331)): Allows either global "relay" ID or databaseId for MediaItem object mutations. Thanks @justlevine!
+- ([#2328](https://github.com/wp-graphql/wp-graphql/pull/2328)): Allows either global "relay" ID or databaseId for Comment object mutations. Thanks @justlevine!
+
 
 ### Chores / Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
-- ([#2363](https://github.com/wp-graphql/wp-graphql/pull/2363)): Adds "uri" field to MenuItem type which resolves the path of the node which can then be used in a `nodeByUri` query to get the linked node. The path is relative and does not contain subdirectory path in a subdirectory multisite. the `path` field does include the multisite subdirectory path, still. Thanks @josephfusco and @justlevine!\
+- ([#2363](https://github.com/wp-graphql/wp-graphql/pull/2363)): Adds "uri" field to MenuItem type which resolves the path of the node which can then be used in a `nodeByUri` query to get the linked node. The path is relative and does not contain subdirectory path in a subdirectory multisite. the `path` field does include the multisite subdirectory path, still. Thanks @josephfusco and @justlevine!
 
 
 ### Chores / Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.8.2
+
+### New Features
+
+### Chores / Bugfixes
+
 ## 1.8.1
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### New Features
 
 - ([#2363](https://github.com/wp-graphql/wp-graphql/pull/2363)): Adds "uri" field to MenuItem type which resolves the path of the node which can then be used in a `nodeByUri` query to get the linked node. The path is relative and does not contain subdirectory path in a subdirectory multisite. the `path` field does include the multisite subdirectory path, still. Thanks @josephfusco and @justlevine!
-
+- ([#2337](https://github.com/wp-graphql/wp-graphql/pull/2337)): Allows for either global ID or databaseId to be supplied in the ID field for user mutations. Thanks @justlevine!
+- ([#2338](https://github.com/wp-graphql/wp-graphql/pull/2338)): Allows either global "relay" ID or databaseId for post object mutations. Thanks @justlevine!
 
 ### Chores / Bugfixes
 

--- a/README.md
+++ b/README.md
@@ -13,16 +13,18 @@ Below are some links to help you get started with WPGraphQL
 - <a href="https://join.slack.com/t/wp-graphql/shared_invite/zt-3vloo60z-PpJV2PFIwEathWDOxCTTLA" target="_blank">Join the WPGraphQL community on Slack</a>
 
 -----
+
 [![Total Downloads](https://poser.pugx.org/wp-graphql/wp-graphql/downloads)](https://packagist.org/packages/wp-graphql/wp-graphql)
 [![Monthly Downloads](https://poser.pugx.org/wp-graphql/wp-graphql/d/monthly)](https://packagist.org/packages/wp-graphql/wp-graphql)
 [![Daily Downloads](https://poser.pugx.org/wp-graphql/wp-graphql/d/daily)](https://packagist.org/packages/wp-graphql/wp-graphql)
 [![Latest Stable Version](https://poser.pugx.org/wp-graphql/wp-graphql/v/stable)](https://packagist.org/packages/wp-graphql/wp-graphql)
 [![License](https://poser.pugx.org/wp-graphql/wp-graphql/license)](https://packagist.org/packages/wp-graphql/wp-graphql)
 [![Actions Status](https://github.com/wp-graphql/wp-graphql/workflows/Testing%20Integration/badge.svg)](https://github.com/wp-graphql/wp-graphql/actions?query=workflow%3A%22Testing+Integration%22) [![Actions Status](https://github.com/wp-graphql/wp-graphql/workflows/WordPress%20Coding%20Standards/badge.svg)](https://github.com/wp-graphql/wp-graphql/actions?query=workflow%3A%22WordPress+Coding+Standards%22)
-[![codecov](https://codecov.io/gh/wp-graphql/wp-graphql/branch/master/graph/badge.svg)](https://codecov.io/gh/wp-graphql/wp-graphql)
+[![Coverage Status](https://coveralls.io/repos/github/wp-graphql/wp-graphql/badge.svg)](https://coveralls.io/github/wp-graphql/wp-graphql)
 -----
 
 ## Install
+
 - Requires PHP 7.1+
 - Requires WordPress 5.0+
 
@@ -41,36 +43,34 @@ Follow the WPGraphQL Quick Start instructions to install and activate WPGraphQL
 ## Shout Outs
 
 - Special thanks to [Gatsby](http://gatsbyjs.com) and [WPEngine](https://wpengine.com) for allocating development resources to push the project forward!
-- This plugin brings the power of GraphQL (http://graphql.org/) to WordPress.
-- The plugin is built on top of the graphql-php library by Webonyx (https://github.com/webonyx/graphql-php) and makes use 
-of the graphql-relay-php library by Ivome (https://github.com/ivome/graphql-relay-php/)
-- Some of the concepts and code are based on the WordPress Rest API. Much love to the folks (https://github.com/orgs/WP-API/people) 
-that put their blood, sweat and tears into the WP-API project, as it's been huge in moving WordPress forward as a 
+- This plugin brings the power of GraphQL (<http://graphql.org/>) to WordPress.
+- The plugin is built on top of the graphql-php library by Webonyx (<https://github.com/webonyx/graphql-php>) and makes use
+of the graphql-relay-php library by Ivome (<https://github.com/ivome/graphql-relay-php/>)
+- Some of the concepts and code are based on the WordPress Rest API. Much love to the folks (<https://github.com/orgs/WP-API/people>)
+that put their blood, sweat and tears into the WP-API project, as it's been huge in moving WordPress forward as a
 platform and helped inspire and direct the development of WPGraphQL.
-- Much love to Facebook® for open sourcing the GraphQL spec (https://facebook.github.io/graphql/), the amazing GraphiQL 
-dev tools (https://github.com/graphql/graphiql), and maintaining the JavaScript GraphQL reference 
-implementation (https://github.com/graphql/graphql-js)
-- Much love to Apollo (Meteor Development Group) for their work on driving GraphQL forward and providing a lot of insight 
-into how to design GraphQL schemas, etc. Check them out: http://www.apollodata.com/
+- Much love to Facebook® for open sourcing the GraphQL spec (<https://facebook.github.io/graphql/>), the amazing GraphiQL
+dev tools (<https://github.com/graphql/graphiql>), and maintaining the JavaScript GraphQL reference
+implementation (<https://github.com/graphql/graphql-js>)
+- Much love to Apollo (Meteor Development Group) for their work on driving GraphQL forward and providing a lot of insight
+into how to design GraphQL schemas, etc. Check them out: <http://www.apollodata.com/>
 
 ## Contributors
 
 This project exists thanks to all the people who contribute. [[Contribute](.github/CONTRIBUTING.md)].
 <a href="https://github.com/wp-graphql/wp-graphql/graphs/contributors"><img src="https://opencollective.com/wp-graphql/contributors.svg?width=890&button=false" /></a>
 
-
 ## Backers
 
-[![Backers on Open Collective](https://opencollective.com/wp-graphql/backers/badge.svg)](#backers) 
+[![Backers on Open Collective](https://opencollective.com/wp-graphql/backers/badge.svg)](#backers)
 
 Thank you to all our backers! 🙏 [[Become a backer](https://opencollective.com/wp-graphql#backer)]
 
 <a href="https://opencollective.com/wp-graphql#backers" target="_blank"><img src="https://opencollective.com/wp-graphql/backers.svg?width=890"></a>
 
-
 ## Sponsors
 
-[![Sponsors on Open Collective](https://opencollective.com/wp-graphql/sponsors/badge.svg)](#sponsors) 
+[![Sponsors on Open Collective](https://opencollective.com/wp-graphql/sponsors/badge.svg)](#sponsors)
 
 Support this project by becoming a sponsor. Your logo will show up here with a link to your website. [[Become a sponsor](https://opencollective.com/wp-graphql#sponsor)]
 

--- a/codeception.yml
+++ b/codeception.yml
@@ -63,6 +63,7 @@ modules:
             themes: '/wp-content/themes'
             uploads: '/wp-content/uploads'
         WPLoader:
+            multisite: '%MULTISITE%'
             wpRootFolder: '%TEST_WP_ROOT_FOLDER%'
             dbName: '%TEST_DB_NAME%'
             dbHost: '%TEST_DB_HOST%'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-graphql",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "GraphQL API for WordPress",
   "homepage": "https://github.com/wp-graphql/wp-graphql#readme",
   "author": "WPGraphQL <info@wpgraphql.com> (https://www.wpgraphql.com)",

--- a/phpstan/constants.php
+++ b/phpstan/constants.php
@@ -7,4 +7,5 @@ define( 'WP_LANG_DIR', true );
 define( 'SAVEQUERIES', true );
 define( 'WPGRAPHQL_PLUGIN_URL', true );
 define( 'WP_CONTENT_DIR', true );
+define( 'WP_PLUGIN_DIR', true );
 define( 'PHPSTAN', true );

--- a/readme.txt
+++ b/readme.txt
@@ -136,6 +136,9 @@ Composer dependencies are no longer versioned in Github. Recommended install sou
 **New Features**
 
 - ([#2363](https://github.com/wp-graphql/wp-graphql/pull/2363)): Adds "uri" field to MenuItem type which resolves the path of the node which can then be used in a `nodeByUri` query to get the linked node. The path is relative and does not contain subdirectory path in a subdirectory multisite. the `path` field does include the multisite subdirectory path, still. Thanks @josephfusco and @justlevine!
+- ([#2337](https://github.com/wp-graphql/wp-graphql/pull/2337)): Allows for either global ID or databaseId to be supplied in the ID field for user mutations. Thanks @justlevine!
+- ([#2338](https://github.com/wp-graphql/wp-graphql/pull/2338)): Allows either global "relay" ID or databaseId for post object mutations. Thanks @justlevine!
+
 
 **Chores/Bugfixes**
 

--- a/readme.txt
+++ b/readme.txt
@@ -138,6 +138,9 @@ Composer dependencies are no longer versioned in Github. Recommended install sou
 - ([#2363](https://github.com/wp-graphql/wp-graphql/pull/2363)): Adds "uri" field to MenuItem type which resolves the path of the node which can then be used in a `nodeByUri` query to get the linked node. The path is relative and does not contain subdirectory path in a subdirectory multisite. the `path` field does include the multisite subdirectory path, still. Thanks @josephfusco and @justlevine!
 - ([#2337](https://github.com/wp-graphql/wp-graphql/pull/2337)): Allows for either global ID or databaseId to be supplied in the ID field for user mutations. Thanks @justlevine!
 - ([#2338](https://github.com/wp-graphql/wp-graphql/pull/2338)): Allows either global "relay" ID or databaseId for post object mutations. Thanks @justlevine!
+- ([#2336](https://github.com/wp-graphql/wp-graphql/pull/2336)): Allows either global "relay" ID or databaseId for term object mutations. Thanks @justlevine!
+- ([#2331](https://github.com/wp-graphql/wp-graphql/pull/2331)): Allows either global "relay" ID or databaseId for MediaItem object mutations. Thanks @justlevine!
+- ([#2328](https://github.com/wp-graphql/wp-graphql/pull/2328)): Allows either global "relay" ID or databaseId for Comment object mutations. Thanks @justlevine!
 
 
 **Chores/Bugfixes**

--- a/readme.txt
+++ b/readme.txt
@@ -135,8 +135,18 @@ Composer dependencies are no longer versioned in Github. Recommended install sou
 
 **New Features**
 
+- ([#2363](https://github.com/wp-graphql/wp-graphql/pull/2363)): Adds "uri" field to MenuItem type which resolves the path of the node which can then be used in a `nodeByUri` query to get the linked node. The path is relative and does not contain subdirectory path in a subdirectory multisite. the `path` field does include the multisite subdirectory path, still. Thanks @josephfusco and @justlevine!
+
 **Chores/Bugfixes**
 
+- ([#2368](https://github.com/wp-graphql/wp-graphql/pull/2368)): Updates dependencies for Schema Linter workflow.
+- ([#2369](https://github.com/wp-graphql/wp-graphql/pull/2369)): Replaces the Codecov badge in the README with Coveralls badge. Thanks @justlevine!
+- ([#2374](https://github.com/wp-graphql/wp-graphql/pull/2374)): Updates descriptions for PostObjectFieldFormatEnum. Thanks @justlevine!
+- ([#2375](https://github.com/wp-graphql/wp-graphql/pull/2375)): Sets up the testing integration workflow to be able to run in multisite. Adds one workflow that runs in multisite. Fixes tests related to multisite.
+- ([#2376](https://github.com/wp-graphql/wp-graphql/pull/2276)): Adds support for `['auth']['callback']` and `isPrivate` for the `register_graphql_mutation()` API.
+- ([#2379](https://github.com/wp-graphql/wp-graphql/pull/2379)): Fixes a bug where term mutations were adding slashes when being stored in the database.
+- ([#2380](https://github.com/wp-graphql/wp-graphql/pull/2380)): Fixes a bug where WPGraphQL wasn't sending the Wp class to the `parse_request` filter as a reference.
+- ([#2382](https://github.com/wp-graphql/wp-graphql/pull/2382)): Fixes a bug where `register_graphql_field()` was not being respected by GraphQL Types added to the schema to represent Setting Groups of the core WordPress `register_setting()` API.
 
 
 = 1.8.1 =

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, API, Gatsby, Headless, Decoupled, React, Nextjs, Vue, Apollo, RES
 Requires at least: 5.0
 Tested up to: 5.9.1
 Requires PHP: 7.1
-Stable tag: 1.8.1
+Stable tag: 1.8.2
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -130,6 +130,14 @@ The `uri` field was non-null on some Types in the Schema but has been changed to
 Composer dependencies are no longer versioned in Github. Recommended install source is WordPress.org or using Composer to get the code from Packagist.org or WPackagist.org.
 
 == Changelog ==
+
+= 1.8.2 =
+
+**New Features**
+
+**Chores/Bugfixes**
+
+
 
 = 1.8.1 =
 

--- a/src/Data/CommentMutation.php
+++ b/src/Data/CommentMutation.php
@@ -6,6 +6,7 @@ use Exception;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
+use WPGraphQL\Utils\Utils;
 
 /**
  * Class CommentMutation
@@ -85,7 +86,7 @@ class CommentMutation {
 		}
 
 		if ( ! empty( $input['parent'] ) ) {
-			$output_args['comment_parent'] = $input['parent'];
+			$output_args['comment_parent'] = Utils::get_database_id_from_id( $input['parent'] );
 		}
 
 		if ( ! empty( $input['type'] ) ) {

--- a/src/Data/Connection/ThemeConnectionResolver.php
+++ b/src/Data/Connection/ThemeConnectionResolver.php
@@ -1,11 +1,6 @@
 <?php
 namespace WPGraphQL\Data\Connection;
 
-use GraphQL\Type\Definition\ResolveInfo;
-use GraphQLRelay\Relay;
-use WPGraphQL\AppContext;
-use WPGraphQL\Data\DataSource;
-
 /**
  * Class ThemeConnectionResolver
  *
@@ -53,7 +48,10 @@ class ThemeConnectionResolver extends AbstractConnectionResolver {
 	 * @return array
 	 */
 	public function get_query_args() {
-		return $this->query_args;
+
+		$query_args            = $this->query_args;
+		$query_args['allowed'] = null;
+		return $query_args;
 	}
 
 
@@ -128,44 +126,6 @@ class ThemeConnectionResolver extends AbstractConnectionResolver {
 	 */
 	public function should_execute() {
 		return true;
-	}
-
-	/**
-	 * Creates the connection for themes
-	 *
-	 * @param mixed       $source  The query results of the query calling this relation
-	 * @param array       $args    Query arguments
-	 * @param AppContext  $context The AppContext object
-	 * @param ResolveInfo $info    The ResolveInfo object
-	 *
-	 * @since  0.5.0
-	 * @return array
-	 * @throws \Exception
-	 */
-	public static function resolve( $source, array $args, AppContext $context, ResolveInfo $info ) {
-		$themes_array = [];
-		$themes       = wp_get_themes();
-		if ( is_array( $themes ) && ! empty( $themes ) ) {
-			foreach ( $themes as $theme ) {
-				$theme_obj = DataSource::resolve_theme( $theme->get_stylesheet() );
-				if ( 'private' !== $theme_obj->get_visibility() ) {
-					$themes_array[] = $theme_obj;
-				}
-			}
-		}
-
-		$connection = Relay::connectionFromArray( $themes_array, $args );
-
-		$nodes = [];
-		if ( ! empty( $connection['edges'] ) && is_array( $connection['edges'] ) ) {
-			foreach ( $connection['edges'] as $edge ) {
-				$nodes[] = ! empty( $edge['node'] ) ? $edge['node'] : null;
-			}
-		}
-
-		$connection['nodes'] = ! empty( $nodes ) ? $nodes : null;
-
-		return ! empty( $themes_array ) ? $connection : [];
 	}
 
 }

--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -117,7 +117,6 @@ class DataSource {
 	 */
 	public static function resolve_plugins_connection( $source, array $args, AppContext $context, ResolveInfo $info ) {
 		$resolver = new PluginConnectionResolver( $source, $args, $context, $info );
-
 		return $resolver->get_connection();
 	}
 
@@ -270,7 +269,8 @@ class DataSource {
 	 * @since  0.0.5
 	 */
 	public static function resolve_themes_connection( $source, array $args, AppContext $context, ResolveInfo $info ) {
-		return ThemeConnectionResolver::resolve( $source, $args, $context, $info );
+		$resolver = new ThemeConnectionResolver( $source, $args, $context, $info );
+		return $resolver->get_connection();
 	}
 
 	/**

--- a/src/Data/MediaItemMutation.php
+++ b/src/Data/MediaItemMutation.php
@@ -6,6 +6,7 @@ use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
 use WP_Post_Type;
 use WPGraphQL\AppContext;
+use WPGraphQL\Utils\Utils;
 
 /**
  * Class MediaItemMutation
@@ -60,9 +61,8 @@ class MediaItemMutation {
 			$insert_post_args['post_title'] = basename( $file['file'] );
 		}
 
-		$author_id_parts = ! empty( $input['authorId'] ) ? Relay::fromGlobalId( $input['authorId'] ) : null;
-		if ( is_array( $author_id_parts ) && ! empty( $author_id_parts['id'] ) ) {
-			$insert_post_args['post_author'] = absint( $author_id_parts['id'] );
+		if ( ! empty( $input['authorId'] ) ) {
+			$insert_post_args['post_author'] = Utils::get_database_id_from_id( $input['authorId'] );
 		}
 
 		if ( ! empty( $input['commentStatus'] ) ) {
@@ -90,16 +90,7 @@ class MediaItemMutation {
 		}
 
 		if ( ! empty( $input['parentId'] ) ) {
-			if ( absint( $input['parentId'] ) ) {
-				$insert_post_args['post_parent'] = absint( $input['parentId'] );
-			} else {
-
-				$parent_id_parts = ( ! empty( $input['parentId'] ) ? Relay::fromGlobalId( $input['parentId'] ) : null );
-
-				if ( is_array( $parent_id_parts ) && absint( $parent_id_parts['id'] ) ) {
-					$insert_post_args['post_parent'] = absint( $parent_id_parts['id'] );
-				}
-			}
+			$insert_post_args['post_parent'] = Utils::get_database_id_from_id( $input['parentId'] );
 		}
 
 		/**

--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -347,7 +347,7 @@ class NodeResolver {
 
 		unset( $this->wp->query_vars['graphql'] );
 
-		do_action_ref_array( 'parse_request', [ $this->wp ] );
+		do_action_ref_array( 'parse_request', [ &$this->wp ] );
 
 		// If the request is for the homepage, determine
 		if ( '/' === $uri ) {

--- a/src/Data/PostObjectMutation.php
+++ b/src/Data/PostObjectMutation.php
@@ -6,6 +6,7 @@ use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
 use WP_Post_Type;
 use WPGraphQL\AppContext;
+use WPGraphQL\Utils\Utils;
 
 /**
  * Class PostObjectMutation
@@ -36,9 +37,8 @@ class PostObjectMutation {
 		 * Prepare the data for inserting the post
 		 * NOTE: These are organized in the same order as: https://developer.wordpress.org/reference/functions/wp_insert_post/
 		 */
-		$author_id_parts = ! empty( $input['authorId'] ) ? Relay::fromGlobalId( $input['authorId'] ) : null;
-		if ( is_array( $author_id_parts ) && ! empty( $author_id_parts['id'] ) && absint( $author_id_parts['id'] ) ) {
-			$insert_post_args['post_author'] = absint( $author_id_parts['id'] );
+		if ( ! empty( $input['authorId'] ) ) {
+			$insert_post_args['post_author'] = Utils::get_database_id_from_id( $input['authorId'] );
 		}
 
 		if ( ! empty( $input['date'] ) && false !== strtotime( $input['date'] ) ) {
@@ -85,9 +85,8 @@ class PostObjectMutation {
 			$insert_post_args['pinged'] = $input['pinged'];
 		}
 
-		$parent_id_parts = ! empty( $input['parentId'] ) ? Relay::fromGlobalId( $input['parentId'] ) : null;
-		if ( is_array( $parent_id_parts ) && ! empty( $parent_id_parts['id'] ) && absint( $parent_id_parts['id'] ) ) {
-			$insert_post_args['post_parent'] = absint( $parent_id_parts['id'] );
+		if ( ! empty( $input['parentId'] ) ) {
+			$insert_post_args['post_parent'] = Utils::get_database_id_from_id( $input['parentId'] );
 		}
 
 		if ( ! empty( $input['menuOrder'] ) ) {

--- a/src/Model/MenuItem.php
+++ b/src/Model/MenuItem.php
@@ -145,6 +145,11 @@ class MenuItem extends Model {
 				'title'            => function () {
 					return ( ! empty( $this->data->attr_title ) ) ? $this->data->attr_title : null;
 				},
+				'uri'              => function () {
+					$url = $this->data->url;
+
+					return ! empty( $url ) ? str_ireplace( home_url(), '', $url ) : null;
+				},
 				'url'              => function () {
 					return ! empty( $this->data->url ) ? $this->data->url : null;
 				},

--- a/src/Model/Plugin.php
+++ b/src/Model/Plugin.php
@@ -46,7 +46,13 @@ class Plugin extends Model {
 	 */
 	protected function is_private() {
 
-		if ( ! current_user_can( 'activate_plugins' ) ) {
+		if ( is_multisite() ) {
+				// update_, install_, and delete_ are handled above with is_super_admin().
+				$menu_perms = get_site_option( 'menu_items', [] );
+			if ( empty( $menu_perms['plugins'] ) && ! current_user_can( 'manage_network_plugins' ) ) {
+				return true;
+			}
+		} elseif ( ! current_user_can( 'activate_plugins' ) ) {
 			return true;
 		}
 

--- a/src/Mutation/CommentCreate.php
+++ b/src/Mutation/CommentCreate.php
@@ -36,7 +36,7 @@ class CommentCreate {
 		return [
 			'commentOn'   => [
 				'type'        => 'Int',
-				'description' => __( 'The ID of the post object the comment belongs to.', 'wp-graphql' ),
+				'description' => __( 'The database ID of the post object the comment belongs to.', 'wp-graphql' ),
 			],
 			'author'      => [
 				'type'        => 'String',
@@ -60,7 +60,7 @@ class CommentCreate {
 			],
 			'parent'      => [
 				'type'        => 'ID',
-				'description' => __( 'Parent comment of current comment.', 'wp-graphql' ),
+				'description' => __( 'Parent comment ID of current comment.', 'wp-graphql' ),
 			],
 			'date'        => [
 				'type'        => 'String',

--- a/src/Mutation/CommentDelete.php
+++ b/src/Mutation/CommentDelete.php
@@ -8,6 +8,7 @@ use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
 use WPGraphQL\Model\Comment;
+use WPGraphQL\Utils\Utils;
 
 class CommentDelete {
 	/**
@@ -80,16 +81,11 @@ class CommentDelete {
 	 */
 	public static function mutate_and_get_payload() {
 		return function ( $input ) {
-			/**
-			 * Get the ID from the global ID
-			 */
-			$id_parts = Relay::fromGlobalId( $input['id'] );
+			// Get the database ID for the comment.
+			$comment_id = Utils::get_database_id_from_id( $input['id'] );
 
-			/**
-			 * Get the post object before deleting it
-			 */
-			$comment_id            = absint( $id_parts['id'] );
-			$comment_before_delete = get_comment( $comment_id );
+			// Get the post object before deleting it.
+			$comment_before_delete = ! empty( $comment_id ) ? get_comment( $comment_id ) : false;
 
 			if ( empty( $comment_before_delete ) ) {
 				throw new UserError( __( 'The Comment could not be deleted', 'wp-graphql' ) );
@@ -133,7 +129,7 @@ class CommentDelete {
 			/**
 			 * Delete the comment
 			 */
-			wp_delete_comment( $id_parts['id'], $force_delete );
+			wp_delete_comment( (int) $comment_id, $force_delete );
 
 			return [
 				'commentObject' => $comment_before_delete,

--- a/src/Mutation/CommentRestore.php
+++ b/src/Mutation/CommentRestore.php
@@ -7,6 +7,7 @@ use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
 use WPGraphQL\Data\DataSource;
+use WPGraphQL\Utils\Utils;
 
 /**
  * Class CommentRestore
@@ -82,27 +83,20 @@ class CommentRestore {
 	 */
 	public static function mutate_and_get_payload() {
 		return function ( $input ) {
-			/**
-			 * Get the ID from the global ID
-			 */
-			$id_parts = Relay::fromGlobalId( $input['id'] );
-
-			/**
-			 * Get the post object before deleting it
-			 */
-			$comment_id = absint( $id_parts['id'] );
-
-			/**
-			 * Stop now if a user isn't allowed to delete the comment
-			 */
+			// Stop now if a user isn't allowed to delete the comment.
 			if ( ! current_user_can( 'moderate_comments' ) ) {
 				throw new UserError( __( 'Sorry, you are not allowed to restore this comment.', 'wp-graphql' ) );
 			}
 
-			/**
-			 * Delete the comment
-			 */
-			wp_untrash_comment( $id_parts['id'] );
+			// Get the database ID for the comment.
+			$comment_id = Utils::get_database_id_from_id( $input['id'] );
+
+			if ( false === $comment_id ) {
+				throw new UserError( __( 'Sorry, you are not allowed to restore this comment.', 'wp-graphql' ) );
+			}
+
+			// Delete the comment.
+			wp_untrash_comment( $comment_id );
 
 			$comment = get_comment( $comment_id );
 

--- a/src/Mutation/CommentUpdate.php
+++ b/src/Mutation/CommentUpdate.php
@@ -8,6 +8,7 @@ use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
 use WPGraphQL\Data\CommentMutation;
+use WPGraphQL\Utils\Utils;
 
 /**
  * Class CommentUpdate
@@ -67,15 +68,10 @@ class CommentUpdate {
 	 */
 	public static function mutate_and_get_payload() {
 		return function ( $input, AppContext $context, ResolveInfo $info ) {
-			/**
-			 * Throw an exception if there's no input
-			 */
-			if ( ( empty( $input ) || ! is_array( $input ) ) ) {
-				throw new UserError( __( 'Mutation not processed. There was no input for the mutation or the comment_object was invalid', 'wp-graphql' ) );
-			}
+			// Get the database ID for the comment.
+			$comment_id = ! empty( $input['id'] ) ? Utils::get_database_id_from_id( $input['id'] ) : null;
 
-			$id_parts     = ! empty( $input['id'] ) ? Relay::fromGlobalId( $input['id'] ) : null;
-			$comment_id   = isset( $id_parts['id'] ) && absint( $id_parts['id'] ) ? absint( $id_parts['id'] ) : null;
+			// Get the args from the existing comment.
 			$comment_args = ! empty( $comment_id ) ? get_comment( $comment_id, ARRAY_A ) : null;
 
 			if ( empty( $comment_id ) || empty( $comment_args ) ) {

--- a/src/Mutation/MediaItemCreate.php
+++ b/src/Mutation/MediaItemCreate.php
@@ -8,6 +8,7 @@ use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
 use WPGraphQL\Data\DataSource;
 use WPGraphQL\Data\MediaItemMutation;
+use WPGraphQL\Utils\Utils;
 
 class MediaItemCreate {
 	/**
@@ -39,7 +40,7 @@ class MediaItemCreate {
 				'description' => __( 'Alternative text to display when mediaItem is not displayed', 'wp-graphql' ),
 			],
 			'authorId'      => [
-				'type'        => 'Id',
+				'type'        => 'ID',
 				'description' => __( 'The userId to assign as the author of the mediaItem', 'wp-graphql' ),
 			],
 			'caption'       => [
@@ -87,8 +88,8 @@ class MediaItemCreate {
 				'description' => __( 'The ping status for the mediaItem', 'wp-graphql' ),
 			],
 			'parentId'      => [
-				'type'        => 'Id',
-				'description' => __( 'The WordPress post ID or the graphQL postId of the parent object', 'wp-graphql' ),
+				'type'        => 'ID',
+				'description' => __( 'The ID of the parent object', 'wp-graphql' ),
 			],
 		];
 	}
@@ -125,6 +126,25 @@ class MediaItemCreate {
 			 */
 			if ( ! current_user_can( 'upload_files' ) ) {
 				throw new UserError( __( 'Sorry, you are not allowed to upload mediaItems', 'wp-graphql' ) );
+			}
+
+			$post_type_object = get_post_type_object( 'attachment' );
+			if ( empty( $post_type_object ) ) {
+				throw new UserError( __( 'The Media Item could not be created', 'wp-graphql' ) );
+			}
+
+			/**
+			 * If the mediaItem being created is being assigned to another user that's not the current user, make sure
+			 * the current user has permission to edit others mediaItems
+			 */
+			if ( ! empty( $input['authorId'] ) ) {
+				// Ensure authorId is a valid databaseId.
+				$input['authorId'] = Utils::get_database_id_from_id( $input['authorId'] );
+
+				// Bail if cant edit other users' attachments.
+				if ( get_current_user_id() !== $input['authorId'] && ( ! isset( $post_type_object->cap->edit_others_posts ) || ! current_user_can( $post_type_object->cap->edit_others_posts ) ) ) {
+					throw new UserError( __( 'Sorry, you are not allowed to create mediaItems as this user', 'wp-graphql' ) );
+				}
 			}
 
 			/**
@@ -196,12 +216,6 @@ class MediaItemCreate {
 				throw new UserError( __( 'Sorry, the URL for this file is invalid, it must be a path to the mediaItem file', 'wp-graphql' ) );
 			}
 
-			$post_type_object = get_post_type_object( 'attachment' );
-
-			if ( empty( $post_type_object ) ) {
-				return null;
-			}
-
 			/**
 			 * Insert the mediaItem object and get the ID
 			 */
@@ -210,7 +224,7 @@ class MediaItemCreate {
 			/**
 			 * Get the post parent and if it's not set, set it to 0
 			 */
-			$attachment_parent_id = ! empty( $media_item_args['post_parent'] ) ? absint( $media_item_args['post_parent'] ) : 0;
+			$attachment_parent_id = ! empty( $media_item_args['post_parent'] ) ? $media_item_args['post_parent'] : 0;
 
 			/**
 			 * Stop now if a user isn't allowed to edit the parent post
@@ -229,16 +243,6 @@ class MediaItemCreate {
 				}
 			}
 
-			$post_type_object = get_post_type_object( 'attachment' );
-
-			/**
-			 * If the mediaItem being created is being assigned to another user that's not the current user, make sure
-			 * the current user has permission to edit others mediaItems
-			 */
-			if ( ! empty( $input['authorId'] ) && get_current_user_id() !== $input['authorId'] && ( ! isset( $post_type_object->cap->edit_others_posts ) || ! current_user_can( $post_type_object->cap->edit_others_posts ) ) ) {
-				throw new UserError( __( 'Sorry, you are not allowed to create mediaItems as this user', 'wp-graphql' ) );
-			}
-
 			/**
 			 * Insert the mediaItem
 			 *
@@ -251,7 +255,7 @@ class MediaItemCreate {
 			 */
 			$attachment_id = wp_insert_attachment( $media_item_args, $file['file'], $attachment_parent_id );
 
-			if ( is_wp_error( $attachment_id ) ) {
+			if ( 0 === $attachment_id || is_wp_error( $attachment_id ) ) {
 				throw new UserError( __( 'The Media Item failed to create', 'wp-graphql' ) );
 			}
 
@@ -267,12 +271,6 @@ class MediaItemCreate {
 			 */
 			$attachment_data = wp_generate_attachment_metadata( $attachment_id, $file['file'] );
 			wp_update_attachment_metadata( $attachment_id, $attachment_data );
-
-			$post_type_object = get_post_type_object( 'attachment' );
-
-			if ( empty( $post_type_object ) ) {
-				throw new UserError( __( 'The Media Item could not be created', 'wp-graphql' ) );
-			}
 
 			/**
 			 * Update alt text postmeta for mediaItem

--- a/src/Mutation/MediaItemDelete.php
+++ b/src/Mutation/MediaItemDelete.php
@@ -5,6 +5,7 @@ use Exception;
 use GraphQL\Error\UserError;
 use GraphQLRelay\Relay;
 use WPGraphQL\Model\Post;
+use WPGraphQL\Utils\Utils;
 
 class MediaItemDelete {
 	/**
@@ -79,25 +80,30 @@ class MediaItemDelete {
 	 */
 	public static function mutate_and_get_payload() {
 		return function ( $input ) {
-			$post_type_object = get_post_type_object( 'attachment' );
+			// Get the database ID for the comment.
+			$media_item_id = Utils::get_database_id_from_id( $input['id'] );
 
 			/**
-			 * Get the ID from the global ID
+			 * Get the mediaItem object before deleting it
 			 */
-			$id_parts            = Relay::fromGlobalId( $input['id'] );
-			$existing_media_item = get_post( absint( $id_parts['id'] ) );
+			$existing_media_item = ! empty( $media_item_id ) ? get_post( $media_item_id ) : null;
 
-			/**
-			 * If there's no existing mediaItem, throw an exception
-			 */
-			if ( empty( $existing_media_item ) ) {
-				throw new UserError( __( 'No mediaItem could be found to delete', 'wp-graphql' ) );
+			// If there's no existing mediaItem, throw an exception.
+			if ( null === $existing_media_item ) {
+				throw new UserError( __( 'No mediaItem with that ID could be found to delete', 'wp-graphql' ) );
+			}
+
+			// Stop now if the post isn't a mediaItem.
+			if ( 'attachment' !== $existing_media_item->post_type ) {
+				throw new UserError( sprintf( __( 'Sorry, the item you are trying to delete is a %1%s, not a mediaItem', 'wp-graphql' ), $existing_media_item->post_type ) );
 			}
 
 			/**
 			 * Stop now if a user isn't allowed to delete a mediaItem
 			 */
-			if ( ! isset( $post_type_object->cap->delete_post ) || ! current_user_can( $post_type_object->cap->delete_post, absint( $id_parts['id'] ) ) ) {
+			$post_type_object = get_post_type_object( 'attachment' );
+
+			if ( ! isset( $post_type_object->cap->delete_post ) || ! current_user_can( $post_type_object->cap->delete_post, $media_item_id ) ) {
 				throw new UserError( __( 'Sorry, you are not allowed to delete mediaItems', 'wp-graphql' ) );
 			}
 
@@ -107,43 +113,26 @@ class MediaItemDelete {
 			$force_delete = ! empty( $input['forceDelete'] ) && true === $input['forceDelete'];
 
 			/**
-			 * Get the mediaItem object before deleting it
-			 */
-			$media_item_before_delete = get_post( absint( $id_parts['id'] ) );
-			$media_item_before_delete = isset( $media_item_before_delete->ID ) && absint( $media_item_before_delete->ID ) ? new Post( $media_item_before_delete ) : $media_item_before_delete;
-
-			if ( empty( $media_item_before_delete ) ) {
-				throw new UserError( __( 'The Media Item could not be deleted', 'wp-graphql' ) );
-			}
-
-			/**
-			 * If the mediaItem isn't of the attachment post type, throw an error
-			 */
-			if ( 'attachment' !== $media_item_before_delete->post_type ) {
-				throw new UserError( sprintf( __( 'Sorry, the item you are trying to delete is a %1%s, not a mediaItem', 'wp-graphql' ), $media_item_before_delete->post_type ) );
-			}
-
-			/**
 			 * If the mediaItem is already in the trash, and the forceDelete input was not passed,
 			 * don't remove from the trash
 			 */
-			if ( 'trash' === $media_item_before_delete->post_status ) {
-				if ( true !== $force_delete ) {
-					// Translators: the first placeholder is the post_type of the object being deleted and the second placeholder is the unique ID of that object
-					throw new UserError( sprintf( __( 'The mediaItem with id %1$s is already in the trash. To remove from the trash, use the forceDelete input', 'wp-graphql' ), $input['id'] ) );
-				}
+			if ( 'trash' === $existing_media_item->post_status && true !== $force_delete ) {
+				// Translators: the first placeholder is the post_type of the object being deleted and the second placeholder is the unique ID of that object
+				throw new UserError( sprintf( __( 'The mediaItem with id %1$s is already in the trash. To remove from the trash, use the forceDelete input', 'wp-graphql' ), $input['id'] ) );
 			}
 
 			/**
 			 * Delete the mediaItem. This will not throw false thanks to
 			 * all of the above validation
 			 */
-			$deleted = wp_delete_attachment( $id_parts['id'], $force_delete );
+			$deleted = wp_delete_attachment( (int) $media_item_id, $force_delete );
 
 			/**
 			 * If the post was moved to the trash, spoof the object's status before returning it
 			 */
-			$media_item_before_delete->post_status = ( false !== $deleted && true !== $force_delete ) ? 'trash' : $media_item_before_delete->post_status;
+			$existing_media_item->post_status = ( false !== $deleted && true !== $force_delete ) ? 'trash' : $existing_media_item->post_status;
+
+			$media_item_before_delete = new Post( $existing_media_item );
 
 			/**
 			 * Return the deletedId and the mediaItem before it was deleted
@@ -151,7 +140,6 @@ class MediaItemDelete {
 			return [
 				'mediaItemObject' => $media_item_before_delete,
 			];
-
 		};
 	}
 }

--- a/src/Mutation/MediaItemUpdate.php
+++ b/src/Mutation/MediaItemUpdate.php
@@ -8,6 +8,7 @@ use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
 use WPGraphQL\Data\MediaItemMutation;
+use WPGraphQL\Utils\Utils;
 
 class MediaItemUpdate {
 	/**
@@ -71,10 +72,15 @@ class MediaItemUpdate {
 				return null;
 			}
 
-			$mutation_name = 'updateMediaItem';
+			// Get the database ID for the comment.
+			$media_item_id = Utils::get_database_id_from_id( $input['id'] );
 
-			$id_parts            = ! empty( $input['id'] ) ? Relay::fromGlobalId( $input['id'] ) : null;
-			$existing_media_item = isset( $id_parts['id'] ) && absint( $id_parts['id'] ) ? get_post( absint( $id_parts['id'] ) ) : null;
+			/**
+			 * Get the mediaItem object before deleting it
+			 */
+			$existing_media_item = ! empty( $media_item_id ) ? get_post( $media_item_id ) : null;
+
+			$mutation_name = 'updateMediaItem';
 
 			/**
 			 * If there's no existing mediaItem, throw an exception
@@ -105,8 +111,10 @@ class MediaItemUpdate {
 			 * make sure they have permission to edit others posts
 			 */
 			if ( ! empty( $input['authorId'] ) ) {
-				$author_id_parts = Relay::fromGlobalId( $input['authorId'] );
-				$author_id       = absint( $author_id_parts['id'] );
+				// Ensure authorId is a valid databaseId.
+				$input['authorId'] = Utils::get_database_id_from_id( $input['authorId'] );
+				// Use the new author for checks.
+				$author_id = $input['authorId'];
 			}
 
 			/**
@@ -120,9 +128,8 @@ class MediaItemUpdate {
 			/**
 			 * Insert the post object and get the ID
 			 */
-			$post_args                = MediaItemMutation::prepare_media_item( $input, $post_type_object, $mutation_name, false );
-			$post_args['ID']          = isset( $id_parts['id'] ) ? absint( $id_parts['id'] ) : null;
-			$post_args['post_author'] = $author_id;
+			$post_args       = MediaItemMutation::prepare_media_item( $input, $post_type_object, $mutation_name, false );
+			$post_args['ID'] = $media_item_id;
 
 			$clean_args = wp_slash( (array) $post_args );
 
@@ -138,7 +145,7 @@ class MediaItemUpdate {
 			 */
 			$post_id = wp_update_post( $clean_args, true );
 
-			if ( is_wp_error( $post_id ) ) {
+			if ( 0 === $post_id || is_wp_error( $post_id ) ) {
 				throw new UserError( __( 'The media item failed to update', 'wp-graphql' ) );
 			}
 

--- a/src/Mutation/PostObjectCreate.php
+++ b/src/Mutation/PostObjectCreate.php
@@ -7,6 +7,7 @@ use GraphQL\Type\Definition\ResolveInfo;
 use WP_Post_Type;
 use WPGraphQL\AppContext;
 use WPGraphQL\Data\PostObjectMutation;
+use WPGraphQL\Utils\Utils;
 
 /**
  * Class PostObjectCreate
@@ -127,7 +128,7 @@ class PostObjectCreate {
 			'revision',
 		], true ) ) {
 			$fields['parentId'] = [
-				'type'        => 'Id',
+				'type'        => 'ID',
 				'description' => __( 'The ID of the parent object', 'wp-graphql' ),
 			];
 		}
@@ -209,9 +210,20 @@ class PostObjectCreate {
 			 * If the post being created is being assigned to another user that's not the current user, make sure
 			 * the current user has permission to edit others posts for this post_type
 			 */
-			if ( ( isset( $input['authorId'] ) && get_current_user_id() !== $input['authorId'] ) && ( ! isset( $post_type_object->cap->edit_others_posts ) || ! current_user_can( $post_type_object->cap->edit_others_posts ) ) ) {
-				// translators: the $post_type_object->graphql_plural_name placeholder is the name of the object being mutated
-				throw new UserError( sprintf( __( 'Sorry, you are not allowed to create %1$s as this user', 'wp-graphql' ), $post_type_object->graphql_plural_name ) );
+			if ( ! empty( $input['authorId'] ) ) {
+				// Ensure authorId is a valid databaseId.
+				$input['authorId'] = Utils::get_database_id_from_id( $input['authorId'] );
+
+				$author = ! empty( $input['authorId'] ) ? get_user_by( 'ID', $input['authorId'] ) : false;
+
+				if ( false === $author ) {
+					throw new UserError( __( 'The provided `authorId` is not a valid user', 'wp-graphql' ) );
+				}
+
+				if ( get_current_user_id() !== $input['authorId'] && ( ! isset( $post_type_object->cap->edit_others_posts ) || ! current_user_can( $post_type_object->cap->edit_others_posts ) ) ) {
+					// translators: the $post_type_object->graphql_plural_name placeholder is the name of the object being mutated
+					throw new UserError( sprintf( __( 'Sorry, you are not allowed to create %1$s as this user', 'wp-graphql' ), $post_type_object->graphql_plural_name ) );
+				}
 			}
 
 			/**

--- a/src/Mutation/PostObjectDelete.php
+++ b/src/Mutation/PostObjectDelete.php
@@ -7,6 +7,7 @@ use GraphQL\Error\UserError;
 use GraphQLRelay\Relay;
 use WP_Post_Type;
 use WPGraphQL\Model\Post;
+use WPGraphQL\Utils\Utils;
 
 class PostObjectDelete {
 	/**
@@ -63,7 +64,7 @@ class PostObjectDelete {
 	public static function get_output_fields( WP_Post_Type $post_type_object ) {
 		return [
 			'deletedId'                            => [
-				'type'        => 'Id',
+				'type'        => 'ID',
 				'description' => __( 'The ID of the deleted object', 'wp-graphql' ),
 				'resolve'     => function ( $payload ) {
 					$deleted = (object) $payload['postObject'];
@@ -93,16 +94,13 @@ class PostObjectDelete {
 	 */
 	public static function mutate_and_get_payload( WP_Post_Type $post_type_object, string $mutation_name ) {
 		return function ( $input ) use ( $post_type_object ) {
-
-			/**
-			 * Get the ID from the global ID
-			 */
-			$id_parts = Relay::fromGlobalId( $input['id'] );
+			// Get the database ID for the post.
+			$post_id = Utils::get_database_id_from_id( $input['id'] );
 
 			/**
 			 * Stop now if a user isn't allowed to delete a post
 			 */
-			if ( ! isset( $post_type_object->cap->delete_post ) || ! current_user_can( $post_type_object->cap->delete_post, absint( $id_parts['id'] ) ) ) {
+			if ( ! isset( $post_type_object->cap->delete_post ) || ! current_user_can( $post_type_object->cap->delete_post, $post_id ) ) {
 				// translators: the $post_type_object->graphql_plural_name placeholder is the name of the object being mutated
 				throw new UserError( sprintf( __( 'Sorry, you are not allowed to delete %1$s', 'wp-graphql' ), $post_type_object->graphql_plural_name ) );
 			}
@@ -115,7 +113,7 @@ class PostObjectDelete {
 			/**
 			 * Get the post object before deleting it
 			 */
-			$post_before_delete = get_post( absint( $id_parts['id'] ) );
+			$post_before_delete = ! empty( $post_id ) ? get_post( $post_id ) : null;
 
 			if ( empty( $post_before_delete ) ) {
 				throw new UserError( __( 'The post could not be deleted', 'wp-graphql' ) );
@@ -127,17 +125,15 @@ class PostObjectDelete {
 			 * If the post is already in the trash, and the forceDelete input was not passed,
 			 * don't remove from the trash
 			 */
-			if ( 'trash' === $post_before_delete->post_status ) {
-				if ( true !== $force_delete ) {
-					// Translators: the first placeholder is the post_type of the object being deleted and the second placeholder is the unique ID of that object
-					throw new UserError( sprintf( __( 'The %1$s with id %2$s is already in the trash. To remove from the trash, use the forceDelete input', 'wp-graphql' ), $post_type_object->graphql_single_name, $input['id'] ) );
-				}
+			if ( 'trash' === $post_before_delete->post_status && true !== $force_delete ) {
+				// Translators: the first placeholder is the post_type of the object being deleted and the second placeholder is the unique ID of that object
+				throw new UserError( sprintf( __( 'The %1$s with id %2$s is already in the trash. To remove from the trash, use the forceDelete input', 'wp-graphql' ), $post_type_object->graphql_single_name, $post_id ) );
 			}
 
 			/**
 			 * Delete the post
 			 */
-			$deleted = wp_delete_post( $id_parts['id'], $force_delete );
+			$deleted = wp_delete_post( (int) $post_id, $force_delete );
 
 			/**
 			 * If the post was moved to the trash, spoof the object's status before returning it

--- a/src/Mutation/PostObjectUpdate.php
+++ b/src/Mutation/PostObjectUpdate.php
@@ -8,6 +8,7 @@ use GraphQLRelay\Relay;
 use WP_Post_Type;
 use WPGraphQL\AppContext;
 use WPGraphQL\Data\PostObjectMutation;
+use WPGraphQL\Utils\Utils;
 
 class PostObjectUpdate {
 	/**
@@ -74,21 +75,21 @@ class PostObjectUpdate {
 	 */
 	public static function mutate_and_get_payload( $post_type_object, $mutation_name ) {
 		return function ( $input, AppContext $context, ResolveInfo $info ) use ( $post_type_object, $mutation_name ) {
-
-			$id_parts      = ! empty( $input['id'] ) ? Relay::fromGlobalId( $input['id'] ) : null;
-			$existing_post = isset( $id_parts['id'] ) && absint( $id_parts['id'] ) ? get_post( absint( $id_parts['id'] ) ) : null;
+			// Get the database ID for the comment.
+			$post_id       = Utils::get_database_id_from_id( $input['id'] );
+			$existing_post = ! empty( $post_id ) ? get_post( $post_id ) : null;
 
 			/**
 			 * If there's no existing post, throw an exception
 			 */
-			if ( ! isset( $id_parts['id'] ) || empty( $existing_post ) ) {
+			if ( null === $existing_post ) {
 				// translators: the placeholder is the name of the type of post being updated
 				throw new UserError( sprintf( __( 'No %1$s could be found to update', 'wp-graphql' ), $post_type_object->graphql_single_name ) );
 			}
 
 			if ( $post_type_object->name !== $existing_post->post_type ) {
 				// translators: The first placeholder is an ID and the second placeholder is the name of the post type being edited
-				throw new UserError( sprintf( __( 'The id %1$d is not of the type "%2$s"', 'wp-graphql' ), $id_parts['id'], $post_type_object->name ) );
+				throw new UserError( sprintf( __( 'The id %1$d is not of the type "%2$s"', 'wp-graphql' ), $post_id, $post_type_object->name ) );
 			}
 
 			/**
@@ -107,12 +108,24 @@ class PostObjectUpdate {
 				throw new UserError( sprintf( __( 'Sorry, you are not allowed to update another author\'s %1$s', 'wp-graphql' ), $post_type_object->graphql_single_name ) );
 			}
 
+			$author_id = absint( $existing_post->post_author );
+
 			/**
 			 * If the mutation is setting the author to be someone other than the user making the request
 			 * make sure they have permission to edit others posts
 			 */
-			$author_id_parts = ! empty( $input['authorId'] ) ? Relay::fromGlobalId( $input['authorId'] ) : null;
-			if ( ! empty( $author_id_parts['id'] ) && get_current_user_id() !== $author_id_parts['id'] && ( ! isset( $post_type_object->cap->edit_others_posts ) || ! current_user_can( $post_type_object->cap->edit_others_posts ) ) ) {
+			if ( ! empty( $input['authorId'] ) ) {
+				// Ensure authorId is a valid databaseId.
+				$input['authorId'] = Utils::get_database_id_from_id( $input['authorId'] );
+				// Use the new author for checks.
+				$author_id = $input['authorId'];
+			}
+
+			/**
+			 * Check to see if the existing_media_item author matches the current user,
+			 * if not they need to be able to edit others posts to proceed
+			 */
+			if ( get_current_user_id() !== $author_id && ( ! isset( $post_type_object->cap->edit_others_posts ) || ! current_user_can( $post_type_object->cap->edit_others_posts ) ) ) {
 				// translators: the $post_type_object->graphql_single_name placeholder is the name of the object being mutated
 				throw new UserError( sprintf( __( 'Sorry, you are not allowed to update %1$s as this user.', 'wp-graphql' ), $post_type_object->graphql_plural_name ) );
 			}
@@ -131,7 +144,7 @@ class PostObjectUpdate {
 			 * Insert the post object and get the ID
 			 */
 			$post_args       = PostObjectMutation::prepare_post_object( $input, $post_type_object, $mutation_name );
-			$post_args['ID'] = absint( $id_parts['id'] );
+			$post_args['ID'] = $post_id;
 
 			$clean_args = wp_slash( (array) $post_args );
 
@@ -142,12 +155,12 @@ class PostObjectUpdate {
 			/**
 			 * Insert the post and retrieve the ID
 			 */
-			$post_id = wp_update_post( $clean_args, true );
+			$updated_post_id = wp_update_post( $clean_args, true );
 
 			/**
 			 * Throw an exception if the post failed to update
 			 */
-			if ( is_wp_error( $post_id ) ) {
+			if ( 0 === $post_id || is_wp_error( $updated_post_id ) ) {
 				throw new UserError( __( 'The object failed to update', 'wp-graphql' ) );
 			}
 
@@ -180,7 +193,7 @@ class PostObjectUpdate {
 			 * The input for the postObjectMutation will be passed, along with the $new_post_id for the
 			 * postObject that was updated so that relations can be set, meta can be updated, etc.
 			 */
-			PostObjectMutation::update_additional_post_object_data( $post_id, $input, $post_type_object, $mutation_name, $context, $info );
+			PostObjectMutation::update_additional_post_object_data( (int) $post_id, $input, $post_type_object, $mutation_name, $context, $info );
 
 			/**
 			 * Return the payload

--- a/src/Mutation/TermObjectCreate.php
+++ b/src/Mutation/TermObjectCreate.php
@@ -70,7 +70,7 @@ class TermObjectCreate {
 		 */
 		if ( true === $taxonomy->hierarchical ) {
 			$fields['parentId'] = [
-				'type'        => 'Id',
+				'type'        => 'ID',
 				// Translators: The placeholder is the name of the taxonomy for the object being mutated
 				'description' => sprintf( __( 'The ID of the %1$s that should be set as the parent', 'wp-graphql' ), $taxonomy->name ),
 			];

--- a/src/Mutation/TermObjectDelete.php
+++ b/src/Mutation/TermObjectDelete.php
@@ -6,6 +6,7 @@ use GraphQL\Error\UserError;
 use GraphQLRelay\Relay;
 use WP_Taxonomy;
 use WPGraphQL\Model\Term;
+use WPGraphQL\Utils\Utils;
 
 /**
  * Class TermObjectDelete
@@ -90,12 +91,10 @@ class TermObjectDelete {
 	 */
 	public static function mutate_and_get_payload( WP_Taxonomy $taxonomy, string $mutation_name ) {
 		return function ( $input ) use ( $taxonomy ) {
+			// Get the database ID for the comment.
+			$term_id = Utils::get_database_id_from_id( $input['id'] );
 
-			$id_parts = Relay::fromGlobalId( $input['id'] );
-
-			if ( ! empty( $id_parts['id'] ) && absint( $id_parts['id'] ) ) {
-				$term_id = absint( $id_parts['id'] );
-			} else {
+			if ( empty( $term_id ) ) {
 				// Translators: The placeholder is the name of the taxonomy for the term being deleted
 				throw new UserError( sprintf( __( 'The ID for the %1$s was not valid', 'wp-graphql' ), $taxonomy->graphql_single_name ) );
 			}

--- a/src/Mutation/UserDelete.php
+++ b/src/Mutation/UserDelete.php
@@ -5,6 +5,7 @@ namespace WPGraphQL\Mutation;
 use GraphQL\Error\UserError;
 use GraphQLRelay\Relay;
 use WPGraphQL\Model\User;
+use WPGraphQL\Utils\Utils;
 
 /**
  * Class UserDelete
@@ -80,19 +81,21 @@ class UserDelete {
 	 */
 	public static function mutate_and_get_payload() {
 		return static function ( $input ) {
-			/**
-			 * Get the ID from the global ID
-			 */
-			$id_parts = Relay::fromGlobalId( $input['id'] );
+			// Get the user ID.
+			$user_id = Utils::get_database_id_from_id( $input['id'] );
 
-			if ( ! current_user_can( 'delete_users', absint( $id_parts['id'] ) ) ) {
+			if ( empty( $user_id ) ) {
+				throw new UserError( __( 'The user ID passed is invalid', 'wp-graphql' ) );
+			}
+
+			if ( ! current_user_can( 'delete_users', $user_id ) ) {
 				throw new UserError( __( 'Sorry, you are not allowed to delete users.', 'wp-graphql' ) );
 			}
 
 			/**
 			 * Retrieve the user object before it's deleted
 			 */
-			$user_before_delete = get_user_by( 'id', absint( $id_parts['id'] ) );
+			$user_before_delete = get_user_by( 'id', $user_id );
 
 			/**
 			 * Throw an error if the user we are trying to delete doesn't exist
@@ -102,28 +105,56 @@ class UserDelete {
 			}
 
 			/**
-			 * Get the DB id for the user to reassign posts to from the relay ID.
+			 * Get the user to reassign posts to.
 			 */
-			$reassign_id_parts = ( ! empty( $input['reassignId'] ) ) ? Relay::fromGlobalId( $input['reassignId'] ) : null;
-			$reassign_id       = ( ! empty( $reassign_id_parts ) ) ? absint( $reassign_id_parts['id'] ) : null;
+			$reassign_id = 0;
+			if ( ! empty( $input['reassignId'] ) ) {
+				$reassign_id = Utils::get_database_id_from_id( $input['reassignId'] );
 
-			/**
-			 * If wpmu_delete_user() or wp_delete_user() doesn't exist yet,
-			 * load the files in which each is defined. I think we need to
-			 * load this manually here because WordPress only uses this
-			 * function on the user edit screen normally.
+				if ( empty( $reassign_id ) ) {
+					throw new UserError( __( 'The user ID passed to `reassignId` is invalid', 'wp-graphql' ) );
+				}
+				/**
+			 * Retrieve the user object before it's deleted
 			 */
-			if ( ! function_exists( 'wpmu_delete_user' ) ) {
-				require_once ABSPATH . 'wp-admin/includes/ms.php';
+				$reassign_user = get_user_by( 'id', $reassign_id );
+
+				if ( false === $reassign_user ) {
+					throw new UserError( __( 'Could not find the existing user to reassign.', 'wp-graphql' ) );
+				}
 			}
+
 			if ( ! function_exists( 'wp_delete_user' ) ) {
 				require_once ABSPATH . 'wp-admin/includes/user.php';
 			}
 
 			if ( is_multisite() ) {
-				$deleted_user = wpmu_delete_user( absint( $id_parts['id'] ) );
+
+				/**
+				 * If wpmu_delete_user() or remove_user_from_blog() doesn't exist yet,
+				 * load the files in which each is defined. I think we need to
+				 * load this manually here because WordPress only uses this
+				 * function on the user edit screen normally.
+				 */
+
+				// only include these files for multisite requests
+				if ( ! function_exists( 'wpmu_delete_user' ) ) {
+					require_once ABSPATH . 'wp-admin/includes/ms.php';
+				}
+				if ( ! function_exists( 'remove_user_from_blog' ) ) {
+					require_once ABSPATH . 'wp-admin/includes/ms-functions.php';
+				}
+
+				$blog_id = get_current_blog_id();
+
+				// remove the user from the blog and reassign their posts
+				remove_user_from_blog( $user_id, $blog_id, $reassign_id );
+
+				// delete the user
+				$deleted_user = wpmu_delete_user( $user_id );
+
 			} else {
-				$deleted_user = wp_delete_user( absint( $id_parts['id'] ), $reassign_id );
+				$deleted_user = wp_delete_user( $user_id, $reassign_id );
 			}
 
 			if ( true !== $deleted_user ) {

--- a/src/Mutation/UserUpdate.php
+++ b/src/Mutation/UserUpdate.php
@@ -4,9 +4,9 @@ namespace WPGraphQL\Mutation;
 use Exception;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
-use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
 use WPGraphQL\Data\UserMutation;
+use WPGraphQL\Utils\Utils;
 
 class UserUpdate {
 	/**
@@ -62,14 +62,18 @@ class UserUpdate {
 	 */
 	public static function mutate_and_get_payload() {
 		return function ( $input, AppContext $context, ResolveInfo $info ) {
+			// Get the user ID.
+			$user_id = Utils::get_database_id_from_id( $input['id'] );
 
-			$id_parts      = ! empty( $input['id'] ) ? Relay::fromGlobalId( $input['id'] ) : null;
-			$existing_user = isset( $id_parts['id'] ) && absint( $id_parts['id'] ) ? get_user_by( 'ID', absint( $id_parts['id'] ) ) : null;
+			if ( empty( $user_id ) ) {
+				throw new UserError( __( 'The user ID passed is invalid', 'wp-graphql' ) );
+			}
+			$existing_user = get_user_by( 'ID', $user_id );
 
 			/**
 			 * If there's no existing user, throw an exception
 			 */
-			if ( ! isset( $id_parts['id'] ) || empty( $existing_user ) ) {
+			if ( false === $existing_user ) {
 				throw new UserError( __( 'A user could not be updated with the provided ID', 'wp-graphql' ) );
 			}
 
@@ -83,18 +87,18 @@ class UserUpdate {
 			}
 
 			$user_args       = UserMutation::prepare_user_object( $input, 'updateUser' );
-			$user_args['ID'] = absint( $id_parts['id'] );
+			$user_args['ID'] = $user_id;
 
 			/**
 			 * Update the user
 			 */
-			$user_id = wp_update_user( $user_args );
+			$updated_user_id = wp_update_user( $user_args );
 
 			/**
 			 * Throw an exception if the post failed to create
 			 */
-			if ( is_wp_error( $user_id ) ) {
-				$error_message = $user_id->get_error_message();
+			if ( is_wp_error( $updated_user_id ) ) {
+				$error_message = $updated_user_id->get_error_message();
 				if ( ! empty( $error_message ) ) {
 					throw new UserError( esc_html( $error_message ) );
 				} else {
@@ -103,23 +107,23 @@ class UserUpdate {
 			}
 
 			/**
-			 * If the $user_id is empty, we should throw an exception
+			 * If the $updated_user_id is empty, we should throw an exception
 			 */
-			if ( empty( $user_id ) ) {
+			if ( empty( $updated_user_id ) ) {
 				throw new UserError( __( 'The user failed to update', 'wp-graphql' ) );
 			}
 
 			/**
 			 * Update additional user data
 			 */
-			UserMutation::update_additional_user_object_data( $user_id, $input, 'updateUser', $context, $info );
+			UserMutation::update_additional_user_object_data( $updated_user_id, $input, 'updateUser', $context, $info );
 
 			/**
 			 * Return the new user ID
 			 */
 			return [
-				'id'   => $user_id,
-				'user' => $context->get_loader( 'user' )->load_deferred( $user_id ),
+				'id'   => $updated_user_id,
+				'user' => $context->get_loader( 'user' )->load_deferred( $updated_user_id ),
 			];
 		};
 	}

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -485,7 +485,7 @@ class TypeRegistry {
 				$group_name = DataSource::format_group_name( $group_name );
 				$type_name  = SettingGroup::register_settings_group( $group_name, $group_name, $this );
 
-				if ( ! $type_name || ! $this->get_type( $type_name ) ) {
+				if ( ! $type_name ) {
 					continue;
 				}
 
@@ -1070,7 +1070,7 @@ class TypeRegistry {
 		$this->register_field(
 			'rootMutation',
 			$mutation_name,
-			[
+			array_merge( $config, [
 				'description' => sprintf( __( 'The payload for the %s mutation', 'wp-graphql' ), $mutation_name ),
 				'args'        => [
 					'input' => [
@@ -1099,7 +1099,7 @@ class TypeRegistry {
 
 					return $payload;
 				},
-			]
+			])
 		);
 
 	}

--- a/src/Type/Enum/PostObjectFieldFormatEnum.php
+++ b/src/Type/Enum/PostObjectFieldFormatEnum.php
@@ -17,12 +17,12 @@ class PostObjectFieldFormatEnum {
 				'values'      => [
 					'RAW'      => [
 						'name'        => 'RAW',
-						'description' => __( 'Provide the field value directly from database', 'wp-graphql' ),
+						'description' => __( 'Provide the field value directly from database. Null on unauthenticated requests.', 'wp-graphql' ),
 						'value'       => 'raw',
 					],
 					'RENDERED' => [
 						'name'        => 'RENDERED',
-						'description' => __( 'Apply the default WordPress rendering', 'wp-graphql' ),
+						'description' => __( 'Provide the field value as rendered by WordPress. Default.', 'wp-graphql' ),
 						'value'       => 'rendered',
 					],
 				],

--- a/src/Type/ObjectType/MenuItem.php
+++ b/src/Type/ObjectType/MenuItem.php
@@ -118,6 +118,12 @@ class MenuItem {
 						'type'        => 'String',
 						'description' => __( 'URL or destination of the menu item.', 'wp-graphql' ),
 					],
+					// Note: this field is added to the MenuItem type instead of applied by the "UniformResourceIdentifiable" interface
+					// because a MenuItem is not identifiable by a uri, the connected resource is identifiable by the uri.
+					'uri'              => [
+						'type'        => 'String',
+						'description' => __( 'The uri of the resource the menu item links to', 'wp-graphql' ),
+					],
 					'path'             => [
 						'type'        => 'String',
 						'description' => __( 'Path for the resource. Relative path for internal resources. Absolute path for external resources.', 'wp-graphql' ),

--- a/src/Type/ObjectType/SettingGroup.php
+++ b/src/Type/ObjectType/SettingGroup.php
@@ -30,7 +30,7 @@ class SettingGroup {
 			return null;
 		}
 
-		$type_registry->register_object_type(
+		register_graphql_object_type(
 			ucfirst( $group_name ) . 'Settings',
 			[
 				'description' => sprintf( __( 'The %s setting type', 'wp-graphql' ), $group_name ),

--- a/src/Utils/InstrumentSchema.php
+++ b/src/Utils/InstrumentSchema.php
@@ -216,7 +216,7 @@ class InstrumentSchema {
 			return true;
 		}
 
-		if ( ! isset( $field->config['auth'] ) || ! is_array( $field->config['auth'] ) ) {
+		if ( ( ! isset( $field->config['auth'] ) || ! is_array( $field->config['auth'] ) ) && ! isset( $field->config['isPrivate'] ) ) {
 			return true;
 		}
 

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -130,7 +130,7 @@ final class WPGraphQL {
 
 		// Plugin version.
 		if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-			define( 'WPGRAPHQL_VERSION', '1.8.1' );
+			define( 'WPGRAPHQL_VERSION', '1.8.2' );
 		}
 
 		// Plugin Folder Path.

--- a/tests/wpunit.suite.dist.yml
+++ b/tests/wpunit.suite.dist.yml
@@ -12,6 +12,7 @@ modules:
     WPDb:
       cleanup: false
     WPLoader:
+      multisite: '%MULTISITE%'
       plugins:
         - wp-graphql/wp-graphql.php
       activatePlugins:

--- a/tests/wpunit/CommentMutationsTest.php
+++ b/tests/wpunit/CommentMutationsTest.php
@@ -182,6 +182,59 @@ class CommentMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->assertEquals( $this->subscriber, $actual['data']['createComment']['comment']['author']['node']['databaseId'] );
 	}
 
+	public function testCreateChildComment() {
+		// Create parent comment.
+		$this->createComment( $post_id, $comment_id, $this->author, $this->subscriber );
+
+		$query = '
+			mutation createChildCommentTest( $commentOn: Int!, $parent: ID, $content: String!){
+				createComment(
+					input: {
+						commentOn: $commentOn,
+						content: $content,
+						parent: $parent,
+					}
+				){
+					success
+					comment {
+						databaseId
+						parent {
+							node {
+								databaseId
+							}
+						}
+					}
+				}
+			}
+		';
+
+		wp_set_current_user( $this->admin );
+
+		// Test with database Id
+		$variables = [
+			'commentOn' => $post_id,
+			'content'   => $this->content,
+			'parent'    => $comment_id,
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertTrue( $actual['data']['createComment']['success'] );
+		$this->assertEquals( $comment_id, $actual['data']['createComment']['comment']['parent']['node']['databaseId'] );
+
+		// Test with global Id
+		$variables = [
+			'commentOn' => $post_id,
+			'content'   => 'Testing with global Id',
+			'parent'    => \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_id ),
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertTrue( $actual['data']['createComment']['success'] );
+		$this->assertEquals( $comment_id, $actual['data']['createComment']['comment']['parent']['node']['databaseId'] );
+	}
+
 	public function testUpdateCommentWithAuthorConnection() {
 		$this->createComment( $post_id, $comment_id, $this->author, $this->subscriber );
 
@@ -200,7 +253,7 @@ class CommentMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$content = 'Updated Content';
 
-		$query     = '
+		$query = '
 		mutation updateCommentTest( $id: ID!, $content: String! ) {
 			updateComment( 
 				input: {
@@ -211,32 +264,43 @@ class CommentMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 			{
 				comment {
 					id
-					commentId
+					databaseId
 					content
 				}
 			}
 		}
 		';
-		$variables = [
-			'id'      => \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_id ),
-			'content' => $content,
-		];
-
-		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
 		$expected = [
 			'updateComment' => [
 				'comment' => [
-					'id'        => \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_id ),
-					'commentId' => $comment_id,
-					'content'   => apply_filters( 'comment_text', $content ),
+					'id'         => \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_id ),
+					'databaseId' => $comment_id,
+					'content'    => apply_filters( 'comment_text', $content ),
 				],
 			],
 		];
 
-		/**
-		 * Compare the actual output vs the expected output
-		 */
+		// Test with database ID.
+		$variables = [
+			'id'      => $comment_id,
+			'content' => $content,
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEquals( $expected, $actual['data'] );
+
+		// Test with global ID
+		$content   = 'Updated via Global ID';
+		$variables = [
+			'id'      => \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_id ),
+			'content' => $content,
+		];
+		$expected['updateComment']['comment']['content'] = apply_filters( 'comment_text', $content );
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertEquals( $expected, $actual['data'] );
 	}
 
@@ -266,15 +330,16 @@ class CommentMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 				deletedId
 				comment {
 					id
-					commentId
+					databaseId
 					content
 				}
 			}
 		}
 		';
 
+		// Test with database ID.
 		$variables = [
-			'id' => \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_id ),
+			'id' => $comment_id,
 		];
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
@@ -283,16 +348,31 @@ class CommentMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 			'deleteComment' => [
 				'deletedId' => \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_id ),
 				'comment'   => [
-					'id'        => \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_id ),
-					'commentId' => $comment_id,
-					'content'   => apply_filters( 'comment_text', $content ),
+					'id'         => \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_id ),
+					'databaseId' => $comment_id,
+					'content'    => apply_filters( 'comment_text', $content ),
 				],
 			],
 		];
 
-		/**
-		 * Compare the actual output vs the expected output
-		 */
+		$this->assertEquals( $expected, $actual['data'] );
+		// Test with global Id
+		$this->createComment( $post_id, $comment_id, $this->author, $this->subscriber );
+		$variables['id'] = \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_id );
+
+		$expected = [
+			'deleteComment' => [
+				'deletedId' => \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_id ),
+				'comment'   => [
+					'id'         => \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_id ),
+					'databaseId' => $comment_id,
+					'content'    => apply_filters( 'comment_text', $content ),
+				],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+		codecept_debug( $actual );
 		$this->assertEquals( $expected, $actual['data'] );
 	}
 
@@ -324,36 +404,54 @@ class CommentMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 				restoredId
 				comment {
 					id
-					commentId
+					databaseId
 					content
 				}
 			}
 		}
 		';
 
+		// Test database ID
 		$variables = [
-			'id' => \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_id ),
+			'id' => $comment_id,
 		];
-
-		wp_set_current_user( $this->admin );
-
-		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
 		$expected = [
 			'restoreComment' => [
 				'restoredId' => \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_id ),
 				'comment'    => [
-					'id'        => \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_id ),
-					'commentId' => $comment_id,
-					'content'   => apply_filters( 'comment_text', $content ),
+					'id'         => \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_id ),
+					'databaseId' => $comment_id,
+					'content'    => apply_filters( 'comment_text', $content ),
 				],
 			],
 		];
 
-		/**
-		 * Compare the actual output vs the expected output
-		 */
+		// Test without permissions
+		wp_set_current_user( 0 );
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+		$this->assertArrayHasKey( 'errors', $actual );
+
+		// Test with permissions
+		wp_set_current_user( $this->admin );
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
 		$this->assertEquals( $expected, $actual['data'] );
+
+		// Test global Id
+		$this->trashComment( $comment_id );
+
+		$variables['id'] = \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_id );
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertEquals( $expected, $actual['data'] );
+
+		// Test bad ID
+		$variables['id'] = '3ab21';
+		$actual          = $this->graphql( compact( 'query', 'variables' ) );
+		$this->assertArrayHasKey( 'errors', $actual );
 	}
 
 	/**

--- a/tests/wpunit/MediaItemMutationsTest.php
+++ b/tests/wpunit/MediaItemMutationsTest.php
@@ -1,13 +1,13 @@
 <?php
 
-class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
-{
+class MediaItemMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
+
 
 	public $altText;
 	public $authorId;
 	public $caption;
 	public $commentStatus;
-    public $current_date_gmt;
+	public $current_date_gmt;
 	public $date;
 	public $dateGmt;
 	public $description;
@@ -17,7 +17,6 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	public $status;
 	public $title;
 	public $parentId;
-	public $clientMutationId;
 	public $updated_title;
 	public $updated_description;
 	public $updated_altText;
@@ -27,7 +26,6 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	public $updated_dateGmt;
 	public $updated_slug;
 	public $updated_status;
-	public $updated_clientMutationId;
 
 	public $create_variables;
 	public $update_variables;
@@ -43,132 +41,128 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	public $attachment_id;
 	public $media_item_id;
 
-    public function setUp(): void
-    {
-        // before
-        parent::setUp();
+	public function setUp(): void {
+		// before
+		parent::setUp();
 
-        // We don't want this funking with our tests
-	    remove_image_size( 'twentyseventeen-thumbnail-avatar' );
+		// We don't want this funking with our tests
+		remove_image_size( 'twentyseventeen-thumbnail-avatar' );
 
-	    /**
-	     * Set up different user roles for permissions testing
-	     */
-	    $this->subscriber = $this->factory()->user->create( [
-		    'role' => 'subscriber',
-	    ] );
-	    $this->subscriber_name = 'User ' . $this->subscriber;
+		/**
+		 * Set up different user roles for permissions testing
+		 */
+		$this->subscriber      = $this->factory()->user->create( [
+			'role' => 'subscriber',
+		] );
+		$this->subscriber_name = 'User ' . $this->subscriber;
 
-	    $this->author = $this->factory()->user->create( [
-		    'role' => 'author',
-	    ] );
-	    $this->author_name = 'User ' . $this->author;
+		$this->author      = $this->factory()->user->create( [
+			'role' => 'author',
+		] );
+		$this->author_name = 'User ' . $this->author;
 
-	    $this->admin = $this->factory()->user->create( [
-		    'role' => 'administrator',
-	    ] );
-	    $this->admin_name = 'User ' . $this->admin;
+		$this->admin      = $this->factory()->user->create( [
+			'role' => 'administrator',
+		] );
+		$this->admin_name = 'User ' . $this->admin;
 
-	    /**
-	     * Populate the mediaItem input fields
-	     */
-	    $this->altText          = 'A gif of Shia doing Magic.';
-	    $this->authorId         = \GraphQLRelay\Relay::toGlobalId( 'user', $this->admin );
-	    $this->caption          = 'Shia shows off some magic in this caption.';
-	    $this->commentStatus    = 'closed';
-	    $this->date             = '2017-08-01T15:00:00';
-	    $this->dateGmt          = '2017-08-01T21:00:00';
-	    $this->description      = 'This is a magic description.';
-	    $this->filePath         = 'https://content.wpgraphql.com/wp-content/uploads/2020/12/mgc.gif';
-	    $this->fileType         = 'IMAGE_GIF';
-	    $this->slug             = 'magic-shia';
-	    $this->status           = 'INHERIT';
-	    $this->title            = 'Magic Shia Gif';
-	    $this->parentId         = null;
-	    $this->clientMutationId = 'someUniqueId';
+		/**
+		 * Populate the mediaItem input fields
+		 */
+		$this->altText       = 'A gif of Shia doing Magic.';
+		$this->authorId      = $this->admin;
+		$this->caption       = 'Shia shows off some magic in this caption.';
+		$this->commentStatus = 'closed';
+		$this->date          = '2017-08-01T15:00:00';
+		$this->dateGmt       = '2017-08-01T21:00:00';
+		$this->description   = 'This is a magic description.';
+		$this->filePath      = 'https://content.wpgraphql.com/wp-content/uploads/2020/12/mgc.gif';
+		$this->fileType      = 'IMAGE_GIF';
+		$this->slug          = 'magic-shia';
+		$this->status        = 'INHERIT';
+		$this->title         = 'Magic Shia Gif';
+		$this->parentId      = null;
 
-	    /**
-	     * Set up the updateMediaItem variables
-	     */
-	    $this->updated_title = 'Updated Magic Shia Gif';
-	    $this->updated_description = 'This is an updated magic description.';
-	    $this->updated_altText = 'Some updated alt text';
-	    $this->updated_caption = 'Shia shows off some magic in this updated caption.';
-	    $this->updated_commentStatus = 'open';
-	    $this->updated_date = '2017-08-01T16:00:00';
-	    $this->updated_dateGmt = '2017-08-01T22:00:00';
-	    $this->updated_slug = 'updated-shia-magic';
-	    $this->updated_status = 'INHERIT';
-	    $this->updated_clientMutationId = 'someUpdatedUniqueId';
+		/**
+		 * Set up the updateMediaItem variables
+		 */
+		$this->updated_title         = 'Updated Magic Shia Gif';
+		$this->updated_description   = 'This is an updated magic description.';
+		$this->updated_altText       = 'Some updated alt text';
+		$this->updated_caption       = 'Shia shows off some magic in this updated caption.';
+		$this->updated_commentStatus = 'open';
+		$this->updated_date          = '2017-08-01T16:00:00';
+		$this->updated_dateGmt       = '2017-08-01T22:00:00';
+		$this->updated_slug          = 'updated-shia-magic';
+		$this->updated_status        = 'INHERIT';
 
-	    /**
-	     * Create a mediaItem to update and store it's WordPress post ID
-	     * and it's WPGraphQL ID for using in our updateMediaItem mutation
-	     */
-	    $this->attachment_id = $this->factory()->attachment->create( ['post_mime_type' => 'image/gif', 'post_author' => $this->admin] );
-	    $this->media_item_id = \GraphQLRelay\Relay::toGlobalId( 'post', $this->attachment_id );
+		/**
+		 * Create a mediaItem to update and store it's WordPress post ID
+		 * and it's WPGraphQL ID for using in our updateMediaItem mutation
+		 */
+		$this->attachment_id = $this->factory()->attachment->create( [
+			'post_mime_type' => 'image/gif',
+			'post_author'    => $this->admin,
+		] );
+		$this->media_item_id = \GraphQLRelay\Relay::toGlobalId( 'post', $this->attachment_id );
 
-	    /**
-	     * Set the createMediaItem mutation input variables
-	     */
-	    $this->create_variables = [
-		    'input' => [
-			    'filePath'         => $this->filePath,
-			    'fileType'         => $this->fileType,
-			    'clientMutationId' => $this->clientMutationId,
-			    'title'            => $this->title,
-			    'description'      => $this->description,
-			    'altText'          => $this->altText,
-			    'parentId'         => $this->parentId,
-			    'caption'          => $this->caption,
-			    'commentStatus'    => $this->commentStatus,
-			    'date'             => $this->date,
-			    'dateGmt'          => $this->dateGmt,
-			    'slug'             => $this->slug,
-			    'status'           => $this->status,
-			    'authorId'         => $this->authorId,
-		    ],
-	    ];
+		/**
+		 * Set the createMediaItem mutation input variables
+		 */
+		$this->create_variables = [
+			'input' => [
+				'filePath'      => $this->filePath,
+				'fileType'      => $this->fileType,
+				'title'         => $this->title,
+				'description'   => $this->description,
+				'altText'       => $this->altText,
+				'parentId'      => $this->parentId,
+				'caption'       => $this->caption,
+				'commentStatus' => $this->commentStatus,
+				'date'          => $this->date,
+				'dateGmt'       => $this->dateGmt,
+				'slug'          => $this->slug,
+				'status'        => $this->status,
+				'authorId'      => $this->authorId,
+			],
+		];
 
-	    /**
-	     * Set the updateMediaItem mutation input variables
-	     */
-	    $this->update_variables = [
-		    'input' => [
-			    'id'               => $this->media_item_id,
-			    'clientMutationId' => $this->updated_clientMutationId,
-			    'title'            => $this->updated_title,
-			    'description'      => $this->updated_description,
-			    'altText'          => $this->updated_altText,
-			    'caption'          => $this->updated_caption,
-			    'commentStatus'    => $this->updated_commentStatus,
-			    'date'             => $this->updated_date,
-			    'dateGmt'          => $this->updated_dateGmt,
-			    'slug'             => $this->updated_slug,
-			    'status'           => $this->updated_status,
-			    'fileType'         => $this->fileType,
-		    ]
-	    ];
+		/**
+		 * Set the updateMediaItem mutation input variables
+		 */
+		$this->update_variables = [
+			'input' => [
+				'id'            => $this->media_item_id,
+				'title'         => $this->updated_title,
+				'description'   => $this->updated_description,
+				'altText'       => $this->updated_altText,
+				'caption'       => $this->updated_caption,
+				'commentStatus' => $this->updated_commentStatus,
+				'date'          => $this->updated_date,
+				'dateGmt'       => $this->updated_dateGmt,
+				'slug'          => $this->updated_slug,
+				'status'        => $this->updated_status,
+				'fileType'      => $this->fileType,
+			],
+		];
 
-	    /**
-	     * Set the deleteMediaItem input variables
-	     */
-	    $this->delete_variables = [
-		    'input' => [
-			    'id'               => $this->media_item_id,
-			    'clientMutationId' => $this->clientMutationId,
-			    'forceDelete'      => true,
-		    ]
-	    ];
-    }
+		/**
+		 * Set the deleteMediaItem input variables
+		 */
+		$this->delete_variables = [
+			'input' => [
+				'id'          => $this->media_item_id,
+				'forceDelete' => true,
+			],
+		];
+	}
 
-    public function tearDown(): void
-    {
-        // your tear down methods here
+	public function tearDown(): void {
+		// your tear down methods here
 
-        // then
-        parent::tearDown();
-    }
+		// then
+		parent::tearDown();
+	}
 
 	/**
 	 * This function tests the createMediaItem mutation
@@ -178,70 +172,69 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	 * @return array $actual
 	 */
 	public function createMediaItemMutation() {
-
 		/**
 		 * Set up the createMediaItem mutation
 		 */
-		$mutation = '
+		$query = '
 			mutation createMediaItem( $input: CreateMediaItemInput! ){
-			  createMediaItem(input: $input){
-			    clientMutationId
-			    mediaItem{
-			      id
-			      mediaItemId
-			      mediaType
-			      date
-			      dateGmt
-			      slug
-			      status
-			      title
-			      commentStatus
-			      altText
-			      caption
-			      description
-			      mimeType
-			      parent {
-			        node {
-				      ... on Post {
-				        id
-				      }
-			        }
-			      }
-			      sourceUrl
-			      mediaDetails {
-			          file
-			          height
-			          meta {
-			            aperture
-			            credit
-			            camera
-			            caption
-			            createdTimestamp
-			            copyright
-			            focalLength
-			            iso
-			            shutterSpeed
-			            title
-			            orientation
-			          }
-			          width
-			          sizes {
-			            name
-			            file
-			            width
-			            height
-			            mimeType
-			            sourceUrl
-			          }
-			        }
-			    }
-			  }
+				createMediaItem(input: $input){
+					mediaItem{
+						id
+						databaseId
+						mediaType
+						date
+						dateGmt
+						slug
+						status
+						title
+						commentStatus
+						altText
+						caption
+						description
+						mimeType
+						parent {
+							node {
+							... on Post {
+								id
+							}
+							}
+						}
+						sourceUrl
+						mediaDetails {
+								file
+								height
+								meta {
+									aperture
+									credit
+									camera
+									caption
+									createdTimestamp
+									copyright
+									focalLength
+									iso
+									shutterSpeed
+									title
+									orientation
+								}
+								width
+								sizes {
+									name
+									file
+									width
+									height
+									mimeType
+									sourceUrl
+								}
+							}
+					}
+				}
 			}
 		';
 
-		$actual = do_graphql_request( $mutation, 'createMediaItem', $this->create_variables );
-
-		return $actual;
+		return $this->graphql( [
+			'query'     => $query,
+			'variables' => $this->create_variables,
+		]);
 	}
 
 	/**
@@ -267,7 +260,7 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	public function testCreateMediaItemFilePath() {
 		wp_set_current_user( $this->admin );
 		$this->create_variables['input']['filePath'] = 'file:///Users/hdevore/Desktop/Current/colorado_lake.jpeg';
-		$actual = $this->createMediaItemMutation();
+		$actual                                      = $this->createMediaItemMutation();
 		$this->assertArrayHasKey( 'errors', $actual );
 		$this->create_variables['input']['filePath'] = $this->filePath;
 	}
@@ -285,25 +278,25 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 		/**
 		 * Set up the createMediaItem mutation
 		 */
-		$mutation = '
+		$query = '
 		mutation createMediaItem( $input: CreateMediaItemInput! ){
-		  createMediaItem(input: $input){
-		    clientMutationId
-		    mediaItem{
-		      id
-		    }
-		  }
+			createMediaItem(input: $input){
+				mediaItem{
+					id
+				}
+			}
 		}
 		';
 
-		$empty_variables = '';
-		$actual = do_graphql_request( $mutation, 'createMediaItem', $empty_variables );
+		$actual = $this->graphql([
+			'query'     => $query,
+			'variables' => '',
+		]);
 		$this->assertArrayHasKey( 'errors', $actual );
 	}
 
 	/**
-	 * Set the current user to subscriber (someone who can't create posts)
-	 * and test whether they can create posts with someone else's id
+	 * Test whether the current can create posts with someone else's id
 	 *
 	 * @source wp-content/plugins/wp-graphql/src/Type/MediaItem/MediaItemCreate.php:61
 	 * @return void
@@ -313,14 +306,19 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 		/**
 		 * Set up the createMediaItem mutation
 		 */
-		$mutation = '
+		$query = '
 		mutation createMediaItem( $input: CreateMediaItemInput! ){
-		  createMediaItem(input: $input){
-		    clientMutationId
-		    mediaItem{
-		      id
-		    }
-		  }
+			createMediaItem(input: $input){
+				mediaItem{
+					id
+					author {
+						node {
+							name
+							databaseId
+						}
+					}
+				}
+			}
 		}
 		';
 
@@ -329,26 +327,42 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 		 */
 		$variables = [
 			'input' => [
-				'filePath'         => $this->filePath,
-				'fileType'         => $this->fileType,
-				'clientMutationId' => $this->clientMutationId,
-				'title'            => $this->title,
-				'description'      => $this->description,
-				'altText'          => $this->altText,
-				'parentId'         => $this->parentId,
-				'caption'          => $this->caption,
-				'commentStatus'    => $this->commentStatus,
-				'date'             => $this->date,
-				'dateGmt'          => $this->dateGmt,
-				'slug'             => $this->slug,
-				'status'           => $this->status,
-				'authorId'         => $this->admin,
+				'filePath'      => $this->filePath,
+				'fileType'      => $this->fileType,
+				'title'         => $this->title,
+				'description'   => $this->description,
+				'altText'       => $this->altText,
+				'parentId'      => $this->parentId,
+				'caption'       => $this->caption,
+				'commentStatus' => $this->commentStatus,
+				'date'          => $this->date,
+				'dateGmt'       => $this->dateGmt,
+				'slug'          => $this->slug,
+				'status'        => $this->status,
+				'authorId'      => $this->admin,
 			],
 		];
 
 		wp_set_current_user( $this->author );
-		$actual = do_graphql_request( $mutation, 'createMediaItem', $variables );
+		$actual = graphql( compact( 'query', 'variables' ) );
 		$this->assertArrayHasKey( 'errors', $actual );
+
+		// Test with permissions
+		wp_set_current_user( $this->admin );
+
+		// test with database Id
+		$variables['input']['authorId'] = $this->author;
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEquals( $this->author, $actual['data']['createMediaItem']['mediaItem']['author']['node']['databaseId'] );
+
+		// test with global Id
+		$variables['input']['authorId'] = \GraphQLRelay\Relay::toGlobalId( 'user', $this->author );
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEquals( $this->author, $actual['data']['createMediaItem']['mediaItem']['author']['node']['databaseId'] );
 	}
 
 	/**
@@ -361,7 +375,7 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	public function testCreateMediaItemWithInvalidUrl() {
 		wp_set_current_user( $this->author );
 		$this->create_variables['input']['filePath'] = 'htt://vice.co.um/images/2016/09/16/bill-murray-has-a-couple-of-shifts-at-a-brooklyn-bar-this-weekend-body-image-1473999364.jpg?crop=1xw:1xh;center,center&resize=1440:*';
-		$actual = $this->createMediaItemMutation();
+		$actual                                      = $this->createMediaItemMutation();
 		$this->assertArrayHasKey( 'errors', $actual );
 		$this->create_variables['input']['filePath'] = $this->filePath;
 	}
@@ -376,7 +390,7 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	public function testCreateMediaItemWithNoFile() {
 		wp_set_current_user( $this->author );
 		$this->create_variables['input']['filePath'] = 'https://i-d-images.vice.com/images/2016/09/16/bill-murray-has-a-couple-of-shifts-at-a-brooklyn-bar-this-weekend-body-image-1473999364.jpg?crop=1xw:1xh;center,center&resize=1440:*';
-		$actual = $this->createMediaItemMutation();
+		$actual                                      = $this->createMediaItemMutation();
 		$this->assertArrayHasKey( 'errors', $actual );
 		$this->create_variables['input']['filePath'] = $this->filePath;
 	}
@@ -392,7 +406,7 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	public function testCreateMediaItemAttachToParentAsAuthor() {
 		$post                                        = $this->factory()->post->create( [
 			'post_author' => $this->admin,
-			'post_status' => 'publish'
+			'post_status' => 'publish',
 		] );
 		$this->create_variables['input']['parentId'] = absint( $post );
 
@@ -403,8 +417,6 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 		wp_set_current_user( $this->author );
 		$actual = $this->createMediaItemMutation();
 
-		codecept_debug( $actual );
-
 		$this->assertArrayHasKey( 'errors', $actual );
 
 	}
@@ -413,67 +425,65 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 
 		$post                                        = $this->factory()->post->create( [
 			'post_author' => $this->admin,
-			'post_status' => 'publish'
+			'post_status' => 'publish',
 		] );
 		$this->create_variables['input']['parentId'] = absint( $post );
 
 		wp_set_current_user( $this->admin );
+		// Test with databaseId
 		$actual = $this->createMediaItemMutation();
 
-		codecept_debug( $actual );
-
-		$media_item_id = $actual["data"]["createMediaItem"]["mediaItem"]["id"];
-		$attachment_id = $actual["data"]["createMediaItem"]["mediaItem"]["mediaItemId"];
-		$attachment_url = wp_get_attachment_url( $attachment_id );
+		$media_item_id      = $actual['data']['createMediaItem']['mediaItem']['id'];
+		$attachment_id      = $actual['data']['createMediaItem']['mediaItem']['databaseId'];
+		$attachment_url     = wp_get_attachment_url( $attachment_id );
 		$attachment_details = wp_get_attachment_metadata( $attachment_id );
 
 		$expected = [
 			'createMediaItem' => [
-				'clientMutationId' => $this->clientMutationId,
 				'mediaItem' => [
-					'id'               => $media_item_id,
-					'mediaItemId'      => $attachment_id,
-					'title'            => $this->title,
-					'description'      => apply_filters( 'the_content', $this->description ),
-					'altText'          => $this->altText,
-					'caption'          => apply_filters( 'the_content', $this->caption ),
-					'commentStatus'    => $this->commentStatus,
-					'date'             => $this->date,
-					'dateGmt'          => $this->dateGmt,
-					'slug'             => $this->slug,
-					'status'           => strtolower( $this->status ),
-					'mimeType'         => 'image/gif',
-					'parent'           => [
+					'id'            => $media_item_id,
+					'databaseId'    => $attachment_id,
+					'title'         => $this->title,
+					'description'   => apply_filters( 'the_content', $this->description ),
+					'altText'       => $this->altText,
+					'caption'       => apply_filters( 'the_content', $this->caption ),
+					'commentStatus' => $this->commentStatus,
+					'date'          => $this->date,
+					'dateGmt'       => $this->dateGmt,
+					'slug'          => $this->slug,
+					'status'        => strtolower( $this->status ),
+					'mimeType'      => 'image/gif',
+					'parent'        => [
 						'node' => [
 							'id' => \GraphQLRelay\Relay::toGlobalId( 'post', $post ),
 						],
 					],
-					'mediaType'        => 'image',
-					'sourceUrl'        => $attachment_url,
-					'mediaDetails'     => [
+					'mediaType'     => 'image',
+					'sourceUrl'     => $attachment_url,
+					'mediaDetails'  => [
 						'file'   => $attachment_details['file'],
 						'height' => $attachment_details['height'],
 						'meta'   => [
-							'aperture' => 0.0,
-							'credit'   => '',
-							'camera'   => '',
-							'caption'  => '',
+							'aperture'         => 0.0,
+							'credit'           => '',
+							'camera'           => '',
+							'caption'          => '',
 							'createdTimestamp' => null,
-							'copyright' => '',
-							'focalLength' => null,
-							'iso' => 0,
-							'shutterSpeed' => null,
-							'title' => '',
-							'orientation' => '0',
+							'copyright'        => '',
+							'focalLength'      => null,
+							'iso'              => 0,
+							'shutterSpeed'     => null,
+							'title'            => '',
+							'orientation'      => '0',
 						],
-						'width' => $attachment_details['width'],
-						'sizes' => [
+						'width'  => $attachment_details['width'],
+						'sizes'  => [
 							0 => [
-								'name' => 'thumbnail',
-								'file' => $attachment_details['sizes']['thumbnail']['file'],
-								'width' => (int) $attachment_details['sizes']['thumbnail']['width'],
-								'height' => (int) $attachment_details['sizes']['thumbnail']['height'],
-								'mimeType' => $attachment_details['sizes']['thumbnail']['mime-type'],
+								'name'      => 'thumbnail',
+								'file'      => $attachment_details['sizes']['thumbnail']['file'],
+								'width'     => (int) $attachment_details['sizes']['thumbnail']['width'],
+								'height'    => (int) $attachment_details['sizes']['thumbnail']['height'],
+								'mimeType'  => $attachment_details['sizes']['thumbnail']['mime-type'],
 								'sourceUrl' => wp_get_attachment_image_src( $attachment_id, 'thumbnail' )[0],
 							],
 						],
@@ -483,8 +493,14 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 		];
 
 		$this->assertEquals( $expected, $actual['data'] );
-		$this->create_variables['input']['parentId'] = $this->parentId;
 
+		// Test with globalId
+		$this->create_variables['input']['parentId'] = \GraphQLRelay\Relay::toGlobalId( 'post', $this->parentId );
+
+		$actual = $this->createMediaItemMutation();
+		$this->assertArrayNotHasKey( 'errors', $actual );
+
+		$this->create_variables['input']['parentId'] = $this->parentId;
 	}
 
 	/**
@@ -501,15 +517,14 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 		] );
 		wp_set_current_user( $this->author );
 		$this->create_variables['input']['parentId'] = $post;
-		$actual = $this->createMediaItemMutation();
+		$actual                                      = $this->createMediaItemMutation();
 		$this->assertArrayHasKey( 'errors', $actual );
 		$this->create_variables['input']['parentId'] = $this->parentId;
 	}
 
 	/**
-	 * Test the MediaItemMutation by setting the default values:
+	 * Test the MediaItemMutation by setting the default values: post_status
 	 *
-	 * post_status
 	 * @source wp-content/plugins/wp-graphql/src/Type/MediaItem/Mutation/MediaItemMutation.php:136
 	 *
 	 * post_title
@@ -536,124 +551,122 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 		/**
 		 * Set up the createMediaItem mutation
 		 */
-		$default_mutation = '
+		$query = '
 		mutation createMediaItem( $input: CreateMediaItemInput! ){
-		  createMediaItem(input: $input){
-		    clientMutationId
-		    mediaItem{
-		      id
-		      mediaItemId
-		      status
-		      title
-		      author {
-		        node {
-		          id
-		        }
-		      }
-		      description
-		      mimeType
-		      parent {
-		        node {
-  		          ... on Post {
-  		            id
-		          }
-		        }
-		      }
-		      sourceUrl
-		      mediaDetails {
-	            file
-	            height
-	            meta {
-	              aperture
-	              credit
-	              camera
-	              caption
-	              createdTimestamp
-	              copyright
-	              focalLength
-	              iso
-	              shutterSpeed
-	              title
-	              orientation
-	            }
-	            width
-	            sizes {
-	              name
-	              file
-	              width
-	              height
-	              mimeType
-	              sourceUrl
-	            }
-	          }
-		    }
-		  }
+			createMediaItem(input: $input){
+				mediaItem{
+					id
+					databaseId
+					status
+					title
+					author {
+						node {
+							id
+						}
+					}
+					description
+					mimeType
+					parent {
+						node {
+								... on Post {
+									id
+							}
+						}
+					}
+					sourceUrl
+					mediaDetails {
+							file
+							height
+							meta {
+								aperture
+								credit
+								camera
+								caption
+								createdTimestamp
+								copyright
+								focalLength
+								iso
+								shutterSpeed
+								title
+								orientation
+							}
+							width
+							sizes {
+								name
+								file
+								width
+								height
+								mimeType
+								sourceUrl
+							}
+						}
+				}
+			}
 		}
 		';
 
 		/**
 		 * Set new input variables without changing defaults
 		 */
-		$default_variables = [
+		$variables = [
 			'input' => [
-				'filePath'         => $this->filePath,
-				'clientMutationId' => $this->clientMutationId,
+				'filePath' => $this->filePath,
 			],
 		];
 
 		/**
 		 * Do the graphQL request using the above variables for input in the above mutation
 		 */
-		$actual = do_graphql_request( $default_mutation, 'createMediaItem', $default_variables );
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+		$this->assertArrayNotHasKey( 'errors', $actual );
 
-		$media_item_id = $actual["data"]["createMediaItem"]["mediaItem"]["id"];
-		$attachment_id = $actual["data"]["createMediaItem"]["mediaItem"]["mediaItemId"];
-		$attachment_data = get_post( $attachment_id );
-		$attachment_title = $attachment_data->post_title;
-		$attachment_url = wp_get_attachment_url( $attachment_id );
+		$media_item_id      = $actual['data']['createMediaItem']['mediaItem']['id'];
+		$attachment_id      = $actual['data']['createMediaItem']['mediaItem']['databaseId'];
+		$attachment_data    = get_post( $attachment_id );
+		$attachment_title   = $attachment_data->post_title;
+		$attachment_url     = wp_get_attachment_url( $attachment_id );
 		$attachment_details = wp_get_attachment_metadata( $attachment_id );
 
 		$expected = [
 			'createMediaItem' => [
-				'clientMutationId' => $this->clientMutationId,
 				'mediaItem' => [
-					'id'               => $media_item_id,
-					'mediaItemId'      => $attachment_id,
-					'status'           => strtolower( $this->status ),
-					'title'            => $attachment_title,
-					'description'      => '',
-					'mimeType'         => 'image/gif',
-					'author'           => [
+					'id'           => $media_item_id,
+					'databaseId'   => $attachment_id,
+					'status'       => strtolower( $this->status ),
+					'title'        => $attachment_title,
+					'description'  => '',
+					'mimeType'     => 'image/gif',
+					'author'       => [
 						'node' => [
 							'id' => \GraphQLRelay\Relay::toGlobalId( 'user', $this->admin ),
 						],
 					],
-					'parent'           => null,
-					'sourceUrl'        => $attachment_url,
-					'mediaDetails'     => [
+					'parent'       => null,
+					'sourceUrl'    => $attachment_url,
+					'mediaDetails' => [
 						'file'   => $attachment_details['file'],
 						'height' => $attachment_details['height'],
 						'meta'   => [
-							'aperture' => 0.0,
-							'credit'   => '',
-							'camera'   => '',
-							'caption'  => '',
+							'aperture'         => 0.0,
+							'credit'           => '',
+							'camera'           => '',
+							'caption'          => '',
 							'createdTimestamp' => null,
-							'copyright' => '',
-							'focalLength' => null,
-							'iso' => 0,
-							'shutterSpeed' => null,
-							'title' => '',
-							'orientation' => '0',
+							'copyright'        => '',
+							'focalLength'      => null,
+							'iso'              => 0,
+							'shutterSpeed'     => null,
+							'title'            => '',
+							'orientation'      => '0',
 						],
-						'width' => $attachment_details['width'],
-						'sizes' => [
+						'width'  => $attachment_details['width'],
+						'sizes'  => [
 							0 => [
-								'name' => 'thumbnail',
-								'file' => $attachment_details['sizes']['thumbnail']['file'],
-								'width' => (int) $attachment_details['sizes']['thumbnail']['width'],
-								'height' => (int) $attachment_details['sizes']['thumbnail']['height'],
-								'mimeType' => $attachment_details['sizes']['thumbnail']['mime-type'],
+								'name'      => 'thumbnail',
+								'file'      => $attachment_details['sizes']['thumbnail']['file'],
+								'width'     => (int) $attachment_details['sizes']['thumbnail']['width'],
+								'height'    => (int) $attachment_details['sizes']['thumbnail']['height'],
+								'mimeType'  => $attachment_details['sizes']['thumbnail']['mime-type'],
 								'sourceUrl' => wp_get_attachment_image_src( $attachment_id, 'thumbnail' )[0],
 							],
 						],
@@ -685,54 +698,53 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 		 */
 		$actual = $this->createMediaItemMutation();
 
-		$media_item_id = $actual["data"]["createMediaItem"]["mediaItem"]["id"];
-		$attachment_id = $actual["data"]["createMediaItem"]["mediaItem"]["mediaItemId"];
-		$attachment_url = wp_get_attachment_url( $attachment_id );
+		$media_item_id      = $actual['data']['createMediaItem']['mediaItem']['id'];
+		$attachment_id      = $actual['data']['createMediaItem']['mediaItem']['databaseId'];
+		$attachment_url     = wp_get_attachment_url( $attachment_id );
 		$attachment_details = wp_get_attachment_metadata( $attachment_id );
 
 		$expected = [
 			'createMediaItem' => [
-				'clientMutationId' => $this->clientMutationId,
 				'mediaItem' => [
-					'id'               => $media_item_id,
-					'mediaItemId'      => $attachment_id,
-					'title'            => $this->title,
-					'description'      => apply_filters( 'the_content', $this->description ),
-					'altText'          => $this->altText,
-					'caption'          => apply_filters( 'the_content', $this->caption ),
-					'commentStatus'    => $this->commentStatus,
-					'date'             => $this->date,
-					'dateGmt'          => $this->dateGmt,
-					'slug'             => $this->slug,
-					'status'           => strtolower( $this->status ),
-					'mimeType'         => 'image/gif',
-					'parent'           => null,
-					'mediaType'        => 'image',
-					'sourceUrl'        => $attachment_url,
-					'mediaDetails'     => [
+					'id'            => $media_item_id,
+					'databaseId'    => $attachment_id,
+					'title'         => $this->title,
+					'description'   => apply_filters( 'the_content', $this->description ),
+					'altText'       => $this->altText,
+					'caption'       => apply_filters( 'the_content', $this->caption ),
+					'commentStatus' => $this->commentStatus,
+					'date'          => $this->date,
+					'dateGmt'       => $this->dateGmt,
+					'slug'          => $this->slug,
+					'status'        => strtolower( $this->status ),
+					'mimeType'      => 'image/gif',
+					'parent'        => null,
+					'mediaType'     => 'image',
+					'sourceUrl'     => $attachment_url,
+					'mediaDetails'  => [
 						'file'   => $attachment_details['file'],
 						'height' => $attachment_details['height'],
 						'meta'   => [
-							'aperture' => 0.0,
-							'credit'   => '',
-							'camera'   => '',
-							'caption'  => '',
+							'aperture'         => 0.0,
+							'credit'           => '',
+							'camera'           => '',
+							'caption'          => '',
 							'createdTimestamp' => null,
-							'copyright' => '',
-							'focalLength' => null,
-							'iso' => 0,
-							'shutterSpeed' => null,
-							'title' => '',
-							'orientation' => '0',
+							'copyright'        => '',
+							'focalLength'      => null,
+							'iso'              => 0,
+							'shutterSpeed'     => null,
+							'title'            => '',
+							'orientation'      => '0',
 						],
-						'width' => $attachment_details['width'],
-						'sizes' => [
+						'width'  => $attachment_details['width'],
+						'sizes'  => [
 							0 => [
-								'name' => 'thumbnail',
-								'file' => $attachment_details['sizes']['thumbnail']['file'],
-								'width' => (int) $attachment_details['sizes']['thumbnail']['width'],
-								'height' => (int) $attachment_details['sizes']['thumbnail']['height'],
-								'mimeType' => $attachment_details['sizes']['thumbnail']['mime-type'],
+								'name'      => 'thumbnail',
+								'file'      => $attachment_details['sizes']['thumbnail']['file'],
+								'width'     => (int) $attachment_details['sizes']['thumbnail']['width'],
+								'height'    => (int) $attachment_details['sizes']['thumbnail']['height'],
+								'mimeType'  => $attachment_details['sizes']['thumbnail']['mime-type'],
 								'sourceUrl' => wp_get_attachment_image_src( $attachment_id, 'thumbnail' )[0],
 							],
 						],
@@ -742,7 +754,6 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 		];
 
 		$this->assertEquals( $expected, $actual['data'] );
-
 	}
 
 	/**
@@ -756,36 +767,36 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 		/**
 		 * Prepare the updateMediaItem mutation
 		 */
-		$mutation = '
+		$query = '
 		mutation updateMediaItem( $input: UpdateMediaItemInput! ){
-		  updateMediaItem (input: $input){
-		    clientMutationId
-		    mediaItem {
-		      id
-		      mediaItemId
-		      date
-		      dateGmt
-		      slug
-		      status
-		      title
-		      commentStatus
-		      altText
-		      caption
-		      description
-		      mimeType
-		      author {
-		        node {
-		          id
-		        }
-		      }
-		    }
-		  }
+			updateMediaItem (input: $input){
+				mediaItem {
+					id
+					databaseId
+					date
+					dateGmt
+					slug
+					status
+					title
+					commentStatus
+					altText
+					caption
+					description
+					mimeType
+					author {
+						node {
+							databaseId
+						}
+					}
+				}
+			}
 		}
 		';
 
-		$actual = do_graphql_request( $mutation, 'updateMediaItem', $this->update_variables );
-
-		return $actual;
+		return $this->graphql([
+			'query'     => $query,
+			'variables' => $this->update_variables,
+		]);
 	}
 
 	/**
@@ -798,7 +809,7 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testUpdateMediaItemInvalidId() {
 		$this->update_variables['input']['id'] = \GraphQLRelay\Relay::toGlobalId( 'post', 123456 );
-		$actual = $this->updateMediaItemMutation();
+		$actual                                = $this->updateMediaItemMutation();
 		$this->assertArrayHasKey( 'errors', $actual );
 		$this->update_variables['input']['id'] = $this->media_item_id;
 	}
@@ -810,9 +821,9 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	 * @return void
 	 */
 	public function testUpdateMediaItemUpdatePost() {
-		$test_post = $this->factory()->post->create();
+		$test_post                             = $this->factory()->post->create();
 		$this->update_variables['input']['id'] = \GraphQLRelay\Relay::toGlobalId( 'post', $test_post );
-		$actual = $this->updateMediaItemMutation();
+		$actual                                = $this->updateMediaItemMutation();
 		$this->assertArrayHasKey( 'errors', $actual );
 		$this->update_variables['input']['id'] = $this->media_item_id;
 	}
@@ -844,7 +855,7 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 		] );
 		wp_set_current_user( $this->author );
 		$this->update_variables['input']['parentId'] = $post;
-		$actual = $this->updateMediaItemMutation();
+		$actual                                      = $this->updateMediaItemMutation();
 		$this->assertArrayHasKey( 'errors', $actual );
 		$this->update_variables['input']['parentId'] = $this->parentId;
 	}
@@ -859,8 +870,8 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testUpdateMediaItemAddOtherAuthorsAsAuthor() {
 		wp_set_current_user( $this->author );
-		$this->update_variables['input']['authorId'] = \GraphQLRelay\Relay::toGlobalId( 'user', $this->admin );
-		$actual = $this->updateMediaItemMutation();
+		$this->update_variables['input']['authorId'] = $this->admin;
+		$actual                                      = $this->updateMediaItemMutation();
 		$this->assertArrayHasKey( 'errors', $actual );
 		$this->update_variables['input']['authorId'] = false;
 	}
@@ -874,12 +885,20 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testUpdateMediaItemAddOtherAuthorsAsAdmin() {
 		wp_set_current_user( $this->admin );
-		$this->update_variables['input']['authorId'] = \GraphQLRelay\Relay::toGlobalId( 'user', $this->author );
-		$actual = $this->updateMediaItemMutation();
 
-		$actual_created = $actual['data']['updateMediaItem']['mediaItem'];
-		$this->assertArrayHasKey( 'id', $actual_created );
-		$update_variables['input']['authorId'] = false;
+		// Test as databaseId
+		$this->update_variables['input']['authorId'] = $this->author;
+		$actual                                      = $this->updateMediaItemMutation();
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEquals( $this->author, $actual['data']['updateMediaItem']['mediaItem']['author']['node']['databaseId'] );
+
+		// Test as global Id
+		$this->update_variables['input']['authorId'] = \GraphQLRelay\Relay::toGlobalId( 'user', $this->author );
+		$actual                                      = $this->updateMediaItemMutation();
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEquals( $this->author, $actual['data']['updateMediaItem']['mediaItem']['author']['node']['databaseId'] );
 	}
 
 	/**
@@ -898,29 +917,27 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 
 		$actual = $this->updateMediaItemMutation();
 
-
 		/**
 		 * Define the expected output.
 		 */
 		$expected = [
 			'updateMediaItem' => [
-				'clientMutationId' => $this->updated_clientMutationId,
-				'mediaItem'             => [
-					'id'               => $this->media_item_id,
-					'title'            => $this->updated_title,
-					'description'      => apply_filters( 'the_content', $this->updated_description ),
-					'mediaItemId'      => $this->attachment_id,
-					'altText'          => $this->updated_altText,
-					'caption'          => apply_filters( 'the_content', $this->updated_caption ),
-					'commentStatus'    => $this->updated_commentStatus,
-					'date'             => $this->updated_date,
-					'dateGmt'          => $this->updated_dateGmt,
-					'slug'             => $this->updated_slug,
-					'status'           => strtolower( $this->updated_status ),
-					'mimeType'         => 'image/gif',
-					'author'           => [
+				'mediaItem' => [
+					'id'            => $this->media_item_id,
+					'title'         => $this->updated_title,
+					'description'   => apply_filters( 'the_content', $this->updated_description ),
+					'databaseId'    => $this->attachment_id,
+					'altText'       => $this->updated_altText,
+					'caption'       => apply_filters( 'the_content', $this->updated_caption ),
+					'commentStatus' => $this->updated_commentStatus,
+					'date'          => $this->updated_date,
+					'dateGmt'       => $this->updated_dateGmt,
+					'slug'          => $this->updated_slug,
+					'status'        => strtolower( $this->updated_status ),
+					'mimeType'      => 'image/gif',
+					'author'        => [
 						'node' => [
-							'id'       => \GraphQLRelay\Relay::toGlobalId( 'user', $this->admin ),
+							'databaseId' => $this->admin,
 						],
 					],
 				],
@@ -949,20 +966,20 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 		 */
 		$mutation = '
 		mutation deleteMediaItem( $input: DeleteMediaItemInput! ){
-		  deleteMediaItem(input: $input) {
-		    clientMutationId
-		    deletedId
-		    mediaItem{
-		      id
-		      mediaItemId
-		    }
-		  }
+			deleteMediaItem(input: $input) {
+				deletedId
+				mediaItem{
+					id
+					databaseId
+				}
+			}
 		}
 		';
 
-		$actual = do_graphql_request( $mutation, 'deleteMediaItem', $this->delete_variables );
-
-		return $actual;
+		return $this->graphql( [
+			'query'     => $mutation,
+			'variables' => $this->delete_variables,
+		]);
 	}
 
 	/**
@@ -973,7 +990,7 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testDeleteMediaItemInvalidId() {
 		$this->delete_variables['input']['id'] = 12345;
-		$actual = $this->deleteMediaItemMutation();
+		$actual                                = $this->deleteMediaItemMutation();
 		$this->assertArrayHasKey( 'errors', $actual );
 		$this->delete_variables['input']['id'] = $this->media_item_id;
 	}
@@ -1007,14 +1024,13 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 		 */
 		$mutation = '
 		mutation deleteMediaItem( $input: DeleteMediaItemInput! ){
-		  deleteMediaItem(input: $input) {
-		    clientMutationId
-		    deletedId
-		    mediaItem {
-		      id
-		      mediaItemId
-		    }
-		  }
+			deleteMediaItem(input: $input) {
+				deletedId
+				mediaItem {
+					id
+					databaseId
+				}
+			}
 		}
 		';
 
@@ -1023,15 +1039,13 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 		 */
 		$delete_trash_variables = [
 			'input' => [
-				'id'               => \GraphQLRelay\Relay::toGlobalId( 'post', $deleted_media_item ),
-				'clientMutationId' => $this->clientMutationId,
-				'forceDelete'      => false,
-			]
+				'id'          => \GraphQLRelay\Relay::toGlobalId( 'post', $deleted_media_item ),
+				'forceDelete' => false,
+			],
 		];
 
 		wp_set_current_user( $this->admin );
 		$actual = do_graphql_request( $mutation, 'deleteMediaItem', $delete_trash_variables );
-
 
 		$this->assertArrayHasKey( 'errors', $actual );
 	}
@@ -1045,21 +1059,19 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 	public function testForceDeleteMediaItemAlreadyInTrash() {
 
 		$deleted_media_item = $this->factory()->attachment->create( [ 'post_status' => 'trash' ] );
-		$post               = get_post( $deleted_media_item );
 
 		/**
 		 * Prepare the deleteMediaItem mutation
 		 */
 		$mutation = '
 		mutation deleteMediaItem( $input: DeleteMediaItemInput! ){
-		  deleteMediaItem(input: $input) {
-		    clientMutationId
-		    deletedId
-		    mediaItem {
-		      id
-		      mediaItemId
-		    }
-		  }
+			deleteMediaItem(input: $input) {
+				deletedId
+				mediaItem {
+					id
+					databaseId
+				}
+			}
 		}
 		';
 
@@ -1068,16 +1080,15 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 		 */
 		$delete_trash_variables = [
 			'input' => [
-				'id'               => \GraphQLRelay\Relay::toGlobalId( 'post', $deleted_media_item ),
-				'clientMutationId' => $this->clientMutationId,
-				'forceDelete'      => false,
-			]
+				'id'          => \GraphQLRelay\Relay::toGlobalId( 'post', $deleted_media_item ),
+				'forceDelete' => false,
+			],
 		];
 
 		wp_set_current_user( $this->admin );
 
 		$delete_trash_variables['input']['forceDelete'] = true;
-		$actual = do_graphql_request( $mutation, 'deleteMediaItem', $delete_trash_variables );
+		$actual              = do_graphql_request( $mutation, 'deleteMediaItem', $delete_trash_variables );
 		$actual_deleted_item = $actual['data']['deleteMediaItem'];
 		$this->assertArrayHasKey( 'deletedId', $actual_deleted_item );
 
@@ -1110,7 +1121,7 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 		/**
 		 * Create a page to test against and set the post id in the mutation variables
 		 */
-		$post_to_delete = $this->factory->post->create( $args );
+		$post_to_delete                        = $this->factory->post->create( $args );
 		$this->delete_variables['input']['id'] = \GraphQLRelay\Relay::toGlobalId( 'post', $post_to_delete );
 
 		/**
@@ -1145,11 +1156,10 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 		 */
 		$expected = [
 			'deleteMediaItem' => [
-				'clientMutationId' => $this->clientMutationId,
 				'deletedId' => $this->media_item_id,
 				'mediaItem' => [
-					'id'               => $this->media_item_id,
-					'mediaItemId'      => $this->attachment_id,
+					'id'         => $this->media_item_id,
+					'databaseId' => $this->attachment_id,
 				],
 			],
 		];
@@ -1157,7 +1167,7 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 		/**
 		 * Compare the actual output vs the expected output
 		 */
-		$this->assertEquals( $expected,  $actual['data'] );
+		$this->assertEquals( $expected, $actual['data'] );
 
 		/**
 		 * Try to delete again but we should have errors, because there's nothing to be deleted
@@ -1165,27 +1175,34 @@ class MediaItemMutationsTest extends \Codeception\TestCase\WPTestCase
 		$actual = $this->deleteMediaItemMutation();
 		$this->assertArrayHasKey( 'errors', $actual );
 
+		// test global Id
+		$deleted_media_item                    = $this->factory()->attachment->create();
+		$this->delete_variables['input']['id'] = \GraphQLRelay\Relay::toGlobalId( 'post', $deleted_media_item );
+
+		$actual = $this->deleteMediaItemMutation();
+		$this->assertArrayNotHasKey( 'error', $actual );
+		$this->assertEquals( $deleted_media_item, $actual['data']['deleteMediaItem']['mediaItem']['databaseId'] );
+
+		$this->delete_variables['input']['id'] = $this->media_item_id;
 	}
 
 	public function testUpdateMediaItemOwnedByUserUpdatingIt() {
 
 		$media_item_1 = $this->factory()->attachment->create( [
 			'post_mime_type' => 'image/gif',
-			'post_author' => $this->author
+			'post_author'    => $this->author,
 		] );
 
 		wp_set_current_user( $this->author );
 
 		$this->update_variables = [
 			'input' => [
-				'id' => \GraphQLRelay\Relay::toGlobalId( 'post', $media_item_1 ),
-				'title' => 'Test update title...'
-			]
+				'id'    => \GraphQLRelay\Relay::toGlobalId( 'post', $media_item_1 ),
+				'title' => 'Test update title...',
+			],
 		];
 
-		$actual =  $this->updateMediaItemMutation();
-
-//		codecept_debug( $actual );
+		$actual = $this->updateMediaItemMutation();
 
 		$this->assertArrayNotHasKey( 'errors', $actual );
 

--- a/tests/wpunit/MenuItemQueriesTest.php
+++ b/tests/wpunit/MenuItemQueriesTest.php
@@ -2,121 +2,184 @@
 
 use GraphQLRelay\Relay;
 
-class MenuItemQueriesTest extends \Codeception\TestCase\WPTestCase {
+class MenuItemQueriesTest extends  \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 	public $admin;
+	public $location_name;
+	public $menu_id;
+	public $menu_slug;
+
 
 	public function setUp(): void {
 		parent::setUp();
 		$this->admin = $this->factory()->user->create([
-			'role' => 'administrator'
+			'role' => 'administrator',
 		]);
-		WPGraphQL::clear_schema();}
+
+		add_theme_support( 'nav_menus' );
+
+		$this->location_name = 'test-location';
+		register_nav_menu( $this->location_name, 'test menu...' );
+
+		$this->menu_slug = 'my-test-menu';
+		$this->menu_id   = wp_create_nav_menu( $this->menu_slug );
+
+		set_theme_mod( 'nav_menu_locations', [ $this->location_name => $this->menu_id ] );
+
+		WPGraphQL::clear_schema();
+	}
 
 	public function tearDown(): void {
+		remove_theme_support( 'nav_menus' );
+		wp_delete_nav_menu( $this->menu_id );
+		unregister_nav_menu( $this->location_name );
+
 		WPGraphQL::clear_schema();
 		parent::tearDown();
 	}
 
-	public function testMenuItemQuery() {
+	public function testMenuItemQueryWithPostObject() {
+		$post_id   = $this->factory()->post->create();
+		$permalink = get_permalink( $post_id );
 
-		add_theme_support( 'nav_menus' );
-		$location_name = 'test-location';
-		register_nav_menu( $location_name, 'test menu...' );
+		$menu_args = [
+			'menu-item-attr-title'  => 'Menu item',
+			'menu-item-classes'     => 'my-class my-other-class',
+			'menu-item-description' => 'Some description',
+			'menu-item-object-id'   => $post_id,
+			'menu-item-object'      => 'post',
+			'menu-item-position'    => 1,
+			'menu-item-status'      => 'publish',
+			'menu-item-title'       => 'Menu item',
+			'menu-item-type'        => 'post_type',
+			'menu-item-target'      => '_blank',
+		];
 
-		$menu_slug = 'my-test-menu';
-		$menu_id = wp_create_nav_menu( $menu_slug );
-		$post_id = $this->factory()->post->create();
-
-		$menu_item_id = wp_update_nav_menu_item(
-			$menu_id,
-			0,
-			[
-				'menu-item-title'     => 'Menu item',
-				'menu-item-object'    => 'post',
-				'menu-item-object-id' => $post_id,
-				'menu-item-status'    => 'publish',
-				'menu-item-type'      => 'post_type',
-			]
-		);
-
-		set_theme_mod( 'nav_menu_locations', [ $location_name => $menu_id ] );
-
-		codecept_debug( get_theme_mod( 'nav_menu_locations' ) );
+		$menu_item_id = wp_update_nav_menu_item( $this->menu_id, 0, $menu_args );
 
 		$menu_item_relay_id = Relay::toGlobalId( 'post', $menu_item_id );
 
-		$query = '
-		{
-			menuItem( id: "' . $menu_item_relay_id . '" ) {
-				id
-				databaseId
-				connectedObject {
-					... on Post {
-						id
-						postId
-					}
-				}
-				locations
-				menu {
-				  node {
-				    slug
-				    locations
-				  }
-				}
-			}
-		}
-		';
+		codecept_debug( get_theme_mod( 'nav_menu_locations' ) );
 
-		$actual = do_graphql_request( $query );
+		// test with database ID.
+		$query = $this->get_query();
 
+		$variables = [
+			'id'     => $menu_item_id,
+			'idType' => 'DATABASE_ID',
+		];
 
-		codecept_debug( $actual );
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertEquals( explode( ' ', $menu_args['menu-item-classes'] ), $actual['data']['menuItem']['cssClasses'] );
+		$this->assertEquals( $post_id, $actual['data']['menuItem']['connectedNode']['node']['databaseId'] );
+		$this->assertEquals( $menu_item_id, $actual['data']['menuItem']['databaseId'] );
+		$this->assertEquals( $menu_args['menu-item-description'], $actual['data']['menuItem']['description'] );
+		$this->assertEquals( $menu_item_relay_id, $actual['data']['menuItem']['id'] );
+		$this->assertEquals( $menu_args['menu-item-title'], $actual['data']['menuItem']['label'] );
+		$this->assertEquals( [ \WPGraphQL\Type\WPEnumType::get_safe_name( $this->location_name ) ], $actual['data']['menuItem']['locations'] );
+		$this->assertEquals( [ \WPGraphQL\Type\WPEnumType::get_safe_name( $this->location_name ) ], $actual['data']['menuItem']['menu']['node']['locations'] );
+		$this->assertEquals( $this->menu_slug, $actual['data']['menuItem']['menu']['node']['slug'] );
+		$this->assertEquals( $menu_args['menu-item-position'], $actual['data']['menuItem']['order'] );
+		$this->assertEquals( $menu_args['menu-item-target'], $actual['data']['menuItem']['target'] );
+		$this->assertEquals( $menu_args['menu-item-attr-title'], $actual['data']['menuItem']['title'] );
+		$this->assertEquals( str_ireplace( home_url(), '', $permalink ), $actual['data']['menuItem']['uri'] );
+		$this->assertEquals( $permalink, $actual['data']['menuItem']['url'] );
+
+		// Test with relay Id.
+		$variables = [
+			'id'     => $menu_item_relay_id,
+			'idType' => 'ID',
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
 		$this->assertEquals( $menu_item_id, $actual['data']['menuItem']['databaseId'] );
 		$this->assertEquals( $menu_item_relay_id, $actual['data']['menuItem']['id'] );
-		$this->assertEquals( $post_id, $actual['data']['menuItem']['connectedObject']['postId'] );
-		$this->assertEquals( $menu_slug, $actual['data']['menuItem']['menu']['node']['slug'] );
-		$this->assertEquals( [ \WPGraphQL\Type\WPEnumType::get_safe_name( $location_name ) ], $actual['data']['menuItem']['locations'] );
-		$this->assertEquals( [ \WPGraphQL\Type\WPEnumType::get_safe_name( $location_name ) ], $actual['data']['menuItem']['menu']['node']['locations'] );
+	}
 
-		$old_id = Relay::toGlobalId( 'nav_menu_itemci', $menu_item_id );
+	public function testCustomMenuItemWithChildren() {
+		$parent_args = [
+			'menu-item-title'     => 'Parent Item',
+			'menu-item-parent-id' => 0,
+			'menu-item-url'       => 'http://example.com/',
+			'menu-item-status'    => 'publish',
+			'menu-item-type'      => 'custom',
+		];
 
-		$query = '
-		{
-			menuItem( id: "' . $old_id . '" ) {
-				id
-				databaseId
-				connectedObject {
-					... on Post {
-						id
-						postId
+		$parent_database_id = wp_update_nav_menu_item( $this->menu_id, 0, $parent_args );
+
+		$child_args = [
+			'menu-item-title'     => 'Child Item',
+			'menu-item-parent-id' => $parent_database_id,
+			'menu-item-url'       => 'http://example.com/child',
+			'menu-item-status'    => 'publish',
+			'menu-item-type'      => 'custom',
+		];
+
+		$child_database_id = wp_update_nav_menu_item( $this->menu_id, 0, $child_args );
+
+		$query = $this->get_query();
+
+		$variables = [
+			'id'     => $parent_database_id,
+			'idType' => 'DATABASE_ID',
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+		$this->assertEquals( $parent_database_id, $actual['data']['menuItem']['databaseId'] );
+
+		// When external, these are all the same.
+		$this->assertEquals( $parent_args['menu-item-url'], $actual['data']['menuItem']['path'] );
+		$this->assertEquals( $parent_args['menu-item-url'], $actual['data']['menuItem']['uri'] );
+		$this->assertEquals( $parent_args['menu-item-url'], $actual['data']['menuItem']['url'] );
+
+		$this->assertEquals( $parent_database_id, $actual['data']['menuItem']['childItems']['nodes'][0]['parentDatabaseId'] );
+		$this->assertEquals( $child_database_id, $actual['data']['menuItem']['childItems']['nodes'][0]['databaseId'] );
+	}
+
+	public function get_query() {
+		return '
+			query menuItem( $id: ID!, $idType: MenuItemNodeIdTypeEnum) {
+				menuItem( id: $id, idType: $idType ) {
+					childItems {
+						nodes {
+							databaseId
+							parentDatabaseId
+						}
 					}
-				}
-				locations
-				menu {
-				  node {
-				    slug
-				    locations
-				  }
+					connectedNode {
+						node {
+							... on Post {
+								id
+								databaseId
+							}
+						}
+					}
+					cssClasses
+					databaseId
+					description
+					id
+					label
+					linkRelationship
+					locations
+					menu {
+						node {
+							locations
+							slug
+						}
+					}
+					order
+					parentDatabaseId
+					parentId
+					path
+					target
+					title
+					uri
+					url
 				}
 			}
-		}
 		';
-
-		$actual = do_graphql_request( $query );
-
-
-		codecept_debug( $actual );
-
-		$this->assertEquals( $menu_item_id, $actual['data']['menuItem']['databaseId'] );
-		$this->assertEquals( $menu_item_relay_id, $actual['data']['menuItem']['id'] );
-		$this->assertEquals( $post_id, $actual['data']['menuItem']['connectedObject']['postId'] );
-		$this->assertEquals( $menu_slug, $actual['data']['menuItem']['menu']['node']['slug'] );
-		$this->assertEquals( [ \WPGraphQL\Type\WPEnumType::get_safe_name( $location_name ) ], $actual['data']['menuItem']['locations'] );
-		$this->assertEquals( [ \WPGraphQL\Type\WPEnumType::get_safe_name( $location_name ) ], $actual['data']['menuItem']['menu']['node']['locations'] );
-
-
 	}
 
 }

--- a/tests/wpunit/NodesTest.php
+++ b/tests/wpunit/NodesTest.php
@@ -11,6 +11,10 @@ class NodesTest extends \Codeception\TestCase\WPTestCase {
 		$this->admin = $this->factory()->user->create( [
 			'role' => 'administrator'
 		] );
+
+		if ( is_multisite() ) {
+			grant_super_admin( $this->admin );
+		}
 	}
 
 	public function tearDown(): void {
@@ -239,7 +243,9 @@ class NodesTest extends \Codeception\TestCase\WPTestCase {
 		}";
 
 		wp_set_current_user( $this->admin );
-		$actual = do_graphql_request( $query );
+		$actual = graphql([ 'query' => $query ] );
+
+		codecept_debug( $actual );
 
 		$expected = [
 			'node' => [

--- a/tests/wpunit/PluginConnectionQueriesTest.php
+++ b/tests/wpunit/PluginConnectionQueriesTest.php
@@ -16,6 +16,9 @@ class PluginConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTes
 		$this->admin            = $this->factory()->user->create( [
 			'role' => 'administrator',
 		] );
+		if ( is_multisite() ) {
+			grant_super_admin( $this->admin );
+		}
 
 	}
 
@@ -53,6 +56,9 @@ class PluginConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTes
 		}
 		';
 
+		if ( is_multisite() ) {
+			grant_super_admin( $this->admin );
+		}
 		wp_set_current_user( $this->admin );
 		$actual = $this->graphql( [ 'query' => $query ] );
 
@@ -183,6 +189,9 @@ class PluginConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTes
 		];
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		codecept_debug( $actual );
+
 		$this->assertIsValidQueryResponse( $actual );
 
 		$actual_plugins = array_column( $actual['data']['plugins']['nodes'], 'name' );

--- a/tests/wpunit/PluginObjectQueriesTest.php
+++ b/tests/wpunit/PluginObjectQueriesTest.php
@@ -10,6 +10,9 @@ class PluginObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$this->admin = $this->factory()->user->create( [
 			'role' => 'administrator',
 		] );
+		if ( is_multisite() ) {
+			grant_super_admin( $this->admin );
+		}
 	}
 
 	public function tearDown(): void {

--- a/tests/wpunit/PostObjectMutationsTest.php
+++ b/tests/wpunit/PostObjectMutationsTest.php
@@ -1,10 +1,9 @@
 <?php
 
-class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
+class PostObjectMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 	public $title;
 	public $content;
-	public $client_mutation_id;
 	public $admin;
 	public $subscriber;
 	public $author;
@@ -14,9 +13,8 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 		// before
 		parent::setUp();
 
-		$this->title              = 'some title';
-		$this->content            = 'some content';
-		$this->client_mutation_id = 'someUniqueId';
+		$this->title   = 'some title';
+		$this->content = 'some content';
 
 		$this->author = $this->factory()->user->create( [
 			'role' => 'author',
@@ -52,432 +50,54 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 	 */
 	public function createPostMutation() {
 
-		$mutation = '
-		mutation createPost( $clientMutationId:String!, $title:String!, $content:String! ){
-		  createPost(
-		    input:{
-		      clientMutationId:$clientMutationId,
-		      title:$title
-		      content:$content
-		    }
-		  ){
-		    clientMutationId
-		    post{
-		      title
-		      content
-		    }
-		  }
-		}
-		';
-
-		$variables = wp_json_encode( [
-			'clientMutationId' => $this->client_mutation_id,
-			'title'            => $this->title,
-			'content'          => $this->content,
-		] );
-
-		$actual = do_graphql_request( $mutation, 'createPost', $variables );
-
-		return $actual;
-
-	}
-
-	public function createPageMutation() {
-
-		$mutation = '
-		mutation createPage( $clientMutationId:String!, $title:String!, $content:String! ){
-		  createPage(
-		    input:{
-		      clientMutationId:$clientMutationId,
-		      title:$title
-		      content:$content
-		    }
-		  ){
-		    clientMutationId
-		    page{
-		      title
-		      content
-		    }
-		  }
-		}
-		';
-
-		$variables = wp_json_encode( [
-			'clientMutationId' => $this->client_mutation_id,
-			'title'            => $this->title,
-			'content'          => $this->content,
-		] );
-
-		$actual = do_graphql_request( $mutation, 'createPage', $variables );
-
-		return $actual;
-
-	}
-
-	public function testUpdatePageMutation() {
-
-		$args = [
-			'post_type'    => 'page',
-			'post_status'  => 'publish',
-			'post_title'   => 'Original Title',
-			'post_content' => 'Original Content',
-		];
-
-		/**
-		 * Create a page to test against
-		 */
-		$page_id = $this->factory()->post->create( $args );
-
-		/**
-		 * Get the new page object
-		 */
-		$new_page = get_post( $page_id );
-
-		/**
-		 * Verify the page was created with the original content as expected
-		 */
-		$this->assertEquals( $new_page->post_type, 'page' );
-		$this->assertEquals( $new_page->post_title, 'Original Title' );
-		$this->assertEquals( $new_page->post_content, 'Original Content' );
-
-		/**
-		 * Prepare the mutation
-		 */
-		$mutation = '
-		mutation updatePageTest( $clientMutationId:String! $id:ID! $title:String $content:String ){
-		  updatePage(
-		    input: {
-		        clientMutationId:$clientMutationId
-		        id:$id,
-		        title:$title,
-		        content:$content,
-		    }
-		  ) {
-		    clientMutationId
-		    page{
-		      id
-		      title
-		      content
-		      pageId
-		    }
-		  }
-		}';
-
-		/**
-		 * Set the variables to use with the mutation
-		 */
-		$variables = wp_json_encode( [
-			'id'               => \GraphQLRelay\Relay::toGlobalId( 'post', $page_id ),
-			'title'            => 'Some updated title',
-			'content'          => 'Some updated content',
-			'clientMutationId' => 'someId',
-		] );
-
-		/**
-		 * Set the current user as the subscriber so we can test, and expect to fail
-		 */
-		wp_set_current_user( $this->subscriber );
-
-		/**
-		 * Execute the request
-		 */
-		$actual = do_graphql_request( $mutation, 'updatePageTest', $variables );
-
-		/**
-		 * We should get an error because the user is a subscriber and can't edit posts
-		 */
-		$this->assertArrayHasKey( 'errors', $actual );
-
-		/**
-		 * Set the current user to a user with permission to edit posts, but NOT permission to edit OTHERS posts
-		 */
-		wp_set_current_user( $this->author );
-
-		/**
-		 * Execute the request
-		 */
-		$actual = do_graphql_request( $mutation, 'updatePageTest', $variables );
-
-		/**
-		 * We should get an error because the user is an and can't edit others posts
-		 */
-		$this->assertArrayHasKey( 'errors', $actual );
-
-		/**
-		 * Set the current user as the admin role so we
-		 * successfully run the mutation
-		 */
-		wp_set_current_user( $this->admin );
-
-		/**
-		 * Execute the request
-		 */
-		$actual = do_graphql_request( $mutation, 'updatePageTest', $variables );
-
-		/**
-		 * Define the expected output.
-		 *
-		 * The mutation should've updated the article to contain the updated content
-		 */
-		$expected = [
-			'updatePage' => [
-				'clientMutationId' => 'someId',
-				'page'             => [
-					'id'      => \GraphQLRelay\Relay::toGlobalId( 'post', $page_id ),
-					'title'   => apply_filters( 'the_title', 'Some updated title' ),
-					'content' => apply_filters( 'the_content', 'Some updated content' ),
-					'pageId'  => $page_id,
-				],
-			],
-		];
-
-		/**
-		 * Compare the actual output vs the expected output
-		 */
-		$this->assertEquals( $expected, $actual['data'] );
-
-		/**
-		 * Make sure the edit lock is removed after the mutation has finished
-		 */
-		$this->assertFalse( get_post_meta( '_edit_lock', $page_id, true ) );
-
-	}
-
-	public function testDeletePageMutation() {
-
-		/**
-		 * Set the current user as the subscriber role so we
-		 * can test the mutation and assert that it failed
-		 */
-		wp_set_current_user( $this->subscriber );
-
-		$args = [
-			'post_type'    => 'page',
-			'post_status'  => 'publish',
-			'post_title'   => 'Original Title',
-			'post_content' => 'Original Content',
-		];
-
-		/**
-		 * Create a page to test against
-		 */
-		$page_id = $this->factory()->post->create( $args );
-
-		/**
-		 * Get the new page object
-		 */
-		$new_page = get_post( $page_id );
-
-		/**
-		 * Verify the page was created with the original content as expected
-		 */
-		$this->assertEquals( $new_page->post_type, 'page' );
-		$this->assertEquals( $new_page->post_title, 'Original Title' );
-		$this->assertEquals( $new_page->post_content, 'Original Content' );
-
-		/**
-		 * Prepare the mutation
-		 */
-		$mutation = '
-		mutation deletePageTest($input:DeletePageInput!){
-		  deletePage(input:$input){
-		    clientMutationId
-		    deletedId
-		    page{
-		      id
-		      title
-		      content
-		      pageId
-		    }
-		  }
-		}';
-
-		/**
-		 * Set the variables to use with the mutation
-		 */
-		$variables = [
-			'input' => [
-				'id'               => \GraphQLRelay\Relay::toGlobalId( 'post', $page_id ),
-				'clientMutationId' => 'someId',
-			],
-		];
-
-
-		/**
-		 * Execute the request
-		 */
-		$actual = do_graphql_request( $mutation, 'deletePageTest', $variables );
-
-		/**
-		 * The deletion should fail because we're a subscriber
-		 */
-		$this->assertArrayHasKey( 'errors', $actual );
-
-		/**
-		 * Set the user to an admin and try again
-		 */
-		wp_set_current_user( $this->admin );
-
-		/**
-		 * Execute the request
-		 */
-		$actual = do_graphql_request( $mutation, 'deletePageTest', $variables );
-
-		/**
-		 * Define the expected output.
-		 *
-		 * The mutation should've updated the article to contain the updated content
-		 */
-		$expected = [
-			'deletePage' => [
-				'clientMutationId' => 'someId',
-				'deletedId'        => \GraphQLRelay\Relay::toGlobalId( 'post', $page_id ),
-				'page'             => [
-					'id'      => \GraphQLRelay\Relay::toGlobalId( 'post', $page_id ),
-					'title'   => apply_filters( 'the_title', 'Original Title' ),
-					'content' => apply_filters( 'the_content', 'Original Content' ),
-					'pageId'  => $page_id,
-				],
-			],
-		];
-
-		/**
-		 * Compare the actual output vs the expected output
-		 */
-		$this->assertEquals( $expected, $actual['data'] );
-
-		/**
-		 * Try to delete again
-		 */
-		$actual = do_graphql_request( $mutation, 'deletePageTest', $variables );
-
-		/**
-		 * We should get an error because we're not using forceDelete
-		 */
-		$this->assertArrayHasKey( 'errors', $actual );
-
-		/**
-		 * Try to delete again, this time with forceDelete
-		 */
-		$variables = [
-			'input' => [
-				'id'               => \GraphQLRelay\Relay::toGlobalId( 'post', $page_id ),
-				'clientMutationId' => 'someId',
-				'forceDelete'      => true,
-			],
-		];
-		$actual    = do_graphql_request( $mutation, 'deletePageTest', $variables );
-
-
-		/**
-		 * This time, we used forceDelete so the mutation should have succeeded
-		 */
-		$this->assertArrayNotHasKey( 'errors', $actual );
-		$this->assertEquals( 'someId', $actual['data']['deletePage']['clientMutationId'] );
-		$this->assertEquals( \GraphQLRelay\Relay::toGlobalId( 'post', $page_id ), $actual['data']['deletePage']['deletedId'] );
-
-		/**
-		 * Try to delete the page one more time, and now there's nothing to delete, not even from the trash
-		 */
-		$actual = do_graphql_request( $mutation, 'deletePageTest', $variables );
-
-		/**
-		 * Now we should have errors again, because there's nothing to be deleted
-		 */
-		$this->assertArrayHasKey( 'errors', $actual );
-
-
-	}
-
-	public function testUpdatePostWithInvalidId() {
-
-		$mutation = '
-		mutation updatePostWithInvalidId($input:UpdatePostInput!) {
-			updatePost(input:$input) {
-				clientMutationId
+		$query = '
+		mutation createPost( $title:String!, $content:String! ){
+			createPost(
+				input:{
+					title:$title
+					content:$content
+				}
+			){
+				post{
+					title
+					content
+				}
 			}
 		}
 		';
 
 		$variables = [
-			'input' => [
-				'clientMutationId' => 'someId',
-				'id'               => 'invalidIdThatShouldThrowAnError',
-			],
+			'title'   => $this->title,
+			'content' => $this->content,
 		];
 
-		$actual = do_graphql_request( $mutation, 'updatePostWithInvalidId', $variables );
-
-		codecept_debug( $actual );
-
-		/**
-		 * We should get an error thrown if we try and update a post with an invalid id
-		 */
-		$this->assertArrayHasKey( 'errors', $actual );
-
-		$page_id   = $this->factory()->post->create( [
-			'post_type' => 'page',
-		] );
-		$global_id = \GraphQLRelay\Relay::toGlobalId( 'post', $page_id );
-
-		$variables = [
-			'input' => [
-				'clientMutationId' => 'someId',
-				'id'               => $global_id,
-			],
-		];
-
-		/**
-		 * Try to update a post, with a valid ID of a page
-		 */
-		$actual = do_graphql_request( $mutation, 'updatePostWithInvalidId', $variables );
-
-		/**
-		 * We should get an error here because the updatePost mutation should only be able to update "post" objects
-		 */
-		$this->assertArrayHasKey( 'errors', $actual );
-
+		return graphql( compact( 'query', 'variables' ) );
 	}
 
-	public function testDeletePostOfAnotherType() {
+	public function createPageMutation() {
 
-		$args = [
-			'post_type'    => 'page',
-			'post_status'  => 'publish',
-			'post_title'   => 'Original Title',
-			'post_content' => 'Original Content',
-		];
-
-		/**
-		 * Create a page to test against
-		 */
-		$page_id = $this->factory()->post->create( $args );
-
-		$mutation = '
-		mutation deletePostWithPageIdShouldFail{
-		  deletePost( $clientMutationId:String! $id:ID! ){
-		    post{
-		      id
-		    }
-		  }
+		$query = '
+		mutation createPage( $title:String!, $content:String! ){
+			createPage(
+				input:{
+					title:$title
+					content:$content
+				}
+			){
+				page{
+					title
+					content
+				}
+			}
 		}
 		';
 
-		$variables = wp_json_encode( [
-			'id'               => \GraphQLRelay\Relay::toGlobalId( 'post', $page_id ),
-			'clientMutationId' => 'someId',
-		] );
+		$variables = [
+			'title'   => $this->title,
+			'content' => $this->content,
+		];
 
-		/**
-		 * Run the mutation
-		 */
-		$actual = do_graphql_request( $mutation, 'deletePostWithPageIdShouldFail', $variables );
-
-		/**
-		 * The mutation should fail because the ID is for a page, but we're trying to delete a post
-		 */
-		$this->assertArrayHasKey( 'errors', $actual );
-
+		return graphql( compact( 'query', 'variables' ) );
 	}
 
 	/**
@@ -522,15 +142,11 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 		 * Run the mutation
 		 */
 		$actual = $this->createPageMutation();
+		codecept_debug( $actual );
 
-		/**
-		 * We're expecting to have createPage returned with a nested clientMutationId matching the
-		 * clientMutationId we sent through, as well as the title and content we passed through in the mutation
-		 */
 		$expected = [
 			'createPage' => [
-				'clientMutationId' => $this->client_mutation_id,
-				'page'             => [
+				'page' => [
 					'title'   => apply_filters( 'the_title', $this->title ),
 					'content' => apply_filters( 'the_content', $this->content ),
 				],
@@ -543,17 +159,17 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 
 	public function testCreatePostWithNoInput() {
 
-		$mutation = '
+		$query = '
 		mutation {
-		  createPost{
-		    post{
-		      id
-		    }
-		  }
+			createPost{
+				post{
+					id
+				}
+			}
 		}
 		';
 
-		$actual = do_graphql_request( $mutation );
+		$actual = graphql( compact( 'query' ) );
 
 		/**
 		 * Make sure we're throwing an error if there's no $input with the mutation
@@ -564,35 +180,28 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 
 	public function testCreatePostByAuthorCanHavePublishStatus() {
 
-		$mutation = '
+		$query = '
 		mutation createPost($input:CreatePostInput!){
-		  createPost(input:$input){
-		    clientMutationId
-		    post{
-		      id
-		      title
-		      status
-		    }
-		  }
+			createPost(input:$input){
+				post{
+					id
+					title
+					status
+				}
+			}
 		}
 		';
 
 		$variables = [
 			'input' => [
-				'clientMutationId' => 'CreatePost',
-				'title' => 'Test Post as Contributor',
+				'title'  => 'Test Post as Contributor',
 				'status' => 'PUBLISH',
 			],
 		];
 
 		wp_set_current_user( $this->author );
 
-		$actual = graphql([
-			'query' => $mutation,
-			'variables' => $variables
-		]);
-
-		codecept_debug( $actual );
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
 		/**
 		 * Make sure we're throwing an error if there's no $input with the mutation
@@ -600,41 +209,33 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertSame( 'publish', $actual['data']['createPost']['post']['status'] );
 		$this->assertSame( $variables['input']['title'], $actual['data']['createPost']['post']['title'] );
-		$this->assertSame( $variables['input']['clientMutationId'], $actual['data']['createPost']['clientMutationId'] );
 
 	}
 
 	public function testCreatePostByContributorCannotHavePublishStatus() {
 
-		$mutation = '
+		$query = '
 		mutation createPost($input:CreatePostInput!){
-		  createPost(input:$input){
-		    clientMutationId
-		    post{
-		      id
-		      title
-		      status
-		    }
-		  }
+			createPost(input:$input){
+				post{
+					id
+					title
+					status
+				}
+			}
 		}
 		';
 
 		$variables = [
 			'input' => [
-				'clientMutationId' => 'CreatePost',
-				'title' => 'Test Post as Contributor',
+				'title'  => 'Test Post as Contributor',
 				'status' => 'PUBLISH',
 			],
 		];
 
 		wp_set_current_user( $this->contributor );
 
-		$actual = graphql([
-			'query' => $mutation,
-			'variables' => $variables
-		]);
-
-		codecept_debug( $actual );
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
 		/**
 		 * Make sure we're throwing an error if there's no $input with the mutation
@@ -642,295 +243,796 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertSame( 'pending', $actual['data']['createPost']['post']['status'] );
 		$this->assertSame( $variables['input']['title'], $actual['data']['createPost']['post']['title'] );
-		$this->assertSame( $variables['input']['clientMutationId'], $actual['data']['createPost']['clientMutationId'] );
 
+	}
+
+	public function testCreatePageWithParent() {
+		wp_set_current_user( $this->admin );
+
+		$parent_page_id = $this->factory()->post->create(  [
+			'post_type'    => 'page',
+			'post_status'  => 'publish',
+			'post_title'   => 'Parent Page',
+			'post_content' => 'Parent Content',
+		] );
+
+		$query = '
+		mutation createPage( $input:CreatePageInput! ){
+			createPage( input:$input ) {
+				page {
+					parent {
+						node{
+							databaseId
+							id
+						}
+					}
+				}
+			}
+		}
+		';
+
+		// Test with bad parent ID
+		$variables = [
+			'input' => [
+				'title'    => $this->title,
+				'content'  => $this->content,
+				'parentId' => 99999,
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+		$this->assertEquals( null, $actual['data']['createPage']['page']['parent'] );
+
+		// Test with databaseId
+		$variables['input']['parentId'] = $parent_page_id;
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertEquals( $parent_page_id, $actual['data']['createPage']['page']['parent']['node']['databaseId'] );
+
+		// Test with global Id
+		$global_id = \GraphQLRelay\Relay::toGlobalId( 'post', $parent_page_id );
+		$variables = [
+			'input' => [
+				'title'    => $this->title . ' 2',
+				'content'  => $this->content,
+				'parentId' => $global_id,
+			],
+		];
+		$actual    = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertEquals( $global_id, $actual['data']['createPage']['page']['parent']['node']['id'] );
+	}
+
+	public function testCreatePostWithPostAuthor() {
+		wp_set_current_user( $this->admin );
+
+		$query = '
+		mutation createPost( $input:CreatePostInput! ){
+			createPost( input:$input ) {
+				post{
+					author {
+						node {
+							databaseId
+							id
+						}
+					}
+				}
+			}
+		}
+		';
+
+		// Test with bad author ID
+		$variables = [
+			'input' => [
+				'title'    => $this->title,
+				'content'  => $this->content,
+				'authorId' => 99999,
+			],
+		];
+
+		$actual = graphql( compact( 'query', 'variables' ) );
+		$this->assertArrayHasKey( 'errors', $actual );
+
+		// Test with databaseId
+		$variables['input']['authorId'] = $this->contributor;
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertEquals( $this->contributor, $actual['data']['createPost']['post']['author']['node']['databaseId'] );
+
+		// Test with global Id
+		$global_id = \GraphQLRelay\Relay::toGlobalId( 'user', $this->contributor );
+		$variables = [
+			'input' => [
+				'title'    => $this->title . ' 2',
+				'content'  => $this->content,
+				'authorId' => $global_id,
+			],
+		];
+		$actual    = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertEquals( $global_id, $actual['data']['createPost']['post']['author']['node']['id'] );
 	}
 
 	public function createPostWithDatesMutation( $input ) {
 
-        wp_set_current_user( $this->admin );
+		wp_set_current_user( $this->admin );
 
-        $mutation = 'mutation createPost( $input:CreatePostInput! ) {
-          createPost(input: $input) {
-            post {
-              id
-              postId
-              title
-              date
-              dateGmt
-              modified
-              modifiedGmt
-            }
-          }
+		$query = 'mutation createPost( $input:CreatePostInput! ) {
+			createPost(input: $input) {
+				post {
+					id
+					postId
+					title
+					date
+					dateGmt
+					modified
+					modifiedGmt
+				}
+			}
 		}
-        ';
+		';
 
-        $defaults = [
-            'clientMutationId' => uniqid(),
-            'title' => 'New Post',
-            'status' => 'PUBLISH',
-        ];
+		$defaults = [
+			'title'  => 'New Post',
+			'status' => 'PUBLISH',
+		];
 
-        $input = array_merge( $defaults, $input );
+		$input = array_merge( $defaults, $input );
 
-        $variables = [
-            'input' => $input,
-        ];
+		$variables = [
+			'input' => $input,
+		];
 
-        /**
-         * Run the mutation.
-         */
+		/**
+		 * Run the mutation.
+		 */
 
-        $results = do_graphql_request( $mutation, 'createPost', $variables );
-
-	    return $results;
+		return graphql( compact( 'query', 'variables' ) );
 	}
 
-    public function testDateInputsForCreatePost() {
+	public function testDateInputsForCreatePost() {
 
-        /**
-         * Set the current user as the admin role so we
-         * can test the mutation
-         */
+		/**
+		 * Set the current user as the admin role so we
+		 * can test the mutation
+		 */
 
-        wp_set_current_user( $this->admin );
+		wp_set_current_user( $this->admin );
 
-        /**
-         * Set the expected date outcome
-         */
+		/**
+		 * Set the expected date outcome
+		 */
 
-        $dateExpected = '2017-01-03T00:00:00';
-        $dateGmtExpected = '2017-01-03T00:00:00';
+		$dateExpected    = '2017-01-03T00:00:00';
+		$dateGmtExpected = '2017-01-03T00:00:00';
 
-        $results = $this->createPostWithDatesMutation([
-            'date' => '1/3/2017',
-            'status' => 'PUBLISH'
-        ]);
-
-        /**
-         * Make sure there are no errors
-         */
-        $this->assertArrayNotHasKey( 'errors', $results );
-
-        /**
-         * We're expecting the date variable to match the date entry regardless of the way user enters it
-         */
-
-        $this->assertEquals( $dateExpected, $results['data']['createPost']['post']['date'] );
-        $this->assertEquals( $dateGmtExpected, $results['data']['createPost']['post']['dateGmt'] );
-        $this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modified'] );
-        $this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modifiedGmt'] );
-
-    }
-
-    public function testDateInputsWithSlashFormattingForCreatePost() {
-
-        /**
-         * Set the current user as the admin role so we
-         * can test the mutation
-         */
-
-        wp_set_current_user( $this->admin );
-
-        /**
-         * Set the input and expected date outcome
-         */
-
-        $dateExpected = '2017-01-03T00:00:00';
-        $dateGmtExpected = '2017-01-03T00:00:00';
-
-        $results = $this->createPostWithDatesMutation([
-            'date' => '2017/01/03',
-        ]);
-
-        /**
-         * Make sure there are no errors
-         */
-
-        $this->assertArrayNotHasKey( 'errors', $results );
-
-        /**
-         * We're expecting the date variable to match the date entry regardless of the way user enters it
-         */
-
-        $this->assertEquals( $dateExpected, $results['data']['createPost']['post']['date'] );
-        $this->assertEquals( $dateGmtExpected, $results['data']['createPost']['post']['dateGmt'] );
-	    $this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modified'] );
-	    $this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modifiedGmt'] );
-
-    }
-
-    public function testDateInputsWithStatusPendingAndDashesCreatePost() {
-
-        /**
-         * Set the current user as the admin role so we
-         * can test the mutation
-         */
-
-        wp_set_current_user( $this->admin );
-
-        /**
-         * Set the input and expected date outcome
-         */
-
-        $dateExpected = '2017-01-03T00:00:00';
-        $dateGmtExpected = null;
-
-        $results = $this->createPostWithDatesMutation([
-            'date' => '3-1-2017',
-            'status' => 'PENDING'
-        ]);
-
-        /**
-         * Make sure there are no errors
-         */
-
-        $this->assertArrayNotHasKey( 'errors', $results );
-
-        /**
-         * We're expecting the date variable to match the date entry regardless of the way user enters it
-         */
-
-        $this->assertEquals( $dateExpected, $results['data']['createPost']['post']['date'] );
-        $this->assertEquals( $dateGmtExpected, $results['data']['createPost']['post']['dateGmt'] );
-	    $this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modified'] );
-	    $this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modifiedGmt'] );
-
-    }
-
-    public function testDateInputsWithDraftAndPublishUpdatePost() {
-
-        /**
-         * Set the current user as the admin role so we
-         * can test the mutation
-         */
-        wp_set_current_user( $this->admin );
-
-        /**
-         * Create a post to test against and set global ID
-         */
-        $test_post = $this->factory()->post->create( [
-            'post_title' => 'My Test Post',
-            'post_status' => 'draft',
-        ] );
-
-        $global_id = \GraphQLRelay\Relay::toGlobalId( 'post', $test_post );
-
-        /**
-         * Prepare mutation for GQL request
-         */
-        $request = '
-        {
-            post( id: "'. $global_id . '" ) {
-              id
-              postId
-              title
-              date
-              dateGmt
-              modified
-              modifiedGmt
-            }
-        }
-        ';
-
-        /**
-         * Run GQl request
-         */
-        $results = do_graphql_request( $request );
-
-        /**
-         * Set the expected dateGmt outcome
-         */
-        $dateGmtExpected = null;
-
-        /**
-         * Assert results dateGmt equals the expected outcome
-         */
-        $this->assertEquals( $dateGmtExpected, $results['data']['post']['dateGmt'] );
-
-        /**
-         * Update post to test against status: published
-         */
-        wp_update_post( [
-            'ID'          => $test_post,
-            'post_status' => 'publish',
-        ] );
-
-        /**
-         * Run GQl request
-         */
-        $results = do_graphql_request( $request );
-
-        /**
-         * Assert timestamp is not null
-         */
-        $this->assertNotNull( $results['data']['post']['dateGmt'] );
-
-        /**
-         * Update post back to draft
-         */
-        wp_update_post( [
-            'ID' => $test_post,
-            'post_status' => 'draft'
-        ] );
-
-        /**
-         * Run GQl request
-         */
-        $results = do_graphql_request( $request );
-
-        /**
-         * Assert timestamp is STILL not null
-         */
-        $this->assertNotNull( $results['data']['post']['dateGmt'] );
-    }
-
-	/**
-	 * @throws Exception
-	 */
-    public function testUserWithoutProperCapabilityCannotUpdateOthersPosts() {
-
-		$admin_created_post_id = $this->factory()->post->create([
-			'post_type' => 'post',
-			'post_status' => 'publish',
-			'post_title' => 'Test Post from Admin, Edit by Contributor',
-			'post_author' => $this->admin
+		$results = $this->createPostWithDatesMutation([
+			'date'   => '1/3/2017',
+			'status' => 'PUBLISH',
 		]);
+		codecept_debug( $results );
 
-		$global_id = \GraphQLRelay\Relay::toGlobalId( 'post', $admin_created_post_id );
+		/**
+		 * Make sure there are no errors
+		 */
+		$this->assertArrayNotHasKey( 'errors', $results );
 
-		$mutation = '
-		mutation UpdatePost($input: UpdatePostInput! ) {
-		  updatePost(input:$input) {
-		    post {
-		      id
-		      title
-		      content
-		    }
-		  }
+		/**
+		 * We're expecting the date variable to match the date entry regardless of the way user enters it
+		 */
+
+		$this->assertEquals( $dateExpected, $results['data']['createPost']['post']['date'] );
+		$this->assertEquals( $dateGmtExpected, $results['data']['createPost']['post']['dateGmt'] );
+		$this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modified'] );
+		$this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modifiedGmt'] );
+
+	}
+
+	public function testDateInputsWithSlashFormattingForCreatePost() {
+
+		/**
+		 * Set the current user as the admin role so we
+		 * can test the mutation
+		 */
+
+		wp_set_current_user( $this->admin );
+
+		/**
+		 * Set the input and expected date outcome
+		 */
+
+		$dateExpected    = '2017-01-03T00:00:00';
+		$dateGmtExpected = '2017-01-03T00:00:00';
+
+		$results = $this->createPostWithDatesMutation([
+			'date' => '2017/01/03',
+		]);
+		codecept_debug( $results );
+
+		/**
+		 * Make sure there are no errors
+		 */
+
+		$this->assertArrayNotHasKey( 'errors', $results );
+
+		/**
+		 * We're expecting the date variable to match the date entry regardless of the way user enters it
+		 */
+
+		$this->assertEquals( $dateExpected, $results['data']['createPost']['post']['date'] );
+		$this->assertEquals( $dateGmtExpected, $results['data']['createPost']['post']['dateGmt'] );
+		$this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modified'] );
+		$this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modifiedGmt'] );
+
+	}
+
+	public function testDateInputsWithStatusPendingAndDashesCreatePost() {
+
+		/**
+		 * Set the current user as the admin role so we
+		 * can test the mutation
+		 */
+
+		wp_set_current_user( $this->admin );
+
+		/**
+		 * Set the input and expected date outcome
+		 */
+
+		$dateExpected    = '2017-01-03T00:00:00';
+		$dateGmtExpected = null;
+
+		$results = $this->createPostWithDatesMutation([
+			'date'   => '3-1-2017',
+			'status' => 'PENDING',
+		]);
+		codecept_debug( $results );
+
+		/**
+		 * Make sure there are no errors
+		 */
+
+		$this->assertArrayNotHasKey( 'errors', $results );
+
+		/**
+		 * We're expecting the date variable to match the date entry regardless of the way user enters it
+		 */
+
+		$this->assertEquals( $dateExpected, $results['data']['createPost']['post']['date'] );
+		$this->assertEquals( $dateGmtExpected, $results['data']['createPost']['post']['dateGmt'] );
+		$this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modified'] );
+		$this->assertNotEquals( '0000-00-00 00:00:00', $results['data']['createPost']['post']['modifiedGmt'] );
+
+	}
+
+	public function testDateInputsWithDraftAndPublishUpdatePost() {
+
+		/**
+		 * Set the current user as the admin role so we
+		 * can test the mutation
+		 */
+		wp_set_current_user( $this->admin );
+
+		/**
+		 * Create a post to test against and set global ID
+		 */
+		$test_post = $this->factory()->post->create( [
+			'post_title'  => 'My Test Post',
+			'post_status' => 'draft',
+		] );
+
+		$global_id = \GraphQLRelay\Relay::toGlobalId( 'post', $test_post );
+
+		/**
+		 * Prepare mutation for GQL request
+		 */
+		$query = '
+		{
+			post( id: "' . $global_id . '" ) {
+				id
+				postId
+				title
+				date
+				dateGmt
+				modified
+				modifiedGmt
+			}
+		}
+		';
+
+		/**
+		 * Run GQl request
+		 */
+		$results = $this->graphql( compact( 'query' ) );
+
+		/**
+		 * Set the expected dateGmt outcome
+		 */
+		$dateGmtExpected = null;
+
+		/**
+		 * Assert results dateGmt equals the expected outcome
+		 */
+		$this->assertEquals( $dateGmtExpected, $results['data']['post']['dateGmt'] );
+
+		/**
+		 * Update post to test against status: published
+		 */
+		wp_update_post( [
+			'ID'          => $test_post,
+			'post_status' => 'publish',
+		] );
+
+		/**
+		 * Run GQl request
+		 */
+		$results = $this->graphql( compact( 'query' ) );
+
+		/**
+		 * Assert timestamp is not null
+		 */
+		$this->assertNotNull( $results['data']['post']['dateGmt'] );
+
+		/**
+		 * Update post back to draft
+		 */
+		wp_update_post( [
+			'ID'          => $test_post,
+			'post_status' => 'draft',
+		] );
+
+		/**
+		 * Run GQl request
+		 */
+		$results = $this->graphql( compact( 'query' ) );
+
+		/**
+		 * Assert timestamp is STILL not null
+		 */
+		$this->assertNotNull( $results['data']['post']['dateGmt'] );
+	}
+
+	public function testDeletePageMutation() {
+		wp_set_current_user( $this->admin );
+
+		$args = [
+			'post_type'    => 'page',
+			'post_status'  => 'publish',
+			'post_title'   => 'Original Title',
+			'post_content' => 'Original Content',
+		];
+
+		/**
+		 * Create a page to test against
+		 */
+		$page_id = $this->factory()->post->create( $args );
+
+		/**
+		 * Get the new page object
+		 */
+		$new_page = get_post( $page_id );
+
+		/**
+		 * Verify the page was created with the original content as expected
+		 */
+		$this->assertEquals( $new_page->post_type, 'page' );
+		$this->assertEquals( $new_page->post_title, 'Original Title' );
+		$this->assertEquals( $new_page->post_content, 'Original Content' );
+
+		/**
+		 * Prepare the mutation
+		 */
+		$query = '
+		mutation deletePageTest($input:DeletePageInput!){
+			deletePage(input:$input){
+				deletedId
+				page{
+					id
+					title
+					content
+					databaseId
+				}
+			}
+		}';
+
+		// Test with no id.
+		$variables = [
+			'input' => [
+				'id' => '',
+			],
+		];
+
+		$actual = graphql( compact( 'query', 'variables' ) );
+		$this->assertArrayHasKey( 'errors', $actual );
+
+		// Test with bad Id.
+		$variables['input']['id'] = 999999;
+
+		$actual = graphql( compact( 'query', 'variables' ) );
+		$this->assertArrayHasKey( 'errors', $actual );
+
+		// Test with global Id.
+
+		/**
+		 * Set the current user as the subscriber role so we
+		 * can test the mutation and assert that it failed
+		 */
+		wp_set_current_user( $this->subscriber );
+
+		$variables['input']['id'] = \GraphQLRelay\Relay::toGlobalId( 'post', $page_id );
+
+		/**
+		 * Execute the request
+		 */
+		$actual = graphql( compact( 'query', 'variables' ) );
+
+		/**
+		 * The deletion should fail because we're a subscriber
+		 */
+		$this->assertArrayHasKey( 'errors', $actual );
+
+		/**
+		 * Set the user to an admin and try again
+		 */
+		wp_set_current_user( $this->admin );
+
+		/**
+		 * Execute the request
+		 */
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		/**
+		 * Define the expected output.
+		 *
+		 * The mutation should've updated the article to contain the updated content
+		 */
+		$expected = [
+			'deletePage' => [
+				'deletedId' => \GraphQLRelay\Relay::toGlobalId( 'post', $page_id ),
+				'page'      => [
+					'id'         => \GraphQLRelay\Relay::toGlobalId( 'post', $page_id ),
+					'title'      => apply_filters( 'the_title', 'Original Title' ),
+					'content'    => apply_filters( 'the_content', 'Original Content' ),
+					'databaseId' => $page_id,
+				],
+			],
+		];
+
+		/**
+		 * Compare the actual output vs the expected output
+		 */
+		$this->assertEquals( $expected, $actual['data'] );
+
+		// Test with database ID
+		wp_update_post( [
+			'ID'          => $page_id,
+			'post_status' => 'publish',
+		] );
+
+		$variables['input']['id'] = $page_id;
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertEquals( $expected, $actual['data'] );
+
+		/**
+		 * Try to delete again
+		 */
+		$actual = graphql( compact( 'query', 'variables' ) );
+
+		/**
+		 * We should get an error because we're not using forceDelete
+		 */
+		$this->assertArrayHasKey( 'errors', $actual );
+
+		/**
+		 * Try to delete again, this time with forceDelete
+		 */
+		$variables = [
+			'input' => [
+				'id'          => \GraphQLRelay\Relay::toGlobalId( 'post', $page_id ),
+				'forceDelete' => true,
+			],
+		];
+		$actual    = $this->graphql( compact( 'query', 'variables' ) );
+
+		/**
+		 * This time, we used forceDelete so the mutation should have succeeded
+		 */
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEquals( \GraphQLRelay\Relay::toGlobalId( 'post', $page_id ), $actual['data']['deletePage']['deletedId'] );
+
+		/**
+		 * Try to delete the page one more time, and now there's nothing to delete, not even from the trash
+		 */
+		$actual = graphql( compact( 'query', 'variables' ) );
+
+		/**
+		 * Now we should have errors again, because there's nothing to be deleted
+		 */
+		$this->assertArrayHasKey( 'errors', $actual );
+
+	}
+
+	public function testDeletePostOfAnotherType() {
+
+		$args = [
+			'post_type'    => 'page',
+			'post_status'  => 'publish',
+			'post_title'   => 'Original Title',
+			'post_content' => 'Original Content',
+		];
+
+		/**
+		 * Create a page to test against
+		 */
+		$page_id = $this->factory()->post->create( $args );
+
+		$query = '
+		mutation deletePostWithPageIdShouldFail{
+			deletePost( $id:ID! ){
+				post{
+					id
+				}
+			}
+		}
+		';
+
+		$variables = [
+			'id' => \GraphQLRelay\Relay::toGlobalId( 'post', $page_id ),
+		];
+
+		/**
+		 * Run the mutation
+		 */
+		$actual = graphql( compact( 'query', 'variables' ) );
+
+		/**
+		 * The mutation should fail because the ID is for a page, but we're trying to delete a post
+		 */
+		$this->assertArrayHasKey( 'errors', $actual );
+
+	}
+
+	public function testUpdatePageMutation() {
+
+		$args = [
+			'post_type'    => 'page',
+			'post_status'  => 'publish',
+			'post_title'   => 'Original Title',
+			'post_content' => 'Original Content',
+		];
+
+		/**
+		 * Create a page to test against
+		 */
+		$page_id = $this->factory()->post->create( $args );
+
+		/**
+		 * Get the new page object
+		 */
+		$new_page = get_post( $page_id );
+
+		/**
+		 * Verify the page was created with the original content as expected
+		 */
+		$this->assertEquals( $new_page->post_type, 'page' );
+		$this->assertEquals( $new_page->post_title, 'Original Title' );
+		$this->assertEquals( $new_page->post_content, 'Original Content' );
+
+		/**
+		 * Prepare the mutation
+		 */
+		$query = '
+		mutation updatePageTest( $id:ID! $title:String $content:String ){
+			updatePage(
+				input: {
+					id:$id,
+					title:$title,
+					content:$content,
+				}
+			) {
+				page{
+					id
+					title
+					content
+					databaseId
+				}
+			}
+		}';
+
+		/**
+		 * Set the variables to use with the mutation
+		 */
+		$variables = [
+			'id'      => \GraphQLRelay\Relay::toGlobalId( 'post', $page_id ),
+			'title'   => 'Some updated title',
+			'content' => 'Some updated content',
+		];
+
+		/**
+		 * Set the current user as the subscriber so we can test, and expect to fail
+		 */
+		wp_set_current_user( $this->subscriber );
+
+		/**
+		 * Execute the request
+		 */
+		$actual = graphql( compact( 'query', 'variables' ) );
+
+		/**
+		 * We should get an error because the user is a subscriber and can't edit posts
+		 */
+		$this->assertArrayHasKey( 'errors', $actual );
+
+		/**
+		 * Set the current user to a user with permission to edit posts, but NOT permission to edit OTHERS posts
+		 */
+		wp_set_current_user( $this->author );
+
+		/**
+		 * Execute the request
+		 */
+		$actual = graphql( compact( 'query', 'variables' ) );
+
+		/**
+		 * We should get an error because the user is an and can't edit others posts
+		 */
+		$this->assertArrayHasKey( 'errors', $actual );
+
+		/**
+		 * Set the current user as the admin role so we
+		 * successfully run the mutation
+		 */
+		wp_set_current_user( $this->admin );
+
+		/**
+		 * Execute the request
+		 */
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		/**
+		 * Define the expected output.
+		 *
+		 * The mutation should've updated the article to contain the updated content
+		 */
+		$expected = [
+			'updatePage' => [
+				'page' => [
+					'id'         => \GraphQLRelay\Relay::toGlobalId( 'post', $page_id ),
+					'title'      => apply_filters( 'the_title', 'Some updated title' ),
+					'content'    => apply_filters( 'the_content', 'Some updated content' ),
+					'databaseId' => $page_id,
+				],
+			],
+		];
+
+		/**
+		 * Compare the actual output vs the expected output
+		 */
+		$this->assertEquals( $expected, $actual['data'] );
+
+		/**
+		 * Make sure the edit lock is removed after the mutation has finished
+		 */
+		$this->assertFalse( get_post_meta( '_edit_lock', $page_id, true ) );
+
+		// Test with no id
+		$variables = [
+			'id'      => '',
+			'title'   => 'Some updated title 2',
+			'content' => 'Some updated content 2',
+		];
+
+		$actual = graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayHasKey( 'errors', $actual );
+
+		// Test with bad id
+		$variables['id'] = 999999;
+
+		$actual = graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayHasKey( 'errors', $actual );
+
+		// Test with databaseId
+		$variables['id'] = $page_id;
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertEquals( $page_id, $actual['data']['updatePage']['page']['databaseId'] );
+	}
+
+	public function testUpdatePostWithInvalidId() {
+
+		$query = '
+		mutation updatePostWithInvalidId($input:UpdatePostInput!) {
+			updatePost(input:$input) {
+				post {
+					databaseId
+				}
+			}
 		}
 		';
 
 		$variables = [
 			'input' => [
-				'clientMutationId' => 'UpdatePost',
+				'id' => 'invalidIdThatShouldThrowAnError',
+			],
+		];
+
+		$actual = graphql( compact( 'query', 'variables' ) );
+
+		/**
+		 * We should get an error thrown if we try and update a post with an invalid id
+		 */
+		$this->assertArrayHasKey( 'errors', $actual );
+
+		$page_id   = $this->factory()->post->create( [
+			'post_type' => 'page',
+		] );
+		$global_id = \GraphQLRelay\Relay::toGlobalId( 'post', $page_id );
+
+		$variables = [
+			'input' => [
 				'id' => $global_id,
-				'title' => 'New Title'
-			]
+			],
+		];
+
+		/**
+		 * Try to update a post, with a valid ID of a page
+		 */
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		/**
+		 * We should get an error here because the updatePost mutation should only be able to update "post" objects
+		 */
+		$this->assertArrayHasKey( 'errors', $actual );
+
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function testUserWithoutProperCapabilityCannotUpdateOthersPosts() {
+
+		$admin_created_post_id = $this->factory()->post->create([
+			'post_type'   => 'post',
+			'post_status' => 'publish',
+			'post_title'  => 'Test Post from Admin, Edit by Contributor',
+			'post_author' => $this->admin,
+		]);
+
+		$global_id = \GraphQLRelay\Relay::toGlobalId( 'post', $admin_created_post_id );
+
+		$query = '
+		mutation UpdatePost($input: UpdatePostInput! ) {
+			updatePost(input:$input) {
+				post {
+					id
+					title
+					content
+				}
+			}
+		}
+		';
+
+		$variables = [
+			'input' => [
+				'id'    => $global_id,
+				'title' => 'New Title',
+			],
 		];
 
 		wp_set_current_user( $this->contributor );
 
-		$actual = graphql([
-			'query' => $mutation,
-			'variables' => $variables,
-		]);
-
-		codecept_debug( $actual );
+		$actual = graphql( compact( 'query', 'variables' ) );
 
 		$this->assertArrayHasKey( 'errors', $actual );
 
-    }
+	}
 
 	/**
 	 * @throws Exception
@@ -941,39 +1043,33 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 			'post_type'   => 'page',
 			'post_status' => 'publish',
 			'post_title'  => 'Test Page from Admin, Edit by Contributor',
-			'post_author' => $this->admin
+			'post_author' => $this->admin,
 		] );
 
 		$global_id = \GraphQLRelay\Relay::toGlobalId( 'post', $admin_created_page_id );
 
-		$mutation = '
+		$query = '
 		mutation UpdatePage($input: UpdatePageInput! ) {
-		  updatePage(input:$input) {
-		    page {
-		      id
-		      title
-		      content
-		    }
-		  }
+			updatePage(input:$input) {
+				page {
+					id
+					title
+					content
+				}
+			}
 		}
 		';
 
 		$variables = [
 			'input' => [
-				'clientMutationId' => 'UpdatePage',
-				'id'               => $global_id,
-				'title'            => 'New Title'
-			]
+				'id'    => $global_id,
+				'title' => 'New Title',
+			],
 		];
 
 		wp_set_current_user( $this->contributor );
 
-		$actual = graphql( [
-			'query'     => $mutation,
-			'variables' => $variables,
-		] );
-
-		codecept_debug( $actual );
+		$actual = graphql( compact( 'query', 'variables' ) );
 
 		$this->assertArrayHasKey( 'errors', $actual );
 
@@ -982,35 +1078,33 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 	public function testUpdatingPostByOtherAuthorRequiresEditOtherPostCapability() {
 
 		$post_id = $this->factory()->post->create([
-			'post_type' => 'post',
+			'post_type'   => 'post',
 			'post_status' => 'publish',
-			'post_author' => $this->author
+			'post_author' => $this->author,
 		]);
 
 		wp_set_current_user( $this->contributor );
 
-		$mutation = '
+		$query = '
 		mutation updatePost( $input: UpdatePostInput! ) {
-		  updatePost( input: $input ) {
-		    post {
-		      id
-		      title
-		    }
-		  }
+			updatePost( input: $input ) {
+				post {
+					id
+					title
+				}
+			}
 		}
 		';
 
 		$actual = graphql([
-			'query' => $mutation,
+			'query'     => $query,
 			'variables' => [
 				'input' => [
-					'id' => \GraphQLRelay\Relay::toGlobalId( 'post', $post_id ),
+					'id'    => \GraphQLRelay\Relay::toGlobalId( 'post', $post_id ),
 					'title' => 'Test Update',
-					'clientMutationId' => 'test...'
 				],
 			],
 		]);
-
 
 		// A contributor cannot edit another authors posts
 		$this->assertArrayHasKey( 'errors', $actual );
@@ -1019,18 +1113,15 @@ class PostObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 
 		$updated_title = uniqid();
 
-		$actual = graphql([
-			'query' => $mutation,
+		$actual = $this->graphql([
+			'query'     => $query,
 			'variables' => [
 				'input' => [
-					'id' => \GraphQLRelay\Relay::toGlobalId( 'post', $post_id ),
+					'id'    => \GraphQLRelay\Relay::toGlobalId( 'post', $post_id ),
 					'title' => $updated_title,
-					'clientMutationId' => 'test...'
 				],
 			],
 		]);
-
-		codecept_debug( $actual );
 
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertSame( $updated_title, $actual['data']['updatePost']['post']['title'] );

--- a/tests/wpunit/RootQueryConnectionsTest.php
+++ b/tests/wpunit/RootQueryConnectionsTest.php
@@ -15,6 +15,9 @@ class RootQueryConnectionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 			'role' => 'administrator'
 		]);
 		// your set up methods here
+		if ( is_multisite() ) {
+			grant_super_admin( $this->admin );
+		}
 	}
 
 	public function tearDown(): void {
@@ -137,6 +140,8 @@ class RootQueryConnectionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 		';
 
 		$actual = graphql( [ 'query' => $query ] );
+
+		codecept_debug( $actual );
 
 		$this->assertQuerySuccessful( $actual, [
 			$this->expectedNode( 'themes.nodes', [

--- a/tests/wpunit/SettingsQueriesTest.php
+++ b/tests/wpunit/SettingsQueriesTest.php
@@ -159,4 +159,28 @@ class WP_GraphQL_Test_Settings_Queries extends \Codeception\TestCase\WPTestCase 
 		$this->assertEquals( $mock_options['use_smilies'], $allSettings['writingSettingsUseSmilies'] );
 	}
 
+	/**
+	 * @see: https://github.com/wp-graphql/wp-graphql/pull/2276
+	 * @throws Exception
+	 */
+	public function testGeneralSettingsUrlDoesntThrowErrorOnMultisite() {
+
+		$query = '
+		{
+		  generalSettings {
+		    dateFormat
+		    url
+		  }
+		}
+		';
+
+		$actual = graphql( [
+			'query' => $query,
+		]);
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertNotEmpty( $actual['data']['generalSettings']['url'] );
+
+	}
+
 }

--- a/tests/wpunit/TermObjectMutationsTest.php
+++ b/tests/wpunit/TermObjectMutationsTest.php
@@ -1,7 +1,6 @@
 <?php
 
-class TermObjectMutationsTest extends \Codeception\TestCase\WPTestCase
-{
+class TermObjectMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 	public $category_name;
 	public $tag_name;
@@ -11,67 +10,62 @@ class TermObjectMutationsTest extends \Codeception\TestCase\WPTestCase
 	public $admin;
 	public $subscriber;
 
-    public function setUp(): void
-    {
-        parent::setUp();
+	public function setUp(): void {
+		parent::setUp();
 
-	    WPGraphQL::clear_schema();
+		WPGraphQL::clear_schema();
 
-	    $this->category_name = 'Test Category';
-	    $this->tag_name = 'Test Tag';
-	    $this->description = 'Test Term Description';
-	    $this->description_update = 'Description Update';
-	    $this->client_mutation_id = 'someUniqueId';
+		$this->category_name      = 'Test Category';
+		$this->tag_name           = 'Test Tag';
+		$this->description        = 'Test Term Description';
+		$this->description_update = 'Description Update';
+		$this->client_mutation_id = 'someUniqueId';
 
-	    $this->admin = $this->factory()->user->create([
-		    'role' => 'administrator',
-	    ]);
+		$this->admin = $this->factory()->user->create([
+			'role' => 'administrator',
+		]);
 
-	    $this->subscriber = $this->factory()->user->create([
-		    'role' => 'subscriber',
-	    ]);
-    }
+		$this->subscriber = $this->factory()->user->create([
+			'role' => 'subscriber',
+		]);
+	}
 
-    public function tearDown(): void
-    {
-        // your tear down methods here
-	    WPGraphQL::clear_schema();
-        // then
-        parent::tearDown();
-    }
+	public function tearDown(): void {
+		// your tear down methods here
+		WPGraphQL::clear_schema();
+		// then
+		parent::tearDown();
+	}
 
 	/**
 	 * Function that executes the mutation
 	 */
 	public function createCategoryMutation() {
 
-		$mutation = '
-		mutation createCategory( $clientMutationId:String!, $name:String!, $description:String ) {
-		  createCategory(
-			input: {
-			  clientMutationId: $clientMutationId
-			  name: $name
-			  description: $description
+		$query = '
+		mutation createCategory( $name:String!, $description:String ) {
+			createCategory(
+				input: {
+					name: $name
+					description: $description
+				}
+			) {
+				category {
+					id
+					databaseId
+					name
+					description
+				}
 			}
-		  ) {
-			clientMutationId
-			category {
-			  id
-			  name
-			  description
-			}
-		  }
 		}
 		';
 
-		$variables = wp_json_encode([
-			'clientMutationId' => $this->client_mutation_id,
-			'name' => $this->category_name,
+		$variables = [
+			'name'        => $this->category_name,
 			'description' => $this->description,
-		]);
+		];
 
-		return do_graphql_request( $mutation, 'createCategory', $variables );
-
+		return graphql( compact( 'query', 'variables' ) );
 	}
 
 	/**
@@ -79,33 +73,30 @@ class TermObjectMutationsTest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function createTagMutation() {
 
-		$mutation = '
-		mutation createTag( $clientMutationId:String!, $name:String!, $description:String ) {
-		  createTag(
-		    input: {
-			  clientMutationId: $clientMutationId
-			    name: $name
-				description: $description
+		$query = '
+		mutation createTag( $name:String!, $description:String ) {
+			createTag(
+				input: {
+					name: $name
+					description: $description
+				}
+			) {
+				tag {
+					id
+					databaseId
+					name
+					description
+				}
 			}
-		  ) {
-			clientMutationId
-			tag {
-			  id
-			  name
-			  description
-			}
-		  }
 		}
 		';
 
-		$variables = wp_json_encode([
-			'clientMutationId' => $this->client_mutation_id,
-			'name' => $this->tag_name,
+		$variables = [
+			'name'        => $this->tag_name,
 			'description' => $this->description,
-		]);
+		];
 
-		return do_graphql_request( $mutation, 'createTag', $variables );
-
+		return graphql( compact( 'query', 'variables' ) );
 	}
 
 	/**
@@ -116,62 +107,56 @@ class TermObjectMutationsTest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function updateTagMutation( $id ) {
 
-		$mutation = '
-		mutation updateTag( $clientMutationId:String!, $id:ID! $description:String ) {
-		  updateTag(
-		    input: {
-			  clientMutationId: $clientMutationId
-			  description: $description
-			  id: $id
-			}
-		  ) {
-			clientMutationId
+		$query = '
+		mutation updateTag( $id:ID! $description:String ) {
+			updateTag(
+				input: {
+					description: $description
+					id: $id
+				}
+			) {
 			tag {
-			  id
-			  name
-			  description
+					id
+					databaseId
+					name
+					description
+				}
 			}
-		  }
 		}
 		';
 
-		$variables = wp_json_encode([
-			'clientMutationId' => $this->client_mutation_id,
-			'id' => $id,
+		$variables = [
+			'id'          => $id,
 			'description' => $this->description_update,
-		]);
+		];
 
-		return do_graphql_request( $mutation, 'updateTag', $variables );
-
+		return graphql( compact( 'query', 'variables' ) );
 	}
 
 	public function deleteTagMutation( $id ) {
 
-		$mutation = '
-		mutation deleteTag( $clientMutationId:String!, $id:ID! ) {
-		  deleteTag(
-		    input: {
-			  id: $id
-			  clientMutationId: $clientMutationId
-		    }
-		  ) {
-		    clientMutationId
-		    deletedId
-		    tag {
-		        id
-		        name
-		    }
-		  }
+		$query = '
+		mutation deleteTag( $id:ID! ) {
+			deleteTag(
+				input: {
+					id: $id
+				}
+			) {
+				deletedId
+				tag {
+					databaseId
+					id
+					name
+				}
+			}
 		}
 		';
 
-		$variables = wp_json_encode([
+		$variables = [
 			'id' => $id,
-			'clientMutationId' => $this->client_mutation_id,
-		]);
+		];
 
-		return do_graphql_request( $mutation, 'deleteTag', $variables );
-
+		return graphql( compact( 'query', 'variables' ) );
 	}
 
 	/**
@@ -182,61 +167,55 @@ class TermObjectMutationsTest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function updateCategoryMutation( $id ) {
 
-		$mutation = '
-		mutation updateCategory( $clientMutationId:String!, $id:ID! $description:String ) {
-		  updateCategory(
-		    input: {
-			  clientMutationId: $clientMutationId
-			  description: $description
-			  id: $id
+		$query = '
+		mutation updateCategory( $id:ID! $description:String ) {
+			updateCategory(
+				input: {
+					description: $description
+					id: $id
+				}
+			) {
+				category {
+					databaseId
+					id
+					name
+					description
+				}
 			}
-		  ) {
-			clientMutationId
-			category {
-			  id
-			  name
-			  description
-			}
-		  }
 		}
 		';
 
-		$variables = wp_json_encode([
-			'clientMutationId' => $this->client_mutation_id,
-			'id' => $id,
+		$variables = [
+			'id'          => $id,
 			'description' => $this->description_update,
-		]);
+		];
 
-		return do_graphql_request( $mutation, 'updateCategory', $variables );
-
+		return graphql( compact( 'query', 'variables' ) );
 	}
 
 	public function deleteCategoryMutation( $id ) {
 
-		$mutation = '
-		mutation deleteCategory( $clientMutationId:String!, $id:ID! ) {
-		  deleteCategory(
-		    input: {
-			  id: $id
-			  clientMutationId: $clientMutationId
-		    }
-		  ) {
-		    clientMutationId
-		    category {
-		        id
-		        name
-		    }
-		  }
+		$query = '
+		mutation deleteCategory( $id:ID! ) {
+			deleteCategory(
+				input: {
+					id: $id
+				}
+			) {
+				category {
+					databaseId
+					id
+					name
+				}
+			}
 		}
 		';
 
-		$variables = wp_json_encode([
+		$variables = [
 			'id' => $id,
-			'clientMutationId' => $this->client_mutation_id,
-		]);
+		];
 
-		return do_graphql_request( $mutation, 'deleteCategory', $variables );
-
+		return graphql( compact( 'query', 'variables' ) );
 	}
 
 
@@ -255,11 +234,12 @@ class TermObjectMutationsTest extends \Codeception\TestCase\WPTestCase
 		 * Run the mutation
 		 */
 		$actual = $this->createCategoryMutation();
+		codecept_debug( $actual );
 
 		/**
 		 * Assert that the created tag is what it should be
 		 */
-		$this->assertEquals( $actual['data']['createCategory']['clientMutationId'], $this->client_mutation_id );
+		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertNotEmpty( $actual['data']['createCategory']['category']['id'] );
 		$id_parts = \GraphQLRelay\Relay::fromGlobalId( $actual['data']['createCategory']['category']['id'] );
 		$this->assertEquals( $id_parts['type'], 'term' );
@@ -271,29 +251,38 @@ class TermObjectMutationsTest extends \Codeception\TestCase\WPTestCase
 		 * Try to update a Tag using a category ID, which should return errors
 		 */
 		$try_to_update_tag = $this->updateTagMutation( $actual['data']['createCategory']['category']['id'] );
-		$this->assertNotEmpty( $try_to_update_tag['errors'] );
+		$this->assertArrayHasKey( 'errors', $try_to_update_tag );
 
 		/**
 		 * Try to update a Tag using a category ID, which should return errors
 		 */
 		$try_to_delete_tag = $this->deleteTagMutation( $actual['data']['createCategory']['category']['id'] );
-		$this->assertNotEmpty( $try_to_delete_tag['errors'] );
+		$this->assertArrayHasKey( 'errors', $try_to_delete_tag );
 
 		/**
-		 * Run the update mutation with the ID of the created tag
+		 * Run the update mutation with the ID of the created created
 		 */
 		$updated_category = $this->updateCategoryMutation( $actual['data']['createCategory']['category']['id'] );
+		codecept_debug( $updated_category );
+		$this->assertArrayNotHasKey( 'errors', $updated_category );
 
 		/**
 		 * Make some assertions on the response
 		 */
-		$this->assertEquals( $updated_category['data']['updateCategory']['clientMutationId'], $this->client_mutation_id );
 		$this->assertNotEmpty( $updated_category['data']['updateCategory']['category']['id'] );
 		$id_parts = \GraphQLRelay\Relay::fromGlobalId( $updated_category['data']['updateCategory']['category']['id'] );
 		$this->assertEquals( $id_parts['type'], 'term' );
 		$this->assertNotEmpty( $id_parts['id'] );
 		$this->assertEquals( $updated_category['data']['updateCategory']['category']['name'], $this->category_name );
 		$this->assertEquals( $updated_category['data']['updateCategory']['category']['description'], $this->description_update );
+
+		/**
+		 * Run the update mutation with the databaseID
+		 */
+		$updated_category = $this->updateCategoryMutation( $actual['data']['createCategory']['category']['databaseId'] );
+		codecept_debug( $updated_category );
+		$this->assertArrayNotHasKey( 'errors', $updated_category );
+		$this->assertEquals( $actual['data']['createCategory']['category']['databaseId'], $updated_category['data']['updateCategory']['category']['databaseId'] );
 
 		/**
 		 * Delete the tag
@@ -311,18 +300,24 @@ class TermObjectMutationsTest extends \Codeception\TestCase\WPTestCase
 		 */
 		wp_set_current_user( $this->admin );
 		$deleted_category = $this->deleteCategoryMutation( $updated_category['data']['updateCategory']['category']['id'] );
-
 		codecept_debug( $deleted_category );
 
 		/**
 		 * Make some assertions on the response
 		 */
-		$this->assertNotEmpty( $deleted_category );
-		$this->assertEquals( $deleted_category['data']['deleteCategory']['clientMutationId'], $this->client_mutation_id );
+		$this->assertArrayNotHasKey( 'errors', $deleted_category );
 		$id_parts = \GraphQLRelay\Relay::fromGlobalId( $deleted_category['data']['deleteCategory']['category']['id'] );
 		$this->assertEquals( $id_parts['type'], 'term' );
 		$this->assertNotEmpty( $id_parts['id'] );
 		$this->assertEquals( $deleted_category['data']['deleteCategory']['category']['name'], $this->category_name );
+
+		/**
+		 * Test delete with databaseId
+		 */
+		$category_id      = $this->factory()->category->create();
+		$deleted_category = $this->deleteCategoryMutation( $category_id );
+		$this->assertArrayNotHasKey( 'errors', $deleted_category );
+		$this->assertEquals( $category_id, $deleted_category['data']['deleteCategory']['category']['databaseId'] );
 	}
 
 	public function testCreateTagThatAlreadyExists() {
@@ -394,7 +389,7 @@ class TermObjectMutationsTest extends \Codeception\TestCase\WPTestCase
 		/**
 		 * Now let's filter to mimick the response returning a WP_Error to make sure we also respond with an error
 		 */
-		add_filter( 'get_post_tag', function() {
+		add_filter( 'get_post_tag', function () {
 			return new \WP_Error( 'this is a test error' );
 		} );
 
@@ -403,13 +398,13 @@ class TermObjectMutationsTest extends \Codeception\TestCase\WPTestCase
 		 */
 		$term = $this->factory()->term->create([
 			'taxonomy' => 'post_tag',
-			'name' => 'some random name',
+			'name'     => 'some random name',
 		]);
 
 		/**
 		 * Now try and delete it.
 		 */
-		$id = \GraphQLRelay\Relay::toGlobalId( 'term', $term );
+		$id     = \GraphQLRelay\Relay::toGlobalId( 'term', $term );
 		$actual = $this->deleteTagMutation( $id );
 
 		/**
@@ -417,36 +412,32 @@ class TermObjectMutationsTest extends \Codeception\TestCase\WPTestCase
 		 */
 		$this->assertArrayHasKey( 'errors', $actual );
 
-
 	}
 
 	public function testCreateTagWithNoName() {
 
-		$mutation = '
-		mutation createTag( $clientMutationId:String!, $name:String!, $description:String ) {
-		  createTag(
-		    input: {
-			  clientMutationId: $clientMutationId
-			    name: $name
-				description: $description
+		$query = '
+		mutation createTag( $name:String!, $description:String ) {
+			createTag(
+				input: {
+					name: $name
+					description: $description
+				}
+			) {
+				tag {
+					id
+					name
+					description
+				}
 			}
-		  ) {
-			clientMutationId
-			tag {
-			  id
-			  name
-			  description
-			}
-		  }
 		}
 		';
 
-		$variables = wp_json_encode([
-			'clientMutationId' => $this->client_mutation_id,
+		$variables = [
 			'description' => $this->description,
-		]);
+		];
 
-		$actual = do_graphql_request( $mutation, 'createTag', $variables );
+		$actual = graphql( compact( 'query', 'variables' ) );
 
 		$this->assertNotEmpty( $actual );
 		$this->assertArrayHasKey( 'errors', $actual );
@@ -468,11 +459,11 @@ class TermObjectMutationsTest extends \Codeception\TestCase\WPTestCase
 		 * Run the mutation
 		 */
 		$actual = $this->createTagMutation();
+		codecept_debug( $actual );
 
 		/**
 		 * Assert that the created tag is what it should be
 		 */
-		$this->assertEquals( $actual['data']['createTag']['clientMutationId'], $this->client_mutation_id );
 		$this->assertNotEmpty( $actual['data']['createTag']['tag']['id'] );
 		$id_parts = \GraphQLRelay\Relay::fromGlobalId( $actual['data']['createTag']['tag']['id'] );
 		$this->assertEquals( $id_parts['type'], 'term' );
@@ -500,17 +491,15 @@ class TermObjectMutationsTest extends \Codeception\TestCase\WPTestCase
 		$try_to_delete_category = $this->updateCategoryMutation( $actual['data']['createTag']['tag']['id'] );
 		$this->assertNotEmpty( $try_to_delete_category['errors'] );
 
-
-
 		/**
 		 * Run the update mutation with the ID of the created tag
 		 */
 		$updated_tag = $this->updateTagMutation( $actual['data']['createTag']['tag']['id'] );
+		codecept_debug( $updated_tag );
 
 		/**
 		 * Make some assertions on the response
 		 */
-		$this->assertEquals( $updated_tag['data']['updateTag']['clientMutationId'], $this->client_mutation_id );
 		$this->assertNotEmpty( $updated_tag['data']['updateTag']['tag']['id'] );
 		$id_parts = \GraphQLRelay\Relay::fromGlobalId( $updated_tag['data']['updateTag']['tag']['id'] );
 		$this->assertEquals( $id_parts['type'], 'term' );
@@ -519,21 +508,37 @@ class TermObjectMutationsTest extends \Codeception\TestCase\WPTestCase
 		$this->assertEquals( $updated_tag['data']['updateTag']['tag']['description'], $this->description_update );
 
 		/**
+		 * Run the update mutation with the databaseID
+		 */
+		$updated_tag = $this->updateTagMutation( $actual['data']['createTag']['tag']['databaseId'] );
+		codecept_debug( $updated_tag );
+
+		$this->assertArrayNotHasKey( 'errors', $updated_tag );
+		$this->assertEquals( $actual['data']['createTag']['tag']['databaseId'], $updated_tag['data']['updateTag']['tag']['databaseId'] );
+
+		/**
 		 * Delete the tag
 		 */
 		$deleted_tag = $this->deleteTagMutation( $updated_tag['data']['updateTag']['tag']['id'] );
+		codecept_debug( $deleted_tag );
 
 		/**
 		 * Make some assertions on the response
 		 */
 		$this->assertNotEmpty( $deleted_tag );
-		$this->assertEquals( $deleted_tag['data']['deleteTag']['clientMutationId'], $this->client_mutation_id );
 		$this->assertNotEmpty( $deleted_tag['data']['deleteTag']['deletedId'] );
 		$id_parts = \GraphQLRelay\Relay::fromGlobalId( $deleted_tag['data']['deleteTag']['tag']['id'] );
 		$this->assertEquals( $id_parts['type'], 'term' );
 		$this->assertNotEmpty( $id_parts['id'] );
 		$this->assertEquals( $deleted_tag['data']['deleteTag']['tag']['name'], $this->tag_name );
 
+		// Test delete with database_id
+		$tag_id      = $this->factory()->tag->create();
+		$deleted_tag = $this->deleteTagMutation( $tag_id );
+		codecept_debug( $deleted_tag );
+
+		$this->assertArrayNotHasKey( 'errors', $deleted_tag );
+		$this->assertEquals( $tag_id, $deleted_tag['data']['deleteTag']['tag']['databaseId'] );
 	}
 
 	/**
@@ -586,47 +591,202 @@ class TermObjectMutationsTest extends \Codeception\TestCase\WPTestCase
 
 	}
 
-	public function testUpdateCategoryParent() {
+	/**
+	 * Tests updating a category with bad id.
+	 */
+	public function testUpdateCategoryWithBadId() {
+		$query =
+		'mutation updateCategory( $id:ID! $description:String ) {
+			updateCategory(
+				input: {
+					description: $description
+					id: $id
+				}
+			) {
+				category {
+					databaseId
+					id
+					name
+					description
+				}
+			}
+		}
+		';
+
+		// Test no id.
+		$variables = [
+			'id'          => '',
+			'description' => 'Some description',
+		];
+		$actual    = graphql( compact( 'query', 'variables' ) );
+		$this->assertArrayHasKey( 'errors', $actual );
+
+		// Test non-existent id.
+		$variables['id'] = 99999999;
+		$actual          = $this->graphql( compact( 'query', 'variables' ) );
+		$this->assertArrayHasKey( 'errors', $actual );
+	}
+
+	/**
+	 * Tests category mutations with a parent category.
+	 */
+	public function testCategoryParent() {
 
 		wp_set_current_user( $this->admin );
 
 		$parent_term_id = $this->factory()->term->create([
 			'taxonomy' => 'category',
-			'name' => 'Parent Category',
+			'name'     => 'Parent Category',
 		]);
 
 		$query = '
 		mutation createChildCategory($input: CreateCategoryInput!) {
-		  createCategory(input: $input) {
-		    category {
-		      parent{
-		        node {
-		          id
-		        }
-		      }
+			createCategory(input: $input) {
+				category {
+					databaseId
+					id
+					parent {
+						node {
+							databaseId
+							id
+						}
+					}
+				}
+			}
+		}
+		';
+
+		// Test with bad parent ID
+		$variables = [
+			'input' => [
+				'name'     => 'Child Category 1',
+				'parentId' => 'notarealid',
+			],
+		];
+
+		$actual = graphql( compact( 'query', 'variables' ) );
+		$this->assertArrayHasKey( 'errors', $actual );
+
+		// Test with non-existent parent ID
+		$variables['input']['parentId'] = 999999;
+
+		$actual = graphql( compact( 'query', 'variables' ) );
+		$this->assertArrayHasKey( 'errors', $actual );
+
+		// Test with database ID
+		$variables['input']['parentId'] = $parent_term_id;
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEquals( $parent_term_id, $actual['data']['createCategory']['category']['parent']['node']['databaseId'] );
+
+		// Test with globalId ID
+		$parent_id = \GraphQLRelay\Relay::toGlobalId( 'term', $parent_term_id );
+		// Test with database ID
+		$variables = [
+			'input' => [
+				'name'     => 'Child Category 2',
+				'parentId' => $parent_id,
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEquals( $parent_id, $actual['data']['createCategory']['category']['parent']['node']['id'] );
+
+		// Test changing parent ID.
+		$database_id        = $actual['data']['createCategory']['category']['databaseId'];
+		$new_parent_term_id = $this->factory()->term->create([
+			'taxonomy' => 'category',
+			'name'     => 'Parent Category 2',
+		]);
+
+		$query = '
+		mutation updateChildCategory($input: UpdateCategoryInput!) {
+			updateCategory(input: $input) {
+				category {
+					parent{
+						node {
+							databaseId
+							id
+						}
+					}
+				}
+			}
+		}
+		';
+
+		// Test with database ID
+		$variables = [
+			'input' => [
+				'id'       => $database_id,
+				'parentId' => $new_parent_term_id,
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEquals( $new_parent_term_id, $actual['data']['updateCategory']['category']['parent']['node']['databaseId'] );
+
+		// Test with global ID
+		$variables['input']['parentId'] = $parent_id; // Switch back to previous parent.
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEquals( $parent_id, $actual['data']['updateCategory']['category']['parent']['node']['id'] );
+	}
+
+  /**
+	 * @see: https://github.com/wp-graphql/wp-graphql/issues/2378
+	 * @return void
+	 * @throws Exception
+	 */
+	public function testCreateTermWithApostropheInNameDoesntStoreSlashInDatabase() {
+
+		$mutation = '
+		mutation ($input: CreateTagInput!) {
+		  createTag(input: $input) {
+		    tag {
+		      databaseId
+		      name
+		      slug
+		      description
 		    }
 		  }
 		}
 		';
 
-		$parent_id = \GraphQLRelay\Relay::toGlobalId( 'term', $parent_term_id );
+		$expected_name = "what's up";
+		$slug_input = "what's-up"; // includes apostrophe
+		$expected_slug = sanitize_title( $slug_input ); // wp should strip it on save
+		$expected_description = "what's up, description";
 
-		$variables = [
-			'input' => [
-				'clientMutationId' => 'someId',
-				'name' => 'Child Category',
-				'parentId' => $parent_id,
-			],
-		];
+		wp_set_current_user( $this->admin );
 
-		$actual = do_graphql_request( $query, 'createChildCategory', $variables );
+		$actual = graphql([
+			'query' => $mutation,
+			'variables' => [
+				'input' => [
+					'name' => $expected_name,
+					'slug' => $slug_input,
+					'description' => $expected_description,
+				]
+			]
+		]);
 
 		codecept_debug( $actual );
 
 		$this->assertArrayNotHasKey( 'errors', $actual );
-		$this->assertEquals( $parent_id, $actual['data']['createCategory']['category']['parent']['node']['id'] );
+		$this->assertSame( $expected_name, $actual['data']['createTag']['tag']['name'] );
+		$this->assertSame( $expected_slug, $actual['data']['createTag']['tag']['slug'] );
+		$this->assertSame( $expected_description, $actual['data']['createTag']['tag']['description'] );
+		$this->assertSame( $expected_name, get_term(  $actual['data']['createTag']['tag']['databaseId'], 'post_tag' )->name );
+		$this->assertSame( $expected_slug, get_term(  $actual['data']['createTag']['tag']['databaseId'], 'post_tag' )->slug );
+		$this->assertSame( $expected_description, get_term(  $actual['data']['createTag']['tag']['databaseId'], 'post_tag' )->description );
 
 	}
-
-
 }

--- a/tests/wpunit/ThemeConnectionQueriesTest.php
+++ b/tests/wpunit/ThemeConnectionQueriesTest.php
@@ -62,9 +62,7 @@ class ThemeConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTest
 		}
 		';
 
-		$themes = wp_get_themes();
-
-		codecept_debug( $themes );
+		$themes = wp_get_themes([ 'allowed' => null ]);
 
 		if ( ! empty( $user ) ) {
 			$current_user = $this->admin;
@@ -74,7 +72,12 @@ class ThemeConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTest
 			$return_count = 1;
 		}
 
+		if ( is_multisite() ) {
+			grant_super_admin( $current_user );
+		}
+
 		wp_set_current_user( $current_user );
+
 		$actual = $this->graphql( [ 'query' => $query ] );
 
 		/**
@@ -99,6 +102,11 @@ class ThemeConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTest
 	 * Tests querying for theme with pagination args.
 	 */
 	public function testThemesQueryPagination() {
+
+
+		if ( is_multisite() ) {
+			grant_super_admin( $this->admin );
+		}
 		wp_set_current_user( $this->admin );
 
 		$query = '
@@ -152,7 +160,9 @@ class ThemeConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTest
 			'before' => null,
 		];
 
+
 		$expected = array_slice( $nodes, count( $nodes ) - $variables['last'], null, true );
+		codecept_debug( [ 'expected' => $expected ] );
 		$actual   = $this->graphql( compact( 'query', 'variables' ) );
 		$this->assertEqualSets( $expected, $actual['data']['themes']['nodes'] );
 
@@ -168,7 +178,7 @@ class ThemeConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTest
 				'user' => 'admin',
 			],
 			[
-				'user' => '',
+				'user' => null,
 			],
 		];
 	}

--- a/tests/wpunit/UserObjectMutationsTest.php
+++ b/tests/wpunit/UserObjectMutationsTest.php
@@ -652,7 +652,13 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 		/**
 		 * Enable new user registration.
 		 */
-		update_option( 'users_can_register', 1 );
+		if ( is_multisite() ) {
+			// multisite doesn't like uppercase letters in usernames 🤷‍️
+			$username = strtolower( $username );
+			update_site_option( 'registration', 'user' );
+		} else {
+			update_option( 'users_can_register', 1 );
+		}
 
 		/**
 		 * Run the mutation.
@@ -661,6 +667,8 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 			'username' => $username,
 			'email'    => $email,
 		] );
+
+		codecept_debug( $actual );
 
 		$expected = [
 			'registerUser' => [

--- a/tests/wpunit/UserObjectMutationsTest.php
+++ b/tests/wpunit/UserObjectMutationsTest.php
@@ -1,10 +1,9 @@
 <?php
 
-class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
+class UserObjectMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 	public $first_name;
 	public $last_name;
-	public $client_mutation_id;
 
 	public $author;
 	public $admin;
@@ -22,9 +21,8 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 		remove_all_filters( 'enable_edit_any_user_configuration' );
 		add_filter( 'enable_edit_any_user_configuration', '__return_true' );
 
-		$this->client_mutation_id = 'someUniqueId';
-		$this->first_name         = 'Test';
-		$this->last_name          = 'User';
+		$this->first_name = 'Test';
+		$this->last_name  = 'User';
 
 		$this->author = $this->factory->user->create( [
 			'role' => 'author',
@@ -66,7 +64,7 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 
 		foreach ( $caps as $key => $capability ) {
 
-			if ( $capability != 'do_not_allow' ) {
+			if ( 'do_not_allow' !== $capability ) {
 				continue;
 			}
 
@@ -90,41 +88,36 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 
 	public function createUserMutation( $args ) {
 
-		$mutation = '
+		$query = '
 		mutation createUser($input:CreateUserInput!) {
-		  createUser(input:$input){
-			clientMutationId
-			user{
-			  firstName
-			  lastName
-			  roles {
-			    nodes {
-			      name
-			    }
-			  }
-			  email
-			  username
+			createUser(input:$input){
+				user{
+					firstName
+					lastName
+					roles {
+						nodes {
+							name
+						}
+					}
+					email
+					username
+				}
 			}
-		  }
 		}';
 
 		$variables = [
 			'input' => [
-				'clientMutationId' => $this->client_mutation_id,
-				'username'         => $args['username'],
-				'email'            => $args['email'],
-				'firstName'        => $this->first_name,
-				'lastName'         => $this->last_name,
-				'roles'            => [
+				'username'  => $args['username'],
+				'email'     => $args['email'],
+				'firstName' => $this->first_name,
+				'lastName'  => $this->last_name,
+				'roles'     => [
 					'administrator',
-				]
-			]
+				],
+			],
 		];
 
-		$actual = do_graphql_request( $mutation, 'createUser', $variables );
-
-		return $actual;
-
+		return graphql( compact( 'query', 'variables' ) );
 	}
 
 	public function testCreateUserObjectWithoutProperCapabilities() {
@@ -149,7 +142,7 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 		 * because this user doesn't have permissions to create a user as a
 		 * subscriber
 		 */
-		$this->assertNotEmpty( $actual['errors'] );
+		$this->assertArrayHasKey( 'errors', $actual );
 
 	}
 
@@ -165,23 +158,24 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 			'email'    => $email,
 		] );
 
+		codecept_debug( $actual );
+
 		$expected = [
 			'createUser' => [
-				'clientMutationId' => $this->client_mutation_id,
-				'user'             => [
+				'user' => [
 					'firstName' => $this->first_name,
 					'lastName'  => $this->last_name,
 					'roles'     => [
 						'nodes' => [
 							[
 								'name' => 'administrator',
-							]
+							],
 						],
 					],
 					'email'     => $email,
 					'username'  => $username,
-				]
-			]
+				],
+			],
 		];
 
 		$this->assertEquals( $expected, $actual['data'] );
@@ -195,7 +189,7 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 		$username = 'duplicateUsername';
 
 		$this->factory->user->create( [
-			'user_login' => $username
+			'user_login' => $username,
 		] );
 
 		$second_user = $this->createUserMutation( [
@@ -269,24 +263,23 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertEquals( $user_object->first_name, $first_name );
 		$this->assertEquals( $user_object->last_name, $last_name );
 
-		$mutation = '
+		$query = '
 		mutation updateUser($input:UpdateUserInput!) {
-		  updateUser(input:$input){
-			clientMutationId
-			user{
-			  firstName
-			  lastName
-			  roles {
-			    nodes {
-			      name
-			    }
-			  }
-			  username
-			  email
-			  databaseId
-			  id
+			updateUser(input:$input){
+				user{
+					firstName
+					lastName
+					roles {
+						nodes {
+							name
+						}
+					}
+					username
+					email
+					databaseId
+					id
+				}
 			}
-		  }
 		}
 		';
 
@@ -294,101 +287,67 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 		$updated_firstname = 'Testupdate';
 		$updated_lastname  = 'Updatetest';
 
+		// Test with no id
 		$variables = [
 			'input' => [
-				'id'               => $guid,
-				'clientMutationId' => $this->client_mutation_id,
-				'email'            => $updated_email,
-				'firstName'        => $updated_firstname,
-				'lastName'         => $updated_lastname,
-				'roles'            => [
+				'id'        => '',
+				'email'     => $updated_email,
+				'firstName' => $updated_firstname,
+				'lastName'  => $updated_lastname,
+				'roles'     => [
 					'administrator',
-				]
-			]
+				],
+			],
 		];
 
-		$actual = do_graphql_request( $mutation, 'updateUser', $variables );
+		$actual = graphql( compact( 'query', 'variables' ) );
+		$this->assertArrayHasKey( 'errors', $actual );
+
+		// Test with bad id
+		$variables['input']['id'] = 999999;
+
+		$actual = graphql( compact( 'query', 'variables' ) );
+		$this->assertArrayHasKey( 'errors', $actual );
+
+		// Test with database ID.
+		$variables['input']['id'] = $user_id;
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
 		$expected = [
 			'updateUser' => [
-				'clientMutationId' => $this->client_mutation_id,
-				'user'             => [
-					'firstName' => $updated_firstname,
-					'lastName'  => $updated_lastname,
-					'roles'     => [
+				'user' => [
+					'firstName'  => $updated_firstname,
+					'lastName'   => $updated_lastname,
+					'roles'      => [
 						'nodes' => [
 							[
 								'name' => 'administrator',
-							]
+							],
 						],
 					],
-					'username'  => $user_login,
-					'email'     => $updated_email,
-					'databaseId'    => $user_id,
-					'id'        => $guid,
-				]
-			]
+					'username'   => $user_login,
+					'email'      => $updated_email,
+					'databaseId' => $user_id,
+					'id'         => $guid,
+				],
+			],
 		];
 
 		$this->assertEquals( $expected, $actual['data'] );
 
-	}
+		// Test with global ID.
+		$updated_email = 'testUserUpdated2@test.com';
 
-	public function testDeleteUserWithCapability() {
-
-		wp_set_current_user( $this->admin );
-
-		$username = 'user_to_delete_with_capability';
-
-		$user_id = $this->factory->user->create( [
-			'role'       => 'subscriber',
-			'user_login' => $username,
-		] );
-
-		$guid = \GraphQLRelay\Relay::toGlobalId( 'user', $user_id );
-
-		$mutation = '
-		mutation deleteUser($input:DeleteUserInput!) {
-		  deleteUser(input:$input){
-			clientMutationId
-			user {
-			  username
-			  databaseId
-			  id
-			}
-		  }
-		}
-		';
-
-		$variables = [
-			'input' => [
-				'id'               => $guid,
-				'clientMutationId' => $this->client_mutation_id,
-			]
+		$variables['input'] = [
+			'id'    => $guid,
+			'email' => $updated_email,
 		];
 
-		$actual = do_graphql_request( $mutation, 'deleteUser', $variables );
-
-		$expected = [
-			'deleteUser' => [
-				'clientMutationId' => $this->client_mutation_id,
-				'user'             => [
-					'username' => $username,
-					'databaseId'   => $user_id,
-					'id'       => $guid,
-				]
-			]
-		];
-
-		$this->assertEquals( $expected, $actual['data'] );
-
-		$user_obj_after_delete = get_user_by( 'id', $user_id );
-
-		/**
-		 * Make sure the user actually got deleted.
-		 */
-		$this->assertEquals( false, $user_obj_after_delete );
-
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+		$this->assertEquals( $guid, $actual['data']['updateUser']['user']['id'] );
+		$this->assertEquals( $user_id, $actual['data']['updateUser']['user']['databaseId'] );
+		$this->assertEquals( $updated_email, $actual['data']['updateUser']['user']['email'] );
 	}
 
 	public function testDeleteUserWithoutCapability() {
@@ -402,27 +361,25 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 
 		$guid = \GraphQLRelay\Relay::toGlobalId( 'user', $user_id );
 
-		$mutation = '
+		$query = '
 		mutation deleteUser($input:DeleteUserInput!) {
-		  deleteUser(input:$input){
-			clientMutationId
-			user{
-			  username
-			  databaseId
-			  id
+			deleteUser(input:$input){
+				user{
+					username
+					databaseId
+					id
+				}
 			}
-		  }
 		}
 		';
 
 		$variables = [
 			'input' => [
-				'id'               => $guid,
-				'clientMutationId' => $this->client_mutation_id,
-			]
+				'id' => $guid,
+			],
 		];
 
-		$actual = do_graphql_request( $mutation, 'deleteUser', $variables );
+		$actual = graphql( compact( 'query', 'variables' ) );
 
 		$this->assertEquals( 'Sorry, you are not allowed to delete users.', $actual['errors'][0]['message'] );
 
@@ -435,13 +392,192 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 
 	}
 
+	public function testDeleteUserWithCapability() {
+
+		wp_set_current_user( $this->admin );
+
+		$username = 'user_to_delete_with_capability';
+
+		$query = '
+		mutation deleteUser($input:DeleteUserInput!) {
+			deleteUser(input:$input){
+				deletedId
+				user {
+					username
+					databaseId
+					id
+				}
+			}
+		}
+		';
+
+		// Test with no Id
+		$variables = [
+			'input' => [
+				'id' => '',
+			],
+		];
+
+		$actual = graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayHasKey( 'errors', $actual );
+
+		// Test with bad Id
+		$variables['input']['id'] = 999999;
+
+		$actual = graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayHasKey( 'errors', $actual );
+
+		// Test with databaseId
+		$user_id = $this->factory->user->create( [
+			'role'       => 'subscriber',
+			'user_login' => $username,
+		] );
+
+		$guid = \GraphQLRelay\Relay::toGlobalId( 'user', $user_id );
+
+		$variables['input']['id'] = $user_id;
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$expected = [
+			'deleteUser' => [
+				'deletedId' => $guid,
+				'user'      => [
+					'username'   => $username,
+					'databaseId' => $user_id,
+					'id'         => $guid,
+				],
+			],
+		];
+
+		$this->assertEquals( $expected, $actual['data'] );
+
+		$user_obj_after_delete = get_user_by( 'id', $user_id );
+
+		/**
+		 * Make sure the user actually got deleted.
+		 */
+		$this->assertEquals( false, $user_obj_after_delete );
+
+		// Test with global Id
+		$user_id = $this->factory->user->create( [
+			'role'       => 'subscriber',
+			'user_login' => $username,
+		] );
+
+		$guid = \GraphQLRelay\Relay::toGlobalId( 'user', $user_id );
+
+		$variables['input']['id'] = $guid;
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$expected = [
+			'deleteUser' => [
+				'deletedId' => $guid,
+				'user'      => [
+					'username'   => $username,
+					'databaseId' => $user_id,
+					'id'         => $guid,
+				],
+			],
+		];
+
+		$this->assertEquals( $expected, $actual['data'] );
+
+		$user_obj_after_delete = get_user_by( 'id', $user_id );
+
+		/**
+		 * Make sure the user actually got deleted.
+		 */
+		$this->assertEquals( false, $user_obj_after_delete );
+	}
+
+	public function testDeleteUserWithReassign() {
+
+		wp_set_current_user( $this->admin );
+
+		$username = 'user_to_delete_with_reassign';
+
+		$query = '
+		mutation deleteUser($input:DeleteUserInput!) {
+			deleteUser(input:$input){
+				user {
+					databaseId
+				}
+			}
+		}
+		';
+
+		// Test with no Id
+		$user_id = $this->factory->user->create( [
+			'role'       => 'subscriber',
+			'user_login' => $username,
+		] );
+
+		$post = $this->factory()->post->create( [
+			'post_author' => $user_id,
+		]);
+
+		// Test with bad id.
+		$variables = [
+			'input' => [
+				'reassignId' => 999999,
+				'id'         => $user_id,
+			],
+		];
+
+		$actual = graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayHasKey( 'errors', $actual );
+
+		// Test with databaseId
+		$variables['input']['reassignId'] = $this->admin;
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertEquals( $user_id, $actual['data']['deleteUser']['user']['databaseId'] );
+
+		$post_obj_after_delete = get_post( $post );
+
+		// Make sure the user actually got reassigned.
+		$this->assertEquals( $this->admin, $post_obj_after_delete->post_author );
+
+		// Test with global Id
+		$user_id = $this->factory->user->create( [
+			'role'       => 'subscriber',
+			'user_login' => $username,
+		] );
+		wp_update_post( [
+			'ID'          => $post,
+			'post_author' => $user_id,
+		] );
+
+		$this->assertEquals( $user_id, get_post( $post )->post_author );
+
+		$guid = \GraphQLRelay\Relay::toGlobalId( 'user', $this->admin );
+
+		$variables['input']['id']         = $user_id;
+		$variables['input']['reassignId'] = $guid;
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertEquals( $user_id, $actual['data']['deleteUser']['user']['databaseId'] );
+
+		$post_obj_after_delete = get_post( $post );
+
+		// Make sure the user actually got reassigned.
+		$this->assertEquals( $this->admin, $post_obj_after_delete->post_author );
+	}
+
 	public function testCreateUserWithExtraFields() {
 
 		$username    = 'userwithextrafields';
 		$email       = 'userWithExtraFields@test.com';
 		$nicename    = 'user NiceName';
 		$url         = 'http://wpgraphql.com';
-		$date        = date( "Y-m-d H:i:s" );
+		$date        = date( 'Y-m-d H:i:s' );
 		$displayName = 'User Display Name';
 		$nickname    = 'User Nickname';
 		$description = 'User Description';
@@ -451,29 +587,27 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 
 		$variables = [
 			'input' => [
-				'firstName'        => $this->first_name,
-				'lastName'         => $this->last_name,
-				'clientMutationId' => $this->client_mutation_id,
-				'username'         => $username,
-				'email'            => $email,
-				'password'         => 'somePassword',
-				'websiteUrl'       => $url,
-				'nicename'         => $nicename,
-				'displayName'      => $displayName,
-				'nickname'         => $nickname,
-				'description'      => $description,
-				'registered'       => $date,
-				'locale'           => $locale,
-				'roles'            => [
+				'firstName'   => $this->first_name,
+				'lastName'    => $this->last_name,
+				'username'    => $username,
+				'email'       => $email,
+				'password'    => 'somePassword',
+				'websiteUrl'  => $url,
+				'nicename'    => $nicename,
+				'displayName' => $displayName,
+				'nickname'    => $nickname,
+				'description' => $description,
+				'registered'  => $date,
+				'locale'      => $locale,
+				'roles'       => [
 					'administrator',
 				],
 			],
 		];
 
-		$mutation = '
+		$query = '
 		mutation createAndGetUser( $input:CreateUserInput! ) {
 			createUser( input: $input ) {
-				clientMutationId
 				user {
 					firstName
 					lastName
@@ -489,12 +623,11 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 		}
 		';
 
-		$actual = do_graphql_request( $mutation, 'createAndGetUser', $variables );
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
 		$expected = [
 			'createUser' => [
-				'clientMutationId' => $this->client_mutation_id,
-				'user'             => [
+				'user' => [
 					'firstName'   => $this->first_name,
 					'lastName'    => $this->last_name,
 					'email'       => $email,
@@ -503,9 +636,9 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 					'name'        => $displayName,
 					'nickname'    => $nickname,
 					'description' => $description,
-					'locale'      => $locale
-				]
-			]
+					'locale'      => $locale,
+				],
+			],
 		];
 
 		$this->assertEquals( $expected, $actual['data'] );
@@ -514,10 +647,9 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 
 	public function testCreateUserWithoutRoles() {
 
-		$mutation = '
+		$query = '
 		mutation createUserWithoutRoles( $input:CreateUserInput! ) {
 			createUser( input: $input ) {
-				clientMutationId
 				user {
 					firstName
 					lastName
@@ -529,21 +661,19 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 
 		$variables = [
 			'input' => [
-				'firstName'        => $this->first_name,
-				'lastName'         => $this->last_name,
-				'username'         => 'createuserwithoutroles',
-				'clientMutationId' => $this->client_mutation_id,
+				'firstName' => $this->first_name,
+				'lastName'  => $this->last_name,
+				'username'  => 'createuserwithoutroles',
 			],
 		];
 
 		wp_set_current_user( $this->admin );
 
-		$actual = do_graphql_request( $mutation, 'createUserWithoutRoles', $variables );
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
 		$expected = [
 			'createUser' => [
-				'clientMutationId' => $this->client_mutation_id,
-				'user'             => [
+				'user' => [
 					'firstName' => $this->first_name,
 					'lastName'  => $this->last_name,
 					'username'  => 'createuserwithoutroles',
@@ -551,18 +681,15 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 			],
 		];
 
-		codecept_debug( $actual );
-
 		$this->assertEquals( $expected, $actual['data'] );
 
 	}
 
 	public function testUpdateUserWithInvalidRole() {
 
-		$mutation = '
+		$query = '
 		mutation updateUserWithInvalidRole( $input:UpdateUserInput! ) {
 			updateUser( input: $input )	{
-				clientMutationId
 				user {
 					id
 					name
@@ -573,17 +700,16 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 
 		$variables = [
 			'input' => [
-				'clientMutationId' => $this->client_mutation_id,
-				'id'               => \GraphQLRelay\Relay::toGlobalId( 'user', $this->author ),
-				'roles'            => [
-					'invalidRole'
+				'id'    => \GraphQLRelay\Relay::toGlobalId( 'user', $this->author ),
+				'roles' => [
+					'invalidRole',
 				],
 			],
 		];
 
 		wp_set_current_user( $this->admin );
 
-		$actual = do_graphql_request( $mutation, 'updateUserWithInvalidRole', $variables );
+		$actual = graphql( compact( 'query', 'variables' ) );
 
 		$this->assertTrue( ( 'Sorry, you are not allowed to give this the following role: invalidRole.' === $actual['errors'][0]['message'] ) || ( 'Internal server error' === $actual['errors'][0]['message'] ) );
 
@@ -591,33 +717,28 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 
 	public function registerUserMutation( $args ) {
 
-		$mutation = '
+		$query = '
 		mutation registerUser($input:RegisterUserInput!) {
-		  registerUser(input:$input) {
-		    clientMutationId
-			user {
-			  name
-			  slug
+			registerUser(input:$input) {
+				user {
+					name
+					slug
+				}
 			}
-		  }
 		}';
 
 		$variables = [
 			'input' => [
-				'clientMutationId' => $this->client_mutation_id,
-				'username'         => $args['username'],
-				'email'            => $args['email'],
-			]
+				'username' => $args['username'],
+				'email'    => $args['email'],
+			],
 		];
 
 		if ( ! empty( $args['password'] ) ) {
 			$variables['input']['password'] = $args['password'];
 		}
 
-		$actual = do_graphql_request( $mutation, 'registerUser', $variables );
-
-		return $actual;
-
+		return graphql( compact( 'query', 'variables' ) );
 	}
 
 	public function testRegisterUserWithRegistrationDisabled() {
@@ -635,7 +756,6 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 			'email'    => 'emailDoesNotExist@test.com',
 		] );
 
-
 		/**
 		 * We're asserting that this will properly return an error
 		 * because registration is disabled.
@@ -646,8 +766,8 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 
 	public function testRegisterUserWithRegistrationEnabled() {
 
-		$username     = 'userDoesNotExist';
-		$email        = 'emailDoesNotExist@test.com';
+		$username = 'userDoesNotExist';
+		$email    = 'emailDoesNotExist@test.com';
 
 		/**
 		 * Enable new user registration.
@@ -668,16 +788,13 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 			'email'    => $email,
 		] );
 
-		codecept_debug( $actual );
-
 		$expected = [
 			'registerUser' => [
-				'clientMutationId' => $this->client_mutation_id,
-				'user'             => [
+				'user' => [
 					'name' => $username,
 					'slug' => strtolower( $username ),
-				]
-			]
+				],
+			],
 		];
 
 		$this->assertEquals( $expected, $actual['data'] );
@@ -686,17 +803,16 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 
 	public function resetUserPasswordMutation( $args ) {
 
-		$mutation = '
+		$query = '
 		mutation resetUserPassword($input:ResetUserPasswordInput!) {
 			resetUserPassword(input:$input){
-				clientMutationId
 				user {
 					username
 					email
 					roles {
-					  nodes {
-					    name
-					  }
+						nodes {
+							name
+						}
 					}
 				}
 			}
@@ -704,14 +820,13 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 
 		$variables = [
 			'input' => [
-				'clientMutationId' => $this->client_mutation_id,
-				'key'              => $args['key'],
-				'login'            => $args['login'],
-				'password'         => $args['password'],
-			]
+				'key'      => $args['key'],
+				'login'    => $args['login'],
+				'password' => $args['password'],
+			],
 		];
 
-		return do_graphql_request( $mutation, 'resetUserPassword', $variables );
+		return graphql( compact( 'query', 'variables' ) );
 
 	}
 
@@ -772,18 +887,18 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 		wp_set_current_user( $this->admin );
 
 		$actual = $this->resetUserPasswordMutation( $args );
+		codecept_debug( $actual );
 
 		$role_nodes = [];
-		foreach( $roles as $role ) {
+		foreach ( $roles as $role ) {
 			$role_nodes[] = [
-				'name' => $role
+				'name' => $role,
 			];
 		}
 
 		$expected = [
 			'resetUserPassword' => [
-				'clientMutationId' => $this->client_mutation_id,
-				'user'             => [
+				'user' => [
 					'username' => $login,
 					'email'    => $email,
 					'roles'    => [
@@ -830,32 +945,29 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	public function sendPasswordResetEmailMutation( $username ) {
-		$mutation  = '
+		$query = '
 		mutation sendPasswordResetEmail( $input:SendPasswordResetEmailInput! ) {
 			sendPasswordResetEmail( input: $input ) {
-				clientMutationId
 				user {
 					databaseId
 				} 
 			}
 		}
 		';
+
 		$variables = [
 			'input' => [
-				'clientMutationId' => $this->client_mutation_id,
-				'username'         => $username,
+				'username' => $username,
 			],
 		];
 
-		return do_graphql_request( $mutation, 'sendPasswordResetEmail', $variables );
+		return graphql( compact( 'query', 'variables' ) );
 	}
 
 	public function testSendPasswordResetEmailWithInvalidUsername() {
 		$username = 'userDoesNotExist';
 		// Run the mutation, passing in an invalid username.
 		$actual = $this->sendPasswordResetEmailMutation( $username );
-
-		codecept_debug( $actual );
 
 		/**
 		 * We're asserting that this will properly return an error
@@ -868,7 +980,7 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 		$user     = get_userdata( $this->author );
 		$username = $user->user_login;
 		// Run the mutation, passing in a valid username.
-		$actual   = $this->sendPasswordResetEmailMutation( $username );
+		$actual = $this->sendPasswordResetEmailMutation( $username );
 
 		codecept_debug( $actual );
 
@@ -883,7 +995,7 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 		$user  = get_userdata( $this->author );
 		$email = $user->user_email;
 		// Run the mutation, passing in a valid email address.
-		$actual   = $this->sendPasswordResetEmailMutation( $email );
+		$actual = $this->sendPasswordResetEmailMutation( $email );
 
 		codecept_debug( $actual );
 
@@ -895,15 +1007,14 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	public function getSendPasswordResetEmailExpected() {
-		$user     = get_userdata( $this->author );
+		$user = get_userdata( $this->author );
 
 		return [
 			'sendPasswordResetEmail' => [
-				'clientMutationId' => $this->client_mutation_id,
-				'user'             => [
+				'user' => [
 					'databaseId' => $user->ID,
-				]
-			]
+				],
+			],
 		];
 	}
 
@@ -982,7 +1093,7 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 		$was_password_change_email_sent = false;
 
 		// If this filter is run, we know the "Password Changed" email is being sent.
-		add_filter( 'password_change_email', function( $pass_change_email ) use ( &$was_password_change_email_sent ) {
+		add_filter( 'password_change_email', function ( $pass_change_email ) use ( &$was_password_change_email_sent ) {
 			$was_password_change_email_sent = true;
 			return $pass_change_email;
 		} );
@@ -990,7 +1101,7 @@ class UserObjectMutationsTest extends \Codeception\TestCase\WPTestCase {
 		$this->registerUserMutation( [
 			'username' => 'password-changed-email-test-user',
 			'email'    => 'password-changed-email-test-user@example.com',
-			'password' => 'password-changed-email-test-user-password'
+			'password' => 'password-changed-email-test-user-password',
 		] );
 
 		/**

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.8.1
+ * Version: 1.8.2
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.8.1
+ * @version  1.8.2
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
# Release Notes

## New Features

- ([#2363](https://github.com/wp-graphql/wp-graphql/pull/2363)): Adds "uri" field to MenuItem type which resolves the path of the node which can then be used in a `nodeByUri` query to get the linked node. The path is relative and does not contain subdirectory path in a subdirectory multisite. the `path` field does include the multisite subdirectory path, still. Thanks @josephfusco and @justlevine!
- ([#2337](https://github.com/wp-graphql/wp-graphql/pull/2337)): Allows for either global ID or databaseId to be supplied in the ID field for user mutations. Thanks @justlevine!
- ([#2338](https://github.com/wp-graphql/wp-graphql/pull/2338)): Allows either global "relay" ID or databaseId for post object mutations. Thanks @justlevine!
- ([#2336](https://github.com/wp-graphql/wp-graphql/pull/2336)): Allows either global "relay" ID or databaseId for term object mutations. Thanks @justlevine!
- ([#2331](https://github.com/wp-graphql/wp-graphql/pull/2331)): Allows either global "relay" ID or databaseId for MediaItem object mutations. Thanks @justlevine!
- ([#2328](https://github.com/wp-graphql/wp-graphql/pull/2328)): Allows either global "relay" ID or databaseId for Comment object mutations. Thanks @justlevine!


## Chores/Bugfixes

- ([#2368](https://github.com/wp-graphql/wp-graphql/pull/2368)): Updates dependencies for Schema Linter workflow.
- ([#2369](https://github.com/wp-graphql/wp-graphql/pull/2369)): Replaces the Codecov badge in the README with Coveralls badge. Thanks @justlevine!
- ([#2374](https://github.com/wp-graphql/wp-graphql/pull/2374)): Updates descriptions for PostObjectFieldFormatEnum. Thanks @justlevine!
- ([#2375](https://github.com/wp-graphql/wp-graphql/pull/2375)): Sets up the testing integration workflow to be able to run in multisite. Adds one workflow that runs in multisite. Fixes tests related to multisite.
- ([#2376](https://github.com/wp-graphql/wp-graphql/pull/2276)): Adds support for `['auth']['callback']` and `isPrivate` for the `register_graphql_mutation()` API.
- ([#2379](https://github.com/wp-graphql/wp-graphql/pull/2379)): Fixes a bug where term mutations were adding slashes when being stored in the database.
- ([#2380](https://github.com/wp-graphql/wp-graphql/pull/2380)): Fixes a bug where WPGraphQL wasn't sending the Wp class to the `parse_request` filter as a reference.
- ([#2382](https://github.com/wp-graphql/wp-graphql/pull/2382)): Fixes a bug where `register_graphql_field()` was not being respected by GraphQL Types added to the schema to represent Setting Groups of the core WordPress `register_setting()` API.
