### PR TITLE
feat: login user after successful `resetUserPassword` mutation

### DIFF
--- a/src/Mutation/ResetUserPassword.php
+++ b/src/Mutation/ResetUserPassword.php
@@ -101,6 +101,9 @@ class ResetUserPassword {
 			 */
 			reset_password( $user, $input['password'] );
 
+			// Log in the user, since they already authenticated with the reset key.
+			wp_set_current_user( $user->ID );
+
 			/**
 			 * Return the user ID
 			 */

--- a/tests/wpunit/UserObjectMutationsTest.php
+++ b/tests/wpunit/UserObjectMutationsTest.php
@@ -884,7 +884,7 @@ class UserObjectMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCas
 			'password' => $new_password,
 		];
 
-		wp_set_current_user( $this->admin );
+		wp_set_current_user( $this->subscriber );
 
 		$actual = $this->resetUserPasswordMutation( $args );
 		codecept_debug( $actual );

--- a/tests/wpunit/UserObjectMutationsTest.php
+++ b/tests/wpunit/UserObjectMutationsTest.php
@@ -826,7 +826,7 @@ class UserObjectMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCas
 			],
 		];
 
-		return graphql( compact( 'query', 'variables' ) );
+		return $this->graphql( compact( 'query', 'variables' ) );
 
 	}
 
@@ -884,10 +884,10 @@ class UserObjectMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCas
 			'password' => $new_password,
 		];
 
-		wp_set_current_user( $this->subscriber );
+		// Ensure user is logged out
+		wp_set_current_user( 0 );
 
 		$actual = $this->resetUserPasswordMutation( $args );
-		codecept_debug( $actual );
 
 		$role_nodes = [];
 		foreach ( $roles as $role ) {
@@ -934,6 +934,8 @@ class UserObjectMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCas
 		$this->resetUserPasswordMutation( $args );
 
 		// Try to authenticate user using new password.
+		wp_set_current_user( 0 );
+
 		$authenticated_user   = wp_authenticate( $login, $new_password );
 		$was_reset_successful = ! is_wp_error( $authenticated_user );
 


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR logs in the user after they successfully `resetUserPassword`, as they have successfully authenticated themselves.
This gives them permissions to see their own `user` data in the GraphQL response.


Does this close any currently open issues?
------------------------------------------
#2100 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
Discussion may still be necessary to decide both if we should return the user at all and whether logging in the user is the best way to do it. But it was a simple PR, and I had some free time.


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + PHP 8.0.19)

**WordPress Version:** 6.0.2
