### PR TITLE
Chore:fix PHPCompatibilityWP lint config

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -54,8 +54,9 @@
 	</rule>
 
 	<!-- Tests for PHP version compatibility -->
+	<config name="testVersion" value="7.1-"/>
 	<rule ref="PHPCompatibilityWP">
-		<config name="testVersion" value="7.1-"/>
+		<include-pattern>*\.php$</include-pattern>
 	</rule>
 
 	<!-- Enforce short array syntax -->

--- a/src/Data/Connection/PluginConnectionResolver.php
+++ b/src/Data/Connection/PluginConnectionResolver.php
@@ -227,7 +227,7 @@ class PluginConnectionResolver extends AbstractConnectionResolver {
 						}
 
 						return false;
-					},
+					}
 				)
 			);
 			if ( ! empty( $matches ) ) {


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR fixes a mistake with the `phpcs.xml.dist` config, where PHPCompatibilityWP was not correctly checking againt PHP v7.1.
Also fixes an extraneous comma that was throwing a fatal error in PHP 7.2

Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
Proof linting is working from before the bugfix.
![image](https://user-images.githubusercontent.com/29322304/180517193-d555882a-02a8-4810-96d4-0b0f935f9def.png)

Any other comments?
-------------------
Our `composer.lock` and several dependencies arent compatible with WP 7.1 either... Will open a separate issue to address.

Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (WSL2 + devilbox + PHP 8.0.19)

**WordPress Version:** 6.0.1
