### PR TITLE
feat: Add QueryAnalyzer and Expose "X-GraphQL-Keys" in headers

### DIFF
--- a/access-functions.php
+++ b/access-functions.php
@@ -7,6 +7,7 @@
 
 use GraphQL\Type\Definition\Type;
 use WPGraphQL\Registry\TypeRegistry;
+use WPGraphQL\Request;
 use WPGraphQL\Router;
 
 /**
@@ -48,25 +49,31 @@ function graphql_format_type_name( $type_name ) {
 	if ( ! empty( $replace_type_name ) ) {
 		$type_name = $replace_type_name;
 	}
-	$type_name = ucfirst( $type_name );
-
-	return $type_name;
+	return ucfirst( $type_name );
 }
 
 
 /**
- * Provides a simple way to run a GraphQL query with out posting a request to the endpoint.
+ * Provides a simple way to run a GraphQL query without posting a request to the endpoint.
  *
- * @param array $request_data The GraphQL request data (query, variables, operation_name).
+ * @param array $request_data   The GraphQL request data (query, variables, operation_name).
+ * @param bool  $return_request If true, return the Request object, else return the results of the request execution
  *
- * @return array
+ * @return array | Request
  * @throws Exception
  * @since  0.2.0
  */
-function graphql( $request_data = [] ) {
-	$request = new \WPGraphQL\Request( $request_data );
+function graphql( array $request_data = [], bool $return_request = false ) {
+	$request = new Request( $request_data );
+
+	// allow calls to graphql() to return the full Request instead of
+	// just the results of the request execution
+	if ( true === $return_request ) {
+		return $request;
+	}
 
 	return $request->execute();
+
 }
 
 /**
@@ -76,18 +83,20 @@ function graphql( $request_data = [] ) {
  * @param string $query          The GraphQL query to run
  * @param string $operation_name The name of the operation
  * @param array  $variables      Variables to be passed to your GraphQL request
+ * @param bool   $return_requst If true, return the Request object, else return the results of the request execution
  *
- * @return array
- * @throws \Exception
+ * @return array | Request
+ * @throws Exception
  * @since  0.0.2
  */
-function do_graphql_request( $query, $operation_name = '', $variables = [] ) {
+function do_graphql_request( $query, $operation_name = '', $variables = [], $return_requst = false ) {
 	return graphql(
 		[
 			'query'          => $query,
 			'variables'      => $variables,
 			'operation_name' => $operation_name,
-		]
+		],
+		$return_requst
 	);
 }
 

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -334,7 +334,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 						}
 					}
 
-					$query_args['orderby'][ esc_sql( $orderby_input['field'] ) ] = esc_sql( $order );
+					$query_args['orderby'][ $orderby_input['field'] ] = (string) $order;
 				}
 			}
 		}

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -334,7 +334,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 						}
 					}
 
-					$query_args['orderby'][ $orderby_input['field'] ] = (string) $order;
+					$query_args['orderby'][ esc_sql( $orderby_input['field'] ) ] = esc_sql( $order );
 				}
 			}
 		}

--- a/src/Mutation/MediaItemUpdate.php
+++ b/src/Mutation/MediaItemUpdate.php
@@ -45,7 +45,7 @@ class MediaItemUpdate {
 						'non_null' => 'ID',
 					],
 					// translators: the placeholder is the name of the type of post object being updated
-					'description' => sprintf( __( 'The ID of the %1$s object', 'wp-graphql' ), $post_type_object->graphql_single_name ?? 'MediaItem' ),
+					'description' => sprintf( __( 'The ID of the %1$s object', 'wp-graphql' ), $post_type_object->graphql_single_name ),
 				],
 			]
 		);

--- a/src/Mutation/MediaItemUpdate.php
+++ b/src/Mutation/MediaItemUpdate.php
@@ -6,6 +6,7 @@ use Exception;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
+use WP_Post_Type;
 use WPGraphQL\AppContext;
 use WPGraphQL\Data\MediaItemMutation;
 use WPGraphQL\Utils\Utils;
@@ -34,7 +35,7 @@ class MediaItemUpdate {
 	 * @return array
 	 */
 	public static function get_input_fields() {
-		/** @var \WP_Post_Type $post_type_object */
+		/** @var WP_Post_Type $post_type_object */
 		$post_type_object = get_post_type_object( 'attachment' );
 		return array_merge(
 			MediaItemCreate::get_input_fields(),
@@ -44,7 +45,7 @@ class MediaItemUpdate {
 						'non_null' => 'ID',
 					],
 					// translators: the placeholder is the name of the type of post object being updated
-					'description' => sprintf( __( 'The ID of the %1$s object', 'wp-graphql' ), $post_type_object->graphql_single_name ),
+					'description' => sprintf( __( 'The ID of the %1$s object', 'wp-graphql' ), $post_type_object->graphql_single_name ?? 'MediaItem' ),
 				],
 			]
 		);

--- a/src/Request.php
+++ b/src/Request.php
@@ -16,6 +16,7 @@ use WPGraphQL\Server\ValidationRules\QueryDepth;
 use WPGraphQL\Server\ValidationRules\RequireAuthentication;
 use WPGraphQL\Server\WPHelper;
 use WPGraphQL\Utils\DebugLog;
