### PR TITLE
Create zip file on pull-request

### DIFF
--- a/.github/workflows/zip-plugin-on-pull-request.yml
+++ b/.github/workflows/zip-plugin-on-pull-request.yml
@@ -2,10 +2,6 @@ name: Create plugin zip artifact for pull-request
 on:
   pull_request_target:
     types: [labeled]
-    branches:
-      - main
-      - master
-      - develop
 
 permissions: write-all
 

--- a/.github/workflows/zip-plugin-on-pull-request.yml
+++ b/.github/workflows/zip-plugin-on-pull-request.yml
@@ -1,0 +1,32 @@
+name: Create plugin zip artifact for pull-request
+on:
+  pull_request:
+    branches:
+      - main
+      - master
+      - develop
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.0
+          tools: composer
+      - name: Install PHP dependencies
+        run: |
+          composer install --no-dev --optimize-autoloader
+      - name: Create Artifact
+        run: |
+          mkdir plugin-build
+          composer archive -vvv --format=zip --file="plugin-build/wp-graphql"
+      - name: Upload artifact
+        uses: gavv/pull-request-artifacts@v1.0.0
+        with:
+          commit: ${{ github.event.pull_request.head.sha }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: |
+            plugin-build/wp-graphql.zip

--- a/.github/workflows/zip-plugin-on-pull-request.yml
+++ b/.github/workflows/zip-plugin-on-pull-request.yml
@@ -11,6 +11,7 @@ permissions: write-all
 jobs:
   tag:
     runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'build plugin zip')
 
     # permissions:
     #   contents: write

--- a/.github/workflows/zip-plugin-on-pull-request.yml
+++ b/.github/workflows/zip-plugin-on-pull-request.yml
@@ -5,9 +5,12 @@ on:
       - main
       - master
       - develop
+
 jobs:
   tag:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/zip-plugin-on-pull-request.yml
+++ b/.github/workflows/zip-plugin-on-pull-request.yml
@@ -8,6 +8,8 @@ permissions: write-all
 jobs:
   build:
     runs-on: ubuntu-latest
+    name: Create plugin zip artifact for pull-request
+    if: contains(github.event.pull_request.labels.*.name, 'build plugin zip')
 
     # permissions:
     #   contents: write

--- a/.github/workflows/zip-plugin-on-pull-request.yml
+++ b/.github/workflows/zip-plugin-on-pull-request.yml
@@ -12,7 +12,6 @@ permissions: write-all
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'build plugin zip')
 
     # permissions:
     #   contents: write

--- a/.github/workflows/zip-plugin-on-pull-request.yml
+++ b/.github/workflows/zip-plugin-on-pull-request.yml
@@ -9,8 +9,13 @@ on:
 jobs:
   tag:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
+
+    permissions: write-all
+    # permissions: 
+    #   contents: write
+    #   discussions: write
+    #   pull-requests: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/zip-plugin-on-pull-request.yml
+++ b/.github/workflows/zip-plugin-on-pull-request.yml
@@ -1,6 +1,7 @@
 name: Create plugin zip artifact for pull-request
 on:
-  pull_request:
+  pull_request_target:
+    types: [labeled]
     branches:
       - main
       - master

--- a/.github/workflows/zip-plugin-on-pull-request.yml
+++ b/.github/workflows/zip-plugin-on-pull-request.yml
@@ -10,7 +10,7 @@ on:
 permissions: write-all
 
 jobs:
-  tag:
+  build:
     runs-on: ubuntu-latest
     if: contains(github.event.pull_request.labels.*.name, 'build plugin zip')
 

--- a/.github/workflows/zip-plugin-on-pull-request.yml
+++ b/.github/workflows/zip-plugin-on-pull-request.yml
@@ -6,12 +6,13 @@ on:
       - master
       - develop
 
+permissions: write-all
+
 jobs:
   tag:
     runs-on: ubuntu-latest
 
-    permissions: write-all
-    # permissions: 
+    # permissions:
     #   contents: write
     #   discussions: write
     #   pull-requests: write


### PR DESCRIPTION

What does this implement/fix? Explain your changes.
---------------------------------------------------
For a pull request, build the plugin zip file from the pull request branch and make it available for download in the pull request for easy download.

Does this close any currently open issues?
------------------------------------------
https://github.com/wp-graphql/wp-graphql/issues/2272


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
