### PR TITLE
fix: previews should only be on publicly queryable types

### DIFF
--- a/src/Registry/Utils/PostObject.php
+++ b/src/Registry/Utils/PostObject.php
@@ -137,7 +137,7 @@ class PostObject {
 				'toType'             => $post_type_object->graphql_single_name,
 				'connectionTypeName' => ucfirst( $post_type_object->graphql_single_name ) . 'ToPreviewConnection',
 				'oneToOne'           => true,
-				'deprecationReason'   => ! $post_type_object->publicly_queryable ? sprintf( __( 'The "%s" Type is not publicly queryable and does not support previews. This field will be removed in the future.', 'wp-graphql' ), WPGraphQL\Utils\Utils::format_type_name( $post_type_object->graphql_single_name ) ) : null,
+				'deprecationReason'  => ! $post_type_object->publicly_queryable ? sprintf( __( 'The "%s" Type is not publicly queryable and does not support previews. This field will be removed in the future.', 'wp-graphql' ), WPGraphQL\Utils\Utils::format_type_name( $post_type_object->graphql_single_name ) ) : null,
 				'resolve'            => function ( Post $post, $args, AppContext $context, ResolveInfo $info ) {
 					if ( $post->isRevision ) {
 						return null;

--- a/src/Registry/Utils/PostObject.php
+++ b/src/Registry/Utils/PostObject.php
@@ -137,7 +137,7 @@ class PostObject {
 				'toType'             => $post_type_object->graphql_single_name,
 				'connectionTypeName' => ucfirst( $post_type_object->graphql_single_name ) . 'ToPreviewConnection',
 				'oneToOne'           => true,
-				'deprecationReason'  => ! $post_type_object->publicly_queryable ? sprintf( __( 'The "%s" Type is not publicly queryable and does not support previews. This field will be removed in the future.', 'wp-graphql' ), WPGraphQL\Utils\Utils::format_type_name( $post_type_object->graphql_single_name ) ) : null,
+				'deprecationReason'  => ( true === $post_type_object->publicly_queryable || true === $post_type_object->public ) ? null : sprintf( __( 'The "%s" Type is not publicly queryable and does not support previews. This field will be removed in the future.', 'wp-graphql' ), WPGraphQL\Utils\Utils::format_type_name( $post_type_object->graphql_single_name ) ),
 				'resolve'            => function ( Post $post, $args, AppContext $context, ResolveInfo $info ) {
 					if ( $post->isRevision ) {
 						return null;
@@ -265,7 +265,7 @@ class PostObject {
 		}
 
 		// Only post types that are publicly_queryable are previewable
-		if ( true === $post_type_object->publicly_queryable ) {
+		if ( 'attachment' !== $post_type_object->name && ( true === $post_type_object->publicly_queryable || true === $post_type_object->public ) ) {
 			$interfaces[] = 'Previewable';
 		}
 

--- a/src/Registry/Utils/PostObject.php
+++ b/src/Registry/Utils/PostObject.php
@@ -261,6 +261,10 @@ class PostObject {
 
 		if ( true === $post_type_object->public ) {
 			$interfaces[] = 'UniformResourceIdentifiable';
+		}
+
+		// Only post types that are publicly queryable are previewable
+		if ( true === $post_type_object->publicly_queryable ) {
 			$interfaces[] = 'Previewable';
 		}
 

--- a/src/Registry/Utils/PostObject.php
+++ b/src/Registry/Utils/PostObject.php
@@ -137,6 +137,7 @@ class PostObject {
 				'toType'             => $post_type_object->graphql_single_name,
 				'connectionTypeName' => ucfirst( $post_type_object->graphql_single_name ) . 'ToPreviewConnection',
 				'oneToOne'           => true,
+				'deprecationReason'   => ! $post_type_object->publicly_queryable ? sprintf( __( 'The "%s" Type is not publicly queryable and does not support previews. This field will be removed in the future.', 'wp-graphql' ), WPGraphQL\Utils\Utils::format_type_name( $post_type_object->graphql_single_name ) ) : null,
 				'resolve'            => function ( Post $post, $args, AppContext $context, ResolveInfo $info ) {
 					if ( $post->isRevision ) {
 						return null;
@@ -263,7 +264,7 @@ class PostObject {
 			$interfaces[] = 'UniformResourceIdentifiable';
 		}
 
-		// Only post types that are publicly queryable are previewable
+		// Only post types that are publicly_queryable are previewable
 		if ( true === $post_type_object->publicly_queryable ) {
 			$interfaces[] = 'Previewable';
 		}


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This deprecates the `$postType.preview` connection for post types that are not publicly queryable, and limits the (not yet released) `Previewable` Interface to just `publicly_queryable` post types. 

Does this close any currently open issues?
------------------------------------------
closes #2621 