### PR TITLE
feat: allow global/database IDs in Term connection where args ID inputs 

### DIFF
--- a/src/Connection/TermObjects.php
+++ b/src/Connection/TermObjects.php
@@ -243,6 +243,58 @@ class TermObjects {
 	public static function get_connection_args( $args = [] ) {
 		return array_merge(
 			[
+				'childless'           => [
+					'type'        => 'Boolean',
+					'description' => __( 'True to limit results to terms that have no children. This parameter has no effect on non-hierarchical taxonomies. Default false.', 'wp-graphql' ),
+				],
+				'childOf'             => [
+					'type'        => 'Int',
+					'description' => __( 'Term ID to retrieve child terms of. If multiple taxonomies are passed, $child_of is ignored. Default 0.', 'wp-graphql' ),
+				],
+				'cacheDomain'         => [
+					'type'        => 'String',
+					'description' => __( 'Unique cache key to be produced when this query is stored in an object cache. Default is \'core\'.', 'wp-graphql' ),
+				],
+				'descriptionLike'     => [
+					'type'        => 'String',
+					'description' => __( 'Retrieve terms where the description is LIKE the input value. Default empty.', 'wp-graphql' ),
+				],
+				'exclude'             => [ // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude
+					'type'        => [
+						'list_of' => 'ID',
+					],
+					'description' => __( 'Array of term ids to exclude. If $include is non-empty, $exclude is ignored. Default empty array.', 'wp-graphql' ),
+				],
+				'excludeTree'         => [
+					'type'        => [
+						'list_of' => 'ID',
+					],
+					'description' => __( 'Array of term ids to exclude along with all of their descendant terms. If $include is non-empty, $exclude_tree is ignored. Default empty array.', 'wp-graphql' ),
+				],
+				'hideEmpty'           => [
+					'type'        => 'Boolean',
+					'description' => __( 'Whether to hide terms not assigned to any posts. Accepts true or false. Default false', 'wp-graphql' ),
+				],
+				'hierarchical'        => [
+					'type'        => 'Boolean',
+					'description' => __( 'Whether to include terms that have non-empty descendants (even if $hide_empty is set to true). Default true.', 'wp-graphql' ),
+				],
+				'include'             => [
+					'type'        => [
+						'list_of' => 'ID',
+					],
+					'description' => __( 'Array of term ids to include. Default empty array.', 'wp-graphql' ),
+				],
+				'name'                => [
+					'type'        => [
+						'list_of' => 'String',
+					],
+					'description' => __( 'Array of names to return term(s) for. Default empty.', 'wp-graphql' ),
+				],
+				'nameLike'            => [
+					'type'        => 'String',
+					'description' => __( 'Retrieve terms where the name is LIKE the input value. Default empty.', 'wp-graphql' ),
+				],
 				'objectIds'           => [
 					'type'        => [
 						'list_of' => 'ID',
@@ -257,33 +309,17 @@ class TermObjects {
 					'type'        => 'OrderEnum',
 					'description' => __( 'Direction the connection should be ordered in', 'wp-graphql' ),
 				],
-				'hideEmpty'           => [
+				'padCounts'           => [
 					'type'        => 'Boolean',
-					'description' => __( 'Whether to hide terms not assigned to any posts. Accepts true or false. Default false', 'wp-graphql' ),
+					'description' => __( 'Whether to pad the quantity of a term\'s children in the quantity of each term\'s "count" object variable. Default false.', 'wp-graphql' ),
 				],
-				'include'             => [
-					'type'        => [
-						'list_of' => 'ID',
-					],
-					'description' => __( 'Array of term ids to include. Default empty array.', 'wp-graphql' ),
+				'parent'              => [
+					'type'        => 'Int',
+					'description' => __( 'Parent term ID to retrieve direct-child terms of. Default empty.', 'wp-graphql' ),
 				],
-				'exclude'             => [ // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude
-					'type'        => [
-						'list_of' => 'ID',
-					],
-					'description' => __( 'Array of term ids to exclude. If $include is non-empty, $exclude is ignored. Default empty array.', 'wp-graphql' ),
-				],
-				'excludeTree'         => [
-					'type'        => [
-						'list_of' => 'ID',
-					],
-					'description' => __( 'Array of term ids to exclude along with all of their descendant terms. If $include is non-empty, $exclude_tree is ignored. Default empty array.', 'wp-graphql' ),
-				],
-				'name'                => [
-					'type'        => [
-						'list_of' => 'String',
-					],
-					'description' => __( 'Array of names to return term(s) for. Default empty.', 'wp-graphql' ),
+				'search'              => [
+					'type'        => 'String',
+					'description' => __( 'Search criteria to match terms. Will be SQL-formatted with wildcards before and after. Default empty.', 'wp-graphql' ),
 				],
 				'slug'                => [
 					'type'        => [
@@ -296,42 +332,6 @@ class TermObjects {
 						'list_of' => 'ID',
 					],
 					'description' => __( 'Array of term taxonomy IDs, to match when querying terms.', 'wp-graphql' ),
-				],
-				'hierarchical'        => [
-					'type'        => 'Boolean',
-					'description' => __( 'Whether to include terms that have non-empty descendants (even if $hide_empty is set to true). Default true.', 'wp-graphql' ),
-				],
-				'search'              => [
-					'type'        => 'String',
-					'description' => __( 'Search criteria to match terms. Will be SQL-formatted with wildcards before and after. Default empty.', 'wp-graphql' ),
-				],
-				'nameLike'            => [
-					'type'        => 'String',
-					'description' => __( 'Retrieve terms where the name is LIKE the input value. Default empty.', 'wp-graphql' ),
-				],
-				'descriptionLike'     => [
-					'type'        => 'String',
-					'description' => __( 'Retrieve terms where the description is LIKE the input value. Default empty.', 'wp-graphql' ),
-				],
-				'padCounts'           => [
-					'type'        => 'Boolean',
-					'description' => __( 'Whether to pad the quantity of a term\'s children in the quantity of each term\'s "count" object variable. Default false.', 'wp-graphql' ),
-				],
-				'childOf'             => [
-					'type'        => 'Int',
-					'description' => __( 'Term ID to retrieve child terms of. If multiple taxonomies are passed, $child_of is ignored. Default 0.', 'wp-graphql' ),
-				],
-				'parent'              => [
-					'type'        => 'Int',
-					'description' => __( 'Parent term ID to retrieve direct-child terms of. Default empty.', 'wp-graphql' ),
-				],
-				'childless'           => [
-					'type'        => 'Boolean',
-					'description' => __( 'True to limit results to terms that have no children. This parameter has no effect on non-hierarchical taxonomies. Default false.', 'wp-graphql' ),
-				],
-				'cacheDomain'         => [
-					'type'        => 'String',
-					'description' => __( 'Unique cache key to be produced when this query is stored in an object cache. Default is \'core\'.', 'wp-graphql' ),
 				],
 				'updateTermMetaCache' => [
 					'type'        => 'Boolean',

--- a/src/Connection/TermObjects.php
+++ b/src/Connection/TermObjects.php
@@ -332,6 +332,13 @@ class TermObjects {
 						'list_of' => 'ID',
 					],
 					'description' => __( 'Array of term taxonomy IDs, to match when querying terms.', 'wp-graphql' ),
+					'deprecationReason' => __( 'Use `termTaxonomyId` instead', 'wp-graphql' ),
+				],
+				'termTaxonomyId'      => [
+					'type'        => [
+						'list_of' => 'ID',
+					],
+					'description' => __( 'Array of term taxonomy IDs, to match when querying terms.', 'wp-graphql' ),
 				],
 				'updateTermMetaCache' => [
 					'type'        => 'Boolean',

--- a/src/Connection/TermObjects.php
+++ b/src/Connection/TermObjects.php
@@ -328,10 +328,10 @@ class TermObjects {
 					'description' => __( 'Array of slugs to return term(s) for. Default empty.', 'wp-graphql' ),
 				],
 				'termTaxonomId'       => [
-					'type'        => [
+					'type'              => [
 						'list_of' => 'ID',
 					],
-					'description' => __( 'Array of term taxonomy IDs, to match when querying terms.', 'wp-graphql' ),
+					'description'       => __( 'Array of term taxonomy IDs, to match when querying terms.', 'wp-graphql' ),
 					'deprecationReason' => __( 'Use `termTaxonomyId` instead', 'wp-graphql' ),
 				],
 				'termTaxonomyId'      => [

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -143,11 +143,6 @@ abstract class AbstractConnectionResolver {
 		$this->source = $source;
 
 		/**
-		 * Set the args for the resolver
-		 */
-		$this->args = $args;
-
-		/**
 		 * Set the context of the resolver
 		 */
 		$this->context = $context;
@@ -161,6 +156,22 @@ abstract class AbstractConnectionResolver {
 		 * Get the loader for the Connection
 		 */
 		$this->loader = $this->getLoader();
+
+		/**
+		 * Set the args for the resolver
+		 */
+		$this->args = $args;
+
+		/**
+		 *
+		 * Filters the GraphQL args before they are used in get_query_args().
+		 *
+		 * @param array                      $args                The GraphQL args passed to the resolver.
+		 * @param AbstractConnectionResolver $connection_resolver Instance of the ConnectionResolver
+		 *
+		 * @since @todo
+		 */
+		$this->args = apply_filters( 'graphql_connection_args', $this->getArgs(), $this );
 
 		/**
 		 * Determine the query amount for the resolver.

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -171,7 +171,7 @@ abstract class AbstractConnectionResolver {
 		 *
 		 * @since @todo
 		 */
-		$this->args = apply_filters( 'graphql_connection_args', $this->getArgs(), $this );
+		$this->args = apply_filters( 'graphql_connection_args', $this->get_args(), $this );
 
 		/**
 		 * Determine the query amount for the resolver.
@@ -223,12 +223,28 @@ abstract class AbstractConnectionResolver {
 		return $this->context->get_loader( $name );
 	}
 
-	/**
+		/**
 	 * Returns the $args passed to the connection
+	 *
+	 * Deprecated in favor of $this->get_args();
+	 *
+	 * @deprecated @todo
 	 *
 	 * @return array
 	 */
 	public function getArgs(): array {
+		_deprecated_function( __FUNCTION__, '@todo', 'get_args' );
+		return $this->get_args();
+	}
+
+	/**
+	 * Returns the $args passed to the connection.
+	 *
+	 * Useful for modifying the $args before they are passed to $this->get_query_args().
+	 *
+	 * @return array
+	 */
+	public function get_args() {
 		return $this->args;
 	}
 

--- a/src/Data/Connection/TermObjectConnectionResolver.php
+++ b/src/Data/Connection/TermObjectConnectionResolver.php
@@ -298,7 +298,7 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 		 * Filters the GraphQL args before they are used in get_query_args().
 		 *
 		 * @param array                     $args                The GraphQL args passed to the resolver.
-		 * @param CommentConnectionResolver $connection_resolver Instance of the ConnectionResolver
+		 * @param TermObjectConnectionResolver $connection_resolver Instance of the ConnectionResolver
 		 *
 		 * @since @todo
 		 */

--- a/src/Data/Connection/TermObjectConnectionResolver.php
+++ b/src/Data/Connection/TermObjectConnectionResolver.php
@@ -302,10 +302,7 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 		 *
 		 * @since @todo
 		 */
-		$args = apply_filters( 'graphql_comment_connection_args', $args, $this );
-
-		return $args;
-
+		return apply_filters( 'graphql_term_object_connection_args', $args, $this );
 	}
 
 	/**

--- a/src/Data/Connection/TermObjectConnectionResolver.php
+++ b/src/Data/Connection/TermObjectConnectionResolver.php
@@ -209,6 +209,7 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 			'hideEmpty'           => 'hide_empty',
 			'excludeTree'         => 'exclude_tree',
 			'termTaxonomId'       => 'term_taxonomy_id',
+			'termTaxonomyId'      => 'term_taxonomy_id',
 			'nameLike'            => 'name__like',
 			'descriptionLike'     => 'description__like',
 			'padCounts'           => 'pad_counts',
@@ -219,6 +220,16 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 		];
 
 		$where_args = ! empty( $this->args['where'] ) ? $this->args['where'] : null;
+
+		// Deprecate usage of 'termTaxonomId'.
+		if ( ! empty( $where_args['termTaxonomId'] ) ) {
+			_deprecated_argument( 'where.termTaxonomId', '@todo', 'The `termTaxonomId` where arg is deprecated. Use `termTaxonomyId` instead.' );
+
+			// Only convert value if 'termTaxonomyId' isnt already set.
+			if ( empty( $where_args['termTaxonomyId'] ) ) {
+				$where_args['termTaxonomyId'] = $where_args['termTaxonomId'];
+			}
+		}
 
 		/**
 		 * Map and sanitize the input args to the WP_Term_Query compatible args


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR allows Term connection where args with a type ID to accept either global IDs or database IDs.

It also deprecates the `termTaxonomId` where arg, in favor of the correctly-spelled `termTaxonomyId`.

This PR replaces https://github.com/wp-graphql/wp-graphql/pull/2340 , and requires https://github.com/wp-graphql/wp-graphql/pull/2521 to be merged as a prerequisite.


Does this close any currently open issues?
------------------------------------------
Part of https://github.com/wp-graphql/wp-graphql/issues/998


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
Did not backfill tests for `cacheDomain`, `padCounts`, and `updateTermMetaCache`. I'm not entirely sure the effects of these nor how to test if the where arg has any effect on the query results.
No code has changed regarding the handling of those args, so they're not technically required for this PR to merge.

Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + PHP 8.0.19)

**WordPress Version:** 6.0.2
