### PR TITLE
release: v1.12.2

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -16,7 +16,7 @@ jobs:
     name: Check code
     strategy:
       matrix:
-        php: [ 8.0 ]
+        php: [ 8.1 ]
 
     steps:
       - name: Cancel previous runs of this workflow (pull requests only)

--- a/.github/workflows/testing-integration.yml
+++ b/.github/workflows/testing-integration.yml
@@ -21,25 +21,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '7.4', '7.3' ]
-        wordpress: [ '5.9', '5.8', '5.7.2', '5.6.2' ]
+        php: [ '8.0', '7.4', ]
+        wordpress: [ '6.1', '6.0', '5.9', '5.8', '5.7', '5.6' ]
         include:
           - php: '8.1'
+            wordpress: '6.1'
+            multisite: true
+          - php: '8.1'
             wordpress: '6.0'
-          - php: '8.0'
-            wordpress: '6.0'
-          - php: '7.4'
-            wordpress: '6.0'
-          - php: '8.0'
-            wordpress: '5.9'
-          - php: '8.0'
-            wordpress: '5.9'
-            multisite: 1
-          - php: '8.0'
-            wordpress: '5.8'
-          - php: '7.4'
-            wordpress: '5.8'
             coverage: 1
+          - php: '8.1'
+            wordpress: '5.9'
+          - php: '7.3'
+            wordpress: '5.9'
+          - php: '7.3'
+            wordpress: '5.8'
+          - php: '7.3'
+            wordpress: '5.7'
+          - php: '7.3'
+            wordpress: '5.6'
 
     steps:
       - name: Checkout

--- a/.github/workflows/wordpress-coding-standards.yml
+++ b/.github/workflows/wordpress-coding-standards.yml
@@ -16,7 +16,7 @@ jobs:
     name: PHPCS
     strategy:
       matrix:
-        php: [ 8.0 ]
+        php: [ 8.1 ]
 
     steps:
       - name: Cancel previous runs of this workflow (pull requests only)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.12.2
