### PR TITLE
ci: add linter to ensure PR titles adhere to conventional commit standards

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,8 @@ Thanks for sending a pull request! Please make sure you click the link above to 
 
 🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.
 
-- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
+- [ ] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
+- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
 - [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!
 
 -->

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   main:
-    name: Validate PR Title
+    name: Validate Pull Request Title
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v4

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,48 @@
+name: "Lint Pull Request"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # see: https://github.com/commitizen/conventional-commit-types
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          scopes: |
+            core
+            ui
+            graphiql
+            tests
+            docs
+          requireScope: false
+          ignoreLabels: |
+            bot
+            ignore-semantic-pull-request
+          # For work-in-progress PRs you can typically use draft pull requests
+          # from GitHub. However, private repositories on the free plan don't have
+          # this option and therefore this action allows you to opt-in to using the
+          # special "[WIP]" prefix to indicate this state. This will avoid the
+          # validation of the PR title and the pull request checks remain pending.
+          # Note that a second check will be reported if this is enabled.
+          wip: true

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -29,12 +29,6 @@ jobs:
             ci
             chore
             revert
-          scopes: |
-            core
-            ui
-            graphiql
-            tests
-            docs
           requireScope: false
           ignoreLabels: |
             bot


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This adds a workflow to validate PR titles when PRs are opened. 

Does this close any currently open issues?
------------------------------------------
closes #988 
