### PR TITLE
feat: add `idType` arg to `RootQuery.comment`

### DIFF
--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -73,6 +73,7 @@ use WPGraphQL\Type\Union\PostObjectUnion;
 use WPGraphQL\Type\Union\MenuItemObjectUnion;
 use WPGraphQL\Type\Enum\AvatarRatingEnum;
 use WPGraphQL\Type\Enum\CommentsConnectionOrderbyEnum;
+use WPGraphQL\Type\Enum\CommentNodeIdTypeEnum;
 use WPGraphQL\Type\Enum\MediaItemSizeEnum;
 use WPGraphQL\Type\Enum\MediaItemStatusEnum;
 use WPGraphQL\Type\Enum\MenuLocationEnum;
@@ -301,6 +302,7 @@ class TypeRegistry {
 
 		AvatarRatingEnum::register_type();
 		CommentsConnectionOrderbyEnum::register_type();
+		CommentNodeIdTypeEnum::register_type();
 		ContentNodeIdTypeEnum::register_type();
 		ContentTypeEnum::register_type();
 		ContentTypeIdTypeEnum::register_type();

--- a/src/Type/Enum/CommentNodeIdTypeEnum.php
+++ b/src/Type/Enum/CommentNodeIdTypeEnum.php
@@ -1,0 +1,33 @@
+<?php
+namespace WPGraphQL\Type\Enum;
+
+/**
+ * Class CommentNodeIdTypeEnum
+ *
+ * @package WPGraphQL\Type\Enum
+ */
+class CommentNodeIdTypeEnum {
+
+	/**
+	 * Register the CommentNodeIdTypeEnum
+	 *
+	 * @return void
+	 */
+	public static function register_type() {
+		register_graphql_enum_type( 'CommentNodeIdTypeEnum', [
+			'description' => __( 'The Type of Identifier used to fetch a single comment node. Default is "ID". To be used along with the "id" field.', 'wp-graphql' ),
+			'values'      => [
+				'ID'          => [
+					'name'        => 'ID',
+					'value'       => 'global_id',
+					'description' => __( 'Identify a resource by the (hashed) Global ID.', 'wp-graphql' ),
+				],
+				'DATABASE_ID' => [
+					'name'        => 'DATABASE_ID',
+					'value'       => 'database_id',
+					'description' => __( 'Identify a resource by the Database ID.', 'wp-graphql' ),
+				],
+			],
+		]);
+	}
+}

--- a/tests/wpunit/CommentObjectQueriesTest.php
+++ b/tests/wpunit/CommentObjectQueriesTest.php
@@ -95,8 +95,8 @@ class CommentObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 		 * Create the query string to pass to the $query
 		 */
 		$query = '
-		query testCommentQuery( $id: ID! ) {
-			comment(id: $id ) {
+		query testCommentQuery( $id: ID!, $idType: CommentNodeIdTypeEnum ) {
+			comment(id: $id, idType: $idType ) {
 				agent
 				approved
 				author{
@@ -108,15 +108,15 @@ class CommentObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 					}
 				}
 				authorIp
-				commentId
+				databaseId
 				replies {
 					edges {
 						node {
 							id
-							commentId
+							databaseId
 							parent {
 								node {
-									commentId
+									databaseId
 								}
 							}
 						}
@@ -140,8 +140,10 @@ class CommentObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 			}
 		}';
 
+		// Test with database_id.
 		$variables = [
-			'id' => $global_id,
+			'id'     => $comment_id,
+			'idType' => 'DATABASE_ID',
 		];
 
 		/**
@@ -166,7 +168,7 @@ class CommentObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 				'replies'     => [
 					'edges' => [],
 				],
-				'commentId'   => $comment_id,
+				'databaseId'  => $comment_id,
 				'commentedOn' => [
 					'node' => [
 						'__typename' => 'Post',
@@ -180,6 +182,16 @@ class CommentObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 				'parent'      => null,
 			],
 		];
+
+		$this->assertEqualSets( $expected, $actual['data'] );
+
+		// Test with global_id.
+		$variables = [
+			'id'     => $global_id,
+			'idType' => 'ID',
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
 		$this->assertEqualSets( $expected, $actual['data'] );
 	}


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds `idType` arg to `RootQuery.comment` field, enabling querying by either global (default) or database ID.


Does this close any currently open issues?
------------------------------------------
closes #2395 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (WSL2 + devilbox + php 8.0.19)

**WordPress Version:** 6.0.2
