### PR TITLE
fix: failing tests for restricted user queries in wp 6.1

### DIFF
--- a/src/Connection/Users.php
+++ b/src/Connection/Users.php
@@ -63,11 +63,11 @@ class Users {
 			'resolve'            => function ( Post $source, $args, $context, $info ) {
 
 				if ( ! isset( $source->editLock[1] ) || ! absint( $source->editLock[1] ) ) {
-					return $source->editLock;
+					return null;
 				}
 
 				$resolver = new UserConnectionResolver( $source, $args, $context, $info );
-				$resolver->one_to_one()->set_query_arg( 'include', [ $source->editLock[1] ] );
+				$resolver->one_to_one()->set_query_arg( 'include', [ absint( $source->editLock[1] ) ] );
 
 				return $resolver->get_connection();
 
@@ -83,8 +83,12 @@ class Users {
 			'oneToOne'           => true,
 			'resolve'            => function ( Post $source, $args, $context, $info ) {
 
+				if ( empty( $post->editLastId ) ) {
+					return null;
+				}
+
 				$resolver = new UserConnectionResolver( $source, $args, $context, $info );
-				$resolver->set_query_arg( 'include', [ $source->editLastId ] );
+				$resolver->set_query_arg( 'include', [ absint( $source->editLastId ) ] );
 				return $resolver->one_to_one()->get_connection();
 
 			},
@@ -97,8 +101,12 @@ class Users {
 			'oneToOne'      => true,
 			'resolve'       => function ( Post $post, $args, AppContext $context, ResolveInfo $info ) {
 
+				if ( empty( $post->authorDatabaseId ) ) {
+					return null;
+				}
+
 				$resolver = new UserConnectionResolver( $post, $args, $context, $info );
-				$resolver->set_query_arg( 'include', [ $post->authorDatabaseId ] );
+				$resolver->set_query_arg( 'include', [ absint( $post->authorDatabaseId ) ] );
 				return $resolver->one_to_one()->get_connection();
 			},
 		] );

--- a/src/Connection/Users.php
+++ b/src/Connection/Users.php
@@ -83,7 +83,7 @@ class Users {
 			'oneToOne'           => true,
 			'resolve'            => function ( Post $source, $args, $context, $info ) {
 
-				if ( empty( $post->editLastId ) ) {
+				if ( empty( $source->editLastId ) ) {
 					return null;
 				}
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This updates the resolvers for user connections to check the values of the author databaseId more strictly before using it to resolve. If the value is empty, we can prevent resolution altogether and return null.

Does this close any currently open issues?
------------------------------------------
Follow-up to: #2605 
