### PR TITLE
fix: mutations being added to the schema without enforcing lowercase first letter

### DIFF
--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -889,8 +889,10 @@ class TypeRegistry {
 	protected function prepare_field( $field_name, $field_config, $type_name ) {
 
 		if ( ! isset( $field_config['name'] ) ) {
-			$field_config['name'] = lcfirst( $field_name );
+			$field_config['name'] = $field_name;
 		}
+
+		$field_config['name'] = Utils::format_field_name( $field_config['name'] );
 
 		if ( ! isset( $field_config['type'] ) ) {
 			graphql_debug( sprintf( __( 'The registered field \'%s\' does not have a Type defined. Make sure to define a type for all fields.', 'wp-graphql' ), $field_name ), [

--- a/src/Type/WPMutationType.php
+++ b/src/Type/WPMutationType.php
@@ -293,7 +293,7 @@ class WPMutationType {
 	protected function register_mutation_field() : void {
 		$this->type_registry->register_field(
 			'rootMutation',
-			Utils::format_field_name( $this->mutation_name ),
+			$this->mutation_name,
 			array_merge( $this->config,
 				[
 					'args'        => [
@@ -308,7 +308,6 @@ class WPMutationType {
 					'isPrivate'   => $this->is_private,
 					'type'        => $this->mutation_name . 'Payload',
 					'resolve'     => $this->resolve_mutation,
-					'name'        => Utils::format_field_name( $this->mutation_name ),
 				]
 			)
 		);

--- a/src/Type/WPMutationType.php
+++ b/src/Type/WPMutationType.php
@@ -7,6 +7,7 @@ use GraphQL\Exception\InvalidArgument;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
 use WPGraphQL\Registry\TypeRegistry;
+use WPGraphQL\Utils\Utils;
 
 /**
  * Class WPMutationType
@@ -292,7 +293,7 @@ class WPMutationType {
 	protected function register_mutation_field() : void {
 		$this->type_registry->register_field(
 			'rootMutation',
-			lcfirst( $this->mutation_name ),
+			Utils::format_field_name( $this->mutation_name ),
 			array_merge( $this->config,
 				[
 					'args'        => [
@@ -307,6 +308,7 @@ class WPMutationType {
 					'isPrivate'   => $this->is_private,
 					'type'        => $this->mutation_name . 'Payload',
 					'resolve'     => $this->resolve_mutation,
+					'name'        => Utils::format_field_name( $this->mutation_name ),
 				]
 			)
 		);

--- a/tests/wpunit/AccessFunctionsTest.php
+++ b/tests/wpunit/AccessFunctionsTest.php
@@ -1505,4 +1505,39 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 	}
 
+	public function testRegisterMutationWithUppercaseFirstAddsToSchemaWithLcFirst() {
+
+		register_graphql_mutation( 'CreateSomething', [
+			'inputFields' => [ 'test' => [ 'type' => 'String' ] ],
+			'outputFields' => [ 'test' => [ 'type' => 'String' ] ],
+			'mutateAndGetPayload' => function( $input ) {
+				return [ 'test' => $input['test'] ];
+			}
+		] );
+
+		$query = '
+		mutation CreateSomething($test: String) {
+			createSomething(input:{ test: $test }) {
+				test
+			}
+		}
+		';
+
+		$test_input = uniqid( 'wpgraphql', true );
+
+		$actual = $this->graphql([
+			'query' => $query,
+			'variables' => [
+				'test' => $test_input
+			]
+		]);
+
+		codecept_debug( $actual );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+
+		$this->assertSame( $test_input, $actual['data']['createSomething']['test'] );
+
+	}
+
 }

--- a/tests/wpunit/AccessFunctionsTest.php
+++ b/tests/wpunit/AccessFunctionsTest.php
@@ -1540,4 +1540,62 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 	}
 
+	public function testRegisterFieldWithUppercaseNameIsAddedToSchemaWithLcFirst() {
+
+		$expected = uniqid( 'gql', true );
+
+		register_graphql_field( 'RootQuery', 'UppercaseField', [
+			'type' => 'String',
+			'resolve' => function() use ( $expected ) {
+				return $expected;
+			}
+		]);
+
+		$query = '
+		query {
+		  uppercaseField
+		}
+		';
+
+
+		$actual = $this->graphql([
+			'query' => $query
+		]);
+
+		codecept_debug( $actual );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertSame( $expected, $actual['data']['uppercaseField'] );
+
+	}
+
+	public function testRegisterFieldWithUnderscoreIsAddedAsFormattedField() {
+
+		$expected = uniqid( 'gql', true );
+
+		register_graphql_field( 'RootQuery', 'field_with_underscore', [
+			'type' => 'String',
+			'resolve' => function() use ( $expected ) {
+				return $expected;
+			}
+		]);
+
+		$query = '
+		query {
+		  fieldWithUnderscore
+		}
+		';
+
+
+		$actual = $this->graphql([
+			'query' => $query
+		]);
+
+		codecept_debug( $actual );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertSame( $expected, $actual['data']['fieldWithUnderscore'] );
+
+	}
+
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

This fixes a regression where registering a mutation with an uppercase first letter is added to the schema as a field with an uppercase first letter instead of being transformed to a lowercase-first letter.

- Failing Test: https://github.com/wp-graphql/wp-graphql/actions/runs/3568456806/jobs/5997350686#step:7:752
- Passing Test: https://github.com/wp-graphql/wp-graphql/actions/runs/3568686398/jobs/5997835419

Does this close any currently open issues?
------------------------------------------
closes #2624 
