### PR TITLE
chore: bump tested WP version to v6.1

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -16,7 +16,7 @@ jobs:
     name: Check code
     strategy:
       matrix:
-        php: [ 8.0 ]
+        php: [ 8.1 ]
 
     steps:
       - name: Cancel previous runs of this workflow (pull requests only)

--- a/.github/workflows/testing-integration.yml
+++ b/.github/workflows/testing-integration.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.0', '7.4', '7.3' ]
+        php: [ '8.0', '7.4', ]
         wordpress: [ '6.1', '6.0', '5.9', '5.8', '5.7', '5.6' ]
         include:
           - php: '8.1'
@@ -29,11 +29,17 @@ jobs:
             multisite: true
           - php: '8.1'
             wordpress: '6.0'
+            coverage: 1
           - php: '8.1'
             wordpress: '5.9'
-          - php: '8.0'
-            wordpress: '6.1'
-            coverage: 1
+          - php: '7.3'
+            wordpress: '5.9'
+          - php: '7.3'
+            wordpress: '5.8'
+          - php: '7.3'
+            wordpress: '5.7'
+          - php: '7.3'
+            wordpress: '5.6'
 
     steps:
       - name: Checkout

--- a/.github/workflows/testing-integration.yml
+++ b/.github/workflows/testing-integration.yml
@@ -21,24 +21,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '7.4', '7.3' ]
-        wordpress: [ '5.9', '5.8', '5.7.2', '5.6.2' ]
+        php: [ '8.0', '7.4', '7.3' ]
+        wordpress: [ '6.1', '6.0', '5.9', '5.8', '5.7', '5.6' ]
         include:
           - php: '8.1'
+            wordpress: '6.1'
+            multisite: true
+          - php: '8.1'
             wordpress: '6.0'
-          - php: '8.0'
-            wordpress: '6.0'
-          - php: '7.4'
-            wordpress: '6.0'
-          - php: '8.0'
+          - php: '8.1'
             wordpress: '5.9'
           - php: '8.0'
-            wordpress: '5.9'
-            multisite: 1
-          - php: '8.0'
-            wordpress: '5.8'
-          - php: '7.4'
-            wordpress: '5.8'
+            wordpress: '6.1'
             coverage: 1
 
     steps:

--- a/.github/workflows/wordpress-coding-standards.yml
+++ b/.github/workflows/wordpress-coding-standards.yml
@@ -16,7 +16,7 @@ jobs:
     name: PHPCS
     strategy:
       matrix:
-        php: [ 8.0 ]
+        php: [ 8.1 ]
 
     steps:
       - name: Cancel previous runs of this workflow (pull requests only)

--- a/bin/run-docker.sh
+++ b/bin/run-docker.sh
@@ -16,11 +16,11 @@ print_usage_instructions() {
     echo "  composer build-app";
     echo "  composer run-app";
     echo "";
-    echo "  WP_VERSION=5.9 PHP_VERSION=8.0 composer build-app";
-    echo "  WP_VERSION=5.9 PHP_VERSION=8.0 composer run-app";
+    echo "  WP_VERSION=6.1 PHP_VERSION=8.1 composer build-app";
+    echo "  WP_VERSION=6.1 PHP_VERSION=8.1 composer run-app";
     echo "";
-    echo "  WP_VERSION=5.9 PHP_VERSION=8.0  bin/run-docker.sh build -a";
-    echo "  WP_VERSION=5.9 PHP_VERSION=8.0  bin/run-docker.sh run -a";
+    echo "  WP_VERSION=6.1 PHP_VERSION=8.1  bin/run-docker.sh build -a";
+    echo "  WP_VERSION=6.1 PHP_VERSION=8.1  bin/run-docker.sh run -a";
     exit 1
 }
 
@@ -29,8 +29,8 @@ if [ $# -eq 0 ]; then
 fi
 
 TAG=${TAG-latest}
-WP_VERSION=${WP_VERSION-5.9}
-PHP_VERSION=${PHP_VERSION-8.0}
+WP_VERSION=${WP_VERSION-6.1}
+PHP_VERSION=${PHP_VERSION-8.1}
 
 BUILD_NO_CACHE=${BUILD_NO_CACHE-}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   app:
     depends_on:
       - app_db
-    image: wp-graphql:latest-wp${WP_VERSION-5.9}-php${PHP_VERSION-8.0}
+    image: wp-graphql:latest-wp${WP_VERSION-6.1}-php${PHP_VERSION-8.1}
     volumes:
       - '.:/var/www/html/wp-content/plugins/wp-graphql'
       - './.log/app:/var/log/apache2'
@@ -34,7 +34,7 @@ services:
   testing:
     depends_on:
       - app_db
-    image: wp-graphql-testing:latest-wp${WP_VERSION-5.9}-php${PHP_VERSION-8.0}
+    image: wp-graphql-testing:latest-wp${WP_VERSION-6.1}-php${PHP_VERSION-8.1}
     volumes:
       - '.:/var/www/html/wp-content/plugins/wp-graphql'
       - './.log/testing:/var/log/apache2'

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -191,7 +191,7 @@ PHP_VERSION=7.4 composer build-test
 Build the environment with specific version of WordPress:
 
 ```shell
-WP_VERSION=6.0 composer build-test
+WP_VERSION=6.1 composer build-test
 ```
 
 ```shell

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: jasonbahl, tylerbarnes1, ryankanner, hughdevore, chopinbach, kidunot89
 Tags: GraphQL, API, Gatsby, Headless, Decoupled, React, Nextjs, Vue, Apollo, REST, JSON,  HTTP, Remote, Query Language
 Requires at least: 5.0
-Tested up to: 5.9.1
+Tested up to: 6.1
 Requires PHP: 7.1
 Stable tag: 1.12.0
 License: GPL-3

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -10,7 +10,7 @@
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
- * Tested up to: 5.9.1
+ * Tested up to: 6.1
  * Requires PHP: 7.1
  * License: GPL-3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR bumps the WP version to test against to v6.1. The test matrices were also cleaned up, (per: https://make.wordpress.org/core/handbook/references/php-compatibility-and-wordpress-versions/).


Does this close any currently open issues?
------------------------------------------
...

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
The default PHP version has also been bumped to 8.1 (since 7.4 sunsets this month).


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (WSL2 + devilbox + PHP8.0)

**WordPress Version:** 6.1
