### PR TITLE
fix: (phpstan) check if wp_parse_url() returns array

### DIFF
--- a/src/Registry/Utils/TermObject.php
+++ b/src/Registry/Utils/TermObject.php
@@ -308,7 +308,7 @@ class TermObject {
 					$url = $term->link;
 					if ( ! empty( $url ) ) {
 						$parsed = wp_parse_url( $url );
-						if ( isset( $parsed ) ) {
+						if ( is_array( $parsed ) ) {
 							$path  = isset( $parsed['path'] ) ? $parsed['path'] : '';
 							$query = isset( $parsed['query'] ) ? ( '?' . $parsed['query'] ) : '';
 							return trim( $path . $query );


### PR DESCRIPTION

<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR fixes the PHPStan error in the latest merges to develop in prep for `v1.12.0`

`isset( $parsed = myFunc() )` will always return true, so we more explicitly check that wp_parse_url( $term->link ) gives us a valid array.


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + PHP 8.0.19)

**WordPress Version:** 6.0.2
