### PR TITLE
fix(resolver): check if `name` is an array

### DIFF
--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -134,6 +134,10 @@ class NodeResolver {
 			if ( isset( $this->wp->query_vars['post_type'] ) && in_array( $this->wp->query_vars['post_type'], $allowed_post_types, true ) ) {
 				$post_type = $this->wp->query_vars['post_type'];
 			}
+			
+			if ( is_array( $this->wp->query_vars['name'] ) ) {
+				$this->wp->query_vars['name'] = implode( $this->wp->query_vars['name'] );
+			}
 
 			$post = get_page_by_path( $this->wp->query_vars['name'], 'OBJECT', $post_type ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.get_page_by_path_get_page_by_path
 

--- a/tests/wpunit/PageByUriTest.php
+++ b/tests/wpunit/PageByUriTest.php
@@ -111,4 +111,27 @@ class PageByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 	}
 
+		public function testQueryPageForPostsByUriNameWithArrayReturnsNull() {
+
+		$query = '
+		query GetPageByUri($id:ID!) {
+			page(id: $id, idType: URI) {
+				__typename
+			}
+		}
+		';
+
+		$actual = $this->graphql([
+			'query' => $query,
+			'variables' => [
+				'id' => '/non-existent-page?name[]=example',
+			]
+		]);
+
+		$this->assertQuerySuccessful( $actual, [
+			$this->expectedField( 'page', self::IS_NULL ),
+		]);
+
+	}
+
 }


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------

This is a fairly big edge case but we're using WPGraphQL with Next.js. Our application replaces a bunch of different CMS and as a result there are backlinks from other sites to legacy URLs. Most of those result in successful 404's which we can handle on the frontend however we noticed one edge case with an old URL which has the following URL pattern:

`/api/getServices?name[]=<slug>`

Essentially any request that has `?name=[]` will end up hitting this issue.

Currently this causes an error for us and we'd prefer if it just returned a `null` value for the page without an Internal server error.


Does this close any currently open issues?
------------------------------------------

No. 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

Before:

<img width="2260" alt="before" src="https://user-images.githubusercontent.com/1377956/204948459-ac0d9727-14b6-44c4-9416-e4a03a2c2383.png">

After:

<img width="2260" alt="after" src="https://user-images.githubusercontent.com/1377956/204948587-27b160da-bcfb-48ed-b0f7-e6e5de44ad4e.png">



Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:**
* Ubuntu Jammy Jellyfish

**WordPress Version:**

* 6.1.1
