### PR TITLE
chore: move `parse_request()` logic from `NodeResolver::resolve_uri()` to its own method.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
 		"codeception/util-universalframework": "^1.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
 		"phpstan/phpstan": "^1.7",
-		"szepeviktor/phpstan-wordpress": "1.1.1",
+		"szepeviktor/phpstan-wordpress": "1.1.3",
 		"codeception/module-rest": "^1.2",
 		"wp-graphql/wp-graphql-testcase": "~2.3",
 		"phpunit/phpunit": "^9.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "91c2373b99ab6de0eed6cfc19ae85eef",
+    "content-hash": "46f4bb96554ebf2c54a9e15474fd3a75",
     "packages": [
         {
             "name": "appsero/client",
@@ -2561,16 +2561,16 @@
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v5.9.3",
+            "version": "v6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "18d56875e5078a50b8ea4bc4b20b735ca61edeee"
+                "reference": "e04781a84e364615a7b5f70fdc345c8253ca5b8f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/18d56875e5078a50b8ea4bc4b20b735ca61edeee",
-                "reference": "18d56875e5078a50b8ea4bc4b20b735ca61edeee",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/e04781a84e364615a7b5f70fdc345c8253ca5b8f",
+                "reference": "e04781a84e364615a7b5f70fdc345c8253ca5b8f",
                 "shasum": ""
             },
             "replace": {
@@ -2602,9 +2602,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v5.9.3"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.0.1"
             },
-            "time": "2022-04-06T15:33:59+00:00"
+            "time": "2022-07-15T11:10:45+00:00"
         },
         {
             "name": "php-webdriver/webdriver",
@@ -3117,16 +3117,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.8.2",
+            "version": "1.8.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "c53312ecc575caf07b0e90dee43883fdf90ca67c"
+                "reference": "c386ab2741e64cc9e21729f891b28b2b10fe6618"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c53312ecc575caf07b0e90dee43883fdf90ca67c",
-                "reference": "c53312ecc575caf07b0e90dee43883fdf90ca67c",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c386ab2741e64cc9e21729f891b28b2b10fe6618",
+                "reference": "c386ab2741e64cc9e21729f891b28b2b10fe6618",
                 "shasum": ""
             },
             "require": {
@@ -3150,9 +3150,13 @@
                 "MIT"
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.8.2"
+                "source": "https://github.com/phpstan/phpstan/tree/1.8.6"
             },
             "funding": [
                 {
@@ -3164,15 +3168,11 @@
                     "type": "github"
                 },
                 {
-                    "url": "https://www.patreon.com/phpstan",
-                    "type": "patreon"
-                },
-                {
                     "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-07-20T09:57:31+00:00"
+            "time": "2022-09-23T09:54:39+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -7204,21 +7204,21 @@
         },
         {
             "name": "szepeviktor/phpstan-wordpress",
-            "version": "v1.1.1",
+            "version": "v1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/szepeviktor/phpstan-wordpress.git",
-                "reference": "99cfea6b4c15af12dec09110b25dbc7521363f78"
+                "reference": "e644df734e1bbe95810e0f617d17df091048a94e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/szepeviktor/phpstan-wordpress/zipball/99cfea6b4c15af12dec09110b25dbc7521363f78",
-                "reference": "99cfea6b4c15af12dec09110b25dbc7521363f78",
+                "url": "https://api.github.com/repos/szepeviktor/phpstan-wordpress/zipball/e644df734e1bbe95810e0f617d17df091048a94e",
+                "reference": "e644df734e1bbe95810e0f617d17df091048a94e",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2 || ^8.0",
-                "php-stubs/wordpress-stubs": "^4.7 || ^5.0",
+                "php-stubs/wordpress-stubs": "^4.7 || ^5.0 || ^6.0",
                 "phpstan/phpstan": "^1.6",
                 "symfony/polyfill-php73": "^1.12.0"
             },
@@ -7257,15 +7257,19 @@
             ],
             "support": {
                 "issues": "https://github.com/szepeviktor/phpstan-wordpress/issues",
-                "source": "https://github.com/szepeviktor/phpstan-wordpress/tree/v1.1.1"
+                "source": "https://github.com/szepeviktor/phpstan-wordpress/tree/v1.1.3"
             },
             "funding": [
                 {
                     "url": "https://www.paypal.me/szepeviktor",
                     "type": "custom"
+                },
+                {
+                    "url": "https://github.com/szepeviktor",
+                    "type": "github"
                 }
             ],
