### PR TITLE
fix: removed connection classes as deprecated wrappers (regression)

### DIFF
--- a/src/Connection/Comments.php
+++ b/src/Connection/Comments.php
@@ -9,30 +9,30 @@ class Comments extends \WPGraphQL\Type\Connection\Comments {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @deprecated @todo
+	 * @deprecated 1.13.0
 	 */
 	public static function register_connections() {
-		_deprecated_function( __METHOD__, '@todo', '\WPGraphQL\Type\Connection\Comments::register_connections' );
+		_deprecated_function( __METHOD__, '1.13.0', '\WPGraphQL\Type\Connection\Comments::register_connections' );
 		parent::register_connections();
 	}
 
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @deprecated @todo
+	 * @deprecated 1.13.0
 	 */
 	public static function get_connection_config( $args = [] ) {
-		_deprecated_function( __METHOD__, '@todo', '\WPGraphQL\Type\Connection\Comments::get_connection_config' );
+		_deprecated_function( __METHOD__, '1.13.0', '\WPGraphQL\Type\Connection\Comments::get_connection_config' );
 		return parent::get_connection_config( $args );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @deprecated @todo
+	 * @deprecated 1.13.0
 	 */
 	public static function get_connection_args() {
-		_deprecated_function( __METHOD__, '@todo', '\WPGraphQL\Type\Connection\Comments::get_connection_args' );
+		_deprecated_function( __METHOD__, '1.13.0', '\WPGraphQL\Type\Connection\Comments::get_connection_args' );
 		return parent::get_connection_args();
 	}
 }

--- a/src/Connection/Comments.php
+++ b/src/Connection/Comments.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace WPGraphQL\Connection;
+
+/**
+ * Deprecated class for backwards compatibility.
+ */
+class Comments extends \WPGraphQL\Type\Connection\Comments {
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @deprecated @todo
+	 */
+	public static function register_connections() {
+		_deprecated_function( __METHOD__, '@todo', '\WPGraphQL\Type\Connection\Comments::register_connections' );
+		parent::register_connections();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @deprecated @todo
+	 */
+	public static function get_connection_config( $args = [] ) {
+		_deprecated_function( __METHOD__, '@todo', '\WPGraphQL\Type\Connection\Comments::get_connection_config' );
+		return parent::get_connection_config( $args );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @deprecated @todo
+	 */
+	public static function get_connection_args() {
+		_deprecated_function( __METHOD__, '@todo', '\WPGraphQL\Type\Connection\Comments::get_connection_args' );
+		return parent::get_connection_args();
+	}
+}

--- a/src/Connection/MenuItems.php
+++ b/src/Connection/MenuItems.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace WPGraphQL\Connection;
+
+/**
+ * Deprecated class for backwards compatibility.
+ */
+class MenuItems extends \WPGraphQL\Type\Connection\MenuItems {
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @deprecated @todo
+	 */
+	public static function register_connections() {
+		_deprecated_function( __METHOD__, '@todo', '\WPGraphQL\Type\Connection\MenuItems::register_connections' );
+		parent::register_connections();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @deprecated @todo
+	 */
+	public static function get_connection_config( $args = [] ) {
+		_deprecated_function( __METHOD__, '@todo', '\WPGraphQL\Type\Connection\MenuItems::get_connection_config' );
+		return parent::get_connection_config( $args );
+	}
+
+}

--- a/src/Connection/MenuItems.php
+++ b/src/Connection/MenuItems.php
@@ -9,20 +9,20 @@ class MenuItems extends \WPGraphQL\Type\Connection\MenuItems {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @deprecated @todo
+	 * @deprecated 1.13.0
 	 */
 	public static function register_connections() {
-		_deprecated_function( __METHOD__, '@todo', '\WPGraphQL\Type\Connection\MenuItems::register_connections' );
+		_deprecated_function( __METHOD__, '1.13.0', '\WPGraphQL\Type\Connection\MenuItems::register_connections' );
 		parent::register_connections();
 	}
 
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @deprecated @todo
+	 * @deprecated 1.13.0
 	 */
 	public static function get_connection_config( $args = [] ) {
-		_deprecated_function( __METHOD__, '@todo', '\WPGraphQL\Type\Connection\MenuItems::get_connection_config' );
+		_deprecated_function( __METHOD__, '1.13.0', '\WPGraphQL\Type\Connection\MenuItems::get_connection_config' );
 		return parent::get_connection_config( $args );
 	}
 

--- a/src/Connection/PostObjects.php
+++ b/src/Connection/PostObjects.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace WPGraphQL\Connection;
+
+/**
+ * Deprecated class for backwards compatibility.
+ */
+class PostObjects extends \WPGraphQL\Type\Connection\PostObjects {
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @deprecated @todo
+	 */
+	public static function register_connections() {
+		_deprecated_function( __METHOD__, '@todo', '\WPGraphQL\Type\Connection\PostObjects::register_connections' );
+		parent::register_connections();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @deprecated @todo
+	 */
+	public static function get_connection_config( $graphql_object, $args = [] ) {
+		_deprecated_function( __METHOD__, '@todo', '\WPGraphQL\Type\Connection\PostObjects::get_connection_config' );
+		return parent::get_connection_config( $graphql_object, $args );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @deprecated @todo
+	 */
+	public static function get_connection_args( $args = [], $post_type_object = null ) {
+		_deprecated_function( __METHOD__, '@todo', '\WPGraphQL\Type\Connection\PostObjects::get_connection_args' );
+		return parent::get_connection_args( $args, $post_type_object );
+	}
+
+}

--- a/src/Connection/PostObjects.php
+++ b/src/Connection/PostObjects.php
@@ -9,30 +9,30 @@ class PostObjects extends \WPGraphQL\Type\Connection\PostObjects {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @deprecated @todo
+	 * @deprecated 1.13.0
 	 */
 	public static function register_connections() {
-		_deprecated_function( __METHOD__, '@todo', '\WPGraphQL\Type\Connection\PostObjects::register_connections' );
+		_deprecated_function( __METHOD__, '1.13.0', '\WPGraphQL\Type\Connection\PostObjects::register_connections' );
 		parent::register_connections();
 	}
 
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @deprecated @todo
+	 * @deprecated 1.13.0
 	 */
 	public static function get_connection_config( $graphql_object, $args = [] ) {
-		_deprecated_function( __METHOD__, '@todo', '\WPGraphQL\Type\Connection\PostObjects::get_connection_config' );
+		_deprecated_function( __METHOD__, '1.13.0', '\WPGraphQL\Type\Connection\PostObjects::get_connection_config' );
 		return parent::get_connection_config( $graphql_object, $args );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @deprecated @todo
+	 * @deprecated 1.13.0
 	 */
 	public static function get_connection_args( $args = [], $post_type_object = null ) {
-		_deprecated_function( __METHOD__, '@todo', '\WPGraphQL\Type\Connection\PostObjects::get_connection_args' );
+		_deprecated_function( __METHOD__, '1.13.0', '\WPGraphQL\Type\Connection\PostObjects::get_connection_args' );
 		return parent::get_connection_args( $args, $post_type_object );
 	}
 

--- a/src/Connection/Taxonomies.php
+++ b/src/Connection/Taxonomies.php
@@ -9,10 +9,10 @@ class Taxonomies extends \WPGraphQL\Type\Connection\Taxonomies {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @deprecated @todo
+	 * @deprecated 1.13.0
 	 */
 	public static function register_connections() {
-		_deprecated_function( __METHOD__, '@todo', '\WPGraphQL\Type\Connection\Taxonomies::register_connections' );
+		_deprecated_function( __METHOD__, '1.13.0', '\WPGraphQL\Type\Connection\Taxonomies::register_connections' );
 		parent::register_connections();
 	}
 }

--- a/src/Connection/Taxonomies.php
+++ b/src/Connection/Taxonomies.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace WPGraphQL\Connection;
+
+/**
+ * Deprecated class for backwards compatibility.
+ */
+class Taxonomies extends \WPGraphQL\Type\Connection\Taxonomies {
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @deprecated @todo
+	 */
+	public static function register_connections() {
+		_deprecated_function( __METHOD__, '@todo', '\WPGraphQL\Type\Connection\Taxonomies::register_connections' );
+		parent::register_connections();
+	}
+}

--- a/src/Connection/TermObjects.php
+++ b/src/Connection/TermObjects.php
@@ -9,30 +9,30 @@ class TermObjects extends \WPGraphQL\Type\Connection\TermObjects {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @deprecated @todo
+	 * @deprecated 1.13.0
 	 */
 	public static function register_connections() {
-		_deprecated_function( __METHOD__, '@todo', '\WPGraphQL\Type\Connection\TermObjects::register_connections' );
+		_deprecated_function( __METHOD__, '1.13.0', '\WPGraphQL\Type\Connection\TermObjects::register_connections' );
 		parent::register_connections();
 	}
 
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @deprecated @todo
+	 * @deprecated 1.13.0
 	 */
 	public static function get_connection_config( $tax_object, $args = [] ) {
-		_deprecated_function( __METHOD__, '@todo', '\WPGraphQL\Type\Connection\TermObjects::get_connection_config' );
+		_deprecated_function( __METHOD__, '1.13.0', '\WPGraphQL\Type\Connection\TermObjects::get_connection_config' );
 		return parent::get_connection_config( $tax_object, $args );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @deprecated @todo
+	 * @deprecated 1.13.0
 	 */
 	public static function get_connection_args( $args = [] ) {
-		_deprecated_function( __METHOD__, '@todo', '\WPGraphQL\Type\Connection\TermObjects::get_connection_args' );
+		_deprecated_function( __METHOD__, '1.13.0', '\WPGraphQL\Type\Connection\TermObjects::get_connection_args' );
 		return parent::get_connection_args( $args );
 	}
 }

--- a/src/Connection/TermObjects.php
+++ b/src/Connection/TermObjects.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace WPGraphQL\Connection;
+
+/**
+ * Deprecated class for backwards compatibility.
+ */
+class TermObjects extends \WPGraphQL\Type\Connection\TermObjects {
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @deprecated @todo
+	 */
+	public static function register_connections() {
+		_deprecated_function( __METHOD__, '@todo', '\WPGraphQL\Type\Connection\TermObjects::register_connections' );
+		parent::register_connections();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @deprecated @todo
+	 */
+	public static function get_connection_config( $tax_object, $args = [] ) {
+		_deprecated_function( __METHOD__, '@todo', '\WPGraphQL\Type\Connection\TermObjects::get_connection_config' );
+		return parent::get_connection_config( $tax_object, $args );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @deprecated @todo
+	 */
+	public static function get_connection_args( $args = [] ) {
+		_deprecated_function( __METHOD__, '@todo', '\WPGraphQL\Type\Connection\TermObjects::get_connection_args' );
+		return parent::get_connection_args( $args );
+	}
+}

--- a/src/Connection/Users.php
+++ b/src/Connection/Users.php
@@ -9,20 +9,20 @@ class Users extends \WPGraphQL\Type\Connection\Users {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @deprecated @todo
+	 * @deprecated 1.13.0
 	 */
 	public static function register_connections() {
-		_deprecated_function( __METHOD__, '@todo', '\WPGraphQL\Type\Connection\Users::register_connections' );
+		_deprecated_function( __METHOD__, '1.13.0', '\WPGraphQL\Type\Connection\Users::register_connections' );
 		parent::register_connections();
 	}
 
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @deprecated @todo
+	 * @deprecated 1.13.0
 	 */
 	public static function get_connection_args() {
-		_deprecated_function( __METHOD__, '@todo', '\WPGraphQL\Type\Connection\Users::get_connection_args' );
+		_deprecated_function( __METHOD__, '1.13.0', '\WPGraphQL\Type\Connection\Users::get_connection_args' );
 		return parent::get_connection_args();
 	}
 }

--- a/src/Connection/Users.php
+++ b/src/Connection/Users.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace WPGraphQL\Connection;
+
+/**
+ * Deprecated class for backwards compatibility.
+ */
+class Users extends \WPGraphQL\Type\Connection\Users {
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @deprecated @todo
+	 */
+	public static function register_connections() {
+		_deprecated_function( __METHOD__, '@todo', '\WPGraphQL\Type\Connection\Users::register_connections' );
+		parent::register_connections();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @deprecated @todo
+	 */
+	public static function get_connection_args() {
+		_deprecated_function( __METHOD__, '@todo', '\WPGraphQL\Type\Connection\Users::get_connection_args' );
+		return parent::get_connection_args();
+	}
+}


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR restores the `WPGraphQL\Connection` classes removed in #2617 , as backwards-compatible deprecation wrappers for the new classes.


Does this close any currently open issues?
------------------------------------------
[Slack](https://wp-graphql.slack.com/archives/CCYJRDN4A/p1669679113213969)

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
- Since the class is static, each method needs to be deprecated (vs placing one notice in the constructor in an instance class).
- Not entirely sure if this is _worth_ doing, but it was an easy-enough PR to write up.


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (WSL2 + devilbox + php 8.0.19)

**WordPress Version:** 6.1.1
