### PR TITLE
fix: set IDE direction to prevent breaks in RTL mode

### DIFF
--- a/src/Admin/GraphiQL/GraphiQL.php
+++ b/src/Admin/GraphiQL/GraphiQL.php
@@ -114,7 +114,7 @@ class GraphiQL {
 	 * @return void
 	 */
 	public function render_graphiql_admin_page() {
-		$rendered = apply_filters( 'graphql_render_admin_page', '<div class="wrap"><div id="graphiql" class="graphiql-container">Loading ...</div></div>' );
+		$rendered = apply_filters( 'graphql_render_admin_page', '<div class="wrap" dir="ltr"><div id="graphiql" class="graphiql-container">Loading ...</div></div>' );
 
 		echo wp_kses_post( $rendered );
 	}


### PR DESCRIPTION
from: https://github.com/mehdikhody/wp-graphql/commit/7f3ec5cf3408d425a37f794b475abcd5b298e1bb

<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR ensures GraphiQL IDE continues to display LTR even when using WordPress in a RTL language.

Full props go to @mehdikhody 
I just used https://github.com/mehdikhody/wp-graphql/commit/7f3ec5cf3408d425a37f794b475abcd5b298e1bb to open the PR


Does this close any currently open issues?
------------------------------------------
Fixes #2512 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
Before: 
![image](https://user-images.githubusercontent.com/29322304/192093920-c3885764-9a8c-4daa-a9c7-09f363a4d2ae.png)

After: 
![image](https://user-images.githubusercontent.com/29322304/192093936-81cced28-fd32-4314-bef4-20b72a478fb0.png)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (WSL2 + Devilbox + PHP 8.0.19)

**WordPress Version:** 6.0.2
