### PR TITLE
release: v1.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
 
-# 1.13.0
+## 1.13.1
 
-## Possible Breaking Change for some users
+### Chores / Bugfixes
+
+- ([#2625](https://github.com/wp-graphql/wp-graphql/pull/2625)): fix: Fixes a regression to v1.13.0 where mutations registered with an uppercase first letter weren't properly being transformed to a lowercase first letter when the field is added to the Schema.
+
+## 1.13.0
+
+### Possible Breaking Change for some users
 
 The work to introduce the `Connection` and `Edge` (and other) Interfaces required the `User.revisions` and `RootQuery.revisions` connection to 
 change from resolving to the `ContentRevisionUnion` type and instead resolve to the `ContentNode` type. 
@@ -21,7 +27,7 @@ Would need to be updated to reference these types instead:
 
 For example:
 
-### BEFORE
+#### BEFORE
 
 ```graphql
 {
@@ -64,7 +70,7 @@ For example:
 }
 ```
 
-### AFTER
+#### AFTER
 
 ```graphql
 {
@@ -107,14 +113,14 @@ For example:
 }
 ```
 
-## New Features
+### New Features
 
 - ([#2617](https://github.com/wp-graphql/wp-graphql/pull/2617): feat: Introduce Connection, Edge and other common Interfaces. 
 - ([#2563](https://github.com/wp-graphql/wp-graphql/pull/2563): feat: refactor mutation registration to use new `WPMutationType`. Thanks @justlevine!
 - ([#2557](https://github.com/wp-graphql/wp-graphql/pull/2557): feat: add `deregister_graphql_type()` access function and corresponding `graphql_excluded_types` filter. Thanks @justlevine!
 - ([#2546](https://github.com/wp-graphql/wp-graphql/pull/2546): feat: Add new `register_graphql_edge_fields()` and `register_graphql_connection_where_args()` access functions. Thanks @justlevine!
 
-## Chores / Bugfixes
+### Chores / Bugfixes
 
 - ([#2622](https://github.com/wp-graphql/wp-graphql/pull/2622): fix: deprecate the `previews` field for non-publicly queryable post types, and limit the `Previewable` Interface to publicly queryable post types.
 - ([#2614](https://github.com/wp-graphql/wp-graphql/pull/2614): chore(deps): bump loader-utils from 2.0.3 to 2.0.4.

--- a/readme.txt
+++ b/readme.txt
@@ -232,6 +232,13 @@ Composer dependencies are no longer versioned in Github. Recommended install sou
 
 == Changelog ==
 
+= 1.13.1 =
+
+**Chores / Bugfixes**
+
+- ([#2625](https://github.com/wp-graphql/wp-graphql/pull/2625)): fix: Fixes a regression to v1.13.0 where mutations registered with an uppercase first letter weren't properly being transformed to a lowercase first letter when the field is added to the Schema.
+
+
 = 1.13.0 =
 
 **Possible Breaking Change for some users**

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -889,8 +889,10 @@ class TypeRegistry {
 	protected function prepare_field( $field_name, $field_config, $type_name ) {
 
 		if ( ! isset( $field_config['name'] ) ) {
-			$field_config['name'] = lcfirst( $field_name );
+			$field_config['name'] = $field_name;
 		}
+
+		$field_config['name'] = Utils::format_field_name( $field_config['name'] );
 
 		if ( ! isset( $field_config['type'] ) ) {
 			graphql_debug( sprintf( __( 'The registered field \'%s\' does not have a Type defined. Make sure to define a type for all fields.', 'wp-graphql' ), $field_name ), [

--- a/src/Type/WPMutationType.php
+++ b/src/Type/WPMutationType.php
@@ -7,6 +7,7 @@ use GraphQL\Exception\InvalidArgument;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
 use WPGraphQL\Registry\TypeRegistry;
+use WPGraphQL\Utils\Utils;
 
 /**
  * Class WPMutationType
@@ -292,7 +293,7 @@ class WPMutationType {
 	protected function register_mutation_field() : void {
 		$this->type_registry->register_field(
 			'rootMutation',
-			lcfirst( $this->mutation_name ),
+			$this->mutation_name,
 			array_merge( $this->config,
 				[
 					'args'        => [

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -130,7 +130,7 @@ final class WPGraphQL {
 
 		// Plugin version.
 		if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-			define( 'WPGRAPHQL_VERSION', '1.13.0' );
+			define( 'WPGRAPHQL_VERSION', '1.13.1' );
 		}
 
 		// Plugin Folder Path.

--- a/tests/wpunit/AccessFunctionsTest.php
+++ b/tests/wpunit/AccessFunctionsTest.php
@@ -1505,4 +1505,97 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 	}
 
+	public function testRegisterMutationWithUppercaseFirstAddsToSchemaWithLcFirst() {
+
+		register_graphql_mutation( 'CreateSomething', [
+			'inputFields' => [ 'test' => [ 'type' => 'String' ] ],
+			'outputFields' => [ 'test' => [ 'type' => 'String' ] ],
+			'mutateAndGetPayload' => function( $input ) {
+				return [ 'test' => $input['test'] ];
+			}
+		] );
+
+		$query = '
+		mutation CreateSomething($test: String) {
+			createSomething(input:{ test: $test }) {
+				test
+			}
+		}
+		';
+
+		$test_input = uniqid( 'wpgraphql', true );
+
+		$actual = $this->graphql([
+			'query' => $query,
+			'variables' => [
+				'test' => $test_input
+			]
+		]);
+
+		codecept_debug( $actual );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+
+		$this->assertSame( $test_input, $actual['data']['createSomething']['test'] );
+
+	}
+
+	public function testRegisterFieldWithUppercaseNameIsAddedToSchemaWithLcFirst() {
+
+		$expected = uniqid( 'gql', true );
+
+		register_graphql_field( 'RootQuery', 'UppercaseField', [
+			'type' => 'String',
+			'resolve' => function() use ( $expected ) {
+				return $expected;
+			}
+		]);
+
+		$query = '
+		query {
+		  uppercaseField
+		}
+		';
+
+
+		$actual = $this->graphql([
+			'query' => $query
+		]);
+
+		codecept_debug( $actual );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertSame( $expected, $actual['data']['uppercaseField'] );
+
+	}
+
+	public function testRegisterFieldWithUnderscoreIsAddedAsFormattedField() {
+
+		$expected = uniqid( 'gql', true );
+
+		register_graphql_field( 'RootQuery', 'field_with_underscore', [
+			'type' => 'String',
+			'resolve' => function() use ( $expected ) {
+				return $expected;
+			}
+		]);
+
+		$query = '
+		query {
+		  fieldWithUnderscore
+		}
+		';
+
+
+		$actual = $this->graphql([
+			'query' => $query
+		]);
+
+		codecept_debug( $actual );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertSame( $expected, $actual['data']['fieldWithUnderscore'] );
+
+	}
+
 }

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.13.0
+ * Version: 1.13.1
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.13.0
+ * @version  1.13.1
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
# Release Notes

## Chores / Bugfixes

- ([#2625](https://github.com/wp-graphql/wp-graphql/pull/2625)): fix: Fixes a regression of v1.13.0 where mutations registered with an uppercase first letter weren't properly being transformed to a lowercase first letter when the field is added to the Schema.

