### PR TITLE
fix: make GraphiQL user switch accessible

### DIFF
--- a/packages/graphiql-auth-switch/AuthSwitch.js
+++ b/packages/graphiql-auth-switch/AuthSwitch.js
@@ -39,20 +39,26 @@ const AuthSwitch = () => {
           placement="bottom"
           title={title}
         >
-          <Badge dot={!usePublicFetcher} status="success">
-            <Avatar
+          <button
+              aria-label={title}
+              type="button"
               onClick={toggleUsePublicFetcher}
-              shape={"circle"}
-              size={"small"}
-              title={title}
-              src={window?.wpGraphiQLSettings?.avatarUrl ?? null}
-              icon={
-                window?.wpGraphiQLSettings?.avatarUrl ? null : (
-                  <UserAddOutlined />
-                )
-              }
-            />
-          </Badge>
+              className="toolbar-button"
+          >
+              <Badge dot={!usePublicFetcher} status="success">
+                <Avatar
+                  shape={"circle"}
+                  size={"small"}
+                  title={title}
+                  src={window?.wpGraphiQLSettings?.avatarUrl ?? null}
+                  icon={
+                    window?.wpGraphiQLSettings?.avatarUrl ? null : (
+                      <UserAddOutlined />
+                    )
+                  }
+                />
+              </Badge>
+          </button>
         </Tooltip>
       </span>
     </StyledAvatar>

--- a/tests/e2e/graphiql.spec.js
+++ b/tests/e2e/graphiql.spec.js
@@ -169,4 +169,26 @@ describe('Graphiql', function () {
 
     })
 
+    it ('can toggle from a public to a logged-in user', async() => {
+        await loadGraphiQL();
+
+        const userToggleButton = await page.$(".graphiql-auth-toggle button");
+
+        // Confirm the default user toggle state is to toggle to the logged-in user.
+        let userToggleButtonLabel = await page.evaluate(() => {
+            return document.querySelector(".graphiql-auth-toggle button").ariaLabel;
+        });
+        expect(userToggleButtonLabel).toContain( 'logged-in user' );
+
+        // Toggle to the logged-in user.
+        userToggleButton.click();
+
+        // Confirm user badge appears on the icon and button text now mentions public users.
+        await page.waitForSelector('.ant-badge-dot'); // Green logged-in user badge.
+        userToggleButtonLabel = await page.evaluate(() => {
+            return document.querySelector(".graphiql-auth-toggle button").ariaLabel;
+        });
+        expect(userToggleButtonLabel).toContain( 'public user' );
+    })
+
 })


### PR DESCRIPTION
- [x] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!


What does this implement/fix? Explain your changes.
---------------------------------------------------
Tiny tweaks to the “switch to [public|logged-in] user” button in GraphiQL to:

1. Style it as a button to make it more obvious that you can interact with it (I've helped a couple of users toggle to a logged-in user to fix unexpected query results because they didn't realise they could toggle user state via that button).
2. Make the button focusable/keyboard-accessible and add ARIA text to describe to screen readers what it does.

Also extends existing e2e tests with coverage for the user toggle button.

Does this close any currently open issues?
------------------------------------------
#2372 

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

| Before | After |
| - | - |
| <img width="309" alt="Screenshot 2022-08-15 at 21 01 42" src="https://user-images.githubusercontent.com/647669/184699359-a881798d-39dc-45d7-80cf-5391ff318273.png"> | <img width="310" alt="Screenshot 2022-08-15 at 20 59 54" src="https://user-images.githubusercontent.com/647669/184699460-8f19dd80-71d2-43e8-95b5-f9a77c4cf4ea.png"> |

Any other comments?
-------------------
If I need to commit generated `/build` files with this PR feel free to let me know.

Where has this been tested?
---------------------------
**Operating System:** macOS 12.4 (Tested Chrome, Firefox, VoiceOver)

**WordPress Version:** 6.0.1
