### PR TITLE
fix: only enqueue admin scripts on the Settings page

### DIFF
--- a/src/Admin/Settings/Settings.php
+++ b/src/Admin/Settings/Settings.php
@@ -29,9 +29,11 @@ class Settings {
 	public function init() {
 		$this->wp_environment = $this->get_wp_environment();
 		$this->settings_api   = new SettingsRegistry();
+
 		add_action( 'admin_menu', [ $this, 'add_options_page' ] );
 		add_action( 'init', [ $this, 'register_settings' ] );
 		add_action( 'admin_init', [ $this, 'initialize_settings_page' ] );
+		add_action( 'admin_enqueue_scripts', [ $this, 'initialize_settings_page_scripts' ] );
 	}
 
 	/**
@@ -228,6 +230,15 @@ class Settings {
 	 */
 	public function initialize_settings_page() {
 		$this->settings_api->admin_init();
+	}
+
+	/**
+	 * Initialize the styles and scripts used on the settings admin page
+	 *
+	 * @param string $hook_suffix The current admin page.
+	 */
+	public function initialize_settings_page_scripts( string $hook_suffix ) : void {
+		$this->settings_api->admin_enqueue_scripts( $hook_suffix );
 	}
 
 	/**

--- a/src/Admin/Settings/SettingsRegistry.php
+++ b/src/Admin/Settings/SettingsRegistry.php
@@ -32,15 +32,6 @@ class SettingsRegistry {
 	protected $settings_fields = [];
 
 	/**
-	 * SettingsRegistry constructor.
-	 *
-	 * @return void
-	 */
-	public function __construct() {
-		add_action( 'admin_enqueue_scripts', [ $this, 'admin_enqueue_scripts' ] );
-	}
-
-	/**
 	 * @return array
 	 */
 	public function get_settings_sections() {
@@ -57,14 +48,22 @@ class SettingsRegistry {
 	/**
 	 * Enqueue scripts and styles
 	 *
+	 * @param string $hook_suffix The current admin page.
+	 *
 	 * @return void
 	 */
-	public function admin_enqueue_scripts() {
-		wp_enqueue_style( 'wp-color-picker' );
+	public function admin_enqueue_scripts( string $hook_suffix ) {
+		if ( 'graphql_page_graphql-settings' !== $hook_suffix ) {
+			return;
+		}
 
+		wp_enqueue_style( 'wp-color-picker' );
 		wp_enqueue_media();
 		wp_enqueue_script( 'wp-color-picker' );
 		wp_enqueue_script( 'jquery' );
+
+		// Action to enqueue scripts on the WPGraphQL Settings page.
+		do_action( 'graphql_settings_enqueue_scripts' );
 	}
 
 	/**
@@ -151,7 +150,6 @@ class SettingsRegistry {
 	 * @return void
 	 */
 	public function admin_init() {
-
 		// Action that fires when settings are being initialized
 		do_action( 'graphql_init_settings', $this );
 


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR improves backend performance by only loading the scripts/stylesheets needed for the Settings page _on_ the settings page itself.

Additionally, it ditches the antipattern of using `add_action()` in a constructor, by moving `add_action( 'admin_enqueue_scripts' )` from the `SettingsRegistry` constructor to `Settings::init()`.


Does this close any currently open issues?
------------------------------------------
Fixes #2434 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
This PR _doesn't_ address why we are enqueuing scripts for field types we dont actually use, like color-picker and upload, but that's beyond the scope. 


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php 8.0.19)

**WordPress Version:** 6.0.1
