### PR TITLE
Add filter in execute() for query string

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -611,9 +611,19 @@ class Request {
 			$response = apply_filters( 'pre_graphql_execute_request', null, $this );
 
 			if ( null === $response ) {
+
+				/**
+				 * Allow the query string to be determined by a filter. Ex, when params->queryId is present, query can be retrieved.
+				 */
+				$query = apply_filters(
+					'graphql_execute_query_params',
+					isset( $this->params->query ) ? $this->params->query : '',
+					$this->params
+				);
+
 				$result = \GraphQL\GraphQL::executeQuery(
 					$this->schema,
-					isset( $this->params->query ) ? $this->params->query : '',
+					$query,
 					$this->root_value,
 					$this->app_context,
 					isset( $this->params->variables ) ? $this->params->variables : null,


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
For when using the graphql() function directly to invoke a request, ie, during unit testing, queryId is not honored/processed.  The query string is empty and the parser throws error on the query string.

This filter allows the graphql() invocation, which uses the execute() function to return a query string. The smart cache plugin can use this callback filter to look for queryId when the query string is not present in the params and look up a saved query string.


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
