### PR TITLE
Release/v1.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.8.4.1
+
+### Chores / Bugfixes
+
+- ([#2422](https://github.com/wp-graphql/wp-graphql/pull/2422)): Fixes a regression of the 1.8.3 release where there could be fatal errors when GraphQL Tracing is enabled.
+
+
 ## 1.8.4
 
 ### Chores / Bugfixes 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.8.4.1
+## 1.8.5
 
 ### Chores / Bugfixes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-graphql",
-  "version": "1.8.4",
+  "version": "1.8.4.1",
   "description": "GraphQL API for WordPress",
   "homepage": "https://github.com/wp-graphql/wp-graphql#readme",
   "author": "WPGraphQL <info@wpgraphql.com> (https://www.wpgraphql.com)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-graphql",
-  "version": "1.8.4.1",
+  "version": "1.8.5",
   "description": "GraphQL API for WordPress",
   "homepage": "https://github.com/wp-graphql/wp-graphql#readme",
   "author": "WPGraphQL <info@wpgraphql.com> (https://www.wpgraphql.com)",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, API, Gatsby, Headless, Decoupled, React, Nextjs, Vue, Apollo, RES
 Requires at least: 5.0
 Tested up to: 5.9.1
 Requires PHP: 7.1
-Stable tag: 1.8.4.1
+Stable tag: 1.8.5
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -131,7 +131,7 @@ Composer dependencies are no longer versioned in Github. Recommended install sou
 
 == Changelog ==
 
-= 1.8.4.1 =
+= 1.8.5 =
 
 **Chores / Bugfixes**
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, API, Gatsby, Headless, Decoupled, React, Nextjs, Vue, Apollo, RES
 Requires at least: 5.0
 Tested up to: 5.9.1
 Requires PHP: 7.1
-Stable tag: 1.8.3
+Stable tag: 1.8.4.1
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -130,6 +130,13 @@ The `uri` field was non-null on some Types in the Schema but has been changed to
 Composer dependencies are no longer versioned in Github. Recommended install source is WordPress.org or using Composer to get the code from Packagist.org or WPackagist.org.
 
 == Changelog ==
+
+= 1.8.4.1 =
+
+**Chores / Bugfixes**
+
+- ([#2422](https://github.com/wp-graphql/wp-graphql/pull/2422)): Fixes a regression of the 1.8.3 release where there could be fatal errors when GraphQL Tracing is enabled.
+
 
 = 1.8.4 =
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -493,7 +493,7 @@ class Request {
 		 *
 		 * @param mixed|array $response  The response your GraphQL request
 		 * @param WPSchema    $schema    The schema object for the root request
-		 * @param string      $operation The name of the operation
+		 * @param mixed|string|null      $operation The name of the operation
 		 * @param string      $query     The query that GraphQL executed
 		 * @param array|null  $variables Variables to passed to your GraphQL query
 		 * @param Request     $request   Instance of the Request

--- a/src/Utils/Tracing.php
+++ b/src/Utils/Tracing.php
@@ -264,12 +264,12 @@ class Tracing {
 	 *
 	 * @param mixed|array|object $response       The response of the GraphQL Request
 	 * @param mixed              $schema         The WPGraphQL Schema
-	 * @param string             $operation_name The operation name being executed
+	 * @param mixed|string|null             $operation_name The operation name being executed
 	 * @param string             $request        The GraphQL Request being made
 	 *
 	 * @return mixed $response
 	 */
-	public function add_tracing_to_response_extensions( $response, $schema, string $operation_name, string $request ) {
+	public function add_tracing_to_response_extensions( $response, $schema, $operation_name, string $request ) {
 
 		// Get the trace
 		$trace = $this->get_trace();

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -130,7 +130,7 @@ final class WPGraphQL {
 
 		// Plugin version.
 		if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-			define( 'WPGRAPHQL_VERSION', '1.8.4.1' );
+			define( 'WPGRAPHQL_VERSION', '1.8.5' );
 		}
 
 		// Plugin Folder Path.

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -130,7 +130,7 @@ final class WPGraphQL {
 
 		// Plugin version.
 		if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-			define( 'WPGRAPHQL_VERSION', '1.8.4' );
+			define( 'WPGRAPHQL_VERSION', '1.8.4.1' );
 		}
 
 		// Plugin Folder Path.

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -292,11 +292,13 @@ final class WPGraphQL {
 		// Initialize Admin functionality
 		add_action( 'after_setup_theme', [ $this, 'init_admin' ] );
 
-		$tracing = new \WPGraphQL\Utils\Tracing();
-		$tracing->init();
+		add_action( 'init_graphql_request', function () {
+			$tracing = new \WPGraphQL\Utils\Tracing();
+			$tracing->init();
 
-		$query_log = new \WPGraphQL\Utils\QueryLog();
-		$query_log->init();
+			$query_log = new \WPGraphQL\Utils\QueryLog();
+			$query_log->init();
+		} );
 
 	}
 

--- a/tests/wpunit/TracingTest.php
+++ b/tests/wpunit/TracingTest.php
@@ -1,0 +1,45 @@
+<?php
+
+class TracingTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
+
+	private $admin;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->admin = $this->factory()->user->create( [ 'role' => 'administrator' ] );
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+	}
+
+	public function testQueryWithTracingEnabledForAnyUser() {
+
+		// enable tracing for any user
+		$settings = get_option( 'graphql_general_settings', [] );
+		$settings['tracing_enabled'] = 'on';
+		$settings['tracing_user_role'] = 'any';
+		update_option( 'graphql_general_settings', $settings  );
+
+		$query = '
+		{
+		  posts { 
+		    nodes { 
+		      id 
+		    } 
+		  }
+		}
+		';
+
+		$response = $this->graphql([
+			'query' => $query
+		]);
+
+		codecept_debug( $response );
+
+		$this->assertIsValidQueryResponse( $response );
+		$this->assertNotEmpty( $response['extensions']['tracing'] );
+
+	}
+
+}

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.8.4.1
+ * Version: 1.8.5
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.8.4.1
+ * @version  1.8.5
  */
 
 // Exit if accessed directly.

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.8.4
+ * Version: 1.8.4.1
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.8.4
+ * @version  1.8.4.1
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
## 1.8.5

### Chores / Bugfixes

- ([#2422](https://github.com/wp-graphql/wp-graphql/pull/2422)): Fixes a regression of the 1.8.3 release where there could be fatal errors when GraphQL Tracing is enabled.
