### PR TITLE
release: v1.11.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,7 +9,7 @@ body:
         Please remember, a bug report is not the place to ask questions. You can
         use [Slack](https://join.slack.com/t/wp-graphql/shared_invite/zt-3vloo60z-PpJV2PFIwEathWDOxCTTLA) for that, or start a topic in [GitHub
         Discussions](https://github.com/wp-graphql/wp-graphql/discussions).
-  - type: input
+  - type: textarea
     attributes:
       label: Description
       description: >-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ## Chores / Bugfixes
 
 - ([#2551](https://github.com/wp-graphql/wp-graphql/pull/2551)): Chunks X-GraphQL-Keys header into multiple headers under a set max header limit length.
+- ([#2539](https://github.com/wp-graphql/wp-graphql/pull/2539)): Set IDE direction to prevent breaks in RTL mode. Thanks @justlevine!
+- ([#2549](https://github.com/wp-graphql/wp-graphql/pull/2549)): Fix bug_report.yml field to be textarea instead of input. Thanks @justlevine!
 
 ## 1.11.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.11.2
+
+## Chores / Bugfixes
+
+- ([#2551](https://github.com/wp-graphql/wp-graphql/pull/2551)): Chunks X-GraphQL-Keys header into multiple headers under a set max header limit length.
+
 ## 1.11.1
 
 ## Chores / Bugfixes

--- a/readme.txt
+++ b/readme.txt
@@ -174,7 +174,8 @@ Composer dependencies are no longer versioned in Github. Recommended install sou
 **Chores / Bugfixes**
 
 - ([#2551](https://github.com/wp-graphql/wp-graphql/pull/2551)): Chunks X-GraphQL-Keys header into multiple headers under a set max header limit length.
-
+- ([#2539](https://github.com/wp-graphql/wp-graphql/pull/2539)): Set IDE direction to prevent breaks in RTL mode. Thanks @justlevine!
+- ([#2549](https://github.com/wp-graphql/wp-graphql/pull/2549)): Fix bug_report.yml field to be textarea instead of input. Thanks @justlevine!
 
 = 1.11.1 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, API, Gatsby, Headless, Decoupled, React, Nextjs, Vue, Apollo, RES
 Requires at least: 5.0
 Tested up to: 5.9.1
 Requires PHP: 7.1
-Stable tag: 1.11.1
+Stable tag: 1.11.2
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -168,6 +168,13 @@ The `uri` field was non-null on some Types in the Schema but has been changed to
 Composer dependencies are no longer versioned in Github. Recommended install source is WordPress.org or using Composer to get the code from Packagist.org or WPackagist.org.
 
 == Changelog ==
+
+= 1.11.2 =
+
+**Chores / Bugfixes**
+
+- ([#2551](https://github.com/wp-graphql/wp-graphql/pull/2551)): Chunks X-GraphQL-Keys header into multiple headers under a set max header limit length.
+
 
 = 1.11.1 =
 

--- a/src/Admin/GraphiQL/GraphiQL.php
+++ b/src/Admin/GraphiQL/GraphiQL.php
@@ -114,7 +114,7 @@ class GraphiQL {
 	 * @return void
 	 */
 	public function render_graphiql_admin_page() {
-		$rendered = apply_filters( 'graphql_render_admin_page', '<div class="wrap"><div id="graphiql" class="graphiql-container">Loading ...</div></div>' );
+		$rendered = apply_filters( 'graphql_render_admin_page', '<div class="wrap" dir="ltr"><div id="graphiql" class="graphiql-container">Loading ...</div></div>' );
 
 		echo wp_kses_post( $rendered );
 	}

--- a/src/Utils/QueryAnalyzer.php
+++ b/src/Utils/QueryAnalyzer.php
@@ -105,6 +105,12 @@ class QueryAnalyzer {
 	public function init(): void {
 
 		// allow query analyzer functionality to be disabled
+		/**
+		 * Filters whether to analyze queries or not
+		 *
+		 * @param bool $should_analyze_queries Whether to analyze queries or not. Default true
+		 * @param QueryAnalyzer $query_analyzer The QueryAnalyzer instance
+		 */
 		$should_analyze_queries = apply_filters( 'graphql_should_analyze_queries', true, $this );
 
 		// If query analyzer is disabled, bail
@@ -112,18 +118,23 @@ class QueryAnalyzer {
 			return;
 		}
 
-		// Filter the header key limit. Default is 8000 (8k) to play nice
-		// with common clients such as:
-		//
-		// Next: https://vercel.com/docs/concepts/functions/edge-functions/limitations#limits-on-requests
-		// Varnish: https://varnish-cache.org/docs/4.1/reference/varnishd.html?highlight=storage%20types#http-req-hdr-len,
-		// Node: https://nodejs.org/api/cli.html#--max-http-header-sizesize
-		// Fastly: https://docs.fastly.com/en/guides/resource-limits#request-and-response-limits
-		//
-		// Next, Varnish, Node, Fastly and others. (some support 16k).
-		// 8k will be the default, but filter away.
-		//
-		// and others.
+
+		/**
+		 * Filter the header key limit. Default is 8000 (8k) to play nice
+		 * with common clients such as:
+		 *
+		 * Next: https://vercel.com/docs/concepts/functions/edge-functions/limitations#limits-on-requests
+		 * Varnish: https://varnish-cache.org/docs/4.1/reference/varnishd.html?highlight=storage%20types#http-req-hdr-len,
+		 * Node: https://nodejs.org/api/cli.html#--max-http-header-sizesize
+		 * Fastly: https://docs.fastly.com/en/guides/resource-limits#request-and-response-limits
+		 *
+		 * Next, Varnish, Node, Fastly and others. (some support 16k).
+		 * 8k will be the default, but filter away.
+		 *
+		 * and others.
+		 *
+		 * @param int $header_length_limit The max limit headers should be. Longer than this, they're chunked into multiple headers.
+		 */
 		$this->header_length_limit = apply_filters( 'graphql_query_analyzer_header_length_limit', 8192 );
 
 		// track keys related to the query
@@ -295,6 +306,10 @@ class QueryAnalyzer {
 		$map = array_values( array_unique( array_filter( $type_map ) ) );
 
 		// @phpcs:ignore
+
+		/**
+		 * Filter teh list types
+		 */
 		return apply_filters( 'graphql_cache_collection_get_list_types', $map, $schema, $query, $type_info );
 	}
 

--- a/src/Utils/QueryAnalyzer.php
+++ b/src/Utils/QueryAnalyzer.php
@@ -197,8 +197,7 @@ class QueryAnalyzer {
 	 * @return array
 	 */
 	public function get_query_types(): array {
-		return array_unique( $this->query_types );
-
+		return array_unique( $this->queried_types );
 	}
 
 	/**
@@ -216,7 +215,7 @@ class QueryAnalyzer {
 		 * @param array $runtime_nodes Nodes that were resolved during execution
 		 */
 		$runtime_nodes = apply_filters( 'graphql_query_analyzer_get_runtime_nodes', $this->runtime_nodes );
-		return is_array( $runtime_nodes ) ? array_unique( $runtime_nodes ) : [];
+		return array_unique( $runtime_nodes );
 
 	}
 

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -130,7 +130,7 @@ final class WPGraphQL {
 
 		// Plugin version.
 		if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-			define( 'WPGRAPHQL_VERSION', '1.11.1' );
+			define( 'WPGRAPHQL_VERSION', '1.11.2' );
 		}
 
 		// Plugin Folder Path.

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.11.1
+ * Version: 1.11.2
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.11.1
+ * @version  1.11.2
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
# Release Notes

## Chores / Bugfixes

- ([#2551](https://github.com/wp-graphql/wp-graphql/pull/2551)): Chunks X-GraphQL-Keys header into multiple headers under a set max header limit length.
- ([#2539](https://github.com/wp-graphql/wp-graphql/pull/2539)): Set IDE direction to prevent breaks in RTL mode. Thanks @justlevine!
- ([#2549](https://github.com/wp-graphql/wp-graphql/pull/2549)): Fix bug_report.yml field to be textarea instead of input. Thanks @justlevine!

