### PR TITLE
feat: allow global/database IDs in Comment connection where args `ID` inputs

### DIFF
--- a/src/Connection/Comments.php
+++ b/src/Connection/Comments.php
@@ -173,6 +173,74 @@ class Comments {
 				],
 				'description' => __( 'Array of IDs of users whose unapproved comments will be returned by the query regardless of status.', 'wp-graphql' ),
 			],
+			'commentType'        => [
+				'type'        => 'String',
+				'description' => __( 'Include comments of a given type.', 'wp-graphql' ),
+			],
+			'commentTypeIn'      => [
+				'type'        => [
+					'list_of' => 'String',
+				],
+				'description' => __( 'Include comments from a given array of comment types.', 'wp-graphql' ),
+			],
+			'commentTypeNotIn'   => [
+				'type'        => 'String',
+				'description' => __( 'Exclude comments from a given array of comment types.', 'wp-graphql' ),
+			],
+			'contentAuthor'      => [
+				'type'        => [
+					'list_of' => 'ID',
+				],
+				'description' => __( 'Content object author ID to limit results by.', 'wp-graphql' ),
+			],
+			'contentAuthorIn'    => [
+				'type'        => [
+					'list_of' => 'ID',
+				],
+				'description' => __( 'Array of author IDs to retrieve comments for.', 'wp-graphql' ),
+			],
+			'contentAuthorNotIn' => [
+				'type'        => [
+					'list_of' => 'ID',
+				],
+				'description' => __( 'Array of author IDs *not* to retrieve comments for.', 'wp-graphql' ),
+			],
+			'contentId'          => [
+				'type'        => 'ID',
+				'description' => __( 'Limit results to those affiliated with a given content object ID.', 'wp-graphql' ),
+			],
+			'contentIdIn'        => [
+				'type'        => [
+					'list_of' => 'ID',
+				],
+				'description' => __( 'Array of content object IDs to include affiliated comments for.', 'wp-graphql' ),
+			],
+			'contentIdNotIn'     => [
+				'type'        => [
+					'list_of' => 'ID',
+				],
+				'description' => __( 'Array of content object IDs to exclude affiliated comments for.', 'wp-graphql' ),
+			],
+			'contentStatus'      => [
+				'type'        => [
+					'list_of' => 'PostStatusEnum',
+				],
+				'description' => __( 'Array of content object statuses to retrieve affiliated comments for. Pass \'any\' to match any value.', 'wp-graphql' ),
+			],
+			'contentType'        => [
+				'type'        => [
+					'list_of' => 'ContentTypeEnum',
+				],
+				'description' => __( 'Content object type or array of types to retrieve affiliated comments for. Pass \'any\' to match any value.', 'wp-graphql' ),
+			],
+			'contentName'        => [
+				'type'        => 'String',
+				'description' => __( 'Content object name (i.e. slug ) to retrieve affiliated comments for.', 'wp-graphql' ),
+			],
+			'contentParent'      => [
+				'type'        => 'Int',
+				'description' => __( 'Content Object parent ID to retrieve affiliated comments for.', 'wp-graphql' ),
+			],
 			'includeUnapproved'  => [
 				'type'        => [
 					'list_of' => 'ID',
@@ -207,60 +275,6 @@ class Comments {
 				],
 				'description' => __( 'Array of parent IDs of comments *not* to retrieve children for.', 'wp-graphql' ),
 			],
-			'contentAuthorIn'    => [
-				'type'        => [
-					'list_of' => 'ID',
-				],
-				'description' => __( 'Array of author IDs to retrieve comments for.', 'wp-graphql' ),
-			],
-			'contentAuthorNotIn' => [
-				'type'        => [
-					'list_of' => 'ID',
-				],
-				'description' => __( 'Array of author IDs *not* to retrieve comments for.', 'wp-graphql' ),
-			],
-			'contentId'          => [
-				'type'        => 'ID',
-				'description' => __( 'Limit results to those affiliated with a given content object ID.', 'wp-graphql' ),
-			],
-			'contentIdIn'        => [
-				'type'        => [
-					'list_of' => 'ID',
-				],
-				'description' => __( 'Array of content object IDs to include affiliated comments for.', 'wp-graphql' ),
-			],
-			'contentIdNotIn'     => [
-				'type'        => [
-					'list_of' => 'ID',
-				],
-				'description' => __( 'Array of content object IDs to exclude affiliated comments for.', 'wp-graphql' ),
-			],
-			'contentAuthor'      => [
-				'type'        => [
-					'list_of' => 'ID',
-				],
-				'description' => __( 'Content object author ID to limit results by.', 'wp-graphql' ),
-			],
-			'contentStatus'      => [
-				'type'        => [
-					'list_of' => 'PostStatusEnum',
-				],
-				'description' => __( 'Array of content object statuses to retrieve affiliated comments for. Pass \'any\' to match any value.', 'wp-graphql' ),
-			],
-			'contentType'        => [
-				'type'        => [
-					'list_of' => 'ContentTypeEnum',
-				],
-				'description' => __( 'Content object type or array of types to retrieve affiliated comments for. Pass \'any\' to match any value.', 'wp-graphql' ),
-			],
-			'contentName'        => [
-				'type'        => 'String',
-				'description' => __( 'Content object name to retrieve affiliated comments for.', 'wp-graphql' ),
-			],
-			'contentParent'      => [
-				'type'        => 'Int',
-				'description' => __( 'Content Object parent ID to retrieve affiliated comments for.', 'wp-graphql' ),
-			],
 			'search'             => [
 				'type'        => 'String',
 				'description' => __( 'Search term(s) to retrieve matching comments for.', 'wp-graphql' ),
@@ -268,20 +282,6 @@ class Comments {
 			'status'             => [
 				'type'        => 'String',
 				'description' => __( 'Comment status to limit results by.', 'wp-graphql' ),
-			],
-			'commentType'        => [
-				'type'        => 'String',
-				'description' => __( 'Include comments of a given type.', 'wp-graphql' ),
-			],
-			'commentTypeIn'      => [
-				'type'        => [
-					'list_of' => 'String',
-				],
-				'description' => __( 'Include comments from a given array of comment types.', 'wp-graphql' ),
-			],
-			'commentTypeNotIn'   => [
-				'type'        => 'String',
-				'description' => __( 'Exclude comments from a given array of comment types.', 'wp-graphql' ),
 			],
 			'userId'             => [
 				'type'        => 'ID',

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -281,9 +281,13 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * @return AbstractConnectionResolver
 	 *
-	 * @deprecated in favor of set_query_arg
+	 * @deprecated 0.3.0
+	 *
+	 * @codeCoverageIgnore
 	 */
 	public function setQueryArg( $key, $value ) {
+		_deprecated_function( __FUNCTION__, '0.3.0', 'set_query_arg' );
+
 		return $this->set_query_arg( $key, $value );
 	}
 

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -143,11 +143,6 @@ abstract class AbstractConnectionResolver {
 		$this->source = $source;
 
 		/**
-		 * Set the args for the resolver
-		 */
-		$this->args = $args;
-
-		/**
 		 * Set the context of the resolver
 		 */
 		$this->context = $context;
@@ -161,6 +156,22 @@ abstract class AbstractConnectionResolver {
 		 * Get the loader for the Connection
 		 */
 		$this->loader = $this->getLoader();
+
+		/**
+		 * Set the args for the resolver
+		 */
+		$this->args = $args;
+
+		/**
+		 *
+		 * Filters the GraphQL args before they are used in get_query_args().
+		 *
+		 * @param array                      $args                The GraphQL args passed to the resolver.
+		 * @param AbstractConnectionResolver $connection_resolver Instance of the ConnectionResolver
+		 *
+		 * @since @todo
+		 */
+		$this->args = apply_filters( 'graphql_connection_args', $this->getArgs(), $this );
 
 		/**
 		 * Determine the query amount for the resolver.

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -230,7 +230,7 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * @deprecated @todo
 	 *
-	 * @return array
+	 * @codeCoverageIgnore
 	 */
 	public function getArgs(): array {
 		_deprecated_function( __FUNCTION__, '@todo', 'get_args' );
@@ -611,6 +611,8 @@ abstract class AbstractConnectionResolver {
 	 * GraphQL query.
 	 *
 	 * @deprecated 1.9.0
+	 *
+	 * @codeCoverageIgnore
 	 *
 	 * @return int|mixed
 	 */

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -171,7 +171,7 @@ abstract class AbstractConnectionResolver {
 		 *
 		 * @since @todo
 		 */
-		$this->args = apply_filters( 'graphql_connection_args', $this->getArgs(), $this );
+		$this->args = apply_filters( 'graphql_connection_args', $this->get_args(), $this );
 
 		/**
 		 * Determine the query amount for the resolver.
@@ -223,12 +223,28 @@ abstract class AbstractConnectionResolver {
 		return $this->context->get_loader( $name );
 	}
 
-	/**
+		/**
 	 * Returns the $args passed to the connection
+	 *
+	 * Deprecated in favor of $this->get_args();
+	 *
+	 * @deprecated @todo
 	 *
 	 * @return array
 	 */
 	public function getArgs(): array {
+		_deprecated_function( __FUNCTION__, '@todo', 'get_args' );
+		return $this->get_args();
+	}
+
+	/**
+	 * Returns the $args passed to the connection.
+	 *
+	 * Useful for modifying the $args before they are passed to $this->get_query_args().
+	 *
+	 * @return array
+	 */
+	public function get_args() {
 		return $this->args;
 	}
 

--- a/src/Data/Connection/CommentConnectionResolver.php
+++ b/src/Data/Connection/CommentConnectionResolver.php
@@ -236,10 +236,16 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 						$args['where'][ $input_key ] = Utils::get_database_id_from_id( $input_value );
 						break;
 					case 'includeUnapproved':
-						if ( is_email( $input_value ) ) {
-							break;
+						if ( is_string( $input_value ) ) {
+							$input_value = [ $input_value ];
 						}
-						$args['where'][ $input_key ] = Utils::get_database_id_from_id( $input_value );
+						$args['where'][ $input_key ] = array_map( function ( $id ) {
+							if ( is_email( $id ) ) {
+								return $id;
+							}
+
+							return Utils::get_database_id_from_id( $id );
+						}, $input_value );
 						break;
 				}
 			}

--- a/src/Data/Connection/CommentConnectionResolver.php
+++ b/src/Data/Connection/CommentConnectionResolver.php
@@ -260,10 +260,7 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 		 *
 		 * @since @todo
 		 */
-		$args = apply_filters( 'graphql_comment_connection_args', $args, $this );
-
-		return $args;
-
+		return apply_filters( 'graphql_comment_connection_args', $args, $this );
 	}
 
 	/**

--- a/src/Data/Connection/CommentConnectionResolver.php
+++ b/src/Data/Connection/CommentConnectionResolver.php
@@ -197,6 +197,69 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 		return true;
 	}
 
+
+	/**
+	 * Filters the GraphQL args before they are used in get_query_args().
+	 *
+	 * @return array
+	 */
+	public function get_args() {
+		$args = $this->args;
+
+		if ( ! empty( $args['where'] ) ) {
+			// Ensure all IDs are converted to database IDs.
+			foreach ( $args['where'] as $input_key => $input_value ) {
+				if ( empty( $input_value ) ) {
+					continue;
+				}
+
+				switch ( $input_key ) {
+					case 'authorIn':
+					case 'authorNotIn':
+					case 'commentIn':
+					case 'commentNotIn':
+					case 'parentIn':
+					case 'parentNotIn':
+					case 'contentAuthorIn':
+					case 'contentAuthorNotIn':
+					case 'contentId':
+					case 'contentIdIn':
+					case 'contentIdNotIn':
+					case 'contentAuthor':
+					case 'userId':
+						if ( is_array( $input_value ) ) {
+							$args['where'][ $input_key ] = array_map( function ( $id ) {
+								return Utils::get_database_id_from_id( $id );
+							}, $input_value );
+							break;
+						}
+						$args['where'][ $input_key ] = Utils::get_database_id_from_id( $input_value );
+						break;
+					case 'includeUnapproved':
+						if ( is_email( $input_value ) ) {
+							break;
+						}
+						$args['where'][ $input_key ] = Utils::get_database_id_from_id( $input_value );
+						break;
+				}
+			}
+		}
+
+		/**
+		 *
+		 * Filters the GraphQL args before they are used in get_query_args().
+		 *
+		 * @param array                     $args                The GraphQL args passed to the resolver.
+		 * @param CommentConnectionResolver $connection_resolver Instance of the ConnectionResolver
+		 *
+		 * @since @todo
+		 */
+		$args = apply_filters( 'graphql_comment_connection_args', $args, $this );
+
+		return $args;
+
+	}
+
 	/**
 	 * This sets up the "allowed" args, and translates the GraphQL-friendly keys to
 	 * WP_Comment_Query friendly keys.


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR allows Comment connection where args with a type `ID` to accept either global IDs or database IDs.

This PR replaces #2340 , and requires #2521 to be merged as a prerequisite.

Does this close any currently open issues?
------------------------------------------

Part of #998


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php 8.0.19)

**WordPress Version:** 6.0.2