-            "time": "2022-05-11T18:41:40+00:00"
+            "time": "2022-09-22T13:14:50+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -24,5 +24,3 @@ parameters:
         - */node_modules/*
         - */vendor/*
     ignoreErrors:
-        # Ignore any filters that are applied with more than 2 paramaters
-        - '#^Function apply_filters(_ref_array)? invoked with ([1-9]|1[0-2]) parameters, 2 required\.$#'

--- a/src/Data/Connection/PluginConnectionResolver.php
+++ b/src/Data/Connection/PluginConnectionResolver.php
@@ -188,7 +188,8 @@ class PluginConnectionResolver extends AbstractConnectionResolver {
 		$plugins_by_status['all'] = array_flip( array_keys( $all_plugins ) );
 
 		// Filter the plugins by stati.
-		$filtered_plugins = ! empty( $active_stati ) ? array_merge( ... array_values( array_intersect_key( $plugins_by_status, $active_stati ) ) ) : $plugins_by_status['all'];
+		// @phpstan-ignore-next-line
+		$filtered_plugins = ! empty( $active_stati ) ? array_merge( ...array_values( array_intersect_key( $plugins_by_status, $active_stati ) ) ) : $plugins_by_status['all'];
 
 		if ( ! empty( $this->args['where']['search'] ) ) {
 			// Filter by search args.

--- a/src/Data/Connection/PluginConnectionResolver.php
+++ b/src/Data/Connection/PluginConnectionResolver.php
@@ -187,9 +187,12 @@ class PluginConnectionResolver extends AbstractConnectionResolver {
 
 		$plugins_by_status['all'] = array_flip( array_keys( $all_plugins ) );
 
-		// Filter the plugins by stati.
-		// @phpstan-ignore-next-line
-		$filtered_plugins = ! empty( $active_stati ) ? array_merge( ...array_values( array_intersect_key( $plugins_by_status, $active_stati ) ) ) : $plugins_by_status['all'];
+		/**
+		 * Filters the plugins by status.
+		 * */
+		$filtered_plugins = ! empty( $active_stati ) ? array_values( array_intersect_key( $plugins_by_status, $active_stati ) ) : [];
+		// If plugins exist for the filter, flatten and return them. Otherwise, return the full list.
+		$filtered_plugins = ! empty( $filtered_plugins ) ? array_merge( ...$filtered_plugins ) : $plugins_by_status['all'];
 
 		if ( ! empty( $this->args['where']['search'] ) ) {
 			// Filter by search args.

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -308,7 +308,12 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		 */
 		if ( isset( $this->args['where']['orderby'] ) && is_array( $this->args['where']['orderby'] ) ) {
 			$query_args['orderby'] = [];
+
 			foreach ( $this->args['where']['orderby'] as $orderby_input ) {
+				if ( empty( $orderby_input['field'] ) ) {
+					continue;
+				}
+
 				/**
 				 * These orderby options should not include the order parameter.
 				 */
@@ -322,20 +327,22 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 					true
 				) ) {
 					$query_args['orderby'] = esc_sql( $orderby_input['field'] );
-				} elseif ( ! empty( $orderby_input['field'] ) ) {
 
-					$order = $orderby_input['order'];
-
-					if ( isset( $query_args['graphql_args']['last'] ) && ! empty( $query_args['graphql_args']['last'] ) ) {
-						if ( 'ASC' === $order ) {
-							$order = 'DESC';
-						} else {
-							$order = 'ASC';
-						}
-					}
-
-					$query_args['orderby'][ esc_sql( $orderby_input['field'] ) ] = esc_sql( $order );
+					// If we're ordering explicitly, there's no reason to check other orderby inputs.
+					break;
 				}
+
+				$order = $orderby_input['order'];
+
+				if ( isset( $query_args['graphql_args']['last'] ) && ! empty( $query_args['graphql_args']['last'] ) ) {
+					if ( 'ASC' === $order ) {
+						$order = 'DESC';
+					} else {
+						$order = 'ASC';
+					}
+				}
+
+				$query_args['orderby'][ esc_sql( $orderby_input['field'] ) ] = esc_sql( $order );
 			}
 		}
 

