### PR TITLE
fix: #1687 fix node resolver when page for posts is set

### DIFF
--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -423,8 +423,8 @@ class NodeResolver {
 				return null;
 			}
 
-			if ( get_option( 'page_for_posts', 0 ) === $post->ID ) {
-				return $this->context->get_loader( 'post' )->load_deferred( $post->ID );
+			if ( (int) get_option( 'page_for_posts', 0 ) === $post->ID ) {
+				return $this->context->get_loader( 'post_type' )->load_deferred( 'post' );
 			}
 
 			return $this->context->get_loader( 'post' )->load_deferred( $post->ID );

--- a/tests/wpunit/NodeByUriTest.php
+++ b/tests/wpunit/NodeByUriTest.php
@@ -699,4 +699,49 @@ class NodeByUriTest extends \Codeception\TestCase\WPTestCase {
 
 	}
 
+	public function testNodeByUriReturnsContentTypeWhenPageIsSetToPageForPosts() {
+
+		$page_id = self::factory()->post->create([
+			'post_type' => 'page',
+			'post_status' => 'publish',
+			'post_title' => 'Blog'
+		]);
+
+		update_option( 'page_for_posts', $page_id );
+
+		$query = '
+		query NodeByUri($uri:String!) {
+		  nodeByUri( uri: $uri ) {
+		    __typename
+		    uri
+		  }
+		}
+		';
+
+		$actual = graphql([
+			'query' => $query,
+			'variables' => [
+				'uri' => '/blog'
+			]
+		]);
+
+		codecept_debug( $actual );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertSame( 'ContentType', $actual['data']['nodeByUri']['__typename'] );
+
+		delete_option( 'page_for_posts' );
+
+		$actual = graphql([
+			'query' => $query,
+			'variables' => [
+				'uri' => '/blog'
+			]
+		]);
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertSame( 'Page', $actual['data']['nodeByUri']['__typename'] );
+
+	}
+
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This fixes a bug where the incorrect Type is returned when a page is set as the "page_for_posts" value. 

Does this close any currently open issues?
------------------------------------------
closes #1687 


Any other comments?
-------------------

When a Page is set as the "page_for_posts" setting under Reading Settings:

![CleanShot 2022-08-02 at 16 39 43](https://user-images.githubusercontent.com/1260765/182485555-41be13f3-f1c3-4a1a-afd1-f363bf47e24e.png)

Querying the path for that page should return a `ContentType` and not the `Page`

![CleanShot 2022-08-02 at 16 47 38](https://user-images.githubusercontent.com/1260765/182486392-bf3039b9-5194-4730-aa66-1739b1eed562.png)


Much like visiting the path in the browser returns the "blog" archive with the posts, instead of a static page: 

![CleanShot 2022-08-02 at 16 43 49](https://user-images.githubusercontent.com/1260765/182486053-490734af-68da-43ec-baee-904162fe7bd0.png)

If the reading settings do not have a `page_for_posts` set

![CleanShot 2022-08-02 at 16 45 19](https://user-images.githubusercontent.com/1260765/182486215-058d10fe-13e7-4f95-9d9e-ddc09effa1ee.png)

Then a `Page` type should be returned:

![CleanShot 2022-08-02 at 16 47 07](https://user-images.githubusercontent.com/1260765/182486418-e13634cf-4615-48ae-b74d-948ad3843ae2.png)



Much like you would see when visiting the WordPress rendered URL:

![CleanShot 2022-08-02 at 16 46 41](https://user-images.githubusercontent.com/1260765/182486287-2412f8c9-96c1-4aed-9b2c-9194bc5d900f.png)