### PR TITLE
chore: use ENV variables for installing WordPress test environment

### DIFF
--- a/bin/install-test-env.sh
+++ b/bin/install-test-env.sh
@@ -148,7 +148,7 @@ install_db() {
 configure_wordpress() {
     cd $WP_CORE_DIR
     wp config create --dbname="$DB_NAME" --dbuser="$DB_USER" --dbpass="$DB_PASS" --dbhost="$DB_HOST" --skip-check --force=true
-    wp core install --url=wp.test --title="WPGraphQL Tests" --admin_user=admin --admin_password=password --admin_email=admin@wp.test
+    wp core install --url="$WP_DOMAIN" --title="WPGraphQL Tests" --admin_user="$ADMIN_USERNAME" --admin_password="$ADMIN_PASSWORD" --admin_email="$ADMIN_EMAIL"
     wp rewrite structure '/%year%/%monthnum%/%postname%/'
 }
 


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR changes `install-test-env.sh` to use `.env` variables for the `wp core install` command, allowing testers to spinup a test site using whatever `url` etc that is convenient for them, instead of `wp.test`.

*Note*: Based on the current `.env.dist`, the generated install will now default to`localhost` and not `wp.test` and the admin email to `admin@example.com` instead of `admin@wp.test`. If people want to use those old values nstead, they shold update their local .env file.



Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
Personally, I use wp.test as my project playground, and `codecept.test` for a clean site install to run Codeception against. Its getting too annoying to manually change the site/home urls.


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php 8.0.19)

**WordPress Version:** 6.0.2
