### PR TITLE
fix(noderesolver): adding extra_query_vars in graphql_pre_resolve_uri…

### DIFF
--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -86,7 +86,7 @@ class NodeResolver {
 		 * @param AppContext $content The app context.
 		 * @param WP $wp WP object.
 		 */
-		$node = apply_filters( 'graphql_pre_resolve_uri', null, $uri, $this->context, $this->wp );
+		$node = apply_filters( 'graphql_pre_resolve_uri', null, $uri, $this->context, $this->wp, $extra_query_vars );
 
 		if ( ! empty( $node ) ) {
 			return $node;

--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -85,6 +85,7 @@ class NodeResolver {
 		 * @param string $uri The uri being searched.
 		 * @param AppContext $content The app context.
 		 * @param WP $wp WP object.
+		 * @param mixed|array|string $extra_query_vars Any extra query vars to consider.
 		 */
 		$node = apply_filters( 'graphql_pre_resolve_uri', null, $uri, $this->context, $this->wp, $extra_query_vars );
 


### PR DESCRIPTION
From tag v1.8.7

Does this close any currently open issues?
------------------------------------------
Solve wp-graphql/wp-graphql #2515
Solve LEDE-740

Where has this been tested?
---------------------------
**WordPress Version:** 5.8.4
wp-graphql 1.8.7
sitepress-multingual-cms: 4.5.8 (wpml)
