### PR TITLE
release: v1.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.11.1
+
+## Chores / Bugfixes
+
+- ([#2530](https://github.com/wp-graphql/wp-graphql/pull/2530)): Fixes a regression introduced in v1.11.0 where querying menuItems with parentId where arg set to 0 was returning all menuItems instead of just top level items.
+
 ## 1.11.0
 
 ## New Features

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, API, Gatsby, Headless, Decoupled, React, Nextjs, Vue, Apollo, RES
 Requires at least: 5.0
 Tested up to: 5.9.1
 Requires PHP: 7.1
-Stable tag: 1.11.0
+Stable tag: 1.11.1
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -168,6 +168,13 @@ The `uri` field was non-null on some Types in the Schema but has been changed to
 Composer dependencies are no longer versioned in Github. Recommended install source is WordPress.org or using Composer to get the code from Packagist.org or WPackagist.org.
 
 == Changelog ==
+
+= 1.11.1 =
+
+**Chores / Bugfixes**
+
+- ([#2530](https://github.com/wp-graphql/wp-graphql/pull/2530)): Fixes a regression introduced in v1.11.0 where querying menuItems with parentId where arg set to 0 was returning all menuItems instead of just top level items.
+
 
 = 1.11.0 =
 

--- a/src/Data/Connection/MenuItemConnectionResolver.php
+++ b/src/Data/Connection/MenuItemConnectionResolver.php
@@ -50,10 +50,9 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 			$query_args['meta_value'] = (int) $this->args['where']['parentDatabaseId']; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 		}
 
-		if ( ! empty( $this->args['where']['parentId'] ) ) {
-
-				$query_args['meta_key']   = '_menu_item_menu_item_parent'; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-				$query_args['meta_value'] = $this->args['where']['parentId']; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+		if ( ! empty( $this->args['where']['parentId'] ) || ( isset( $this->args['where']['parentId'] ) && 0 === (int) $this->args['where']['parentId'] ) ) {
+			$query_args['meta_key']   = '_menu_item_menu_item_parent'; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+			$query_args['meta_value'] = $this->args['where']['parentId']; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 		}
 
 		// Get unique list of locations as the default limitation of

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -130,7 +130,7 @@ final class WPGraphQL {
 
 		// Plugin version.
 		if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-			define( 'WPGRAPHQL_VERSION', '1.11.0' );
+			define( 'WPGRAPHQL_VERSION', '1.11.1' );
 		}
 
 		// Plugin Folder Path.

--- a/tests/wpunit/MenuItemConnectionQueriesTest.php
+++ b/tests/wpunit/MenuItemConnectionQueriesTest.php
@@ -733,4 +733,65 @@ class MenuItemConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 		$this->assertEquals( $end_cursor, $actual['data']['menuItems']['pageInfo']['endCursor'] );
 	}
 
+	public function testQueryMenuItemsWithParentIdSetToZero() {
+
+		$menu_location = 'my-menu-items-location';
+		register_nav_menu( $menu_location, 'My MenuItems' );
+		WPGraphQL::clear_schema();
+
+		$created = $this->create_nested_menu( 3, $menu_location );
+
+		$actual = $this->graphql([
+			'query' => $this->getQuery(),
+			'variables' => [
+				'first' => 100,
+				'after' => null,
+				'where' => [
+					'parentId' => 0
+				],
+			],
+		]);
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+
+		codecept_debug( $actual );
+
+		foreach ( $actual['data']['menuItems']['edges'] as $edge ) {
+			$node = $edge['node'];
+			$this->assertSame( 0, $node['parentDatabaseId'] );
+			$this->assertNull( $node['parentId'] );
+		}
+
+	}
+
+	public function testQueryMenuItemsWithParentDatabaseIdSetToZero() {
+
+		$menu_location = 'my-menu-items-location';
+		register_nav_menu( $menu_location, 'My MenuItems' );
+		WPGraphQL::clear_schema();
+
+		$created = $this->create_nested_menu( 3, $menu_location );
+
+		$actual = $this->graphql([
+			'query' => $this->getQuery(),
+			'variables' => [
+				'first' => 100,
+				'where' => [
+					'parentDatabaseId' => 0
+				]
+			]
+		]);
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+
+		codecept_debug( $actual );
+
+		foreach ( $actual['data']['menuItems']['edges'] as $edge ) {
+			$node = $edge['node'];
+			$this->assertSame( 0, $node['parentDatabaseId'] );
+			$this->assertNull( $node['parentId'] );
+		}
+
+	}
+
 }

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.11.0
+ * Version: 1.11.1
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.11.0
+ * @version  1.11.1
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
## 1.11.1

## Chores / Bugfixes

- ([#2530](https://github.com/wp-graphql/wp-graphql/pull/2530)): Fixes a regression introduced in v1.11.0 where querying menuItems with parentId where arg set to 0 was returning all menuItems instead of just top level items.
