### PR TITLE
- update tests to run in php 8.1 with WP 6.0

### DIFF
--- a/.github/workflows/deploy-docker-image.yml
+++ b/.github/workflows/deploy-docker-image.yml
@@ -18,6 +18,14 @@ jobs:
         exclude:
           - php: '8.0'
             wordpress: '5.5.3'
+          - php: '8.1'
+            wordpress: '5.5.3'
+          - php: '8.1'
+            wordpress: '5.6'
+          - php: '8.1'
+            wordpress: '5.7.2'
+          - php: '7.3'
+            wordpress: '6.0'
       fail-fast: false
     name: WordPress ${{ matrix.wordpress }} on PHP ${{ matrix.php }}
     steps:

--- a/.github/workflows/deploy-docker-image.yml
+++ b/.github/workflows/deploy-docker-image.yml
@@ -13,8 +13,8 @@ jobs:
       packages: write
     strategy:
       matrix:
-        php: [ '8.0', '7.4', '7.3' ]
-        wordpress: [ '5.9', '5.8', '5.7.2', '5.6', '5.5.3' ]
+        php: [ '8.1', '8.0', '7.4', '7.3' ]
+        wordpress: [ '6.0', '5.9', '5.8', '5.7.2', '5.6', '5.5.3' ]
         exclude:
           - php: '8.0'
             wordpress: '5.5.3'

--- a/.github/workflows/testing-integration.yml
+++ b/.github/workflows/testing-integration.yml
@@ -22,6 +22,12 @@ jobs:
         php: [ '7.4', '7.3' ]
         wordpress: [ '5.9', '5.8', '5.7.2', '5.6.2' ]
         include:
+          - php: '8.1'
+            wordpress: '6.0'
+          - php: '8.0'
+            wordpress: '6.0'
+          - php: '7.4'
+            wordpress: '6.0'
           - php: '8.0'
             wordpress: '5.9'
           - php: '8.0'


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This updates the testing workflow to run tests with WordPress 6.0

It doesn't add 6.0 to the matrix because all of the versions of the matrix are not available as WordPress images on Dockerhub

This also updates our Docker deploy script to deploy Docker images of WPGraphQL

Does this close any currently open issues?
------------------------------------------
closes #2397 