### PR TITLE
fix: Add list of node types as X-GraphQL-Keys instead of list of edge types

### DIFF
--- a/tests/functional/GraphQLHeadersCept.php
+++ b/tests/functional/GraphQLHeadersCept.php
@@ -47,7 +47,7 @@ $I->assertNotEmpty( $x_graphql_keys );
 $I->assertNotEmpty( $x_graphql_url );
 $post_cache_key = base64_encode( 'post:' . $post_id );
 $I->assertContains( $post_cache_key, explode( ' ', $x_graphql_keys ) );
-$list_post_key = base64_encode( 'list:post' );
+$list_post_key = 'list:post';
 $I->assertContains( $list_post_key, explode( ' ', $x_graphql_keys ) );
 
 
@@ -65,5 +65,5 @@ $I->assertNotEmpty( $x_graphql_keys );
 $I->assertNotEmpty( $x_graphql_url );
 $post_cache_key = base64_encode( 'post:' . $post_id );
 $I->assertContains( $post_cache_key, explode( ' ', $x_graphql_keys ) );
-$list_post_key = base64_encode( 'list:post' );
+$list_post_key = 'list:post';
 $I->assertContains( $list_post_key, explode( ' ', $x_graphql_keys ) );

--- a/tests/functional/GraphQLHeadersCept.php
+++ b/tests/functional/GraphQLHeadersCept.php
@@ -32,3 +32,38 @@ $I->assertNotEmpty( $x_graphql_keys );
 $I->assertNotEmpty( $x_graphql_url );
 $post_cache_key = base64_encode( 'post:' . $post_id );
 $I->assertContains( $post_cache_key, explode( ' ', $x_graphql_keys ) );
+
+// query for edges
+$query = '{ posts { edges { node { title } } } }';
+
+$I->sendGet( 'http://localhost/graphql?query=' . $query );
+
+$I->seeResponseCodeIs( 200 );
+$I->seeResponseIsJson();
+$x_graphql_keys = $I->grabHttpHeader( 'X-GraphQL-Keys' );
+$x_graphql_url = $I->grabHttpHeader( 'X-GraphQL-URL' );
+
+$I->assertNotEmpty( $x_graphql_keys );
+$I->assertNotEmpty( $x_graphql_url );
+$post_cache_key = base64_encode( 'post:' . $post_id );
+$I->assertContains( $post_cache_key, explode( ' ', $x_graphql_keys ) );
+$list_post_key = base64_encode( 'list:post' );
+$I->assertContains( $list_post_key, explode( ' ', $x_graphql_keys ) );
+
+
+// query for contentNodes.edges
+$query = '{ contentNodes { edges { node { __typename } } } }';
+
+$I->sendGet( 'http://localhost/graphql?query=' . $query );
+
+$I->seeResponseCodeIs( 200 );
+$I->seeResponseIsJson();
+$x_graphql_keys = $I->grabHttpHeader( 'X-GraphQL-Keys' );
+$x_graphql_url = $I->grabHttpHeader( 'X-GraphQL-URL' );
+
+$I->assertNotEmpty( $x_graphql_keys );
+$I->assertNotEmpty( $x_graphql_url );
+$post_cache_key = base64_encode( 'post:' . $post_id );
+$I->assertContains( $post_cache_key, explode( ' ', $x_graphql_keys ) );
+$list_post_key = base64_encode( 'list:post' );
+$I->assertContains( $list_post_key, explode( ' ', $x_graphql_keys ) );


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This update visitor in the QueryAnalyzer to find the "node" type that's being queried in a list and add it to the keys instead of adding the "edge" type.


Does this close any currently open issues?
------------------------------------------
closes #2589 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

### Before (Posts.edges): 

The following query:

```graphql
{
  posts(first:5) { 
    edges { 
      node { 
        id
        title
      }
    }
  }
}
```

Would produce the following X-GraphQL-Keys:

```bash
b682e8e049ae0f0a6c6c65d66a42af48 graphql:Query 
list:rootquerytopostconnectionedge cG9zdDoxMTY3 
cG9zdDoxMTM1 cG9zdDoxMTIw cG9zdDoxMTA5 cG9zdDoxMDk3
```

### After (Posts.edges):

The same query produces the following X-GraphQL-Keys:

```bash
b682e8e049ae0f0a6c6c65d66a42af48 graphql:Query list:post 
cG9zdDoxMTY3 cG9zdDoxMTM1 cG9zdDoxMTIw 
cG9zdDoxMTA5 cG9zdDoxMDk3
```

### Before: (ContentNodes.edges)

The following query:

```graphql
{
  contentNodes(first:5) { 
    edges { 
      node { 
        id
        ...on NodeWithTitle {
          title
        }
      }
    }
  }
}
```

Would produce the following X-GraphQL-Keys:

```bash
4c854ebb7a8311233d939e1f7c01c37d graphql:Query 
list:rootquerytocontentnodeconnectionedge cG9zdDoxMjM3 
cG9zdDoxMTY3 cG9zdDoxMTM1
```

### After (ContentNodes.edges):

The same query produces the following X-GraphQL-Keys:

```bash
4c854ebb7a8311233d939e1f7c01c37d graphql:Query 
list:contentnode list:mediaitem list:page list:post list:graphqldocument 
cG9zdDoxMjM3 cG9zdDoxMTY3 cG9zdDoxMTM1
```
