### PR TITLE
Bugfix/taxonomy pagination

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3119,16 +3119,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.7.14",
+            "version": "1.7.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "e6f145f196a59c7ca91ea926c87ef3d936c4305f"
+                "reference": "cd0202ea1b1fc6d1bbe156c6e2e18a03e0ff160a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e6f145f196a59c7ca91ea926c87ef3d936c4305f",
-                "reference": "e6f145f196a59c7ca91ea926c87ef3d936c4305f",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/cd0202ea1b1fc6d1bbe156c6e2e18a03e0ff160a",
+                "reference": "cd0202ea1b1fc6d1bbe156c6e2e18a03e0ff160a",
                 "shasum": ""
             },
             "require": {
@@ -3154,7 +3154,7 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.7.14"
+                "source": "https://github.com/phpstan/phpstan/tree/1.7.15"
             },
             "funding": [
                 {
@@ -3174,7 +3174,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-14T13:09:35+00:00"
+            "time": "2022-06-20T08:29:01+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3496,16 +3496,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.20",
+            "version": "9.5.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "12bc8879fb65aef2138b26fc633cb1e3620cffba"
+                "reference": "0e32b76be457de00e83213528f6bb37e2a38fcb1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/12bc8879fb65aef2138b26fc633cb1e3620cffba",
-                "reference": "12bc8879fb65aef2138b26fc633cb1e3620cffba",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0e32b76be457de00e83213528f6bb37e2a38fcb1",
+                "reference": "0e32b76be457de00e83213528f6bb37e2a38fcb1",
                 "shasum": ""
             },
             "require": {
@@ -3539,7 +3539,6 @@
                 "sebastian/version": "^3.0.2"
             },
             "require-dev": {
-                "ext-pdo": "*",
                 "phpspec/prophecy-phpunit": "^2.0.1"
             },
             "suggest": {
@@ -3583,7 +3582,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.20"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.21"
             },
             "funding": [
                 {
@@ -3595,7 +3594,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-04-01T12:37:26+00:00"
+            "time": "2022-06-19T12:14:25+00:00"
         },
         {
             "name": "psr/container",
@@ -5124,16 +5123,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.7.0",
+            "version": "3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "a2cd51b45bcaef9c1f2a4bda48f2dd2fa2b95563"
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/a2cd51b45bcaef9c1f2a4bda48f2dd2fa2b95563",
-                "reference": "a2cd51b45bcaef9c1f2a4bda48f2dd2fa2b95563",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
                 "shasum": ""
             },
             "require": {
@@ -5176,7 +5175,7 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2022-06-13T06:31:38+00:00"
+            "time": "2022-06-18T07:21:10+00:00"
         },
         {
             "name": "symfony/browser-kit",

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -532,7 +532,7 @@ abstract class AbstractConnectionResolver {
 	 */
 	public function has_next_page() {
 		if ( ! empty( $this->args['first'] ) ) {
-			return ! empty( $this->ids ) ? count( $this->ids ) > $this->query_amount : false;
+			return ! empty( $this->ids ) && count( $this->ids ) > $this->query_amount;
 		}
 
 		if ( ! empty( $this->args['before'] ) ) {
@@ -555,7 +555,7 @@ abstract class AbstractConnectionResolver {
 	 */
 	public function has_previous_page() {
 		if ( ! empty( $this->args['last'] ) ) {
-			return ! empty( $this->ids ) ? count( $this->ids ) > $this->query_amount : false;
+			return ! empty( $this->ids ) && count( $this->ids ) > $this->query_amount;
 		}
 
 		if ( ! empty( $this->args['after'] ) ) {

--- a/src/Data/Connection/TaxonomyConnectionResolver.php
+++ b/src/Data/Connection/TaxonomyConnectionResolver.php
@@ -29,6 +29,30 @@ class TaxonomyConnectionResolver extends AbstractConnectionResolver {
 		parent::__construct( $source, $args, $context, $info );
 	}
 
+	public function has_next_page() {
+
+		$last_key = array_key_last( $this->get_ids_for_nodes() );
+		$index = array_search( $last_key, array_keys( $this->get_ids() ), true );
+		$count = count( $this->get_ids() );
+
+		if ( ! empty( $this->args['first'] ) ) {
+			return $index + 1 < $count;
+		}
+
+		return false;
+	}
+
+	public function has_previous_page() {
+		$first_key = array_key_first( $this->get_ids_for_nodes() );
+		$index = array_search( $first_key, array_keys( $this->get_ids() ), true );
+
+		if ( ! empty( $this->args['last'] ) ) {
+			return $index > 0;
+		}
+
+		return false;
+	}
+
 	/**
 	 * @return bool|int|mixed|null|string
 	 */
@@ -77,11 +101,9 @@ class TaxonomyConnectionResolver extends AbstractConnectionResolver {
 	 */
 	public function get_query_args() {
 
-		$query_args = [
+		return [
 			'show_in_graphql' => true,
 		];
-
-		return $query_args;
 
 	}
 
@@ -111,12 +133,14 @@ class TaxonomyConnectionResolver extends AbstractConnectionResolver {
 
 		if ( ! empty( $this->get_offset() ) ) {
 			// Determine if the offset is in the array
-			$key = array_search( $this->get_offset(), $ids, true );
+			$keys = array_keys( $ids );
+			$key = array_search( $this->get_offset(), $keys, true );
+
 			if ( false !== $key ) {
 				$key = absint( $key );
 				if ( ! empty( $this->args['before'] ) ) {
 					// Slice the array from the back.
-					$ids = array_slice( $ids, 0, $key, true );
+					$ids = array_slice( $ids, $key + 1, $this->get_query_amount(), true );
 				} else {
 					// Slice the array from the front.
 					$key ++;
@@ -125,9 +149,11 @@ class TaxonomyConnectionResolver extends AbstractConnectionResolver {
 			}
 		}
 
-		$ids = array_slice( $ids, 0, $this->query_amount, true );
 
-		return $ids;
+		$ids = array_slice( $ids, 0, $this->query_amount, true );
+		return ! empty( $this->args['last'] ) ? array_reverse( $ids ) : $ids;
+
+
 	}
 
 	/**
@@ -147,7 +173,7 @@ class TaxonomyConnectionResolver extends AbstractConnectionResolver {
 	 * @return bool
 	 */
 	public function is_valid_offset( $offset ) {
-		return true;
+		return (bool) get_taxonomy( $offset );
 	}
 
 	/**

--- a/src/Data/Connection/TaxonomyConnectionResolver.php
+++ b/src/Data/Connection/TaxonomyConnectionResolver.php
@@ -32,8 +32,8 @@ class TaxonomyConnectionResolver extends AbstractConnectionResolver {
 	public function has_next_page() {
 
 		$last_key = array_key_last( $this->get_ids_for_nodes() );
-		$index = array_search( $last_key, array_keys( $this->get_ids() ), true );
-		$count = count( $this->get_ids() );
+		$index    = array_search( $last_key, array_keys( $this->get_ids() ), true );
+		$count    = count( $this->get_ids() );
 
 		if ( ! empty( $this->args['first'] ) ) {
 			return $index + 1 < $count;
@@ -44,7 +44,7 @@ class TaxonomyConnectionResolver extends AbstractConnectionResolver {
 
 	public function has_previous_page() {
 		$first_key = array_key_first( $this->get_ids_for_nodes() );
-		$index = array_search( $first_key, array_keys( $this->get_ids() ), true );
+		$index     = array_search( $first_key, array_keys( $this->get_ids() ), true );
 
 		if ( ! empty( $this->args['last'] ) ) {
 			return $index > 0;
@@ -134,7 +134,7 @@ class TaxonomyConnectionResolver extends AbstractConnectionResolver {
 		if ( ! empty( $this->get_offset() ) ) {
 			// Determine if the offset is in the array
 			$keys = array_keys( $ids );
-			$key = array_search( $this->get_offset(), $keys, true );
+			$key  = array_search( $this->get_offset(), $keys, true );
 
 			if ( false !== $key ) {
 				$key = absint( $key );
@@ -149,10 +149,8 @@ class TaxonomyConnectionResolver extends AbstractConnectionResolver {
 			}
 		}
 
-
 		$ids = array_slice( $ids, 0, $this->query_amount, true );
 		return ! empty( $this->args['last'] ) ? array_reverse( $ids ) : $ids;
-
 
 	}
 

--- a/tests/wpunit/TaxonomyConnectionQueriesTest.php
+++ b/tests/wpunit/TaxonomyConnectionQueriesTest.php
@@ -2,19 +2,39 @@
 
 class TaxonomyConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
+	/**
+	 * @var array|string[]|WP_Taxonomy[]
+	 */
+	public $taxonomies = [];
+
 	public function setUp(): void {
 		parent::setUp();
+
+
+		$this->clearSchema();
+
+		$alphabet = range( 'A', 'Z' );
+
+		// Create posts
+		for ( $i = 0; $i <= count( $alphabet ) - 1; $i ++ ) {
+			register_taxonomy( $alphabet[ $i ], 'post', [
+				'public' => true,
+				'show_in_graphql' => true,
+				'graphql_single_name' => $alphabet[ $i ],
+				'graphql_plural_name' => 'all' . lcfirst( $alphabet[ $i ] ),
+			] );
+		}
+
+		$this->taxonomies = get_taxonomies([ 'show_in_graphql' => true ] );
+
 	}
 
 	public function tearDown(): void {
 		parent::tearDown();
 	}
 
-	/**
-	 * Tests querying for plugins with pagination args.
-	 */
-	public function testTaxonomiesQueryPagination() {
-		$query = '
+	public function taxonomyQuery() {
+		return '
 			query testTaxonomies($first: Int, $after: String, $last: Int, $before: String ) {
 				taxonomies(first: $first, last: $last, before: $before, after: $after) {
 					pageInfo {
@@ -30,49 +50,120 @@ class TaxonomyConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 				}
 			}
 		';
+	}
 
-		// Get all for comparison
+	public function testTaxonomyForwardPagination() {
+
+		$first = 5;
+
 		$variables = [
-			'first'  => null,
-			'after'  => null,
-			'last'   => null,
-			'before' => null,
+			'first' => $first
 		];
 
-		$actual = $this->graphql( compact( 'query', 'variables' ) );
+		$actual = $this->graphql([
+			'query' => $this->taxonomyQuery(),
+			'variables' => $variables,
+		]);
 
 		$this->assertIsValidQueryResponse( $actual );
+		$this->assertCount( 5, $actual['data']['taxonomies']['nodes'] );
+		$names = wp_list_pluck( $actual['data']['taxonomies']['nodes'], 'name' );
 
-		$nodes = $actual['data']['taxonomies']['nodes'];
+		// assert that the first 5 taxonomies from the query are the first 5 from get_taxonomies
+		$this->assertSame( $names, array_slice( array_values( $this->taxonomies ), 0, $first ) );
 
-		// Get first two taxonomies
-		$variables['first'] = 2;
 
-		$expected = array_slice( $nodes, 0, $variables['first'], true );
-		$actual   = $this->graphql( compact( 'query', 'variables' ) );
-		$this->assertEqualSets( $expected, $actual['data']['taxonomies']['nodes'] );
+		$endCursor = $actual['data']['taxonomies']['pageInfo']['endCursor'];
 
-		// Test with empty `after`.
-		$variables['after'] = '';
-		$actual             = $this->graphql( compact( 'query', 'variables' ) );
-		$this->assertEqualSets( $expected, $actual['data']['taxonomies']['nodes'] );
-
-		// Get last two taxonomies
 		$variables = [
-			'first'  => null,
-			'after'  => null,
-			'last'   => 2,
-			'before' => null,
+			'first' => $first,
+			'after' => $endCursor
 		];
 
-		$expected = array_slice( $nodes, count( $nodes ) - $variables['last'], null, true );
-		$actual   = $this->graphql( compact( 'query', 'variables' ) );
-		$this->assertEqualSets( $expected, $actual['data']['taxonomies']['nodes'] );
+		$page_2 = $this->graphql([
+			'query' => $this->taxonomyQuery(),
+			'variables' => $variables,
+		]);
 
-		// Test with empty `before`.
-		$variables['before'] = '';
-		$actual              = $this->graphql( compact( 'query', 'variables' ) );
-		$this->assertEqualSets( $expected, $actual['data']['taxonomies']['nodes'] );
+		$page_2_names = wp_list_pluck( $page_2['data']['taxonomies']['nodes'], 'name' );
+
+		$page_2_endCursor = $page_2['data']['taxonomies']['pageInfo']['endCursor'];
+
+		// assert that the page 2 names are the same as the 2nd set of 5 names from the taxonomies list
+		$this->assertSame( $page_2_names, array_slice( array_values( $this->taxonomies ), 5, $first ) );
+
+		$variables = [
+			'first' => $first,
+			'after' => $page_2_endCursor
+		];
+
+		$page_3 = $this->graphql([
+			'query' => $this->taxonomyQuery(),
+			'variables' => $variables,
+		]);
+
+		$page_3_names = wp_list_pluck( $page_3['data']['taxonomies']['nodes'], 'name' );
+
+		// assert that the page 2 names are the same as the 3rd set of 5 names from the taxonomies list
+		$this->assertSame( $page_3_names, array_slice( array_values( $this->taxonomies ), 10, $first ) );
+
+	}
+
+	public function testTaxonomiesBackwardPagination() {
+
+		$backward_taxonomies = array_reverse( $this->taxonomies );
+
+		$last = 5;
+
+		$page_1 = $this->graphql([
+			'query' => $this->taxonomyQuery(),
+			'variables' => [
+				'last' => $last,
+				'before' => null,
+			]
+		]);
+
+		$this->assertIsValidQueryResponse( $page_1 );
+
+		$page_1_names = wp_list_pluck( $page_1['data']['taxonomies']['nodes'], 'name' );
+
+
+		// the first page should be the first 5 taxonomies
+		$this->assertSame( $page_1_names, array_reverse( array_slice( array_values( $backward_taxonomies ), 0, $last ) ) );
+
+		$page_1_start_cursor =  $page_1['data']['taxonomies']['pageInfo']['startCursor'];
+
+		$page_2 = $this->graphql([
+			'query' => $this->taxonomyQuery(),
+			'variables' => [
+				'last' => $last,
+				'before' => $page_1_start_cursor
+			]
+		]);
+
+		$this->assertIsValidQueryResponse( $page_2 );
+
+		$page_2_names = wp_list_pluck( $page_2['data']['taxonomies']['nodes'], 'name' );
+
+		$this->assertSame( $page_2_names, array_reverse( array_slice( array_values( $backward_taxonomies ), 5, $last ) ) );
+
+		$page_2_start_cursor =  $page_2['data']['taxonomies']['pageInfo']['startCursor'];
+
+		$page_3 = $this->graphql([
+			'query' => $this->taxonomyQuery(),
+			'variables' => [
+				'last' => $last,
+				'before' => $page_2_start_cursor
+			]
+		]);
+
+		$this->assertIsValidQueryResponse( $page_3 );
+
+		$page_3_names = wp_list_pluck( $page_3['data']['taxonomies']['nodes'], 'name' );
+
+		// page 3 should be the 3rd set of 5 names from the taxonomies list
+		$this->assertSame( $page_3_names, array_reverse( array_slice( array_values( $backward_taxonomies ), 10, $last ) ) );
+
 	}
 
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This fixes a bug with taxonomy pagination where the end cursor wasn't properly being respected for subsequent paginated requests. 


Does this close any currently open issues?
------------------------------------------
closes #2343 


Any other comments?
-------------------

With the following snippet I've registered a taxonomy for every letter of the alphabet. 

So we end up with the following list of taxonomies:

```json
{
  "category": "category",
  "post_tag": "post_tag",
  "post_format": "post_format",
  "A": "A",
  "B": "B",
  "C": "C",
  "D": "D",
  "E": "E",
  "F": "F",
  "G": "G",
  "H": "H",
  "I": "I",
  "J": "J",
  "K": "K",
  "L": "L",
  "M": "M",
  "N": "N",
  "O": "O",
  "P": "P",
  "Q": "Q",
  "R": "R",
  "S": "S",
  "T": "T",
  "U": "U",
  "V": "V",
  "W": "W",
  "X": "X",
  "Y": "Y",
  "Z": "Z"
}
```

I can then make a query for a set of these taxonomies like so:

```graphql
query testTaxonomies($first: Int, $after: String, $last: Int, $before: String ) {
  taxonomies(first: $first, last: $last, before: $before, after: $after) {
    pageInfo {
      endCursor
      hasNextPage
      hasPreviousPage
      startCursor
    }
    nodes {
      id
      name
    }
  }
}
```

with variables: 

```json
{
  "first": 5
}
```

and we should expect to get the first 5 taxonomies in response:

```json
  "category": "category",
  "post_tag": "post_tag",
  "post_format": "post_format",
  "A": "A",
  "B": "B",
```

We can see this working as expected.

<img width="1102" alt="CleanShot 2022-06-20 at 11 14 53@2x" src="https://user-images.githubusercontent.com/1260765/174651362-784fd647-21cc-48db-b82d-fb3fd804d94f.png">

Then, we should be able to take the `pageInfo.endCursor` value and use it as the input value for the `after` variable to query the next page. 

Like so:

```json
{
  "first": 5,
  "after": "YXJyYXljb25uZWN0aW9uOkI="
}
```

This is where the bug was happening. 

We should expect nodes (the _first_ 5 nodes _after_ node "B"):

```json
  "C": "C",
  "D": "D",
  "E": "E",
  "F": "F",
  "G": "G",
```

**BEFORE**

Before this PR, we would get the following output:

```json
{
  "data": {
    "taxonomies": {
      "pageInfo": {
        "endCursor": "YXJyYXljb25uZWN0aW9uOkM=",
        "hasNextPage": true,
        "hasPreviousPage": true,
        "startCursor": "YXJyYXljb25uZWN0aW9uOnBvc3RfdGFn"
      },
      "nodes": [
        {
          "id": "dGF4b25vbXk6cG9zdF90YWc=",
          "name": "post_tag"
        },
        {
          "id": "dGF4b25vbXk6cG9zdF9mb3JtYXQ=",
          "name": "post_format"
        },
        {
          "id": "dGF4b25vbXk6QQ==",
          "name": "A"
        },
        {
          "id": "dGF4b25vbXk6Qg==",
          "name": "B"
        },
        {
          "id": "dGF4b25vbXk6Qw==",
          "name": "C"
        }
      ]
    }
  },
}
```

This is not what we want!

**AFTER**

After this PR, the same query returns the following:

```json
{
  "data": {
    "taxonomies": {
      "pageInfo": {
        "endCursor": "YXJyYXljb25uZWN0aW9uOkc=",
        "hasNextPage": true,
        "hasPreviousPage": false,
        "startCursor": "YXJyYXljb25uZWN0aW9uOkM="
      },
      "nodes": [
        {
          "id": "dGF4b25vbXk6Qw==",
          "name": "C"
        },
        {
          "id": "dGF4b25vbXk6RA==",
          "name": "D"
        },
        {
          "id": "dGF4b25vbXk6RQ==",
          "name": "E"
        },
        {
          "id": "dGF4b25vbXk6Rg==",
          "name": "F"
        },
        {
          "id": "dGF4b25vbXk6Rw==",
          "name": "G"
        }
      ]
    }
  },
}
```

This is what we were expecting! 🥳 🎉 

We can take the end cursor (for node "G") and do another request, expecting nodes "H" through "L"

And we see we get the expected results:

```json
{
  "data": {
    "taxonomies": {
      "pageInfo": {
        "endCursor": "YXJyYXljb25uZWN0aW9uOkw=",
        "hasNextPage": true,
        "hasPreviousPage": false,
        "startCursor": "YXJyYXljb25uZWN0aW9uOkg="
      },
      "nodes": [
        {
          "id": "dGF4b25vbXk6SA==",
          "name": "H"
        },
        {
          "id": "dGF4b25vbXk6SQ==",
          "name": "I"
        },
        {
          "id": "dGF4b25vbXk6Sg==",
          "name": "J"
        },
        {
          "id": "dGF4b25vbXk6Sw==",
          "name": "K"
        },
        {
          "id": "dGF4b25vbXk6TA==",
          "name": "L"
        }
      ]
    }
  },
}
```

