### PR TITLE
feat: Obfuscate `SendPasswordResetEmail` response.

### DIFF
--- a/src/Mutation/SendPasswordResetEmail.php
+++ b/src/Mutation/SendPasswordResetEmail.php
@@ -33,7 +33,7 @@ class SendPasswordResetEmail {
 	 *
 	 * @return array
 	 */
-	public static function get_input_fields() {
+	public static function get_input_fields() : array {
 		return [
 			'username' => [
 				'type'        => [
@@ -49,7 +49,7 @@ class SendPasswordResetEmail {
 	 *
 	 * @return array
 	 */
-	public static function get_output_fields() {
+	public static function get_output_fields() : array {
 		return [
 			'user'    => [
 				'type'              => 'User',
@@ -71,7 +71,7 @@ class SendPasswordResetEmail {
 	 *
 	 * @return callable
 	 */
-	public static function mutate_and_get_payload() {
+	public static function mutate_and_get_payload() : callable {
 		return function ( $input, AppContext $context, ResolveInfo $info ) {
 			if ( ! self::was_username_provided( $input ) ) {
 				throw new UserError( __( 'Enter a username or email address.', 'wp-graphql' ) );
@@ -80,6 +80,8 @@ class SendPasswordResetEmail {
 			// We obsfucate the actual success of this mutation to prevent user enumeration.
 			$payload = [
 				'success' => true,
+				'id'      => null,
+				'user'    => null,
 			];
 
 			$user_data = self::get_user_data( $input['username'] );

--- a/src/Mutation/SendPasswordResetEmail.php
+++ b/src/Mutation/SendPasswordResetEmail.php
@@ -72,7 +72,7 @@ class SendPasswordResetEmail {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload() : callable {
-		return function ( $input, AppContext $context, ResolveInfo $info ) {
+		return function ( $input ) {
 			if ( ! self::was_username_provided( $input ) ) {
 				throw new UserError( __( 'Enter a username or email address.', 'wp-graphql' ) );
 			}
@@ -81,7 +81,6 @@ class SendPasswordResetEmail {
 			$payload = [
 				'success' => true,
 				'id'      => null,
-				'user'    => null,
 			];
 
 			$user_data = self::get_user_data( $input['username'] );

--- a/src/Mutation/SendPasswordResetEmail.php
+++ b/src/Mutation/SendPasswordResetEmail.php
@@ -21,66 +21,92 @@ class SendPasswordResetEmail {
 			'sendPasswordResetEmail',
 			[
 				'description'         => __( 'Send password reset email to user', 'wp-graphql' ),
-				'inputFields'         => [
-					'username' => [
-						'type'        => [
-							'non_null' => 'String',
-						],
-						'description' => __( 'A string that contains the user\'s username or email address.', 'wp-graphql' ),
-					],
-				],
-				'outputFields'        => [
-					'user' => [
-						'type'        => 'User',
-						'description' => __( 'The user that the password reset email was sent to', 'wp-graphql' ),
-					],
-				],
-				'mutateAndGetPayload' => function ( $input, AppContext $context, ResolveInfo $info ) {
-
-					if ( ! self::was_username_provided( $input ) ) {
-						throw new UserError( __( 'Enter a username or email address.', 'wp-graphql' ) );
-					}
-					$user_data = self::get_user_data( $input['username'] );
-
-					if ( ! $user_data ) {
-						throw new UserError( self::get_user_not_found_error_message( $input['username'] ) );
-					}
-					$key = get_password_reset_key( $user_data );
-					if ( is_wp_error( $key ) ) {
-						throw new UserError( __( 'Unable to generate a password reset key.', 'wp-graphql' ) );
-					}
-					$subject = self::get_email_subject( $user_data );
-					$message = self::get_email_message( $user_data, $key );
-
-					$email_sent = wp_mail( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_mail_wp_mail
-						$user_data->user_email,
-						wp_specialchars_decode( $subject ),
-						$message
-					);
-
-					// wp_mail can return a wp_error, but the docblock for it in WP Core is incorrect.
-					// phpstan should ignore this check.
-					// @phpstan-ignore-next-line
-					if ( is_wp_error( $email_sent ) ) {
-
-						$message = __( 'The email could not be sent.', 'wp-graphql' ) . "<br />\n" . __( 'Possible reason: your host may have disabled the mail() function.', 'wp-graphql' );
-						if ( ! \WPGraphQL::debug() ) {
-							throw new UserError( $message );
-						} else {
-							graphql_debug( $message );
-						}
-					}
-
-					/**
-					 * Return the ID of the user
-					 */
-					return [
-						'id'   => $user_data->ID,
-						'user' => $context->get_loader( 'user' )->load_deferred( $user_data->ID ),
-					];
-				},
+				'inputFields'         => self::get_input_fields(),
+				'outputFields'        => self::get_output_fields(),
+				'mutateAndGetPayload' => self::mutate_and_get_payload(),
 			]
 		);
+	}
+
+	/**
+	 * Defines the mutation input field configuration.
+	 *
+	 * @return array
+	 */
+	public static function get_input_fields() {
+		return [
+			'username' => [
+				'type'        => [
+					'non_null' => 'String',
+				],
+				'description' => __( 'A string that contains the user\'s username or email address.', 'wp-graphql' ),
+			],
+		];
+	}
+
+	/**
+	 * Defines the mutation output field configuration.
+	 *
+	 * @return array
+	 */
+	public static function get_output_fields() {
+		return [
+			'user' => [
+				'type'        => 'User',
+				'description' => __( 'The user that the password reset email was sent to', 'wp-graphql' ),
+			],
+		];
+	}
+
+	/**
+	 * Defines the mutation data modification closure.
+	 *
+	 * @return callable
+	 */
+	public static function mutate_and_get_payload() {
+		return function ( $input, AppContext $context, ResolveInfo $info ) {
+			if ( ! self::was_username_provided( $input ) ) {
+				throw new UserError( __( 'Enter a username or email address.', 'wp-graphql' ) );
+			}
+			$user_data = self::get_user_data( $input['username'] );
+
+			if ( ! $user_data ) {
+				throw new UserError( self::get_user_not_found_error_message( $input['username'] ) );
+			}
+			$key = get_password_reset_key( $user_data );
+			if ( is_wp_error( $key ) ) {
+				throw new UserError( __( 'Unable to generate a password reset key.', 'wp-graphql' ) );
+			}
+			$subject = self::get_email_subject( $user_data );
+			$message = self::get_email_message( $user_data, $key );
+
+			$email_sent = wp_mail( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_mail_wp_mail
+				$user_data->user_email,
+				wp_specialchars_decode( $subject ),
+				$message
+			);
+
+			// wp_mail can return a wp_error, but the docblock for it in WP Core is incorrect.
+			// phpstan should ignore this check.
+			// @phpstan-ignore-next-line
+			if ( is_wp_error( $email_sent ) ) {
+
+				$message = __( 'The email could not be sent.', 'wp-graphql' ) . "<br />\n" . __( 'Possible reason: your host may have disabled the mail() function.', 'wp-graphql' );
+				if ( ! \WPGraphQL::debug() ) {
+					throw new UserError( $message );
+				} else {
+					graphql_debug( $message );
+				}
+			}
+
+			/**
+			 * Return the ID of the user
+			 */
+			return [
+				'id'   => $user_data->ID,
+				'user' => $context->get_loader( 'user' )->load_deferred( $user_data->ID ),
+			];
+		};
 	}
 
 	/**

--- a/src/Mutation/SendPasswordResetEmail.php
+++ b/src/Mutation/SendPasswordResetEmail.php
@@ -55,7 +55,7 @@ class SendPasswordResetEmail {
 				'type'              => 'User',
 				'description'       => __( 'The user that the password reset email was sent to', 'wp-graphql' ),
 				'deprecationReason' => __( 'This field will be removed in a future version of WPGraphQL', 'wp-graphql' ),
-				'resolve'           => function ( $payload, $args, AppContext $context, ) {
+				'resolve'           => function ( $payload, $args, AppContext $context ) {
 					return ! empty( $payload['id'] ) ? $context->get_loader( 'user' )->load_deferred( $payload['id'] ) : null;
 				},
 			],


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR refactors `SendPasswordResetEmail` to both provide a valid indicator of the mutation's `success`, as well as obfuscate any errors that could be used to enumerate valid users on the site, by logging them with `graphql_debug()` instead of throwing an exception.

### Details
- chore: Refactor `SendPasswordResetEmail` registration config to use static methods.
- feat: add the `success` field to `SendPasswordResetEmailPayload`.
- feat: deprecate the `user` field from `SendPasswordResetEmailPayload`.
- feat: log `SendPasswordResetEmail` mutation errors with `graphql_debug()` to prevent user enumeration.

Does this close any currently open issues?
------------------------------------------
closes #2100

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
- `SendPasswordResetEmailPayload.user` currently returns `public` user data if the user name/email is valid. I think even before the field is removed entirely we might want to at least limit this to logged-in users with the `list_users` cap to prevent email reverse lookups. 


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php 8.0.19)

**WordPress Version:** 6.0.2
