### PR TITLE
feat: refactor mutation registration to use `WPMutationType`

### DIFF
--- a/src/Mutation/TermObjectUpdate.php
+++ b/src/Mutation/TermObjectUpdate.php
@@ -23,7 +23,7 @@ class TermObjectUpdate {
 	 * @return void
 	 */
 	public static function register_mutation( WP_Taxonomy $taxonomy ) {
-		$mutation_name = 'Update' . ucwords( $taxonomy->graphql_single_name );
+		$mutation_name = 'update' . ucwords( $taxonomy->graphql_single_name );
 		register_graphql_mutation(
 			$mutation_name,
 			[

--- a/src/Type/WPMutationType.php
+++ b/src/Type/WPMutationType.php
@@ -1,0 +1,305 @@
+<?php
+namespace WPGraphQL\Type;
+
+use Closure;
+use Exception;
+use GraphQL\Exception\InvalidArgument;
+use GraphQL\Type\Definition\ResolveInfo;
+use WPGraphQL\AppContext;
+use WPGraphQL\Registry\TypeRegistry;
+
+/**
+ * Class WPMutationType
+ *
+ * @package WPGraphQL\Type
+ */
+class WPMutationType {
+	/**
+	 * Configuration for how auth should be handled on the connection field
+	 *
+	 * @var array
+	 */
+	protected $auth;
+
+	/**
+	 * The config for the connection
+	 *
+	 * @var array
+	 */
+	protected $config;
+
+	/**
+	 * The name of the mutation field
+	 *
+	 * @var string
+	 */
+	protected $mutation_name;
+
+	/**
+	 * Whether the user must be authenticated to use the mutation.
+	 *
+	 * @var bool
+	 */
+	protected $is_private;
+
+	/**
+	 * The mutation input field config.
+	 *
+	 * @var array
+	 */
+	protected $input_fields;
+
+	/**
+	 * The mutation output field config.
+	 *
+	 * @var array
+	 */
+	protected $output_fields;
+
+	/**
+	 * The resolver function to resole the connection
+	 *
+	 * @var callable|Closure
+	 */
+	protected $resolve_mutation;
+
+	/**
+	 * The WPGraphQL TypeRegistry
+	 *
+	 * @var TypeRegistry
+	 */
+	protected $type_registry;
+
+	/**
+	 * WPMutationType constructor.
+	 *
+	 * @param array        $config The config array for the mutation
+	 * @param TypeRegistry $type_registry Instance of the WPGraphQL Type Registry
+	 */
+	public function __construct( array $config, TypeRegistry $type_registry ) {
+
+		/**
+		 * Filter the config of WPMutationType
+		 *
+		 * @param array        $config         Array of configuration options passed to the WPMutationType when instantiating a new type
+		 * @param WPMutationType $wp_mutation_type The instance of the WPMutationType class
+		 *
+		 * @since @todo
+		 */
+		$config = apply_filters( 'graphql_wp_mutation_type_config', $config, $this );
+
+		$this->validate_config( $config );
+
+		$this->config           = $config;
+		$this->type_registry    = $type_registry;
+		$this->mutation_name    = $config['name'];
+		$this->auth             = array_key_exists( 'auth', $config ) && is_array( $config['auth'] ) ? $config['auth'] : [];
+		$this->is_private       = array_key_exists( 'isPrivate', $config ) ? $config['isPrivate'] : false;
+		$this->input_fields     = $this->get_input_fields();
+		$this->output_fields    = $this->get_output_fields();
+		$this->resolve_mutation = $this->get_resolver();
+
+		/**
+		 * Run an action when the WPMutationType is instantiating.
+		 *
+		 * @param array        $config         Array of configuration options passed to the WPObjectType when instantiating a new type
+		 * @param WPMutationType $wp_mutation_type The instance of the WPMutationType class
+		 *
+		 * @since @todo
+		 */
+		do_action( 'graphql_wp_mutation_type', $config, $this );
+
+		$this->register_mutation();
+	}
+
+	/**
+	 * Validates that essential key/value pairs are passed to the connection config.
+	 *
+	 * @param array $config
+	 *
+	 * @return void
+	 */
+	protected function validate_config( array $config ) {
+
+		if ( ! array_key_exists( 'name', $config ) || ! is_string( $config['name'] ) ) {
+			throw new InvalidArgument( __( 'Mutation config needs to have a valid name.', 'wp-graphql' ) );
+		}
+
+		if ( ! array_key_exists( 'mutateAndGetPayload', $config ) || ! is_callable( $config['mutateAndGetPayload'] ) ) {
+			throw new InvalidArgument( __( 'Mutation config needs to have "mutateAndGetPayload" defined as a callable.', 'wp-graphql' ) );
+		}
+
+	}
+
+	/**
+	 * Gets the mutation input fields.
+	 */
+	protected function get_input_fields() : array {
+		$input_fields = [
+			'clientMutationId' => [
+				'type'        => 'String',
+				'description' => __( 'This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions.', 'wp-graphql' ),
+			],
+		];
+
+		if ( ! empty( $this->config['inputFields'] ) && is_array( $this->config['inputFields'] ) ) {
+			$input_fields = array_merge( $input_fields, $this->config['inputFields'] );
+		}
+
+		return $input_fields;
+	}
+
+	/**
+	 * Gets the mutation output fields.
+	 */
+	protected function get_output_fields() : array {
+		$output_fields = [
+			'clientMutationId' => [
+				'type'        => 'String',
+				'description' => __( 'If a \'clientMutationId\' input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.', 'wp-graphql' ),
+			],
+		];
+
+		if ( ! empty( $this->config['outputFields'] ) && is_array( $this->config['outputFields'] ) ) {
+			$output_fields = array_merge( $output_fields, $this->config['outputFields'] );
+		}
+
+		return $output_fields;
+	}
+
+	protected function get_resolver() : callable {
+		return function ( $root, array $args, AppContext $context, ResolveInfo $info ) {
+
+			/**
+			 * Filters the mutation input before it's passed to the `mutateAndGetPayload` callback.
+			 *
+			 * @param array $input The mutation input args.
+			 * @param AppContext $context The AppContext object.
+			 * @param ResolveInfo $info The ResolveInfo object.
+			 * @param string $mutation_name The name of the mutation field.
+			 */
+			$input = apply_filters( 'graphql_mutation_input', $args['input'], $context, $info, $this->mutation_name );
+
+			/**
+			 * Filter to short circuit the mutateAndGetPayload callback.
+			 * Returning anything other than null will stop the callback for the mutation from executing,
+			 * and will return your data or execute your callback instead.
+			 *
+			 * @param array|callable|null $payload. The payload returned from the callback. Null by default.
+			 * @param string $mutation_name The name of the mutation field.
+			 * @param callable|Closure $mutateAndGetPayload The callback for the mutation.
+			 * @param array $input The mutation input args.
+			 * @param AppContext $context The AppContext object.
+			 * @param ResolveInfo $info The ResolveInfo object.
+			 */
+			$pre = apply_filters( 'graphql_pre_mutate_and_get_payload', null, $this->mutation_name, $this->config['mutateAndGetPayload'], $input, $context, $info );
+
+			if ( ! is_null( $pre ) ) {
+				$payload = is_callable( $pre ) ? $pre( $input, $context, $info ) : $pre;
+			} else {
+				$payload = $this->config['mutateAndGetPayload']( $input, $context, $info );
+
+				/**
+				 * Filters the payload returned from the default mutateAndGetPayload callback.
+				 * 
+				 * @param array $payload The payload returned from the callback.
+				 * @param string $mutation_name The name of the mutation field.
+				 * @param array $input The mutation input args.
+				 * @param AppContext $context The AppContext object.
+				 * @param ResolveInfo $info The ResolveInfo object.
+				 */
+				$payload = apply_filters( 'graphql_mutation_payload', $payload, $this->mutation_name, $input, $context, $info );
+			}
+
+			/**
+			 * Fires after the mutation payload has been returned from the `mutateAndGetPayload` callback.
+			 *
+			 * @param array $payload The Payload returned from the mutation.
+			 * @param array $input The mutation input args, after being filtered by 'graphql_mutation_input'.
+			 * @param AppContext $context The AppContext object.
+			 * @param ResolveInfo $info The ResolveInfo object.
+			 * @param string $mutation_name The name of the mutation field.
+			 */
+			do_action( 'graphql_mutation_response', $payload, $input, $context, $info, $this->mutation_name );
+
+			// Add the client mutation ID to the payload
+			if ( ! empty( $input['clientMutationId'] ) ) {
+				$payload['clientMutationId'] = $input['clientMutationId'];
+			}
+
+			return $payload;
+		};
+	}
+
+	/**
+	 * Registers the input args for the mutation.
+	 */
+	protected function register_mutation_input() : void {
+		$input_name = $this->mutation_name . 'Input';
+
+		if ( $this->type_registry->has_type( $input_name ) ) {
+			return;
+		}
+
+		$this->type_registry->register_input_type(
+			$input_name,
+			[
+				'description' => sprintf( __( 'Input for the %1$s mutation.', 'wp-graphql' ), $this->mutation_name ),
+				'fields'      => $this->input_fields,
+			]
+		);
+	}
+
+	protected function register_mutation_payload() : void {
+		$object_name = $this->mutation_name . 'Payload';
+
+		if ( $this->type_registry->has_type( $object_name ) ) {
+			return;
+		}
+
+		$this->type_registry->register_object_type(
+			$object_name,
+			[
+				'description' => sprintf( __( 'The payload for the %s mutation.', 'wp-graphql' ), $this->mutation_name ),
+				'fields'      => $this->output_fields,
+			]
+		);
+	}
+
+	/**
+	 * Registers the mutation in the Graph.
+	 */
+	protected function register_mutation_field() : void {
+		$this->type_registry->register_field(
+			'rootMutation',
+			lcfirst( $this->mutation_name ),
+			array_merge( $this->config,
+				[
+					'args'        => [
+						'input' => [
+							'type'        => [ 'non_null' => $this->mutation_name . 'Input' ],
+							'description' => sprintf( __( 'Input for the %s mutation', 'wp-graphql' ), $this->mutation_name ),
+						],
+					],
+					'auth'        => $this->auth,
+					'description' => ! empty( $this->config['description'] ) ? $this->config['description'] : sprintf( __( 'The %s mutation', 'wp-graphql' ), $this->mutation_name ),
+					'isPrivate'   => $this->is_private,
+					'type'        => $this->mutation_name . 'Payload',
+					'resolve'     => $this->resolve_mutation,
+				]
+			)
+		);
+	}
+
+	/**
+	 * Registers the Mutation Types and field to the Schema.
+	 *
+	 * @throws Exception
+	 */
+	protected function register_mutation() :void {
+		$this->register_mutation_payload();
+		$this->register_mutation_input();
+		$this->register_mutation_field();
+	}
+
+}

--- a/src/Type/WPMutationType.php
+++ b/src/Type/WPMutationType.php
@@ -170,6 +170,7 @@ class WPMutationType {
 	protected function get_resolver() : callable {
 		return function ( $root, array $args, AppContext $context, ResolveInfo $info ) {
 
+$unfiltered_input = $args['input'];
 			/**
 			 * Filters the mutation input before it's passed to the `mutateAndGetPayload` callback.
 			 *
@@ -178,7 +179,7 @@ class WPMutationType {
 			 * @param ResolveInfo $info The ResolveInfo object.
 			 * @param string $mutation_name The name of the mutation field.
 			 */
-			$input = apply_filters( 'graphql_mutation_input', $args['input'], $context, $info, $this->mutation_name );
+			$input = apply_filters( 'graphql_mutation_input', $unfiltered_input, $context, $info, $this->mutation_name );
 
 			/**
 			 * Filter to short circuit the mutateAndGetPayload callback.
@@ -216,11 +217,12 @@ class WPMutationType {
 			 *
 			 * @param array $payload The Payload returned from the mutation.
 			 * @param array $input The mutation input args, after being filtered by 'graphql_mutation_input'.
+			 * @param array $unfiltered_input The unfiltered input args of the mutation
 			 * @param AppContext $context The AppContext object.
 			 * @param ResolveInfo $info The ResolveInfo object.
 			 * @param string $mutation_name The name of the mutation field.
 			 */
-			do_action( 'graphql_mutation_response', $payload, $input, $context, $info, $this->mutation_name );
+			do_action( 'graphql_mutation_response', $payload, $input, $unfiltered_input, $context, $info, $this->mutation_name );
 
 			// Add the client mutation ID to the payload
 			if ( ! empty( $input['clientMutationId'] ) ) {

--- a/src/Type/WPMutationType.php
+++ b/src/Type/WPMutationType.php
@@ -169,8 +169,8 @@ class WPMutationType {
 
 	protected function get_resolver() : callable {
 		return function ( $root, array $args, AppContext $context, ResolveInfo $info ) {
+			$unfiltered_input = $args['input'];
 
-$unfiltered_input = $args['input'];
 			/**
 			 * Filters the mutation input before it's passed to the `mutateAndGetPayload` callback.
 			 *


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR refactors mutation registration to use the new `WPMutationType` class, in line with other GraphQL types and pseudo-types (like connections), paving the way for better extensibility.

### Details
- fix: `TermObjectUpdate` mutation names should start with lowercase.
- feat: Use `WPMutationType` to register mutations to the GraphQL schema.
- dev: Add the following filters: `graphql_wp_mutation_type_config`, `graphql_pre_mutate_and_get_payload`, `graphql_mutation_payload`.
- dev: Add the following action: `graphql_wp_mutation_type`.


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
- Explicit tests are not currently implemented. The overall functionality is tested via the existing mutation tests, and we cannot test the new actions/filters until a `deregister_graphql_mutation()` function is added to the API.
- Not sure if this invalidates #143 . We already have the existing `auth` and `isPrivate` config values, and we can use the new `graphql_pre_mutate_and_get_payload` to centralize other permission checks e.g.:
```php
add_filter( 'graphql_pre_mutate_and_get_payload',
  function( $payload, string $mutation_name, $mutateAndGetPayload, array $input, AppContext $context, ResolveInfo $info ) {
    if( ! current_user_can( 'do_something', $input['postId') ){
      throw new UserError( __( 'Sorry, bud', 'text-domain' ) );
    }
  
    // return null to run the normal $mutateAndGetPayload callback.
    // return null; 
  
    // use $mutateAndGetPayload with other functionality.
    do_something_before();
    $payload = $mutateAndGetPayload( $input, $context, $info );
    $payload = do_something_after( $payload );
  
    return $payload;
  },
10, 6 );
```
- This PR _does not_ refactor existing mutations. Action/Filter parity (#331) should occur separately.


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (WSL2 + devilbox + php 8.0.19)

**WordPress Version:** 6.0.2
