### PR TITLE
release: v1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 1.11.0
+
+## New Features
+
+- ([#2519](https://github.com/wp-graphql/wp-graphql/pull/2519)): Add new "QueryAnalyzer" class which tracks Types, Models and Nodes asked for and returned in a request and adds them to the response headers. 
+- ([#2519](https://github.com/wp-graphql/wp-graphql/pull/2519)): Add 2nd argument to `graphql()` function that will return the `Request` object instead executing and returning the response.
+- ([#2522](https://github.com/wp-graphql/wp-graphql/pull/2522)): Allow global/database IDs in Comment connection where args. Thanks @justlevine!
+- ([#2523](https://github.com/wp-graphql/wp-graphql/pull/2523)): Allow global/database IDs in MenuItem connection where args ID Inputs. Thanks @justlevine!
+- ([#2524](https://github.com/wp-graphql/wp-graphql/pull/2524)): Allow global/database IDs in Term connection where args ID Inputs. Thanks @justlevine!
+- ([#2525](https://github.com/wp-graphql/wp-graphql/pull/2525)): Allow global/database IDs in Post connection where args ID Inputs. Thanks @justlevine!
+
+## Chores / Bugfixes
+
+- ([#2521](https://github.com/wp-graphql/wp-graphql/pull/2521)): Refactor `$args` in AbstractConnectionResolver. Thanks @justlevine!
+- ([#2526](https://github.com/wp-graphql/wp-graphql/pull/2526)): Ensure tracked data in QueryAnalyzer is unique.
+
+
 ## 1.10.0
 
 ### Upgrading

--- a/access-functions.php
+++ b/access-functions.php
@@ -7,6 +7,7 @@
 
 use GraphQL\Type\Definition\Type;
 use WPGraphQL\Registry\TypeRegistry;
+use WPGraphQL\Request;
 use WPGraphQL\Router;
 
 /**
@@ -48,25 +49,31 @@ function graphql_format_type_name( $type_name ) {
 	if ( ! empty( $replace_type_name ) ) {
 		$type_name = $replace_type_name;
 	}
-	$type_name = ucfirst( $type_name );
-
-	return $type_name;
+	return ucfirst( $type_name );
 }
 
 
 /**
- * Provides a simple way to run a GraphQL query with out posting a request to the endpoint.
+ * Provides a simple way to run a GraphQL query without posting a request to the endpoint.
  *
- * @param array $request_data The GraphQL request data (query, variables, operation_name).
+ * @param array $request_data   The GraphQL request data (query, variables, operation_name).
+ * @param bool  $return_request If true, return the Request object, else return the results of the request execution
  *
- * @return array
+ * @return array | Request
  * @throws Exception
  * @since  0.2.0
  */
-function graphql( $request_data = [] ) {
-	$request = new \WPGraphQL\Request( $request_data );
+function graphql( array $request_data = [], bool $return_request = false ) {
+	$request = new Request( $request_data );
+
+	// allow calls to graphql() to return the full Request instead of
+	// just the results of the request execution
+	if ( true === $return_request ) {
+		return $request;
+	}
 
 	return $request->execute();
+
 }
 
 /**
@@ -76,18 +83,20 @@ function graphql( $request_data = [] ) {
  * @param string $query          The GraphQL query to run
  * @param string $operation_name The name of the operation
  * @param array  $variables      Variables to be passed to your GraphQL request
+ * @param bool   $return_requst If true, return the Request object, else return the results of the request execution
  *
- * @return array
- * @throws \Exception
+ * @return array | Request
+ * @throws Exception
  * @since  0.0.2
  */
-function do_graphql_request( $query, $operation_name = '', $variables = [] ) {
+function do_graphql_request( $query, $operation_name = '', $variables = [], $return_requst = false ) {
 	return graphql(
 		[
 			'query'          => $query,
 			'variables'      => $variables,
 			'operation_name' => $operation_name,
-		]
+		],
+		$return_requst
 	);
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, API, Gatsby, Headless, Decoupled, React, Nextjs, Vue, Apollo, RES
 Requires at least: 5.0
 Tested up to: 5.9.1
 Requires PHP: 7.1
-Stable tag: 1.10.0
+Stable tag: 1.11.0
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -168,6 +168,23 @@ The `uri` field was non-null on some Types in the Schema but has been changed to
 Composer dependencies are no longer versioned in Github. Recommended install source is WordPress.org or using Composer to get the code from Packagist.org or WPackagist.org.
 
 == Changelog ==
+
+= 1.11.0 =
+
+**New Features**
+
+- ([#2519](https://github.com/wp-graphql/wp-graphql/pull/2519)): Add new "QueryAnalyzer" class which tracks Types, Models and Nodes asked for and returned in a request and adds them to the response headers.
+- ([#2519](https://github.com/wp-graphql/wp-graphql/pull/2519)): Add 2nd argument to `graphql()` function that will return the `Request` object instead executing and returning the response.
+- ([#2522](https://github.com/wp-graphql/wp-graphql/pull/2522)): Allow global/database IDs in Comment connection where args. Thanks @justlevine!
+- ([#2523](https://github.com/wp-graphql/wp-graphql/pull/2523)): Allow global/database IDs in MenuItem connection where args ID Inputs. Thanks @justlevine!
+- ([#2524](https://github.com/wp-graphql/wp-graphql/pull/2524)): Allow global/database IDs in Term connection where args ID Inputs. Thanks @justlevine!
+- ([#2525](https://github.com/wp-graphql/wp-graphql/pull/2525)): Allow global/database IDs in Post connection where args ID Inputs. Thanks @justlevine!
+
+**Chores / Bugfixes**
+
+- ([#2521](https://github.com/wp-graphql/wp-graphql/pull/2521)): Refactor `$args` in AbstractConnectionResolver. Thanks @justlevine!
+- ([#2526](https://github.com/wp-graphql/wp-graphql/pull/2526)): Ensure tracked data in QueryAnalyzer is unique.
+
 
 = 1.10.0 =
 

--- a/src/Connection/Comments.php
+++ b/src/Connection/Comments.php
@@ -173,6 +173,74 @@ class Comments {
 				],
 				'description' => __( 'Array of IDs of users whose unapproved comments will be returned by the query regardless of status.', 'wp-graphql' ),
 			],
+			'commentType'        => [
+				'type'        => 'String',
+				'description' => __( 'Include comments of a given type.', 'wp-graphql' ),
+			],
+			'commentTypeIn'      => [
+				'type'        => [
+					'list_of' => 'String',
+				],
+				'description' => __( 'Include comments from a given array of comment types.', 'wp-graphql' ),
+			],
+			'commentTypeNotIn'   => [
+				'type'        => 'String',
+				'description' => __( 'Exclude comments from a given array of comment types.', 'wp-graphql' ),
+			],
+			'contentAuthor'      => [
+				'type'        => [
+					'list_of' => 'ID',
+				],
+				'description' => __( 'Content object author ID to limit results by.', 'wp-graphql' ),
+			],
+			'contentAuthorIn'    => [
+				'type'        => [
+					'list_of' => 'ID',
+				],
+				'description' => __( 'Array of author IDs to retrieve comments for.', 'wp-graphql' ),
+			],
+			'contentAuthorNotIn' => [
+				'type'        => [
+					'list_of' => 'ID',
+				],
+				'description' => __( 'Array of author IDs *not* to retrieve comments for.', 'wp-graphql' ),
+			],
+			'contentId'          => [
+				'type'        => 'ID',
+				'description' => __( 'Limit results to those affiliated with a given content object ID.', 'wp-graphql' ),
+			],
+			'contentIdIn'        => [
+				'type'        => [
+					'list_of' => 'ID',
+				],
+				'description' => __( 'Array of content object IDs to include affiliated comments for.', 'wp-graphql' ),
+			],
+			'contentIdNotIn'     => [
+				'type'        => [
+					'list_of' => 'ID',
+				],
+				'description' => __( 'Array of content object IDs to exclude affiliated comments for.', 'wp-graphql' ),
+			],
+			'contentStatus'      => [
+				'type'        => [
+					'list_of' => 'PostStatusEnum',
+				],
+				'description' => __( 'Array of content object statuses to retrieve affiliated comments for. Pass \'any\' to match any value.', 'wp-graphql' ),
+			],
+			'contentType'        => [
+				'type'        => [
+					'list_of' => 'ContentTypeEnum',
+				],
+				'description' => __( 'Content object type or array of types to retrieve affiliated comments for. Pass \'any\' to match any value.', 'wp-graphql' ),
+			],
+			'contentName'        => [
+				'type'        => 'String',
+				'description' => __( 'Content object name (i.e. slug ) to retrieve affiliated comments for.', 'wp-graphql' ),
+			],
+			'contentParent'      => [
+				'type'        => 'Int',
+				'description' => __( 'Content Object parent ID to retrieve affiliated comments for.', 'wp-graphql' ),
+			],
 			'includeUnapproved'  => [
 				'type'        => [
 					'list_of' => 'ID',
@@ -207,60 +275,6 @@ class Comments {
 				],
 				'description' => __( 'Array of parent IDs of comments *not* to retrieve children for.', 'wp-graphql' ),
 			],
-			'contentAuthorIn'    => [
-				'type'        => [
-					'list_of' => 'ID',
-				],
-				'description' => __( 'Array of author IDs to retrieve comments for.', 'wp-graphql' ),
-			],
-			'contentAuthorNotIn' => [
-				'type'        => [
-					'list_of' => 'ID',
-				],
-				'description' => __( 'Array of author IDs *not* to retrieve comments for.', 'wp-graphql' ),
-			],
-			'contentId'          => [
-				'type'        => 'ID',
-				'description' => __( 'Limit results to those affiliated with a given content object ID.', 'wp-graphql' ),
-			],
-			'contentIdIn'        => [
-				'type'        => [
-					'list_of' => 'ID',
-				],
-				'description' => __( 'Array of content object IDs to include affiliated comments for.', 'wp-graphql' ),
-			],
-			'contentIdNotIn'     => [
-				'type'        => [
-					'list_of' => 'ID',
-				],
-				'description' => __( 'Array of content object IDs to exclude affiliated comments for.', 'wp-graphql' ),
-			],
-			'contentAuthor'      => [
-				'type'        => [
-					'list_of' => 'ID',
-				],
-				'description' => __( 'Content object author ID to limit results by.', 'wp-graphql' ),
-			],
-			'contentStatus'      => [
-				'type'        => [
-					'list_of' => 'PostStatusEnum',
-				],
-				'description' => __( 'Array of content object statuses to retrieve affiliated comments for. Pass \'any\' to match any value.', 'wp-graphql' ),
-			],
-			'contentType'        => [
-				'type'        => [
-					'list_of' => 'ContentTypeEnum',
-				],
-				'description' => __( 'Content object type or array of types to retrieve affiliated comments for. Pass \'any\' to match any value.', 'wp-graphql' ),
-			],
-			'contentName'        => [
-				'type'        => 'String',
-				'description' => __( 'Content object name to retrieve affiliated comments for.', 'wp-graphql' ),
-			],
-			'contentParent'      => [
-				'type'        => 'Int',
-				'description' => __( 'Content Object parent ID to retrieve affiliated comments for.', 'wp-graphql' ),
-			],
 			'search'             => [
 				'type'        => 'String',
 				'description' => __( 'Search term(s) to retrieve matching comments for.', 'wp-graphql' ),
@@ -268,20 +282,6 @@ class Comments {
 			'status'             => [
 				'type'        => 'String',
 				'description' => __( 'Comment status to limit results by.', 'wp-graphql' ),
-			],
-			'commentType'        => [
-				'type'        => 'String',
-				'description' => __( 'Include comments of a given type.', 'wp-graphql' ),
-			],
-			'commentTypeIn'      => [
-				'type'        => [
-					'list_of' => 'String',
-				],
-				'description' => __( 'Include comments from a given array of comment types.', 'wp-graphql' ),
-			],
-			'commentTypeNotIn'   => [
-				'type'        => 'String',
-				'description' => __( 'Exclude comments from a given array of comment types.', 'wp-graphql' ),
 			],
 			'userId'             => [
 				'type'        => 'ID',

--- a/src/Connection/MenuItems.php
+++ b/src/Connection/MenuItems.php
@@ -104,6 +104,10 @@ class MenuItems {
 						'type'        => 'Int',
 						'description' => __( 'The database ID of the object', 'wp-graphql' ),
 					],
+					'location'         => [
+						'type'        => 'MenuLocationEnum',
+						'description' => __( 'The menu location for the menu being queried', 'wp-graphql' ),
+					],
 					'parentId'         => [
 						'type'        => 'ID',
 						'description' => __( 'The ID of the parent menu object', 'wp-graphql' ),
@@ -111,10 +115,6 @@ class MenuItems {
 					'parentDatabaseId' => [
 						'type'        => 'Int',
 						'description' => __( 'The database ID of the parent menu object', 'wp-graphql' ),
-					],
-					'location'         => [
-						'type'        => 'MenuLocationEnum',
-						'description' => __( 'The menu location for the menu being queried', 'wp-graphql' ),
 					],
 				],
 				'resolve'        => function ( $source, $args, $context, $info ) {

--- a/src/Connection/PostObjects.php
+++ b/src/Connection/PostObjects.php
@@ -401,13 +401,27 @@ class PostObjects {
 				'type'        => 'Int',
 				'description' => __( 'Specific database ID of the object', 'wp-graphql' ),
 			],
+			'in'          => [
+				'type'        => [
+					'list_of' => 'ID',
+				],
+				'description' => __( 'Array of IDs for the objects to retrieve', 'wp-graphql' ),
+			],
+			'notIn'       => [
+				'type'        => [
+					'list_of' => 'ID',
+				],
+				'description' => __( 'Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored', 'wp-graphql' ),
+			],
 			'name'        => [
 				'type'        => 'String',
 				'description' => __( 'Slug / post_name of the object', 'wp-graphql' ),
 			],
-			'title'       => [
-				'type'        => 'String',
-				'description' => __( 'Title of the object', 'wp-graphql' ),
+			'nameIn'      => [
+				'type'        => [
+					'list_of' => 'String',
+				],
+				'description' => __( 'Specify objects to retrieve. Use slugs', 'wp-graphql' ),
 			],
 			'parent'      => [
 				'type'        => 'ID',
@@ -425,23 +439,9 @@ class PostObjects {
 				],
 				'description' => __( 'Specify posts whose parent is not in an array', 'wp-graphql' ),
 			],
-			'in'          => [
-				'type'        => [
-					'list_of' => 'ID',
-				],
-				'description' => __( 'Array of IDs for the objects to retrieve', 'wp-graphql' ),
-			],
-			'notIn'       => [
-				'type'        => [
-					'list_of' => 'ID',
-				],
-				'description' => __( 'Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored', 'wp-graphql' ),
-			],
-			'nameIn'      => [
-				'type'        => [
-					'list_of' => 'String',
-				],
-				'description' => __( 'Specify objects to retrieve. Use slugs', 'wp-graphql' ),
+			'title'       => [
+				'type'        => 'String',
+				'description' => __( 'Title of the object', 'wp-graphql' ),
 			],
 
 			/**
@@ -478,10 +478,6 @@ class PostObjects {
 				'type'        => 'PostStatusEnum',
 				'description' => __( 'Show posts with a specific status.', 'wp-graphql' ),
 			],
-
-			/**
-			 * List of post status parameters
-			 */
 			'stati'       => [
 				'type'        => [
 					'list_of' => 'PostStatusEnum',
@@ -501,10 +497,22 @@ class PostObjects {
 				],
 				'description' => __( 'What paramater to use to order the objects by.', 'wp-graphql' ),
 			],
+
+			/**
+			 * Date parameters
+			 *
+			 * @see https://developer.wordpress.org/reference/classes/wp_query/#date-parameters
+			 */
 			'dateQuery'   => [
 				'type'        => 'DateQueryInput',
 				'description' => __( 'Filter the connection based on dates', 'wp-graphql' ),
 			],
+
+			/**
+			 * Mime type parameters
+			 *
+			 * @see https://developer.wordpress.org/reference/classes/wp_query/#mime-type-parameters
+			 */
 			'mimeType'    => [
 				'type'        => 'MimeTypeEnum',
 				'description' => __( 'Get objects with a specific mimeType property', 'wp-graphql' ),
@@ -664,13 +672,13 @@ class PostObjects {
 					'type'        => [
 						'list_of' => 'String',
 					],
-					'description' => __( 'Array of tag slugs, used to display objects from one tag OR another', 'wp-graphql' ),
+					'description' => __( 'Array of tag slugs, used to display objects from one tag AND another', 'wp-graphql' ),
 				];
 				$fields['tagSlugIn']  = [
 					'type'        => [
 						'list_of' => 'String',
 					],
-					'description' => __( 'Array of tag slugs, used to exclude objects in specified tags', 'wp-graphql' ),
+					'description' => __( 'Array of tag slugs, used to include objects in ANY specified tags', 'wp-graphql' ),
 				];
 			}
 		} elseif ( $post_type_object instanceof WP_Taxonomy ) {

--- a/src/Connection/TermObjects.php
+++ b/src/Connection/TermObjects.php
@@ -243,6 +243,58 @@ class TermObjects {
 	public static function get_connection_args( $args = [] ) {
 		return array_merge(
 			[
+				'childless'           => [
+					'type'        => 'Boolean',
+					'description' => __( 'True to limit results to terms that have no children. This parameter has no effect on non-hierarchical taxonomies. Default false.', 'wp-graphql' ),
+				],
+				'childOf'             => [
+					'type'        => 'Int',
+					'description' => __( 'Term ID to retrieve child terms of. If multiple taxonomies are passed, $child_of is ignored. Default 0.', 'wp-graphql' ),
+				],
+				'cacheDomain'         => [
+					'type'        => 'String',
+					'description' => __( 'Unique cache key to be produced when this query is stored in an object cache. Default is \'core\'.', 'wp-graphql' ),
+				],
+				'descriptionLike'     => [
+					'type'        => 'String',
+					'description' => __( 'Retrieve terms where the description is LIKE the input value. Default empty.', 'wp-graphql' ),
+				],
+				'exclude'             => [ // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude
+					'type'        => [
+						'list_of' => 'ID',
+					],
+					'description' => __( 'Array of term ids to exclude. If $include is non-empty, $exclude is ignored. Default empty array.', 'wp-graphql' ),
+				],
+				'excludeTree'         => [
+					'type'        => [
+						'list_of' => 'ID',
+					],
+					'description' => __( 'Array of term ids to exclude along with all of their descendant terms. If $include is non-empty, $exclude_tree is ignored. Default empty array.', 'wp-graphql' ),
+				],
+				'hideEmpty'           => [
+					'type'        => 'Boolean',
+					'description' => __( 'Whether to hide terms not assigned to any posts. Accepts true or false. Default false', 'wp-graphql' ),
+				],
+				'hierarchical'        => [
+					'type'        => 'Boolean',
+					'description' => __( 'Whether to include terms that have non-empty descendants (even if $hide_empty is set to true). Default true.', 'wp-graphql' ),
+				],
+				'include'             => [
+					'type'        => [
+						'list_of' => 'ID',
+					],
+					'description' => __( 'Array of term ids to include. Default empty array.', 'wp-graphql' ),
+				],
+				'name'                => [
+					'type'        => [
+						'list_of' => 'String',
+					],
+					'description' => __( 'Array of names to return term(s) for. Default empty.', 'wp-graphql' ),
+				],
+				'nameLike'            => [
+					'type'        => 'String',
+					'description' => __( 'Retrieve terms where the name is LIKE the input value. Default empty.', 'wp-graphql' ),
+				],
 				'objectIds'           => [
 					'type'        => [
 						'list_of' => 'ID',
@@ -257,33 +309,17 @@ class TermObjects {
 					'type'        => 'OrderEnum',
 					'description' => __( 'Direction the connection should be ordered in', 'wp-graphql' ),
 				],
-				'hideEmpty'           => [
+				'padCounts'           => [
 					'type'        => 'Boolean',
-					'description' => __( 'Whether to hide terms not assigned to any posts. Accepts true or false. Default false', 'wp-graphql' ),
+					'description' => __( 'Whether to pad the quantity of a term\'s children in the quantity of each term\'s "count" object variable. Default false.', 'wp-graphql' ),
 				],
-				'include'             => [
-					'type'        => [
-						'list_of' => 'ID',
-					],
-					'description' => __( 'Array of term ids to include. Default empty array.', 'wp-graphql' ),
+				'parent'              => [
+					'type'        => 'Int',
+					'description' => __( 'Parent term ID to retrieve direct-child terms of. Default empty.', 'wp-graphql' ),
 				],
-				'exclude'             => [ // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude
-					'type'        => [
-						'list_of' => 'ID',
-					],
-					'description' => __( 'Array of term ids to exclude. If $include is non-empty, $exclude is ignored. Default empty array.', 'wp-graphql' ),
-				],
-				'excludeTree'         => [
-					'type'        => [
-						'list_of' => 'ID',
-					],
-					'description' => __( 'Array of term ids to exclude along with all of their descendant terms. If $include is non-empty, $exclude_tree is ignored. Default empty array.', 'wp-graphql' ),
-				],
-				'name'                => [
-					'type'        => [
-						'list_of' => 'String',
-					],
-					'description' => __( 'Array of names to return term(s) for. Default empty.', 'wp-graphql' ),
+				'search'              => [
+					'type'        => 'String',
+					'description' => __( 'Search criteria to match terms. Will be SQL-formatted with wildcards before and after. Default empty.', 'wp-graphql' ),
 				],
 				'slug'                => [
 					'type'        => [
@@ -292,46 +328,17 @@ class TermObjects {
 					'description' => __( 'Array of slugs to return term(s) for. Default empty.', 'wp-graphql' ),
 				],
 				'termTaxonomId'       => [
+					'type'              => [
+						'list_of' => 'ID',
+					],
+					'description'       => __( 'Array of term taxonomy IDs, to match when querying terms.', 'wp-graphql' ),
+					'deprecationReason' => __( 'Use `termTaxonomyId` instead', 'wp-graphql' ),
+				],
+				'termTaxonomyId'      => [
 					'type'        => [
 						'list_of' => 'ID',
 					],
 					'description' => __( 'Array of term taxonomy IDs, to match when querying terms.', 'wp-graphql' ),
-				],
-				'hierarchical'        => [
-					'type'        => 'Boolean',
-					'description' => __( 'Whether to include terms that have non-empty descendants (even if $hide_empty is set to true). Default true.', 'wp-graphql' ),
-				],
-				'search'              => [
-					'type'        => 'String',
-					'description' => __( 'Search criteria to match terms. Will be SQL-formatted with wildcards before and after. Default empty.', 'wp-graphql' ),
-				],
-				'nameLike'            => [
-					'type'        => 'String',
-					'description' => __( 'Retrieve terms where the name is LIKE the input value. Default empty.', 'wp-graphql' ),
-				],
-				'descriptionLike'     => [
-					'type'        => 'String',
-					'description' => __( 'Retrieve terms where the description is LIKE the input value. Default empty.', 'wp-graphql' ),
-				],
-				'padCounts'           => [
-					'type'        => 'Boolean',
-					'description' => __( 'Whether to pad the quantity of a term\'s children in the quantity of each term\'s "count" object variable. Default false.', 'wp-graphql' ),
-				],
-				'childOf'             => [
-					'type'        => 'Int',
-					'description' => __( 'Term ID to retrieve child terms of. If multiple taxonomies are passed, $child_of is ignored. Default 0.', 'wp-graphql' ),
-				],
-				'parent'              => [
-					'type'        => 'Int',
-					'description' => __( 'Parent term ID to retrieve direct-child terms of. Default empty.', 'wp-graphql' ),
-				],
-				'childless'           => [
-					'type'        => 'Boolean',
-					'description' => __( 'True to limit results to terms that have no children. This parameter has no effect on non-hierarchical taxonomies. Default false.', 'wp-graphql' ),
-				],
-				'cacheDomain'         => [
-					'type'        => 'String',
-					'description' => __( 'Unique cache key to be produced when this query is stored in an object cache. Default is \'core\'.', 'wp-graphql' ),
 				],
 				'updateTermMetaCache' => [
 					'type'        => 'Boolean',

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -143,11 +143,6 @@ abstract class AbstractConnectionResolver {
 		$this->source = $source;
 
 		/**
-		 * Set the args for the resolver
-		 */
-		$this->args = $args;
-
-		/**
 		 * Set the context of the resolver
 		 */
 		$this->context = $context;
@@ -161,6 +156,22 @@ abstract class AbstractConnectionResolver {
 		 * Get the loader for the Connection
 		 */
 		$this->loader = $this->getLoader();
+
+		/**
+		 * Set the args for the resolver
+		 */
+		$this->args = $args;
+
+		/**
+		 *
+		 * Filters the GraphQL args before they are used in get_query_args().
+		 *
+		 * @param array                      $args                The GraphQL args passed to the resolver.
+		 * @param AbstractConnectionResolver $connection_resolver Instance of the ConnectionResolver
+		 *
+		 * @since @todo
+		 */
+		$this->args = apply_filters( 'graphql_connection_args', $this->get_args(), $this );
 
 		/**
 		 * Determine the query amount for the resolver.
@@ -212,12 +223,28 @@ abstract class AbstractConnectionResolver {
 		return $this->context->get_loader( $name );
 	}
 
-	/**
+		/**
 	 * Returns the $args passed to the connection
+	 *
+	 * Deprecated in favor of $this->get_args();
+	 *
+	 * @deprecated @todo
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public function getArgs(): array {
+		_deprecated_function( __FUNCTION__, '@todo', 'get_args' );
+		return $this->get_args();
+	}
+
+	/**
+	 * Returns the $args passed to the connection.
+	 *
+	 * Useful for modifying the $args before they are passed to $this->get_query_args().
 	 *
 	 * @return array
 	 */
-	public function getArgs(): array {
+	public function get_args() {
 		return $this->args;
 	}
 
@@ -254,9 +281,13 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * @return AbstractConnectionResolver
 	 *
-	 * @deprecated in favor of set_query_arg
+	 * @deprecated 0.3.0
+	 *
+	 * @codeCoverageIgnore
 	 */
 	public function setQueryArg( $key, $value ) {
+		_deprecated_function( __FUNCTION__, '0.3.0', 'set_query_arg' );
+
 		return $this->set_query_arg( $key, $value );
 	}
 
@@ -584,6 +615,8 @@ abstract class AbstractConnectionResolver {
 	 * GraphQL query.
 	 *
 	 * @deprecated 1.9.0
+	 *
+	 * @codeCoverageIgnore
 	 *
 	 * @return int|mixed
 	 */

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -169,7 +169,7 @@ abstract class AbstractConnectionResolver {
 		 * @param array                      $args                The GraphQL args passed to the resolver.
 		 * @param AbstractConnectionResolver $connection_resolver Instance of the ConnectionResolver
 		 *
-		 * @since @todo
+		 * @since 1.11.0
 		 */
 		$this->args = apply_filters( 'graphql_connection_args', $this->get_args(), $this );
 
@@ -223,17 +223,15 @@ abstract class AbstractConnectionResolver {
 		return $this->context->get_loader( $name );
 	}
 
-		/**
+	/**
 	 * Returns the $args passed to the connection
 	 *
-	 * Deprecated in favor of $this->get_args();
-	 *
-	 * @deprecated @todo
+	 * @deprecated Deprecated since v1.11.0 in favor of $this->get_args();
 	 *
 	 * @codeCoverageIgnore
 	 */
 	public function getArgs(): array {
-		_deprecated_function( __FUNCTION__, '@todo', 'get_args' );
+		_deprecated_function( __FUNCTION__, '1.11.0', 'get_args' );
 		return $this->get_args();
 	}
 
@@ -244,7 +242,7 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * @return array
 	 */
-	public function get_args() {
+	public function get_args(): array {
 		return $this->args;
 	}
 

--- a/src/Data/Connection/CommentConnectionResolver.php
+++ b/src/Data/Connection/CommentConnectionResolver.php
@@ -203,7 +203,7 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 	 *
 	 * @return array
 	 */
-	public function get_args() {
+	public function get_args(): array {
 		$args = $this->args;
 
 		if ( ! empty( $args['where'] ) ) {
@@ -258,7 +258,7 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 		 * @param array                     $args                The GraphQL args passed to the resolver.
 		 * @param CommentConnectionResolver $connection_resolver Instance of the ConnectionResolver
 		 *
-		 * @since @todo
+		 * @since 1.11.0
 		 */
 		return apply_filters( 'graphql_comment_connection_args', $args, $this );
 	}

--- a/src/Data/Connection/CommentConnectionResolver.php
+++ b/src/Data/Connection/CommentConnectionResolver.php
@@ -197,6 +197,72 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 		return true;
 	}
 
+
+	/**
+	 * Filters the GraphQL args before they are used in get_query_args().
+	 *
+	 * @return array
+	 */
+	public function get_args() {
+		$args = $this->args;
+
+		if ( ! empty( $args['where'] ) ) {
+			// Ensure all IDs are converted to database IDs.
+			foreach ( $args['where'] as $input_key => $input_value ) {
+				if ( empty( $input_value ) ) {
+					continue;
+				}
+
+				switch ( $input_key ) {
+					case 'authorIn':
+					case 'authorNotIn':
+					case 'commentIn':
+					case 'commentNotIn':
+					case 'parentIn':
+					case 'parentNotIn':
+					case 'contentAuthorIn':
+					case 'contentAuthorNotIn':
+					case 'contentId':
+					case 'contentIdIn':
+					case 'contentIdNotIn':
+					case 'contentAuthor':
+					case 'userId':
+						if ( is_array( $input_value ) ) {
+							$args['where'][ $input_key ] = array_map( function ( $id ) {
+								return Utils::get_database_id_from_id( $id );
+							}, $input_value );
+							break;
+						}
+						$args['where'][ $input_key ] = Utils::get_database_id_from_id( $input_value );
+						break;
+					case 'includeUnapproved':
+						if ( is_string( $input_value ) ) {
+							$input_value = [ $input_value ];
+						}
+						$args['where'][ $input_key ] = array_map( function ( $id ) {
+							if ( is_email( $id ) ) {
+								return $id;
+							}
+
+							return Utils::get_database_id_from_id( $id );
+						}, $input_value );
+						break;
+				}
+			}
+		}
+
+		/**
+		 *
+		 * Filters the GraphQL args before they are used in get_query_args().
+		 *
+		 * @param array                     $args                The GraphQL args passed to the resolver.
+		 * @param CommentConnectionResolver $connection_resolver Instance of the ConnectionResolver
+		 *
+		 * @since @todo
+		 */
+		return apply_filters( 'graphql_comment_connection_args', $args, $this );
+	}
+
 	/**
 	 * This sets up the "allowed" args, and translates the GraphQL-friendly keys to
 	 * WP_Comment_Query friendly keys.

--- a/src/Data/Connection/MenuItemConnectionResolver.php
+++ b/src/Data/Connection/MenuItemConnectionResolver.php
@@ -51,7 +51,7 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 		}
 
 		if ( ! empty( $this->args['where']['parentId'] ) ) {
-			
+
 				$query_args['meta_key']   = '_menu_item_menu_item_parent'; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 				$query_args['meta_value'] = $this->args['where']['parentId']; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 		}
@@ -97,7 +97,7 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 	 *
 	 * @return array
 	 */
-	public function get_args() {
+	public function get_args(): array {
 		$args = $this->args;
 
 		if ( ! empty( $args['where'] ) ) {
@@ -121,7 +121,7 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 		 *
 		 * @param array $args The GraphQL args passed to the resolver.
 		 *
-		 * @since @todo
+		 * @since 1.11.0
 		 */
 		return apply_filters( 'graphql_menu_item_connection_args', $args );
 	}

--- a/src/Data/Connection/MenuItemConnectionResolver.php
+++ b/src/Data/Connection/MenuItemConnectionResolver.php
@@ -5,6 +5,7 @@ use Exception;
 use GraphQLRelay\Relay;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
+use WPGraphQL\Utils\Utils;
 
 /**
  * Class MenuItemConnectionResolver
@@ -49,12 +50,10 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 			$query_args['meta_value'] = (int) $this->args['where']['parentDatabaseId']; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 		}
 
-		if ( isset( $this->args['where']['parentId'] ) ) {
-			$id_parts = Relay::fromGlobalId( $this->args['where']['parentId'] );
-			if ( isset( $id_parts['id'] ) ) {
+		if ( ! empty( $this->args['where']['parentId'] ) ) {
+			
 				$query_args['meta_key']   = '_menu_item_menu_item_parent'; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-				$query_args['meta_value'] = (int) $id_parts['id']; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
-			}
+				$query_args['meta_value'] = $this->args['where']['parentId']; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 		}
 
 		// Get unique list of locations as the default limitation of
@@ -91,6 +90,40 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 		}
 
 		return $query_args;
+	}
+
+	/**
+	 * Filters the GraphQL args before they are used in get_query_args().
+	 *
+	 * @return array
+	 */
+	public function get_args() {
+		$args = $this->args;
+
+		if ( ! empty( $args['where'] ) ) {
+			// Ensure all IDs are converted to database IDs.
+			foreach ( $args['where'] as $input_key => $input_value ) {
+				if ( empty( $input_value ) ) {
+					continue;
+				}
+
+				switch ( $input_key ) {
+					case 'parentId':
+						$args['where'][ $input_key ] = Utils::get_database_id_from_id( $input_value );
+						break;
+				}
+			}
+		}
+
+		/**
+		 *
+		 * Filters the GraphQL args before they are used in get_query_args().
+		 *
+		 * @param array $args The GraphQL args passed to the resolver.
+		 *
+		 * @since @todo
+		 */
+		return apply_filters( 'graphql_menu_item_connection_args', $args );
 	}
 
 }

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -553,7 +553,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	 *
 	 * @return array
 	 */
-	public function get_args() {
+	public function get_args(): array {
 		$args = $this->args;
 
 		if ( ! empty( $args['where'] ) ) {
@@ -596,7 +596,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		 * @param array                        $args                The GraphQL args passed to the resolver.
 		 * @param PostObjectConnectionResolver $connection_resolver Instance of the ConnectionResolver
 		 *
-		 * @since @todo
+		 * @since 1.11.0
 		 */
 		return apply_filters( 'graphql_post_object_connection_args', $args, $this );
 	}

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -549,6 +549,59 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
+	 * Filters the GraphQL args before they are used in get_query_args().
+	 *
+	 * @return array
+	 */
+	public function get_args() {
+		$args = $this->args;
+
+		if ( ! empty( $args['where'] ) ) {
+			// Ensure all IDs are converted to database IDs.
+			foreach ( $args['where'] as $input_key => $input_value ) {
+				if ( empty( $input_value ) ) {
+					continue;
+				}
+
+				switch ( $input_key ) {
+					case 'in':
+					case 'notIn':
+					case 'parent':
+					case 'parentIn':
+					case 'parentNotIn':
+					case 'authorIn':
+					case 'authorNotIn':
+					case 'categoryIn':
+					case 'categoryNotIn':
+					case 'tagId':
+					case 'tagIn':
+					case 'tagNotIn':
+						if ( is_array( $input_value ) ) {
+							$args['where'][ $input_key ] = array_map( function ( $id ) {
+								return Utils::get_database_id_from_id( $id );
+							}, $input_value );
+							break;
+						}
+
+						$args['where'][ $input_key ] = Utils::get_database_id_from_id( $input_value );
+						break;
+				}
+			}
+		}
+
+		/**
+		 *
+		 * Filters the GraphQL args before they are used in get_query_args().
+		 *
+		 * @param array                        $args                The GraphQL args passed to the resolver.
+		 * @param PostObjectConnectionResolver $connection_resolver Instance of the ConnectionResolver
+		 *
+		 * @since @todo
+		 */
+		return apply_filters( 'graphql_post_object_connection_args', $args, $this );
+	}
+
+	/**
 	 * Determine whether or not the the offset is valid, i.e the post corresponding to the offset
 	 * exists. Offset is equivalent to post_id. So this function is equivalent to checking if the
 	 * post with the given ID exists.

--- a/src/Data/Connection/TermObjectConnectionResolver.php
+++ b/src/Data/Connection/TermObjectConnectionResolver.php
@@ -6,6 +6,7 @@ use Exception;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
 use WPGraphQL\Types;
+use WPGraphQL\Utils\Utils;
 
 /**
  * Class TermObjectConnectionResolver
@@ -209,6 +210,7 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 			'hideEmpty'           => 'hide_empty',
 			'excludeTree'         => 'exclude_tree',
 			'termTaxonomId'       => 'term_taxonomy_id',
+			'termTaxonomyId'      => 'term_taxonomy_id',
 			'nameLike'            => 'name__like',
 			'descriptionLike'     => 'description__like',
 			'padCounts'           => 'pad_counts',
@@ -219,6 +221,16 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 		];
 
 		$where_args = ! empty( $this->args['where'] ) ? $this->args['where'] : null;
+
+		// Deprecate usage of 'termTaxonomId'.
+		if ( ! empty( $where_args['termTaxonomId'] ) ) {
+			_deprecated_argument( 'where.termTaxonomId', '@todo', 'The `termTaxonomId` where arg is deprecated. Use `termTaxonomyId` instead.' );
+
+			// Only convert value if 'termTaxonomyId' isnt already set.
+			if ( empty( $where_args['termTaxonomyId'] ) ) {
+				$where_args['termTaxonomyId'] = $where_args['termTaxonomId'];
+			}
+		}
 
 		/**
 		 * Map and sanitize the input args to the WP_Term_Query compatible args
@@ -244,7 +256,53 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 		$query_args = apply_filters( 'graphql_map_input_fields_to_get_terms', $query_args, $where_args, $this->taxonomy, $this->source, $this->args, $this->context, $this->info );
 
 		return ! empty( $query_args ) && is_array( $query_args ) ? $query_args : [];
+	}
 
+	/**
+	 * Filters the GraphQL args before they are used in get_query_args().
+	 *
+	 * @return array
+	 */
+	public function get_args() {
+		$args = $this->args;
+
+		if ( ! empty( $args['where'] ) ) {
+			// Ensure all IDs are converted to database IDs.
+			foreach ( $args['where'] as $input_key => $input_value ) {
+				if ( empty( $input_value ) ) {
+					continue;
+				}
+
+				switch ( $input_key ) {
+					case 'exclude':
+					case 'excludeTree':
+					case 'include':
+					case 'objectIds':
+					case 'termTaxonomId':
+					case 'termTaxonomyId':
+						if ( is_array( $input_value ) ) {
+							$args['where'][ $input_key ] = array_map( function ( $id ) {
+								return Utils::get_database_id_from_id( $id );
+							}, $input_value );
+							break;
+						}
+
+						$args['where'][ $input_key ] = Utils::get_database_id_from_id( $input_value );
+						break;
+				}
+			}
+		}
+
+		/**
+		 *
+		 * Filters the GraphQL args before they are used in get_query_args().
+		 *
+		 * @param array                     $args                The GraphQL args passed to the resolver.
+		 * @param TermObjectConnectionResolver $connection_resolver Instance of the ConnectionResolver
+		 *
+		 * @since @todo
+		 */
+		return apply_filters( 'graphql_term_object_connection_args', $args, $this );
 	}
 
 	/**
@@ -259,5 +317,4 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 	public function is_valid_offset( $offset ) {
 		return get_term( absint( $offset ) ) instanceof \WP_Term;
 	}
-
 }

--- a/src/Data/Connection/TermObjectConnectionResolver.php
+++ b/src/Data/Connection/TermObjectConnectionResolver.php
@@ -224,7 +224,7 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 
 		// Deprecate usage of 'termTaxonomId'.
 		if ( ! empty( $where_args['termTaxonomId'] ) ) {
-			_deprecated_argument( 'where.termTaxonomId', '@todo', 'The `termTaxonomId` where arg is deprecated. Use `termTaxonomyId` instead.' );
+			_deprecated_argument( 'where.termTaxonomId', '1.11.0', 'The `termTaxonomId` where arg is deprecated. Use `termTaxonomyId` instead.' );
 
 			// Only convert value if 'termTaxonomyId' isnt already set.
 			if ( empty( $where_args['termTaxonomyId'] ) ) {
@@ -263,7 +263,7 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 	 *
 	 * @return array
 	 */
-	public function get_args() {
+	public function get_args(): array {
 		$args = $this->args;
 
 		if ( ! empty( $args['where'] ) ) {
@@ -300,7 +300,7 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 		 * @param array                     $args                The GraphQL args passed to the resolver.
 		 * @param TermObjectConnectionResolver $connection_resolver Instance of the ConnectionResolver
 		 *
-		 * @since @todo
+		 * @since 1.11.0
 		 */
 		return apply_filters( 'graphql_term_object_connection_args', $args, $this );
 	}

--- a/src/Mutation/MediaItemUpdate.php
+++ b/src/Mutation/MediaItemUpdate.php
@@ -6,6 +6,7 @@ use Exception;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
+use WP_Post_Type;
 use WPGraphQL\AppContext;
 use WPGraphQL\Data\MediaItemMutation;
 use WPGraphQL\Utils\Utils;
@@ -34,7 +35,7 @@ class MediaItemUpdate {
 	 * @return array
 	 */
 	public static function get_input_fields() {
-		/** @var \WP_Post_Type $post_type_object */
+		/** @var WP_Post_Type $post_type_object */
 		$post_type_object = get_post_type_object( 'attachment' );
 		return array_merge(
 			MediaItemCreate::get_input_fields(),

--- a/src/Type/ObjectType/Avatar.php
+++ b/src/Type/ObjectType/Avatar.php
@@ -2,6 +2,8 @@
 
 namespace WPGraphQL\Type\ObjectType;
 
+use WPGraphQL\Model\Avatar as AvatarModel;
+
 class Avatar {
 
 	/**
@@ -14,6 +16,7 @@ class Avatar {
 			'Avatar',
 			[
 				'description' => __( 'Avatars are profile images for users. WordPress by default uses the Gravatar service to host and fetch avatars from.', 'wp-graphql' ),
+				'model'       => AvatarModel::class,
 				'fields'      => [
 					'size'         => [
 						'type'        => 'Int',

--- a/src/Type/ObjectType/Comment.php
+++ b/src/Type/ObjectType/Comment.php
@@ -4,6 +4,7 @@ namespace WPGraphQL\Type\ObjectType;
 
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
+use WPGraphQL\Model\Comment as CommentModel;
 
 /**
  * Class Comment
@@ -22,6 +23,7 @@ class Comment {
 			'Comment',
 			[
 				'description' => __( 'A Comment object', 'wp-graphql' ),
+				'model'       => CommentModel::class,
 				'interfaces'  => [ 'Node', 'DatabaseIdentifier' ],
 				'connections' => [
 					'author' => [

--- a/src/Type/ObjectType/CommentAuthor.php
+++ b/src/Type/ObjectType/CommentAuthor.php
@@ -2,6 +2,8 @@
 
 namespace WPGraphQL\Type\ObjectType;
 
+use \WPGraphQL\Model\CommentAuthor as CommentAuthorModel;
+
 class CommentAuthor {
 
 	/**
@@ -15,6 +17,7 @@ class CommentAuthor {
 			[
 				'description'     => __( 'A Comment Author object', 'wp-graphql' ),
 				'interfaces'      => [ 'Node', 'Commenter' ],
+				'model'           => CommentAuthorModel::class,
 				'eagerlyLoadType' => true,
 				'fields'          => [
 					'id'           => [

--- a/src/Type/ObjectType/ContentType.php
+++ b/src/Type/ObjectType/ContentType.php
@@ -2,6 +2,8 @@
 
 namespace WPGraphQL\Type\ObjectType;
 
+use WPGraphQL\Model\PostType;
+
 class ContentType {
 
 	/**
@@ -18,6 +20,7 @@ class ContentType {
 			[
 				'description' => __( 'An Post Type object', 'wp-graphql' ),
 				'interfaces'  => $interfaces,
+				'model'       => PostType::class,
 				'fields'      => [
 					'id'                  => [
 						'description' => __( 'The globally unique identifier of the post-type object.', 'wp-graphql' ),

--- a/src/Type/ObjectType/Menu.php
+++ b/src/Type/ObjectType/Menu.php
@@ -2,6 +2,8 @@
 
 namespace WPGraphQL\Type\ObjectType;
 
+use \WPGraphQL\Model\Menu as MenuModel;
+
 class Menu {
 
 	/**
@@ -15,6 +17,7 @@ class Menu {
 			[
 				'description' => __( 'Menus are the containers for navigation items. Menus can be assigned to menu locations, which are typically registered by the active theme.', 'wp-graphql' ),
 				'interfaces'  => [ 'Node', 'DatabaseIdentifier' ],
+				'model'       => MenuModel::class,
 				'fields'      => [
 					'id'           => [
 						'description' => __( 'The globally unique identifier of the nav menu object.', 'wp-graphql' ),

--- a/src/Type/ObjectType/MenuItem.php
+++ b/src/Type/ObjectType/MenuItem.php
@@ -22,6 +22,7 @@ class MenuItem {
 			[
 				'description' => __( 'Navigation menu items are the individual items assigned to a menu. These are rendered as the links in a navigation menu.', 'wp-graphql' ),
 				'interfaces'  => [ 'Node', 'DatabaseIdentifier' ],
+				'model'       => MenuItemModel::class,
 				'connections' => [
 					'connectedNode' => [
 						'toType'               => 'MenuItemLinkable',

--- a/src/Type/ObjectType/Plugin.php
+++ b/src/Type/ObjectType/Plugin.php
@@ -2,6 +2,8 @@
 
 namespace WPGraphQL\Type\ObjectType;
 
+use \WPGraphQL\Model\Plugin as PluginModel;
+
 /**
  * Class Plugin
  *
@@ -19,6 +21,7 @@ class Plugin {
 			'Plugin',
 			[
 				'interfaces'  => [ 'Node' ],
+				'model'       => PluginModel::class,
 				'description' => __( 'An plugin object', 'wp-graphql' ),
 				'fields'      => [
 					'id'           => [

--- a/src/Type/ObjectType/PostObject.php
+++ b/src/Type/ObjectType/PostObject.php
@@ -89,6 +89,7 @@ class PostObject {
 				'description' => sprintf( __( 'The %s type', 'wp-graphql' ), $single_name ),
 				'interfaces'  => $interfaces,
 				'fields'      => self::get_post_object_fields( $post_type_object, $type_registry ),
+				'model'       => Post::class,
 			]
 		);
 

--- a/src/Type/ObjectType/Taxonomy.php
+++ b/src/Type/ObjectType/Taxonomy.php
@@ -21,6 +21,7 @@ class Taxonomy {
 			[
 				'description' => __( 'A taxonomy object', 'wp-graphql' ),
 				'interfaces'  => [ 'Node' ],
+				'model'       => TaxonomyModel::class,
 				'connections' => [
 					'connectedContentTypes' => [
 						'toType'               => 'ContentType',

--- a/src/Type/ObjectType/TermObject.php
+++ b/src/Type/ObjectType/TermObject.php
@@ -41,6 +41,7 @@ class TermObject {
 			[
 				'description' => sprintf( __( 'The %s type', 'wp-graphql' ), $single_name ),
 				'interfaces'  => $interfaces,
+				'model'       => Term::class,
 				'fields'      => [
 					$single_name . 'Id' => [
 						'type'              => 'Int',

--- a/src/Type/ObjectType/Theme.php
+++ b/src/Type/ObjectType/Theme.php
@@ -2,6 +2,8 @@
 
 namespace WPGraphQL\Type\ObjectType;
 
+use WPGraphQL\Model\Theme as ThemeModel;
+
 /**
  * Class Theme
  *
@@ -20,6 +22,7 @@ class Theme {
 			[
 				'description' => __( 'A theme object', 'wp-graphql' ),
 				'interfaces'  => [ 'Node' ],
+				'model'       => ThemeModel::class,
 				'fields'      => [
 					'id'           => [
 						'description' => __( 'The globally unique identifier of the theme object.', 'wp-graphql' ),

--- a/src/Type/ObjectType/User.php
+++ b/src/Type/ObjectType/User.php
@@ -25,6 +25,7 @@ class User {
 			'User',
 			[
 				'description' => __( 'A User object', 'wp-graphql' ),
+				'model'       => UserModel::class,
 				'interfaces'  => [ 'Node', 'UniformResourceIdentifiable', 'Commenter', 'DatabaseIdentifier' ],
 				'connections' => [
 					'enqueuedScripts'     => [

--- a/src/Type/ObjectType/UserRole.php
+++ b/src/Type/ObjectType/UserRole.php
@@ -2,6 +2,8 @@
 
 namespace WPGraphQL\Type\ObjectType;
 
+use WPGraphQL\Model\UserRole as UserRoleModel;
+
 class UserRole {
 
 	/**
@@ -14,6 +16,7 @@ class UserRole {
 			'UserRole',
 			[
 				'description' => __( 'A user role object', 'wp-graphql' ),
+				'model'       => UserRoleModel::class,
 				'interfaces'  => [ 'Node' ],
 				'fields'      => [
 					'id'           => [

--- a/src/Type/WPUnionType.php
+++ b/src/Type/WPUnionType.php
@@ -70,11 +70,11 @@ class WPUnionType extends UnionType {
 		/**
 		 * Filter the possible_types to allow systems to add to the possible resolveTypes.
 		 *
-		 * @param array       $types         The possible types for the Union
+		 * @param mixed       $types         The possible types for the Union
 		 * @param array       $config        The config for the Union Type
 		 * @param WPUnionType $wp_union_type The WPUnionType instance
 		 *
-		 * @return array
+		 * @return mixed|array
 		 */
 		$config['types'] = apply_filters( 'graphql_union_possible_types', $config['types'], $config, $this );
 

--- a/src/Utils/QueryAnalyzer.php
+++ b/src/Utils/QueryAnalyzer.php
@@ -1,0 +1,505 @@
+<?php
+
+namespace WPGraphQL\Utils;
+
+use Exception;
+use GraphQL\Error\SyntaxError;
+use GraphQL\Language\Parser;
+use GraphQL\Language\Visitor;
+use GraphQL\Server\OperationParams;
+use GraphQL\Type\Definition\InterfaceType;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type;
+use GraphQL\Type\Schema;
+use GraphQL\Utils\TypeInfo;
+use WPGraphQL\Model\Model;
+use WPGraphQL\Request;
+
+/**
+ * This class is used to identify "keys" relevant to the GraphQL Request.
+ *
+ * These keys can be used to identify common patterns across documents.
+ *
+ * A common use case would be for caching a GraphQL request and tagging the cached
+ * object with these keys, then later using these keys to evict the cached
+ * document.
+ *
+ * These keys can also be used by loggers to identify patterns, etc.
+ */
+class QueryAnalyzer {
+
+	/**
+	 * @var Schema
+	 */
+	protected $schema;
+
+	/**
+	 * Types that are referenced in the query
+	 *
+	 * @var array
+	 */
+	protected $queried_types = [];
+
+	/**
+	 * @var string
+	 */
+	protected $root_operation = 'Query';
+
+	/**
+	 * Models that are referenced in the query
+	 *
+	 * @var array
+	 */
+	protected $models = [];
+
+	/**
+	 * Types in the query that are lists
+	 *
+	 * @var array
+	 */
+	protected $list_types = [];
+
+	/**
+	 * @var array
+	 */
+	protected $runtime_nodes = [];
+
+	/**
+	 * @var string
+	 */
+	protected $query_id;
+
+	/**
+	 * @var Request
+	 */
+	protected $request;
+
+	/**
+	 * @param Request $request The GraphQL request being executed
+	 */
+	public function __construct( Request $request ) {
+		$this->request       = $request;
+		$this->schema        = $request->schema;
+		$this->runtime_nodes = [];
+		$this->models        = [];
+		$this->list_types    = [];
+		$this->queried_types = [];
+	}
+
+	/**
+	 * @return Request
+	 */
+	public function get_request(): Request {
+		return $this->request;
+	}
+
+	/**
+	 * @return void
+	 */
+	public function init(): void {
+
+		// allow query analyzer functionality to be disabled
+		$should_analyze_queries = apply_filters( 'graphql_should_analyze_queries', true, $this );
+
+		// If query analyzer is disabled, bail
+		if ( true !== $should_analyze_queries ) {
+			return;
+		}
+
+		// track keys related to the query
+		add_action( 'do_graphql_request', [ $this, 'determine_graphql_keys' ], 10, 4 );
+
+		// Track models loaded during execution
+		add_filter( 'graphql_dataloader_get_model', [ $this, 'track_nodes' ], 10, 1 );
+
+	}
+
+	/**
+	 * Determine the keys associated with the GraphQL document being executed
+	 *
+	 * @param ?string         $query     The GraphQL query
+	 * @param ?string         $operation The name of the operation
+	 * @param ?array          $variables Variables to be passed to your GraphQL request
+	 * @param OperationParams $params    The Operation Params. This includes any extra params, such as extenions or any other modifications to the request body
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function determine_graphql_keys( ?string $query, ?string $operation, ?array $variables, OperationParams $params ): void {
+
+		// @todo: support for QueryID?
+
+		// if the query is empty, get it from the request params
+		if ( empty( $query ) ) {
+			$query = $this->request->params->query ?: null;
+		}
+
+		if ( empty( $query ) ) {
+			return;
+		}
+
+		$query_id       = Utils::get_query_id( $query );
+		$this->query_id = $query_id ?: uniqid( 'gql:', true );
+
+		// if there's a query (either saved or part of the request params)
+		// get the GraphQL Types being asked for by the query
+		$this->list_types    = $this->set_list_types( $this->schema, $query );
+		$this->queried_types = $this->set_query_types( $this->schema, $query );
+		$this->models        = $this->set_query_models( $this->schema, $query );
+
+		/**
+		 * @param QueryAnalyzer $query_analyzer The instance of the query analyzer
+		 * @param string $query The query string being executed
+		 */
+		do_action( 'graphql_determine_graphql_keys', $this, $query );
+
+	}
+
+	/**
+	 * @return array
+	 */
+	public function get_list_types(): array {
+		return array_unique( $this->list_types );
+	}
+
+	/**
+	 * @return array
+	 */
+	public function get_query_types(): array {
+		return array_unique( $this->queried_types );
+	}
+
+	/**
+	 * @return array
+	 */
+	public function get_query_models(): array {
+		return array_unique( $this->models );
+	}
+
+	/**
+	 * @return array
+	 */
+	public function get_runtime_nodes(): array {
+		return array_unique( $this->runtime_nodes );
+	}
+
+	/**
+	 * @return string
+	 */
+	public function get_root_operation(): string {
+		return $this->root_operation;
+	}
+
+	/**
+	 * @return string|null
+	 */
+	public function get_query_id(): ?string {
+		return $this->query_id;
+	}
+
+	/**
+	 * Given the Schema and a query string, return a list of GraphQL Types that are being asked for
+	 * by the query.
+	 *
+	 * @param ?Schema $schema The WPGraphQL Schema
+	 * @param ?string $query  The query string
+	 *
+	 * @return array
+	 * @throws SyntaxError|Exception
+	 */
+	public function set_list_types( ?Schema $schema, ?string $query ): array {
+
+		/**
+		 * @param array|null $null Default value for the filter
+		 * @param ?Schema $schema The WPGraphQL Schema for the current request
+		 * @param ?string $query The query string being requested
+		 */
+		$null               = null;
+		$pre_get_list_types = apply_filters( 'graphql_pre_query_analyzer_get_list_types', $null, $schema, $query );
+
+		if ( null !== $pre_get_list_types ) {
+			return $pre_get_list_types;
+		}
+
+		if ( empty( $query ) || null === $schema ) {
+			return [];
+		}
+
+		try {
+			$ast = Parser::parse( $query );
+		} catch ( SyntaxError $error ) {
+			return [];
+		}
+
+		$type_map  = [];
+		$type_info = new TypeInfo( $schema );
+
+		$visitor = [
+			'enter' => function ( $node, $key, $parent, $path, $ancestors ) use ( $type_info, &$type_map, $schema ) {
+
+				$type_info->enter( $node );
+				$type = $type_info->getType();
+
+				if ( ! $type ) {
+					return;
+				}
+
+				$named_type = Type::getNamedType( $type );
+
+				// determine if the field is returning a list of types
+				// or singular types
+				// @todo: this might still be too fragile. We might need to adjust for cases where we can have list_of( nonNull( type ) ), etc
+				$is_list_type = $named_type && ( Type::listOf( $named_type )->name === $type->name );
+
+				if ( $named_type instanceof InterfaceType ) {
+					$possible_types = $schema->getPossibleTypes( $named_type );
+					foreach ( $possible_types as $possible_type ) {
+						// if the type is a list, store it
+						if ( $is_list_type && 0 !== strpos( $possible_type, '__' ) ) {
+							$type_map[] = 'list:' . strtolower( $possible_type );
+						}
+					}
+				} elseif ( $named_type instanceof ObjectType ) {
+					// if the type is a list, store it
+					if ( $is_list_type && 0 !== strpos( $named_type, '__' ) ) {
+						$type_map[] = 'list:' . strtolower( $named_type );
+					}
+				}
+			},
+			'leave' => function ( $node, $key, $parent, $path, $ancestors ) use ( $type_info ) {
+				$type_info->leave( $node );
+			},
+		];
+
+		Visitor::visit( $ast, Visitor::visitWithTypeInfo( $type_info, $visitor ) );
+		$map = array_values( array_unique( array_filter( $type_map ) ) );
+
+		// @phpcs:ignore
+		return apply_filters( 'graphql_cache_collection_get_list_types', $map, $schema, $query, $type_info );
+	}
+
+	/**
+	 * Given the Schema and a query string, return a list of GraphQL Types that are being asked for
+	 * by the query.
+	 *
+	 * @param ?Schema $schema The WPGraphQL Schema
+	 * @param ?string $query  The query string
+	 *
+	 * @return array
+	 * @throws Exception
+	 */
+	public function set_query_types( ?Schema $schema, ?string $query ): array {
+
+		/**
+		 * @param array|null $null Default value for the filter
+		 * @param ?Schema $schema The WPGraphQL Schema for the current request
+		 * @param ?string $query The query string being requested
+		 */
+		$null                = null;
+		$pre_get_query_types = apply_filters( 'graphql_pre_query_analyzer_get_query_types', $null, $schema, $query );
+
+		if ( null !== $pre_get_query_types ) {
+			return $pre_get_query_types;
+		}
+
+		if ( empty( $query ) || null === $schema ) {
+			return [];
+		}
+		try {
+			$ast = Parser::parse( $query );
+		} catch ( SyntaxError $error ) {
+			return [];
+		}
+		$type_map  = [];
+		$type_info = new TypeInfo( $schema );
+		$visitor   = [
+			'enter' => function ( $node, $key, $parent, $path, $ancestors ) use ( $type_info, &$type_map, $schema ) {
+				$type_info->enter( $node );
+				$type = $type_info->getType();
+				if ( ! $type ) {
+					return;
+				}
+
+				if ( empty( $this->root_operation ) ) {
+
+					if ( $type === $schema->getQueryType() ) {
+						$this->root_operation = 'Query';
+					}
+
+					if ( $type === $schema->getMutationType() ) {
+						$this->root_operation = 'Mutation';
+					}
+
+					if ( $type === $schema->getSubscriptionType() ) {
+						$this->root_operation = 'Subscription';
+					}
+				}
+
+				$named_type = Type::getNamedType( $type );
+
+				if ( $named_type instanceof InterfaceType ) {
+					$possible_types = $schema->getPossibleTypes( $named_type );
+					foreach ( $possible_types as $possible_type ) {
+						$type_map[] = strtolower( $possible_type );
+					}
+				} elseif ( $named_type instanceof ObjectType ) {
+					$type_map[] = strtolower( $named_type );
+				}
+			},
+			'leave' => function ( $node, $key, $parent, $path, $ancestors ) use ( $type_info ) {
+				$type_info->leave( $node );
+			},
+		];
+
+		Visitor::visit( $ast, Visitor::visitWithTypeInfo( $type_info, $visitor ) );
+		$map = array_values( array_unique( array_filter( $type_map ) ) );
+
+		// @phpcs:ignore
+		return apply_filters( 'graphql_cache_collection_get_query_types', $map, $schema, $query, $type_info );
+	}
+
+	/**
+	 * Given the Schema and a query string, return a list of GraphQL model names that are being asked for
+	 * by the query.
+	 *
+	 * @param ?Schema $schema The WPGraphQL Schema
+	 * @param ?string $query  The query string
+	 *
+	 * @return array
+	 * @throws SyntaxError|Exception
+	 */
+	public function set_query_models( ?Schema $schema, ?string $query ): array {
+
+		/**
+		 * @param array|null $null Default value for the filter
+		 * @param ?Schema $schema The WPGraphQL Schema for the current request
+		 * @param ?string $query The query string being requested
+		 */
+		$null           = null;
+		$pre_get_models = apply_filters( 'graphql_pre_query_analyzer_get_models', $null, $schema, $query );
+
+		if ( null !== $pre_get_models ) {
+			return $pre_get_models;
+		}
+
+		if ( empty( $query ) || null === $schema ) {
+			return [];
+		}
+		try {
+			$ast = Parser::parse( $query );
+		} catch ( SyntaxError $error ) {
+			return [];
+		}
+		$type_map  = [];
+		$type_info = new TypeInfo( $schema );
+		$visitor   = [
+			'enter' => function ( $node, $key, $parent, $path, $ancestors ) use ( $type_info, &$type_map, $schema ) {
+				$type_info->enter( $node );
+				$type = $type_info->getType();
+				if ( ! $type ) {
+					return;
+				}
+
+				$named_type = Type::getNamedType( $type );
+
+				if ( $named_type instanceof InterfaceType ) {
+					$possible_types = $schema->getPossibleTypes( $named_type );
+					foreach ( $possible_types as $possible_type ) {
+						if ( ! isset( $possible_type->config['model'] ) ) {
+							continue;
+						}
+						$type_map[] = $possible_type->config['model'];
+					}
+				} elseif ( $named_type instanceof ObjectType ) {
+					if ( ! isset( $named_type->config['model'] ) ) {
+						return;
+					}
+					$type_map[] = $named_type->config['model'];
+				}
+			},
+			'leave' => function ( $node, $key, $parent, $path, $ancestors ) use ( $type_info ) {
+				$type_info->leave( $node );
+			},
+		];
+
+		Visitor::visit( $ast, Visitor::visitWithTypeInfo( $type_info, $visitor ) );
+		$map = array_values( array_unique( array_filter( $type_map ) ) );
+
+		// @phpcs:ignore
+		return apply_filters( 'graphql_cache_collection_get_query_models', $map, $schema, $query, $type_info );
+	}
+
+	/**
+	 * Track the nodes that were resolved by ensuring the Node's model
+	 * matches one of the models asked for in the query
+	 *
+	 * @param mixed $model The Model to be returned by the loader
+	 *
+	 * @return mixed
+	 */
+	public function track_nodes( $model ) {
+
+		if ( isset( $model->id ) && in_array( get_class( $model ), $this->get_query_models(), true ) ) {
+			// Is this model type part of the requested/returned data in the asked for query?
+
+			/**
+			 * Filter the node ID before returning to the list of resolved nodes
+			 *
+			 * @param int    $model_id      The ID of the model (node) being returned
+			 * @param object $model         The Model object being returned
+			 * @param array  $runtime_nodes The runtimes nodes already collected
+			 */
+			$node_id = apply_filters( 'graphql_query_analyzer_runtime_node', $model->id, $model, $this->runtime_nodes );
+
+			$this->runtime_nodes[] = $node_id;
+		}
+
+		return $model;
+	}
+
+
+	/**
+	 * Return headers
+	 *
+	 * @param array $headers The array of headers being returned
+	 *
+	 * @return array
+	 */
+	public function get_headers( array $headers = [] ): array {
+
+		$keys = [];
+
+		if ( ! empty( $this->get_list_types() ) && is_array( $this->get_list_types() ) ) {
+			$headers['X-GraphQL-List-Types'] = implode( ' ', array_unique( array_values( $this->get_list_types() ) ) );
+			$keys                            = array_merge( $keys, $this->get_list_types() );
+
+		}
+
+		if ( ! empty( $this->get_runtime_nodes() ) && is_array( $this->get_runtime_nodes() ) ) {
+			$headers['X-GraphQL-Nodes'] = implode( ' ', array_unique( array_values( $this->get_runtime_nodes() ) ) );
+			$keys                       = array_merge( $keys, $this->get_runtime_nodes() );
+		}
+
+		if ( ! empty( $this->get_root_operation() ) ) {
+			$headers['X-GraphQL-Operation-Type'] = $this->get_root_operation();
+			$keys[]                              = 'graphql:' . $this->get_root_operation();
+		}
+
+		if ( ! empty( $keys ) ) {
+
+			if ( $this->get_query_id() ) {
+				$keys[] = $this->get_query_id();
+			}
+
+			$key_string = implode( ' ', array_unique( array_values( $keys ) ) );
+
+			$headers['X-GraphQL-Query-ID']  = $this->query_id;
+			$headers['X-GraphQL-Keys']      = $key_string;
+			$headers['X-GraphQL-Keys-Size'] = strlen( $key_string ); // calculate the bytes of the keys
+
+		}
+
+		return $headers;
+	}
+
+}

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -8,7 +8,26 @@ use WPGraphQL\Model\Model;
 class Utils {
 
 	/**
-	 * Maps new input query args and sanitizes the input
+	 * Given a GraphQL Query string, return a hash
+	 *
+	 * @param string $query The Query String to hash
+	 *
+	 * @return string|null
+	 */
+	public static function get_query_id( string $query ) {
+
+		try {
+			$query_ast = \GraphQL\Language\Parser::parse( $query );
+			$query     = \GraphQL\Language\Printer::doPrint( $query_ast );
+			return md5( $query );
+		} catch ( \Exception $exception ) {
+			return null;
+		}
+
+	}
+
+	/**
+	 * Maps new input query args and sa nitizes the input
 	 *
 	 * @param mixed|array|string $args The raw query args from the GraphQL query
 	 * @param mixed|array|string $map  The mapping of where each of the args should go

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -130,7 +130,7 @@ final class WPGraphQL {
 
 		// Plugin version.
 		if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-			define( 'WPGRAPHQL_VERSION', '1.10.0' );
+			define( 'WPGRAPHQL_VERSION', '1.11.0' );
 		}
 
 		// Plugin Folder Path.

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -245,7 +245,8 @@ final class WPGraphQL {
 			function () {
 
 				new \WPGraphQL\Data\Config();
-				new Router();
+				$router = new Router();
+				$router->init();
 				$instance = self::instance();
 
 				/**

--- a/tests/functional/GraphQLHeadersCept.php
+++ b/tests/functional/GraphQLHeadersCept.php
@@ -1,0 +1,32 @@
+<?php
+
+$I = new FunctionalTester( $scenario );
+$I->wantTo( 'Test GraphQL Keys returned in headers');
+
+$admin_id = $I->haveUserInDatabase( 'admin', 'administrator' );
+$post_id = $I->havePostInDatabase([
+	'post_type' => 'post',
+	'post_status' => 'publish',
+	'post_title' => 'test post',
+	'post_content' => 'test post',
+	'post_author' => $admin_id,
+]);
+$page_id = $I->havePostInDatabase([
+	'post_type' => 'page',
+	'post_status' => 'publish',
+	'post_title' => 'test page',
+	'post_content' => 'test page',
+	'post_author' => $admin_id,
+]);
+
+$query = '{ posts { nodes { title } } }';
+
+$I->sendGet( 'http://localhost/graphql?query=' . $query );
+
+$I->seeResponseCodeIs( 200 );
+$I->seeResponseIsJson();
+$x_graphql_keys = $I->grabHttpHeader( 'X-GraphQL-Keys' );
+
+$I->assertNotEmpty( $x_graphql_keys );
+$post_cache_key = base64_encode( 'post:' . $post_id );
+$I->assertContains( $post_cache_key, explode( ' ', $x_graphql_keys ) );

--- a/tests/wpunit/AccessFunctionsTest.php
+++ b/tests/wpunit/AccessFunctionsTest.php
@@ -120,9 +120,11 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		}';
 		$response = $this->graphql( compact( 'query' ) );
 
+		codecept_debug( $response );
+
 		$this->assertArrayHasKey( 'debug', $response['extensions'] );
 
-		$has_debug_message = null;
+		$has_debug_message = false;
 
 		foreach ( $response['extensions']['debug'] as $debug_message ) {
 			if (
@@ -131,6 +133,7 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 				'INVALID_FIELD_NAME' === $debug_message['type']
 			) {
 				$has_debug_message = true;
+				break;
 			}
 		}
 

--- a/tests/wpunit/CommentConnectionQueriesTest.php
+++ b/tests/wpunit/CommentConnectionQueriesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use GraphQLRelay\Relay;
+
 class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 	public $admin;
@@ -27,6 +29,11 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 	}
 
 	public function tearDown(): void {
+		foreach ( $this->created_comment_ids as $comment ) {
+			wp_delete_comment( $comment, true );
+		}
+		wp_delete_post( $this->post_id, true );
+
 		// then
 		parent::tearDown();
 	}
@@ -45,7 +52,7 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 		 */
 		$defaults = [
 			'comment_post_ID'  => $post_id,
-			'comment_author'   => $this->admin,
+			'user_id'          => $this->admin,
 			'comment_content'  => 'Test comment content',
 			'comment_approved' => 1,
 		];
@@ -173,7 +180,6 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-//		$this->markTestIncomplete( 'Comments missing cursor pagination support' );
 		$this->assertValidPagination( $expected, $actual );
 		$this->assertEquals( true, $actual['data']['comments']['pageInfo']['hasPreviousPage'] );
 		$this->assertEquals( true, $actual['data']['comments']['pageInfo']['hasNextPage'] );
@@ -267,7 +273,7 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 		$expected = $wp_query->query( $query_args );
 		$expected = array_reverse( $expected );
 
-		$actual   = $this->graphql( compact( 'query', 'variables' ) );
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
 		$this->assertValidPagination( $expected, $actual );
 		$this->assertEquals( true, $actual['data']['comments']['pageInfo']['hasPreviousPage'] );
@@ -352,8 +358,6 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 		// Using first and last should throw an error.
 		$actual = graphql( compact( 'query', 'variables' ) );
 
-
-
 		$this->assertArrayHasKey( 'errors', $actual );
 
 		unset( $variables['first'] );
@@ -367,7 +371,130 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 
 	}
 
-	public function testWhereArgs() {
+	public function testAuthorWhereArgs() {
+		$query = $this->getQuery();
+
+		$author_one_id      = $this->factory()->user->create(
+			[
+				'role'       => 'subscriber',
+				'user_email' => 'subscriber@wpgraphql.test',
+			]
+		);
+		$author_two_id      = $this->factory()->user->create(
+			[
+				'role'       => 'author',
+				'user_email' => 'author@wpgraphql.test',
+			]
+		);
+		$author_three_email = 'guest@wpgraphql.test';
+		$author_four_url    = 'https://myguestsite.test';
+
+		$comment_ids = [
+			$this->createCommentObject( [
+				'user_id'              => $author_one_id,
+				'comment_author_email' => 'subscriber@wpgraphql.test',
+			] ),
+			$this->createCommentObject( [
+				'user_id'              => $author_two_id,
+				'comment_author_email' => 'author@wpgraphql.test',
+				'comment_author_url'   => 'https://myguestsite.test',
+			] ),
+		];
+
+		// test authorEmail.
+		$variables = [
+			'where' => [
+				'authorEmail' => 'subscriber@wpgraphql.test',
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertCount( 1, $actual['data']['comments']['nodes'] );
+		$this->assertEquals( $comment_ids[0], $actual['data']['comments']['nodes'][0]['databaseId'] );
+
+		// test authorUrl.
+		$variables = [
+			'where' => [
+				'authorUrl' => 'https://myguestsite.test',
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertCount( 1, $actual['data']['comments']['nodes'] );
+		$this->assertEquals( $comment_ids[1], $actual['data']['comments']['nodes'][0]['databaseId'] );
+
+		// test authorIn with ID + databaseId
+		$author_one_global_id = GraphQLRelay\Relay::toGlobalId( 'user', $author_one_id );
+
+		$variables = [
+			'where' => [
+				'authorIn' => [ $author_one_global_id, $author_two_id ],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertCount( 2, $actual['data']['comments']['nodes'] );
+		$this->assertEquals( $comment_ids[1], $actual['data']['comments']['nodes'][0]['databaseId'] );
+		$this->assertEquals( $comment_ids[0], $actual['data']['comments']['nodes'][1]['databaseId'] );
+
+		// test authorNotIn with ID + databaseId
+
+		$variables = [
+			'where' => [
+				'authorNotIn' => [ $author_one_global_id, $author_two_id ],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertCount( 6, $actual['data']['comments']['nodes'] );
+		$this->assertNotEquals( $comment_ids[1], $actual['data']['comments']['nodes'][0]['databaseId'] );
+		$this->assertNotEquals( $comment_ids[0], $actual['data']['comments']['nodes'][0]['databaseId'] );
+	}
+
+	public function testCommentInWhereArgs() {
+		$query = $this->getQuery();
+
+		$comment_one_global_id = Relay::toGlobalId( 'comment', $this->created_comment_ids[1] );
+
+		// Test commentIn with global + db IDs.
+		$variables = [
+			'where' => [
+				'commentIn' => [ $comment_one_global_id, $this->created_comment_ids[2] ],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertCount( 2, $actual['data']['comments']['nodes'] );
+		$this->assertEquals( $this->created_comment_ids[1], $actual['data']['comments']['nodes'][1]['databaseId'] );
+		$this->assertEquals( $this->created_comment_ids[2], $actual['data']['comments']['nodes'][0]['databaseId'] );
+
+		// Test commentNotIn with global + db IDs
+
+		$variables = [
+			'where' => [
+				'commentNotIn' => [ $comment_one_global_id, $this->created_comment_ids[2] ],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertCount( 4, $actual['data']['comments']['nodes'] );
+		$this->assertNotEquals( $this->created_comment_ids[1], $actual['data']['comments']['nodes'][0]['databaseId'] );
+		$this->assertNotEquals( $this->created_comment_ids[2], $actual['data']['comments']['nodes'][0]['databaseId'] );
+	}
+
+	public function testCommentTypeWhereArgs() {
 		$query = $this->getQuery();
 
 		$comment_type_one = 'custom-type-one';
@@ -419,7 +546,456 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 		$this->assertEquals( $comment_ids[0], $actual['data']['comments']['nodes'][1]['databaseId'] );
 	}
 
+	public function testContentWhereArgs() {
+		$query = $this->getQuery();
 
+		$author_one_id = $this->factory->user->create( [ 'role' => 'author' ] );
+		$author_two_id = $this->factory->user->create( [ 'role' => 'author' ] );
+
+		$post_one_id = $this->factory->post->create( [
+			'post_author' => $author_one_id,
+			'post_type' => 'post',
+		] );
+
+		$post_two_id = $this->factory->post->create( [
+			'post_author' => $author_two_id,
+			'post_type' => 'page',
+			'post_title' => 'Page for testing content where args',
+			''
+		] );
+
+		$comment_one_id = $this->createCommentObject( [
+			'comment_post_ID' => $post_one_id,
+			'comment_approved' => true,
+		] );
+
+		$comment_two_id = $this->createCommentObject( [
+			'comment_post_ID' => $post_two_id,
+			'comment_approved' => true,
+		] );
+
+		$author_one_global_id = Relay::toGlobalId( 'user', $author_one_id );
+
+		// Test contentAuthorIn with global + db IDs.
+		$variables = [
+			'where' => [
+				'contentAuthorIn' => [ $author_one_global_id, $author_two_id ],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount( 2, $actual['data']['comments']['nodes'] );
+
+		// Test contentAuthorNotIn with global + db IDs.
+		$variables = [
+			'where' => [
+				'contentAuthorNotIn' => [ $author_one_global_id, $author_two_id ],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+
+		$this->assertCount( 6, $actual['data']['comments']['nodes'] );
+
+		// Test contentId with databaseId
+		$variables = [
+			'where' => [
+				'contentId' => $post_one_id,
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount( 1, $actual['data']['comments']['nodes'] );
+
+
+		// Test contentId with global Id
+		$expected = $actual['data']['comments']['nodes'];
+
+		$post_one_global_id = Relay::toGlobalId( 'post', $post_one_id );
+
+		$variables = [
+			'where' => [
+				'contentId' => $post_one_global_id
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount( 1, $actual['data']['comments']['nodes'] );
+		$this->assertEqualSets( $expected, $actual['data']['comments']['nodes'] );
+
+		// Test contentIdIn with global + db IDs.
+		$variables = [
+			'where' => [
+				'contentIdIn' => [ $post_one_global_id, $post_two_id ],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount( 2, $actual['data']['comments']['nodes'] );
+
+		// Test contentIdNotIn with global + db IDs.
+		$variables = [
+			'where' => [
+				'contentIdNotIn' => [ $post_one_global_id, $post_two_id ],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount( 6, $actual['data']['comments']['nodes'] );
+
+		// Test contentName
+		$post_two = get_post( $post_two_id );
+		$variables = [
+			'where' => [
+				'contentName' => $post_two->post_name,
+			],
+		];
+		
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount( 1, $actual['data']['comments']['nodes'] );
+
+		// Test contentType
+		$variables = [
+			'where' => [
+				'contentType' => 'PAGE',
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount( 1, $actual['data']['comments']['nodes'] );
+	}
+
+	public function testContentStatusWhereArgs() {
+		$query = $this->getQuery();
+
+		$post_id = $this->factory->post->create(
+			[
+				'post_status' => 'pending',
+			]
+		);
+
+		$comment_id = $this->createCommentObject( [
+			'comment_post_ID' => $post_id,
+			'comment_approved' => true,
+		] );
+
+		$variables = [
+			'where' => [
+				'contentStatus' => 'PENDING',
+			],
+		];
+
+		// Test logged out user.
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEmpty( $actual['data']['comments']['nodes'] );
+
+		// Test logged in user.
+		wp_set_current_user( $this->admin );
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount( 1, $actual['data']['comments']['nodes'] );
+	}
+
+	public function testContentParentWhereArgs() {
+		$query = $this->getQuery();
+
+		$parent_post_id = $this->factory->post->create(
+			[
+				'post_status' => 'publish',
+			]
+		);
+
+		$child_post_id_one = $this->factory->post->create(
+			[
+				'post_status' => 'publish',
+				'post_parent' => $parent_post_id,
+			]
+		);
+
+		$child_post_id_two = $this->factory->post->create(
+			[
+				'post_status' => 'publish',
+				'post_parent' => $parent_post_id,
+			]
+		);
+
+		$comment_one_id = $this->createCommentObject( [
+			'comment_post_ID' => $child_post_id_one,
+			'comment_approved' => true,
+		] );
+
+		$comment_id_two = $this->createCommentObject( [
+			'comment_post_ID' => $child_post_id_two,
+			'comment_approved' => true,
+		] );
+
+		// Test contentParent with global Id
+		$variables = [
+			'where' => [
+				'contentParent' =>  $parent_post_id
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount( 2, $actual['data']['comments']['nodes'] );
+	}
+
+	public function testIncludeUnapprovedWhereArgs() {
+		$query = $this->getQuery();
+
+		$author_id      = $this->factory()->user->create(
+			[
+				'role'       => 'subscriber',
+				'user_email' => 'subscriber@wpgraphql.test',
+			]
+		);
+
+		$comment_ids = [
+			$this->createCommentObject( [
+				'user_id' => $this->admin,
+				'comment_approved' => 0,
+			] ),
+			$this->createCommentObject( [
+				'user_id' => $author_id,
+				'comment_approved' => 0,
+			] ),
+		];
+
+		// Test unapproved comments are excluded by default.
+		$actual = $this->graphql( compact( 'query' ) );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertCount( 6, $actual['data']['comments']['nodes'] );
+
+		// test includeUnapproved with global + db author ids.
+
+		$author_global_id = Relay::toGlobalId( 'user', $author_id );
+
+		$variables = [
+			'where' => [
+				'includeUnapproved' => [ $this->admin, $author_global_id ]
+			],
+		];
+
+		// While user doesn't have moderate permissions, only the approved comments will be returned.
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertCount( 6, $actual['data']['comments']['nodes'] );
+
+		// test user with permissions
+
+		wp_set_current_user( $this->admin );
+		
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertCount( 8, $actual['data']['comments']['nodes'] );
+	}
+
+	public function testOrderWhereArgs() {
+		$query = $this->getQuery();
+
+		// Test ascending by COMMENT_ID.
+		$variables = [
+			'where' => [
+				'order' => 'ASC',
+				'orderby' => 'COMMENT_ID'
+			]
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+		$this->assertIsValidQueryResponse( $actual );
+
+		$this->assertCount( 6, $actual['data']['comments']['nodes'] );
+		$this->assertGreaterThan( $actual['data']['comments']['nodes'][0]['databaseId'], $actual['data']['comments']['nodes'][1]['databaseId'] );
+
+		// Test descending.
+		$expected = array_reverse( $actual['data']['comments']['nodes'] );
+		$variables['where']['order'] = 'DESC';
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertEqualSets( $expected, $actual['data']['comments']['nodes'] );
+	}
+
+
+
+	public function testParentWhereArgs() {
+		$query = $this->getQuery();
+
+		$comment_one_id = $this->createCommentObject( [
+			'comment_post_ID' => $this->post_id,
+			'comment_parent'  => $this->created_comment_ids[1],
+		] );
+
+		$comment_two_id = $this->createCommentObject( [
+			'comment_post_ID' => $this->post_id,
+			'comment_parent'  => $this->created_comment_ids[2],
+		] );
+
+		// Test parent
+		$variables = [
+			'where' => [
+				'parent' => $this->created_comment_ids[1],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+		
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount( 1, $actual['data']['comments']['nodes'] );
+		$this->assertEquals( $comment_one_id, $actual['data']['comments']['nodes'][0]['databaseId'] );
+
+		$parent_one_global_id = Relay::toGlobalId( 'comment', $this->created_comment_ids[1] );
+
+		// Test parentIn with global + database Ids
+		$variables = [
+			'where' => [
+				'parentIn' => [
+					$parent_one_global_id,
+					$this->created_comment_ids[2],
+				],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+		
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount( 2, $actual['data']['comments']['nodes'] );
+
+		// Test parentNotIn with global + database Ids
+		$variables = [
+			'where' => [
+				'parentNotIn' => [
+					$parent_one_global_id,
+					$this->created_comment_ids[2],
+				],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount( 6, $actual['data']['comments']['nodes'] );
+	}
+
+	public function testSearchWhereArgs() {
+		$query = $this->getQuery();
+
+		$comment_one_id = $this->createCommentObject( [
+			'comment_post_ID' => $this->post_id,
+			'comment_content' => 'This is a comment with a search term',
+		] );
+
+		$variables = [
+			'where' => [
+				'search' => 'search term',
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount( 1, $actual['data']['comments']['nodes'] );
+		$this->assertEquals( $comment_one_id, $actual['data']['comments']['nodes'][0]['databaseId'] );
+	}
+
+	public function testStatusWhereArgs() {
+		$query = $this->getQuery();
+
+		$comment_one_id = $this->createCommentObject( [
+			'comment_post_ID' => $this->post_id,
+			'comment_approved' => 0,
+		] );
+
+		$variables = [
+			'where' => [
+				'status' => 'hold',
+			],
+		];
+
+		wp_set_current_user( $this->admin );
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount( 1, $actual['data']['comments']['nodes'] );
+		$this->assertEquals( $comment_one_id, $actual['data']['comments']['nodes'][0]['databaseId'] );
+	}
+
+	public function testUserIdWhereArgs() {
+		$query = $this->getQuery();
+
+		$user_id = $this->factory()->user->create( [
+			'role' => 'author',
+		] );
+
+		$comment_id = $this->createCommentObject( [
+			'comment_post_ID' => $this->post_id,
+			'user_id' => $user_id,
+		] );
+
+		// Test by database ID
+		$variables = [
+			'where' => [
+				'userId' => $user_id,
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount( 1, $actual['data']['comments']['nodes'] );
+		$this->assertEquals( $comment_id, $actual['data']['comments']['nodes'][0]['databaseId'] );
+
+		// Test by global ID
+		$comment_global_id = Relay::toGlobalId( 'comment', $comment_id );
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount( 1, $actual['data']['comments']['nodes'] );
+		$this->assertEquals( $comment_id, $actual['data']['comments']['nodes'][0]['databaseId'] );
+	}
 
 	/**
 	 * Common asserts for testing pagination.

--- a/tests/wpunit/MenuItemConnectionQueriesTest.php
+++ b/tests/wpunit/MenuItemConnectionQueriesTest.php
@@ -389,7 +389,7 @@ class MenuItemConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 		$this->assertSame( $expected, $actual['data']['menuItems']['nodes'][0] );
 	}
 
-	public function testMenuItemsQueryById() {
+	public function testIdWhereArgs() {
 		$menu_item_id = intval( $this->created_menu_items['menu_item_ids'][2] );
 		$post_id      = intval( $this->created_menu_items['post_ids'][2] );
 
@@ -409,7 +409,7 @@ class MenuItemConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 		$this->compareResults( [ $menu_item_id ], [ $post_id ], $actual );
 	}
 
-	public function testMenuItemsQueryByLocation() {
+	public function testLocationWhereArgs() {
 		$menu_item_id = intval( $this->created_menu_items['menu_item_ids'][2] );
 		$post_id      = intval( $this->created_menu_items['post_ids'][2] );
 
@@ -436,7 +436,7 @@ class MenuItemConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 		$this->compareResults( $created['menu_item_ids'], $created['post_ids'], $actual );
 	}
 
-	public function testMenuItemsQueryWithChildItemsAsFlat() {
+	public function testLocationWhereArgsWithChildItemsFlat() {
 		$menu_location = 'my-menu-items-location';
 		register_nav_menu( $menu_location, 'My MenuItems' );
 		WPGraphQL::clear_schema();
@@ -489,7 +489,7 @@ class MenuItemConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 
 	}
 
-	public function testMenuItemsQueryWithChildItemsUsingRelayParentId() {
+	public function testParentIdWhereArgsNonExplicit() {
 		$menu_location = 'my-menu-items-location';
 		register_nav_menu( $menu_location, 'My MenuItems' );
 		WPGraphQL::clear_schema();
@@ -498,6 +498,7 @@ class MenuItemConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 
 		$query = $this->getQuery();
 
+		// Test non with global id
 		$variables = [
 			'where' => [
 				'parentId' => '0',
@@ -512,25 +513,9 @@ class MenuItemConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 
 		// The fourth menu item has the expected number of child items.
 		$this->assertEquals( 3, count( $actual['data']['menuItems']['edges'][3]['node']['childItems']['edges'] ) );
-	}
 
-	public function testMenuItemsQueryWithChildItemsUsingDatabaseParentId() {
-		$menu_location = 'my-menu-items-location';
-		register_nav_menu( $menu_location, 'My MenuItems' );
-		WPGraphQL::clear_schema();
-
-		$created = $this->create_nested_menu( 3, $menu_location );
-
-		$query = $this->getQuery();
-
-		$variables = [
-			'where' => [
-				'parentDatabaseId' => 0,
-				'location'         => WPEnumType::get_safe_name( $menu_location ),
-			],
-		];
-
-		$actual = $this->graphql( compact( 'query', 'variables' ) );
+		// Test with database id
+		$variables['where']['parentId'] = 0;
 
 		// Perform some common assertions.
 		$this->compareResults( $created['menu_item_ids'], $created['post_ids'], $actual );
@@ -539,7 +524,8 @@ class MenuItemConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 		$this->assertEquals( 3, count( $actual['data']['menuItems']['edges'][3]['node']['childItems']['edges'] ) );
 	}
 
-	public function testMenuItemsQueryWithExplicitParentDatabaseId() {
+
+	public function testParentIdWhereArgsExplicit() {
 		$menu_location = 'my-menu-items-location';
 		register_nav_menu( $menu_location, 'My MenuItems' );
 		WPGraphQL::clear_schema();
@@ -549,11 +535,12 @@ class MenuItemConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 		$query = $this->getQuery();
 
 		// The nesting is added to the fourth item
-		$parent_database_id = $created['menu_item_ids'][3];
+		$parent_id = $created['menu_item_ids'][3];
 
+		// Test with database Id.
 		$variables = [
 			'where' => [
-				'parentDatabaseId' => $parent_database_id,
+				'parentId' => $parent_id,
 				'location'         => WPEnumType::get_safe_name( $menu_location ),
 			],
 		];
@@ -563,8 +550,17 @@ class MenuItemConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 		$this->assertEquals( 3, count( $actual['data']['menuItems']['edges'] ) );
 
 		// The parentDatabaseId matches with the requested parent database id
-		$this->assertEquals( $parent_database_id, $actual['data']['menuItems']['edges'][0]['node']['parentDatabaseId'] );
+		$this->assertEquals( $parent_id, $actual['data']['menuItems']['edges'][0]['node']['parentDatabaseId'] );
 
+		// Test with global ID
+		$variables['where']['parentId'] =  Relay::toGlobalId( 'post', $parent_id );
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertEquals( 3, count( $actual['data']['menuItems']['edges'] ) );
+
+		// The parentDatabaseId matches with the requested parent database id
+		$this->assertEquals( $parent_id, $actual['data']['menuItems']['edges'][0]['node']['parentDatabaseId'] );
 	}
 
 	public function testMenuItemsQueryWithExplicitParentId() {

--- a/tests/wpunit/NodesTest.php
+++ b/tests/wpunit/NodesTest.php
@@ -61,9 +61,9 @@ class NodesTest extends \Codeception\TestCase\WPTestCase {
 			} 
 		}';
 
-		$variables = wp_json_encode( [
+		$variables = [
 			'id' => $global_id,
-		] );
+		];
 
 		/**
 		 * Run the GraphQL query
@@ -130,7 +130,7 @@ class NodesTest extends \Codeception\TestCase\WPTestCase {
 		/**
 		 * Run the GraphQL query
 		 */
-		$actual = do_graphql_request( $query, '', '' );
+		$actual = do_graphql_request( $query );
 
 		/**
 		 * Establish the expectation for the output of the query

--- a/tests/wpunit/PostObjectConnectionQueriesTest.php
+++ b/tests/wpunit/PostObjectConnectionQueriesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use GraphQLRelay\Relay;
+
 class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 	public $current_time;
 	public $current_date;
@@ -88,7 +90,7 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 	 *
 	 * @return array
 	 */
-	public function create_posts( $count = 20 ) {
+	public function create_posts( $count = 6 ) {
 
 		// Create posts
 		$created_posts = [];
@@ -109,9 +111,9 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 
 	}
 
-	public function postsQuery( $variables ) {
-
-		$query = 'query postsQuery($first:Int $last:Int $after:String $before:String $where:RootQueryToPostConnectionWhereArgs ){
+	public function getQuery() {
+		return '
+		query postsQuery($first:Int $last:Int $after:String $before:String $where:RootQueryToPostConnectionWhereArgs ){
 			posts( first:$first last:$last after:$after before:$before where:$where ) {
 				pageInfo {
 					hasNextPage
@@ -123,7 +125,7 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 					cursor
 					node {
 						id
-						postId
+						databaseId
 						title
 						date
 						content
@@ -132,13 +134,11 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 				}
 				nodes {
 					id
-					postId
+					databaseId
 				}
 			}
-		}';
-
-		return do_graphql_request( $query, 'postsQuery', $variables );
-
+		}
+		';
 	}
 
 	private function getReturnField( $data, $post, $field = '' ) {
@@ -159,17 +159,20 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 		// Create some additional posts to test a large query.
 		$this->create_posts( 150 );
 
+		$query = $this->getQuery();
+
 		$variables = [
 			'first' => 150,
 		];
-		$results   = $this->postsQuery( $variables );
-		$this->assertNotEmpty( $results );
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+		$this->assertNotEmpty( $actual );
 
 		/**
 		 * The max that can be queried by default is 100 items
 		 */
-		$this->assertCount( 100, $results['data']['posts']['edges'] );
-		$this->assertTrue( $results['data']['posts']['pageInfo']['hasNextPage'] );
+		$this->assertCount( 100, $actual['data']['posts']['edges'] );
+		$this->assertTrue( $actual['data']['posts']['pageInfo']['hasNextPage'] );
 
 		/**
 		 * Test the filter to make sure it's capping the results properly
@@ -184,7 +187,8 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 		$variables = [
 			'first' => 150,
 		];
-		$results   = $this->postsQuery( $variables );
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
 		add_filter(
 			'graphql_connection_max_query_amount',
@@ -193,119 +197,8 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 			}
 		);
 
-		$this->assertCount( 20, $results['data']['posts']['edges'] );
-		$this->assertTrue( $results['data']['posts']['pageInfo']['hasNextPage'] );
-	}
-
-	public function testPostHasPassword() {
-		// Create a test post with a password
-		$this->createPostObject(
-			[
-				'post_title'    => 'Password protected',
-				'post_type'     => 'post',
-				'post_status'   => 'publish',
-				'post_password' => 'password',
-			]
-		);
-
-		/**
-		 * WP_Query posts with a password
-		 */
-		$wp_query_posts_with_password = new WP_Query(
-			[
-				'has_password' => true,
-			]
-		);
-
-		/**
-		 * GraphQL query posts that have a password
-		 */
-		$variables = [
-			'where' => [
-				'hasPassword' => true,
-			],
-		];
-
-		wp_set_current_user( $this->admin );
-		$request = $this->postsQuery( $variables );
-
-		$this->assertNotEmpty( $request );
-		$this->assertArrayNotHasKey( 'errors', $request );
-
-		$edges = $request['data']['posts']['edges'];
-		$this->assertNotEmpty( $edges );
-
-		/**
-		 * Loop through all the returned posts
-		 */
-		foreach ( $edges as $edge ) {
-
-			/**
-			 * Assert that all posts returned have a password, since we queried for
-			 * posts using "has_password => true"
-			 */
-			$password = get_post( $edge['node']['postId'] )->post_password;
-			$this->assertNotEmpty( $password );
-
-		}
-
-	}
-
-	public function testPageWithChildren() {
-
-		$parent_id = $this->factory->post->create(
-			[
-				'post_type' => 'page',
-			]
-		);
-
-		$child_id = $this->factory->post->create(
-			[
-				'post_type'   => 'page',
-				'post_parent' => $parent_id,
-			]
-		);
-
-		$global_id       = \GraphQLRelay\Relay::toGlobalId( 'post', $parent_id );
-		$global_child_id = \GraphQLRelay\Relay::toGlobalId( 'post', $child_id );
-
-		$query = '
-		{
-			page( id: "' . $global_id . '" ) {
-				id
-				pageId
-				children {
-					edges {
-						node {
-								...on Page {
-								id
-								pageId
-							}
-						}
-					}
-				}
-			}
-		}
-		';
-
-		$actual = do_graphql_request( $query );
-
-		/**
-		 * Make sure the query didn't return any errors
-		 */
-		$this->assertArrayNotHasKey( 'errors', $actual );
-
-		$parent = $actual['data']['page'];
-		$child  = $parent['children']['edges'][0]['node'];
-
-		/**
-		 * Make sure the child and parent data matches what we expect
-		 */
-		$this->assertEquals( $global_id, $parent['id'] );
-		$this->assertEquals( $parent_id, $parent['pageId'] );
-		$this->assertEquals( $global_child_id, $child['id'] );
-		$this->assertEquals( $child_id, $child['pageId'] );
-
+		$this->assertCount( 20, $actual['data']['posts']['edges'] );
+		$this->assertTrue( $actual['data']['posts']['pageInfo']['hasNextPage'] );
 	}
 
 	/**
@@ -326,12 +219,20 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 		$post_1_id = $this->createPostObject( $post_1_args );
 		$post_2_id = $this->createPostObject( $post_2_args );
 
-		$request = $this->postsQuery( [ 'where' => [ 'in' => [ $post_1_id, $post_2_id ] ] ] );
+		$query = $this->getQuery();
 
-		$this->assertNotEmpty( $request );
-		$this->assertArrayNotHasKey( 'errors', $request );
+		$variables = [
+			'where' => [
+				'in' => [ $post_1_id, $post_2_id ]
+			]
+		];
 
-		$edges = $request['data']['posts']['edges'];
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertNotEmpty( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+
+		$edges = $actual['data']['posts']['edges'];
 		$this->assertNotEmpty( $edges );
 
 		$this->assertNotEquals( $edges[0]['node']['excerpt'], $edges[1]['node']['excerpt'] );
@@ -352,20 +253,21 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 			]
 		);
 
-		wp_set_current_user( $this->subscriber );
-		$actual = $this->postsQuery(
-			[
-				'where' => [
-					'in'    => [ $private_post, $public_post ],
-					'stati' => [ 'PUBLISH', 'PRIVATE' ],
-				],
+		$query = $this->getQuery();
+
+		$variables = [
+			'where' => [
+				'in' => [ $private_post, $public_post ],
+				'stati' => [ 'PUBLISH', 'PRIVATE' ],
 			]
-		);
+		];
+
+		wp_set_current_user( $this->subscriber );
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
 		$this->assertCount( 1, $actual['data']['posts']['edges'] );
 		$this->assertNotEmpty( $this->getReturnField( $actual, 0, 'id' ) );
 		$this->assertEmpty( $this->getReturnField( $actual, 1 ) );
-
 	}
 
 	public function testPrivatePostsWithProperCaps() {
@@ -378,20 +280,32 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 
 		$post_id = $this->createPostObject( $post_args );
 
-		wp_set_current_user( $this->admin );
-		$actual = $this->postsQuery(
-			[
-				'where' => [
-					'in'    => [ $post_id ],
-					'stati' => [ 'PUBLISH', 'PRIVATE' ],
-				],
-			]
-		);
+		$query = $this->getQuery();
 
-		codecept_debug( $actual );
+		$variables = [
+			'where' => [
+				'in' => [ $post_id ],
+				'stati' => [ 'PUBLISH', 'PRIVATE' ],
+			]
+		];
+
+		wp_set_current_user( $this->admin );
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
 		$this->assertEquals( $post_args['post_title'], $this->getReturnField( $actual, 0, 'title' ) );
 
+		// Test with single status
+		$variables = [
+			'where' => [
+				'status' => 'PRIVATE',
+			]
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount( 1, $actual['data']['posts']['nodes'] );
+		$this->assertEquals( $post_id, $actual['data']['posts']['nodes'][0]['databaseId'] );
 	}
 
 	public function testPrivatePostsForCurrentUser() {
@@ -404,15 +318,17 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 
 		$post_id = $this->createPostObject( $post_args );
 
-		wp_set_current_user( $this->subscriber );
-		$actual = $this->postsQuery(
-			[
-				'where' => [
-					'in'    => [ $post_id ],
-					'stati' => [ 'PUBLISH', 'PRIVATE' ],
-				],
+		$query = $this->getQuery();
+
+		$variables = [
+			'where' => [
+				'in' => [ $post_id ],
+				'stati' => [ 'PUBLISH', 'PRIVATE' ],
 			]
-		);
+		];
+
+		wp_set_current_user( $this->subscriber );
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
 		/**
 		 * Since we're querying for a private post, we want to make sure a subscriber, even if they
@@ -454,7 +370,7 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 			posts( where:{in:[\"{$parent_post}\"]}){
 				edges{
 					node{
-						postId
+						databaseId
 						id
 						title
 						content
@@ -462,7 +378,7 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 							edges {
 								node{
 									id
-									postId
+									databaseId
 									title
 									content
 								}
@@ -482,7 +398,7 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 		$this->assertNotEmpty( $actual['data']['posts']['edges'] );
 
 		if ( true === $show_revisions ) {
-			$this->assertEquals( $revision, $actual['data']['posts']['edges'][0]['node']['revisions']['edges'][0]['node']['postId'] );
+			$this->assertEquals( $revision, $actual['data']['posts']['edges'][0]['node']['revisions']['edges'][0]['node']['databaseId'] );
 		} else {
 			$this->assertEmpty( $actual['data']['posts']['edges'][0]['node']['revisions']['edges'] );
 		}
@@ -504,14 +420,16 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 
 		wp_set_current_user( $this->{$role} );
 
-		$actual = $this->postsQuery(
-			[
-				'where' => [
-					'in'    => [ $public_post, $draft_post ],
-					'stati' => [ 'PUBLISH', 'DRAFT' ],
-				],
-			]
-		);
+		$query = $this->getQuery();
+
+		$variables = [
+			'where' => [
+				'in'    => [ $public_post, $draft_post ],
+				'stati' => [ 'PUBLISH', 'DRAFT' ],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
 		if ( 'admin' === $role ) {
 
@@ -558,14 +476,16 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 
 		wp_set_current_user( $this->{$role} );
 
-		$actual = $this->postsQuery(
-			[
-				'where' => [
-					'in'    => [ $public_post, $draft_post ],
-					'stati' => [ 'PUBLISH', 'TRASH' ],
-				],
-			]
-		);
+		$query = $this->getQuery();
+
+		$variables = [
+			'where' => [
+				'in'    => [ $public_post, $draft_post ],
+				'stati' => [ 'PUBLISH', 'TRASH' ],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
 		if ( 'admin' === $role ) {
 			/**
@@ -938,4 +858,755 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 		$this->assertSame( [ $post_ids[0] ], $actual_ids );
 
 	}
+
+	/**
+	 * Test the scenario where a post is assigned to an author
+	 * who is not a user on the site. This could happen for instance,
+	 * if the user was deleted, but their posts were never trashed
+	 * or assigned to another user.
+	 */
+	public function testQueryPostsWithOrphanedAuthorDoesntThrowErrors() {
+		global $wpdb;
+
+		$highest_user_id     = (int) $wpdb->get_var( "SELECT ID FROM {$wpdb->users} ORDER BY ID DESC limit 0,1" );
+		$nonexistent_user_id = $highest_user_id + 1;
+
+		// Create a new post assigned to a nonexistent user ID.
+		$post_id = wp_insert_post( [
+			'post_title'   => 'Post assigned to a non-existent user',
+			'post_content' => 'Post assigned to a non-existent user',
+			'post_status'  => 'publish',
+			'post_author'  => $nonexistent_user_id,
+		] );
+
+		$query = '
+		{
+			posts(first: 5) {
+				nodes {
+					databaseId
+					author {
+						node {
+						userId
+						name
+						}
+					}
+				}
+			}
+		}
+		';
+
+		$actual = graphql( [ 'query' => $query ] );
+
+		$this->assertTrue( $post_id && ! is_wp_error( $post_id ) );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+
+		// Verify that the ID of the first post matches the one we just created.
+		$this->assertEquals( $post_id, $actual['data']['posts']['nodes'][0]['databaseId'] );
+
+		// Verify that the 'author' field is set to null, since the user ID is invalid.
+		$this->assertEquals( null, $actual['data']['posts']['nodes'][0]['author'] );
+
+		wp_delete_post( $post_id, true );
+
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function testUriFieldAvailableForPublicQueries() {
+
+		/**
+		 * Create a password protected post
+		 * so that we can query for it and make sure the link and uri fields are exposed
+		 * to public requests.
+		 *
+		 * @see: https://github.com/wp-graphql/wp-graphql/issues/1338
+		 */
+		$post_id = $this->factory()->post->create([
+			'post_type'     => 'post',
+			'post_status'   => 'publish',
+			'post_password' => 'test',
+			'post_title'    => 'Post with password',
+			'post_content'  => 'Protected content',
+			'post_author'   => $this->admin,
+		]);
+
+		$query = '
+		query {
+			posts(first: 1, where: {status: PUBLISH}) {
+				nodes {
+					databaseId
+					uri
+					link
+				}
+			}
+		}
+		';
+
+		$actual = $this->graphql([
+			'query' => $query,
+		]);
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEquals( $post_id, $actual['data']['posts']['nodes'][0]['databaseId'] );
+		$this->assertNotEmpty( $post_id, $actual['data']['posts']['nodes'][0]['uri'], 'Ensure the uri is not empty for public requests' );
+		$this->assertNotEmpty( $post_id, $actual['data']['posts']['nodes'][0]['link'], 'Ensure the link field is not empty for public requests' );
+
+	}
+
+	public function testQueryPasswordProtectedPost() {
+
+		$title   = 'Test Title for QueryPasswordProtectedPost' . uniqid();
+		$content = 'Test Content for QueryPasswordProtectedPost' . uniqid();
+
+		$this->factory()->post->create([
+			'post_type'     => 'post',
+			'post_status'   => 'publish',
+			'post_password' => 'publish',
+			'post_content'  => $content,
+			'post_title'    => $title,
+		]);
+
+		$query = '
+		{
+			posts {
+				nodes {
+					id
+					title
+					content
+				}
+			}
+		}
+		';
+
+		wp_set_current_user( 0 );
+
+		$actual = graphql([
+			'query' => $query,
+		]);
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertNull( $actual['data']['posts']['nodes'][0]['content'] );
+		// The content should be null for public users because no password was entered
+		$this->assertSame( $title, $actual['data']['posts']['nodes'][0]['title'] );
+
+		wp_set_current_user( $this->admin );
+
+		$actual = graphql([
+			'query' => $query,
+		]);
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		// The content should be public for an admin
+		$this->assertSame( apply_filters( 'the_content', $content ), $actual['data']['posts']['nodes'][0]['content'] );
+		$this->assertSame( $title, $actual['data']['posts']['nodes'][0]['title'] );
+	}
+
+	public function testIsStickyFieldOnPost() {
+
+		$sticky_post_id = $this->factory()->post->create([
+			'post_type'    => 'post',
+			'post_status'  => 'publish',
+			'post_title'   => 'Sticky Post',
+			'post_content' => 'Sticky post content',
+			'post_author'  => $this->admin,
+		]);
+
+		$nonsticky_post_id = $this->factory()->post->create([
+			'post_type'    => 'post',
+			'post_status'  => 'publish',
+			'post_title'   => 'Non-sticky Post',
+			'post_content' => 'Non-sticky post content',
+			'post_author'  => $this->admin,
+		]);
+
+		update_option( 'sticky_posts', [ $sticky_post_id ] );
+
+		$query = '
+		query testStickyPost($ids: [ID]) {
+			posts(first: 2, where: { in: $ids }) {
+				nodes {
+					databaseId
+					uri
+					link
+					isSticky
+				}
+			}
+		}
+		';
+
+		$actual = $this->graphql([
+			'query'     => $query,
+			'variables' => [
+				'ids' => [
+					$sticky_post_id,
+					$nonsticky_post_id,
+				],
+			],
+		]);
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertTrue( $actual['data']['posts']['nodes'][0]['isSticky'] );
+		$this->assertFalse( $actual['data']['posts']['nodes'][1]['isSticky'] );
+	}
+
+	public function testWhereArgs() {
+		$query = $this->getQuery();
+
+		// test id
+		$variables = [
+			'where' => [
+				'id' => $this->created_post_ids[1],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(1, $actual['data']['posts']['nodes']);
+		$this->assertEquals( $this->created_post_ids[1], $actual['data']['posts']['nodes'][0]['databaseId'] );
+
+		// test in with global + db id
+		$global_id = Relay::toGlobalId( 'post', $this->created_post_ids[1] );
+
+		$variables = [
+			'where' => [
+				'in' => [ $global_id, $this->created_post_ids[2] ],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(2, $actual['data']['posts']['nodes']);
+
+		// test notIn with global + db id
+		$variables = [
+			'where' => [
+				'notIn' => [ $global_id, $this->created_post_ids[2] ],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(4, $actual['data']['posts']['nodes']);
+
+		// test name
+		$post_one_name = get_post_field( 'post_name', $this->created_post_ids[1] );
+
+		$variables = [
+			'where' => [
+				'name' => $post_one_name,
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(1, $actual['data']['posts']['nodes']);
+		$this->assertEquals( $this->created_post_ids[1], $actual['data']['posts']['nodes'][0]['databaseId'] );
+
+		// test nameIn
+		$post_two_name = get_post_field( 'post_name', $this->created_post_ids[2] );
+
+		$variables = [
+			'where' => [
+				'nameIn' => [ $post_one_name, $post_two_name ],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(2, $actual['data']['posts']['nodes']);
+
+		// test title
+		$title = get_post_field( 'post_title', $this->created_post_ids[1] );
+
+		$variables = [
+			'where' => [
+				'title' => $title,
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(1, $actual['data']['posts']['nodes']);
+		$this->assertEquals( $this->created_post_ids[1], $actual['data']['posts']['nodes'][0]['databaseId'] );
+	}
+
+	public function testAuthorWhereArgs() {
+		$author_one_id = $this->factory()->user->create( [
+			'role' => 'author',
+			'user_nicename' => 'author-one',
+		] );
+		$author_two_id = $this->factory()->user->create( [
+			'role' => 'author',
+			'user_nicename' => 'author-two',
+		] );
+
+		$post_one_id = $this->factory()->post->create( [
+			'post_author' => $author_one_id,
+			'post_status' => 'publish',
+		] );
+		$post_two_id = $this->factory()->post->create( [
+			'post_author' => $author_two_id,
+			'post_status' => 'publish',
+		] );
+
+		$query = $this->getQuery();
+
+		// test author
+		$variables = [
+			'where' => [
+				'author' => $author_one_id,
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(1, $actual['data']['posts']['nodes']);
+		$this->assertEquals( $post_one_id, $actual['data']['posts']['nodes'][0]['databaseId'] );
+
+		// test authorName
+		$variables = [
+			'where' => [
+				'authorName' => 'author-one',
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(1, $actual['data']['posts']['nodes']);
+		$this->assertEquals( $post_one_id, $actual['data']['posts']['nodes'][0]['databaseId'] );
+
+		// test authorIn with global + db id
+		$author_one_global_id = Relay::toGlobalId( 'user', $author_one_id );
+
+		$variables = [
+			'where' => [
+				'authorIn' => [ $author_one_global_id, $author_two_id ],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(2, $actual['data']['posts']['nodes']);
+
+		// test authorNotIn with global + db id
+		$variables = [
+			'where' => [
+				'authorNotIn' => [ $author_one_global_id, $author_two_id ],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(6, $actual['data']['posts']['nodes']);
+	}
+
+	public function testCategoryWhereArgs() {
+		$term_one_id = $this->factory()->term->create( [
+			'taxonomy' => 'category',
+			'name' => 'term-one',
+		] );
+		$term_two_id = $this->factory()->term->create( [
+			'taxonomy' => 'category',
+			'name' => 'term-two',
+		] );
+
+		wp_set_object_terms( $this->created_post_ids[1], [ $term_one_id ], 'category' );
+		wp_set_object_terms( $this->created_post_ids[2], [ $term_two_id ], 'category' );
+
+		$query = $this->getQuery();
+
+		// test categoryId
+		$variables = [
+			'where' => [
+				'categoryId' => $term_one_id,
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(1, $actual['data']['posts']['nodes']);
+		$this->assertEquals( $this->created_post_ids[1], $actual['data']['posts']['nodes'][0]['databaseId'] );
+
+		// test categoryName
+		$variables = [
+			'where' => [
+				'categoryName' => 'term-one',
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(1, $actual['data']['posts']['nodes']);
+		$this->assertEquals( $this->created_post_ids[1], $actual['data']['posts']['nodes'][0]['databaseId'] );
+
+		// test categoryIn with global + db id
+		$term_one_global_id = Relay::toGlobalId( 'term', $term_one_id );
+
+		$variables = [
+			'where' => [
+				'categoryIn' => [ $term_one_global_id, $term_two_id ],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(2, $actual['data']['posts']['nodes']);
+
+		// test categoryNotIn with global + db id
+		$variables = [
+			'where' => [
+				'categoryNotIn' => [ $term_one_global_id, $term_two_id ],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(4, $actual['data']['posts']['nodes']);
+	}
+
+	public function testContentTypesWhereArgs() {
+		$page_id = $this->factory()->post->create( [
+			'post_type' => 'page',
+			'post_status' => 'publish',
+		] );
+
+		$query ='
+		query contentNodesQuery($first:Int $last:Int $after:String $before:String $where:RootQueryToContentNodeConnectionWhereArgs ){
+			contentNodes( first:$first last:$last after:$after before:$before where:$where ) {
+				nodes {
+					id
+					databaseId
+				}
+			}
+		}
+		';
+
+		// test contentTypes
+		$variables = [
+			'where' => [
+				'contentTypes' => [ 'PAGE' ],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(1, $actual['data']['contentNodes']['nodes']);
+		$this->assertEquals( $page_id, $actual['data']['contentNodes']['nodes'][0]['databaseId'] );
+
+		// test contentTypes with post + page
+		$variables = [
+			'where' => [
+				'contentTypes' => [ 'POST', 'PAGE' ],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(7, $actual['data']['contentNodes']['nodes']);
+	}
+
+	public function testParentWhereArgs() {
+		$query = $this->getQuery();
+
+		$parent_one_id = $this->created_post_ids[1];
+		$parent_two_id = $this->created_post_ids[2];
+
+		$child_one_id = $this->factory()->post->create([
+			'post_type'    => 'post',
+			'post_status'  => 'publish',
+			'post_title'   => 'Child Post',
+			'post_content' => 'Child post content',
+			'post_author'  => $this->admin,
+			'post_parent'  => $parent_one_id,
+		]);
+
+		$child_two_id = $this->factory()->post->create([
+			'post_type'    => 'post',
+			'post_status'  => 'publish',
+			'post_title'   => 'Child Post',
+			'post_content' => 'Child post content',
+			'post_author'  => $this->admin,
+			'post_parent'  => $parent_two_id,
+		]);
+
+		// test Parent with for top-level posts
+		$variables = [
+			'where' => [
+				'parent' => 0,
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(6, $actual['data']['posts']['nodes']);
+
+		// test parent with database Id
+		$variables = [
+			'where' => [
+				'parent' => $parent_one_id,
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(1, $actual['data']['posts']['nodes']);
+		$this->assertEquals( $child_one_id, $actual['data']['posts']['nodes'][0]['databaseId'] );
+
+		// test parent with global Id
+		$parent_one_global_id = Relay::toGlobalId( 'post', $parent_one_id );
+
+		$variables = [
+			'where' => [
+				'parent' => $parent_one_global_id,
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(1, $actual['data']['posts']['nodes']);
+		$this->assertEquals( $child_one_id, $actual['data']['posts']['nodes'][0]['databaseId'] );
+
+		// test parentIn with global + db ID
+		$variables = [
+			'where' => [
+				'parentIn' => [ $parent_one_global_id, $parent_two_id ],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(2, $actual['data']['posts']['nodes']);
+
+		// test parentNotIn with global + db ID
+		$variables = [
+			'where' => [
+				'parentNotIn' => [ $parent_one_global_id, $parent_two_id ],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(6, $actual['data']['posts']['nodes']);
+	}
+
+	public function testPasswordWhereArgs() {
+		// Create a test post with a password
+		$this->createPostObject(
+			[
+				'post_title'    => 'Password protected',
+				'post_type'     => 'post',
+				'post_status'   => 'publish',
+				'post_password' => 'password',
+			]
+		);
+
+		/**
+		 * WP_Query posts with a password
+		 */
+		$wp_query_posts_with_password = new WP_Query(
+			[
+				'has_password' => true,
+			]
+		);
+
+		$query = $this->getQuery();
+
+		wp_set_current_user( $this->admin );
+
+		/**
+		 * GraphQL query posts that have a password
+		 */
+		$variables = [
+			'where' => [
+				'hasPassword' => true,
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertNotEmpty( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+
+		$edges = $actual['data']['posts']['edges'];
+		$this->assertNotEmpty( $edges );
+
+		/**
+		 * Loop through all the returned posts
+		 */
+		foreach ( $edges as $edge ) {
+
+			/**
+			 * Assert that all posts returned have a password, since we queried for
+			 * posts using "has_password => true"
+			 */
+			$password = get_post( $edge['node']['databaseId'] )->post_password;
+			$this->assertNotEmpty( $password );
+
+		}
+
+		// Test with specific password
+		$variables = [
+			'where' => [
+				'password' => 'password',
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertNotEmpty( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+
+		$edges = $actual['data']['posts']['edges'];
+		$this->assertNotEmpty( $edges );
+
+		/**
+		 * Loop through all the returned posts
+		 */
+		foreach ( $edges as $edge ) {
+
+			/**
+			 * Assert that all posts returned have the correct password
+			 */
+			$password = get_post( $edge['node']['databaseId'] )->post_password;
+			$this->assertEquals( $password, 'password' );
+		}
+
+	}
+
+	public function testTagWhereArgs() {
+		$query = $this->getQuery();
+
+		$tag_one_id = $this->factory()->tag->create([
+			'name' => 'test',
+		]);
+		$tag_two_id = $this->factory()->tag->create([
+			'name' => 'test2',
+		]);
+
+		wp_set_object_terms( $this->created_post_ids[1], [ $tag_one_id ], 'post_tag' );
+		wp_set_object_terms( $this->created_post_ids[2], [ $tag_two_id ], 'post_tag' );
+
+		// test tag
+		$variables = [
+			'where' => [
+				'tag' => 'test',
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(1, $actual['data']['posts']['nodes']);
+		$this->assertEquals( $this->created_post_ids[1], $actual['data']['posts']['nodes'][0]['databaseId'] );
+
+		// test tagId with database Id
+		$variables = [
+			'where' => [
+				'tagId' => (string) $tag_one_id, // the input expects a type 'string'.
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(1, $actual['data']['posts']['nodes']);
+		$this->assertEquals( $this->created_post_ids[1], $actual['data']['posts']['nodes'][0]['databaseId'] );
+
+		// test tagId with global Id
+		$tag_one_global_id = \GraphQLRelay\Relay::toGlobalId( 'term', $tag_one_id );
+
+		$variables = [
+			'where' => [
+				'tagId' => $tag_one_global_id,
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(1, $actual['data']['posts']['nodes']);
+		$this->assertEquals( $this->created_post_ids[1], $actual['data']['posts']['nodes'][0]['databaseId'] );
+
+		// test tagIn with global + db id
+		$variables = [
+			'where' => [
+				'tagIn' => [ $tag_one_global_id, $tag_two_id ],
+			],
+		];
+
+		
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(2, $actual['data']['posts']['nodes']);
+
+		// test tagNotIn with global + db id
+		$variables = [
+			'where' => [
+				'tagNotIn' => [ $tag_one_global_id,  $tag_two_id ],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(4, $actual['data']['posts']['nodes']);
+
+		// test tagSlugAnd
+		$variables = [
+			'where' => [
+				'tagSlugAnd' => [ 'test', 'test2' ],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(0, $actual['data']['posts']['nodes']);
+
+		// add second tag to first post
+		wp_set_object_terms( $this->created_post_ids[1], [ $tag_one_id, $tag_two_id ], 'post_tag' );
+
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(1, $actual['data']['posts']['nodes']);
+		$this->assertEquals( $this->created_post_ids[1], $actual['data']['posts']['nodes'][0]['databaseId'] );
+
+		// test tagSlugIn
+		$variables = [
+			'where' => [
+				'tagSlugIn' => [ 'test', 'test2' ],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount(2, $actual['data']['posts']['nodes']);
+	}
+
 }

--- a/tests/wpunit/PostObjectQueriesTest.php
+++ b/tests/wpunit/PostObjectQueriesTest.php
@@ -577,6 +577,63 @@ class PostObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase 
 		$this->assertEquals( $expected, $actual['data'] );
 	}
 
+	public function testPageWithChildren() {
+
+		$parent_id = $this->factory->post->create(
+			[
+				'post_type' => 'page',
+			]
+		);
+
+		$child_id = $this->factory->post->create(
+			[
+				'post_type'   => 'page',
+				'post_parent' => $parent_id,
+			]
+		);
+
+		$global_id       = \GraphQLRelay\Relay::toGlobalId( 'post', $parent_id );
+		$global_child_id = \GraphQLRelay\Relay::toGlobalId( 'post', $child_id );
+
+		$query = '
+		{
+			page( id: "' . $global_id . '" ) {
+				id
+				pageId
+				children {
+					edges {
+						node {
+								...on Page {
+								id
+								pageId
+							}
+						}
+					}
+				}
+			}
+		}
+		';
+
+		$actual = do_graphql_request( $query );
+
+		/**
+		 * Make sure the query didn't return any errors
+		 */
+		$this->assertArrayNotHasKey( 'errors', $actual );
+
+		$parent = $actual['data']['page'];
+		$child  = $parent['children']['edges'][0]['node'];
+
+		/**
+		 * Make sure the child and parent data matches what we expect
+		 */
+		$this->assertEquals( $global_id, $parent['id'] );
+		$this->assertEquals( $parent_id, $parent['pageId'] );
+		$this->assertEquals( $global_child_id, $child['id'] );
+		$this->assertEquals( $child_id, $child['pageId'] );
+
+	}
+
 	/**
 	 * testPostQueryWithTags
 	 *
@@ -1610,56 +1667,6 @@ class PostObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase 
 
 	}
 
-	/**
-	 * Test the scenario where a post is assigned to an author
-	 * who is not a user on the site. This could happen for instance,
-	 * if the user was deleted, but their posts were never trashed
-	 * or assigned to another user.
-	 */
-	public function testQueryPostsWithOrphanedAuthorDoesntThrowErrors() {
-		global $wpdb;
-
-		$highest_user_id     = (int) $wpdb->get_var( "SELECT ID FROM {$wpdb->users} ORDER BY ID DESC limit 0,1" );
-		$nonexistent_user_id = $highest_user_id + 1;
-
-		// Create a new post assigned to a nonexistent user ID.
-		$post_id = wp_insert_post( [
-			'post_title'   => 'Post assigned to a non-existent user',
-			'post_content' => 'Post assigned to a non-existent user',
-			'post_status'  => 'publish',
-			'post_author'  => $nonexistent_user_id,
-		] );
-
-		$query = '
-		{
-			posts(first: 5) {
-				nodes {
-					postId
-					author {
-						node {
-						userId
-						name
-						}
-					}
-				}
-			}
-		}
-		';
-
-		$actual = graphql( [ 'query' => $query ] );
-
-		$this->assertTrue( $post_id && ! is_wp_error( $post_id ) );
-		$this->assertArrayNotHasKey( 'errors', $actual );
-
-		// Verify that the ID of the first post matches the one we just created.
-		$this->assertEquals( $post_id, $actual['data']['posts']['nodes'][0]['postId'] );
-
-		// Verify that the 'author' field is set to null, since the user ID is invalid.
-		$this->assertEquals( null, $actual['data']['posts']['nodes'][0]['author'] );
-
-		wp_delete_post( $post_id, true );
-
-	}
 
 	/**
 	 * Tests to make sure the page set as the front page shows as the front page
@@ -1971,146 +1978,6 @@ class PostObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase 
 		$this->assertSame( $expected, $actual['data']['pageById'] );
 		$this->assertSame( $expected, $actual['data']['pageBypageId'] );
 
-	}
-
-	/**
-	 * @throws Exception
-	 */
-	public function testUriFieldAvailableForPublicQueries() {
-
-		/**
-		 * Create a password protected post
-		 * so that we can query for it and make sure the link and uri fields are exposed
-		 * to public requests.
-		 *
-		 * @see: https://github.com/wp-graphql/wp-graphql/issues/1338
-		 */
-		$post_id = $this->factory()->post->create([
-			'post_type'     => 'post',
-			'post_status'   => 'publish',
-			'post_password' => 'test',
-			'post_title'    => 'Post with password',
-			'post_content'  => 'Protected content',
-			'post_author'   => $this->admin,
-		]);
-
-		$query = '
-		query {
-			posts(first: 1, where: {status: PUBLISH}) {
-				nodes {
-					databaseId
-					uri
-					link
-				}
-			}
-		}
-		';
-
-		$actual = $this->graphql([
-			'query' => $query,
-		]);
-
-		$this->assertArrayNotHasKey( 'errors', $actual );
-		$this->assertEquals( $post_id, $actual['data']['posts']['nodes'][0]['databaseId'] );
-		$this->assertNotEmpty( $post_id, $actual['data']['posts']['nodes'][0]['uri'], 'Ensure the uri is not empty for public requests' );
-		$this->assertNotEmpty( $post_id, $actual['data']['posts']['nodes'][0]['link'], 'Ensure the link field is not empty for public requests' );
-
-	}
-
-	public function testQueryPasswordProtectedPost() {
-
-		$title   = 'Test Title for QueryPasswordProtectedPost' . uniqid();
-		$content = 'Test Content for QueryPasswordProtectedPost' . uniqid();
-
-		$this->factory()->post->create([
-			'post_type'     => 'post',
-			'post_status'   => 'publish',
-			'post_password' => 'publish',
-			'post_content'  => $content,
-			'post_title'    => $title,
-		]);
-
-		$query = '
-		{
-			posts {
-				nodes {
-					id
-					title
-					content
-				}
-			}
-		}
-		';
-
-		wp_set_current_user( 0 );
-
-		$actual = graphql([
-			'query' => $query,
-		]);
-
-		$this->assertArrayNotHasKey( 'errors', $actual );
-		$this->assertNull( $actual['data']['posts']['nodes'][0]['content'] );
-		// The content should be null for public users because no password was entered
-		$this->assertSame( $title, $actual['data']['posts']['nodes'][0]['title'] );
-
-		wp_set_current_user( $this->admin );
-
-		$actual = graphql([
-			'query' => $query,
-		]);
-
-		$this->assertArrayNotHasKey( 'errors', $actual );
-		// The content should be public for an admin
-		$this->assertSame( apply_filters( 'the_content', $content ), $actual['data']['posts']['nodes'][0]['content'] );
-		$this->assertSame( $title, $actual['data']['posts']['nodes'][0]['title'] );
-	}
-
-	public function testIsStickyFieldOnPost() {
-
-		$sticky_post_id = $this->factory()->post->create([
-			'post_type'    => 'post',
-			'post_status'  => 'publish',
-			'post_title'   => 'Sticky Post',
-			'post_content' => 'Sticky post content',
-			'post_author'  => $this->admin,
-		]);
-
-		$nonsticky_post_id = $this->factory()->post->create([
-			'post_type'    => 'post',
-			'post_status'  => 'publish',
-			'post_title'   => 'Non-sticky Post',
-			'post_content' => 'Non-sticky post content',
-			'post_author'  => $this->admin,
-		]);
-
-		update_option( 'sticky_posts', [ $sticky_post_id ] );
-
-		$query = '
-		query testStickyPost($ids: [ID]) {
-			posts(first: 2, where: { in: $ids }) {
-				nodes {
-					databaseId
-					uri
-					link
-					isSticky
-				}
-			}
-		}
-		';
-
-		$actual = $this->graphql([
-			'query'     => $query,
-			'variables' => [
-				'ids' => [
-					$sticky_post_id,
-					$nonsticky_post_id,
-				],
-			],
-		]);
-
-		$this->assertArrayNotHasKey( 'errors', $actual );
-		$this->assertTrue( $actual['data']['posts']['nodes'][0]['isSticky'] );
-		$this->assertFalse( $actual['data']['posts']['nodes'][1]['isSticky'] );
 	}
 
 	public function testQueryPostOfAnotherPostTypeReturnsNull() {

--- a/tests/wpunit/QueryAnalyzerTest.php
+++ b/tests/wpunit/QueryAnalyzerTest.php
@@ -1,0 +1,82 @@
+<?php
+class QueryAnalyzerTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
+
+	public $post_id;
+
+	public function _setUp():void {
+		parent::_setUp();
+
+		$this->post_id = self::factory()->post->create([
+			'post_status' => 'publish',
+			'post_title' => 'test post'
+		]);
+
+	}
+
+	public function _tearDown():void {
+		wp_delete_post( $this->post_id, true );
+		parent::_tearDown();
+	}
+
+	public function testListTypes() {
+
+		$query = '{ posts { nodes { id, title } } }';
+
+		$request = graphql([
+			'query' => $query,
+		], true);
+
+		// before execution, this should be null
+		$this->assertEmpty( $request->get_query_analyzer()->get_list_types() );
+
+
+		// execute the query
+		$request->execute();
+
+		// get the list types that were generated during execution
+		$list_types = $request->get_query_analyzer()->get_list_types();
+
+		// Assert the expected list types are returned
+		$this->assertEqualSets( [ 'list:post' ], $list_types );
+	}
+
+	public function testListModels() {
+		$query = '{ posts { nodes { id, title } } }';
+
+		$request = graphql([
+			'query' => $query,
+		], true);
+
+		// before execution, this should be null (no nodes have loaded)
+		$this->assertEmpty( $request->get_query_analyzer()->get_runtime_nodes() );
+
+		// execute the request
+		$request->execute();
+
+		$nodes = $request->get_query_analyzer()->get_runtime_nodes();
+
+		$node_id = \GraphQLRelay\Relay::toGlobalId( 'post', $this->post_id );
+
+		$this->assertEqualSets( [ $node_id ], $nodes );
+	}
+
+	public function testQueryTypes() {
+
+		$query = '{ posts { nodes { id, title } } }';
+
+		$request = graphql([
+			'query' => $query,
+		], true);
+
+
+		// before execution, this should be null
+		$this->assertEmpty( $request->get_query_analyzer()->get_query_types() );
+
+		// Execute the request
+		$request->execute();
+
+		$types = $request->get_query_analyzer()->get_query_types();
+		$this->assertEqualSets( [ 'rootquery', 'rootquerytopostconnection', 'post' ], $types );
+	}
+
+}

--- a/tests/wpunit/UtilsTest.php
+++ b/tests/wpunit/UtilsTest.php
@@ -1,0 +1,43 @@
+<?php
+
+class UtilsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
+
+
+	public function testGetQueryId() {
+
+
+		$query_without_spaces = '{posts{nodes{id,title}}}';
+		$query_with_spaces = '{ posts { nodes { id, title } } }';
+		$query_with_line_breaks = '
+		{ 
+			posts { 
+				nodes { 
+					id
+					title 
+				} 
+			} 
+		}';
+
+		$id1 = \WPGraphQL\Utils\Utils::get_query_id( $query_without_spaces );
+		$id2 = \WPGraphQL\Utils\Utils::get_query_id( $query_with_spaces );
+		$id3 = \WPGraphQL\Utils\Utils::get_query_id( $query_with_line_breaks );
+
+		codecept_debug([
+			$id1,
+			$id2,
+			$id3
+		]);
+
+		// differently formatted versions of the same query should
+		// all produce the same query_id
+		$this->assertSame( $id1, $id2 );
+		$this->assertSame( $id2, $id3 );
+		$this->assertSame( $id1, $id3 );
+
+		$invalid_query = '{ some { malformatted { query...';
+
+		// if an invalid query is passed, we should get a null response
+		$this->assertNull( \WPGraphQL\Utils\Utils::get_query_id( $invalid_query ) );
+
+	}
+}

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.10.0
+ * Version: 1.11.0
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.10.0
+ * @version  1.11.0
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
# Release Notes

## New Features

- ([#2519](https://github.com/wp-graphql/wp-graphql/pull/2519)): Add new "QueryAnalyzer" class which tracks Types, Models and Nodes asked for and returned in a request and adds them to the response headers. 
- ([#2519](https://github.com/wp-graphql/wp-graphql/pull/2519)): Add 2nd argument to `graphql()` function that will return the `Request` object instead executing and returning the response.
- ([#2522](https://github.com/wp-graphql/wp-graphql/pull/2522)): Allow global/database IDs in Comment connection where args. Thanks @justlevine!
- ([#2523](https://github.com/wp-graphql/wp-graphql/pull/2523)): Allow global/database IDs in MenuItem connection where args ID Inputs. Thanks @justlevine!
- ([#2524](https://github.com/wp-graphql/wp-graphql/pull/2524)): Allow global/database IDs in Term connection where args ID Inputs. Thanks @justlevine!
- ([#2525](https://github.com/wp-graphql/wp-graphql/pull/2525)): Allow global/database IDs in Post connection where args ID Inputs. Thanks @justlevine!

## Chores / Bugfixes

- ([#2521](https://github.com/wp-graphql/wp-graphql/pull/2521)): Refactor `$args` in AbstractConnectionResolver. Thanks @justlevine!
- ([#2526](https://github.com/wp-graphql/wp-graphql/pull/2526)): Ensure tracked data in QueryAnalyzer is unique.

