### PR TITLE
feat: Add `deregister_graphql_type()` access function and corresponding `graphql_excluded_types` filter. 

### DIFF
--- a/access-functions.php
+++ b/access-functions.php
@@ -402,6 +402,59 @@ function register_graphql_scalar( string $type_name, array $config ) {
 }
 
 /**
+ * Given a Type Name, this removes the type from the entire schema
+ *
+ * @param string $type_name The name of the Type to remove.
+ *
+ * @return void
+ */
+function deregister_graphql_type( string $type_name ) : void {
+	// Prevent the type from being registered to the scheme directly.
+	add_filter(
+		'graphql_excluded_types',
+		function ( $excluded_types ) use ( $type_name ) : array {
+			// Transform the type name, just in case a user provided graphql_single_name instead.
+			$type_name = ucfirst( $type_name );
+			// If the type isn't already excluded, add it to the array.
+			if ( ! in_array( $type_name, $excluded_types, true ) ) {
+				$excluded_types[] = $type_name;
+			}
+
+			return $excluded_types;
+		},
+		10
+	);
+
+	// Prevent the type from being inherited as an interface.
+	add_filter(
+		'graphql_type_interfaces',
+		function ( $interfaces ) use ( $type_name ) : array {
+			$key = array_search( $type_name, $interfaces, true );
+			if ( false !== $key ) {
+				unset( $interfaces[ $key ] );
+			}
+
+			return $interfaces;
+		},
+		10
+	);
+
+	// Prevent the type from being added as possible type in a union.
+	add_filter(
+		'graphql_union_possible_types',
+		function ( $possible_types ) use ( $type_name ) : array {
+			$key = array_search( $type_name, $possible_types, true );
+			if ( false !== $key ) {
+				unset( $possible_types[ $key ] );
+			}
+
+			return $possible_types;
+		},
+		10
+	);
+}
+
+/**
  * Given a Type Name and Field Name, this removes the field from the TypeRegistry
  *
  * @param string $type_name  The name of the Type to remove the field from

--- a/access-functions.php
+++ b/access-functions.php
@@ -413,8 +413,8 @@ function deregister_graphql_type( string $type_name ) : void {
 	add_filter(
 		'graphql_excluded_types',
 		function ( $excluded_types ) use ( $type_name ) : array {
-			// Transform the type name, just in case a user provided graphql_single_name instead.
-			$type_name = ucfirst( $type_name );
+			// Normalize the types to prevent case sensitivity issues.
+			$type_name = strtolower( $type_name );
 			// If the type isn't already excluded, add it to the array.
 			if ( ! in_array( $type_name, $excluded_types, true ) ) {
 				$excluded_types[] = $type_name;
@@ -429,7 +429,13 @@ function deregister_graphql_type( string $type_name ) : void {
 	add_filter(
 		'graphql_type_interfaces',
 		function ( $interfaces ) use ( $type_name ) : array {
-			$key = array_search( $type_name, $interfaces, true );
+			// Normalize the needle and haystack to prevent case sensitivity issues.
+			$key = array_search(
+				strtolower( $type_name ),
+				array_map( 'strtolower', $interfaces ),
+				true
+			);
+			// If the type is found, unset it.
 			if ( false !== $key ) {
 				unset( $interfaces[ $key ] );
 			}

--- a/access-functions.php
+++ b/access-functions.php
@@ -406,7 +406,7 @@ function register_graphql_scalar( string $type_name, array $config ) {
  *
  * @param string $type_name The name of the Type to remove.
  *
- * @return void
+ * @since @todo
  */
 function deregister_graphql_type( string $type_name ) : void {
 	// Prevent the type from being registered to the scheme directly.

--- a/access-functions.php
+++ b/access-functions.php
@@ -438,20 +438,6 @@ function deregister_graphql_type( string $type_name ) : void {
 		},
 		10
 	);
