### PR TITLE
Feat/add get home url helper

### DIFF
--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -7,6 +7,7 @@ use WP;
 use WP_Post;
 use WPGraphQL\AppContext;
 use WPGraphQL\Model\Post;
+use WPGraphQL\Utils\Utils;
 
 class NodeResolver {
 
@@ -102,6 +103,7 @@ class NodeResolver {
 				[
 					wp_parse_url( site_url() )['host'],
 					wp_parse_url( home_url() )['host'],
+					wp_parse_url( Utils::get_home_url() )['host'],
 				],
 				true
 			) ) {

--- a/src/Model/MenuItem.php
+++ b/src/Model/MenuItem.php
@@ -6,6 +6,7 @@ use Exception;
 use GraphQL\Error\UserError;
 use GraphQLRelay\Relay;
 use WP_Post;
+use WPGraphQL\Utils\Utils;
 
 /**
  * Class MenuItem - Models the data for the MenuItem object type
@@ -148,7 +149,7 @@ class MenuItem extends Model {
 				'uri'              => function () {
 					$url = $this->data->url;
 
-					return ! empty( $url ) ? str_ireplace( home_url(), '', $url ) : null;
+					return Utils::get_relative_uri( $url );
 				},
 				'url'              => function () {
 					return ! empty( $this->data->url ) ? $this->data->url : null;

--- a/src/Model/MenuItem.php
+++ b/src/Model/MenuItem.php
@@ -161,7 +161,7 @@ class MenuItem extends Model {
 					if ( ! empty( $url ) ) {
 						$parsed = wp_parse_url( $url );
 						if ( isset( $parsed['host'] ) ) {
-							if ( strpos( home_url(), $parsed['host'] ) ) {
+							if ( strpos( Utils::get_home_url(), $parsed['host'] ) ) {
 								return $parsed['path'];
 							} elseif ( strpos( home_url(), $parsed['host'] ) ) {
 								return $parsed['path'];

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -690,13 +690,13 @@ class Post extends Model {
 					return ! empty( $link ) ? $link : null;
 				},
 				'uri'                       => function () {
-					$uri = $this->link;
+					$link = $this->link;
 
 					if ( true === $this->isFrontPage ) {
 						return '/';
 					}
 
-					return ! empty( $uri ) ? str_ireplace( home_url(), '', $uri ) : null;
+					return Utils::get_relative_uri( $link );
 				},
 				'commentCount'              => function () {
 					return ! empty( $this->data->comment_count ) ? absint( $this->data->comment_count ) : null;

--- a/src/Model/PostType.php
+++ b/src/Model/PostType.php
@@ -3,6 +3,7 @@
 namespace WPGraphQL\Model;
 
 use GraphQLRelay\Relay;
+use WPGraphQL\Utils\Utils;
 
 /**
  * Class PostType - Models data for PostTypes
@@ -190,7 +191,7 @@ class PostType extends Model {
 				},
 				'uri'                 => function () {
 					$link = get_post_type_archive_link( $this->name );
-					return ! empty( $link ) ? trailingslashit( str_ireplace( home_url(), '', $link ) ) : null;
+					return ! empty( $link ) ? trailingslashit( (string) Utils::get_relative_uri( $link ) ) : null;
 				},
 				// If the homepage settings are ot set to
 				'isPostsPage'         => function () {

--- a/src/Model/Term.php
+++ b/src/Model/Term.php
@@ -7,6 +7,7 @@ use GraphQLRelay\Relay;
 use WP_Post;
 use WP_Taxonomy;
 use WP_Term;
+use WPGraphQL\Utils\Utils;
 
 /**
  * Class Term - Models data for Terms
@@ -200,9 +201,7 @@ class Term extends Model {
 						return null;
 					}
 
-					$stripped_link = str_ireplace( home_url(), '', $link );
-
-					return trailingslashit( $stripped_link );
+					return trailingslashit( (string) Utils::get_relative_uri( $link ) );
 				},
 			];
 

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -7,6 +7,7 @@ use GraphQLRelay\Relay;
 use WP_Post;
 use WP_User;
 use WPGraphQL;
+use WPGraphQL\Utils\Utils;
 
 /**
  * Class User - Models the data for the User object type
@@ -250,7 +251,7 @@ class User extends Model {
 				'uri'                      => function () {
 					$user_profile_url = get_author_posts_url( $this->data->ID );
 
-					return ! empty( $user_profile_url ) ? str_ireplace( home_url(), '', $user_profile_url ) : '';
+					return Utils::get_relative_uri( $user_profile_url );
 				},
 				'enqueuedScriptsQueue'     => function () {
 					global $wp_scripts;

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -221,6 +221,7 @@ class Utils {
 		/**
 		 * Filter the frontend URL for the current site used throughout the schema.
 		 *
+		 * Should only be used when conditionally filtering `home_url` is not an option.
 		 * Useful when the headless frontend is different than that used by WordPress.
 		 * E.g. `localhost:3000`
 		 *

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -207,4 +207,45 @@ class Utils {
 
 		return ! empty( $id_parts['id'] ) && is_numeric( $id_parts['id'] ) ? absint( $id_parts['id'] ) : false;
 	}
+
+	/**
+	 * Retrieves the URL for the current site to use throughout the schema.
+	 *
+	 * @param string $path Path relative to the home URL. Default ''.
+	 *
+	 * @return string
+	 */
+	public static function get_home_url( string $path = '' ) {
+		$home_url = home_url( $path );
+
+		/**
+		 * Filter the frontend URL for the current site used throughout the schema.
+		 *
+		 * Useful when the headless frontend is different than that used by WordPress.
+		 * E.g. `localhost:3000`
+		 *
+		 * @param string $url The complete home URL including scheme and path.
+		 * @param string $path Path relative to the home URL. Blank string if no path is specified.
+		 */
+		return apply_filters( 'graphql_home_url', $home_url, $path );
+	}
+
+	/**
+	 * Get the relative URI for the provided $url, if possible.
+	 *
+	 * @param string $url
+	 *
+	 * @return string|null
+	 */
+	public static function get_relative_uri( string $url ) {
+		// Bail early.
+		if ( empty( $url ) ) {
+			return null;
+		}
+
+		// Get the filtered home_url.
+		$home_url = self::get_home_url();
+
+		return str_ireplace( $home_url, '', $url );
+	}
 }

