### PR TITLE
feat: add `register_graphql_edge_fields()` and `register_graphql_connection_where_args()` access functions

### DIFF
--- a/access-functions.php
+++ b/access-functions.php
@@ -361,7 +361,7 @@ function register_graphql_edge_fields( string $from_type, string $to_type, array
  *
  * @since @todo
  */
-function register_graphql_connection_input( string $from_type, string $to_type, string $field_name, array $config ) : void {
+function register_graphql_connection_where_arg( string $from_type, string $to_type, string $field_name, array $config ) : void {
 	$connection_name = ucfirst( $from_type ) . 'To' . ucfirst( $to_type ) . 'ConnectionWhereArgs';
 
 	add_action(
@@ -382,7 +382,7 @@ function register_graphql_connection_input( string $from_type, string $to_type, 
  *
  * @since @todo
  */
-function register_graphql_connection_inputs( string $from_type, string $to_type, array $fields ) : void {
+function register_graphql_connection_where_args( string $from_type, string $to_type, array $fields ) : void {
 	$connection_name = ucfirst( $from_type ) . 'To' . ucfirst( $to_type ) . 'ConnectionWhereArgs';
 
 	add_action(

--- a/access-functions.php
+++ b/access-functions.php
@@ -306,6 +306,83 @@ function register_graphql_fields( string $type_name, array $fields ) {
 	);
 }
 
+/**
+ * Adds a field to the Connection Edge between the provided 'From' Type Name and 'To' Type Name.
+ *
+ * @param string $from_type  The name of the Type the connection is coming from.
+ * @param string $to_type    The name of the Type or Alias (the connection config's `FromFieldName`) the connection is going to.
+ * @param string $field_name The name of the field to add to the connection edge.
+ * @param array $config      The field config.
+ */
+function register_graphql_edge_field( string $from_type, string $to_type, string $field_name, array $config ) : void {
+	$connection_name = ucfirst( $from_type ) . 'To' . ucfirst( $to_type ) . 'ConnectionEdge';
+
+	add_action(
+		get_graphql_register_action(),
+		function ( TypeRegistry $type_registry ) use ( $connection_name, $field_name, $config ) {
+			$type_registry->register_field( $connection_name, $field_name, $config );
+		},
+		10
+	);
+}
+
+/**
+ * Adds several fields to the Connection Edge between the provided 'From' Type Name and 'To' Type Name.
+ *
+ * @param string $from_type The name of the Type the connection is coming from.
+ * @param string $to_type   The name of the Type or Alias (the connection config's `FromFieldName`) the connection is going to.
+ * @param array  $fields    An array of field configs.
+ */
+function register_graphql_edge_fields( string $from_type, string $to_type, array $fields ) : void {
+	$connection_name = ucfirst( $from_type ) . 'To' . ucfirst( $to_type ) . 'ConnectionEdge';
+
+	add_action(
+		get_graphql_register_action(),
+		function ( TypeRegistry $type_registry ) use ( $connection_name, $fields ) {
+			$type_registry->register_fields( $connection_name, $fields );
+		},
+		10
+	);
+}
+
+/**
+ * Adds an input field to the Connection Where Args between the provided 'From' Type Name and 'To' Type Name.
+ *
+ * @param string $from_type  The name of the Type the connection is coming from.
+ * @param string $to_type    The name of the Type or Alias (the connection config's `FromFieldName`) the connection is going to.
+ * @param string $field_name The name of the field to add to the connection edge.
+ * @param array $config      The field config.
+ */
+function register_graphql_connection_input( string $from_type, string $to_type, string $field_name, array $config ) : void {
+	$connection_name = ucfirst( $from_type ) . 'To' . ucfirst( $to_type ) . 'ConnectionWhereArgs';
+
+	add_action(
+		get_graphql_register_action(),
+		function ( TypeRegistry $type_registry ) use ( $connection_name, $field_name, $config ) {
+			$type_registry->register_field( $connection_name, $field_name, $config );
+		},
+		10
+	);
+}
+
+/**
+ * Adds several input fields to the Connection Where Args between the provided 'From' Type Name and 'To' Type Name.
+ *
+ * @param string $from_type The name of the Type the connection is coming from.
+ * @param string $to_type   The name of the Type or Alias (the connection config's `FromFieldName`) the connection is going to.
+ * @param array  $fields    An array of field configs.
+ */
+function register_graphql_connection_inputs( string $from_type, string $to_type, array $fields ) : void {
+	$connection_name = ucfirst( $from_type ) . 'To' . ucfirst( $to_type ) . 'ConnectionWhereArgs';
+
+	add_action(
+		get_graphql_register_action(),
+		function ( TypeRegistry $type_registry ) use ( $connection_name, $fields ) {
+			$type_registry->register_fields( $connection_name, $fields );
+		},
+		10
+	);
+}
 
 /**
  * Renames a GraphQL field.

--- a/access-functions.php
+++ b/access-functions.php
@@ -276,6 +276,7 @@ function register_graphql_enum_type( string $type_name, array $config ) {
  * @param array  $config     The Type config
  *
  * @return void
+ * @since 0.1.0
  */
 function register_graphql_field( string $type_name, string $field_name, array $config ) {
 	add_action(
@@ -295,6 +296,7 @@ function register_graphql_field( string $type_name, string $field_name, array $c
  * @param array  $fields    An array of field configs
  *
  * @return void
+ * @since 0.1.0
  */
 function register_graphql_fields( string $type_name, array $fields ) {
 	add_action(
@@ -313,6 +315,8 @@ function register_graphql_fields( string $type_name, array $fields ) {
  * @param string $to_type    The name of the Type or Alias (the connection config's `FromFieldName`) the connection is going to.
  * @param string $field_name The name of the field to add to the connection edge.
  * @param array $config      The field config.
+ *
+ * @since @todo
  */
 function register_graphql_edge_field( string $from_type, string $to_type, string $field_name, array $config ) : void {
 	$connection_name = ucfirst( $from_type ) . 'To' . ucfirst( $to_type ) . 'ConnectionEdge';
@@ -332,6 +336,8 @@ function register_graphql_edge_field( string $from_type, string $to_type, string
  * @param string $from_type The name of the Type the connection is coming from.
  * @param string $to_type   The name of the Type or Alias (the connection config's `FromFieldName`) the connection is going to.
  * @param array  $fields    An array of field configs.
+ *
+ * @since @todo
  */
 function register_graphql_edge_fields( string $from_type, string $to_type, array $fields ) : void {
 	$connection_name = ucfirst( $from_type ) . 'To' . ucfirst( $to_type ) . 'ConnectionEdge';
@@ -352,6 +358,8 @@ function register_graphql_edge_fields( string $from_type, string $to_type, array
  * @param string $to_type    The name of the Type or Alias (the connection config's `FromFieldName`) the connection is going to.
  * @param string $field_name The name of the field to add to the connection edge.
  * @param array $config      The field config.
+ *
+ * @since @todo
  */
 function register_graphql_connection_input( string $from_type, string $to_type, string $field_name, array $config ) : void {
 	$connection_name = ucfirst( $from_type ) . 'To' . ucfirst( $to_type ) . 'ConnectionWhereArgs';
@@ -371,6 +379,8 @@ function register_graphql_connection_input( string $from_type, string $to_type, 
  * @param string $from_type The name of the Type the connection is coming from.
  * @param string $to_type   The name of the Type or Alias (the connection config's `FromFieldName`) the connection is going to.
  * @param array  $fields    An array of field configs.
+ *
+ * @since @todo
  */
 function register_graphql_connection_inputs( string $from_type, string $to_type, array $fields ) : void {
 	$connection_name = ucfirst( $from_type ) . 'To' . ucfirst( $to_type ) . 'ConnectionWhereArgs';
@@ -392,6 +402,7 @@ function register_graphql_connection_inputs( string $from_type, string $to_type,
  * @param string $new_field_name  New field name.
  *
  * @return void
+ * @since 1.3.4
  */
 function rename_graphql_field( string $type_name, string $field_name, string $new_field_name ) {
 	add_filter(
@@ -413,6 +424,8 @@ function rename_graphql_field( string $type_name, string $field_name, string $ne
  *
  * @return void
  * @throws Exception
+ *
+ * @since 1.3.4
  */
 function rename_graphql_type( string $type_name, string $new_type_name ) {
 	add_filter(
@@ -448,6 +461,8 @@ function rename_graphql_type( string $type_name, string $new_type_name ) {
  *
  * @throws Exception
  * @return void
+ *
+ * @since 0.1.0
  */
 function register_graphql_connection( array $config ) {
 	add_action(
@@ -467,6 +482,8 @@ function register_graphql_connection( array $config ) {
  *
  * @throws Exception
  * @return void
+ *
+ * @since 0.8.4
  */
 function register_graphql_scalar( string $type_name, array $config ) {
 	add_action(
@@ -485,6 +502,8 @@ function register_graphql_scalar( string $type_name, array $config ) {
  * @param string $field_name The name of the field to remove
  *
  * @return void
+ *
+ * @since 0.1.0
  */
 function deregister_graphql_field( string $type_name, string $field_name ) {
 	add_action(
@@ -505,6 +524,7 @@ function deregister_graphql_field( string $type_name, string $field_name ) {
  * @throws Exception
  *
  * @return void
+ * @since 0.1.0
  */
 function register_graphql_mutation( string $mutation_name, array $config ) {
 	add_action(
@@ -557,6 +577,7 @@ function is_graphql_http_request() {
  * @param array  $config Array configuring the section. Should include: title
  *
  * @return void
+ * @since 0.13.0
  */
 function register_graphql_settings_section( string $slug, array $config ) {
 	add_action(
@@ -574,6 +595,7 @@ function register_graphql_settings_section( string $slug, array $config ) {
  * @param array  $config The config for the settings field being registered
  *
  * @return void
+ * @since 0.13.0
  */
 function register_graphql_settings_field( string $group, array $config ) {
 	add_action(
@@ -595,6 +617,7 @@ function register_graphql_settings_field( string $group, array $config ) {
  *                                    merged into the debug entry.
  *
  * @return void
+ * @since 0.14.0
  */
 function graphql_debug( $message, $config = [] ) {
 	$debug_backtrace     = debug_backtrace(); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
@@ -631,6 +654,7 @@ function graphql_debug( $message, $config = [] ) {
  * @param string $type_name The name of the type to validate
  *
  * @return bool
+ * @since 0.14.0
  */
 function is_valid_graphql_name( string $type_name ) {
 	if ( preg_match( '/^\d/', $type_name ) ) {
@@ -647,6 +671,7 @@ function is_valid_graphql_name( string $type_name ) {
  * @param array  $fields Array of field configs to register to the group
  *
  * @return void
+ * @since 0.13.0
  */
 function register_graphql_settings_fields( string $group, array $fields ) {
 	add_action(
@@ -665,6 +690,7 @@ function register_graphql_settings_fields( string $group, array $fields ) {
  * @param string $section_name The settings group section that the option belongs to
  *
  * @return mixed|string|int|boolean
+ * @since 0.13.0
  */
 function get_graphql_setting( string $option_name, $default = '', $section_name = 'graphql_general_settings' ) {
 
@@ -700,6 +726,8 @@ function get_graphql_setting( string $option_name, $default = '', $section_name 
  * Polyfill for PHP versions below 7.3
  *
  * @return int|string|null
+ *
+ * @since 0.10.0
  */
 if ( ! function_exists( 'array_key_first' ) ) {
 
@@ -720,6 +748,8 @@ if ( ! function_exists( 'array_key_first' ) ) {
  * Polyfill for PHP versions below 7.3
  *
  * @return mixed|string|int
+ *
+ * @since 0.10.0
  */
 if ( ! function_exists( 'array_key_last' ) ) {
 

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
 		"codeception/util-universalframework": "^1.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
 		"phpstan/phpstan": "^1.7",
-		"szepeviktor/phpstan-wordpress": "1.1.1",
+		"szepeviktor/phpstan-wordpress": "1.1.3",
 		"codeception/module-rest": "^1.2",
 		"wp-graphql/wp-graphql-testcase": "~2.3",
 		"phpunit/phpunit": "^9.5",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 	},
 	"require-dev": {
 		"automattic/vipwpcs": "^2.2",
-		"lucatume/wp-browser": "3.1.0",
+		"lucatume/wp-browser": "^3.1.6",
 		"codeception/module-asserts": "^1.0",
 		"codeception/module-phpbrowser": "^1.0",
 		"codeception/module-webdriver": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "91c2373b99ab6de0eed6cfc19ae85eef",
+    "content-hash": "46f4bb96554ebf2c54a9e15474fd3a75",
     "packages": [
         {
             "name": "appsero/client",
@@ -2561,16 +2561,16 @@
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v5.9.3",
+            "version": "v6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "18d56875e5078a50b8ea4bc4b20b735ca61edeee"
+                "reference": "e04781a84e364615a7b5f70fdc345c8253ca5b8f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/18d56875e5078a50b8ea4bc4b20b735ca61edeee",
-                "reference": "18d56875e5078a50b8ea4bc4b20b735ca61edeee",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/e04781a84e364615a7b5f70fdc345c8253ca5b8f",
+                "reference": "e04781a84e364615a7b5f70fdc345c8253ca5b8f",
                 "shasum": ""
             },
             "replace": {
@@ -2602,9 +2602,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v5.9.3"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.0.1"
             },
-            "time": "2022-04-06T15:33:59+00:00"
+            "time": "2022-07-15T11:10:45+00:00"
         },
         {
             "name": "php-webdriver/webdriver",
@@ -3117,16 +3117,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.8.2",
+            "version": "1.8.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "c53312ecc575caf07b0e90dee43883fdf90ca67c"
+                "reference": "c386ab2741e64cc9e21729f891b28b2b10fe6618"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c53312ecc575caf07b0e90dee43883fdf90ca67c",
-                "reference": "c53312ecc575caf07b0e90dee43883fdf90ca67c",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c386ab2741e64cc9e21729f891b28b2b10fe6618",
+                "reference": "c386ab2741e64cc9e21729f891b28b2b10fe6618",
                 "shasum": ""
             },
             "require": {
@@ -3150,9 +3150,13 @@
                 "MIT"
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.8.2"
+                "source": "https://github.com/phpstan/phpstan/tree/1.8.6"
             },
             "funding": [
                 {
@@ -3164,15 +3168,11 @@
                     "type": "github"
                 },
                 {
-                    "url": "https://www.patreon.com/phpstan",
-                    "type": "patreon"
-                },
-                {
                     "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-07-20T09:57:31+00:00"
+            "time": "2022-09-23T09:54:39+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -7204,21 +7204,21 @@
         },
         {
             "name": "szepeviktor/phpstan-wordpress",
-            "version": "v1.1.1",
+            "version": "v1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/szepeviktor/phpstan-wordpress.git",
-                "reference": "99cfea6b4c15af12dec09110b25dbc7521363f78"
+                "reference": "e644df734e1bbe95810e0f617d17df091048a94e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/szepeviktor/phpstan-wordpress/zipball/99cfea6b4c15af12dec09110b25dbc7521363f78",
-                "reference": "99cfea6b4c15af12dec09110b25dbc7521363f78",
+                "url": "https://api.github.com/repos/szepeviktor/phpstan-wordpress/zipball/e644df734e1bbe95810e0f617d17df091048a94e",
+                "reference": "e644df734e1bbe95810e0f617d17df091048a94e",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2 || ^8.0",
-                "php-stubs/wordpress-stubs": "^4.7 || ^5.0",
+                "php-stubs/wordpress-stubs": "^4.7 || ^5.0 || ^6.0",
                 "phpstan/phpstan": "^1.6",
                 "symfony/polyfill-php73": "^1.12.0"
             },
@@ -7257,15 +7257,19 @@
             ],
             "support": {
                 "issues": "https://github.com/szepeviktor/phpstan-wordpress/issues",
-                "source": "https://github.com/szepeviktor/phpstan-wordpress/tree/v1.1.1"
+                "source": "https://github.com/szepeviktor/phpstan-wordpress/tree/v1.1.3"
             },
             "funding": [
                 {
                     "url": "https://www.paypal.me/szepeviktor",
                     "type": "custom"
+                },
+                {
+                    "url": "https://github.com/szepeviktor",
+                    "type": "github"
                 }
             ],
-            "time": "2022-05-11T18:41:40+00:00"
+            "time": "2022-09-22T13:14:50+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "46f4bb96554ebf2c54a9e15474fd3a75",
+    "content-hash": "58018f4efd8728528c79055327634788",
     "packages": [
         {
             "name": "appsero/client",
@@ -920,16 +920,16 @@
         },
         {
             "name": "codeception/module-webdriver",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeception/module-webdriver.git",
-                "reference": "baa18b7bf70aa024012f967b5ce5021e1faa9151"
+                "reference": "e22ac7da756df659df6dd4fac2dff9c859e30131"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeception/module-webdriver/zipball/baa18b7bf70aa024012f967b5ce5021e1faa9151",
-                "reference": "baa18b7bf70aa024012f967b5ce5021e1faa9151",
+                "url": "https://api.github.com/repos/Codeception/module-webdriver/zipball/e22ac7da756df659df6dd4fac2dff9c859e30131",
+                "reference": "e22ac7da756df659df6dd4fac2dff9c859e30131",
                 "shasum": ""
             },
             "require": {
@@ -970,9 +970,9 @@
             ],
             "support": {
                 "issues": "https://github.com/Codeception/module-webdriver/issues",
-                "source": "https://github.com/Codeception/module-webdriver/tree/1.4.0"
+                "source": "https://github.com/Codeception/module-webdriver/tree/1.4.1"
             },
-            "time": "2021-09-02T12:01:02+00:00"
+            "time": "2022-09-12T05:09:51+00:00"
         },
         {
             "name": "codeception/phpunit-wrapper",
@@ -1970,16 +1970,16 @@
         },
         {
             "name": "lucatume/wp-browser",
-            "version": "3.1.0",
+            "version": "3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lucatume/wp-browser.git",
-                "reference": "415046123ce5373bf306ac0622f9523b720b9a3b"
+                "reference": "5cefdab50d16f69447c48e5a8668d67d4892d6ef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lucatume/wp-browser/zipball/415046123ce5373bf306ac0622f9523b720b9a3b",
-                "reference": "415046123ce5373bf306ac0622f9523b720b9a3b",
+                "url": "https://api.github.com/repos/lucatume/wp-browser/zipball/5cefdab50d16f69447c48e5a8668d67d4892d6ef",
+                "reference": "5cefdab50d16f69447c48e5a8668d67d4892d6ef",
                 "shasum": ""
             },
             "require": {
@@ -2008,6 +2008,8 @@
             },
             "require-dev": {
                 "erusev/parsedown": "^1.7",
+                "ext-pcntl": "*",
+                "ext-sockets": "*",
                 "gumlet/php-image-resize": "^1.6",
                 "lucatume/codeception-snapshot-assertions": "^0.2",
                 "mikey179/vfsstream": "^1.6",
@@ -2037,7 +2039,8 @@
                 ],
                 "psr-4": {
                     "tad\\": "src/tad",
-                    "Codeception\\": "src/Codeception"
+                    "Codeception\\": "src/Codeception",
+                    "lucatume\\WPBrowser\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2060,7 +2063,7 @@
             ],
             "support": {
                 "issues": "https://github.com/lucatume/wp-browser/issues",
-                "source": "https://github.com/lucatume/wp-browser/tree/3.1.0"
+                "source": "https://github.com/lucatume/wp-browser/tree/3.1.6"
             },
             "funding": [
                 {
@@ -2068,7 +2071,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-01-28T16:09:41+00:00"
+            "time": "2022-04-28T06:45:08+00:00"
         },
         {
             "name": "mikehaertl/php-shellcommand",
@@ -2844,233 +2847,6 @@
             "time": "2021-12-30T16:37:40+00:00"
         },
         {
-            "name": "phpdocumentor/reflection-common",
-            "version": "2.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
-                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jaap van Otterdijk",
-                    "email": "opensource@ijaap.nl"
-                }
-            ],
-            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
-            "homepage": "http://www.phpdoc.org",
-            "keywords": [
-                "FQSEN",
-                "phpDocumentor",
-                "phpdoc",
-                "reflection",
-                "static analysis"
-            ],
-            "support": {
-                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
-            },
-            "time": "2020-06-27T09:03:43+00:00"
-        },
-        {
-            "name": "phpdocumentor/reflection-docblock",
-            "version": "5.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/622548b623e81ca6d78b721c5e029f4ce664f170",
-                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170",
-                "shasum": ""
-            },
-            "require": {
-                "ext-filter": "*",
-                "php": "^7.2 || ^8.0",
-                "phpdocumentor/reflection-common": "^2.2",
-                "phpdocumentor/type-resolver": "^1.3",
-                "webmozart/assert": "^1.9.1"
-            },
-            "require-dev": {
-                "mockery/mockery": "~1.3.2",
-                "psalm/phar": "^4.8"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                },
-                {
-                    "name": "Jaap van Otterdijk",
-                    "email": "account@ijaap.nl"
-                }
-            ],
-            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "support": {
-                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.3.0"
-            },
-            "time": "2021-10-19T17:43:47+00:00"
-        },
-        {
-            "name": "phpdocumentor/type-resolver",
-            "version": "1.6.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "77a32518733312af16a44300404e945338981de3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/77a32518733312af16a44300404e945338981de3",
-                "reference": "77a32518733312af16a44300404e945338981de3",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0",
-                "phpdocumentor/reflection-common": "^2.0"
-            },
-            "require-dev": {
-                "ext-tokenizer": "*",
-                "psalm/phar": "^4.8"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                }
-            ],
-            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
-            "support": {
-                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.6.1"
-            },
-            "time": "2022-03-15T21:29:03+00:00"
-        },
-        {
-            "name": "phpspec/prophecy",
-            "version": "v1.15.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "bbcd7380b0ebf3961ee21409db7b38bc31d69a13"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/bbcd7380b0ebf3961ee21409db7b38bc31d69a13",
-                "reference": "bbcd7380b0ebf3961ee21409db7b38bc31d69a13",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/instantiator": "^1.2",
-                "php": "^7.2 || ~8.0, <8.2",
-                "phpdocumentor/reflection-docblock": "^5.2",
-                "sebastian/comparator": "^3.0 || ^4.0",
-                "sebastian/recursion-context": "^3.0 || ^4.0"
-            },
-            "require-dev": {
-                "phpspec/phpspec": "^6.0 || ^7.0",
-                "phpunit/phpunit": "^8.0 || ^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Prophecy\\": "src/Prophecy"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Konstantin Kudryashov",
-                    "email": "ever.zet@gmail.com",
-                    "homepage": "http://everzet.com"
-                },
-                {
-                    "name": "Marcello Duarte",
-                    "email": "marcello.duarte@gmail.com"
-                }
-            ],
-            "description": "Highly opinionated mocking framework for PHP 5.3+",
-            "homepage": "https://github.com/phpspec/prophecy",
-            "keywords": [
-                "Double",
-                "Dummy",
-                "fake",
-                "mock",
-                "spy",
-                "stub"
-            ],
-            "support": {
-                "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/v1.15.0"
-            },
-            "time": "2021-12-08T12:19:24+00:00"
-        },
-        {
             "name": "phpstan/extension-installer",
             "version": "1.1.0",
             "source": {
@@ -3494,16 +3270,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.21",
+            "version": "9.5.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "0e32b76be457de00e83213528f6bb37e2a38fcb1"
+                "reference": "888556852e7e9bbeeedb9656afe46118765ade34"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0e32b76be457de00e83213528f6bb37e2a38fcb1",
-                "reference": "0e32b76be457de00e83213528f6bb37e2a38fcb1",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/888556852e7e9bbeeedb9656afe46118765ade34",
+                "reference": "888556852e7e9bbeeedb9656afe46118765ade34",
                 "shasum": ""
             },
             "require": {
@@ -3518,7 +3294,6 @@
                 "phar-io/manifest": "^2.0.3",
                 "phar-io/version": "^3.0.2",
                 "php": ">=7.3",
-                "phpspec/prophecy": "^1.12.1",
                 "phpunit/php-code-coverage": "^9.2.13",
                 "phpunit/php-file-iterator": "^3.0.5",
                 "phpunit/php-invoker": "^3.1.1",
@@ -3535,9 +3310,6 @@
                 "sebastian/resource-operations": "^3.0.3",
                 "sebastian/type": "^3.0",
                 "sebastian/version": "^3.0.2"
-            },
-            "require-dev": {
-                "phpspec/prophecy-phpunit": "^2.0.1"
             },
             "suggest": {
                 "ext-soap": "*",
@@ -3580,7 +3352,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.21"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.23"
             },
             "funding": [
                 {
@@ -3592,7 +3364,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-06-19T12:14:25+00:00"
+            "time": "2022-08-22T14:01:36+00:00"
         },
         {
             "name": "psr/container",
@@ -7447,64 +7219,6 @@
                 "source": "https://github.com/vria/nodiacritic/tree/0.1.2"
             },
             "time": "2016-09-17T22:03:11+00:00"
-        },
-        {
-            "name": "webmozart/assert",
-            "version": "1.11.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozarts/assert.git",
-                "reference": "11cb2199493b2f8a3b53e7f19068fc6aac760991"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/11cb2199493b2f8a3b53e7f19068fc6aac760991",
-                "reference": "11cb2199493b2f8a3b53e7f19068fc6aac760991",
-                "shasum": ""
-            },
-            "require": {
-                "ext-ctype": "*",
-                "php": "^7.2 || ^8.0"
-            },
-            "conflict": {
-                "phpstan/phpstan": "<0.12.20",
-                "vimeo/psalm": "<4.6.1 || 4.6.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^8.5.13"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.10-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "support": {
-                "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.11.0"
-            },
-            "time": "2022-06-03T18:03:27+00:00"
         },
         {
             "name": "wp-cli/mustangostang-spyc",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -24,5 +24,3 @@ parameters:
         - */node_modules/*
         - */vendor/*
     ignoreErrors:
-        # Ignore any filters that are applied with more than 2 paramaters
-        - '#^Function apply_filters(_ref_array)? invoked with ([1-9]|1[0-2]) parameters, 2 required\.$#'

--- a/src/Data/Connection/PluginConnectionResolver.php
+++ b/src/Data/Connection/PluginConnectionResolver.php
@@ -188,7 +188,8 @@ class PluginConnectionResolver extends AbstractConnectionResolver {
 		$plugins_by_status['all'] = array_flip( array_keys( $all_plugins ) );
 
 		// Filter the plugins by stati.
-		$filtered_plugins = ! empty( $active_stati ) ? array_merge( ... array_values( array_intersect_key( $plugins_by_status, $active_stati ) ) ) : $plugins_by_status['all'];
+		// @phpstan-ignore-next-line
+		$filtered_plugins = ! empty( $active_stati ) ? array_merge( ...array_values( array_intersect_key( $plugins_by_status, $active_stati ) ) ) : $plugins_by_status['all'];
 
 		if ( ! empty( $this->args['where']['search'] ) ) {
 			// Filter by search args.

--- a/src/Data/Connection/PluginConnectionResolver.php
+++ b/src/Data/Connection/PluginConnectionResolver.php
@@ -187,9 +187,12 @@ class PluginConnectionResolver extends AbstractConnectionResolver {
 
 		$plugins_by_status['all'] = array_flip( array_keys( $all_plugins ) );
 
-		// Filter the plugins by stati.
-		// @phpstan-ignore-next-line
-		$filtered_plugins = ! empty( $active_stati ) ? array_merge( ...array_values( array_intersect_key( $plugins_by_status, $active_stati ) ) ) : $plugins_by_status['all'];
+		/**
+		 * Filters the plugins by status.
+		 * */
+		$filtered_plugins = ! empty( $active_stati ) ? array_values( array_intersect_key( $plugins_by_status, $active_stati ) ) : [];
+		// If plugins exist for the filter, flatten and return them. Otherwise, return the full list.
+		$filtered_plugins = ! empty( $filtered_plugins ) ? array_merge( ...$filtered_plugins ) : $plugins_by_status['all'];
 
 		if ( ! empty( $this->args['where']['search'] ) ) {
 			// Filter by search args.

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -308,7 +308,12 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		 */
 		if ( isset( $this->args['where']['orderby'] ) && is_array( $this->args['where']['orderby'] ) ) {
 			$query_args['orderby'] = [];
+
 			foreach ( $this->args['where']['orderby'] as $orderby_input ) {
+				if ( empty( $orderby_input['field'] ) ) {
+					continue;
+				}
+
 				/**
 				 * These orderby options should not include the order parameter.
 				 */
@@ -322,20 +327,22 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 					true
 				) ) {
 					$query_args['orderby'] = esc_sql( $orderby_input['field'] );
-				} elseif ( ! empty( $orderby_input['field'] ) ) {
 
-					$order = $orderby_input['order'];
-
-					if ( isset( $query_args['graphql_args']['last'] ) && ! empty( $query_args['graphql_args']['last'] ) ) {
-						if ( 'ASC' === $order ) {
-							$order = 'DESC';
-						} else {
-							$order = 'ASC';
-						}
-					}
-
-					$query_args['orderby'][ esc_sql( $orderby_input['field'] ) ] = esc_sql( $order );
+					// If we're ordering explicitly, there's no reason to check other orderby inputs.
+					break;
 				}
+
+				$order = $orderby_input['order'];
+
+				if ( isset( $query_args['graphql_args']['last'] ) && ! empty( $query_args['graphql_args']['last'] ) ) {
+					if ( 'ASC' === $order ) {
+						$order = 'DESC';
+					} else {
+						$order = 'ASC';
+					}
+				}
+
+				$query_args['orderby'][ esc_sql( $orderby_input['field'] ) ] = esc_sql( $order );
 			}
 		}
 

--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -96,12 +96,26 @@ class NodeResolver {
 
 		$parsed_url = wp_parse_url( $uri );
 
+		if ( false === $parsed_url ) {
+			graphql_debug( __( 'Cannot parse provided URI', 'wp-graphql' ), [
+				'uri' => $uri,
+			] );
+			return null;
+		}
+
 		if ( isset( $parsed_url['host'] ) ) {
+			$site_url = wp_parse_url( site_url() );
+			$home_url = wp_parse_url( home_url() );
+
+			/**
+			 * @var array $home_url
+			 * @var array $site_url
+			 */
 			if ( ! in_array(
 				$parsed_url['host'],
 				[
-					wp_parse_url( site_url() )['host'],
-					wp_parse_url( home_url() )['host'],
+					$site_url['host'],
+					$home_url['host'],
 				],
 				true
 			) ) {
@@ -115,7 +129,7 @@ class NodeResolver {
 		$this->wp->query_vars = [];
 		$post_type_query_vars = [];
 
-		if ( isset( $parsed_url['query'] ) && '/' === $parsed_url['path'] ) {
+		if ( isset( $parsed_url['query'] ) && ( empty( $parsed_url['path'] ) || '/' === $parsed_url['path'] ) ) {
 			$uri = $parsed_url['query'];
 		} elseif ( isset( $parsed_url['path'] ) ) {
 			$uri = $parsed_url['path'];
@@ -144,7 +158,7 @@ class NodeResolver {
 			$pathinfo         = str_replace( '%', '%25', $pathinfo );
 
 			list( $req_uri ) = explode( '?', $pathinfo );
-			$home_path       = trim( wp_parse_url( home_url(), PHP_URL_PATH ), '/' );
+			$home_path       = trim( (string) wp_parse_url( home_url(), PHP_URL_PATH ), '/' );
 			$home_path_regex = sprintf( '|^%s|i', preg_quote( $home_path, '|' ) );
 
 			// Trim path info from the end and the leading home path from the

--- a/src/Model/MenuItem.php
+++ b/src/Model/MenuItem.php
@@ -158,6 +158,7 @@ class MenuItem extends Model {
 					$url = $this->url;
 
 					if ( ! empty( $url ) ) {
+						/** @var array $parsed */
 						$parsed = wp_parse_url( $url );
 						if ( isset( $parsed['host'] ) && strpos( home_url(), $parsed['host'] ) ) {
 							return $parsed['path'];

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -910,7 +910,7 @@ class TypeRegistry {
 	 * @return void
 	 */
 	public function register_fields( string $type_name, array $fields = [] ) {
-		if ( is_string( $type_name ) && ! empty( $fields ) && is_array( $fields ) ) {
+		if ( ! empty( $fields ) ) {
 			foreach ( $fields as $field_name => $config ) {
 				if ( is_string( $field_name ) && ! empty( $config ) && is_array( $config ) ) {
 					$this->register_field( $type_name, $field_name, $config );

--- a/src/Type/Enum/TimezoneEnum.php
+++ b/src/Type/Enum/TimezoneEnum.php
@@ -21,7 +21,8 @@ class TimezoneEnum {
 
 		$locale           = get_locale();
 		static $mo_loaded = false, $locale_loaded = null;
-		$continents       = [
+
+		$continents = [
 			'Africa',
 			'America',
 			'Antarctica',
@@ -33,6 +34,7 @@ class TimezoneEnum {
 			'Indian',
 			'Pacific',
 		];
+
 		// Load translations for continents and cities.
 		if ( ! $mo_loaded || $locale !== $locale_loaded ) {
 			$locale_loaded = $locale ? $locale : get_locale();
@@ -41,30 +43,30 @@ class TimezoneEnum {
 			load_textdomain( 'continents-cities', $mofile );
 			$mo_loaded = true;
 		}
+	
 		$zonen = [];
 		foreach ( timezone_identifiers_list() as $zone ) {
 			$zone = explode( '/', $zone );
+
 			if ( ! in_array( $zone[0], $continents, true ) ) {
 				continue;
 			}
+
 			// This determines what gets set and translated - we don't translate Etc/* strings here, they are done later
 			$exists = [
-				0 => ! empty( $zone[0] ) ? $zone[0] : null,
-				1 => ! empty( $zone[1] ) ? $zone[1] : null,
-				2 => ! empty( $zone[2] ) ? $zone[2] : null,
+				$zone[0],
+				! empty( $zone[1] ) ? $zone[1] : null,
+				! empty( $zone[2] ) ? $zone[2] : null,
 			];
 
-			$exists[3] = ( $exists[0] && 'Etc' !== $zone[0] );
-			$exists[4] = ( $exists[1] && $exists[3] );
-			$exists[5] = ( $exists[2] && $exists[3] );
 			// phpcs:disable WordPress.WP.I18n.LowLevelTranslationFunction,WordPress.WP.I18n.NonSingularStringLiteralText
 			$zonen[] = [
-				'continent'   => ( $exists[0] ? $zone[0] : '' ),
-				'city'        => ( $exists[1] ? $zone[1] : '' ),
-				'subcity'     => ( $exists[2] ? $zone[2] : '' ),
-				't_continent' => ( $exists[3] ? translate( str_replace( '_', ' ', $zone[0] ), 'wp-graphql' ) : '' ),
-				't_city'      => ( $exists[4] ? translate( str_replace( '_', ' ', $zone[1] ), 'wp-graphql' ) : '' ),
-				't_subcity'   => ( $exists[5] ? translate( str_replace( '_', ' ', $zone[2] ), 'wp-graphql' ) : '' ),
+				'continent'   => $zone[0],
+				'city'        => $exists[1] ? $zone[1] : '',
+				'subcity'     => $exists[2] ? $zone[2] : '',
+				't_continent' => translate( str_replace( '_', ' ', $zone[0] ), 'wp-graphql' ),
+				't_city'      => $exists[1] ? translate( str_replace( '_', ' ', $zone[1] ), 'wp-graphql' ) : '',
+				't_subcity'   => $exists[2] ? translate( str_replace( '_', ' ', $zone[2] ), 'wp-graphql' ) : '',
 			];
 			// phpcs:enable
 		}

--- a/src/Type/ObjectType/TermObject.php
+++ b/src/Type/ObjectType/TermObject.php
@@ -56,7 +56,8 @@ class TermObject {
 							$url = $term->link;
 							if ( ! empty( $url ) ) {
 								$parsed = wp_parse_url( $url );
-								if ( isset( $parsed ) ) {
+
+								if ( is_array( $parsed ) ) {
 									$path  = isset( $parsed['path'] ) ? $parsed['path'] : '';
 									$query = isset( $parsed['query'] ) ? ( '?' . $parsed['query'] ) : '';
 									return trim( $path . $query );

--- a/tests/wpunit/AccessFunctionsTest.php
+++ b/tests/wpunit/AccessFunctionsTest.php
@@ -514,7 +514,7 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 			'public'              => true,
 		] );
 
-		register_graphql_connection_input(
+		register_graphql_connection_where_arg(
 			'RootQuery',
 			'ConnectionInputCpt',
 			'testInputField', 
@@ -572,7 +572,7 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 			'public'              => true,
 		] );
 
-		register_graphql_connection_inputs(
+		register_graphql_connection_where_args(
 			'RootQuery',
 			'ConnectionInputsCpt',
 			[

--- a/tests/wpunit/AccessFunctionsTest.php
+++ b/tests/wpunit/AccessFunctionsTest.php
@@ -100,7 +100,7 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 	}
 
 	// tests
-	public function testMe() {
+	public function testFormatFieldName() {
 		$actual   = graphql_format_field_name( 'This is some field name' );
 		$expected = 'thisIsSomeFieldName';
 		self::assertEquals( $expected, $actual );
@@ -144,7 +144,7 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 	public function testRegisterInputField() {
 
 		/**
-		 * Register Register Input Field CPT
+		 * Register Input Field CPT
 		 */
 		register_post_type( 'access_functions_cpt', [
 			'label'               => __( 'Register Input Field CPT', 'wp-graphql' ),
@@ -397,11 +397,21 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 			'graphqlInResolver',
 			[
 				'type'        => 'String',
-				'description' => __( 'Returns an MD5 hash of the schema, useful in determining if the schema has changed.', 'wp-gatsby' ),
+				'description' => __( 'Returns an MD5 hash of the schema, useful in determining if the schema has changed.', 'wp-graphql' ),
 				'resolve'     => function () {
+					$query = '
+						{
+							posts {
+								nodes {
+									id
+								}
+							}
+						}
+					';
+
 					$graphql = \graphql(
 						[
-							'query' => '{posts{nodes{id}}}',
+							'query' => $query,
 						]
 					);
 
@@ -414,9 +424,9 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		);
 
 		$query = '
-		{
-			graphqlInResolver
-		}
+			{
+				graphqlInResolver
+			}
 		';
 
 		$actual = $this->graphql([
@@ -436,11 +446,21 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 			'graphqlInResolver',
 			[
 				'type'        => 'String',
-				'description' => __( 'Returns an MD5 hash of the schema, useful in determining if the schema has changed.', 'wp-gatsby' ),
+				'description' => __( 'Returns an MD5 hash of the schema, useful in determining if the schema has changed.', 'wp-graphql' ),
 				'resolve'     => function () {
+					$query = '
+						{
+							posts {
+								nodes {
+									id
+								}
+							}
+						}
+					';
+
 					$graphql = \graphql(
 						[
-							'query' => '{posts{nodes{id}}}',
+							'query' => $query,
 						]
 					);
 

--- a/tests/wpunit/AccessFunctionsTest.php
+++ b/tests/wpunit/AccessFunctionsTest.php
@@ -294,6 +294,73 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 	}
 
+	public function testRegisterFields() {
+		/**
+		 * Register Input Field CPT
+		 */
+		register_post_type( 'register_fields_cpt', [
+			'label'               => __( 'Register Fields CPT', 'wp-graphql' ),
+			'labels'              => [
+				'name'          => __( 'Register Fields CPT', 'wp-graphql' ),
+				'singular_name' => __( 'Register Fields CPT', 'wp-graphql' ),
+			],
+			'description'         => __( 'test-post-type', 'wp-graphql' ),
+			'supports'            => [ 'title' ],
+			'show_in_graphql'     => true,
+			'graphql_single_name' => 'RegisterFieldsCpt',
+			'graphql_plural_name' => 'RegisterFieldsCpts',
+		] );
+
+		/**
+		 * Register a GraphQL Input Field to the connection where args
+		 */
+		register_graphql_fields(
+			'RootQueryToRegisterFieldsCptConnectionWhereArgs',
+			[
+				'firstTestField'  => [
+					'type'        => 'String',
+					'description' => 'just testing here',
+				],
+				'secondTestField' => [
+					'type'        => 'String',
+					'description' => 'just testing here',
+				],
+			]
+		);
+
+		/**
+		 * Introspection query to query the names of fields on the Type
+		 */
+		$query = '{
+			__type( name: "RootQueryToRegisterFieldsCptConnectionWhereArgs" ) { 
+				inputFields {
+					name
+				}
+			}
+		}';
+
+		$response = $this->graphql( compact( 'query' ) );
+
+		/**
+		 * Get an array of names from the inputFields
+		 */
+		$names = array_column( $response['data']['__type']['inputFields'], 'name' );
+
+		/**
+		 * Assert that `testTest` exists in the $names (the field was properly registered)
+		 */
+		$this->assertTrue( in_array( 'firstTestField', $names, true ) );
+		$this->assertTrue( in_array( 'secondTestField', $names, true ) );
+
+		/**
+		 * Cleanup
+		 */
+		deregister_graphql_field( 'RootQueryToRegisterFieldsCptConnectionWhereArgs', 'firstTestField' );
+		deregister_graphql_field( 'RootQueryToRegisterFieldsCptConnectionWhereArgs', 'secondTestField' );
+		unregister_post_type( 'register_fields_cpt' );
+		WPGraphQL::clear_schema();
+	}
+
 	public function testRenameGraphQLFieldName() {
 
 		rename_graphql_field( 'RootQuery', 'user', 'wpUser' );


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR adds the `register_graphql_edge_field()`, `register_graphql_edge_fields()`, `register_graphql_connection_where_arg()` and `register_graphql_connection_where_args()` access functions, making it easier to add fields to Connection `edges` and `where` args without needing to know the generated GraphQL type names.

It also cleans up some extraneous conditional logic in `TypeRegistry::get_fields()`, and backfills a WPUnit test for `register_graphql_fields()`


Does this close any currently open issues?
------------------------------------------
Closes #1522, closes #1214


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
- While #1214 doesnt call for a `register_graphql_connection_input()` access function, the logic to justify it is the same as `register_graphql_edge_field()`.
- ~Re naming: I chose to mirror[`WPConnectionType::register_connection_input()`](https://github.com/wp-graphql/wp-graphql/blob/6e8bb30892d877d61961d1eec9783d2e7ddac333/src/Type/WPConnectionType.php#L463), instead of something like `register_graphql_connection_where_arg()` for consistency, but I'm open to calling it whatever.~ 
- This PR is based off of #2545, which should be merged first


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (Wsl2 + devilbox + PHP 8.0.19)

**WordPress Version:** 6.0.2
