### PR TITLE
fix: check for multiple theme capabilities on Theme::is_private()

### DIFF
--- a/src/Model/Theme.php
+++ b/src/Model/Theme.php
@@ -48,8 +48,8 @@ class Theme extends Model {
 	 * @return bool
 	 */
 	protected function is_private() {
-
-		if ( current_user_can( 'edit_themes' ) ) {
+		// Don't assume a capabilities hierarchy, since it's likely headless sites might disable some capabilities site-wide.
+		if ( current_user_can( 'edit_themes' ) || current_user_can( 'switch_themes' ) || current_user_can( 'update_themes' ) ) {
 			return false;
 		}
 

--- a/tests/wpunit/ThemeObjectQueriesTest.php
+++ b/tests/wpunit/ThemeObjectQueriesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class ThemeObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
+class ThemeObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 	public $admin;
 
@@ -30,8 +30,6 @@ class ThemeObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	/**
-	 * testThemeQuery
-	 *
 	 * This tests creating a single theme with data and retrieving said theme via a GraphQL query
 	 *
 	 * @since 0.0.5
@@ -46,9 +44,9 @@ class ThemeObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 		/**
 		 * Create the query string to pass to the $query
 		 */
-		$query = "
-		query {
-			theme(id: \"{$global_id}\") {
+		$query = '
+		query testThemeQuery( $id:ID! ) {
+			theme(id: $id ) {
 				author
 				authorUri
 				description
@@ -60,13 +58,17 @@ class ThemeObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 				themeUri
 				version
 			}
-		}";
+		}';
+
+		$variables = [
+			'id' => $global_id,
+		];
 
 		/**
 		 * Run the GraphQL query
 		 */
 		wp_set_current_user( $this->admin );
-		$actual = do_graphql_request( $query );
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
 		codecept_debug( $actual );
 
@@ -96,8 +98,6 @@ class ThemeObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	/**
-	 * testThemeQueryWhereThemeDoesNotExist
-	 *
 	 * Tests a query for non existant theme.
 	 *
 	 * @since 0.0.5
@@ -111,19 +111,21 @@ class ThemeObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 		/**
 		 * Create the query string to pass to the $query
 		 */
-		$query = "
-		query {
-			theme(id: \"{$global_id}\") {
+		$query = '
+		query testThemeQueryWhereThemeDoesNotExist( $id:ID! ) {
+			theme(id: $id ) {
 				slug
 			}
-		}";
+		}';
+
+		$variables = [
+			'id' => $global_id,
+		];
 
 		/**
 		 * Run the GraphQL query
 		 */
-		$actual = do_graphql_request( $query );
-
-		codecept_debug( $actual );
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
 		/**
 		 * Establish the expectation for the output of the query


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR broadens the allowed capabilities for accessing the Theme model to `'edit_themes' || 'switch_themes' || 'update_themes'`.

The premise for this change is that the existing `edit_themes` is too specific, as it refers to the ability to edit theme _files_ in the backend. However, we don't want to just change it to `switch_themes`, since the likelihood of a headless site disabling individual theme capabilities site-wide is fairly high and individualized, meaning we cant assume some sort of capability hierarchy.


Does this close any currently open issues?
------------------------------------------
Closes #2292


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php 8.0.19)

**WordPress Version:** 6.0.1