+
+### Chores / Bugfixes
+
+- ([#2605](https://github.com/wp-graphql/wp-graphql/pull/2605)): chore: bump tested version of WordPress to 6.1. Thanks @justlevine!
+- ([#2606](https://github.com/wp-graphql/wp-graphql/pull/2606)): fix: update resolver in post->author connection to be more strict about the value of the author ID
+- ([#2609](https://github.com/wp-graphql/wp-graphql/pull/2609)): chore(deps): bump loader-utils from 2.0.2 to 2.0.3
+
 ## 1.12.1
 
 ### New Features

--- a/bin/run-docker.sh
+++ b/bin/run-docker.sh
@@ -16,11 +16,11 @@ print_usage_instructions() {
     echo "  composer build-app";
     echo "  composer run-app";
     echo "";
-    echo "  WP_VERSION=5.9 PHP_VERSION=8.0 composer build-app";
-    echo "  WP_VERSION=5.9 PHP_VERSION=8.0 composer run-app";
+    echo "  WP_VERSION=6.1 PHP_VERSION=8.1 composer build-app";
+    echo "  WP_VERSION=6.1 PHP_VERSION=8.1 composer run-app";
     echo "";
-    echo "  WP_VERSION=5.9 PHP_VERSION=8.0  bin/run-docker.sh build -a";
-    echo "  WP_VERSION=5.9 PHP_VERSION=8.0  bin/run-docker.sh run -a";
+    echo "  WP_VERSION=6.1 PHP_VERSION=8.1  bin/run-docker.sh build -a";
+    echo "  WP_VERSION=6.1 PHP_VERSION=8.1  bin/run-docker.sh run -a";
     exit 1
 }
 
@@ -29,8 +29,8 @@ if [ $# -eq 0 ]; then
 fi
 
 TAG=${TAG-latest}
-WP_VERSION=${WP_VERSION-5.9}
-PHP_VERSION=${PHP_VERSION-8.0}
+WP_VERSION=${WP_VERSION-6.1}
+PHP_VERSION=${PHP_VERSION-8.1}
 
 BUILD_NO_CACHE=${BUILD_NO_CACHE-}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   app:
     depends_on:
       - app_db
-    image: wp-graphql:latest-wp${WP_VERSION-5.9}-php${PHP_VERSION-8.0}
+    image: wp-graphql:latest-wp${WP_VERSION-6.1}-php${PHP_VERSION-8.1}
     volumes:
       - '.:/var/www/html/wp-content/plugins/wp-graphql'
       - './.log/app:/var/log/apache2'
@@ -34,7 +34,7 @@ services:
   testing:
     depends_on:
       - app_db
-    image: wp-graphql-testing:latest-wp${WP_VERSION-5.9}-php${PHP_VERSION-8.0}
+    image: wp-graphql-testing:latest-wp${WP_VERSION-6.1}-php${PHP_VERSION-8.1}
     volumes:
       - '.:/var/www/html/wp-content/plugins/wp-graphql'
       - './.log/testing:/var/log/apache2'

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -191,7 +191,7 @@ PHP_VERSION=7.4 composer build-test
 Build the environment with specific version of WordPress:
 
 ```shell
-WP_VERSION=6.0 composer build-test
+WP_VERSION=6.1 composer build-test
 ```
 
 ```shell

--- a/package-lock.json
+++ b/package-lock.json
@@ -18505,9 +18505,9 @@
       }
     },
     "node_modules/loader-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
+      "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
       "dev": true,
       "dependencies": {
         "big.js": "^5.2.2",
@@ -42585,9 +42585,9 @@
       "dev": true
     },
     "loader-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
+      "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
       "dev": true,
       "requires": {
         "big.js": "^5.2.2",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, API, Gatsby, Headless, Decoupled, React, Nextjs, Vue, Apollo, RES
 Requires at least: 5.0
 Tested up to: 5.9.1
 Requires PHP: 7.1
-Stable tag: 1.12.1
+Stable tag: 1.12.2
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -184,6 +184,15 @@ The `uri` field was non-null on some Types in the Schema but has been changed to
 Composer dependencies are no longer versioned in Github. Recommended install source is WordPress.org or using Composer to get the code from Packagist.org or WPackagist.org.
 
 == Changelog ==
+
+= 1.12.2 =
+
+**Chores / Bugfixes**
+
+- ([#2605](https://github.com/wp-graphql/wp-graphql/pull/2605)): chore: bump tested version of WordPress to 6.1. Thanks @justlevine!
+- ([#2606](https://github.com/wp-graphql/wp-graphql/pull/2606)): fix: update resolver in post->author connection to be more strict about the value of the author ID
+- ([#2609](https://github.com/wp-graphql/wp-graphql/pull/2609)): chore(deps): bump loader-utils from 2.0.2 to 2.0.3
+
 
 = 1.12.1 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: jasonbahl, tylerbarnes1, ryankanner, hughdevore, chopinbach, kidunot89
 Tags: GraphQL, API, Gatsby, Headless, Decoupled, React, Nextjs, Vue, Apollo, REST, JSON,  HTTP, Remote, Query Language
 Requires at least: 5.0
-Tested up to: 5.9.1
+Tested up to: 6.1
 Requires PHP: 7.1
 Stable tag: 1.12.2
 License: GPL-3

--- a/src/AppContext.php
+++ b/src/AppContext.php
@@ -155,6 +155,7 @@ class AppContext {
 	 * @deprecated Use get_loader instead.
 	 */
 	public function getLoader( $key ) {
+		_deprecated_function( __METHOD__, '0.8.4', __CLASS__ . '::get_loader()' );
 		return $this->get_loader( $key );
 	}
 
@@ -180,6 +181,7 @@ class AppContext {
 	 * @return array|mixed
 	 */
 	public function getConnectionArgs() {
+		_deprecated_function( __METHOD__, '0.8.4', __CLASS__ . '::get_connection_args()' );
 		return $this->get_connection_args();
 	}
 
@@ -199,7 +201,6 @@ class AppContext {
 	 */
 	public function get_current_connection() {
 		return isset( $this->currentConnection ) ? $this->currentConnection : null;
-
 	}
 
 	/**

--- a/src/Connection/Users.php
+++ b/src/Connection/Users.php
@@ -63,11 +63,11 @@ class Users {
 			'resolve'            => function ( Post $source, $args, $context, $info ) {
 
 				if ( ! isset( $source->editLock[1] ) || ! absint( $source->editLock[1] ) ) {
-					return $source->editLock;
+					return null;
 				}
 
 				$resolver = new UserConnectionResolver( $source, $args, $context, $info );
-				$resolver->one_to_one()->set_query_arg( 'include', [ $source->editLock[1] ] );
+				$resolver->one_to_one()->set_query_arg( 'include', [ absint( $source->editLock[1] ) ] );
 
 				return $resolver->get_connection();
 
@@ -83,8 +83,12 @@ class Users {
 			'oneToOne'           => true,
 			'resolve'            => function ( Post $source, $args, $context, $info ) {
 
+				if ( empty( $source->editLastId ) ) {
+					return null;
+				}
+
 				$resolver = new UserConnectionResolver( $source, $args, $context, $info );
-				$resolver->set_query_arg( 'include', [ $source->editLastId ] );
+				$resolver->set_query_arg( 'include', [ absint( $source->editLastId ) ] );
 				return $resolver->one_to_one()->get_connection();
 
 			},
@@ -97,8 +101,12 @@ class Users {
 			'oneToOne'      => true,
 			'resolve'       => function ( Post $post, $args, AppContext $context, ResolveInfo $info ) {
 
+				if ( empty( $post->authorDatabaseId ) ) {
+					return null;
+				}
+
 				$resolver = new UserConnectionResolver( $post, $args, $context, $info );
-				$resolver->set_query_arg( 'include', [ $post->authorDatabaseId ] );
+				$resolver->set_query_arg( 'include', [ absint( $post->authorDatabaseId ) ] );
 				return $resolver->one_to_one()->get_connection();
 			},
 		] );

--- a/src/Data/Config.php
+++ b/src/Data/Config.php
@@ -204,13 +204,13 @@ class Config {
 
 		// apply the after cursor to the query
 		if ( ! empty( $query->query_vars['graphql_after_cursor'] ) ) {
-			$after_cursor = new PostObjectCursor( $query, 'after' );
+			$after_cursor = new PostObjectCursor( $query->query_vars, 'after' );
 			$where       .= $after_cursor->get_where();
 		}
 
 		// apply the before cursor to the query
 		if ( ! empty( $query->query_vars['graphql_before_cursor'] ) ) {
-			$before_cursor = new PostObjectCursor( $query, 'before' );
+			$before_cursor = new PostObjectCursor( $query->query_vars, 'before' );
 			$where        .= $before_cursor->get_where();
 		}
 
@@ -256,13 +256,13 @@ class Config {
 
 		// apply the after cursor to the query
 		if ( ! empty( $query->query_vars['graphql_after_cursor'] ) ) {
-			$after_cursor = new UserCursor( $query, 'after' );
+			$after_cursor = new UserCursor( $query->query_vars, 'after' );
 			$where        = $where . $after_cursor->get_where();
 		}
 
 		// apply the before cursor to the query
 		if ( ! empty( $query->query_vars['graphql_before_cursor'] ) ) {
-			$before_cursor = new UserCursor( $query, 'before' );
+			$before_cursor = new UserCursor( $query->query_vars, 'before' );
 			$where         = $where . $before_cursor->get_where();
 		}
 

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -231,7 +231,7 @@ abstract class AbstractConnectionResolver {
 	 * @codeCoverageIgnore
 	 */
 	public function getArgs(): array {
-		_deprecated_function( __FUNCTION__, '1.11.0', 'get_args' );
+		_deprecated_function( __METHOD__, '1.11.0', static::class . '::get_args()' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		return $this->get_args();
 	}
 
@@ -284,7 +284,7 @@ abstract class AbstractConnectionResolver {
 	 * @codeCoverageIgnore
 	 */
 	public function setQueryArg( $key, $value ) {
-		_deprecated_function( __FUNCTION__, '0.3.0', 'set_query_arg' );
+		_deprecated_function( __METHOD__, '0.3.0', static::class . '::set_query_arg()' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		return $this->set_query_arg( $key, $value );
 	}
@@ -619,7 +619,7 @@ abstract class AbstractConnectionResolver {
 	 * @return int|mixed
 	 */
 	public function get_offset() {
-		_deprecated_function( __FUNCTION__, '1.9.0', get_class( $this ) . '::get_offset_for_cursor()' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		_deprecated_function( __METHOD__, '1.9.0', static::class . '::get_offset_for_cursor()' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		// Using shorthand since this is for deprecated code.
 		$cursor = $this->args['after'] ?? null;

--- a/src/Data/Cursor/CommentObjectCursor.php
+++ b/src/Data/Cursor/CommentObjectCursor.php
@@ -27,7 +27,7 @@ class CommentObjectCursor extends AbstractCursor {
 	public function __construct( $query_vars, $cursor = 'after' ) {
 		// Handle deprecated use of $query.
 		if ( $query_vars instanceof \WP_Comment_Query ) {
-			_doing_it_wrong( __FUNCTION__, 'The first argument should be an array of $query_vars, not the WP_Comment_Query object', '1.9.0' );
+			_doing_it_wrong( __METHOD__, 'The first argument should be an array of $query_vars, not the WP_Comment_Query object', '1.9.0' );
 			$query_vars = $query_vars->query_vars;
 		}
 

--- a/src/Data/Cursor/PostObjectCursor.php
+++ b/src/Data/Cursor/PostObjectCursor.php
@@ -31,7 +31,7 @@ class PostObjectCursor extends AbstractCursor {
 	public function __construct( $query_vars, $cursor = 'after' ) {
 		// Handle deprecated use of $query.
 		if ( $query_vars instanceof \WP_Query ) {
-			_doing_it_wrong( __FUNCTION__, 'The first argument should be an array of $query_vars, not the WP_Query object', '1.9.0' );
+			_doing_it_wrong( __METHOD__, 'The first argument should be an array of $query_vars, not the WP_Query object', '1.9.0' );
 			$query_vars = $query_vars->query_vars;
 		}
 
@@ -60,7 +60,7 @@ class PostObjectCursor extends AbstractCursor {
 	 * @return ?\WP_Post
 	 */
 	public function get_cursor_post() {
-		_deprecated_function( __FUNCTION__, '1.9.0', self::class . '::get_cursor_node()' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		_deprecated_function( __METHOD__, '1.9.0', self::class . '::get_cursor_node()' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		return $this->cursor_node;
 	}

--- a/src/Data/Cursor/TermObjectCursor.php
+++ b/src/Data/Cursor/TermObjectCursor.php
@@ -25,7 +25,7 @@ class TermObjectCursor extends AbstractCursor {
 	 * @return mixed|null
 	 */
 	public function get_query_arg( string $name ) {
-		_deprecated_function( __FUNCTION__, '1.9.0', self::class . '::get_query_var()' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		_deprecated_function( __METHOD__, '1.9.0', self::class . '::get_query_var()' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		return $this->get_query_var( $name );
 	}
@@ -50,7 +50,7 @@ class TermObjectCursor extends AbstractCursor {
 	 * @deprecated 1.9.0
 	 */
 	public function get_cursor_term() {
-		_deprecated_function( __FUNCTION__, '1.9.0', self::class . '::get_cursor_node()' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		_deprecated_function( __METHOD__, '1.9.0', self::class . '::get_cursor_node()' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		return $this->cursor_node;
 	}
@@ -145,7 +145,7 @@ class TermObjectCursor extends AbstractCursor {
 	 * @return void
 	 */
 	private function compare_with_meta_field( string $meta_key, string $order ) {
-		$meta_type  = $this->get_query_arg( 'meta_type' );
+		$meta_type  = $this->get_query_var( 'meta_type' );
 		$meta_value = get_term_meta( $this->cursor_offset, $meta_key, true );
 
 		$key = "{$this->wpdb->termmeta}.meta_value";
@@ -173,7 +173,7 @@ class TermObjectCursor extends AbstractCursor {
 	private function get_meta_key( string $by ) {
 
 		if ( 'meta_value' === $by || 'meta_value_num' === $by ) {
-			return $this->get_query_arg( 'meta_key' );
+			return $this->get_query_var( 'meta_key' );
 		}
 
 		/**

--- a/src/Data/Cursor/UserCursor.php
+++ b/src/Data/Cursor/UserCursor.php
@@ -77,7 +77,7 @@ class UserCursor extends AbstractCursor {
 	 * @deprecated 1.9.0
 	 */
 	public function get_cursor_user() {
-		_deprecated_function( __FUNCTION__, '1.9.0', self::class . '::get_cursor_node()' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		_deprecated_function( __METHOD__, '1.9.0', self::class . '::get_cursor_node()' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		return $this->cursor_node;
 	}

--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -67,6 +67,8 @@ class DataSource {
 	 * @deprecated Use the Loader passed in $context instead
 	 */
 	public static function resolve_comment( $id, $context ) {
+		_deprecated_function( __METHOD__, '0.8.4', 'Use $context->get_loader( \'comment\' )->load_deferred( $id ) instead.' );
+
 		return $context->get_loader( 'comment' )->load_deferred( $id );
 	}
 
@@ -135,6 +137,7 @@ class DataSource {
 	 * @deprecated Use the Loader passed in $context instead
 	 */
 	public static function resolve_post_object( int $id, AppContext $context ) {
+		_deprecated_function( __METHOD__, '0.8.4', 'Use $context->get_loader( \'post\' )->load_deferred( $id ) instead.' );
 		return $context->get_loader( 'post' )->load_deferred( $id );
 	}
 
@@ -148,6 +151,7 @@ class DataSource {
 	 * @deprecated Use the Loader passed in $context instead
 	 */
 	public static function resolve_menu_item( int $id, AppContext $context ) {
+		_deprecated_function( __METHOD__, '0.8.4', 'Use $context->get_loader( \'post\' )->load_deferred( $id ) instead.' );
 		return $context->get_loader( 'post' )->load_deferred( $id );
 	}
 
@@ -215,6 +219,7 @@ class DataSource {
 	 * @deprecated Use the Loader passed in $context instead
 	 */
 	public static function resolve_term_object( $id, AppContext $context ) {
+		_deprecated_function( __METHOD__, '0.8.4', 'Use $context->get_loader( \'term\' )->load_deferred( $id ) instead.' );
 		return $context->get_loader( 'term' )->load_deferred( $id );
 	}
 
@@ -286,6 +291,7 @@ class DataSource {
 	 * @deprecated Use the Loader passed in $context instead
 	 */
 	public static function resolve_user( $id, AppContext $context ) {
+		_deprecated_function( __METHOD__, '0.8.4', 'Use $context->get_loader( \'user\' )->load_deferred( $id ) instead.' );
 		return $context->get_loader( 'user' )->load_deferred( $id );
 	}
 

--- a/src/Data/Loader/AbstractDataLoader.php
+++ b/src/Data/Loader/AbstractDataLoader.php
@@ -203,6 +203,7 @@ abstract class AbstractDataLoader {
 	 * @deprecated in favor of clear_all
 	 */
 	public function clearAll() {
+		_deprecated_function( __METHOD__, '0.8.4', static::class . '::clear_all()' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		return $this->clear_all();
 	}
 
@@ -232,6 +233,7 @@ abstract class AbstractDataLoader {
 	 * @deprecated Use load_many instead
 	 */
 	public function loadMany( array $keys, $asArray = false ) {
+		_deprecated_function( __METHOD__, '0.8.4', static::class . '::load_many()' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		return $this->load_many( $keys, $asArray );
 	}
 
@@ -360,6 +362,7 @@ abstract class AbstractDataLoader {
 	 * @deprecated Use key_to_scalar instead
 	 */
 	protected function keyToScalar( $key ) {
+		_deprecated_function( __METHOD__, '0.8.4', static::class . '::key_to_scalar()' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		return $this->key_to_scalar( $key );
 	}
 

--- a/src/Mutation/SendPasswordResetEmail.php
+++ b/src/Mutation/SendPasswordResetEmail.php
@@ -21,66 +21,111 @@ class SendPasswordResetEmail {
 			'sendPasswordResetEmail',
 			[
 				'description'         => __( 'Send password reset email to user', 'wp-graphql' ),
-				'inputFields'         => [
-					'username' => [
-						'type'        => [
-							'non_null' => 'String',
-						],
-						'description' => __( 'A string that contains the user\'s username or email address.', 'wp-graphql' ),
-					],
-				],
-				'outputFields'        => [
-					'user' => [
-						'type'        => 'User',
-						'description' => __( 'The user that the password reset email was sent to', 'wp-graphql' ),
-					],
-				],
-				'mutateAndGetPayload' => function ( $input, AppContext $context, ResolveInfo $info ) {
-
-					if ( ! self::was_username_provided( $input ) ) {
-						throw new UserError( __( 'Enter a username or email address.', 'wp-graphql' ) );
-					}
-					$user_data = self::get_user_data( $input['username'] );
-
-					if ( ! $user_data ) {
-						throw new UserError( self::get_user_not_found_error_message( $input['username'] ) );
-					}
-					$key = get_password_reset_key( $user_data );
-					if ( is_wp_error( $key ) ) {
-						throw new UserError( __( 'Unable to generate a password reset key.', 'wp-graphql' ) );
-					}
-					$subject = self::get_email_subject( $user_data );
-					$message = self::get_email_message( $user_data, $key );
-
-					$email_sent = wp_mail( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_mail_wp_mail
-						$user_data->user_email,
-						wp_specialchars_decode( $subject ),
-						$message
-					);
-
-					// wp_mail can return a wp_error, but the docblock for it in WP Core is incorrect.
-					// phpstan should ignore this check.
-					// @phpstan-ignore-next-line
-					if ( is_wp_error( $email_sent ) ) {
-
-						$message = __( 'The email could not be sent.', 'wp-graphql' ) . "<br />\n" . __( 'Possible reason: your host may have disabled the mail() function.', 'wp-graphql' );
-						if ( ! \WPGraphQL::debug() ) {
-							throw new UserError( $message );
-						} else {
-							graphql_debug( $message );
-						}
-					}
-
-					/**
-					 * Return the ID of the user
-					 */
-					return [
-						'id'   => $user_data->ID,
-						'user' => $context->get_loader( 'user' )->load_deferred( $user_data->ID ),
-					];
-				},
+				'inputFields'         => self::get_input_fields(),
+				'outputFields'        => self::get_output_fields(),
+				'mutateAndGetPayload' => self::mutate_and_get_payload(),
 			]
 		);
+	}
+
+	/**
+	 * Defines the mutation input field configuration.
+	 *
+	 * @return array
+	 */
+	public static function get_input_fields() : array {
+		return [
+			'username' => [
+				'type'        => [
+					'non_null' => 'String',
+				],
+				'description' => __( 'A string that contains the user\'s username or email address.', 'wp-graphql' ),
+			],
+		];
+	}
+
+	/**
+	 * Defines the mutation output field configuration.
+	 *
+	 * @return array
+	 */
+	public static function get_output_fields() : array {
+		return [
+			'user'    => [
+				'type'              => 'User',
+				'description'       => __( 'The user that the password reset email was sent to', 'wp-graphql' ),
+				'deprecationReason' => __( 'This field will be removed in a future version of WPGraphQL', 'wp-graphql' ),
+				'resolve'           => function ( $payload, $args, AppContext $context ) {
+					return ! empty( $payload['id'] ) ? $context->get_loader( 'user' )->load_deferred( $payload['id'] ) : null;
+				},
+			],
+			'success' => [
+				'type'        => 'Boolean',
+				'description' => __( 'Whether the mutation completed successfully. This does NOT necessarily mean that an email was sent.', 'wp-graphql' ),
+			],
+		];
+	}
+
+	/**
+	 * Defines the mutation data modification closure.
+	 *
+	 * @return callable
+	 */
+	public static function mutate_and_get_payload() : callable {
+		return function ( $input ) {
+			if ( ! self::was_username_provided( $input ) ) {
+				throw new UserError( __( 'Enter a username or email address.', 'wp-graphql' ) );
+			}
+
+			// We obsfucate the actual success of this mutation to prevent user enumeration.
+			$payload = [
+				'success' => true,
+				'id'      => null,
+			];
+
+			$user_data = self::get_user_data( $input['username'] );
+
+			if ( ! $user_data ) {
+				graphql_debug( self::get_user_not_found_error_message( $input['username'] ) );
+
+				return $payload;
+			}
+
+			// Get the password reset key.
+			$key = get_password_reset_key( $user_data );
+			if ( is_wp_error( $key ) ) {
+				graphql_debug( __( 'Unable to generate a password reset key.', 'wp-graphql' ) );
+
+				return $payload;
+			}
+
+			// Mail the reset key.
+			$subject = self::get_email_subject( $user_data );
+			$message = self::get_email_message( $user_data, $key );
+
+			$email_sent = wp_mail( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_mail_wp_mail
+				$user_data->user_email,
+				wp_specialchars_decode( $subject ),
+				$message
+			);
+
+			// wp_mail can return a wp_error, but the docblock for it in WP Core is incorrect.
+			// phpstan should ignore this check.
+			// @phpstan-ignore-next-line
+			if ( is_wp_error( $email_sent ) ) {
+				graphql_debug( __( 'The email could not be sent.', 'wp-graphql' ) . "<br />\n" . __( 'Possible reason: your host may have disabled the mail() function.', 'wp-graphql' ) );
+
+				return $payload;
+			}
+
+			/**
+			 * Return the ID of the user
+			 */
+			return [
+				'id'      => $user_data->ID,
+				'success' => true,
+			];
+		};
 	}
 
 	/**

--- a/src/Router.php
+++ b/src/Router.php
@@ -227,6 +227,7 @@ class Router {
 	 * @deprecated 0.4.1 Use Router::is_graphql_http_request instead. This now resolves to it
 	 */
 	public static function is_graphql_request() {
+		_deprecated_function( __METHOD__, '0.4.1', __CLASS__ . 'is_graphql_http_request()' );
 		return self::is_graphql_http_request();
 	}
 

--- a/src/Type/Union/MenuItemObjectUnion.php
+++ b/src/Type/Union/MenuItemObjectUnion.php
@@ -31,6 +31,7 @@ class MenuItemObjectUnion {
 				'typeNames'   => self::get_possible_types(),
 				'description' => __( 'Deprecated in favor of MenuItemLinkeable Interface', 'wp-graphql' ),
 				'resolveType' => function ( $object ) use ( $type_registry ) {
+					_doing_it_wrong( 'MenuItemObjectUnion', esc_attr__( 'The MenuItemObjectUnion GraphQL type is deprecated in favor of MenuItemLinkeable Interface', 'wp-graphql' ), '0.10.3' );
 					// Post object
 					if ( $object instanceof Post && isset( $object->post_type ) && ! empty( $object->post_type ) ) {
 						/** @var \WP_Post_Type $post_type_object */

--- a/src/Types.php
+++ b/src/Types.php
@@ -23,6 +23,7 @@ class Types {
 	 * @return array
 	 */
 	public static function map_input( $args, $map ) {
+		_deprecated_function( __METHOD__, '0.6.0', 'WPGraphQL\Utils\Utils::map_input()' );
 		return Utils::map_input( $args, $map );
 	}
 
@@ -33,6 +34,7 @@ class Types {
 	 * @return string|null ISO8601/RFC3339 formatted datetime.
 	 */
 	public static function prepare_date_response( $date_gmt, $date = null ) {
+		_deprecated_function( __METHOD__, '0.6.0', 'WPGraphQL\Utils\Utils::prepare_date_response()' );
 		return Utils::prepare_date_response( $date_gmt, $date );
 	}
 

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -130,7 +130,7 @@ final class WPGraphQL {
 
 		// Plugin version.
 		if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-			define( 'WPGRAPHQL_VERSION', '1.12.1' );
+			define( 'WPGRAPHQL_VERSION', '1.12.2' );
 		}
 
 		// Plugin Folder Path.

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -403,7 +403,7 @@ final class WPGraphQL {
 				 * @param array                              $config     The config for the Object Type
 				 * @param mixed|WPInterfaceType|WPObjectType $type       The Type instance
 				 */
-				return apply_filters( 'graphql_object_type_interfaces', $interfaces, $config, $type );
+				return apply_filters_deprecated( 'graphql_object_type_interfaces', [ $interfaces, $config, $type ], '1.4.1', 'graphql_type_interfaces' );
 			}
 
 			return $interfaces;
@@ -596,8 +596,7 @@ final class WPGraphQL {
 	public static function get_allowed_post_types( $output = 'names', $args = [] ) {
 		// Support deprecated param order.
 		if ( is_array( $output ) ) {
-			// @todo enable once core usage has been refactored.
-			// _doing_it_wrong( __FUNCTION__, '$args should be passed as the second parameter.', '@todo' );
+			_deprecated_argument( __METHOD__, '1.8.1', '$args should be passed as the second parameter.' );
 			$args   = $output;
 			$output = 'names';
 		}

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.12.1
+ * Version: 1.12.2
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.12.1
+ * @version  1.12.2
  */
 
 // Exit if accessed directly.

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -10,7 +10,7 @@
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
- * Tested up to: 5.9.1
+ * Tested up to: 6.1
  * Requires PHP: 7.1
  * License: GPL-3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
# Release Notes

## New Features: 

- ([#2541](https://github.com/wp-graphql/wp-graphql/pull/2541)): feat: Obfuscate SendPasswordResetEmail response. Thanks @justlevine!

## Chores / Bugfixes

- ([#2544](https://github.com/wp-graphql/wp-graphql/pull/2544)): chore: log and cleanup deprecations. Thanks @justlevine!
- ([#2605](https://github.com/wp-graphql/wp-graphql/pull/2605)): chore: bump tested version of WordPress to 6.1. Thanks @justlevine!
- ([#2606](https://github.com/wp-graphql/wp-graphql/pull/2606)): fix: update resolver in post->author connection to be more strict about the value of the author ID
- ([#2609](https://github.com/wp-graphql/wp-graphql/pull/2609)): chore(deps): bump loader-utils from 2.0.2 to 2.0.3

