### PR TITLE
fix: contentNodes field is not available for custom taxonomies #2441

### DIFF
--- a/src/Connection/PostObjects.php
+++ b/src/Connection/PostObjects.php
@@ -304,7 +304,7 @@ class PostObjects {
 		// Register a connection from all taxonomies that are connected to
 		foreach ( $allowed_taxonomies as $tax_object ) {
 			if ( empty( $tax_object->object_type ) ) {
-				return;
+				continue;
 			}
 
 			// Connection from the Taxonomy to Content Nodes

--- a/src/Connection/PostObjects.php
+++ b/src/Connection/PostObjects.php
@@ -304,7 +304,7 @@ class PostObjects {
 		// Register a connection from all taxonomies that are connected to
 		foreach ( $allowed_taxonomies as $tax_object ) {
 			if ( empty( $tax_object->object_type ) ) {
-				continue;
+				return;
 			}
 
 			// Connection from the Taxonomy to Content Nodes

--- a/tests/wpunit/TermNodeTest.php
+++ b/tests/wpunit/TermNodeTest.php
@@ -729,4 +729,43 @@ class TermNodeTest extends \Codeception\TestCase\WPTestCase {
 
 	}
 
+	public function testQueryContentNodesOnCustomTaxonomyTest() {
+
+
+		register_taxonomy( 'no-posts', [], [
+			'public' => true,
+			'show_in_graphql' => true,
+			'graphql_single_name' => 'NoPost',
+			'graphql_plural_name' => 'NoPosts',
+		]);
+
+		register_taxonomy( 'with-graphql', ['post', 'page'], [
+			'show_in_graphql' => true,
+			'graphql_single_name' => 'TestTax',
+			'graphql_plural_name' => 'AllTestTax',
+			'public' => true,
+		]);
+
+		$query = '
+		{
+		  allTestTax {
+		    nodes {
+		      id
+		      contentNodes {
+		        __typename
+		      }
+		    }
+		  }
+		}
+		';
+
+		$actual = graphql([
+			'query' => $query,
+		]);
+
+		// assert that the query was valid
+		$this->assertArrayNotHasKey( 'errors', $actual );
+
+	}
+
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR makes contentNodes field available for all the custom taxonomies.


Does this close any currently open issues?
------------------------------------------
Closes: [ContentNodes field is not available for custom taxonomies](https://github.com/wp-graphql/wp-graphql/issues/2441).


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
Before:

<img width="680" alt="custom-taxonomy" src="https://user-images.githubusercontent.com/13016829/179422302-5e5d9e27-0d4c-4a01-8c74-7fd924084ed1.png">

After:
<img width="677" alt="after-custom-taxonomy" src="https://user-images.githubusercontent.com/13016829/179422359-dd6d3857-59a9-4791-97ae-0192d96e68a1.png">