-
-	// Prevent the type from being added as possible type in a union.
-	add_filter(
-		'graphql_union_possible_types',
-		function ( $possible_types ) use ( $type_name ) : array {
-			$key = array_search( $type_name, $possible_types, true );
-			if ( false !== $key ) {
-				unset( $possible_types[ $key ] );
-			}
-
-			return $possible_types;
-		},
-		10
-	);
 }
 
 /**

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -1202,8 +1202,9 @@ class TypeRegistry {
 	public function get_excluded_types() : array {
 		/**
 		 * Filter the list of GraphQL types to exclude from the schema.
-		 *
-		 * Useful for excluding types that are registered by plugins or themes
+		 * 
+		 * Note: using this filter directly will NOT remove the type from being referenced as a possible interface or a union type.
+		 * To remove a GraphQL from the schema **entirely**, please use deregister_graphql_type();
 		 *
 		 * @param array $excluded_types The names of the GraphQL Types to exclude.
 		 */

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -1198,6 +1198,8 @@ class TypeRegistry {
 
 	/**
 	 * Get the list of GraphQL type names to exclude from the schema.
+	 *
+	 * @since @todo
 	 */
 	public function get_excluded_types() : array {
 		/**
@@ -1207,8 +1209,10 @@ class TypeRegistry {
 		 * To remove a GraphQL from the schema **entirely**, please use deregister_graphql_type();
 		 *
 		 * @param array $excluded_types The names of the GraphQL Types to exclude.
+		 *
+		 * @since @todo
 		 */
-		return apply_filters( 'graphql_excluded_types', [ 'Post' ] );
+		return apply_filters( 'graphql_excluded_types', [] );
 	}
 
 	/**

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -1199,6 +1199,8 @@ class TypeRegistry {
 	/**
 	 * Get the list of GraphQL type names to exclude from the schema.
 	 *
+	 * Type names are normalized using `strtolower()`, to avoid case sensitivity issues.
+	 *
 	 * @since @todo
 	 */
 	public function get_excluded_types() : array {
@@ -1214,7 +1216,7 @@ class TypeRegistry {
 		 */
 		$excluded_types = apply_filters( 'graphql_excluded_types', [] );
 
-		// Normalize the types to be lowercase, to avoid case-sensitive when comparing.
+		// Normalize the types to be lowercase, to avoid case-sensitivity issue when comparing.
 		return ! empty( $excluded_types ) ? array_map( 'strtolower', $excluded_types ) : [];
 	}
 

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -598,14 +598,8 @@ class TypeRegistry {
 	 * @return void
 	 */
 	public function register_type( string $type_name, $config ) {
-
-		if ( is_array( $config ) && isset( $config['connections'] ) ) {
-			$config['name'] = ucfirst( $type_name );
-			$this->register_connections_from_config( $config );
-		}
-
 		/**
-		 * If the Type Name starts with a number, prefix it with an underscore to make it valid
+		 * If the Type Name starts with a number, skip it.
 		 */
 		if ( ! is_valid_graphql_name( $type_name ) ) {
 			graphql_debug(
@@ -618,6 +612,9 @@ class TypeRegistry {
 			return;
 		}
 
+		/**
+		 * If the Type Name is already registered, skip it.
+		 */
 		if ( isset( $this->types[ $this->format_key( $type_name ) ] ) || isset( $this->type_loaders[ $this->format_key( $type_name ) ] ) ) {
 			graphql_debug(
 				sprintf( __( 'You cannot register duplicate Types to the Schema. The Type \'%1$s\' already exists in the Schema. Make sure to give new Types a unique name.', 'wp-graphql' ), $type_name ),
@@ -627,6 +624,14 @@ class TypeRegistry {
 				]
 			);
 			return;
+		}
+
+		/**
+		 * Register any connections that were passed through the Type config
+		 */
+		if ( is_array( $config ) && isset( $config['connections'] ) ) {
+			$config['name'] = ucfirst( $type_name );
+			$this->register_connections_from_config( $config );
 		}
 
 		$this->type_loaders[ $this->format_key( $type_name ) ] = function () use ( $type_name, $config ) {

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -1081,14 +1081,6 @@ class TypeRegistry {
 	 * @throws Exception
 	 */
 	public function register_mutation( string $mutation_name, array $config ) {
-
-		/**
-		 * If the type should be excpluded from the schema, skip it.
-		 */
-		if ( in_array( $mutation_name, $this->get_excluded_types(), true ) ) {
-			return;
-		}
-
 		$output_fields = [
 			'clientMutationId' => [
 				'type'        => 'String',

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -908,7 +908,7 @@ class TypeRegistry {
 		 */
 		if ( ! empty( $field_config['args'] ) && is_array( $field_config['args'] ) ) {
 			foreach ( $field_config['args'] as $arg_name => $arg_config ) {
-				$arg = $this->prepare_field( $arg_name, $arg_config, $type_name, $field_name );
+				$arg = $this->prepare_field( $arg_name, $arg_config, $type_name );
 				// Bail if the field prepared field is invalid.
 				if ( empty( $arg ) ) {
 					unset( $field_config['args'][ $arg_name ] );

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -168,7 +168,7 @@ class TypeRegistry {
 	 *
 	 * @var array
 	 */
-	protected $excluded_types;
+	protected $excluded_types = null;
 
 	/**
 	 * TypeRegistry constructor.
@@ -1213,7 +1213,7 @@ class TypeRegistry {
 	 * @since @todo
 	 */
 	public function get_excluded_types() : array {
-		if ( ! isset( $this->excluded_types ) ) {
+		if ( null === $this->excluded_types ) {
 			/**
 			 * Filter the list of GraphQL types to exclude from the schema.
 			 * 

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -1036,10 +1036,7 @@ class TypeRegistry {
 	 * @throws Exception
 	 */
 	public function register_connection( array $config ) {
-
-		$connection = new WPConnectionType( $config, $this );
-		$connection->register_connection();
-
+		new WPConnectionType( $config, $this );
 	}
 
 	/**

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -599,9 +599,9 @@ class TypeRegistry {
 	 */
 	public function register_type( string $type_name, $config ) {
 		/**
-		 * If the type should be excpluded from the schema, skip it.
+		 * If the type should be excluded from the schema, skip it.
 		 */
-		if ( in_array( ucfirst( $type_name ), $this->get_excluded_types(), true ) ) {
+		if ( in_array( strtolower( $type_name ), $this->get_excluded_types(), true ) ) {
 			return;
 		}
 		
@@ -877,7 +877,7 @@ class TypeRegistry {
 		 */
 		if ( is_string( $field_config['type'] ) ) {
 			// Bail if the type is excluded from the Schema.
-			if ( in_array( ucfirst( $field_config['type'] ), $this->get_excluded_types(), true ) ) {
+			if ( in_array( strtolower( $field_config['type'] ), $this->get_excluded_types(), true ) ) {
 				return null;
 			}
 
@@ -894,7 +894,7 @@ class TypeRegistry {
 			// Bail if the type is excluded from the Schema.
 			$unmodified_type_name = $this->get_unmodified_type_name( $field_config['type'] );
 
-			if ( empty( $unmodified_type_name ) || in_array( ucfirst( $unmodified_type_name ), $this->get_excluded_types(), true ) ) {
+			if ( empty( $unmodified_type_name ) || in_array( strtolower( $unmodified_type_name ), $this->get_excluded_types(), true ) ) {
 				return null;
 			}
 
@@ -917,6 +917,7 @@ class TypeRegistry {
 
 				$field_config['args'][ $arg_name ] = $arg;
 			}
+
 			// Ensure the array still isn't empty.
 			if ( empty( $field_config['args'] ) ) {
 				unset( $field_config['args'] );
@@ -1208,11 +1209,14 @@ class TypeRegistry {
 		 * Note: using this filter directly will NOT remove the type from being referenced as a possible interface or a union type.
 		 * To remove a GraphQL from the schema **entirely**, please use deregister_graphql_type();
 		 *
-		 * @param array $excluded_types The names of the GraphQL Types to exclude.
+		 * @param string[] $excluded_types The names of the GraphQL Types to exclude.
 		 *
 		 * @since @todo
 		 */
-		return apply_filters( 'graphql_excluded_types', [] );
+		$excluded_types = apply_filters( 'graphql_excluded_types', [] );
+
+		// Normalize the types to be lowercase, to avoid case-sensitive when comparing.
+		return ! empty( $excluded_types ) ? array_map( 'strtolower', $excluded_types ) : [];
 	}
 
 	/**

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -162,6 +162,15 @@ class TypeRegistry {
 	protected $eager_type_map;
 
 	/**
+	 * Stores a list of Types that should be excluded from the schema.
+	 *
+	 * Type names are filtered by `graphql_excluded_types` and normalized using strtolower(), to avoid case sensitivity issues.
+	 *
+	 * @var array
+	 */
+	protected $excluded_types;
+
+	/**
 	 * TypeRegistry constructor.
 	 */
 	public function __construct() {
@@ -1204,20 +1213,24 @@ class TypeRegistry {
 	 * @since @todo
 	 */
 	public function get_excluded_types() : array {
-		/**
-		 * Filter the list of GraphQL types to exclude from the schema.
-		 * 
-		 * Note: using this filter directly will NOT remove the type from being referenced as a possible interface or a union type.
-		 * To remove a GraphQL from the schema **entirely**, please use deregister_graphql_type();
-		 *
-		 * @param string[] $excluded_types The names of the GraphQL Types to exclude.
-		 *
-		 * @since @todo
-		 */
-		$excluded_types = apply_filters( 'graphql_excluded_types', [] );
+		if ( ! isset( $this->excluded_types ) ) {
+			/**
+			 * Filter the list of GraphQL types to exclude from the schema.
+			 * 
+			 * Note: using this filter directly will NOT remove the type from being referenced as a possible interface or a union type.
+			 * To remove a GraphQL from the schema **entirely**, please use deregister_graphql_type();
+			 *
+			 * @param string[] $excluded_types The names of the GraphQL Types to exclude.
+			 *
+			 * @since @todo
+			 */
+			$excluded_types = apply_filters( 'graphql_excluded_types', [] );
 
-		// Normalize the types to be lowercase, to avoid case-sensitivity issue when comparing.
-		return ! empty( $excluded_types ) ? array_map( 'strtolower', $excluded_types ) : [];
+			// Normalize the types to be lowercase, to avoid case-sensitivity issue when comparing.
+			$this->excluded_types = ! empty( $excluded_types ) ? array_map( 'strtolower', $excluded_types ) : [];
+		}
+
+		return $this->excluded_types;
 	}
 
 	/**

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -904,12 +904,13 @@ class TypeRegistry {
 		}
 
 		/**
-		 * If the field has arguments, they need to be prepared as well.
+		 * If the field has arguments, each one must be prepared.
 		 */
-		if ( ! empty( $field_config['args'] ) && is_array( $field_config['args'] ) ) {
+		if ( isset( $field_config['args'] ) && is_array( $field_config['args'] ) ) {
 			foreach ( $field_config['args'] as $arg_name => $arg_config ) {
 				$arg = $this->prepare_field( $arg_name, $arg_config, $type_name );
-				// Bail if the field prepared field is invalid.
+
+				// Remove the arg if the field could not be prepared.
 				if ( empty( $arg ) ) {
 					unset( $field_config['args'][ $arg_name ] );
 					continue;
@@ -917,17 +918,16 @@ class TypeRegistry {
 
 				$field_config['args'][ $arg_name ] = $arg;
 			}
+		}
 
-			// Ensure the array still isn't empty.
-			if ( empty( $field_config['args'] ) ) {
-				unset( $field_config['args'] );
-			}
-		} else {
+		/**
+		 * If the field has no (remaining) valid arguments, unset the key.
+		 */
+		if ( empty( $field_config['args'] ) ) {
 			unset( $field_config['args'] );
 		}
 
 		return $field_config;
-
 	}
 
 	/**

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -604,7 +604,6 @@ class TypeRegistry {
 		if ( in_array( strtolower( $type_name ), $this->get_excluded_types(), true ) ) {
 			return;
 		}
-		
 		/**
 		 * If the Type Name starts with a number, skip it.
 		 */

--- a/src/Type/WPConnectionType.php
+++ b/src/Type/WPConnectionType.php
@@ -158,6 +158,14 @@ class WPConnectionType {
 		$this->connection_interfaces = isset( $config['connectionInterfaces'] ) && is_array( $config['connectionInterfaces'] ) ? $config['connectionInterfaces'] : [];
 		$this->query_class           = array_key_exists( 'queryClass', $config ) && ! empty( $config['queryClass'] ) ? $config['queryClass'] : null;
 
+		/**
+		 * Run an action when the WPConnectionType is instantiating
+		 *
+		 * @param array        $config         Array of configuration options passed to the WPObjectType when instantiating a new type
+		 * @param WPConnectionType $wp_connection_type The instance of the WPConnectionType class
+		 */
+		do_action( 'graphql_wp_connection_type', $config, $this );
+
 		$this->register_connection();
 	}
 

--- a/src/Type/WPConnectionType.php
+++ b/src/Type/WPConnectionType.php
@@ -362,7 +362,7 @@ class WPConnectionType {
 	protected function register_connection_type() {
 
 		$interfaces   = ! empty( $this->connection_interfaces ) ? $this->connection_interfaces : [];
-		$interfaces[] = [ 'Connection' ];
+		$interfaces[] = 'Connection';
 
 		$this->type_registry->register_object_type(
 			$this->connection_name,

--- a/src/Type/WPConnectionType.php
+++ b/src/Type/WPConnectionType.php
@@ -143,7 +143,7 @@ class WPConnectionType {
 		 * Bail if one of the connection types has been excluded from the schema.
 		 */
 		$excluded_types = $type_registry->get_excluded_types();
-		if ( in_array( ucfirst( $config['fromType'] ), $excluded_types, true ) || in_array( ucfirst( $config['toType'] ), $excluded_types, true ) ) {
+		if ( in_array( strtolower( $config['fromType'] ), $excluded_types, true ) || in_array( strtolower( $config['toType'] ), $excluded_types, true ) ) {
 			return;
 		}
 

--- a/src/Type/WPConnectionType.php
+++ b/src/Type/WPConnectionType.php
@@ -139,6 +139,14 @@ class WPConnectionType {
 
 		$this->validate_config( $config );
 
+		/**
+		 * Bail if one of the connection types has been excluded from the schema.
+		 */
+		$excluded_types = $type_registry->get_excluded_types();
+		if ( in_array( ucfirst( $config['fromType'] ), $excluded_types, true ) || in_array( ucfirst( $config['toType'] ), $excluded_types, true ) ) {
+			return;
+		}
+
 		$this->config                = $config;
 		$this->type_registry         = $type_registry;
 		$this->from_type             = $config['fromType'];

--- a/src/Type/WPConnectionType.php
+++ b/src/Type/WPConnectionType.php
@@ -4,7 +4,6 @@ namespace WPGraphQL\Type;
 use Closure;
 use Exception;
 use GraphQL\Exception\InvalidArgument;
-use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\Registry\TypeRegistry;
 
 /**
@@ -159,6 +158,7 @@ class WPConnectionType {
 		$this->connection_interfaces = isset( $config['connectionInterfaces'] ) && is_array( $config['connectionInterfaces'] ) ? $config['connectionInterfaces'] : [];
 		$this->query_class           = array_key_exists( 'queryClass', $config ) && ! empty( $config['queryClass'] ) ? $config['queryClass'] : null;
 
+		$this->register_connection();
 	}
 
 	/**
@@ -456,7 +456,9 @@ class WPConnectionType {
 	}
 
 	/**
-	 * Registers the connection Types and field to the Schema
+	 * Registers the connection Types and field to the Schema.
+	 *
+	 * @todo change to 'Protected'. This is public for now to allow for backwards compatibility.
 	 *
 	 * @return void
 	 *

--- a/src/Type/WPConnectionType.php
+++ b/src/Type/WPConnectionType.php
@@ -167,10 +167,12 @@ class WPConnectionType {
 		$this->query_class           = array_key_exists( 'queryClass', $config ) && ! empty( $config['queryClass'] ) ? $config['queryClass'] : null;
 
 		/**
-		 * Run an action when the WPConnectionType is instantiating
+		 * Run an action when the WPConnectionType is instantiating.
 		 *
 		 * @param array        $config         Array of configuration options passed to the WPObjectType when instantiating a new type
 		 * @param WPConnectionType $wp_connection_type The instance of the WPConnectionType class
+		 *
+		 * @since @todo
 		 */
 		do_action( 'graphql_wp_connection_type', $config, $this );
 

--- a/src/Type/WPUnionType.php
+++ b/src/Type/WPUnionType.php
@@ -47,7 +47,7 @@ class WPUnionType extends UnionType {
 					/**
 					 * Skip if the type is excluded from the schema.
 					 */
-					if ( in_array( ucfirst( $type_name ), $this->type_registry->get_excluded_types(), true ) ) {
+					if ( in_array( strtolower( $type_name ), $this->type_registry->get_excluded_types(), true ) ) {
 						continue;
 					}
 

--- a/src/Type/WPUnionType.php
+++ b/src/Type/WPUnionType.php
@@ -44,6 +44,13 @@ class WPUnionType extends UnionType {
 			if ( ! empty( $config['typeNames'] ) && is_array( $config['typeNames'] ) ) {
 				$prepared_types = [];
 				foreach ( $config['typeNames'] as $type_name ) {
+					/**
+					 * Skip if the type is excluded from the schema.
+					 */
+					if ( in_array( ucfirst( $type_name ), $this->type_registry->get_excluded_types(), true ) ) {
+						continue;
+					}
+
 					$prepared_types[] = $this->type_registry->get_type( $type_name );
 				}
 			}

--- a/tests/wpunit/AccessFunctionsTest.php
+++ b/tests/wpunit/AccessFunctionsTest.php
@@ -878,7 +878,7 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 	public function testDeregisterEnumType() {
 		// Test case-sensitivity.
-		deregister_graphql_type( 'Contentypeenum' );
+		deregister_graphql_type( 'ContentTypeenum' );
 
 		// Ensure the schema is still queryable.
 		$query = '
@@ -891,7 +891,7 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		}
 		';
 
-		$actual = graphql( compact( 'query') );
+		$actual = $this->graphql( compact( 'query') );
 
 		$this->assertIsValidQueryResponse( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );

--- a/tests/wpunit/AccessFunctionsTest.php
+++ b/tests/wpunit/AccessFunctionsTest.php
@@ -877,7 +877,8 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 	}
 
 	public function testDeregisterEnumType() {
-		deregister_graphql_type( 'ContentTypeEnum' );
+		// Test case-sensitivity.
+		deregister_graphql_type( 'Contentypeenum' );
 
 		// Ensure the schema is still queryable.
 		$query = '

--- a/tests/wpunit/AccessFunctionsTest.php
+++ b/tests/wpunit/AccessFunctionsTest.php
@@ -722,4 +722,380 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$this->assertSame( site_url( $expected ), $actual );
 	}
+
+	public function testDeregisterObjectType() {
+		deregister_graphql_type( 'Post' );
+
+		// Ensure the schema is still queryable.
+
+		$query = '
+		{
+			__schema {
+				types {
+					name
+				}
+			}
+		}
+		';
+
+		$actual = graphql( compact( 'query') );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+
+		// Ensure Post-related types have been removed.
+		$types = array_column( $actual['data']['__schema']['types'], 'name' );
+
+		$removed_types = [
+			'UserToPostConnectionWhereArgs',
+			'UserToPostConnection',
+			'UserToPostConnectionEdge',
+			'Post',
+			'NodeWithExcerpt',
+			'NodeWithTrackbacks',
+			'PostToCategoryConnectionWhereArgs',
+			'PostToCategoryConnection',
+			'PostToCategoryConnectionEdge',
+			'PostToCommentConnectionWhereArgs',
+			'PostToCommentConnection',
+			'PostToCommentConnectionEdge',
+			'PostToPostFormatConnectionWhereArgs',
+			'PostToPostFormatConnection',
+			'PostToPostFormatConnectionEdge',
+			'PostFormatToPostConnectionWhereArgs',
+			'PostFormatToPostConnection',
+			'PostFormatToPostConnectionEdge',
+			'PostToPreviewConnectionEdge',
+			'PostToRevisionConnectionWhereArgs',
+			'PostToRevisionConnection',
+			'PostToRevisionConnectionEdge',
+			'PostToTagConnectionWhereArgs',
+			'PostToTagConnection',
+			'PostToTagConnectionEdge',
+			'TagToPostConnectionWhereArgs',
+			'TagToPostConnection',
+			'TagToPostConnectionEdge',
+			'PostToTermNodeConnectionWhereArgs',
+			'PostToTermNodeConnection',
+			'PostToTermNodeConnectionEdge',
+			'CategoryToPostConnectionWhereArgs',
+			'CategoryToPostConnection',
+			'CategoryToPostConnectionEdge',
+			'PostIdType',
+			'RootQueryToPostConnectionWhereArgs',
+			'RootQueryToPostConnection',
+			'RootQueryToPostConnectionEdge',
+		];
+
+		$this->assertEmpty( array_intersect( $types, $removed_types ) );
+
+		// Ensure connection is removed.
+		$query = '
+			{
+				categories {
+					nodes {
+						posts {
+							nodes {
+								__typename
+							}
+						}
+					}
+				}
+			}
+		';
+
+		$actual = $this->graphql( compact( 'query') );
+		
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertArrayHasKey( 'errors', $actual );
+
+		// Ensure Post is removed from interfaces.
+		$query = '
+		{
+			__type(name: "ContentNode") {
+				possibleTypes {
+					name
+				}
+			}
+		}
+		';
+		$actual = $this->graphql( compact( 'query' ) );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertNotContains( 'Post', array_column( $actual['data']['__type']['possibleTypes'], 'name' ) );
+
+		// Ensure Post is removed from unions.
+		$query = '
+		{
+			__type(name: "MenuItemObjectUnion") {
+				possibleTypes {
+					name
+				}
+			}
+		}
+		';
+
+		$actual = $this->graphql( compact( 'query' ) );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertNotContains( 'Post', array_column( $actual['data']['__type']['possibleTypes'], 'name' ) );
+
+		/**
+		 * Since only the Post Type is removed, but the connection is still registered, we should expect the resolvers to still return an unresolved type.
+		 */
+		$post_id = $this->factory()->post->create(
+			[
+				'post_title' => 'Test deregister type',
+				'post_status' => 'publish',
+			]
+		);
+
+		$query = '
+		{
+			contentNodes {
+				nodes {
+					id
+				}
+			}
+			contentTypes {
+				nodes {
+					name
+				}
+			}
+		}
+		';
+
+		$actual = $this->graphql( compact( 'query') );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertArrayHasKey( 'errors', $actual );
+		$this->assertStringContainsString( 'GraphQL Interface Type `ContentNode` returned `null', $actual['errors'][0]['debugMessage'] );
+		$this->assertNull( $actual['data']['contentNodes']['nodes'][0] );
+		$this->assertContains( 'post', array_column( $actual['data']['contentTypes']['nodes'], 'name' ) );
+	}
+
+	public function testDeregisterEnumType() {
+		deregister_graphql_type( 'ContentTypeEnum' );
+
+		// Ensure the schema is still queryable.
+		$query = '
+		{
+			__schema {
+				types {
+					name
+				}
+			}
+		}
+		';
+
+		$actual = graphql( compact( 'query') );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertNotContains( 'ContentTypeEnum', array_column( $actual['data']['__schema']['types'], 'name' ) );
+
+		// Ensure the enum is removed from the schema.
+		$this->assertArrayNotHasKey( 'errors', $actual );
+
+		// Ensure the enum is removed from input arguments.
+		$query = '
+		{
+			__type(name: "RootQueryToContentNodeConnectionWhereArgs") {
+				inputFields {
+					name
+				}
+			}
+		}';
+
+		$actual = graphql( compact( 'query' ) );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertNotContains( 'contentType', array_column( $actual['data']['__type']['inputFields'], 'name' ) );
+
+		// Ensure query still works
+		$post_id = $this->factory()->post->create(
+			[
+				'post_title' => 'Test deregister enum type',
+				'post_status' => 'publish',
+			]
+		);
+
+		$query = '
+		{
+			contentNodes {
+				nodes {
+					id
+				}
+			}
+		}
+		';
+
+		$actual = $this->graphql( compact( 'query' ) );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount( 1, $actual['data']['contentNodes']['nodes'] );
+	}
+
+	public function testDeregisterInputType() {
+		deregister_graphql_type( 'DateQueryInput' );
+
+		// Ensure the schema is still queryable.
+		$query = '
+		{
+			__schema {
+				types {
+					name
+				}
+			}
+		}
+		';
+
+		$actual = graphql( compact( 'query' ) );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertNotContains( 'DateQueryInput', array_column( $actual['data']['__schema']['types'], 'name' ) );
+
+		// Ensure the input is removed from the schema.
+		$query = '
+		{
+			__type(name: "RootQueryToPostConnectionWhereArgs") {
+				inputFields {
+					name
+				}
+			}
+		}';
+
+		$actual = $this->graphql( compact( 'query' ) );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertNotContains( 'dateQuery', array_column( $actual['data']['__type']['inputFields'], 'name' ) );
+
+		// Ensure query still works
+		$post_id = $this->factory()->post->create(
+			[
+				'post_title' => 'Test deregister input type',
+				'post_status' => 'publish',
+			]
+		);
+
+		$query = '
+		{
+			posts {
+				nodes {
+					id
+				}
+			}
+		}
+		';
+
+		$actual = $this->graphql( compact( 'query' ) );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount( 1, $actual['data']['posts']['nodes'] );
+	}
+
+	public function testDeregisterInterfaceType() {
+		deregister_graphql_type( 'NodeWithTitle' );
+
+		// Ensure the schema is still queryable.
+		$query = '
+		{
+			__schema {
+				types {
+					name
+				}
+			}
+		}
+		';
+
+		$actual = graphql( compact( 'query' ) );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertNotContains( 'NodeWithTitle', array_column( $actual['data']['__schema']['types'], 'name' ) );
+
+		// Ensure the interface is removed from the schema.
+		$query = '
+		{
+			__type(name: "Post") {
+				interfaces {
+					name
+				}
+			}
+		}';
+
+		$actual = $this->graphql( compact( 'query' ) );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertNotContains( 'NodeWithTitle', array_column( $actual['data']['__type']['interfaces'], 'name' ) );
+
+		// Ensure query still works
+		$post_id = $this->factory()->post->create(
+			[
+				'post_title' => 'Test deregister interface type',
+				'post_status' => 'publish',
+			]
+		);
+
+		$query = '
+		{
+			posts {
+				nodes {
+					id
+				}
+			}
+		}';
+
+		$actual = $this->graphql( compact( 'query' ) );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertCount( 1, $actual['data']['posts']['nodes'] );
+	}
+
+	public function testDeregisterUnionType() {
+		deregister_graphql_type( 'MenuItemObjectUnion' );
+
+		// Ensure the schema is still queryable.
+		$query = '
+		{
+			__schema {
+				types {
+					name
+				}
+			}
+		}
+		';
+
+		$actual = graphql( compact( 'query' ) );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertNotContains( 'MenuItemObjectUnion', array_column( $actual['data']['__schema']['types'], 'name' ) );
+
+		// Ensure the union is removed from the schema.
+		$query = '
+		{
+			__type(name: "MenuItem") {
+				fields( includeDeprecated: true ) {
+					name
+				}
+			}
+		}';
+
+		$actual = $this->graphql( compact( 'query' ) );
+
+		$this->assertIsValidQueryResponse( $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertNotContains( 'connectedObject', array_column( $actual['data']['__type']['fields'], 'name' ) );
+	}
+
 }


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
The PR adds a new access method: `deregister_graphql_type( string $type_name ) : void;` for removing a GraphQL type _and all of its references_ from the schema.

The function uses on a new `graphql_excluded_types` filter that prevents types (or fields that resolve to that type) from being registered, and then subsequently removes the type from the list of inherited interfaces by use of the existing `graphql_type_interfaces` filter.

### Changelog
- feat: added new `deregister_graphql_type()` access function.
- feat: add the `graphql_excluded_types` filter.
- feat: add the `graphql_wp_connection_type` action.
- dev: Call `WPConnectionType::register_connection()` from within the class constructor. (see below)
- fix: Only register connections from a GraphQL Object `$config` if the type itself is valid. (see below).

Does this close any currently open issues?
------------------------------------------
Prerequisite for #1733 (and to a lesser extent, #874) 

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
1. To make this PR work, I had to move the `TypeRegisty::register_connections_from_config()` call in `TypeRegistry::register_type()` to [_after_ the type name validation](https://github.com/AxeWP/wp-graphql/blob/6f0ecf3c283214de543d010f1185c9930621d04f/src/Registry/TypeRegistry.php#L614). I believe the previous order of operations to have been a bug (i.e. the connections shouldnt register if the type name is invalid).

2. To make this PR work, `WPConnectionType::register_connection()` is now called from within `WPConnectionType::__construct()`. I don't think this should considered be a breaking change (afaik there isnt a use case for `WPConnectionType::register_connection()` _outside_ of the core plugin. If we _are_ worried about usage, we can deprecate `register_connection()` in favor of a more generic `WPConnectionType::register()`.

3. ~Currently, the logic uses a `TypeRegistry::get_excluded_types()` as a wrapper around the `graphql_excluded_types` filter. It would be more performant if we only called the filter itself once (ideally in the constructor), but due to the way the TypeRegistry lifecycle works, I wanted to get a working PoC first.~

4. `deregister_graphql_type()` is a "last resort" function, and not intended for those who don't know what they are doing. Two important caveats to keep in mind are that:
    - Unlike `deregister_graphql_field()`, you cannot register a new type with a deregistered type name.
    - This doesn't affect the internal resolve/ resolveType logic. This is demonstrated in `AccessFunctionsTest::testDeregisterObjectType`. <br />
    
    Most user cases will likely benefit from less 'destructive' removal methods, like `deregister_graphql_field()` (can be used to replace a field with another that resolves to a different type), `$wp_object_type->show_in_graphql = false` (for preventing auto-registering of CPT/Taxonomy types, or the eventual `deregister_graphql_mutation()` and `deregister_graphql_connection()`. 

Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php 8.1.19)

**WordPress Version:** 6.1
