### PR TITLE
Feat: query `menu` by `SLUG` and `LOCATION`.

### DIFF
--- a/src/Type/Enum/MenuNodeIdTypeEnum.php
+++ b/src/Type/Enum/MenuNodeIdTypeEnum.php
@@ -30,7 +30,12 @@ class MenuNodeIdTypeEnum {
 				'NAME'        => [
 					'name'        => 'NAME',
 					'value'       => 'name',
-					'description' => __( 'Identify a menu node by it\'s name', 'wp-graphql' ),
+					'description' => __( 'Identify a menu node by its name', 'wp-graphql' ),
+				],
+				'LOCATION'    => [
+					'name'        => 'LOCATION',
+					'value'       => 'location',
+					'description' => __( 'Identify a menu node by the menu location to which it is assigned', 'wp-graphql' ),
 				],
 			],
 		]);

--- a/src/Type/Enum/MenuNodeIdTypeEnum.php
+++ b/src/Type/Enum/MenuNodeIdTypeEnum.php
@@ -30,7 +30,7 @@ class MenuNodeIdTypeEnum {
 				'LOCATION'    => [
 					'name'        => 'LOCATION',
 					'value'       => 'location',
-					'description' => __( 'Identify a menu node by the menu location to which it is assigned', 'wp-graphql' ),
+					'description' => __( 'Identify a menu node by the slug of menu location to which it is assigned', 'wp-graphql' ),
 				],
 				'NAME'        => [
 					'name'        => 'NAME',

--- a/src/Type/Enum/MenuNodeIdTypeEnum.php
+++ b/src/Type/Enum/MenuNodeIdTypeEnum.php
@@ -27,15 +27,20 @@ class MenuNodeIdTypeEnum {
 					'value'       => 'database_id',
 					'description' => __( 'Identify a menu node by the Database ID.', 'wp-graphql' ),
 				],
+				'LOCATION'    => [
+					'name'        => 'LOCATION',
+					'value'       => 'location',
+					'description' => __( 'Identify a menu node by the menu location to which it is assigned', 'wp-graphql' ),
+				],
 				'NAME'        => [
 					'name'        => 'NAME',
 					'value'       => 'name',
 					'description' => __( 'Identify a menu node by its name', 'wp-graphql' ),
 				],
-				'LOCATION'    => [
-					'name'        => 'LOCATION',
-					'value'       => 'location',
-					'description' => __( 'Identify a menu node by the menu location to which it is assigned', 'wp-graphql' ),
+				'SLUG'        => [
+					'name'        => 'SLUG',
+					'value'       => 'slug',
+					'description' => __( 'Identify a menu node by its slug', 'wp-graphql' ),
 				],
 			],
 		]);

