### PR TITLE
fix: specify when `id` arg takes an (int) database ID

### DIFF
--- a/src/Connection/MenuItems.php
+++ b/src/Connection/MenuItems.php
@@ -102,7 +102,7 @@ class MenuItems {
 				'connectionArgs' => [
 					'id'               => [
 						'type'        => 'Int',
-						'description' => __( 'The ID of the object', 'wp-graphql' ),
+						'description' => __( 'The database ID of the object', 'wp-graphql' ),
 					],
 					'parentId'         => [
 						'type'        => 'ID',

--- a/src/Connection/PostObjects.php
+++ b/src/Connection/PostObjects.php
@@ -399,7 +399,7 @@ class PostObjects {
 			 */
 			'id'          => [
 				'type'        => 'Int',
-				'description' => __( 'Specific ID of the object', 'wp-graphql' ),
+				'description' => __( 'Specific database ID of the object', 'wp-graphql' ),
 			],
 			'name'        => [
 				'type'        => 'String',

--- a/src/Type/ObjectType/RootQuery.php
+++ b/src/Type/ObjectType/RootQuery.php
@@ -48,7 +48,7 @@ class RootQuery {
 						'connectionArgs'       => [
 							'id'       => [
 								'type'        => 'Int',
-								'description' => __( 'The ID of the object', 'wp-graphql' ),
+								'description' => __( 'The database ID of the object', 'wp-graphql' ),
 							],
 							'location' => [
 								'type'        => 'MenuLocationEnum',


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR changes the description for `id` input arguments of type `Int` to specify that they take a WP database ID.

These input args _cannot_ be handled by #2340 , as they require a breaking change to the GraphQL type.

Does this close any currently open issues?
------------------------------------------
#1095 ( the rest of that issue is superseded by #998 / which will be resolved by #2340 )


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + 

**WordPress Version:** 6.0.2