+use WPGraphQL\Utils\QueryAnalyzer;
 
 /**
  * Class Request
@@ -106,6 +107,11 @@ class Request {
 	protected $root_value;
 
 	/**
+	 * @var QueryAnalyzer
+	 */
+	protected $query_analyzer;
+
+	/**
 	 * Constructor
 	 *
 	 * @param array $data The request data (for non-HTTP requests).
@@ -168,13 +174,28 @@ class Request {
 		$app_context->request       = ! empty( $_REQUEST ) ? $_REQUEST : null; // phpcs:ignore
 		$app_context->type_registry = $this->type_registry;
 		$this->app_context          = $app_context;
+
+		$this->query_analyzer = new QueryAnalyzer( $this );
+
+		// The query analyzer tracks nodes, models, list types and more
+		// to return in headers and debug messages to help developers understand
+		// what was resolved, how to cache it, etc.
+		$this->query_analyzer->init();
+
 	}
 
 	/**
-	 * @return null
+	 * @return QueryAnalyzer
+	 */
+	public function get_query_analyzer(): QueryAnalyzer {
+		return $this->query_analyzer;
+	}
+
+	/**
+	 * @return mixed
 	 */
 	protected function get_field_resolver() {
-		return null;
+		return $this->field_resolver;
 	}
 
 	/**
@@ -182,7 +203,7 @@ class Request {
 	 *
 	 * @return array
 	 */
