### PR TITLE
fix: deprecate Comment `approved` field in favor of `status: CommentStatusEnum` 

### DIFF
--- a/src/Data/CommentMutation.php
+++ b/src/Data/CommentMutation.php
@@ -93,7 +93,12 @@ class CommentMutation {
 			$output_args['comment_type'] = $input['type'];
 		}
 
-		if ( ! empty( $input['approved'] ) ) {
+		if ( ! empty( $input['status'] ) ) {
+			$output_args['comment_approved'] = $input['status'];
+		}
+
+		// Fallback to deprecated `approved` input.
+		if ( empty( $output_args['comment_approved'] ) && isset( $input['approved'] ) ) {
 			$output_args['comment_approved'] = $input['approved'];
 		}
 

--- a/src/Model/Comment.php
+++ b/src/Model/Comment.php
@@ -177,15 +177,14 @@ class Comment extends Model {
 				},
 				'approved'           => function () {
 					_doing_it_wrong( __METHOD__, 'The approved field is deprecated in favor of `status`', '@todo' );
-					return isset( $this->data->comment_approved ) ? $this->data->comment_approved : null;
+					return ! empty( $this->data->comment_approved ) && 'hold' !== $this->data->comment_approved;
 				},
 				'status'             => function () {
-					$status = isset( $this->data->comment_approved ) ? $this->data->comment_approved : null;
-
-					if ( ! is_numeric( $status ) ) {
-						return $status;
+					if ( ! is_numeric( $this->data->comment_approved ) ) {
+						return $this->data->comment_approved;
 					}
-					return ! empty( $status ) ? 'approve' : 'hold';
+
+					return '1' === $this->data->comment_approved ? 'approve' : 'hold';
 				},
 				'agent'              => function () {
 					return ! empty( $this->data->comment_agent ) ? $this->data->comment_agent : null;

--- a/src/Model/Comment.php
+++ b/src/Model/Comment.php
@@ -9,25 +9,25 @@ use WP_Comment;
 /**
  * Class Comment - Models data for Comments
  *
- * @property string $id
- * @property int    $commentId
- * @property string $commentAuthorEmail
- * @property string $comment_author
- * @property string $comment_author_url
  * @property int    $comment_ID
  * @property int    $comment_parent_id
- * @property string $parentId
+ * @property int    $commentId
  * @property int    $parentDatabaseId
+ * @property int    $userId
+ * @property string $agent
  * @property string $authorIp
- * @property string $date
- * @property string $dateGmt
+ * @property string $comment_author
+ * @property string $comment_author_url
+ * @property string $commentAuthorEmail
  * @property string $contentRaw
  * @property string $contentRendered
+ * @property string $date
+ * @property string $dateGmt
+ * @property string $id
  * @property string $karma
- * @property int    $approved
- * @property string $agent
+ * @property string $parentId
+ * @property string $status
  * @property string $type
- * @property int    $userId
  *
  * @package WPGraphQL\Model
  */
@@ -62,6 +62,7 @@ class Comment extends Model {
 			'commentedOnId',
 			'comment_post_ID',
 			'approved',
+			'status',
 			'comment_parent_id',
 			'parentId',
 			'parentDatabaseId',
@@ -175,7 +176,16 @@ class Comment extends Model {
 					return ! empty( $this->data->comment_karma ) ? $this->data->comment_karma : null;
 				},
 				'approved'           => function () {
-					return ! empty( $this->data->comment_approved ) ? $this->data->comment_approved : null;
+					_doing_it_wrong( __METHOD__, 'The approved field is deprecated in favor of `status`', '@todo' );
+					return isset( $this->data->comment_approved ) ? $this->data->comment_approved : null;
+				},
+				'status'             => function () {
+					$status = isset( $this->data->comment_approved ) ? $this->data->comment_approved : null;
+
+					if ( ! is_numeric( $status ) ) {
+						return $status;
+					}
+					return ! empty( $status ) ? 'approve' : 'hold';
 				},
 				'agent'              => function () {
 					return ! empty( $this->data->comment_agent ) ? $this->data->comment_agent : null;

--- a/src/Mutation/CommentCreate.php
+++ b/src/Mutation/CommentCreate.php
@@ -34,9 +34,9 @@ class CommentCreate {
 	 */
 	public static function get_input_fields() {
 		return [
-			'commentOn'   => [
-				'type'        => 'Int',
-				'description' => __( 'The database ID of the post object the comment belongs to.', 'wp-graphql' ),
+			'approved'    => [
+				'type'        => 'String',
+				'description' => __( 'The approval status of the comment.', 'wp-graphql' ),
 			],
 			'author'      => [
 				'type'        => 'String',
@@ -50,25 +50,25 @@ class CommentCreate {
 				'type'        => 'String',
 				'description' => __( 'The url of the comment\'s author.', 'wp-graphql' ),
 			],
+			'commentOn'   => [
+				'type'        => 'Int',
+				'description' => __( 'The database ID of the post object the comment belongs to.', 'wp-graphql' ),
+			],
 			'content'     => [
 				'type'        => 'String',
 				'description' => __( 'Content of the comment.', 'wp-graphql' ),
-			],
-			'type'        => [
-				'type'        => 'String',
-				'description' => __( 'Type of comment.', 'wp-graphql' ),
-			],
-			'parent'      => [
-				'type'        => 'ID',
-				'description' => __( 'Parent comment ID of current comment.', 'wp-graphql' ),
 			],
 			'date'        => [
 				'type'        => 'String',
 				'description' => __( 'The date of the object. Preferable to enter as year/month/day ( e.g. 01/31/2017 ) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 ', 'wp-graphql' ),
 			],
-			'approved'    => [
+			'parent'      => [
+				'type'        => 'ID',
+				'description' => __( 'Parent comment ID of current comment.', 'wp-graphql' ),
+			],
+			'type'        => [
 				'type'        => 'String',
-				'description' => __( 'The approval status of the comment.', 'wp-graphql' ),
+				'description' => __( 'Type of comment.', 'wp-graphql' ),
 			],
 		];
 	}

--- a/src/Mutation/CommentCreate.php
+++ b/src/Mutation/CommentCreate.php
@@ -35,8 +35,9 @@ class CommentCreate {
 	public static function get_input_fields() {
 		return [
 			'approved'    => [
-				'type'        => 'String',
-				'description' => __( 'The approval status of the comment.', 'wp-graphql' ),
+				'type'              => 'String',
+				'description'       => __( 'The approval status of the comment.', 'wp-graphql' ),
+				'deprecationReason' => __( 'Deprecated in favor of the status field', 'wp-graphql' ),
 			],
 			'author'      => [
 				'type'        => 'String',
@@ -65,6 +66,10 @@ class CommentCreate {
 			'parent'      => [
 				'type'        => 'ID',
 				'description' => __( 'Parent comment ID of current comment.', 'wp-graphql' ),
+			],
+			'status'      => [
+				'type'        => 'CommentStatusEnum',
+				'description' => __( 'The approval status of the comment', 'wp-graphql' ),
 			],
 			'type'        => [
 				'type'        => 'String',

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -74,6 +74,7 @@ use WPGraphQL\Type\Union\MenuItemObjectUnion;
 use WPGraphQL\Type\Enum\AvatarRatingEnum;
 use WPGraphQL\Type\Enum\CommentsConnectionOrderbyEnum;
 use WPGraphQL\Type\Enum\CommentNodeIdTypeEnum;
+use WPGraphQL\Type\Enum\CommentStatusEnum;
 use WPGraphQL\Type\Enum\MediaItemSizeEnum;
 use WPGraphQL\Type\Enum\MediaItemStatusEnum;
 use WPGraphQL\Type\Enum\MenuLocationEnum;
@@ -301,9 +302,9 @@ class TypeRegistry {
 		UserRole::register_type();
 
 		AvatarRatingEnum::register_type();
-		CommentsConnectionOrderbyEnum::register_type();
 		CommentNodeIdTypeEnum::register_type();
-		ContentNodeIdTypeEnum::register_type();
+		CommentsConnectionOrderbyEnum::register_type();
+		CommentStatusEnum::register_type();
 		ContentTypeEnum::register_type();
 		ContentTypeIdTypeEnum::register_type();
 		MediaItemSizeEnum::register_type();

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -305,6 +305,7 @@ class TypeRegistry {
 		CommentNodeIdTypeEnum::register_type();
 		CommentsConnectionOrderbyEnum::register_type();
 		CommentStatusEnum::register_type();
+		ContentNodeIdTypeEnum::register_type();
 		ContentTypeEnum::register_type();
 		ContentTypeIdTypeEnum::register_type();
 		MediaItemSizeEnum::register_type();

--- a/src/Type/Enum/CommentStatusEnum.php
+++ b/src/Type/Enum/CommentStatusEnum.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace WPGraphQL\Type\Enum;
+
+use WPGraphQL\Type\WPEnumType;
+
+class CommentStatusEnum {
+
+	/**
+	 * Register the CommentStatusEnum Type to the Schema
+	 *
+	 * @return void
+	 */
+	public static function register_type() {
+		$values = [];
+
+		$stati = get_comment_statuses();
+
+		/**
+		 * Loop through the post_stati
+		 */
+		foreach ( $stati as $status => $name ) {
+
+			$values[ WPEnumType::get_safe_name( $status ) ] = [
+				'description' => sprintf( __( 'Comments with the %1$s status', 'wp-graphql' ), $name ),
+				'value'       => $status,
+			];
+		}
+
+		register_graphql_enum_type(
+			'CommentStatusEnum',
+			[
+				'description' => __( 'The status of the comment object.', 'wp-graphql' ),
+				'values'      => $values,
+			]
+		);
+
+	}
+}

--- a/src/Type/Enum/CommentsConnectionOrderbyEnum.php
+++ b/src/Type/Enum/CommentsConnectionOrderbyEnum.php
@@ -19,7 +19,7 @@ class CommentsConnectionOrderbyEnum {
 						'value'       => 'comment_agent',
 					],
 					'COMMENT_APPROVED'     => [
-						'description' => __( 'Order by true/false approval of the comment.', 'wp-graphql' ),
+						'description' => __( 'Order by approval status of the comment.', 'wp-graphql' ),
 						'value'       => 'comment_approved',
 					],
 					'COMMENT_AUTHOR'       => [

--- a/src/Type/ObjectType/Comment.php
+++ b/src/Type/ObjectType/Comment.php
@@ -60,8 +60,12 @@ class Comment {
 						'description' => __( 'User agent used to post the comment. This field is equivalent to WP_Comment->comment_agent and the value matching the "comment_agent" column in SQL.', 'wp-graphql' ),
 					],
 					'approved'         => [
-						'type'        => 'Boolean',
-						'description' => __( 'The approval status of the comment. This field is equivalent to WP_Comment->comment_approved and the value matching the "comment_approved" column in SQL.', 'wp-graphql' ),
+						'type'              => 'Boolean',
+						'description'       => __( 'The approval status of the comment. This field is equivalent to WP_Comment->comment_approved and the value matching the "comment_approved" column in SQL.', 'wp-graphql' ),
+						'deprecationReason' => __( 'Deprecated in favor of the `status` field', 'wp-graphql' ),
+						'resolve'           => function ( $comment, $args, AppContext $context, ResolveInfo $info ) {
+							return 'approve' === $comment->status;
+						},
 					],
 					'authorIp'         => [
 						'type'        => 'String',

--- a/src/Type/ObjectType/Comment.php
+++ b/src/Type/ObjectType/Comment.php
@@ -120,6 +120,10 @@ class Comment {
 						'type'        => 'Int',
 						'description' => __( 'The database id of the parent comment node or null if it is the root comment', 'wp-graphql' ),
 					],
+					'status'           => [
+						'type'        => 'CommentStatusEnum',
+						'description' => __( 'The approval status of the comment. This field is equivalent to WP_Comment->comment_approved and the value matching the "comment_approved" column in SQL.', 'wp-graphql' ),
+					],
 					'type'             => [
 						'type'        => 'String',
 						'description' => __( 'Type of comment. This field is equivalent to WP_Comment->comment_type and the value matching the "comment_type" column in SQL.', 'wp-graphql' ),

--- a/src/Type/ObjectType/Comment.php
+++ b/src/Type/ObjectType/Comment.php
@@ -55,25 +55,22 @@ class Comment {
 					],
 				],
 				'fields'      => [
-					'id'               => [
-						'description' => __( 'The globally unique identifier for the comment object', 'wp-graphql' ),
+					'agent'            => [
+						'type'        => 'String',
+						'description' => __( 'User agent used to post the comment. This field is equivalent to WP_Comment->comment_agent and the value matching the "comment_agent" column in SQL.', 'wp-graphql' ),
 					],
-					'commentId'        => [
-						'type'              => 'Int',
-						'description'       => __( 'ID for the comment, unique among comments.', 'wp-graphql' ),
-						'deprecationReason' => __( 'Deprecated in favor of databaseId', 'wp-graphql' ),
+					'approved'         => [
+						'type'        => 'Boolean',
+						'description' => __( 'The approval status of the comment. This field is equivalent to WP_Comment->comment_approved and the value matching the "comment_approved" column in SQL.', 'wp-graphql' ),
 					],
 					'authorIp'         => [
 						'type'        => 'String',
 						'description' => __( 'IP address for the author. This field is equivalent to WP_Comment->comment_author_IP and the value matching the "comment_author_IP" column in SQL.', 'wp-graphql' ),
 					],
-					'date'             => [
-						'type'        => 'String',
-						'description' => __( 'Date the comment was posted in local time. This field is equivalent to WP_Comment->date and the value matching the "date" column in SQL.', 'wp-graphql' ),
-					],
-					'dateGmt'          => [
-						'type'        => 'String',
-						'description' => __( 'Date the comment was posted in GMT. This field is equivalent to WP_Comment->date_gmt and the value matching the "date_gmt" column in SQL.', 'wp-graphql' ),
+					'commentId'        => [
+						'type'              => 'Int',
+						'description'       => __( 'ID for the comment, unique among comments.', 'wp-graphql' ),
+						'deprecationReason' => __( 'Deprecated in favor of databaseId', 'wp-graphql' ),
 					],
 					'content'          => [
 						'type'        => 'String',
@@ -92,25 +89,24 @@ class Comment {
 							}
 						},
 					],
-					'karma'            => [
-						'type'        => 'Int',
-						'description' => __( 'Karma value for the comment. This field is equivalent to WP_Comment->comment_karma and the value matching the "comment_karma" column in SQL.', 'wp-graphql' ),
-					],
-					'approved'         => [
-						'type'        => 'Boolean',
-						'description' => __( 'The approval status of the comment. This field is equivalent to WP_Comment->comment_approved and the value matching the "comment_approved" column in SQL.', 'wp-graphql' ),
-					],
-					'agent'            => [
+					'date'             => [
 						'type'        => 'String',
-						'description' => __( 'User agent used to post the comment. This field is equivalent to WP_Comment->comment_agent and the value matching the "comment_agent" column in SQL.', 'wp-graphql' ),
+						'description' => __( 'Date the comment was posted in local time. This field is equivalent to WP_Comment->date and the value matching the "date" column in SQL.', 'wp-graphql' ),
 					],
-					'type'             => [
+					'dateGmt'          => [
 						'type'        => 'String',
-						'description' => __( 'Type of comment. This field is equivalent to WP_Comment->comment_type and the value matching the "comment_type" column in SQL.', 'wp-graphql' ),
+						'description' => __( 'Date the comment was posted in GMT. This field is equivalent to WP_Comment->date_gmt and the value matching the "date_gmt" column in SQL.', 'wp-graphql' ),
+					],
+					'id'               => [
+						'description' => __( 'The globally unique identifier for the comment object', 'wp-graphql' ),
 					],
 					'isRestricted'     => [
 						'type'        => 'Boolean',
 						'description' => __( 'Whether the object is restricted from the current viewer', 'wp-graphql' ),
+					],
+					'karma'            => [
+						'type'        => 'Int',
+						'description' => __( 'Karma value for the comment. This field is equivalent to WP_Comment->comment_karma and the value matching the "comment_karma" column in SQL.', 'wp-graphql' ),
 					],
 					'parentId'         => [
 						'type'        => 'ID',
@@ -119,6 +115,10 @@ class Comment {
 					'parentDatabaseId' => [
 						'type'        => 'Int',
 						'description' => __( 'The database id of the parent comment node or null if it is the root comment', 'wp-graphql' ),
+					],
+					'type'             => [
+						'type'        => 'String',
+						'description' => __( 'Type of comment. This field is equivalent to WP_Comment->comment_type and the value matching the "comment_type" column in SQL.', 'wp-graphql' ),
 					],
 				],
 			]

--- a/tests/wpunit/CommentObjectQueriesTest.php
+++ b/tests/wpunit/CommentObjectQueriesTest.php
@@ -44,7 +44,7 @@ class CommentObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 			'comment_author'       => get_user_by( 'id', $this->admin )->user_email,
 			'comment_author_email' => get_user_by( 'id', $this->admin )->user_email,
 			'comment_content'      => 'Test comment content',
-			'comment_approved'     => 1,
+			'comment_approved'     => '1',
 			'comment_date'         => $this->current_date,
 			'comment_date_gmt'     => $this->current_date_gmt,
 			'user_id'              => $this->admin,
@@ -98,7 +98,6 @@ class CommentObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 		query testCommentQuery( $id: ID!, $idType: CommentNodeIdTypeEnum ) {
 			comment(id: $id, idType: $idType ) {
 				agent
-				approved
 				author{
 					node {
 						__typename
@@ -137,6 +136,7 @@ class CommentObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 						id
 					}
 				}
+				status
 			}
 		}';
 
@@ -157,7 +157,6 @@ class CommentObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 		$expected = [
 			'comment' => [
 				'agent'       => null,
-				'approved'    => true,
 				'author'      => [
 					'node' => [
 						'__typename' => 'User',
@@ -180,6 +179,7 @@ class CommentObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 				'id'          => $global_id,
 				'karma'       => null,
 				'parent'      => null,
+				'status' => 'APPROVE',
 			],
 		];
 
@@ -230,7 +230,6 @@ class CommentObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 		query testCommentWithCommentAuthor ( $id: ID! ) {
 			comment(id: $id ) {
 				agent
-				approved
 				author {
 					node {
 						...on CommentAuthor {
@@ -242,6 +241,7 @@ class CommentObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 						}
 					}
 				}
+				status
 			}
 		}';
 
@@ -260,7 +260,6 @@ class CommentObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 		$expected = [
 			'comment' => [
 				'agent'    => null,
-				'approved' => true,
 				'author'   => [
 					'node' => [
 						'id'         => \GraphQLRelay\Relay::toGlobalId( 'comment_author', $comment_id ),
@@ -270,6 +269,7 @@ class CommentObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 						'url'        => get_comment_author_url( $comment_id ),
 					],
 				],
+				'status' => 'APPROVE'
 			],
 		];
 
@@ -288,7 +288,6 @@ class CommentObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 		$expected = [
 			'comment' => [
 				'agent'    => null,
-				'approved' => true,
 				'author'   => [
 					'node' => [
 						'id'         => \GraphQLRelay\Relay::toGlobalId( 'comment_author', $comment_id ),
@@ -298,6 +297,7 @@ class CommentObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 						'url'        => get_comment_author_url( $comment_id ),
 					],
 				],
+				'status' => 'APPROVE'
 			],
 		];
 
@@ -468,13 +468,13 @@ class CommentObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 		$query = '
 		query commentQuery( $id:ID! ) {
 			comment(id: $id) {
-			commentId
+				commentId
 				id
 				authorIp
 				agent
-				approved
 				karma
 				content
+				status
 				commentedOn{
 					node {
 						... on Post{
@@ -555,7 +555,7 @@ class CommentObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 				id
 				authorIp
 				agent
-				approved
+				status
 				karma
 				content
 				commentedOn{
@@ -590,6 +590,7 @@ class CommentObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 			$this->assertEquals( $subscriber_comment, $subscriber_actual['data']['comment']['commentId'] );
 			$this->assertEquals( apply_filters( 'comment_text', $subscriber_args['comment_content'] ), $subscriber_actual['data']['comment']['content'] );
 			$this->assertEquals( apply_filters( 'comment_text', $admin_args['comment_content'] ), $admin_actual['data']['comment']['content'] );
+			$this->assertEquals( 'HOLD', $admin_actual['data']['comment']['status'] );
 		} else {
 			$this->assertEmpty( $admin_actual['data']['comment'] );
 		}
@@ -612,7 +613,7 @@ class CommentObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 		$comment_args = [
 			'comment_post_ID'      => $post_id,
 			'comment_content'      => 'Private Post Comment',
-			'comment_approved'     => 1,
+			'comment_approved'     => '1',
 			'comment_author_email' => 'admin@test.com',
 			'comment_author_IP'    => '127.0.0.1',
 			'comment_agent'        => 'Admin Agent',
@@ -626,7 +627,7 @@ class CommentObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 				id
 				authorIp
 				agent
-				approved
+				status
 				karma
 				content
 				commentedOn{


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR deprecates the `approved` Field from the `Comment` model, object, and mutation inputs in favor of the `status` field, which uses the new `CommentStatusEnum`.

Despite its name `WP_Comment->comment_approved`, actually contains 4 possible stati and allows for 6 different values (`'0'` = `hold`, and `'1'` = `approved`). However, WPGraphQL treats it as a boolean, which has some interesting side effects like #807. 

### Details:

- feat: add `CommentStatusEnum` GraphQL type.
- feat: deprecate `approved` field from `Comment` model, object, and mutations in favor of `status: CommentStatusEnum` field.
- fix: correctly set comment status when using Create/Update mutations.

Does this close any currently open issues?
------------------------------------------
#807 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + PHP 8.0.19)

**WordPress Version:** 6.0.2
