### PR TITLE
feat: allow global/database IDs in MenuItem connection where args ID inputs

### DIFF
--- a/src/Connection/MenuItems.php
+++ b/src/Connection/MenuItems.php
@@ -104,6 +104,10 @@ class MenuItems {
 						'type'        => 'Int',
 						'description' => __( 'The database ID of the object', 'wp-graphql' ),
 					],
+					'location'         => [
+						'type'        => 'MenuLocationEnum',
+						'description' => __( 'The menu location for the menu being queried', 'wp-graphql' ),
+					],
 					'parentId'         => [
 						'type'        => 'ID',
 						'description' => __( 'The ID of the parent menu object', 'wp-graphql' ),
@@ -111,10 +115,6 @@ class MenuItems {
 					'parentDatabaseId' => [
 						'type'        => 'Int',
 						'description' => __( 'The database ID of the parent menu object', 'wp-graphql' ),
-					],
-					'location'         => [
-						'type'        => 'MenuLocationEnum',
-						'description' => __( 'The menu location for the menu being queried', 'wp-graphql' ),
 					],
 				],
 				'resolve'        => function ( $source, $args, $context, $info ) {

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -143,11 +143,6 @@ abstract class AbstractConnectionResolver {
 		$this->source = $source;
 
 		/**
-		 * Set the args for the resolver
-		 */
-		$this->args = $args;
-
-		/**
 		 * Set the context of the resolver
 		 */
 		$this->context = $context;
@@ -161,6 +156,22 @@ abstract class AbstractConnectionResolver {
 		 * Get the loader for the Connection
 		 */
 		$this->loader = $this->getLoader();
+
+		/**
+		 * Set the args for the resolver
+		 */
+		$this->args = $args;
+
+		/**
+		 *
+		 * Filters the GraphQL args before they are used in get_query_args().
+		 *
+		 * @param array                      $args                The GraphQL args passed to the resolver.
+		 * @param AbstractConnectionResolver $connection_resolver Instance of the ConnectionResolver
+		 *
+		 * @since @todo
+		 */
+		$this->args = apply_filters( 'graphql_connection_args', $this->getArgs(), $this );
 
 		/**
 		 * Determine the query amount for the resolver.

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -171,7 +171,7 @@ abstract class AbstractConnectionResolver {
 		 *
 		 * @since @todo
 		 */
-		$this->args = apply_filters( 'graphql_connection_args', $this->getArgs(), $this );
+		$this->args = apply_filters( 'graphql_connection_args', $this->get_args(), $this );
 
 		/**
 		 * Determine the query amount for the resolver.
@@ -223,12 +223,28 @@ abstract class AbstractConnectionResolver {
 		return $this->context->get_loader( $name );
 	}
 
-	/**
+		/**
 	 * Returns the $args passed to the connection
+	 *
+	 * Deprecated in favor of $this->get_args();
+	 *
+	 * @deprecated @todo
 	 *
 	 * @return array
 	 */
 	public function getArgs(): array {
+		_deprecated_function( __FUNCTION__, '@todo', 'get_args' );
+		return $this->get_args();
+	}
+
+	/**
+	 * Returns the $args passed to the connection.
+	 *
+	 * Useful for modifying the $args before they are passed to $this->get_query_args().
+	 *
+	 * @return array
+	 */
+	public function get_args() {
 		return $this->args;
 	}
 

--- a/src/Data/Connection/MenuItemConnectionResolver.php
+++ b/src/Data/Connection/MenuItemConnectionResolver.php
@@ -123,10 +123,7 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 		 *
 		 * @since @todo
 		 */
-		$args = apply_filters( 'graphql_menu_item_connection_args', $args );
-
-		return $args;
-
+		return apply_filters( 'graphql_menu_item_connection_args', $args );
 	}
 
 }

--- a/src/Data/Connection/MenuItemConnectionResolver.php
+++ b/src/Data/Connection/MenuItemConnectionResolver.php
@@ -5,6 +5,7 @@ use Exception;
 use GraphQLRelay\Relay;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
+use WPGraphQL\Utils\Utils;
 
 /**
  * Class MenuItemConnectionResolver
@@ -49,12 +50,10 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 			$query_args['meta_value'] = (int) $this->args['where']['parentDatabaseId']; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 		}
 
-		if ( isset( $this->args['where']['parentId'] ) ) {
-			$id_parts = Relay::fromGlobalId( $this->args['where']['parentId'] );
-			if ( isset( $id_parts['id'] ) ) {
+		if ( ! empty( $this->args['where']['parentId'] ) ) {
+			
 				$query_args['meta_key']   = '_menu_item_menu_item_parent'; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-				$query_args['meta_value'] = (int) $id_parts['id']; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
-			}
+				$query_args['meta_value'] = $this->args['where']['parentId']; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 		}
 
 		// Get unique list of locations as the default limitation of
@@ -91,6 +90,43 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 		}
 
 		return $query_args;
+	}
+
+	/**
+	 * Filters the GraphQL args before they are used in get_query_args().
+	 *
+	 * @return array
+	 */
+	public function get_args() {
+		$args = $this->args;
+
+		if ( ! empty( $args['where'] ) ) {
+			// Ensure all IDs are converted to database IDs.
+			foreach ( $args['where'] as $input_key => $input_value ) {
+				if ( empty( $input_value ) ) {
+					continue;
+				}
+
+				switch ( $input_key ) {
+					case 'parentId':
+						$args['where'][ $input_key ] = Utils::get_database_id_from_id( $input_value );
+						break;
+				}
+			}
+		}
+
+		/**
+		 *
+		 * Filters the GraphQL args before they are used in get_query_args().
+		 *
+		 * @param array $args The GraphQL args passed to the resolver.
+		 *
+		 * @since @todo
+		 */
+		$args = apply_filters( 'graphql_menu_item_connection_args', $args );
+
+		return $args;
+
 	}
 
 }

--- a/tests/wpunit/MenuItemConnectionQueriesTest.php
+++ b/tests/wpunit/MenuItemConnectionQueriesTest.php
@@ -389,7 +389,7 @@ class MenuItemConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 		$this->assertSame( $expected, $actual['data']['menuItems']['nodes'][0] );
 	}
 
