### PR TITLE
Release v1.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.8.4
+
+### Chores / Bugfixes 
+
+- ([#2416](https://github.com/wp-graphql/wp-graphql/pull/2416)): Fixes schema artifact workflow in Github.
+
 ## 1.8.3
 
 ### New Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-graphql",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "GraphQL API for WordPress",
   "homepage": "https://github.com/wp-graphql/wp-graphql#readme",
   "author": "WPGraphQL <info@wpgraphql.com> (https://www.wpgraphql.com)",

--- a/readme.txt
+++ b/readme.txt
@@ -131,6 +131,12 @@ Composer dependencies are no longer versioned in Github. Recommended install sou
 
 == Changelog ==
 
+= 1.8.4 =
+
+**Chores / Bugfixes**
+
+- ([#2416](https://github.com/wp-graphql/wp-graphql/pull/2416)): Fixes schema artifact workflow in Github.
+
 = 1.8.3 =
 
 **New Features**

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -130,7 +130,7 @@ final class WPGraphQL {
 
 		// Plugin version.
 		if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-			define( 'WPGRAPHQL_VERSION', '1.8.3' );
+			define( 'WPGRAPHQL_VERSION', '1.8.4' );
 		}
 
 		// Plugin Folder Path.

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.8.3
+ * Version: 1.8.4
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.8.3
+ * @version  1.8.4
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
## 1.8.4

### Chores / Bugfixes 

- ([#2416](https://github.com/wp-graphql/wp-graphql/pull/2416)): Fixes schema artifact workflow in Github.