### PR TITLE
fix: return CommentAuthor avatar urls to unauthenticated users

### DIFF
--- a/src/Type/ObjectType/CommentAuthor.php
+++ b/src/Type/ObjectType/CommentAuthor.php
@@ -2,8 +2,6 @@
 
 namespace WPGraphQL\Type\ObjectType;
 
-use WPGraphQL\Data\DataSource;
-
 class CommentAuthor {
 
 	/**
@@ -56,8 +54,10 @@ class CommentAuthor {
 
 						],
 						'resolve' => function ( $comment_author, $args, $context, $info ) {
+							// If the user cant see the CommentAuthor's email, grab it from the comment.
+							$comment_author_email = ! empty( $comment_author->email ) ? $comment_author->email : get_comment_author_email( $comment_author->databaseId );
 
-							if ( ! isset( $comment_author->email ) ) {
+							if ( empty( $comment_author_email ) ) {
 								return null;
 							}
 
@@ -77,7 +77,7 @@ class CommentAuthor {
 								$avatar_args['rating'] = esc_sql( $args['rating'] );
 							}
 
-							$avatar = get_avatar_data( $comment_author->email, $avatar_args );
+							$avatar = get_avatar_data( $comment_author_email, $avatar_args );
 
 							// if there's no url returned, return null
 							if ( empty( $avatar['url'] ) ) {


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR ensures the `CommentAuthor` avatar url is visible to unauthenticated users.
It solves this by using the `commentID` (stored as the `CommentAuthor`'s `databaseId`) to fetch the email if the user can't access the CommentAuthor's email directly.

Additionally, Comments without a valid email will now have their `avatar` return `null`, instead of returning a malformed `avatar.url`.


Does this close any currently open issues?
------------------------------------------
#2421


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
![image](https://user-images.githubusercontent.com/29322304/184659856-c7fd2315-51cc-42e6-ae48-d195cacd7c00.png)


Any other comments?
-------------------


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (Wsl2 + devilbox + php 8.0.19)

**WordPress Version:** 6.0.1
