### PR TITLE
fix: regression to menuItem queries when parentId is 0

### DIFF
--- a/src/Data/Connection/MenuItemConnectionResolver.php
+++ b/src/Data/Connection/MenuItemConnectionResolver.php
@@ -50,7 +50,7 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 			$query_args['meta_value'] = (int) $this->args['where']['parentDatabaseId']; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 		}
 
-		if ( isset( $this->args['where']['parentId'] ) ) {
+		if ( ! empty( $this->args['where']['parentId'] ) || ( isset( $this->args['where']['parentId'] ) && 0 === (int) $this->args['where']['parentId'] ) ) {
 			$query_args['meta_key']   = '_menu_item_menu_item_parent'; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 			$query_args['meta_value'] = $this->args['where']['parentId']; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 		}

--- a/src/Data/Connection/MenuItemConnectionResolver.php
+++ b/src/Data/Connection/MenuItemConnectionResolver.php
@@ -50,10 +50,9 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 			$query_args['meta_value'] = (int) $this->args['where']['parentDatabaseId']; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 		}
 
-		if ( ! empty( $this->args['where']['parentId'] ) ) {
-
-				$query_args['meta_key']   = '_menu_item_menu_item_parent'; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-				$query_args['meta_value'] = $this->args['where']['parentId']; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+		if ( isset( $this->args['where']['parentId'] ) ) {
+			$query_args['meta_key']   = '_menu_item_menu_item_parent'; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+			$query_args['meta_value'] = $this->args['where']['parentId']; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 		}
 
 		// Get unique list of locations as the default limitation of

--- a/tests/wpunit/MenuItemConnectionQueriesTest.php
+++ b/tests/wpunit/MenuItemConnectionQueriesTest.php
@@ -733,4 +733,65 @@ class MenuItemConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 		$this->assertEquals( $end_cursor, $actual['data']['menuItems']['pageInfo']['endCursor'] );
 	}
 
+	public function testQueryMenuItemsWithParentIdSetToZero() {
+
+		$menu_location = 'my-menu-items-location';
+		register_nav_menu( $menu_location, 'My MenuItems' );
+		WPGraphQL::clear_schema();
+
+		$created = $this->create_nested_menu( 3, $menu_location );
+
+		$actual = $this->graphql([
+			'query' => $this->getQuery(),
+			'variables' => [
+				'first' => 100,
+				'after' => null,
+				'where' => [
+					'parentId' => 0
+				],
+			],
+		]);
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+
+		codecept_debug( $actual );
+
+		foreach ( $actual['data']['menuItems']['edges'] as $edge ) {
+			$node = $edge['node'];
+			$this->assertSame( 0, $node['parentDatabaseId'] );
+			$this->assertNull( $node['parentId'] );
+		}
+
+	}
+
+	public function testQueryMenuItemsWithParentDatabaseIdSetToZero() {
+
+		$menu_location = 'my-menu-items-location';
+		register_nav_menu( $menu_location, 'My MenuItems' );
+		WPGraphQL::clear_schema();
+
+		$created = $this->create_nested_menu( 3, $menu_location );
+
+		$actual = $this->graphql([
+			'query' => $this->getQuery(),
+			'variables' => [
+				'first' => 100,
+				'where' => [
+					'parentDatabaseId' => 0
+				]
+			]
+		]);
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+
+		codecept_debug( $actual );
+
+		foreach ( $actual['data']['menuItems']['edges'] as $edge ) {
+			$node = $edge['node'];
+			$this->assertSame( 0, $node['parentDatabaseId'] );
+			$this->assertNull( $node['parentId'] );
+		}
+
+	}
+
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This fixes a regression where using 0 as the `parentId` for menuItem queries is no longer returning only menuItems with no parent set. 

Does this close any currently open issues?
------------------------------------------
closes #2530 


Any other comments?
-------------------

Failing test run: https://github.com/wp-graphql/wp-graphql/actions/runs/3100423158/jobs/5020687861#step:7:270
Failing test commit: https://github.com/wp-graphql/wp-graphql/pull/2532/commits/0575f93646418488c27140c4c301084b29fa22ad

Passing test run: https://github.com/wp-graphql/wp-graphql/actions/runs/3100510553/jobs/5020872900
Passing test commit: https://github.com/wp-graphql/wp-graphql/pull/2532/commits/667558891c7fa9c8a6ebd4c8cae88b1923d2daf1



