### PR TITLE
feat: use sha256 instead of md5 for hashing the queryId

### DIFF
--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -16,10 +16,17 @@ class Utils {
 	 */
 	public static function get_query_id( string $query ) {
 
+		/**
+		 * Filter the hash algorithm to allow different algorithms.
+		 *
+		 * @string $algorithm Default is sha256. Possible values are those that work with the PHP hash() function. See: https://www.php.net/manual/en/function.hash-algos.php
+		 */
+		$hash_algorithm = apply_filters( 'graphql_query_id_hash_algorithm', 'sha256' );
+
 		try {
 			$query_ast = \GraphQL\Language\Parser::parse( $query );
 			$query     = \GraphQL\Language\Printer::doPrint( $query_ast );
-			return md5( $query );
+			return hash( $hash_algorithm, $query );
 		} catch ( \Exception $exception ) {
 			return null;
 		}


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This changes the hash for the queryId to use sha256 by default instead of md5. 

The algorithm is filterable to support any algorithm compatible with the php `hash()` function.

This plays nicer with the existing "standard" set by Apollo's Automated Persisted Queries functionality


Does this close any currently open issues?
------------------------------------------
closes #2584 


Any other comments?
------------------------------------------

## Before (md5)
![CleanShot 2022-10-25 at 06 50 08](https://user-images.githubusercontent.com/1260765/197777581-d13c79f8-0681-41cc-af2b-0a1e94432b23.png)


## After (sha256)

![CleanShot 2022-10-25 at 06 51 11](https://user-images.githubusercontent.com/1260765/197777647-f5c68ed1-9665-47fd-a5cb-e3a93607a6f0.png)
