### PR TITLE
fix: resolve asset versions

### DIFF
--- a/src/Type/InterfaceType/EnqueuedAsset.php
+++ b/src/Type/InterfaceType/EnqueuedAsset.php
@@ -52,7 +52,7 @@ class EnqueuedAsset {
 				],
 				'version'      => [
 					'type'        => 'String',
-					'description' => __( 'The version of the enqueued asset', 'wp-graphql' ),
+					'description' => __( 'The version of the enqueued asset. Defaults to the current version of WordPress.', 'wp-graphql' ),
 				],
 				'src'          => [
 					'type'        => 'String',

--- a/src/Type/ObjectType/EnqueuedScript.php
+++ b/src/Type/ObjectType/EnqueuedScript.php
@@ -21,7 +21,7 @@ class EnqueuedScript {
 			'description' => __( 'Script enqueued by the CMS', 'wp-graphql' ),
 			'interfaces'  => [ 'Node', 'EnqueuedAsset' ],
 			'fields'      => [
-				'id'  => [
+				'id'      => [
 					'type'    => [
 						'non_null' => 'ID',
 					],
@@ -29,9 +29,16 @@ class EnqueuedScript {
 						return isset( $asset->handle ) ? Relay::toGlobalId( 'enqueued_script', $asset->handle ) : null;
 					},
 				],
-				'src' => [
+				'src'     => [
 					'resolve' => function ( \_WP_Dependency $script ) {
 						return isset( $script->src ) && is_string( $script->src ) ? $script->src : null;
+					},
+				],
+				'version' => [
+					'resolve' => function ( \_WP_Dependency $script ) {
+						global $wp_scripts;
+
+						return isset( $script->ver ) && is_string( $script->ver ) ? (string) $script->ver : $wp_scripts->default_version;
 					},
 				],
 			],

--- a/src/Type/ObjectType/EnqueuedStylesheet.php
+++ b/src/Type/ObjectType/EnqueuedStylesheet.php
@@ -21,7 +21,7 @@ class EnqueuedStylesheet {
 			'description' => __( 'Stylesheet enqueued by the CMS', 'wp-graphql' ),
 			'interfaces'  => [ 'Node', 'EnqueuedAsset' ],
 			'fields'      => [
-				'id'  => [
+				'id'      => [
 					'type'    => [
 						'non_null' => 'ID',
 					],
@@ -29,9 +29,16 @@ class EnqueuedStylesheet {
 						return isset( $asset->handle ) ? Relay::toGlobalId( 'enqueued_stylesheet', $asset->handle ) : null;
 					},
 				],
-				'src' => [
+				'src'     => [
 					'resolve' => function ( \_WP_Dependency $stylesheet ) {
 						return isset( $stylesheet->src ) && is_string( $stylesheet->src ) ? $stylesheet->src : null;
+					},
+				],
+				'version' => [
+					'resolve' => function ( \_WP_Dependency $stylesheet ) {
+						global $wp_styles;
+
+						return isset( $stylesheet->ver ) && is_string( $stylesheet->ver ) ? (string) $stylesheet->ver : $wp_styles->default_version;
 					},
 				],
 			],

--- a/tests/wpunit/RegisteredScriptConnectionQueriesTest.php
+++ b/tests/wpunit/RegisteredScriptConnectionQueriesTest.php
@@ -29,8 +29,11 @@ class RegisteredScriptConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WP
 						startCursor
 					}
 					nodes {
-						id
+						extra
 						handle
+						id
+						src
+						version
 					}
 				}
 			}
@@ -45,10 +48,18 @@ class RegisteredScriptConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WP
 		];
 		$actual    = $this->graphql( compact( 'query', 'variables' ) );
 
-
 		$this->assertIsValidQueryResponse( $actual );
 
 		$nodes = $actual['data']['registeredScripts']['nodes'];
+
+		// Test fields for first asset.
+		global $wp_scripts;
+		$expected = $wp_scripts->registered[ $nodes[0]['handle'] ];
+
+		$this->assertEquals( $expected->extra['data'], $nodes[0]['extra'] );
+		$this->assertEquals( $expected->handle, $nodes[0]['handle'] );
+		$this->assertEquals( $expected->src, $nodes[0]['src'] );
+		$this->assertEquals( $expected->ver ?: $wp_scripts->default_version, $nodes[0]['version'] );
 
 		// Get first two registeredScripts
 		$variables['first'] = 2;

--- a/tests/wpunit/RegisteredStylesheetConnectionQueriesTest.php
+++ b/tests/wpunit/RegisteredStylesheetConnectionQueriesTest.php
@@ -34,8 +34,11 @@ class RegisteredStylesheetConnectionQueriesTest extends \Tests\WPGraphQL\TestCas
 						startCursor
 					}
 					nodes {
-						id
+						extra
 						handle
+						id
+						src
+						version
 					}
 				}
 			}
@@ -55,6 +58,16 @@ class RegisteredStylesheetConnectionQueriesTest extends \Tests\WPGraphQL\TestCas
 
 		$nodes = $actual['data']['registeredStylesheets']['nodes'];
 
+		// Test fields for first asset.
+		global $wp_styles;
+		$expected = $wp_styles->registered[ $nodes[0]['handle'] ];
+		codecept_debug( $expected );
+
+		$this->assertEquals( $expected->extra['data'] ?? null, $nodes[0]['extra'] );
+		$this->assertEquals( $expected->handle, $nodes[0]['handle'] );
+		$this->assertEquals( is_string( $expected->src ) ? $expected->src : null, $nodes[0]['src'] );
+		$this->assertEquals( $expected->ver ?: $wp_styles->default_version, $nodes[0]['version'] );
+
 		// Get first two registeredStylesheets
 		$variables['first'] = 2;
 		$variables['after'] = null;
@@ -62,10 +75,9 @@ class RegisteredStylesheetConnectionQueriesTest extends \Tests\WPGraphQL\TestCas
 		$expected = array_slice( $nodes, 0, $variables['first'], true );
 		$actual   = $this->graphql( compact( 'query', 'variables' ) );
 
-
 		codecept_debug( [
 			'expected' => $expected,
-			'actual' => $actual['data']['registeredStylesheets']['nodes']
+			'actual'   => $actual['data']['registeredStylesheets']['nodes'],
 		]);
 
 		$this->assertEqualSets( $expected, $actual['data']['registeredStylesheets']['nodes'] );


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR fixes issues with `EnqueuedAsset` types not always having a set version, providing the [default version](https://developer.wordpress.org/reference/classes/wp_dependencies/) when none is explicitly set.


Does this close any currently open issues?
------------------------------------------
#2297 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
Before: 
![image](https://user-images.githubusercontent.com/29322304/169143130-6d35ffde-b388-4877-b901-8173f630416b.png)


After:
![image](https://user-images.githubusercontent.com/29322304/169143058-faa271b5-e039-4686-8cc6-a2630487c5cb.png)



Any other comments?
-------------------
Also backfilled tests for _some_ of the other missing `EnqueuedAsset` fields: `extra`, `handle`, `src`. Unsure how to test `dependencies`, since we can't query for a specific asset, nor predict what array position in `nodes` will contain an asset with a set dependency.

Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (Wsl2 + devilbox + php 8.0.15)

**WordPress Version:** 5.9.3
