### PR TITLE
Release v1.8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.8.6
+
+### Chores / Bugfixes
+
+- ([#2427](https://github.com/wp-graphql/wp-graphql/pull/2427)): Fixes a regression of the 1.8.3 release where there could be fatal errors when GraphQL Tracing is enabled and a queryId is used as a query param.
+
+
 ## 1.8.5
 
 ### Chores / Bugfixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-graphql",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "description": "GraphQL API for WordPress",
   "homepage": "https://github.com/wp-graphql/wp-graphql#readme",
   "author": "WPGraphQL <info@wpgraphql.com> (https://www.wpgraphql.com)",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, API, Gatsby, Headless, Decoupled, React, Nextjs, Vue, Apollo, RES
 Requires at least: 5.0
 Tested up to: 5.9.1
 Requires PHP: 7.1
-Stable tag: 1.8.5
+Stable tag: 1.8.6
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -130,6 +130,13 @@ The `uri` field was non-null on some Types in the Schema but has been changed to
 Composer dependencies are no longer versioned in Github. Recommended install source is WordPress.org or using Composer to get the code from Packagist.org or WPackagist.org.
 
 == Changelog ==
+
+= 1.8.6 =
+
+**Chores / Bugfixes**
+
+- ([#2427](https://github.com/wp-graphql/wp-graphql/pull/2427)): Fixes a regression of the 1.8.3 release where there could be fatal errors when GraphQL Tracing is enabled and a queryId is used as a query param.
+
 
 = 1.8.5 =
 

--- a/src/Utils/Tracing.php
+++ b/src/Utils/Tracing.php
@@ -100,7 +100,7 @@ class Tracing {
 		add_filter( 'graphql_request_results', [
 			$this,
 			'add_tracing_to_response_extensions',
-		], 10, 4 );
+		], 10, 1 );
 		add_action( 'graphql_before_resolve_field', [ $this, 'init_field_resolver_trace' ], 10, 4 );
 		add_action( 'graphql_after_resolve_field', [ $this, 'end_field_resolver_trace' ], 10 );
 	}
@@ -263,13 +263,10 @@ class Tracing {
 	 * Filter the results of the GraphQL Response to include the Query Log
 	 *
 	 * @param mixed|array|object $response       The response of the GraphQL Request
-	 * @param mixed              $schema         The WPGraphQL Schema
-	 * @param mixed|string|null             $operation_name The operation name being executed
-	 * @param string             $request        The GraphQL Request being made
 	 *
 	 * @return mixed $response
 	 */
-	public function add_tracing_to_response_extensions( $response, $schema, $operation_name, string $request ) {
+	public function add_tracing_to_response_extensions( $response ) {
 
 		// Get the trace
 		$trace = $this->get_trace();

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -130,7 +130,7 @@ final class WPGraphQL {
 
 		// Plugin version.
 		if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-			define( 'WPGRAPHQL_VERSION', '1.8.5' );
+			define( 'WPGRAPHQL_VERSION', '1.8.6' );
 		}
 
 		// Plugin Folder Path.

--- a/tests/wpunit/TracingTest.php
+++ b/tests/wpunit/TracingTest.php
@@ -42,4 +42,33 @@ class TracingTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 	}
 
+	public function testQueryByGraphqlIdWorksWithTracingEnabled() {
+
+		// enable tracing for any user
+		$settings = get_option( 'graphql_general_settings', [] );
+		$settings['tracing_enabled'] = 'on';
+		$settings['tracing_user_role'] = 'any';
+		update_option( 'graphql_general_settings', $settings  );
+
+		$query = '
+		{
+		  posts { 
+		    nodes { 
+		      id 
+		    } 
+		  }
+		}
+		';
+
+		$response = $this->graphql([
+			'queryId' => $query
+		]);
+
+		codecept_debug( $response );
+
+		$this->assertIsValidQueryResponse( $response );
+		$this->assertNotEmpty( $response['extensions']['tracing'] );
+
+	}
+
 }

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.8.5
+ * Version: 1.8.6
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.8.5
+ * @version  1.8.6
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
# Release Notes

### Chores / Bugfixes

- ([#2427](https://github.com/wp-graphql/wp-graphql/pull/2427)): Fixes a regression of the 1.8.3 release where there could be fatal errors when GraphQL Tracing is enabled and a queryId is used as a query param.