--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -96,12 +96,26 @@ class NodeResolver {
 
 		$parsed_url = wp_parse_url( $uri );
 
+		if ( false === $parsed_url ) {
+			graphql_debug( __( 'Cannot parse provided URI', 'wp-graphql' ), [
+				'uri' => $uri,
+			] );
+			return null;
+		}
+
 		if ( isset( $parsed_url['host'] ) ) {
+			$site_url = wp_parse_url( site_url() );
+			$home_url = wp_parse_url( home_url() );
+
+			/**
+			 * @var array $home_url
+			 * @var array $site_url
+			 */
 			if ( ! in_array(
 				$parsed_url['host'],
 				[
-					wp_parse_url( site_url() )['host'],
-					wp_parse_url( home_url() )['host'],
+					$site_url['host'],
+					$home_url['host'],
 				],
 				true
 			) ) {
@@ -115,7 +129,7 @@ class NodeResolver {
 		$this->wp->query_vars = [];
 		$post_type_query_vars = [];
 
-		if ( isset( $parsed_url['query'] ) && '/' === $parsed_url['path'] ) {
+		if ( isset( $parsed_url['query'] ) && ( empty( $parsed_url['path'] ) || '/' === $parsed_url['path'] ) ) {
 			$uri = $parsed_url['query'];
 		} elseif ( isset( $parsed_url['path'] ) ) {
 			$uri = $parsed_url['path'];
@@ -144,7 +158,7 @@ class NodeResolver {
 			$pathinfo         = str_replace( '%', '%25', $pathinfo );
 
 			list( $req_uri ) = explode( '?', $pathinfo );
-			$home_path       = trim( wp_parse_url( home_url(), PHP_URL_PATH ), '/' );
+			$home_path       = trim( (string) wp_parse_url( home_url(), PHP_URL_PATH ), '/' );
 			$home_path_regex = sprintf( '|^%s|i', preg_quote( $home_path, '|' ) );
 
 			// Trim path info from the end and the leading home path from the

--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -92,276 +92,7 @@ class NodeResolver {
 			return $node;
 		}
 
-		global $wp_rewrite;
-
-		$parsed_url = wp_parse_url( $uri );
-
-		if ( false === $parsed_url ) {
-			graphql_debug( __( 'Cannot parse provided URI', 'wp-graphql' ), [
-				'uri' => $uri,
-			] );
-			return null;
-		}
-
-		if ( isset( $parsed_url['host'] ) ) {
-			$site_url = wp_parse_url( site_url() );
-			$home_url = wp_parse_url( home_url() );
-
-			/**
-			 * @var array $home_url
-			 * @var array $site_url
-			 */
-			if ( ! in_array(
-				$parsed_url['host'],
-				[
-					$site_url['host'],
-					$home_url['host'],
-				],
-				true
-			) ) {
-				graphql_debug( __( 'Cannot return a resource for an external URI', 'wp-graphql' ), [
-					'uri' => $uri,
-				] );
-				return null;
-			}
-		}
-
-		$this->wp->query_vars = [];
-		$post_type_query_vars = [];
-
-		if ( isset( $parsed_url['query'] ) && ( empty( $parsed_url['path'] ) || '/' === $parsed_url['path'] ) ) {
-			$uri = $parsed_url['query'];
-		} elseif ( isset( $parsed_url['path'] ) ) {
-			$uri = $parsed_url['path'];
-		}
-
-		if ( is_array( $extra_query_vars ) ) {
-			$this->wp->query_vars = &$extra_query_vars;
-		} elseif ( ! empty( $extra_query_vars ) ) {
-			parse_str( $extra_query_vars, $this->wp->extra_query_vars );
-		}
-
-		$this->wp->query_vars['uri'] = $uri;
-		// Process PATH_INFO, REQUEST_URI, and 404 for permalinks.
-
-		// Fetch the rewrite rules.
-		$rewrite = $wp_rewrite->wp_rewrite_rules();
-
-		$error = '404';
-		if ( ! empty( $rewrite ) ) {
-			// If we match a rewrite rule, this will be cleared.
-			$error                   = null;
-			$this->wp->did_permalink = true;
-
-			$pathinfo         = ! empty( $uri ) ? $uri : '';
-			list( $pathinfo ) = explode( '?', $pathinfo );
-			$pathinfo         = str_replace( '%', '%25', $pathinfo );
-
-			list( $req_uri ) = explode( '?', $pathinfo );
-			$home_path       = trim( (string) wp_parse_url( home_url(), PHP_URL_PATH ), '/' );
-			$home_path_regex = sprintf( '|^%s|i', preg_quote( $home_path, '|' ) );
-
-			// Trim path info from the end and the leading home path from the
-			// front. For path info requests, this leaves us with the requesting
-			// filename, if any. For 404 requests, this leaves us with the
-			// requested permalink.
-			$query        = '';
-			$matches      = null;
-			$req_uri      = str_replace( $pathinfo, '', $req_uri );
-			$req_uri      = trim( $req_uri, '/' );
-			$replaced_uri = preg_replace( $home_path_regex, '', $req_uri );
-
-			if ( ! empty( $replaced_uri ) ) {
-				$req_uri = $replaced_uri;
-			}
-
-			$req_uri           = trim( $req_uri, '/' );
-			$pathinfo          = trim( $pathinfo, '/' );
-			$replaced_pathinfo = preg_replace( $home_path_regex, '', $pathinfo );
-			if ( ! empty( $replaced_pathinfo ) ) {
-				$pathinfo = $replaced_pathinfo;
-			}
-			$pathinfo = trim( $pathinfo, '/' );
-
-			// The requested permalink is in $pathinfo for path info requests and
-			// $req_uri for other requests.
-			if ( ! empty( $pathinfo ) && ! preg_match( '|^.*' . $wp_rewrite->index . '$|', $pathinfo ) ) {
-				$requested_path = $pathinfo;
-			} else {
-				// If the request uri is the index, blank it out so that we don't try to match it against a rule.
-				if ( $req_uri === $wp_rewrite->index ) {
-					$req_uri = '';
-				}
-				$requested_path = $req_uri;
-			}
-			$requested_file = $req_uri;
-
-			$this->wp->request = $requested_path;
-
-			// Look for matches.
-			$request_match = $requested_path;
-			if ( empty( $request_match ) ) {
-				// An empty request could only match against ^$ regex
-				if ( isset( $rewrite['$'] ) ) {
-					$this->wp->matched_rule = '$';
-					$query                  = $rewrite['$'];
-					$matches                = [ '' ];
-				}
-			} else {
-				foreach ( (array) $rewrite as $match => $query ) {
-					// If the requested file is the anchor of the match, prepend it to the path info.
-					if ( ! empty( $requested_file ) && strpos( $match, $requested_file ) === 0 && $requested_file !== $requested_path ) {
-						$request_match = $requested_file . '/' . $requested_path;
-					}
-
-					if (
-						preg_match( "#^$match#", $request_match, $matches ) ||
-						preg_match( "#^$match#", urldecode( $request_match ), $matches )
-					) {
-
-						if ( $wp_rewrite->use_verbose_page_rules && preg_match( '/pagename=\$matches\[([0-9]+)\]/', $query, $varmatch ) ) {
-							// This is a verbose page match, let's check to be sure about it.
-							$page = get_page_by_path( $matches[ $varmatch[1] ] ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.get_page_by_path_get_page_by_path
-							if ( ! $page ) {
-								continue;
-							}
-
-							$post_status_obj = get_post_status_object( $page->post_status );
-							if (
-								( ! isset( $post_status_obj->public ) || ! $post_status_obj->public ) &&
-								( ! isset( $post_status_obj->protected ) || ! $post_status_obj->protected ) &&
-								( ! isset( $post_status_obj->private ) || ! $post_status_obj->private ) &&
-								( ! isset( $post_status_obj->exclude_from_search ) || $post_status_obj->exclude_from_search )
-							) {
-								continue;
-							}
-						}
-
-						// Got a match.
-						$this->wp->matched_rule = $match;
-						break;
-					}
-				}
-			}
-
-			if ( ! empty( $this->wp->matched_rule ) ) {
-
-				// Trim the query of everything up to the '?'.
-				$query = preg_replace( '!^.+\?!', '', $query );
-
-				// Substitute the substring matches into the query.
-				$query = addslashes( \WP_MatchesMapRegex::apply( $query, $matches ) );
-
-				// Parse the query.
-				parse_str( $query, $perma_query_vars );
-
-			}
-		}
-
-		/**
-		 * Filters the query variables whitelist before processing.
-		 *
-		 * Allows (publicly allowed) query vars to be added, removed, or changed prior
-		 * to executing the query. Needed to allow custom rewrite rules using your own arguments
-		 * to work, or any other custom query variables you want to be publicly available.
-		 *
-		 * @param string[] $public_query_vars The array of whitelisted query variable names.
-		 *
-		 * @since 1.5.0
-		 */
-		$this->wp->public_query_vars = apply_filters( 'query_vars', $this->wp->public_query_vars );
-
-		$post_type_objects = get_post_types( [ 'show_in_graphql' => true ], 'objects' );
-
-		if ( ! empty( $post_type_objects ) ) {
-			foreach ( $post_type_objects as $post_type_object ) {
-				if ( isset( $post_type_object->show_in_graphql ) && true === $post_type_object->show_in_graphql && $post_type_object->query_var ) {
-					$post_type_query_vars[ $post_type_object->query_var ] = $post_type_object->name;
-				}
-			}
-		}
-
-		foreach ( $this->wp->public_query_vars as $wpvar ) {
-
-			$parsed_query = [];
-			if ( isset( $parsed_url['query'] ) ) {
-				parse_str( $parsed_url['query'], $parsed_query );
-			}
-
-			if ( isset( $this->wp->extra_query_vars[ $wpvar ] ) ) {
-				$this->wp->query_vars[ $wpvar ] = $this->wp->extra_query_vars[ $wpvar ];
-			} elseif ( isset( $_GET[ $wpvar ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-				$this->wp->query_vars[ $wpvar ] = $_GET[ $wpvar ]; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.NonceVerification.Recommended
-			} elseif ( isset( $perma_query_vars[ $wpvar ] ) ) {
-				$this->wp->query_vars[ $wpvar ] = $perma_query_vars[ $wpvar ];
-			} elseif ( isset( $parsed_query[ $wpvar ] ) ) {
-				$this->wp->query_vars[ $wpvar ] = $parsed_query[ $wpvar ];
-			}
-
-			if ( ! empty( $this->wp->query_vars[ $wpvar ] ) ) {
-
-				if ( ! is_array( $this->wp->query_vars[ $wpvar ] ) ) {
-					$this->wp->query_vars[ $wpvar ] = (string) $this->wp->query_vars[ $wpvar ];
-				} else {
-					foreach ( $this->wp->query_vars[ $wpvar ] as $vkey => $v ) {
-						if ( is_scalar( $v ) ) {
-							$this->wp->query_vars[ $wpvar ][ $vkey ] = (string) $v;
-						}
-					}
-				}
-
-				if ( isset( $post_type_query_vars[ $wpvar ] ) ) {
-					$this->wp->query_vars['post_type'] = $post_type_query_vars[ $wpvar ];
-					$this->wp->query_vars['name']      = $this->wp->query_vars[ $wpvar ];
-				}
-			}
-		}
-
-		// Convert urldecoded spaces back into +
-		foreach ( get_taxonomies( [], 'objects' ) as $taxonomy => $t ) {
-			if ( $t->query_var && isset( $this->wp->query_vars[ $t->query_var ] ) ) {
-				$this->wp->query_vars[ $t->query_var ] = str_replace( ' ', '+', $this->wp->query_vars[ $t->query_var ] );
-			}
-		}
-
-		// Limit publicly queried post_types to those that are publicly_queryable
-		if ( isset( $this->wp->query_vars['post_type'] ) ) {
-			$queryable_post_types = \WPGraphQL::get_allowed_post_types();
-
-			if ( ! is_array( $this->wp->query_vars['post_type'] ) ) {
-				if ( ! in_array( $this->wp->query_vars['post_type'], $queryable_post_types, true ) ) {
-					unset( $this->wp->query_vars['post_type'] );
-				}
-			} else {
-				$this->wp->query_vars['post_type'] = array_intersect( $this->wp->query_vars['post_type'], $queryable_post_types );
-			}
-		}
-
-		// Resolve conflicts between posts with numeric slugs and date archive queries.
-		$this->wp->query_vars = wp_resolve_numeric_slug_conflicts( $this->wp->query_vars );
-
-		foreach ( (array) $this->wp->private_query_vars as $var ) {
-			if ( isset( $this->wp->extra_query_vars[ $var ] ) ) {
-				$this->wp->query_vars[ $var ] = $this->wp->extra_query_vars[ $var ];
-			}
-		}
-
-		if ( isset( $error ) ) {
-			$this->wp->query_vars['error'] = $error;
-		}
-
-		/**
-		 * Filters the array of parsed query variables.
-		 *
-		 * @param array $query_vars The array of requested query variables.
-		 *
-		 * @since 2.1.0
-		 */
-		$this->wp->query_vars = apply_filters( 'request', $this->wp->query_vars );
-
-		unset( $this->wp->query_vars['graphql'] );
-
-		do_action_ref_array( 'parse_request', [ &$this->wp ] );
+		$uri = $this->parse_request( $uri, $extra_query_vars );
 
 		// If the request is for the homepage, determine
 		if ( '/' === $uri ) {
@@ -499,5 +230,297 @@ class NodeResolver {
 		}
 
 		return $node;
+	}
+
+	/**
+	 * Parses a URL to produce an array of query variables.
+	 *
+	 * Mimics WP::parse_request()
+	 *
+	 * @param string $uri
+	 * @param array|string $extra_query_vars
+	 *
+	 * @return string|null The parsed uri.
+	 */
+	public function parse_request( string $uri, $extra_query_vars = '' ) {
+		// Attempt to parse the provided URI.
+		$parsed_url = wp_parse_url( $uri );
+
+		if ( false === $parsed_url ) {
+			graphql_debug( __( 'Cannot parse provided URI', 'wp-graphql' ), [
+				'uri' => $uri,
+			] );
+			return null;
+		}
+
+		// Bail if external URI.
+		if ( isset( $parsed_url['host'] ) ) {
+			$site_url = wp_parse_url( site_url() );
+			$home_url = wp_parse_url( home_url() );
+
+			/**
+			 * @var array $home_url
+			 * @var array $site_url
+			 */
+			if ( ! in_array(
+				$parsed_url['host'],
+				[
+					$site_url['host'],
+					$home_url['host'],
+				],
+				true
+			) ) {
+				graphql_debug( __( 'Cannot return a resource for an external URI', 'wp-graphql' ), [
+					'uri' => $uri,
+				] );
+				return null;
+			}
+		}
+
+		if ( isset( $parsed_url['query'] ) && ( empty( $parsed_url['path'] ) || '/' === $parsed_url['path'] ) ) {
+			$uri = $parsed_url['query'];
+		} elseif ( isset( $parsed_url['path'] ) ) {
+			$uri = $parsed_url['path'];
+		}
+
+		/**
+		 * Follows pattern from WP::parse_request()
+		 *
+		 * @see https://github.com/WordPress/wordpress-develop/blob/6.0.2/src/wp-includes/class-wp.php#L135
+		 */
+		global $wp_rewrite;
+
+
+		$this->wp->query_vars = [];
+		$post_type_query_vars = [];
+
+
+		if ( is_array( $extra_query_vars ) ) {
+			$this->wp->query_vars = &$extra_query_vars;
+		} elseif ( ! empty( $extra_query_vars ) ) {
+			parse_str( $extra_query_vars, $this->wp->extra_query_vars );
+		}
+
+		// Set uri to Query vars.
+		$this->wp->query_vars['uri'] = $uri;
+
+		// Process PATH_INFO, REQUEST_URI, and 404 for permalinks.
+
+		// Fetch the rewrite rules.
+		$rewrite = $wp_rewrite->wp_rewrite_rules();
+
+		$error = '404';
+		if ( ! empty( $rewrite ) ) {
+			// If we match a rewrite rule, this will be cleared.
+			$error                   = null;
+			$this->wp->did_permalink = true;
+
+			$pathinfo         = ! empty( $uri ) ? $uri : '';
+			list( $pathinfo ) = explode( '?', $pathinfo );
+			$pathinfo         = str_replace( '%', '%25', $pathinfo );
+
+			list( $req_uri ) = explode( '?', $pathinfo );
+			$home_path       = parse_url( home_url(), PHP_URL_PATH ); // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url
+			$home_path_regex = '';
+			if ( is_string( $home_path ) && '' !== $home_path ) {
+				$home_path       = trim( $home_path, '/' );
+				$home_path_regex = sprintf( '|^%s|i', preg_quote( $home_path, '|' ) );
+			}
+
+			/*
+			 * Trim path info from the end and the leading home path from the front.
+			 * For path info requests, this leaves us with the requesting filename, if any.
+			 * For 404 requests, this leaves us with the requested permalink.
+			 */
+			$query    = '';
+			$matches  = null;
+			$req_uri  = str_replace( $pathinfo, '', $req_uri );
+			$req_uri  = trim( $req_uri, '/' );
+			$pathinfo = trim( $pathinfo, '/' );
+
+			if ( ! empty( $home_path_regex ) ) {
+				$req_uri  = preg_replace( $home_path_regex, '', $req_uri );
+				$req_uri  = trim( $req_uri, '/' ); // @phpstan-ignore-line
+				$pathinfo = preg_replace( $home_path_regex, '', $pathinfo );
+				$pathinfo = trim( $pathinfo, '/' ); // @phpstan-ignore-line
+			}
+
+			// The requested permalink is in $pathinfo for path info requests and
+			// $req_uri for other requests.
+			if ( ! empty( $pathinfo ) && ! preg_match( '|^.*' . $wp_rewrite->index . '$|', $pathinfo ) ) {
+				$requested_path = $pathinfo;
+			} else {
+				// If the request uri is the index, blank it out so that we don't try to match it against a rule.
+				if ( $req_uri === $wp_rewrite->index ) {
+					$req_uri = '';
+				}
+				$requested_path = $req_uri;
+			}
+			$requested_file = $req_uri;
+
+			$this->wp->request = $requested_path;
+
+			// Look for matches.
+			$request_match = $requested_path;
+			if ( empty( $request_match ) ) {
+				// An empty request could only match against ^$ regex
+				if ( isset( $rewrite['$'] ) ) {
+					$this->wp->matched_rule = '$';
+					$query                  = $rewrite['$'];
+					$matches                = [ '' ];
+				}
+			} else {
+				foreach ( (array) $rewrite as $match => $query ) {
+					// If the requested file is the anchor of the match, prepend it to the path info.
+					if ( ! empty( $requested_file ) && strpos( $match, $requested_file ) === 0 && $requested_file !== $requested_path ) {
+						$request_match = $requested_file . '/' . $requested_path;
+					}
+
+					if (
+						preg_match( "#^$match#", $request_match, $matches ) ||
+						preg_match( "#^$match#", urldecode( $request_match ), $matches )
+					) {
+
+						if ( $wp_rewrite->use_verbose_page_rules && preg_match( '/pagename=\$matches\[([0-9]+)\]/', $query, $varmatch ) ) {
+							// This is a verbose page match, let's check to be sure about it.
+							$page = get_page_by_path( $matches[ $varmatch[1] ] ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.get_page_by_path_get_page_by_path
+							if ( ! $page ) {
+								continue;
+							}
+
+							$post_status_obj = get_post_status_object( $page->post_status );
+							if (
+								( ! isset( $post_status_obj->public ) || ! $post_status_obj->public ) &&
+								( ! isset( $post_status_obj->protected ) || ! $post_status_obj->protected ) &&
+								( ! isset( $post_status_obj->private ) || ! $post_status_obj->private ) &&
+								( ! isset( $post_status_obj->exclude_from_search ) || $post_status_obj->exclude_from_search )
+							) {
+								continue;
+							}
+						}
+
+						// Got a match.
+						$this->wp->matched_rule = $match;
+						break;
+					}
+				}
+			}
+
+			if ( ! empty( $this->wp->matched_rule ) ) {
+				// Trim the query of everything up to the '?'.
+				$query = preg_replace( '!^.+\?!', '', $query );
+
+				// Substitute the substring matches into the query.
+				$query = addslashes( \WP_MatchesMapRegex::apply( $query, $matches ) );
+
+				// Parse the query.
+				parse_str( $query, $perma_query_vars );
+
+			}
+		}
+
+		/**
+		 * Filters the query variables allowed before processing.
+		 *
+		 * Allows (publicly allowed) query vars to be added, removed, or changed prior
+		 * to executing the query. Needed to allow custom rewrite rules using your own arguments
+		 * to work, or any other custom query variables you want to be publicly available.
+		 *
+		 * @since 1.5.0
+		 *
+		 * @param string[] $public_query_vars The array of allowed query variable names.
+		 */
+		$this->wp->public_query_vars = apply_filters( 'query_vars', $this->wp->public_query_vars );
+
+
+		foreach ( get_post_types( [ 'show_in_graphql' => true ], 'objects' )  as $post_type => $t ) {
+			/** @var \WP_Post_Type $t */
+			if ( $t->query_var ) {
+				$post_type_query_vars[ $t->query_var ] = $post_type;
+			}
+		}
+
+		foreach ( $this->wp->public_query_vars as $wpvar ) {
+
+			$parsed_query = [];
+			if ( isset( $parsed_url['query'] ) ) {
+				parse_str( $parsed_url['query'], $parsed_query );
+			}
+
+			if ( isset( $this->wp->extra_query_vars[ $wpvar ] ) ) {
+				$this->wp->query_vars[ $wpvar ] = $this->wp->extra_query_vars[ $wpvar ];
+			} elseif ( isset( $_GET[ $wpvar ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+				$this->wp->query_vars[ $wpvar ] = $_GET[ $wpvar ]; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.NonceVerification.Recommended
+			} elseif ( isset( $perma_query_vars[ $wpvar ] ) ) {
+				$this->wp->query_vars[ $wpvar ] = $perma_query_vars[ $wpvar ];
+			} elseif ( isset( $parsed_query[ $wpvar ] ) ) {
+				$this->wp->query_vars[ $wpvar ] = $parsed_query[ $wpvar ];
+			}
+
+			if ( ! empty( $this->wp->query_vars[ $wpvar ] ) ) {
+				if ( ! is_array( $this->wp->query_vars[ $wpvar ] ) ) {
+					$this->wp->query_vars[ $wpvar ] = (string) $this->wp->query_vars[ $wpvar ];
+				} else {
+					foreach ( $this->wp->query_vars[ $wpvar ] as $vkey => $v ) {
+						if ( is_scalar( $v ) ) {
+							$this->wp->query_vars[ $wpvar ][ $vkey ] = (string) $v;
+						}
+					}
+				}
+
+				if ( isset( $post_type_query_vars[ $wpvar ] ) ) {
+					$this->wp->query_vars['post_type'] = $post_type_query_vars[ $wpvar ];
+					$this->wp->query_vars['name']      = $this->wp->query_vars[ $wpvar ];
+				}
+			}
+		}
+
+		// Convert urldecoded spaces back into '+'.
+		foreach ( get_taxonomies( [ 'show_in_graphql' => true ], 'objects' ) as $taxonomy => $t ) {
+			if ( $t->query_var && isset( $this->wp->query_vars[ $t->query_var ] ) ) {
+				$this->wp->query_vars[ $t->query_var ] = str_replace( ' ', '+', $this->wp->query_vars[ $t->query_var ] );
+			}
+		}
+
+		// Limit publicly queried post_types to those that are publicly_queryable
+		if ( isset( $this->wp->query_vars['post_type'] ) ) {
+			$queryable_post_types = get_post_types( [ 'show_in_graphql' => true ] );
+			if ( ! is_array( $this->wp->query_vars['post_type'] ) ) {
+				if ( ! in_array( $this->wp->query_vars['post_type'], $queryable_post_types, true ) ) {
+					unset( $this->wp->query_vars['post_type'] );
+				}
+			} else {
+				$this->wp->query_vars['post_type'] = array_intersect( $this->wp->query_vars['post_type'], $queryable_post_types );
+			}
+		}
+
+		// Resolve conflicts between posts with numeric slugs and date archive queries.
+		$this->wp->query_vars = wp_resolve_numeric_slug_conflicts( $this->wp->query_vars );
+
+		foreach ( (array) $this->wp->private_query_vars as $var ) {
+			if ( isset( $this->wp->extra_query_vars[ $var ] ) ) {
+				$this->wp->query_vars[ $var ] = $this->wp->extra_query_vars[ $var ];
+			}
+		}
+
+		if ( isset( $error ) ) {
+			$this->wp->query_vars['error'] = $error;
+		}
+
+		/**
+		 * Filters the array of parsed query variables.
+		 *
+		 * @param array $query_vars The array of requested query variables.
+		 *
+		 * @since 2.1.0
+		 */
+		$this->wp->query_vars = apply_filters( 'request', $this->wp->query_vars );
+
+		// We don't need the GraphQL args anymore.
+		unset( $this->wp->query_vars['graphql'] );
+
+		do_action_ref_array( 'parse_request', [ &$this->wp ] );
+
+		return $uri;
 	}
 }

--- a/src/Model/MenuItem.php
+++ b/src/Model/MenuItem.php
@@ -158,6 +158,7 @@ class MenuItem extends Model {
 					$url = $this->url;
 
 					if ( ! empty( $url ) ) {
+						/** @var array $parsed */
 						$parsed = wp_parse_url( $url );
 						if ( isset( $parsed['host'] ) && strpos( home_url(), $parsed['host'] ) ) {
 							return $parsed['path'];

--- a/src/Type/Enum/TimezoneEnum.php
+++ b/src/Type/Enum/TimezoneEnum.php
@@ -21,7 +21,8 @@ class TimezoneEnum {
 
 		$locale           = get_locale();
 		static $mo_loaded = false, $locale_loaded = null;
-		$continents       = [
+
+		$continents = [
 			'Africa',
 			'America',
 			'Antarctica',
@@ -33,6 +34,7 @@ class TimezoneEnum {
 			'Indian',
 			'Pacific',
 		];
+
 		// Load translations for continents and cities.
 		if ( ! $mo_loaded || $locale !== $locale_loaded ) {
 			$locale_loaded = $locale ? $locale : get_locale();
@@ -41,30 +43,30 @@ class TimezoneEnum {
 			load_textdomain( 'continents-cities', $mofile );
 			$mo_loaded = true;
 		}
+	
 		$zonen = [];
 		foreach ( timezone_identifiers_list() as $zone ) {
 			$zone = explode( '/', $zone );
+
 			if ( ! in_array( $zone[0], $continents, true ) ) {
 				continue;
 			}
+
 			// This determines what gets set and translated - we don't translate Etc/* strings here, they are done later
 			$exists = [
-				0 => ! empty( $zone[0] ) ? $zone[0] : null,
-				1 => ! empty( $zone[1] ) ? $zone[1] : null,
-				2 => ! empty( $zone[2] ) ? $zone[2] : null,
+				$zone[0],
+				! empty( $zone[1] ) ? $zone[1] : null,
+				! empty( $zone[2] ) ? $zone[2] : null,
 			];
 
-			$exists[3] = ( $exists[0] && 'Etc' !== $zone[0] );
-			$exists[4] = ( $exists[1] && $exists[3] );
-			$exists[5] = ( $exists[2] && $exists[3] );
 			// phpcs:disable WordPress.WP.I18n.LowLevelTranslationFunction,WordPress.WP.I18n.NonSingularStringLiteralText
 			$zonen[] = [
-				'continent'   => ( $exists[0] ? $zone[0] : '' ),
-				'city'        => ( $exists[1] ? $zone[1] : '' ),
-				'subcity'     => ( $exists[2] ? $zone[2] : '' ),
-				't_continent' => ( $exists[3] ? translate( str_replace( '_', ' ', $zone[0] ), 'wp-graphql' ) : '' ),
-				't_city'      => ( $exists[4] ? translate( str_replace( '_', ' ', $zone[1] ), 'wp-graphql' ) : '' ),
-				't_subcity'   => ( $exists[5] ? translate( str_replace( '_', ' ', $zone[2] ), 'wp-graphql' ) : '' ),
+				'continent'   => $zone[0],
+				'city'        => $exists[1] ? $zone[1] : '',
+				'subcity'     => $exists[2] ? $zone[2] : '',
+				't_continent' => translate( str_replace( '_', ' ', $zone[0] ), 'wp-graphql' ),
+				't_city'      => $exists[1] ? translate( str_replace( '_', ' ', $zone[1] ), 'wp-graphql' ) : '',
+				't_subcity'   => $exists[2] ? translate( str_replace( '_', ' ', $zone[2] ), 'wp-graphql' ) : '',
 			];
 			// phpcs:enable
 		}

--- a/src/Type/ObjectType/TermObject.php
+++ b/src/Type/ObjectType/TermObject.php
@@ -56,7 +56,8 @@ class TermObject {
 							$url = $term->link;
 							if ( ! empty( $url ) ) {
 								$parsed = wp_parse_url( $url );
-								if ( isset( $parsed ) ) {
+
+								if ( is_array( $parsed ) ) {
 									$path  = isset( $parsed['path'] ) ? $parsed['path'] : '';
 									$query = isset( $parsed['query'] ) ? ( '?' . $parsed['query'] ) : '';
 									return trim( $path . $query );


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR moves the logic used in `NodeResolver::resolve_uri()` to mimic [`WP::parse_request()`](https://github.com/WordPress/wordpress-develop/blob/6.0.2/src/wp-includes/class-wp.php#L135) into its own method.

This is in lieu of #2342, as the fragility of `resolve_uri()` and lack of unit testing make it hard to ship multiple changes to that method at once. However, since this particular piece of code is dictated externally and includes no change in behavior to the user, we can merge this now to pave the way for a more stable experience.



Does this close any currently open issues?
------------------------------------------
Supersedes #2342 


Any other comments?
-------------------
This pr is based on #2538, which should be merged first.

Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + PHP 8.0.19

**WordPress Version:** 6.0.2
