### PR TITLE
Bug/#2394 node by uri not working with woocommerce

### DIFF
--- a/src/Data/Loader/PostObjectLoader.php
+++ b/src/Data/Loader/PostObjectLoader.php
@@ -87,7 +87,7 @@ class PostObjectLoader extends AbstractDataLoader {
 		 * to the count of the keys provided. The query must also return results
 		 * in the same order the keys were provided in.
 		 */
-		$post_types = \WPGraphQL::get_allowed_post_types();
+		$post_types = get_post_types( [ 'show_in_graphql' => true ] );
 		$post_types = array_merge( $post_types, [ 'revision', 'nav_menu_item' ] );
 		$args       = [
 			'post_type'           => $post_types,

--- a/src/Data/Loader/PostTypeLoader.php
+++ b/src/Data/Loader/PostTypeLoader.php
@@ -29,7 +29,7 @@ class PostTypeLoader extends AbstractDataLoader {
 	 * @throws Exception
 	 */
 	public function loadKeys( array $keys ) {
-		$post_types = \WPGraphQL::get_allowed_post_types( 'objects' );
+		$post_types = get_post_types( [ 'show_in_graphql' => true ], 'objects' );
 
 		$loaded = [];
 		if ( ! empty( $post_types ) && is_array( $post_types ) ) {

--- a/src/Data/Loader/UserLoader.php
+++ b/src/Data/Loader/UserLoader.php
@@ -50,9 +50,10 @@ class UserLoader extends AbstractDataLoader {
 		// Get public post types that are set to show in GraphQL
 		// as public users are determined by whether they've published
 		// content in one of these post types
-		$post_types = \WPGraphQL::get_allowed_post_types( 'names', [
+		$post_types = get_post_types( [
+			'show_in_graphql' => true,
 			'public' => true,
-		] );
+		], 'names' );
 
 		/**
 		 * Exclude revisions and attachments, since neither ever receive the

--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -128,9 +128,7 @@ class NodeResolver {
 		} elseif ( isset( $this->wp->query_vars['name'] ) ) {
 
 			// Target post types with a public URI.
-			$allowed_post_types = get_post_types( [
-				'show_in_graphql' => true,
-			], 'names' );
+			$allowed_post_types = \WPGraphQL::get_allowed_post_types();
 
 			$post_type = 'post';
 			if ( isset( $this->wp->query_vars['post_type'] ) && in_array( $this->wp->query_vars['post_type'], $allowed_post_types, true ) ) {
@@ -157,9 +155,7 @@ class NodeResolver {
 
 			unset( $this->wp->query_vars['uri'] );
 
-			$post_type = isset( $this->wp->query_vars['post_type'] ) ? $this->wp->query_vars['post_type'] : get_post_types( [
-				'show_in_graphql' => true,
-			], 'names' );
+			$post_type = isset( $this->wp->query_vars['post_type'] ) ? $this->wp->query_vars['post_type'] : \WPGraphQL::get_allowed_post_types();
 
 			$post = get_page_by_path( $this->wp->query_vars['pagename'], 'OBJECT', $post_type ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.get_page_by_path_get_page_by_path
 

--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -128,7 +128,9 @@ class NodeResolver {
 		} elseif ( isset( $this->wp->query_vars['name'] ) ) {
 
 			// Target post types with a public URI.
-			$allowed_post_types = \WPGraphQL::get_allowed_post_types();
+			$allowed_post_types = get_post_types( [
+				'show_in_graphql' => true,
+			], 'names' );
 
 			$post_type = 'post';
 			if ( isset( $this->wp->query_vars['post_type'] ) && in_array( $this->wp->query_vars['post_type'], $allowed_post_types, true ) ) {
@@ -155,7 +157,9 @@ class NodeResolver {
 
 			unset( $this->wp->query_vars['uri'] );
 
-			$post_type = isset( $this->wp->query_vars['post_type'] ) ? $this->wp->query_vars['post_type'] : \WPGraphQL::get_allowed_post_types();
+			$post_type = isset( $this->wp->query_vars['post_type'] ) ? $this->wp->query_vars['post_type'] : get_post_types( [
+				'show_in_graphql' => true,
+			], 'names' );
 
 			$post = get_page_by_path( $this->wp->query_vars['pagename'], 'OBJECT', $post_type ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.get_page_by_path_get_page_by_path
 

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -373,8 +373,8 @@ class Post extends Model {
 		 * If the post_type isn't (not registered) or is not allowed in WPGraphQL,
 		 * mark the post as private
 		 */
-
-		if ( empty( $post_type_object->name ) || ! in_array( $post_type_object->name, \WPGraphQL::get_allowed_post_types(), true ) ) {
+		$post_types = get_post_types( [ 'show_in_graphql' => true ], 'names' );
+		if ( empty( $post_type_object->name ) || ! in_array( $post_type_object->name, $post_types, true ) ) {
 			return true;
 		}
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

This fixes a bug where the `NodeByUri` queries weren't properly working with the WPGraphQL for WooCommerce plugin. 

The WooCommerce plugin makes use of the `graphql_post_entities_allowed_post_types ` filter to prevent certain Types from being registered to the Schema so that it can register them differently. 

However, those Types still need to be resolved, and the use of the filter was causing those Types to not be resolvable. 

**FAILING TEST:** https://github.com/wp-graphql/wp-graphql/actions/runs/3579069808/jobs/6019868327#step:7:356
**PASSING TEST:**

Does this close any currently open issues?
------------------------------------------
closes #2394 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

### Before

Null results returned when querying a product by URI

![CleanShot 2022-11-29 at 16 59 48](https://user-images.githubusercontent.com/1260765/204674979-7fc66489-2ec5-4fcd-9070-cac32180d94e.png)



### After

The product is returned when querying by URI

![CleanShot 2022-11-29 at 17 00 21](https://user-images.githubusercontent.com/1260765/204674974-4d53b671-7fc9-437b-8f73-534fc726eb90.png)


Any other comments?
-------------------
I think we might need to explore 2 methods for `WPGraphQL::get_allowed_post_types()`

I think there should be a way to determine what post types should be auto-registered to the Schema and what post types should be resolve-able. 

The problem we're facing here is that we assume they're the same. 

In the Schema generation side, I've left the use of `WPGraphQL::get_allowed_post_types()`, but in the resolver side I moved back to calling `get_post_types( [ 'show_in_graphql' => true ]);` instead. 

In the case of WooCommerce, the type `Product` should still be allowed to resolve, even if it's prevented from automatically registering in the Schema. 

I think some of the work we've done with adding post_type/taxonomy args for `graphql_kind`, etc should also help here too, so WooCommerce wouldn't need to filter the `graphql_post_entities_allowed_post_types`, but that'll take some time to implement on the WooGraphQL side.