-	protected function get_validation_rules() {
+	protected function get_validation_rules(): array {
 
 		$validation_rules = GraphQL::getStandardValidationRules();
 
@@ -227,10 +248,10 @@ class Request {
 	 * @return void
 	 * @throws Error
 	 */
-	private function before_execute() {
+	private function before_execute(): void {
 
 		/**
-		 * Store the global post so it can be reset after GraphQL execution
+		 * Store the global post so that it can be reset after GraphQL execution
 		 *
 		 * This allows for a GraphQL query to be used in the middle of post content, such as in a Shortcode
 		 * without disrupting the flow of the post as the global POST before and after GraphQL execution will be
@@ -576,8 +597,8 @@ class Request {
 		/**
 		 * Run an action for each request.
 		 *
-		 * @param string          $query     The GraphQL query
-		 * @param string          $operation The name of the operation
+		 * @param ?string          $query     The GraphQL query
+		 * @param ?string          $operation The name of the operation
 		 * @param ?array          $variables Variables to be passed to your GraphQL request
 		 * @param OperationParams $params    The Operation Params. This includes any extra params, such as extenions or any other modifications to the request body
 		 */

--- a/src/Type/ObjectType/Avatar.php
+++ b/src/Type/ObjectType/Avatar.php
@@ -2,6 +2,8 @@
 
 namespace WPGraphQL\Type\ObjectType;
 
+use WPGraphQL\Model\Avatar as AvatarModel;
+
 class Avatar {
 
 	/**
@@ -14,6 +16,7 @@ class Avatar {
 			'Avatar',
 			[
 				'description' => __( 'Avatars are profile images for users. WordPress by default uses the Gravatar service to host and fetch avatars from.', 'wp-graphql' ),
+				'model'       => AvatarModel::class,
 				'fields'      => [
 					'size'         => [
 						'type'        => 'Int',

--- a/src/Type/ObjectType/Comment.php
+++ b/src/Type/ObjectType/Comment.php
@@ -4,6 +4,7 @@ namespace WPGraphQL\Type\ObjectType;
 
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
+use WPGraphQL\Model\Comment as CommentModel;
 
 /**
  * Class Comment
@@ -22,6 +23,7 @@ class Comment {
 			'Comment',
 			[
 				'description' => __( 'A Comment object', 'wp-graphql' ),
+				'model'       => CommentModel::class,
 				'interfaces'  => [ 'Node', 'DatabaseIdentifier' ],
 				'connections' => [
 					'author' => [

--- a/src/Type/ObjectType/CommentAuthor.php
+++ b/src/Type/ObjectType/CommentAuthor.php
@@ -2,6 +2,8 @@
 
 namespace WPGraphQL\Type\ObjectType;
 
+use \WPGraphQL\Model\CommentAuthor as CommentAuthorModel;
+
 class CommentAuthor {
 
 	/**
@@ -15,6 +17,7 @@ class CommentAuthor {
 			[
 				'description'     => __( 'A Comment Author object', 'wp-graphql' ),
 				'interfaces'      => [ 'Node', 'Commenter' ],
+				'model'           => CommentAuthorModel::class,
 				'eagerlyLoadType' => true,
 				'fields'          => [
 					'id'           => [

--- a/src/Type/ObjectType/ContentType.php
+++ b/src/Type/ObjectType/ContentType.php
@@ -2,6 +2,8 @@
 
 namespace WPGraphQL\Type\ObjectType;
 
+use WPGraphQL\Model\PostType;
+
 class ContentType {
 
 	/**
@@ -18,6 +20,7 @@ class ContentType {
 			[
 				'description' => __( 'An Post Type object', 'wp-graphql' ),
 				'interfaces'  => $interfaces,
+				'model'       => PostType::class,
 				'fields'      => [
 					'id'                  => [
 						'description' => __( 'The globally unique identifier of the post-type object.', 'wp-graphql' ),

--- a/src/Type/ObjectType/Menu.php
+++ b/src/Type/ObjectType/Menu.php
@@ -2,6 +2,8 @@
 
 namespace WPGraphQL\Type\ObjectType;
 
+use \WPGraphQL\Model\Menu as MenuModel;
+
 class Menu {
 
 	/**
@@ -15,6 +17,7 @@ class Menu {
 			[
 				'description' => __( 'Menus are the containers for navigation items. Menus can be assigned to menu locations, which are typically registered by the active theme.', 'wp-graphql' ),
 				'interfaces'  => [ 'Node', 'DatabaseIdentifier' ],
+				'model'       => MenuModel::class,
 				'fields'      => [
 					'id'           => [
 						'description' => __( 'The globally unique identifier of the nav menu object.', 'wp-graphql' ),

--- a/src/Type/ObjectType/MenuItem.php
+++ b/src/Type/ObjectType/MenuItem.php
@@ -22,6 +22,7 @@ class MenuItem {
 			[
 				'description' => __( 'Navigation menu items are the individual items assigned to a menu. These are rendered as the links in a navigation menu.', 'wp-graphql' ),
 				'interfaces'  => [ 'Node', 'DatabaseIdentifier' ],
+				'model'       => MenuItemModel::class,
 				'connections' => [
 					'connectedNode' => [
 						'toType'               => 'MenuItemLinkable',

--- a/src/Type/ObjectType/Plugin.php
+++ b/src/Type/ObjectType/Plugin.php
@@ -2,6 +2,8 @@
 
 namespace WPGraphQL\Type\ObjectType;
 
+use \WPGraphQL\Model\Plugin as PluginModel;
+
 /**
  * Class Plugin
  *
@@ -19,6 +21,7 @@ class Plugin {
 			'Plugin',
 			[
 				'interfaces'  => [ 'Node' ],
+				'model'       => PluginModel::class,
 				'description' => __( 'An plugin object', 'wp-graphql' ),
 				'fields'      => [
 					'id'           => [

--- a/src/Type/ObjectType/PostObject.php
+++ b/src/Type/ObjectType/PostObject.php
@@ -89,6 +89,7 @@ class PostObject {
 				'description' => sprintf( __( 'The %s type', 'wp-graphql' ), $single_name ),
 				'interfaces'  => $interfaces,
 				'fields'      => self::get_post_object_fields( $post_type_object, $type_registry ),
+				'model'       => Post::class,
 			]
 		);
 

--- a/src/Type/ObjectType/Taxonomy.php
+++ b/src/Type/ObjectType/Taxonomy.php
@@ -21,6 +21,7 @@ class Taxonomy {
 			[
 				'description' => __( 'A taxonomy object', 'wp-graphql' ),
 				'interfaces'  => [ 'Node' ],
+				'model'       => TaxonomyModel::class,
 				'connections' => [
 					'connectedContentTypes' => [
 						'toType'               => 'ContentType',

--- a/src/Type/ObjectType/TermObject.php
+++ b/src/Type/ObjectType/TermObject.php
@@ -41,6 +41,7 @@ class TermObject {
 			[
 				'description' => sprintf( __( 'The %s type', 'wp-graphql' ), $single_name ),
 				'interfaces'  => $interfaces,
+				'model'       => Term::class,
 				'fields'      => [
 					$single_name . 'Id' => [
 						'type'              => 'Int',

--- a/src/Type/ObjectType/Theme.php
+++ b/src/Type/ObjectType/Theme.php
@@ -2,6 +2,8 @@
 
 namespace WPGraphQL\Type\ObjectType;
 
+use WPGraphQL\Model\Theme as ThemeModel;
+
 /**
  * Class Theme
  *
@@ -20,6 +22,7 @@ class Theme {
 			[
 				'description' => __( 'A theme object', 'wp-graphql' ),
 				'interfaces'  => [ 'Node' ],
+				'model'       => ThemeModel::class,
 				'fields'      => [
 					'id'           => [
 						'description' => __( 'The globally unique identifier of the theme object.', 'wp-graphql' ),

--- a/src/Type/ObjectType/User.php
+++ b/src/Type/ObjectType/User.php
@@ -25,6 +25,7 @@ class User {
 			'User',
 			[
 				'description' => __( 'A User object', 'wp-graphql' ),
+				'model'       => UserModel::class,
 				'interfaces'  => [ 'Node', 'UniformResourceIdentifiable', 'Commenter', 'DatabaseIdentifier' ],
 				'connections' => [
 					'enqueuedScripts'     => [

--- a/src/Type/ObjectType/UserRole.php
+++ b/src/Type/ObjectType/UserRole.php
@@ -2,6 +2,8 @@
 
 namespace WPGraphQL\Type\ObjectType;
 
+use WPGraphQL\Model\UserRole as UserRoleModel;
+
 class UserRole {
 
 	/**
@@ -14,6 +16,7 @@ class UserRole {
 			'UserRole',
 			[
 				'description' => __( 'A user role object', 'wp-graphql' ),
+				'model'       => UserRoleModel::class,
 				'interfaces'  => [ 'Node' ],
 				'fields'      => [
 					'id'           => [

--- a/src/Type/WPUnionType.php
+++ b/src/Type/WPUnionType.php
@@ -70,11 +70,11 @@ class WPUnionType extends UnionType {
 		/**
 		 * Filter the possible_types to allow systems to add to the possible resolveTypes.
 		 *
-		 * @param array       $types         The possible types for the Union
+		 * @param mixed       $types         The possible types for the Union
 		 * @param array       $config        The config for the Union Type
 		 * @param WPUnionType $wp_union_type The WPUnionType instance
 		 *
-		 * @return array
+		 * @return mixed|array
 		 */
 		$config['types'] = apply_filters( 'graphql_union_possible_types', $config['types'], $config, $this );
 

--- a/src/Utils/QueryAnalyzer.php
+++ b/src/Utils/QueryAnalyzer.php
@@ -205,7 +205,7 @@ class QueryAnalyzer {
 	public function set_list_types( ?Schema $schema, ?string $query ): array {
 
 		/**
-		 * @param null $null Default value for the filter
+		 * @param array|null $null Default value for the filter
 		 * @param ?Schema $schema The WPGraphQL Schema for the current request
 		 * @param ?string $query The query string being requested
 		 */
@@ -286,7 +286,7 @@ class QueryAnalyzer {
 	public function set_query_types( ?Schema $schema, ?string $query ): array {
 
 		/**
-		 * @param null $null Default value for the filter
+		 * @param array|null $null Default value for the filter
 		 * @param ?Schema $schema The WPGraphQL Schema for the current request
 		 * @param ?string $query The query string being requested
 		 */
@@ -366,7 +366,7 @@ class QueryAnalyzer {
 	public function set_query_models( ?Schema $schema, ?string $query ): array {
 
 		/**
-		 * @param null $null Default value for the filter
+		 * @param array|null $null Default value for the filter
 		 * @param ?Schema $schema The WPGraphQL Schema for the current request
 		 * @param ?string $query The query string being requested
 		 */

--- a/src/Utils/QueryAnalyzer.php
+++ b/src/Utils/QueryAnalyzer.php
@@ -1,0 +1,487 @@
+<?php
+
+namespace WPGraphQL\Utils;
+
+use Exception;
+use GraphQL\Error\SyntaxError;
+use GraphQL\Language\Parser;
+use GraphQL\Language\Visitor;
+use GraphQL\Server\OperationParams;
+use GraphQL\Type\Definition\InterfaceType;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type;
+use GraphQL\Type\Schema;
+use GraphQL\Utils\TypeInfo;
+use WPGraphQL\Request;
+
+/**
+ * This class is used to identify "keys" relevant to the GraphQL Request.
+ *
+ * These keys can be used to identify common patterns across documents.
+ *
+ * A common use case would be for caching a GraphQL request and tagging the cached
+ * object with these keys, then later using these keys to evict the cached
+ * document.
+ *
+ * These keys can also be used by loggers to identify patterns, etc.
+ */
+class QueryAnalyzer {
+
+	/**
+	 * @var Schema
+	 */
+	protected $schema;
+
+	/**
+	 * Types that are referenced in the query
+	 *
+	 * @var array
+	 */
+	protected $queried_types = [];
+
+	/**
+	 * @var string
+	 */
+	protected $root_operation = 'Query';
+
+	/**
+	 * Models that are referenced in the query
+	 *
+	 * @var array
+	 */
+	protected $models = [];
+
+	/**
+	 * Types in the query that are lists
+	 *
+	 * @var array
+	 */
+	protected $list_types = [];
+
+	/**
+	 * @var array
+	 */
+	protected $runtime_nodes = [];
+
+	/**
+	 * @var string
+	 */
+	protected $query_id;
+
+	/**
+	 * @var Request
+	 */
+	protected $request;
+
+	/**
+	 * @param Request $request The GraphQL request being executed
+	 */
+	public function __construct( Request $request ) {
+		$this->request = $request;
+		$this->schema  = $request->schema;
+	}
+
+	/**
+	 * @return Request
+	 */
+	public function get_request(): Request {
+		return $this->request;
+	}
+
+	/**
+	 * @return void
+	 */
+	public function init(): void {
+
+		// allow query analyzer functionality to be disabled
+		$should_analyze_queries = apply_filters( 'graphql_should_analyze_queries', true, $this );
+
+		// If query analyzer is disabled, bail
+		if ( true !== $should_analyze_queries ) {
+			return;
+		}
+
+		// track keys related to the query
+		add_action( 'do_graphql_request', [ $this, 'determine_graphql_keys' ], 10, 4 );
+
+		// Track models loaded during execution
+		add_filter( 'graphql_dataloader_get_model', [ $this, 'track_nodes' ], 10, 1 );
+
+	}
+
+	/**
+	 * Determine the keys associated with the GraphQL document being executed
+	 *
+	 * @param ?string         $query     The GraphQL query
+	 * @param ?string         $operation The name of the operation
+	 * @param ?array          $variables Variables to be passed to your GraphQL request
+	 * @param OperationParams $params    The Operation Params. This includes any extra params, such as extenions or any other modifications to the request body
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function determine_graphql_keys( ?string $query, ?string $operation, ?array $variables, OperationParams $params ): void {
+
+		// @todo: support for QueryID?
+
+		// if the query is empty, get it from the request params
+		if ( empty( $query ) ) {
+			$query = $this->request->params->query ?: null;
+		}
+
+		if ( empty( $query ) ) {
+			return;
+		}
+
+		$query_id       = Utils::get_query_id( $query );
+		$this->query_id = $query_id ?: uniqid( 'gql:', true );
+
+		// if there's a query (either saved or part of the request params)
+		// get the GraphQL Types being asked for by the query
+		$this->list_types    = $this->set_list_types( $this->schema, $query );
+		$this->queried_types = $this->set_query_types( $this->schema, $query );
+		$this->models        = $this->set_query_models( $this->schema, $query );
+
+		/**
+		 * @param QueryAnalyzer $query_analyzer The instance of the query analyzer
+		 * @param string $query The query string being executed
+		 */
+		do_action( 'graphql_determine_graphql_keys', $this, $query );
+
+	}
+
+	/**
+	 * @return array
+	 */
+	public function get_list_types(): array {
+		return $this->list_types;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function get_query_types(): array {
+		return $this->queried_types;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function get_query_models(): array {
+		return $this->models;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function get_runtime_nodes(): array {
+		return $this->runtime_nodes;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function get_root_operation(): string {
+		return $this->root_operation;
+	}
+
+	/**
+	 * @return string|null
+	 */
+	public function get_query_id(): ?string {
+		return $this->query_id;
+	}
+
+	/**
+	 * Given the Schema and a query string, return a list of GraphQL Types that are being asked for
+	 * by the query.
+	 *
+	 * @param ?Schema $schema The WPGraphQL Schema
+	 * @param ?string $query  The query string
+	 *
+	 * @return array
+	 * @throws SyntaxError|Exception
+	 */
+	public function set_list_types( ?Schema $schema, ?string $query ): array {
+
+		/**
+		 * @param null $null Default value for the filter
+		 * @param ?Schema $schema The WPGraphQL Schema for the current request
+		 * @param ?string $query The query string being requested
+		 */
+		$null               = null;
+		$pre_get_list_types = apply_filters( 'graphql_pre_query_analyzer_get_list_types', $null, $schema, $query );
+
+		if ( null !== $pre_get_list_types ) {
+			return $pre_get_list_types;
+		}
+
+		if ( empty( $query ) || null === $schema ) {
+			return [];
+		}
+
+		try {
+			$ast = Parser::parse( $query );
+		} catch ( SyntaxError $error ) {
+			return [];
+		}
+
+		$type_map  = [];
+		$type_info = new TypeInfo( $schema );
+
+		$visitor = [
+			'enter' => function ( $node, $key, $parent, $path, $ancestors ) use ( $type_info, &$type_map, $schema ) {
+
+				$type_info->enter( $node );
+				$type = $type_info->getType();
+
+				if ( ! $type ) {
+					return;
+				}
+
+				$named_type = Type::getNamedType( $type );
+
+				// determine if the field is returning a list of types
+				// or singular types
+				// @todo: this might still be too fragile. We might need to adjust for cases where we can have list_of( nonNull( type ) ), etc
+				$is_list_type = $named_type && ( Type::listOf( $named_type )->name === $type->name );
+
+				if ( $named_type instanceof InterfaceType ) {
+					$possible_types = $schema->getPossibleTypes( $named_type );
+					foreach ( $possible_types as $possible_type ) {
+						// if the type is a list, store it
+						if ( $is_list_type && 0 !== strpos( $possible_type, '__' ) ) {
+							$type_map[] = 'list:' . strtolower( $possible_type );
+						}
+					}
+				} elseif ( $named_type instanceof ObjectType ) {
+					// if the type is a list, store it
+					if ( $is_list_type && 0 !== strpos( $named_type, '__' ) ) {
+						$type_map[] = 'list:' . strtolower( $named_type );
+					}
+				}
+			},
+			'leave' => function ( $node, $key, $parent, $path, $ancestors ) use ( $type_info ) {
+				$type_info->leave( $node );
+			},
+		];
+
+		Visitor::visit( $ast, Visitor::visitWithTypeInfo( $type_info, $visitor ) );
+		$map = array_values( array_unique( array_filter( $type_map ) ) );
+
+		// @phpcs:ignore
+		return apply_filters( 'graphql_cache_collection_get_list_types', $map, $schema, $query, $type_info );
+	}
+
+	/**
+	 * Given the Schema and a query string, return a list of GraphQL Types that are being asked for
+	 * by the query.
+	 *
+	 * @param ?Schema $schema The WPGraphQL Schema
+	 * @param ?string $query  The query string
+	 *
+	 * @return array
+	 * @throws Exception
+	 */
+	public function set_query_types( ?Schema $schema, ?string $query ): array {
+
+		/**
+		 * @param null $null Default value for the filter
+		 * @param ?Schema $schema The WPGraphQL Schema for the current request
+		 * @param ?string $query The query string being requested
+		 */
+		$null                = null;
+		$pre_get_query_types = apply_filters( 'graphql_pre_query_analyzer_get_query_types', $null, $schema, $query );
+
+		if ( null !== $pre_get_query_types ) {
+			return $pre_get_query_types;
+		}
+
+		if ( empty( $query ) || null === $schema ) {
+			return [];
+		}
+		try {
+			$ast = Parser::parse( $query );
+		} catch ( SyntaxError $error ) {
+			return [];
+		}
+		$type_map  = [];
+		$type_info = new TypeInfo( $schema );
+		$visitor   = [
+			'enter' => function ( $node, $key, $parent, $path, $ancestors ) use ( $type_info, &$type_map, $schema ) {
+				$type_info->enter( $node );
+				$type = $type_info->getType();
+				if ( ! $type ) {
+					return;
+				}
+
+				if ( empty( $this->root_operation ) ) {
+
+					if ( $type === $schema->getQueryType() ) {
+						$this->root_operation = 'Query';
+					}
+
+					if ( $type === $schema->getMutationType() ) {
+						$this->root_operation = 'Mutation';
+					}
+
+					if ( $type === $schema->getSubscriptionType() ) {
+						$this->root_operation = 'Subscription';
+					}
+				}
+
+				$named_type = Type::getNamedType( $type );
+
+				if ( $named_type instanceof InterfaceType ) {
+					$possible_types = $schema->getPossibleTypes( $named_type );
+					foreach ( $possible_types as $possible_type ) {
+						$type_map[] = strtolower( $possible_type );
+					}
+				} elseif ( $named_type instanceof ObjectType ) {
+					$type_map[] = strtolower( $named_type );
+				}
+			},
+			'leave' => function ( $node, $key, $parent, $path, $ancestors ) use ( $type_info ) {
+				$type_info->leave( $node );
+			},
+		];
+
+		Visitor::visit( $ast, Visitor::visitWithTypeInfo( $type_info, $visitor ) );
+		$map = array_values( array_unique( array_filter( $type_map ) ) );
+
+		// @phpcs:ignore
+		return apply_filters( 'graphql_cache_collection_get_query_types', $map, $schema, $query, $type_info );
+	}
+
+	/**
+	 * Given the Schema and a query string, return a list of GraphQL model names that are being asked for
+	 * by the query.
+	 *
+	 * @param ?Schema $schema The WPGraphQL Schema
+	 * @param ?string $query  The query string
+	 *
+	 * @return array
+	 * @throws SyntaxError|Exception
+	 */
+	public function set_query_models( ?Schema $schema, ?string $query ): array {
+
+		/**
+		 * @param null $null Default value for the filter
+		 * @param ?Schema $schema The WPGraphQL Schema for the current request
+		 * @param ?string $query The query string being requested
+		 */
+		$null           = null;
+		$pre_get_models = apply_filters( 'graphql_pre_query_analyzer_get_models', $null, $schema, $query );
+
+		if ( null !== $pre_get_models ) {
+			return $pre_get_models;
+		}
+
+		if ( empty( $query ) || null === $schema ) {
+			return [];
+		}
+		try {
+			$ast = Parser::parse( $query );
+		} catch ( SyntaxError $error ) {
+			return [];
+		}
+		$type_map  = [];
+		$type_info = new TypeInfo( $schema );
+		$visitor   = [
+			'enter' => function ( $node, $key, $parent, $path, $ancestors ) use ( $type_info, &$type_map, $schema ) {
+				$type_info->enter( $node );
+				$type = $type_info->getType();
+				if ( ! $type ) {
+					return;
+				}
+
+				$named_type = Type::getNamedType( $type );
+
+				if ( $named_type instanceof InterfaceType ) {
+					$possible_types = $schema->getPossibleTypes( $named_type );
+					foreach ( $possible_types as $possible_type ) {
+						if ( ! isset( $possible_type->config['model'] ) ) {
+							continue;
+						}
+						$type_map[] = $possible_type->config['model'];
+					}
+				} elseif ( $named_type instanceof ObjectType ) {
+					if ( ! isset( $named_type->config['model'] ) ) {
+						return;
+					}
+					$type_map[] = $named_type->config['model'];
+				}
+			},
+			'leave' => function ( $node, $key, $parent, $path, $ancestors ) use ( $type_info ) {
+				$type_info->leave( $node );
+			},
+		];
+
+		Visitor::visit( $ast, Visitor::visitWithTypeInfo( $type_info, $visitor ) );
+		$map = array_values( array_unique( array_filter( $type_map ) ) );
+
+		// @phpcs:ignore
+		return apply_filters( 'graphql_cache_collection_get_query_models', $map, $schema, $query, $type_info );
+	}
+
+	/**
+	 * Track the nodes that were resolved by ensuring the Node's model
+	 * matches one of the models asked for in the query
+	 *
+	 * @param mixed $model The Model to be returned by the loader
+	 *
+	 * @return mixed
+	 */
+	public function track_nodes( $model ) {
+		if ( isset( $model->id ) && in_array( get_class( $model ), $this->models, true ) ) {
+			// Is this model type part of the requested/returned data in the asked for query?
+			$this->runtime_nodes[] = $model->id;
+		}
+
+		return $model;
+	}
+
+
+	/**
+	 * Return headers
+	 *
+	 * @param array $headers The array of headers being returned
+	 *
+	 * @return array
+	 */
+	public function get_headers( array $headers = [] ): array {
+
+		$keys = [];
+
+		if ( ! empty( $this->list_types ) ) {
+			$keys = array_merge( $keys, $this->get_list_types() );
+
+		}
+
+		if ( ! empty( $this->get_runtime_nodes() ) ) {
+			$keys = array_merge( $keys, $this->get_runtime_nodes() );
+		}
+
+		if ( ! empty( $this->get_root_operation() ) ) {
+			$headers['X-GraphQL'] = $this->get_root_operation();
+			$keys[]               = 'graphql:' . $this->get_root_operation();
+		}
+
+		if ( ! empty( $keys ) ) {
+
+			if ( $this->get_query_id() ) {
+				$keys[] = $this->get_query_id();
+			}
+
+			$key_string = implode( ' ', array_unique( array_values( $keys ) ) );
+
+			$headers['X-GraphQL-Query-ID']  = $this->query_id;
+			$headers['X-GraphQL-Keys']      = $key_string;
+			$headers['X-GraphQL-Keys-Size'] = strlen( $key_string ); // calculate the bytes of the keys
+
+		}
+
+		return $headers;
+	}
+
+}

--- a/src/Utils/QueryAnalyzer.php
+++ b/src/Utils/QueryAnalyzer.php
@@ -453,17 +453,19 @@ class QueryAnalyzer {
 
 		$keys = [];
 
-		if ( ! empty( $this->list_types ) ) {
+		if ( ! empty( $this->get_list_types() ) && is_array( $this->get_list_types() ) ) {
+			$headers['X-GraphQL-List-Types'] = implode( ' ', array_unique( array_values( $this->get_list_types() ) ) );
 			$keys = array_merge( $keys, $this->get_list_types() );
 
 		}
 
-		if ( ! empty( $this->get_runtime_nodes() ) ) {
+		if ( ! empty( $this->get_runtime_nodes() ) && is_array( $this->get_runtime_nodes() ) ) {
+			$headers['X-GraphQL-Nodes'] = implode( ' ', array_unique( array_values( $this->get_runtime_nodes() ) ) );
 			$keys = array_merge( $keys, $this->get_runtime_nodes() );
 		}
 
 		if ( ! empty( $this->get_root_operation() ) ) {
-			$headers['X-GraphQL'] = $this->get_root_operation();
+			 $headers['X-GraphQL-Operation-Type'] = $this->get_root_operation();
 			$keys[]               = 'graphql:' . $this->get_root_operation();
 		}
 

--- a/src/Utils/QueryAnalyzer.php
+++ b/src/Utils/QueryAnalyzer.php
@@ -455,18 +455,18 @@ class QueryAnalyzer {
 
 		if ( ! empty( $this->get_list_types() ) && is_array( $this->get_list_types() ) ) {
 			$headers['X-GraphQL-List-Types'] = implode( ' ', array_unique( array_values( $this->get_list_types() ) ) );
-			$keys = array_merge( $keys, $this->get_list_types() );
+			$keys                            = array_merge( $keys, $this->get_list_types() );
 
 		}
 
 		if ( ! empty( $this->get_runtime_nodes() ) && is_array( $this->get_runtime_nodes() ) ) {
 			$headers['X-GraphQL-Nodes'] = implode( ' ', array_unique( array_values( $this->get_runtime_nodes() ) ) );
-			$keys = array_merge( $keys, $this->get_runtime_nodes() );
+			$keys                       = array_merge( $keys, $this->get_runtime_nodes() );
 		}
 
 		if ( ! empty( $this->get_root_operation() ) ) {
 			 $headers['X-GraphQL-Operation-Type'] = $this->get_root_operation();
-			$keys[]               = 'graphql:' . $this->get_root_operation();
+			$keys[]                               = 'graphql:' . $this->get_root_operation();
 		}
 
 		if ( ! empty( $keys ) ) {

--- a/src/Utils/QueryAnalyzer.php
+++ b/src/Utils/QueryAnalyzer.php
@@ -465,8 +465,8 @@ class QueryAnalyzer {
 		}
 
 		if ( ! empty( $this->get_root_operation() ) ) {
-			 $headers['X-GraphQL-Operation-Type'] = $this->get_root_operation();
-			$keys[]                               = 'graphql:' . $this->get_root_operation();
+			$headers['X-GraphQL-Operation-Type'] = $this->get_root_operation();
+			$keys[]                              = 'graphql:' . $this->get_root_operation();
 		}
 
 		if ( ! empty( $keys ) ) {

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -27,7 +27,7 @@ class Utils {
 	}
 
 	/**
-	 * Maps new input query args and sanitizes the input
+	 * Maps new input query args and sa nitizes the input
 	 *
 	 * @param mixed|array|string $args The raw query args from the GraphQL query
 	 * @param mixed|array|string $map  The mapping of where each of the args should go

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -8,6 +8,25 @@ use WPGraphQL\Model\Model;
 class Utils {
 
 	/**
+	 * Given a GraphQL Query string, return a hash
+	 *
+	 * @param string $query The Query String to hash
+	 *
+	 * @return string|null
+	 */
+	public static function get_query_id( string $query ) {
+
+		try {
+			$query_ast = \GraphQL\Language\Parser::parse( $query );
+			$query     = \GraphQL\Language\Printer::doPrint( $query_ast );
+			return md5( $query );
+		} catch ( \Exception $exception ) {
+			return null;
+		}
+
+	}
+
+	/**
 	 * Maps new input query args and sanitizes the input
 	 *
 	 * @param mixed|array|string $args The raw query args from the GraphQL query

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -245,7 +245,8 @@ final class WPGraphQL {
 			function () {
 
 				new \WPGraphQL\Data\Config();
-				new Router();
+				$router = new Router();
+				$router->init();
 				$instance = self::instance();
 
 				/**

--- a/tests/functional/GraphQLHeadersCept.php
+++ b/tests/functional/GraphQLHeadersCept.php
@@ -1,0 +1,32 @@
+<?php
+
+$I = new FunctionalTester( $scenario );
+$I->wantTo( 'Test GraphQL Keys returned in headers');
+
+$admin_id = $I->haveUserInDatabase( 'admin', 'administrator' );
+$post_id = $I->havePostInDatabase([
+	'post_type' => 'post',
+	'post_status' => 'publish',
+	'post_title' => 'test post',
+	'post_content' => 'test post',
+	'post_author' => $admin_id,
+]);
+$page_id = $I->havePostInDatabase([
+	'post_type' => 'page',
+	'post_status' => 'publish',
+	'post_title' => 'test page',
+	'post_content' => 'test page',
+	'post_author' => $admin_id,
+]);
+
+$query = '{ posts { nodes { title } } }';
+
+$I->sendGet( 'http://localhost/graphql?query=' . $query );
+
+$I->seeResponseCodeIs( 200 );
+$I->seeResponseIsJson();
+$x_graphql_keys = $I->grabHttpHeader( 'X-GraphQL-Keys' );
+
+$I->assertNotEmpty( $x_graphql_keys );
+$post_cache_key = base64_encode( 'post:' . $post_id );
+$I->assertContains( $post_cache_key, explode( ' ', $x_graphql_keys ) );

--- a/tests/wpunit/AccessFunctionsTest.php
+++ b/tests/wpunit/AccessFunctionsTest.php
@@ -120,9 +120,11 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		}';
 		$response = $this->graphql( compact( 'query' ) );
 
+		codecept_debug( $response );
+
 		$this->assertArrayHasKey( 'debug', $response['extensions'] );
 
-		$has_debug_message = null;
+		$has_debug_message = false;
 
 		foreach ( $response['extensions']['debug'] as $debug_message ) {
 			if (
@@ -131,6 +133,7 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 				'INVALID_FIELD_NAME' === $debug_message['type']
 			) {
 				$has_debug_message = true;
+				break;
 			}
 		}
 

--- a/tests/wpunit/NodesTest.php
+++ b/tests/wpunit/NodesTest.php
@@ -61,9 +61,9 @@ class NodesTest extends \Codeception\TestCase\WPTestCase {
 			} 
 		}';
 
-		$variables = wp_json_encode( [
+		$variables = [
 			'id' => $global_id,
-		] );
+		];
 
 		/**
 		 * Run the GraphQL query
@@ -130,7 +130,7 @@ class NodesTest extends \Codeception\TestCase\WPTestCase {
 		/**
 		 * Run the GraphQL query
 		 */
-		$actual = do_graphql_request( $query, '', '' );
+		$actual = do_graphql_request( $query );
 
 		/**
 		 * Establish the expectation for the output of the query

--- a/tests/wpunit/QueryAnalyzerTest.php
+++ b/tests/wpunit/QueryAnalyzerTest.php
@@ -1,0 +1,82 @@
+<?php
+class QueryAnalyzerTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
+
+	public $post_id;
+
+	public function _setUp():void {
+		parent::_setUp();
+
+		$this->post_id = self::factory()->post->create([
+			'post_status' => 'publish',
+			'post_title' => 'test post'
+		]);
+
+	}
+
+	public function _tearDown():void {
+		wp_delete_post( $this->post_id, true );
+		parent::_tearDown();
+	}
+
+	public function testListTypes() {
+
+		$query = '{ posts { nodes { id, title } } }';
+
+		$request = graphql([
+			'query' => $query,
+		], true);
+
+		// before execution, this should be null
+		$this->assertEmpty( $request->get_query_analyzer()->get_list_types() );
+
+
+		// execute the query
+		$request->execute();
+
+		// get the list types that were generated during execution
+		$list_types = $request->get_query_analyzer()->get_list_types();
+
+		// Assert the expected list types are returned
+		$this->assertEqualSets( [ 'list:post' ], $list_types );
+	}
+
+	public function testListModels() {
+		$query = '{ posts { nodes { id, title } } }';
+
+		$request = graphql([
+			'query' => $query,
+		], true);
+
+		// before execution, this should be null (no nodes have loaded)
+		$this->assertEmpty( $request->get_query_analyzer()->get_runtime_nodes() );
+
+		// execute the request
+		$request->execute();
+
+		$nodes = $request->get_query_analyzer()->get_runtime_nodes();
+
+		$node_id = \GraphQLRelay\Relay::toGlobalId( 'post', $this->post_id );
+
+		$this->assertEqualSets( [ $node_id ], $nodes );
+	}
+
+	public function testQueryTypes() {
+
+		$query = '{ posts { nodes { id, title } } }';
+
+		$request = graphql([
+			'query' => $query,
+		], true);
+
+
+		// before execution, this should be null
+		$this->assertEmpty( $request->get_query_analyzer()->get_query_types() );
+
+		// Execute the request
+		$request->execute();
+
+		$types = $request->get_query_analyzer()->get_query_types();
+		$this->assertEqualSets( [ 'rootquery', 'rootquerytopostconnection', 'post' ], $types );
+	}
+
+}

--- a/tests/wpunit/UtilsTest.php
+++ b/tests/wpunit/UtilsTest.php
@@ -1,0 +1,43 @@
+<?php
+
+class UtilsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
+
+
+	public function testGetQueryId() {
+
+
+		$query_without_spaces = '{posts{nodes{id,title}}}';
+		$query_with_spaces = '{ posts { nodes { id, title } } }';
+		$query_with_line_breaks = '
+		{ 
+			posts { 
+				nodes { 
+					id
+					title 
+				} 
+			} 
+		}';
+
+		$id1 = \WPGraphQL\Utils\Utils::get_query_id( $query_without_spaces );
+		$id2 = \WPGraphQL\Utils\Utils::get_query_id( $query_with_spaces );
+		$id3 = \WPGraphQL\Utils\Utils::get_query_id( $query_with_line_breaks );
+
+		codecept_debug([
+			$id1,
+			$id2,
+			$id3
+		]);
+
+		// differently formatted versions of the same query should
+		// all produce the same query_id
+		$this->assertSame( $id1, $id2 );
+		$this->assertSame( $id2, $id3 );
+		$this->assertSame( $id1, $id3 );
+
+		$invalid_query = '{ some { malformatted { query...';
+
+		// if an invalid query is passed, we should get a null response
+		$this->assertNull( \WPGraphQL\Utils\Utils::get_query_id( $invalid_query ) );
+
+	}
+}


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This introduces a new "QueryAnalyzer" that tracks Types, Models and Nodes that are queried and returned in any given GraphQL Request, then returns those values in the headers. 

For example, making a query like so `/graphql?query={posts(first:5){nodes{id,title}}}` will return headers like so: 

```bash
X-GraphQL-Keys: list:post cG9zdDoxMTY3 cG9zdDoxMTM1 cG9zdDoxMTIw cG9zdDoxMTA5 cG9zdDoxMDk3 graphql:Query d43c3d17aeaf76b21e747f5350a36262
X-GraphQL-Keys-Size: 121
X-GraphQL-List-Types: list:post
X-GraphQL-Nodes: cG9zdDoxMTY3 cG9zdDoxMTM1 cG9zdDoxMTIw cG9zdDoxMTA5 cG9zdDoxMDk3
X-GraphQL-Operation-Type: Query
X-GraphQL-Query-ID: d43c3d17aeaf76b21e747f5350a36262
```

![CleanShot 2022-09-14 at 14 38 42](https://user-images.githubusercontent.com/1260765/190257672-e1145829-f39c-40c0-9b48-22ddd2fd8573.png)


Does this close any currently open issues?
------------------------------------------
closes #2516 


Any other comments?
-------------------
The goal of this is to centralize collecting info that can be used to identify queries via logs or cache clients (varnish/fastly, etc)

With the information returned in these headers, caches can "tag" the cached query with this information and then corresponding events can evict said caches based on these tags.

Additionally error logging, performance tracking, etc can be better organized by the data returned in these headers.

**Note**: Much of this functionality was originally written in the WPGraphQL Smart Cache plugin. This brings it to the core plugin to help with maintenance overhead and ultimately benefit a wider audience of users.
