### PR TITLE
fix: #2448 - Fixes Comment.author connection resolver to properly load both User and CommentAuthor types

### DIFF
--- a/src/Model/Comment.php
+++ b/src/Model/Comment.php
@@ -4,6 +4,7 @@ namespace WPGraphQL\Model;
 
 use Exception;
 use GraphQLRelay\Relay;
+use WP_Comment;
 
 /**
  * Class Comment - Models data for Comments
@@ -35,18 +36,18 @@ class Comment extends Model {
 	/**
 	 * Stores the incoming WP_Comment object to be modeled
 	 *
-	 * @var \WP_Comment $data
+	 * @var WP_Comment $data
 	 */
 	protected $data;
 
 	/**
 	 * Comment constructor.
 	 *
-	 * @param \WP_Comment $comment The incoming WP_Comment to be modeled
+	 * @param WP_Comment $comment The incoming WP_Comment to be modeled
 	 *
 	 * @throws Exception
 	 */
-	public function __construct( \WP_Comment $comment ) {
+	public function __construct( WP_Comment $comment ) {
 
 		$allowed_restricted_fields = [
 			'id',

--- a/src/Type/ObjectType/Comment.php
+++ b/src/Type/ObjectType/Comment.php
@@ -33,18 +33,18 @@ class Comment {
 
 							$node = null;
 
-							// if the request is authenticated
-							// and the comment is from a user, try and load
-							// the user node
-							if ( ! empty( $comment->userId ) && is_user_logged_in() ) {
+							// try and load the user node
+							if ( ! empty( $comment->userId ) ) {
 								$node = $context->get_loader( 'user' )->load( absint( $comment->userId ) );
 							}
 
 							// If no node is loaded, fallback to the
 							// public comment author data
-							if ( ! $node ) {
+							if ( ! $node || ( true === $node->isPrivate ) ) {
 								$node = ! empty( $comment->commentId ) ? $context->get_loader( 'comment_author' )->load( $comment->commentId ) : null;
 							}
+
+
 
 							return [
 								'node'   => $node,

--- a/src/Type/ObjectType/Comment.php
+++ b/src/Type/ObjectType/Comment.php
@@ -44,8 +44,6 @@ class Comment {
 								$node = ! empty( $comment->commentId ) ? $context->get_loader( 'comment_author' )->load( $comment->commentId ) : null;
 							}
 
-
-
 							return [
 								'node'   => $node,
 								'source' => $comment,

--- a/tests/wpunit/CommentObjectQueriesTest.php
+++ b/tests/wpunit/CommentObjectQueriesTest.php
@@ -721,6 +721,10 @@ class CommentObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->assertSame( 'User', $typename );
 		$this->assertNotEmpty( $actual['data']['comment']['author']['node']['avatar']['url'] );
+
+		wp_delete_comment( $comment_by_user_id );
+		wp_delete_comment( $comment_by_comment_author_id );
+
 	}
 
 

--- a/tests/wpunit/CommentObjectQueriesTest.php
+++ b/tests/wpunit/CommentObjectQueriesTest.php
@@ -666,7 +666,11 @@ class CommentObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 	public function testQueryingAvatarOnUserAuthorsIsValidForPublicAndAuthenticatedRequests() {
 
 		// create a comment with a guest author as the author
-		$comment_id = $this->createCommentObject();
+		$comment_by_comment_author_id = $this->createCommentObject([
+			'user_id' => 0
+		]);
+
+		$comment_by_user_id = $this->createCommentObject();
 
 		$query = '
 		query GetCommentAuthorWithAvatar($id:ID!){
@@ -685,7 +689,7 @@ class CommentObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 		}
 		';
 
-		$global_id = \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_id );
+		$global_id = \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_by_comment_author_id );
 
 		$actual = graphql( [
 			'query' => $query,
@@ -701,7 +705,7 @@ class CommentObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertSame( 'CommentAuthor', $typename );
 		$this->assertNotEmpty( $actual['data']['comment']['author']['node']['avatar']['url'] );
 
-		wp_set_current_user( $this->admin );
+		$global_id = \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_by_user_id );
 
 		$actual = graphql( [
 			'query' => $query,
@@ -709,6 +713,7 @@ class CommentObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 				'id' => $global_id
 			]
 		] );
+
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		codecept_debug( $actual );
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR fixes the resolver for the `Comment.author` connection. 

The current code will only load User objects if the user is logged in. This isn't expected behavior. Instead, the connection should try to load a User and return it if it's considered a public node, otherwise fallback to a CommentAuhor.



Does this close any currently open issues?
------------------------------------------
closes #2448
related: #1139


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
BEFORE:

For non-authenticated requests, the comment author was _always_ loading a `CommentAuthor` type

![CleanShot 2022-07-22 at 15 02 35](https://user-images.githubusercontent.com/1260765/180568129-ccd3042a-cede-4332-a02d-eefdf94338f6.png)


AFTER:

Now a non-authenticated request will return a mix of `User` and `CommentAuthor` depending on if the author of a Comment is indeed a user, and the user node is safe to be returned publicly

![CleanShot 2022-07-22 at 15 01 51](https://user-images.githubusercontent.com/1260765/180568050-1843ef34-db0a-4c6d-ab42-32f5b9a38bc6.png)