-	public function testMenuItemsQueryById() {
+	public function testIdWhereArgs() {
 		$menu_item_id = intval( $this->created_menu_items['menu_item_ids'][2] );
 		$post_id      = intval( $this->created_menu_items['post_ids'][2] );
 
@@ -409,7 +409,7 @@ class MenuItemConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 		$this->compareResults( [ $menu_item_id ], [ $post_id ], $actual );
 	}
 
-	public function testMenuItemsQueryByLocation() {
+	public function testLocationWhereArgs() {
 		$menu_item_id = intval( $this->created_menu_items['menu_item_ids'][2] );
 		$post_id      = intval( $this->created_menu_items['post_ids'][2] );
 
@@ -436,7 +436,7 @@ class MenuItemConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 		$this->compareResults( $created['menu_item_ids'], $created['post_ids'], $actual );
 	}
 
-	public function testMenuItemsQueryWithChildItemsAsFlat() {
+	public function testLocationWhereArgsWithChildItemsFlat() {
 		$menu_location = 'my-menu-items-location';
 		register_nav_menu( $menu_location, 'My MenuItems' );
 		WPGraphQL::clear_schema();
@@ -489,7 +489,7 @@ class MenuItemConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 
 	}
 
-	public function testMenuItemsQueryWithChildItemsUsingRelayParentId() {
+	public function testParentIdWhereArgsNonExplicit() {
 		$menu_location = 'my-menu-items-location';
 		register_nav_menu( $menu_location, 'My MenuItems' );
 		WPGraphQL::clear_schema();
@@ -498,6 +498,7 @@ class MenuItemConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 
 		$query = $this->getQuery();
 
+		// Test non with global id
 		$variables = [
 			'where' => [
 				'parentId' => '0',
@@ -512,25 +513,9 @@ class MenuItemConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 
 		// The fourth menu item has the expected number of child items.
 		$this->assertEquals( 3, count( $actual['data']['menuItems']['edges'][3]['node']['childItems']['edges'] ) );
-	}
 
-	public function testMenuItemsQueryWithChildItemsUsingDatabaseParentId() {
-		$menu_location = 'my-menu-items-location';
-		register_nav_menu( $menu_location, 'My MenuItems' );
-		WPGraphQL::clear_schema();
-
-		$created = $this->create_nested_menu( 3, $menu_location );
-
-		$query = $this->getQuery();
-
-		$variables = [
-			'where' => [
-				'parentDatabaseId' => 0,
-				'location'         => WPEnumType::get_safe_name( $menu_location ),
-			],
-		];
-
-		$actual = $this->graphql( compact( 'query', 'variables' ) );
+		// Test with database id
+		$variables['where']['parentId'] = 0;
 
 		// Perform some common assertions.
 		$this->compareResults( $created['menu_item_ids'], $created['post_ids'], $actual );
@@ -539,7 +524,8 @@ class MenuItemConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 		$this->assertEquals( 3, count( $actual['data']['menuItems']['edges'][3]['node']['childItems']['edges'] ) );
 	}
 
-	public function testMenuItemsQueryWithExplicitParentDatabaseId() {
+
+	public function testParentIdWhereArgsExplicit() {
 		$menu_location = 'my-menu-items-location';
 		register_nav_menu( $menu_location, 'My MenuItems' );
 		WPGraphQL::clear_schema();
@@ -549,11 +535,12 @@ class MenuItemConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 		$query = $this->getQuery();
 
 		// The nesting is added to the fourth item
-		$parent_database_id = $created['menu_item_ids'][3];
+		$parent_id = $created['menu_item_ids'][3];
 
+		// Test with database Id.
 		$variables = [
 			'where' => [
-				'parentDatabaseId' => $parent_database_id,
+				'parentId' => $parent_id,
 				'location'         => WPEnumType::get_safe_name( $menu_location ),
 			],
 		];
@@ -563,8 +550,17 @@ class MenuItemConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 		$this->assertEquals( 3, count( $actual['data']['menuItems']['edges'] ) );
 
 		// The parentDatabaseId matches with the requested parent database id
-		$this->assertEquals( $parent_database_id, $actual['data']['menuItems']['edges'][0]['node']['parentDatabaseId'] );
+		$this->assertEquals( $parent_id, $actual['data']['menuItems']['edges'][0]['node']['parentDatabaseId'] );
 
+		// Test with global ID
+		$variables['where']['parentId'] =  Relay::toGlobalId( 'post', $parent_id );
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertEquals( 3, count( $actual['data']['menuItems']['edges'] ) );
+
+		// The parentDatabaseId matches with the requested parent database id
+		$this->assertEquals( $parent_id, $actual['data']['menuItems']['edges'][0]['node']['parentDatabaseId'] );
 	}
 
 	public function testMenuItemsQueryWithExplicitParentId() {


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR allows Comment connection where args with a type ID to accept either global IDs or database IDs.

This PR replaces https://github.com/wp-graphql/wp-graphql/pull/2340 , and requires https://github.com/wp-graphql/wp-graphql/pull/2521 to be merged as a prerequisite.


Does this close any currently open issues?
------------------------------------------
Part of https://github.com/wp-graphql/wp-graphql/issues/998


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
The `testMenuItemsQueryWithChildItemsUsingDatabaseParentId` was removed, as it is covered by [`testMenuItemsOrder()`](https://github.com/justlevine/wp-graphql/blob/600f9f8fe0b0d3773206479517b42e823e085452/tests/wpunit/MenuItemConnectionQueriesTest.php#L632). Other tests were renamed to match their 'where' arg directly.


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 ( wsl2 + devilbox + php 8.0.19)

**WordPress Version:** 6.0.2
