### PR TITLE
feat: support deprecation reason on connections

### DIFF
--- a/src/Type/WPConnectionType.php
+++ b/src/Type/WPConnectionType.php
@@ -436,6 +436,7 @@ class WPConnectionType {
 				'type'        => true === $this->one_to_one ? $this->connection_name . 'Edge' : $this->connection_name,
 				'args'        => array_merge( $this->get_pagination_args(), $this->where_args ),
 				'auth'        => $this->auth,
+				'deprecationReason' => ! empty( $this->config['deprecationReason'] ) ? $this->config['deprecationReason'] : null,
 				'description' => ! empty( $this->config['description'] ) ? $this->config['description'] : sprintf( __( 'Connection between the %1$s type and the %2$s type', 'wp-graphql' ), $this->from_type, $this->to_type ),
 				'resolve'     => function ( $root, $args, $context, $info ) {
 					$context->connection_query_class = $this->query_class;

--- a/src/Type/WPConnectionType.php
+++ b/src/Type/WPConnectionType.php
@@ -287,6 +287,7 @@ class WPConnectionType {
 						'node' => [
 							'type'        => $this->to_type,
 							'description' => __( 'The node of the connection, without the edges', 'wp-graphql' ),
+							'deprecationReason' => ! empty( $this->config['deprecationReason'] ) ? $this->config['deprecationReason'] : null,
 						],
 					],
 					$this->edge_fields
@@ -318,10 +319,12 @@ class WPConnectionType {
 							'type'        => 'String',
 							'description' => __( 'A cursor for use in pagination', 'wp-graphql' ),
 							'resolve'     => $this->resolve_cursor,
+							'deprecationReason' => ! empty( $this->config['deprecationReason'] ) ? $this->config['deprecationReason'] : null,
 						],
 						'node'   => [
 							'type'        => $this->to_type,
 							'description' => __( 'The item at the end of the edge', 'wp-graphql' ),
+							'deprecationReason' => ! empty( $this->config['deprecationReason'] ) ? $this->config['deprecationReason'] : null,
 						],
 					],
 					$this->edge_fields

--- a/src/Type/WPConnectionType.php
+++ b/src/Type/WPConnectionType.php
@@ -285,8 +285,8 @@ class WPConnectionType {
 				'fields'      => array_merge(
 					[
 						'node' => [
-							'type'        => $this->to_type,
-							'description' => __( 'The node of the connection, without the edges', 'wp-graphql' ),
+							'type'              => $this->to_type,
+							'description'       => __( 'The node of the connection, without the edges', 'wp-graphql' ),
 							'deprecationReason' => ! empty( $this->config['deprecationReason'] ) ? $this->config['deprecationReason'] : null,
 						],
 					],
@@ -316,14 +316,14 @@ class WPConnectionType {
 				'fields'      => array_merge(
 					[
 						'cursor' => [
-							'type'        => 'String',
-							'description' => __( 'A cursor for use in pagination', 'wp-graphql' ),
-							'resolve'     => $this->resolve_cursor,
+							'type'              => 'String',
+							'description'       => __( 'A cursor for use in pagination', 'wp-graphql' ),
+							'resolve'           => $this->resolve_cursor,
 							'deprecationReason' => ! empty( $this->config['deprecationReason'] ) ? $this->config['deprecationReason'] : null,
 						],
 						'node'   => [
-							'type'        => $this->to_type,
-							'description' => __( 'The item at the end of the edge', 'wp-graphql' ),
+							'type'              => $this->to_type,
+							'description'       => __( 'The item at the end of the edge', 'wp-graphql' ),
 							'deprecationReason' => ! empty( $this->config['deprecationReason'] ) ? $this->config['deprecationReason'] : null,
 						],
 					],
@@ -436,12 +436,12 @@ class WPConnectionType {
 			$this->from_type,
 			$this->from_field_name,
 			[
-				'type'        => true === $this->one_to_one ? $this->connection_name . 'Edge' : $this->connection_name,
-				'args'        => array_merge( $this->get_pagination_args(), $this->where_args ),
-				'auth'        => $this->auth,
+				'type'              => true === $this->one_to_one ? $this->connection_name . 'Edge' : $this->connection_name,
+				'args'              => array_merge( $this->get_pagination_args(), $this->where_args ),
+				'auth'              => $this->auth,
 				'deprecationReason' => ! empty( $this->config['deprecationReason'] ) ? $this->config['deprecationReason'] : null,
-				'description' => ! empty( $this->config['description'] ) ? $this->config['description'] : sprintf( __( 'Connection between the %1$s type and the %2$s type', 'wp-graphql' ), $this->from_type, $this->to_type ),
-				'resolve'     => function ( $root, $args, $context, $info ) {
+				'description'       => ! empty( $this->config['description'] ) ? $this->config['description'] : sprintf( __( 'Connection between the %1$s type and the %2$s type', 'wp-graphql' ), $this->from_type, $this->to_type ),
+				'resolve'           => function ( $root, $args, $context, $info ) {
 					$context->connection_query_class = $this->query_class;
 					$resolve_connection              = $this->resolve_connection;
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This passes `deprecationReason` from `register_graphql_connection` config array through to the fields that are registered to create the connection.

Does this close any currently open issues?
------------------------------------------
closes #2579 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

**BEFORE**

Registering a connection with a `deprecationReason` DOES NOT deprecate the field(s) that were registered to create the connection:

![CleanShot 2022-10-13 at 11 56 21](https://user-images.githubusercontent.com/1260765/195670840-aad051d0-2619-461a-b312-24c8221f906c.png)


**AFTER**

Registering a connection with a `deprecationReason` deprecates the field(s) that were registered to create the connection:

![CleanShot 2022-10-13 at 11 55 52](https://user-images.githubusercontent.com/1260765/195670758-a82ddc6b-ecc9-4e35-ada3-3220b895862a.png)