--- a/src/Type/ObjectType/RootQuery.php
+++ b/src/Type/ObjectType/RootQuery.php
@@ -347,6 +347,15 @@ class RootQuery {
 								case 'database_id':
 									$id = absint( $args['id'] );
 									break;
+								case 'location':
+									$locations = get_nav_menu_locations();
+
+									if ( ! isset( $locations[ $args['id'] ] ) || ! absint( $locations[ $args['id'] ] ) ) {
+										throw new UserError( __( 'No menu set for the provided location', 'wp-graphql' ) );
+									}
+
+									$id = absint( $locations[ $args['id'] ] );
+									break;
 								case 'name':
 									$menu = new \WP_Term_Query(
 										[
@@ -359,14 +368,17 @@ class RootQuery {
 									);
 									$id   = ! empty( $menu->terms ) ? (int) $menu->terms[0] : null;
 									break;
-								case 'location':
-									$locations = get_nav_menu_locations();
-
-									if ( ! isset( $locations[ $args['id'] ] ) || ! absint( $locations[ $args['id'] ] ) ) {
-										throw new UserError( __( 'No menu set for the provided location', 'wp-graphql' ) );
-									}
-
-									$id = absint( $locations[ $args['id'] ] );
+								case 'slug':
+									$menu = new \WP_Term_Query(
+										[
+											'taxonomy' => 'nav_menu',
+											'fields'   => 'ids',
+											'slug'     => $args['id'],
+											'include_children' => false,
+											'count'    => false,
+										]
+									);
+									$id   = ! empty( $menu->terms ) ? (int) $menu->terms[0] : null;
 									break;
 								default:
 									$id_components = Relay::fromGlobalId( $args['id'] );

--- a/src/Type/ObjectType/RootQuery.php
+++ b/src/Type/ObjectType/RootQuery.php
@@ -359,6 +359,15 @@ class RootQuery {
 									);
 									$id   = ! empty( $menu->terms ) ? (int) $menu->terms[0] : null;
 									break;
+								case 'location':
+									$locations = get_nav_menu_locations();
+
+									if ( ! isset( $locations[ $args['id'] ] ) || ! absint( $locations[ $args['id'] ] ) ) {
+										throw new UserError( __( 'No menu set for the provided location', 'wp-graphql' ) );
+									}
+
+									$id = absint( $locations[ $args['id'] ] );
+									break;
 								default:
 									$id_components = Relay::fromGlobalId( $args['id'] );
 									if ( ! isset( $id_components['id'] ) || ! absint( $id_components['id'] ) ) {

--- a/tests/wpunit/MenuQueriesTest.php
+++ b/tests/wpunit/MenuQueriesTest.php
@@ -1,45 +1,152 @@
 <?php
 
 use GraphQLRelay\Relay;
+use WPGraphQL\Type\WPEnumType;
 
-class MenuQueriesTest extends \Codeception\TestCase\WPTestCase {
+class MenuQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 	public $admin;
+	public $location_name;
+	public $menu_id;
+	public $menu_slug;
+	public $menu_item_id;
 
 	public function setUp(): void {
 		parent::setUp();
-		$this->admin = $this->factory()->user->create([
-			'role' => 'administrator'
+		$this->admin         = $this->factory()->user->create([
+			'role' => 'administrator',
 		]);
+		$this->location_name = 'test-location';
+		register_nav_menu( $this->location_name, 'test menu...' );
+
+		$this->menu_slug = 'my-test-menu';
+		$this->menu_id   = wp_create_nav_menu( $this->menu_slug );
+
+		$menu_item_args = [
+			'menu-item-title'     => 'Parent Item',
+			'menu-item-parent-id' => 0,
+			'menu-item-url'       => 'http://example.com/',
+			'menu-item-status'    => 'publish',
+			'menu-item-type'      => 'custom',
+		];
+
+		$this->menu_item_id = wp_update_nav_menu_item( $this->menu_id, 0, $menu_item_args );
+	}
+
+	public function tearDown(): void {
+		remove_theme_support( 'nav_menus' );
+		wp_delete_nav_menu( $this->menu_id );
+		unregister_nav_menu( $this->location_name );
+
+		WPGraphQL::clear_schema();
+		parent::tearDown();
 	}
 
 	public function testMenuQuery() {
-		$menu_slug = 'my-test-menu';
-		$menu_id = wp_create_nav_menu( $menu_slug );
-		$menu_relay_id = Relay::toGlobalId( 'term', $menu_id );
+		$query = $this->get_query();
 
-		$query = '
-		{
-			menu( id: "' . $menu_relay_id . '" ) {
-				id
-				menuId
-				name
-			}
-		}
-		';
+		$menu_relay_id = Relay::toGlobalId( 'term', $this->menu_id );
 
-		$actual = do_graphql_request( $query );
+		// Test by DatabaseId
+		$variables = [
+			'id'     => $this->menu_id,
+			'idType' => 'DATABASE_ID',
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
 		// A menu not associated with a location is private for a public request
 		$this->assertNull( $actual['data']['menu'] );
 
 		wp_set_current_user( $this->admin );
 
-		$actual = do_graphql_request( $query );
+		$actual   = $this->graphql( compact( 'query', 'variables' ) );
+		$expected = wp_get_nav_menu_object( $this->menu_id );
 
-		$this->assertEquals( $menu_id, $actual['data']['menu']['menuId'] );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+
+		$this->assertEquals( $expected->count, $actual['data']['menu']['count'] );
+		$this->assertEquals( $this->menu_id, $actual['data']['menu']['databaseId'] );
+		$this->assertNull( $actual['data']['menu']['locations'] );
 		$this->assertEquals( $menu_relay_id, $actual['data']['menu']['id'] );
-		$this->assertEquals( $menu_slug, $actual['data']['menu']['name'] );
+		$this->assertEquals( $expected->name, $actual['data']['menu']['name'] );
+		$this->assertEquals( $expected->slug, $actual['data']['menu']['slug'] );
+		$this->assertEquals( $this->menu_item_id, $actual['data']['menu']['menuItems']['nodes'][0]['databaseId'] );
+
+		// Test with global ID
+		$variables = [
+			'id'     => $menu_relay_id,
+			'idType' => 'ID',
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEquals( $this->menu_id, $actual['data']['menu']['databaseId'] );
+		$this->assertEquals( $menu_relay_id, $actual['data']['menu']['id'] );
+
+		// Test with name.
+		$variables = [
+			'id'     => $expected->name,
+			'idType' => 'NAME',
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEquals( $this->menu_id, $actual['data']['menu']['databaseId'] );
+		$this->assertEquals( $menu_relay_id, $actual['data']['menu']['id'] );
+
+		// Test with slug.
+		$variables = [
+			'id'     => $this->menu_slug,
+			'idType' => 'SLUG',
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEquals( $this->menu_id, $actual['data']['menu']['databaseId'] );
+		$this->assertEquals( $menu_relay_id, $actual['data']['menu']['id'] );
+	}
+
+	public function testMenuQueryByLocation() {
+		set_theme_mod( 'nav_menu_locations', [ $this->location_name => $this->menu_id ] );
+
+		$query = $this->get_query();
+
+		// Test by DatabaseId
+		$variables = [
+			'id'     => $this->location_name,
+			'idType' => 'LOCATION',
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEquals( $this->menu_id, $actual['data']['menu']['databaseId'] );
+
+		$locations = get_nav_menu_locations();
+		$this->assertEquals( WPEnumType::get_safe_name( array_search( $this->menu_id, $locations, true ) ), $actual['data']['menu']['locations'][0] );
+	}
+
+	public function get_query() {
+		return '
+			query menu( $id: ID!, $idType: MenuNodeIdTypeEnum ) {
+				menu( id: $id, idType: $idType ) {
+					count
+					databaseId
+					id
+					locations
+					name
+					slug
+					menuItems {
+						nodes {
+							databaseId
+						}
+					}
+				}
+			}
+		';
 	}
 
 }


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR add the ability for user to query a menu by its provided `slug` and `location`.

Also backfilled tests for querying `menu` by all possible `idType`s.

Does this close any currently open issues?
------------------------------------------
#1458


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
![image](https://user-images.githubusercontent.com/29322304/169166827-dcc4e1e4-93b9-4701-8157-91105958938e.png)

Any other comments?
-------------------
No tests were added for `menu.isRestricted`. I'm unclear under what circumstances a menu would be considered restricted.


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php 8.0.15 )

**WordPress Version:** 5.9.3
