### PR TITLE
fix: bug when querying page set as "Posts Page"

### DIFF
--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -367,7 +367,7 @@ class NodeResolver {
 
 			} else {
 
-				if ( isset( $this->wp->query_vars['nodeType'] ) && 'Page' === $this->wp->query_vars['nodeType'] ) {
+				if ( isset( $this->wp->query_vars['nodeType'] ) && 'ContentNode' === $this->wp->query_vars['nodeType'] ) {
 					return null;
 				}
 
@@ -412,7 +412,6 @@ class NodeResolver {
 			$post_type = isset( $this->wp->query_vars['post_type'] ) ? $this->wp->query_vars['post_type'] : \WPGraphQL::get_allowed_post_types();
 
 			$post = get_page_by_path( $this->wp->query_vars['pagename'], 'OBJECT', $post_type );
-
 			if ( ! $post instanceof WP_Post ) {
 				return null;
 			}
@@ -424,6 +423,11 @@ class NodeResolver {
 			}
 
 			if ( (int) get_option( 'page_for_posts', 0 ) === $post->ID ) {
+
+				if ( isset( $extra_query_vars['nodeType'] ) && 'ContentNode' === $extra_query_vars['nodeType'] ) {
+					return null;
+				}
+
 				return $this->context->get_loader( 'post_type' )->load_deferred( 'post' );
 			}
 
@@ -443,7 +447,7 @@ class NodeResolver {
 		} elseif ( isset( $this->wp->query_vars['post_type'] ) ) {
 
 			// If the query is asking for a Page nodeType with the home uri, try and resolve it.
-			if ( '/' === $this->wp->query_vars['uri'] && ( isset( $this->wp->query_vars['nodeType'] ) && 'Page' === $this->wp->query_vars['nodeType'] ) ) {
+			if ( '/' === $this->wp->query_vars['uri'] && ( isset( $this->wp->query_vars['nodeType'] ) && 'ContentNode' === $this->wp->query_vars['nodeType'] ) ) {
 
 				// If the post type is not a page, but the uri is for the home page, we can return null now
 				if ( 'page' !== $this->wp->query_vars['post_type'] ) {
@@ -456,7 +460,7 @@ class NodeResolver {
 			}
 
 			// If the query is asking for a Page nodeType with the uri, try and resolve it.
-			if ( isset( $this->wp->query_vars['nodeType'] ) && 'Page' === $this->wp->query_vars['nodeType'] && isset( $this->wp->query_vars['uri'] ) ) {
+			if ( isset( $this->wp->query_vars['nodeType'] ) && 'ContentNode' === $this->wp->query_vars['nodeType'] && isset( $this->wp->query_vars['uri'] ) ) {
 				$post_type = $this->wp->query_vars['post_type'];
 
 				$post = get_page_by_path( $this->wp->query_vars['uri'], 'OBJECT', $post_type );

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -692,6 +692,15 @@ class Post extends Model {
 						return '/';
 					}
 
+					// if the page is set as the posts page
+					// the page node itself is not identifiable
+					// by URI. Instead, the uri would return the
+					// Post content type as that uri
+					// represents the blog archive instead of a page
+					if ( true === $this->isPostsPage ) {
+						return null;
+					}
+
 					return ! empty( $uri ) ? str_ireplace( home_url(), '', $uri ) : null;
 				},
 				'commentCount'              => function () {

--- a/src/Type/ObjectType/RootQuery.php
+++ b/src/Type/ObjectType/RootQuery.php
@@ -675,7 +675,7 @@ class RootQuery {
 									[
 										'post_type' => $post_type_object->name,
 										'archive'   => false,
-										'nodeType'  => 'Page',
+										'nodeType'  => 'ContentNode',
 									]
 								);
 							case 'database_id':
@@ -783,7 +783,7 @@ class RootQuery {
 								[
 									'post_type' => $post_type_object->name,
 									'archive'   => false,
-									'nodeType'  => 'Page',
+									'nodeType'  => 'ContentNode',
 								]
 							);
 						} elseif ( ! empty( $args['slug'] ) ) {

--- a/tests/wpunit/PageByUriTest.php
+++ b/tests/wpunit/PageByUriTest.php
@@ -78,11 +78,11 @@ class PageByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$query = '
 		query GetPageByUri($id:ID!) {
-		  page(id: $id, idType: URI) {
-            __typename
-          }
-        }
-		';
+			page(id: $id, idType: URI) {
+				__typename
+			}
+		}
+		run';
 
 		$actual = $this->graphql([
 			'query' => $query,

--- a/tests/wpunit/PageByUriTest.php
+++ b/tests/wpunit/PageByUriTest.php
@@ -82,7 +82,7 @@ class PageByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 				__typename
 			}
 		}
-		run';
+		';
 
 		$actual = $this->graphql([
 			'query' => $query,

--- a/tests/wpunit/PageByUriTest.php
+++ b/tests/wpunit/PageByUriTest.php
@@ -72,4 +72,43 @@ class PageByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->assertSame( $this->page, $actual['data']['page']['databaseId'] );
 		$this->assertSame( str_ireplace( home_url(), '', get_permalink( $this->page ) ), $actual['data']['page']['uri'] );
 	}
+
+	public function testQueryPageForPostsByUriReturnsNull() {
+
+
+		$query = '
+		query GetPageByUri($id:ID!) {
+		  page(id: $id, idType: URI) {
+            __typename
+          }
+        }
+		';
+
+		$actual = $this->graphql([
+			'query' => $query,
+			'variables' => [
+				'id' => '/' . get_post( $this->page )->post_name,
+			]
+		]);
+
+		$this->assertQuerySuccessful( $actual, [
+			$this->expectedField( 'page.__typename', 'Page' ),
+		]);
+
+		// set the page as the page_for_posts
+		update_option( 'page_for_posts', $this->page );
+
+		$actual = $this->graphql([
+			'query' => $query,
+			'variables' => [
+				'id' => '/' . get_post( $this->page )->post_name,
+			]
+		]);
+
+		$this->assertQuerySuccessful( $actual, [
+			$this->expectedField( 'page', self::IS_NULL ),
+		]);
+
+	}
+
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This fixes a bug where querying a page by uri was improperly returning a page node instead of null when that page has been set to be the Posts Page. 

More detailed explanation here: https://github.com/wp-graphql/wp-graphql/issues/2486#issuecomment-1231967361

Does this close any currently open issues?
------------------------------------------
Closes #2486 

Any other comments?
-------------------
- [x] Commit with Failing Test: https://github.com/wp-graphql/wp-graphql/pull/2490/commits/6d85d45a9b0f4b987b34fe8e508f4bb70bbf57c9
- [x] Commit with Fix: https://github.com/wp-graphql/wp-graphql/pull/2490/commits/8e7ad5fd5d114acd777f7900bc5185b1bcce9ec1