### PR TITLE
feat: allow global/database IDs in Post connection where args ID inputs

### DIFF
--- a/src/Connection/PostObjects.php
+++ b/src/Connection/PostObjects.php
@@ -672,13 +672,13 @@ class PostObjects {
 					'type'        => [
 						'list_of' => 'String',
 					],
-					'description' => __( 'Array of tag slugs, used to display objects from one tag OR another', 'wp-graphql' ),
+					'description' => __( 'Array of tag slugs, used to display objects from one tag AND another', 'wp-graphql' ),
 				];
 				$fields['tagSlugIn']  = [
 					'type'        => [
 						'list_of' => 'String',
 					],
-					'description' => __( 'Array of tag slugs, used to exclude objects in specified tags', 'wp-graphql' ),
+					'description' => __( 'Array of tag slugs, used to include objects in ANY specified tags', 'wp-graphql' ),
 				];
 			}
 		} elseif ( $post_type_object instanceof WP_Taxonomy ) {

--- a/src/Connection/PostObjects.php
+++ b/src/Connection/PostObjects.php
@@ -401,13 +401,27 @@ class PostObjects {
 				'type'        => 'Int',
 				'description' => __( 'Specific database ID of the object', 'wp-graphql' ),
 			],
+			'in'          => [
+				'type'        => [
+					'list_of' => 'ID',
+				],
+				'description' => __( 'Array of IDs for the objects to retrieve', 'wp-graphql' ),
+			],
+			'notIn'       => [
+				'type'        => [
+					'list_of' => 'ID',
+				],
+				'description' => __( 'Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored', 'wp-graphql' ),
+			],
 			'name'        => [
 				'type'        => 'String',
 				'description' => __( 'Slug / post_name of the object', 'wp-graphql' ),
 			],
-			'title'       => [
-				'type'        => 'String',
-				'description' => __( 'Title of the object', 'wp-graphql' ),
+			'nameIn'      => [
+				'type'        => [
+					'list_of' => 'String',
+				],
+				'description' => __( 'Specify objects to retrieve. Use slugs', 'wp-graphql' ),
 			],
 			'parent'      => [
 				'type'        => 'ID',
@@ -425,23 +439,9 @@ class PostObjects {
 				],
 				'description' => __( 'Specify posts whose parent is not in an array', 'wp-graphql' ),
 			],
-			'in'          => [
-				'type'        => [
-					'list_of' => 'ID',
-				],
-				'description' => __( 'Array of IDs for the objects to retrieve', 'wp-graphql' ),
-			],
-			'notIn'       => [
-				'type'        => [
-					'list_of' => 'ID',
-				],
-				'description' => __( 'Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored', 'wp-graphql' ),
-			],
-			'nameIn'      => [
-				'type'        => [
-					'list_of' => 'String',
-				],
-				'description' => __( 'Specify objects to retrieve. Use slugs', 'wp-graphql' ),
+			'title'       => [
+				'type'        => 'String',
+				'description' => __( 'Title of the object', 'wp-graphql' ),
 			],
 
 			/**
@@ -478,10 +478,6 @@ class PostObjects {
 				'type'        => 'PostStatusEnum',
 				'description' => __( 'Show posts with a specific status.', 'wp-graphql' ),
 			],
-
-			/**
-			 * List of post status parameters
-			 */
 			'stati'       => [
 				'type'        => [
 					'list_of' => 'PostStatusEnum',
@@ -501,10 +497,22 @@ class PostObjects {
 				],
 				'description' => __( 'What paramater to use to order the objects by.', 'wp-graphql' ),
 			],
+
+			/**
+			 * Date parameters
+			 *
+			 * @see https://developer.wordpress.org/reference/classes/wp_query/#date-parameters
+			 */
 			'dateQuery'   => [
 				'type'        => 'DateQueryInput',
 				'description' => __( 'Filter the connection based on dates', 'wp-graphql' ),
 			],
+
+			/**
+			 * Mime type parameters
+			 *
+			 * @see https://developer.wordpress.org/reference/classes/wp_query/#mime-type-parameters
+			 */
 			'mimeType'    => [
 				'type'        => 'MimeTypeEnum',
 				'description' => __( 'Get objects with a specific mimeType property', 'wp-graphql' ),

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -143,11 +143,6 @@ abstract class AbstractConnectionResolver {
 		$this->source = $source;
 
 		/**
-		 * Set the args for the resolver
-		 */
-		$this->args = $args;
-
-		/**
 		 * Set the context of the resolver
 		 */
 		$this->context = $context;
@@ -161,6 +156,22 @@ abstract class AbstractConnectionResolver {
 		 * Get the loader for the Connection
 		 */
 		$this->loader = $this->getLoader();
+
+		/**
+		 * Set the args for the resolver
+		 */
+		$this->args = $args;
+
+		/**
+		 *
+		 * Filters the GraphQL args before they are used in get_query_args().
+		 *
+		 * @param array                      $args                The GraphQL args passed to the resolver.
+		 * @param AbstractConnectionResolver $connection_resolver Instance of the ConnectionResolver
+		 *
+		 * @since @todo
+		 */
+		$this->args = apply_filters( 'graphql_connection_args', $this->getArgs(), $this );
 
 		/**
 		 * Determine the query amount for the resolver.

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -171,7 +171,7 @@ abstract class AbstractConnectionResolver {
 		 *
 		 * @since @todo
 		 */
-		$this->args = apply_filters( 'graphql_connection_args', $this->getArgs(), $this );
+		$this->args = apply_filters( 'graphql_connection_args', $this->get_args(), $this );
 
 		/**
 		 * Determine the query amount for the resolver.
@@ -223,12 +223,28 @@ abstract class AbstractConnectionResolver {
 		return $this->context->get_loader( $name );
 	}
 
-	/**
+		/**
 	 * Returns the $args passed to the connection
+	 *
+	 * Deprecated in favor of $this->get_args();
+	 *
+	 * @deprecated @todo
 	 *
 	 * @return array
 	 */
 	public function getArgs(): array {
+		_deprecated_function( __FUNCTION__, '@todo', 'get_args' );
+		return $this->get_args();
+	}
+
+	/**
+	 * Returns the $args passed to the connection.
+	 *
+	 * Useful for modifying the $args before they are passed to $this->get_query_args().
+	 *
+	 * @return array
+	 */
+	public function get_args() {
 		return $this->args;
 	}
 

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -573,6 +573,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 					case 'authorNotIn':
 					case 'categoryIn':
 					case 'categoryNotIn':
+					case 'tagId':
 					case 'tagIn':
 					case 'tagNotIn':
 						if ( is_array( $input_value ) ) {

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -549,6 +549,58 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
+	 * Filters the GraphQL args before they are used in get_query_args().
+	 *
+	 * @return array
+	 */
+	public function get_args() {
+		$args = $this->args;
+
+		if ( ! empty( $args['where'] ) ) {
+			// Ensure all IDs are converted to database IDs.
+			foreach ( $args['where'] as $input_key => $input_value ) {
+				if ( empty( $input_value ) ) {
+					continue;
+				}
+
+				switch ( $input_key ) {
+					case 'in':
+					case 'notIn':
+					case 'parent':
+					case 'parentIn':
+					case 'parentNotIn':
+					case 'authorIn':
+					case 'authorNotIn':
+					case 'categoryIn':
+					case 'categoryNotIn':
+					case 'tagIn':
+					case 'tagNotIn':
+						if ( is_array( $input_value ) ) {
+							$args['where'][ $input_key ] = array_map( function ( $id ) {
+								return Utils::get_database_id_from_id( $id );
+							}, $input_value );
+							break;
+						}
+
+						$args['where'][ $input_key ] = Utils::get_database_id_from_id( $input_value );
+						break;
+				}
+			}
+		}
+
+		/**
+		 *
+		 * Filters the GraphQL args before they are used in get_query_args().
+		 *
+		 * @param array                        $args                The GraphQL args passed to the resolver.
+		 * @param PostObjectConnectionResolver $connection_resolver Instance of the ConnectionResolver
+		 *
+		 * @since @todo
+		 */
+		return apply_filters( 'graphql_post_object_connection_args', $args, $this );
+	}
+
+	/**
 	 * Determine whether or not the the offset is valid, i.e the post corresponding to the offset
 	 * exists. Offset is equivalent to post_id. So this function is equivalent to checking if the
 	 * post with the given ID exists.

--- a/tests/wpunit/PostObjectConnectionQueriesTest.php
+++ b/tests/wpunit/PostObjectConnectionQueriesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use GraphQLRelay\Relay;
+
 class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 	public $current_time;
 	public $current_date;
@@ -88,7 +90,7 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 	 *
 	 * @return array
 	 */
-	public function create_posts( $count = 20 ) {
+	public function create_posts( $count = 6 ) {
 
 		// Create posts
 		$created_posts = [];
@@ -123,7 +125,7 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 					cursor
 					node {
 						id
-						postId
+						databaseId
 						title
 						date
 						content
@@ -132,7 +134,7 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 				}
 				nodes {
 					id
-					postId
+					databaseId
 				}
 			}
 		}
@@ -292,6 +294,18 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 
 		$this->assertEquals( $post_args['post_title'], $this->getReturnField( $actual, 0, 'title' ) );
 
+		// Test with single status
+		$variables = [
+			'where' => [
+				'status' => 'PRIVATE',
+			]
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount( 1, $actual['data']['posts']['nodes'] );
+		$this->assertEquals( $post_id, $actual['data']['posts']['nodes'][0]['databaseId'] );
 	}
 
 	public function testPrivatePostsForCurrentUser() {
@@ -356,7 +370,7 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 			posts( where:{in:[\"{$parent_post}\"]}){
 				edges{
 					node{
-						postId
+						databaseId
 						id
 						title
 						content
@@ -364,7 +378,7 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 							edges {
 								node{
 									id
-									postId
+									databaseId
 									title
 									content
 								}
@@ -384,7 +398,7 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 		$this->assertNotEmpty( $actual['data']['posts']['edges'] );
 
 		if ( true === $show_revisions ) {
-			$this->assertEquals( $revision, $actual['data']['posts']['edges'][0]['node']['revisions']['edges'][0]['node']['postId'] );
+			$this->assertEquals( $revision, $actual['data']['posts']['edges'][0]['node']['revisions']['edges'][0]['node']['databaseId'] );
 		} else {
 			$this->assertEmpty( $actual['data']['posts']['edges'][0]['node']['revisions']['edges'] );
 		}
@@ -869,7 +883,7 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 		{
 			posts(first: 5) {
 				nodes {
-					postId
+					databaseId
 					author {
 						node {
 						userId
@@ -887,7 +901,7 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 		$this->assertArrayNotHasKey( 'errors', $actual );
 
 		// Verify that the ID of the first post matches the one we just created.
-		$this->assertEquals( $post_id, $actual['data']['posts']['nodes'][0]['postId'] );
+		$this->assertEquals( $post_id, $actual['data']['posts']['nodes'][0]['databaseId'] );
 
 		// Verify that the 'author' field is set to null, since the user ID is invalid.
 		$this->assertEquals( null, $actual['data']['posts']['nodes'][0]['author'] );
@@ -1036,7 +1050,368 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 		$this->assertFalse( $actual['data']['posts']['nodes'][1]['isSticky'] );
 	}
 
-	public function testHasPasswordWhereArgs() {
+	public function testWhereArgs() {
+		$query = $this->getQuery();
+
+		// test id
+		$variables = [
+			'where' => [
+				'id' => $this->created_post_ids[1],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(1, $actual['data']['posts']['nodes']);
+		$this->assertEquals( $this->created_post_ids[1], $actual['data']['posts']['nodes'][0]['databaseId'] );
+
+		// test in with global + db id
+		$global_id = Relay::toGlobalId( 'post', $this->created_post_ids[1] );
+
+		$variables = [
+			'where' => [
+				'in' => [ $global_id, $this->created_post_ids[2] ],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(2, $actual['data']['posts']['nodes']);
+
+		// test notIn with global + db id
+		$variables = [
+			'where' => [
+				'notIn' => [ $global_id, $this->created_post_ids[2] ],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(4, $actual['data']['posts']['nodes']);
+
+		// test name
+		$post_one_name = get_post_field( 'post_name', $this->created_post_ids[1] );
+
+		$variables = [
+			'where' => [
+				'name' => $post_one_name,
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(1, $actual['data']['posts']['nodes']);
+		$this->assertEquals( $this->created_post_ids[1], $actual['data']['posts']['nodes'][0]['databaseId'] );
+
+		// test nameIn
+		$post_two_name = get_post_field( 'post_name', $this->created_post_ids[2] );
+
+		$variables = [
+			'where' => [
+				'nameIn' => [ $post_one_name, $post_two_name ],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(2, $actual['data']['posts']['nodes']);
+
+		// test title
+		$title = get_post_field( 'post_title', $this->created_post_ids[1] );
+
+		$variables = [
+			'where' => [
+				'title' => $title,
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(1, $actual['data']['posts']['nodes']);
+		$this->assertEquals( $this->created_post_ids[1], $actual['data']['posts']['nodes'][0]['databaseId'] );
+	}
+
+	public function testAuthorWhereArgs() {
+		$author_one_id = $this->factory()->user->create( [
+			'role' => 'author',
+			'user_nicename' => 'author-one',
+		] );
+		$author_two_id = $this->factory()->user->create( [
+			'role' => 'author',
+			'user_nicename' => 'author-two',
+		] );
+
+		$post_one_id = $this->factory()->post->create( [
+			'post_author' => $author_one_id,
+			'post_status' => 'publish',
+		] );
+		$post_two_id = $this->factory()->post->create( [
+			'post_author' => $author_two_id,
+			'post_status' => 'publish',
+		] );
+
+		$query = $this->getQuery();
+
+		// test author
+		$variables = [
+			'where' => [
+				'author' => $author_one_id,
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(1, $actual['data']['posts']['nodes']);
+		$this->assertEquals( $post_one_id, $actual['data']['posts']['nodes'][0]['databaseId'] );
+
+		// test authorName
+		$variables = [
+			'where' => [
+				'authorName' => 'author-one',
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(1, $actual['data']['posts']['nodes']);
+		$this->assertEquals( $post_one_id, $actual['data']['posts']['nodes'][0]['databaseId'] );
+
+		// test authorIn with global + db id
+		$author_one_global_id = Relay::toGlobalId( 'user', $author_one_id );
+
+		$variables = [
+			'where' => [
+				'authorIn' => [ $author_one_global_id, $author_two_id ],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(2, $actual['data']['posts']['nodes']);
+
+		// test authorNotIn with global + db id
+		$variables = [
+			'where' => [
+				'authorNotIn' => [ $author_one_global_id, $author_two_id ],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(6, $actual['data']['posts']['nodes']);
+	}
+
+	public function testCategoryWhereArgs() {
+		$term_one_id = $this->factory()->term->create( [
+			'taxonomy' => 'category',
+			'name' => 'term-one',
+		] );
+		$term_two_id = $this->factory()->term->create( [
+			'taxonomy' => 'category',
+			'name' => 'term-two',
+		] );
+
+		wp_set_object_terms( $this->created_post_ids[1], [ $term_one_id ], 'category' );
+		wp_set_object_terms( $this->created_post_ids[2], [ $term_two_id ], 'category' );
+
+		$query = $this->getQuery();
+
+		// test categoryId
+		$variables = [
+			'where' => [
+				'categoryId' => $term_one_id,
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(1, $actual['data']['posts']['nodes']);
+		$this->assertEquals( $this->created_post_ids[1], $actual['data']['posts']['nodes'][0]['databaseId'] );
+
+		// test categoryName
+		$variables = [
+			'where' => [
+				'categoryName' => 'term-one',
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(1, $actual['data']['posts']['nodes']);
+		$this->assertEquals( $this->created_post_ids[1], $actual['data']['posts']['nodes'][0]['databaseId'] );
+
+		// test categoryIn with global + db id
+		$term_one_global_id = Relay::toGlobalId( 'term', $term_one_id );
+
+		$variables = [
+			'where' => [
+				'categoryIn' => [ $term_one_global_id, $term_two_id ],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(2, $actual['data']['posts']['nodes']);
+
+		// test categoryNotIn with global + db id
+		$variables = [
+			'where' => [
+				'categoryNotIn' => [ $term_one_global_id, $term_two_id ],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(4, $actual['data']['posts']['nodes']);
+	}
+
+	public function testContentTypesWhereArgs() {
+		$page_id = $this->factory()->post->create( [
+			'post_type' => 'page',
+			'post_status' => 'publish',
+		] );
+
+		$query ='
+		query contentNodesQuery($first:Int $last:Int $after:String $before:String $where:RootQueryToContentNodeConnectionWhereArgs ){
+			contentNodes( first:$first last:$last after:$after before:$before where:$where ) {
+				nodes {
+					id
+					databaseId
+				}
+			}
+		}
+		';
+
+		// test contentTypes
+		$variables = [
+			'where' => [
+				'contentTypes' => [ 'PAGE' ],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(1, $actual['data']['contentNodes']['nodes']);
+		$this->assertEquals( $page_id, $actual['data']['contentNodes']['nodes'][0]['databaseId'] );
+
+		// test contentTypes with post + page
+		$variables = [
+			'where' => [
+				'contentTypes' => [ 'POST', 'PAGE' ],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(7, $actual['data']['contentNodes']['nodes']);
+	}
+
+	public function testParentWhereArgs() {
+		$query = $this->getQuery();
+
+		$parent_one_id = $this->created_post_ids[1];
+		$parent_two_id = $this->created_post_ids[2];
+
+		$child_one_id = $this->factory()->post->create([
+			'post_type'    => 'post',
+			'post_status'  => 'publish',
+			'post_title'   => 'Child Post',
+			'post_content' => 'Child post content',
+			'post_author'  => $this->admin,
+			'post_parent'  => $parent_one_id,
+		]);
+
+		$child_two_id = $this->factory()->post->create([
+			'post_type'    => 'post',
+			'post_status'  => 'publish',
+			'post_title'   => 'Child Post',
+			'post_content' => 'Child post content',
+			'post_author'  => $this->admin,
+			'post_parent'  => $parent_two_id,
+		]);
+
+		// test Parent with for top-level posts
+		$variables = [
+			'where' => [
+				'parent' => 0,
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(6, $actual['data']['posts']['nodes']);
+
+		// test parent with database Id
+		$variables = [
+			'where' => [
+				'parent' => $parent_one_id,
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(1, $actual['data']['posts']['nodes']);
+		$this->assertEquals( $child_one_id, $actual['data']['posts']['nodes'][0]['databaseId'] );
+
+		// test parent with global Id
+		$parent_one_global_id = Relay::toGlobalId( 'post', $parent_one_id );
+
+		$variables = [
+			'where' => [
+				'parent' => $parent_one_global_id,
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(1, $actual['data']['posts']['nodes']);
+		$this->assertEquals( $child_one_id, $actual['data']['posts']['nodes'][0]['databaseId'] );
+
+		// test parentIn with global + db ID
+		$variables = [
+			'where' => [
+				'parentIn' => [ $parent_one_global_id, $parent_two_id ],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(2, $actual['data']['posts']['nodes']);
+
+		// test parentNotIn with global + db ID
+		$variables = [
+			'where' => [
+				'parentNotIn' => [ $parent_one_global_id, $parent_two_id ],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(6, $actual['data']['posts']['nodes']);
+	}
+
+	public function testPasswordWhereArgs() {
 		// Create a test post with a password
 		$this->createPostObject(
 			[
@@ -1058,6 +1433,8 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 
 		$query = $this->getQuery();
 
+		wp_set_current_user( $this->admin );
+
 		/**
 		 * GraphQL query posts that have a password
 		 */
@@ -1067,9 +1444,7 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 			],
 		];
 
-		wp_set_current_user( $this->admin );
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
-
 
 		$this->assertNotEmpty( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
@@ -1086,11 +1461,152 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 			 * Assert that all posts returned have a password, since we queried for
 			 * posts using "has_password => true"
 			 */
-			$password = get_post( $edge['node']['postId'] )->post_password;
+			$password = get_post( $edge['node']['databaseId'] )->post_password;
 			$this->assertNotEmpty( $password );
 
 		}
 
+		// Test with specific password
+		$variables = [
+			'where' => [
+				'password' => 'password',
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertNotEmpty( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+
+		$edges = $actual['data']['posts']['edges'];
+		$this->assertNotEmpty( $edges );
+
+		/**
+		 * Loop through all the returned posts
+		 */
+		foreach ( $edges as $edge ) {
+
+			/**
+			 * Assert that all posts returned have the correct password
+			 */
+			$password = get_post( $edge['node']['databaseId'] )->post_password;
+			$this->assertEquals( $password, 'password' );
+		}
+
+	}
+
+	public function testTagWhereArgs() {
+		$query = $this->getQuery();
+
+		$tag_one_id = $this->factory()->tag->create([
+			'name' => 'test',
+		]);
+		$tag_two_id = $this->factory()->tag->create([
+			'name' => 'test2',
+		]);
+
+		wp_set_object_terms( $this->created_post_ids[1], [ $tag_one_id ], 'post_tag' );
+		wp_set_object_terms( $this->created_post_ids[2], [ $tag_two_id ], 'post_tag' );
+
+		// test tag
+		$variables = [
+			'where' => [
+				'tag' => 'test',
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(1, $actual['data']['posts']['nodes']);
+		$this->assertEquals( $this->created_post_ids[1], $actual['data']['posts']['nodes'][0]['databaseId'] );
+
+		// test tagId with database Id
+		$variables = [
+			'where' => [
+				'tagId' => (string) $tag_one_id, // the input expects a type 'string'.
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(1, $actual['data']['posts']['nodes']);
+		$this->assertEquals( $this->created_post_ids[1], $actual['data']['posts']['nodes'][0]['databaseId'] );
+
+		// test tagId with global Id
+		$tag_one_global_id = \GraphQLRelay\Relay::toGlobalId( 'term', $tag_one_id );
+
+		$variables = [
+			'where' => [
+				'tagId' => $tag_one_global_id,
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(1, $actual['data']['posts']['nodes']);
+		$this->assertEquals( $this->created_post_ids[1], $actual['data']['posts']['nodes'][0]['databaseId'] );
+
+		// test tagIn with global + db id
+		$variables = [
+			'where' => [
+				'tagIn' => [ $tag_one_global_id, $tag_two_id ],
+			],
+		];
+
+		
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(2, $actual['data']['posts']['nodes']);
+
+		// test tagNotIn with global + db id
+		$variables = [
+			'where' => [
+				'tagNotIn' => [ $tag_one_global_id,  $tag_two_id ],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(4, $actual['data']['posts']['nodes']);
+
+		// test tagSlugAnd
+		$variables = [
+			'where' => [
+				'tagSlugAnd' => [ 'test', 'test2' ],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(0, $actual['data']['posts']['nodes']);
+
+		// add second tag to first post
+		wp_set_object_terms( $this->created_post_ids[1], [ $tag_one_id, $tag_two_id ], 'post_tag' );
+
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(1, $actual['data']['posts']['nodes']);
+		$this->assertEquals( $this->created_post_ids[1], $actual['data']['posts']['nodes'][0]['databaseId'] );
+
+		// test tagSlugIn
+		$variables = [
+			'where' => [
+				'tagSlugIn' => [ 'test', 'test2' ],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(2, $actual['data']['posts']['nodes']);
 	}
 
 }

--- a/tests/wpunit/PostObjectQueriesTest.php
+++ b/tests/wpunit/PostObjectQueriesTest.php
@@ -577,6 +577,63 @@ class PostObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase 
 		$this->assertEquals( $expected, $actual['data'] );
 	}
 
+	public function testPageWithChildren() {
+
+		$parent_id = $this->factory->post->create(
+			[
+				'post_type' => 'page',
+			]
+		);
+
+		$child_id = $this->factory->post->create(
+			[
+				'post_type'   => 'page',
+				'post_parent' => $parent_id,
+			]
+		);
+
+		$global_id       = \GraphQLRelay\Relay::toGlobalId( 'post', $parent_id );
+		$global_child_id = \GraphQLRelay\Relay::toGlobalId( 'post', $child_id );
+
+		$query = '
+		{
+			page( id: "' . $global_id . '" ) {
+				id
+				pageId
+				children {
+					edges {
+						node {
+								...on Page {
+								id
+								pageId
+							}
+						}
+					}
+				}
+			}
+		}
+		';
+
+		$actual = do_graphql_request( $query );
+
+		/**
+		 * Make sure the query didn't return any errors
+		 */
+		$this->assertArrayNotHasKey( 'errors', $actual );
+
+		$parent = $actual['data']['page'];
+		$child  = $parent['children']['edges'][0]['node'];
+
+		/**
+		 * Make sure the child and parent data matches what we expect
+		 */
+		$this->assertEquals( $global_id, $parent['id'] );
+		$this->assertEquals( $parent_id, $parent['pageId'] );
+		$this->assertEquals( $global_child_id, $child['id'] );
+		$this->assertEquals( $child_id, $child['pageId'] );
+
+	}
+
 	/**
 	 * testPostQueryWithTags
 	 *
@@ -1610,56 +1667,6 @@ class PostObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase 
 
 	}
 
-	/**
-	 * Test the scenario where a post is assigned to an author
-	 * who is not a user on the site. This could happen for instance,
-	 * if the user was deleted, but their posts were never trashed
-	 * or assigned to another user.
-	 */
-	public function testQueryPostsWithOrphanedAuthorDoesntThrowErrors() {
-		global $wpdb;
-
-		$highest_user_id     = (int) $wpdb->get_var( "SELECT ID FROM {$wpdb->users} ORDER BY ID DESC limit 0,1" );
-		$nonexistent_user_id = $highest_user_id + 1;
-
-		// Create a new post assigned to a nonexistent user ID.
-		$post_id = wp_insert_post( [
-			'post_title'   => 'Post assigned to a non-existent user',
-			'post_content' => 'Post assigned to a non-existent user',
-			'post_status'  => 'publish',
-			'post_author'  => $nonexistent_user_id,
-		] );
-
-		$query = '
-		{
-			posts(first: 5) {
-				nodes {
-					postId
-					author {
-						node {
-						userId
-						name
-						}
-					}
-				}
-			}
-		}
-		';
-
-		$actual = graphql( [ 'query' => $query ] );
-
-		$this->assertTrue( $post_id && ! is_wp_error( $post_id ) );
-		$this->assertArrayNotHasKey( 'errors', $actual );
-
-		// Verify that the ID of the first post matches the one we just created.
-		$this->assertEquals( $post_id, $actual['data']['posts']['nodes'][0]['postId'] );
-
-		// Verify that the 'author' field is set to null, since the user ID is invalid.
-		$this->assertEquals( null, $actual['data']['posts']['nodes'][0]['author'] );
-
-		wp_delete_post( $post_id, true );
-
-	}
 
 	/**
 	 * Tests to make sure the page set as the front page shows as the front page
@@ -1971,146 +1978,6 @@ class PostObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase 
 		$this->assertSame( $expected, $actual['data']['pageById'] );
 		$this->assertSame( $expected, $actual['data']['pageBypageId'] );
 
-	}
-
-	/**
-	 * @throws Exception
-	 */
-	public function testUriFieldAvailableForPublicQueries() {
-
-		/**
-		 * Create a password protected post
-		 * so that we can query for it and make sure the link and uri fields are exposed
-		 * to public requests.
-		 *
-		 * @see: https://github.com/wp-graphql/wp-graphql/issues/1338
-		 */
-		$post_id = $this->factory()->post->create([
-			'post_type'     => 'post',
-			'post_status'   => 'publish',
-			'post_password' => 'test',
-			'post_title'    => 'Post with password',
-			'post_content'  => 'Protected content',
-			'post_author'   => $this->admin,
-		]);
-
-		$query = '
-		query {
-			posts(first: 1, where: {status: PUBLISH}) {
-				nodes {
-					databaseId
-					uri
-					link
-				}
-			}
-		}
-		';
-
-		$actual = $this->graphql([
-			'query' => $query,
-		]);
-
-		$this->assertArrayNotHasKey( 'errors', $actual );
-		$this->assertEquals( $post_id, $actual['data']['posts']['nodes'][0]['databaseId'] );
-		$this->assertNotEmpty( $post_id, $actual['data']['posts']['nodes'][0]['uri'], 'Ensure the uri is not empty for public requests' );
-		$this->assertNotEmpty( $post_id, $actual['data']['posts']['nodes'][0]['link'], 'Ensure the link field is not empty for public requests' );
-
-	}
-
-	public function testQueryPasswordProtectedPost() {
-
-		$title   = 'Test Title for QueryPasswordProtectedPost' . uniqid();
-		$content = 'Test Content for QueryPasswordProtectedPost' . uniqid();
-
-		$this->factory()->post->create([
-			'post_type'     => 'post',
-			'post_status'   => 'publish',
-			'post_password' => 'publish',
-			'post_content'  => $content,
-			'post_title'    => $title,
-		]);
-
-		$query = '
-		{
-			posts {
-				nodes {
-					id
-					title
-					content
-				}
-			}
-		}
-		';
-
-		wp_set_current_user( 0 );
-
-		$actual = graphql([
-			'query' => $query,
-		]);
-
-		$this->assertArrayNotHasKey( 'errors', $actual );
-		$this->assertNull( $actual['data']['posts']['nodes'][0]['content'] );
-		// The content should be null for public users because no password was entered
-		$this->assertSame( $title, $actual['data']['posts']['nodes'][0]['title'] );
-
-		wp_set_current_user( $this->admin );
-
-		$actual = graphql([
-			'query' => $query,
-		]);
-
-		$this->assertArrayNotHasKey( 'errors', $actual );
-		// The content should be public for an admin
-		$this->assertSame( apply_filters( 'the_content', $content ), $actual['data']['posts']['nodes'][0]['content'] );
-		$this->assertSame( $title, $actual['data']['posts']['nodes'][0]['title'] );
-	}
-
-	public function testIsStickyFieldOnPost() {
-
-		$sticky_post_id = $this->factory()->post->create([
-			'post_type'    => 'post',
-			'post_status'  => 'publish',
-			'post_title'   => 'Sticky Post',
-			'post_content' => 'Sticky post content',
-			'post_author'  => $this->admin,
-		]);
-
-		$nonsticky_post_id = $this->factory()->post->create([
-			'post_type'    => 'post',
-			'post_status'  => 'publish',
-			'post_title'   => 'Non-sticky Post',
-			'post_content' => 'Non-sticky post content',
-			'post_author'  => $this->admin,
-		]);
-
-		update_option( 'sticky_posts', [ $sticky_post_id ] );
-
-		$query = '
-		query testStickyPost($ids: [ID]) {
-			posts(first: 2, where: { in: $ids }) {
-				nodes {
-					databaseId
-					uri
-					link
-					isSticky
-				}
-			}
-		}
-		';
-
-		$actual = $this->graphql([
-			'query'     => $query,
-			'variables' => [
-				'ids' => [
-					$sticky_post_id,
-					$nonsticky_post_id,
-				],
-			],
-		]);
-
-		$this->assertArrayNotHasKey( 'errors', $actual );
-		$this->assertTrue( $actual['data']['posts']['nodes'][0]['isSticky'] );
-		$this->assertFalse( $actual['data']['posts']['nodes'][1]['isSticky'] );
 	}
 
 	public function testQueryPostOfAnotherPostTypeReturnsNull() {


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR allows Term connection where args with a type ID to accept either global IDs or database IDs.

Additionally, the descriptions of `tagSlugAnd` and `tagSlugIn` have been updated to better convey what they actually do.

This PR replaces https://github.com/wp-graphql/wp-graphql/pull/2340 , and requires https://github.com/wp-graphql/wp-graphql/pull/2521 to be merged as a prerequisite.

Does this close any currently open issues?
------------------------------------------
Part of https://github.com/wp-graphql/wp-graphql/issues/998

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
- Some existing tests were shuffled around to different classes. Queries for multiple `posts`  are in `PostObjectConnectionQueriesTests` and for a singular `post` in `PostObjectQueriesTest`.
- I didn't backfill tests for `dateQuery` or `mimeType` - because I was running out of time and didnt want to :-P . They're not essential to this PR (and no code changes to those inputs have been made), and imo we shouldnt hold up merging this and closing #998 until I have a break from client work.


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + PHP 8.0.19)

**WordPress Version:** 6.0.2