--- a/tests/wpunit/SettingsMutationsTest.php
+++ b/tests/wpunit/SettingsMutationsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class SettingsMutationsTest extends \Codeception\TestCase\WPTestCase  {
+class SettingsMutationsTest extends \Codeception\TestCase\WPTestCase {
 
 	public $clientMutationId;
 	public $defaultCategory;
@@ -32,7 +32,7 @@ class SettingsMutationsTest extends \Codeception\TestCase\WPTestCase  {
 
 		WPGraphQL::clear_schema();
 
-		$this->subscriber = $this->factory->user->create( [
+		$this->subscriber      = $this->factory->user->create( [
 			'role' => 'subscriber',
 		] );
 		$this->subscriber_name = 'User ' . $this->subscriber;
@@ -47,7 +47,7 @@ class SettingsMutationsTest extends \Codeception\TestCase\WPTestCase  {
 
 		$this->author_name = 'User ' . $this->author;
 
-		$this->admin = $this->factory->user->create( [
+		$this->admin      = $this->factory->user->create( [
 			'role' => 'administrator',
 		] );
 		$this->admin_name = 'User ' . $this->admin;
@@ -77,56 +77,56 @@ class SettingsMutationsTest extends \Codeception\TestCase\WPTestCase  {
 		if ( is_multisite() ) {
 			$this->update_variables = [
 				'input' => [
-					'clientMutationId'                       => $this->clientMutationId,
+					'clientMutationId'                    => $this->clientMutationId,
 					'discussionSettingsDefaultCommentStatus' => $this->discussionSettingsDefaultCommentStatus,
-					'discussionSettingsDefaultPingStatus'    => $this->discussionSettingsDefaultPingStatus,
-					'generalSettingsDateFormat'              => $this->generalSettingsDateFormat,
-					'generalSettingsDescription'             => $this->generalSettingsDescription,
-					'generalSettingsLanguage'                => $this->generalSettingsLanguage,
-					'generalSettingsStartOfWeek'             => $this->generalSettingsStartOfWeek,
-					'generalSettingsTimeFormat'              => $this->generalSettingsTimeFormat,
-					'generalSettingsTimezone'                => $this->generalSettingsTimezone,
-					'generalSettingsTitle'                   => $this->generalSettingsTitle,
-					'readingSettingsPostsPerPage'            => $this->readingSettingsPostsPerPage,
-					'writingSettingsDefaultCategory'         => $this->writingSettingsDefaultCategory,
-					'writingSettingsDefaultPostFormat'       => $this->writingSettingsDefaultPostFormat,
-					'writingSettingsUseSmilies'              => $this->writingSettingsUseSmilies,
+					'discussionSettingsDefaultPingStatus' => $this->discussionSettingsDefaultPingStatus,
+					'generalSettingsDateFormat'           => $this->generalSettingsDateFormat,
+					'generalSettingsDescription'          => $this->generalSettingsDescription,
+					'generalSettingsLanguage'             => $this->generalSettingsLanguage,
+					'generalSettingsStartOfWeek'          => $this->generalSettingsStartOfWeek,
+					'generalSettingsTimeFormat'           => $this->generalSettingsTimeFormat,
+					'generalSettingsTimezone'             => $this->generalSettingsTimezone,
+					'generalSettingsTitle'                => $this->generalSettingsTitle,
+					'readingSettingsPostsPerPage'         => $this->readingSettingsPostsPerPage,
+					'writingSettingsDefaultCategory'      => $this->writingSettingsDefaultCategory,
+					'writingSettingsDefaultPostFormat'    => $this->writingSettingsDefaultPostFormat,
+					'writingSettingsUseSmilies'           => $this->writingSettingsUseSmilies,
 				],
 			];
 		} else {
 			$this->update_variables = [
 				'input' => [
-					'clientMutationId'                       => $this->clientMutationId,
+					'clientMutationId'                    => $this->clientMutationId,
 					'discussionSettingsDefaultCommentStatus' => $this->discussionSettingsDefaultCommentStatus,
-					'discussionSettingsDefaultPingStatus'    => $this->discussionSettingsDefaultPingStatus,
-					'generalSettingsDateFormat'              => $this->generalSettingsDateFormat,
-					'generalSettingsDescription'             => $this->generalSettingsDescription,
-					'generalSettingsEmail'                   => $this->generalSettingsEmail,
-					'generalSettingsLanguage'                => $this->generalSettingsLanguage,
-					'generalSettingsStartOfWeek'             => $this->generalSettingsStartOfWeek,
-					'generalSettingsTimeFormat'              => $this->generalSettingsTimeFormat,
-					'generalSettingsTimezone'                => $this->generalSettingsTimezone,
-					'generalSettingsTitle'                   => $this->generalSettingsTitle,
-					'readingSettingsPostsPerPage'            => $this->readingSettingsPostsPerPage,
-					'writingSettingsDefaultCategory'         => $this->writingSettingsDefaultCategory,
-					'writingSettingsDefaultPostFormat'       => $this->writingSettingsDefaultPostFormat,
-					'writingSettingsUseSmilies'              => $this->writingSettingsUseSmilies,
+					'discussionSettingsDefaultPingStatus' => $this->discussionSettingsDefaultPingStatus,
+					'generalSettingsDateFormat'           => $this->generalSettingsDateFormat,
+					'generalSettingsDescription'          => $this->generalSettingsDescription,
+					'generalSettingsEmail'                => $this->generalSettingsEmail,
+					'generalSettingsLanguage'             => $this->generalSettingsLanguage,
+					'generalSettingsStartOfWeek'          => $this->generalSettingsStartOfWeek,
+					'generalSettingsTimeFormat'           => $this->generalSettingsTimeFormat,
+					'generalSettingsTimezone'             => $this->generalSettingsTimezone,
+					'generalSettingsTitle'                => $this->generalSettingsTitle,
+					'readingSettingsPostsPerPage'         => $this->readingSettingsPostsPerPage,
+					'writingSettingsDefaultCategory'      => $this->writingSettingsDefaultCategory,
+					'writingSettingsDefaultPostFormat'    => $this->writingSettingsDefaultPostFormat,
+					'writingSettingsUseSmilies'           => $this->writingSettingsUseSmilies,
 				],
 			];
 		}
 
 		/**
 		* Manually Register a setting for testing
-	    *
-        * This registers a setting as a number to see if it gets the correct type
-        * associated with it and returned through WPGraphQL
-	    */
-		register_setting( 'Zool', 'points', array(
-			'type'         => 'number',
-			'description'  => __( 'Test how many points we have in Zool.' ),
+		*
+		* This registers a setting as a number to see if it gets the correct type
+		* associated with it and returned through WPGraphQL
+		*/
+		register_setting( 'Zool', 'points', [
+			'type'            => 'number',
+			'description'     => __( 'Test how many points we have in Zool.' ),
 			'show_in_graphql' => true,
-			'default' => 4.5,
-		) );
+			'default'         => 4.5,
+		] );
 
 		parent::setUp();
 
@@ -247,7 +247,6 @@ class SettingsMutationsTest extends \Codeception\TestCase\WPTestCase  {
 
 		codecept_debug( $actual );
 
-
 		return $actual;
 	}
 
@@ -288,13 +287,13 @@ class SettingsMutationsTest extends \Codeception\TestCase\WPTestCase  {
 		 */
 		wp_set_current_user( $this->editor );
 
-		$query = "
+		$query  = '
 			query {
 				allSettings {
 				    generalSettingsEmail
 				}
 		    }
-	    ";
+	    ';
 		$actual = do_graphql_request( $query );
 		$this->assertArrayHasKey( 'errors', $actual );
 
@@ -348,18 +347,18 @@ class SettingsMutationsTest extends \Codeception\TestCase\WPTestCase  {
 					'clientMutationId'   => $this->clientMutationId,
 					'allSettings'        => [
 						'discussionSettingsDefaultCommentStatus' => $this->discussionSettingsDefaultCommentStatus,
-						'discussionSettingsDefaultPingStatus'    => $this->discussionSettingsDefaultPingStatus,
-						'generalSettingsDateFormat'              => $this->generalSettingsDateFormat,
-						'generalSettingsDescription'             => $this->generalSettingsDescription,
-						'generalSettingsLanguage'                => $this->generalSettingsLanguage,
-						'generalSettingsStartOfWeek'             => $this->generalSettingsStartOfWeek,
-						'generalSettingsTimeFormat'              => $this->generalSettingsTimeFormat,
-						'generalSettingsTimezone'                => $this->generalSettingsTimezone,
-						'generalSettingsTitle'                   => $this->generalSettingsTitle,
-						'readingSettingsPostsPerPage'            => $this->readingSettingsPostsPerPage,
-						'writingSettingsDefaultCategory'         => $this->writingSettingsDefaultCategory,
-						'writingSettingsDefaultPostFormat'       => $this->writingSettingsDefaultPostFormat,
-						'writingSettingsUseSmilies'              => $this->writingSettingsUseSmilies,
+						'discussionSettingsDefaultPingStatus' => $this->discussionSettingsDefaultPingStatus,
+						'generalSettingsDateFormat'        => $this->generalSettingsDateFormat,
+						'generalSettingsDescription'       => $this->generalSettingsDescription,
+						'generalSettingsLanguage'          => $this->generalSettingsLanguage,
+						'generalSettingsStartOfWeek'       => $this->generalSettingsStartOfWeek,
+						'generalSettingsTimeFormat'        => $this->generalSettingsTimeFormat,
+						'generalSettingsTimezone'          => $this->generalSettingsTimezone,
+						'generalSettingsTitle'             => $this->generalSettingsTitle,
+						'readingSettingsPostsPerPage'      => $this->readingSettingsPostsPerPage,
+						'writingSettingsDefaultCategory'   => $this->writingSettingsDefaultCategory,
+						'writingSettingsDefaultPostFormat' => $this->writingSettingsDefaultPostFormat,
+						'writingSettingsUseSmilies'        => $this->writingSettingsUseSmilies,
 					],
 					'discussionSettings' => [
 						'defaultCommentStatus' => $this->discussionSettingsDefaultCommentStatus,
@@ -387,29 +386,29 @@ class SettingsMutationsTest extends \Codeception\TestCase\WPTestCase  {
 		} else {
 			$expected = [
 				'updateSettings' => [
-					'clientMutationId' => $this->clientMutationId,
-					'allSettings'             => [
-						'discussionSettingsDefaultCommentStatus'         => $this->discussionSettingsDefaultCommentStatus,
-						'discussionSettingsDefaultPingStatus'            => $this->discussionSettingsDefaultPingStatus,
-						'generalSettingsDateFormat'                      => $this->generalSettingsDateFormat,
-						'generalSettingsDescription'                     => $this->generalSettingsDescription,
-						'generalSettingsEmail'                           => $this->generalSettingsEmail,
-						'generalSettingsLanguage'                        => $this->generalSettingsLanguage,
-						'generalSettingsStartOfWeek'                     => $this->generalSettingsStartOfWeek,
-						'generalSettingsTimeFormat'                      => $this->generalSettingsTimeFormat,
-						'generalSettingsTimezone'                        => $this->generalSettingsTimezone,
-						'generalSettingsTitle'                           => $this->generalSettingsTitle,
-						'generalSettingsUrl'                             => 'http://localhost',
-						'readingSettingsPostsPerPage'                    => $this->readingSettingsPostsPerPage,
-						'writingSettingsDefaultCategory'                 => $this->writingSettingsDefaultCategory,
-						'writingSettingsDefaultPostFormat'               => $this->writingSettingsDefaultPostFormat,
-						'writingSettingsUseSmilies'                      => $this->writingSettingsUseSmilies,
+					'clientMutationId'   => $this->clientMutationId,
+					'allSettings'        => [
+						'discussionSettingsDefaultCommentStatus' => $this->discussionSettingsDefaultCommentStatus,
+						'discussionSettingsDefaultPingStatus' => $this->discussionSettingsDefaultPingStatus,
+						'generalSettingsDateFormat'        => $this->generalSettingsDateFormat,
+						'generalSettingsDescription'       => $this->generalSettingsDescription,
+						'generalSettingsEmail'             => $this->generalSettingsEmail,
+						'generalSettingsLanguage'          => $this->generalSettingsLanguage,
+						'generalSettingsStartOfWeek'       => $this->generalSettingsStartOfWeek,
+						'generalSettingsTimeFormat'        => $this->generalSettingsTimeFormat,
+						'generalSettingsTimezone'          => $this->generalSettingsTimezone,
+						'generalSettingsTitle'             => $this->generalSettingsTitle,
+						'generalSettingsUrl'               => site_url(),
+						'readingSettingsPostsPerPage'      => $this->readingSettingsPostsPerPage,
+						'writingSettingsDefaultCategory'   => $this->writingSettingsDefaultCategory,
+						'writingSettingsDefaultPostFormat' => $this->writingSettingsDefaultPostFormat,
+						'writingSettingsUseSmilies'        => $this->writingSettingsUseSmilies,
 					],
-					'discussionSettings'    => [
+					'discussionSettings' => [
 						'defaultCommentStatus' => $this->discussionSettingsDefaultCommentStatus,
 						'defaultPingStatus'    => $this->discussionSettingsDefaultPingStatus,
 					],
-					'generalSettings'       => [
+					'generalSettings'    => [
 						'dateFormat'  => $this->generalSettingsDateFormat,
 						'description' => $this->generalSettingsDescription,
 						'email'       => $this->generalSettingsEmail,
@@ -418,12 +417,12 @@ class SettingsMutationsTest extends \Codeception\TestCase\WPTestCase  {
 						'timeFormat'  => $this->generalSettingsTimeFormat,
 						'timezone'    => $this->generalSettingsTimezone,
 						'title'       => $this->generalSettingsTitle,
-						'url'         => 'http://localhost',
+						'url'         => site_url(),
 					],
-					'readingSettings'       => [
+					'readingSettings'    => [
 						'postsPerPage' => $this->readingSettingsPostsPerPage,
 					],
-					'writingSettings'       => [
+					'writingSettings'    => [
 						'defaultCategory'   => $this->writingSettingsDefaultCategory,
 						'defaultPostFormat' => $this->writingSettingsDefaultPostFormat,
 						'useSmilies'        => $this->writingSettingsUseSmilies,
@@ -468,7 +467,7 @@ class SettingsMutationsTest extends \Codeception\TestCase\WPTestCase  {
 
 		$start_of_week = $actual['data']['updateSettings']['generalSettings']['startOfWeek'];
 
-		$this->assertEquals( 0, $start_of_week);
+		$this->assertEquals( 0, $start_of_week );
 	}
 
 	public function testRegisteringSettingWithUnderscoresAllowsSettingToBeMutated() {
@@ -496,12 +495,12 @@ class SettingsMutationsTest extends \Codeception\TestCase\WPTestCase  {
 		$unique_value = uniqid( 'test', true );
 
 		$actual = graphql([
-			'query' => $query,
+			'query'     => $query,
 			'variables' => [
 				'input' => [
-					'mySettingGroupSettingsMySettingField' => $unique_value
-				]
-			]
+					'mySettingGroupSettingsMySettingField' => $unique_value,
+				],
+			],
 		]);
 
 		codecept_debug( $actual );

--- a/tests/wpunit/UtilsTest.php
+++ b/tests/wpunit/UtilsTest.php
@@ -1,0 +1,97 @@
+<?php
+
+use WPGraphQL\Utils\Utils;
+
+class UtilsTest extends \Codeception\TestCase\WPTestCase {
+
+	public function setUp(): void {
+		// before
+		WPGraphQL::clear_schema();
+		parent::setUp();
+		// your set up methods here
+	}
+
+	public function tearDown(): void {
+		// your tear down methods here
+		WPGraphQL::clear_schema();
+		// then
+		parent::tearDown();
+	}
+
+	/**
+	 * Tests Utils::get_home_url()
+	 */
+	public function testGetHomeUrl() : void {
+		// Test method works the same as home_url().
+		$this->assertEquals( home_url(), Utils::get_home_url() );
+
+		$this->assertEquals( home_url( 'example' ), Utils::get_home_url( 'example' ) );
+
+		// Test with filtered frontend url.
+		$frontend_url = 'https://example.com';
+		add_filter( 'graphql_home_url', function ( $url, $path ) use ( $frontend_url ) {
+			return $frontend_url . '/' . ltrim( $path, '/' );
+		}, 10, 2);
+
+		$actual = Utils::get_home_url( 'example' );
+		codecept_debug( $actual );
+
+		$this->assertNotEquals( home_url( 'example' ), $actual );
+		$this->assertStringStartsWith( $frontend_url, $actual );
+	}
+
+	/**
+	 * Tests Utils::get_relative_uri();
+	 */
+	public function testGetRelativeUri() : void {
+		// Test empty url
+		$this->assertNull( Utils::get_relative_uri( '' ) );
+
+		// Test external url.
+		$expected = 'https://example.com/example';
+
+		$actual = Utils::get_relative_uri( $expected );
+
+		$this->assertEquals( $expected, $actual );
+
+		// Test relative to current site.
+		$expected = '/example';
+		$url      = home_url( $expected );
+
+		$actual = Utils::get_relative_uri( $url );
+
+		$this->assertEquals( $expected, $actual );
+
+		// Test with TLD.
+		add_filter( 'graphql_home_url', function ( $home_url ) {
+			return str_ireplace( home_url(), 'https://example.com', $home_url );
+		} );
+
+		$url    = Utils::get_home_url( $expected );
+		$actual = Utils::get_relative_uri( $url );
+		codecept_debug( $actual );
+
+		$this->assertEquals( $expected, $actual );
+
+		// Test with subdomain.
+		add_filter( 'graphql_home_url', function ( $home_url ) {
+			return str_ireplace( home_url(), 'https://mysubdomain.example.com', $home_url );
+		} );
+
+		$url    = Utils::get_home_url( $expected );
+		$actual = Utils::get_relative_uri( $url );
+
+		$this->assertEquals( $expected, $actual );
+
+		// Test with subdir.
+		add_filter( 'graphql_home_url', function ( $home_url ) {
+			return str_ireplace( home_url(), 'https://www.example.com/my-subdir', $home_url );
+		} );
+
+		$url    = Utils::get_home_url( $expected );
+		$actual = Utils::get_relative_uri( $url );
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+}


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds the `Utils::get_home_url()` and `Utils::get_relative_uri()` helper functions, along with the `graphql_home_url` filter, to allow for DRY and consistent `uri`s regardless of site setup (regular, subsite, subdir, host replacement, etc).


Does this close any currently open issues?
------------------------------------------
#2384 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
- This PR **does not** apply the `graphql_home_url` filter to fully-qualified links, such as those returned from `get_permalink()`. To do so would require `str_replace()` on all those fields, which _to me_ feels like unnecessary overhead. 
IMO devs should ideally be using WP's `home_url`, and I can't think of a use case where this filter would be required over something along the lines of :
```php
add_filter( 'home_url', function( $url, $path, $scheme ) {
  if( is_graphql_request() || 'graphql' === $scheme ) {
    $url = 'my-frontend.com' . $path;
  } 
  return $url;
}, 10, 3 );
```
Would be helpful if someone less biased than myself would review and decide if filtering fully-qualified links is necessary.

- The new methods *are not* currently exposed as access functions. I'm unclear of the criteria that makes a method 'worthy' of an access function over a direct static method call.


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php 8.0.15)

**WordPress Version:** 5.9.3
