### PR TITLE
fix: regression where fields on an object type are forced to be camelCase (snake_case) should still be allowed

### DIFF
--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -875,7 +875,7 @@ class TypeRegistry {
 			$field_config['name'] = $field_name;
 		}
 
-		$field_config['name'] = Utils::format_field_name( $field_config['name'] );
+		$field_config['name'] = lcfirst( $field_config['name'] );
 
 		if ( ! isset( $field_config['type'] ) ) {
 			graphql_debug( sprintf( __( 'The registered field \'%s\' does not have a Type defined. Make sure to define a type for all fields.', 'wp-graphql' ), $field_name ), [

--- a/tests/wpunit/AccessFunctionsTest.php
+++ b/tests/wpunit/AccessFunctionsTest.php
@@ -1598,4 +1598,48 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 	}
 
+	public function testRegisterObjectTypeWithFieldWithUnderscoreIsAddedAsFormattedField() {
+
+		$expected = uniqid( 'gql', true );
+
+		register_graphql_object_type( 'TestType', [
+			'fields' => [
+				'field_with_underscore' => [
+					'type' => 'String',
+					'resolve' => function() use ( $expected ) {
+						return $expected;
+					}
+				]
+			]
+		]);
+
+		register_graphql_field( 'RootQuery', 'testField', [
+			'type' => 'TestType',
+			'resolve' => function() {
+				return true;
+			}
+		]);
+
+
+
+		$query = '
+		query {
+		  testField {
+		    field_with_underscore
+		  }
+		}
+		';
+
+
+		$actual = $this->graphql([
+			'query' => $query
+		]);
+
+		codecept_debug( $actual );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertSame( $expected, $actual['data']['testField']['field_with_underscore'] );
+
+	}
+
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This fixes a regression which was causing fields registered with an underscore to be forcibly rewritten to camelCase instead of snake_case. 

While `camelCase` is the "preferred" casing, `snake_case` fields are allowed.

- **FAILING TEST:** https://github.com/wp-graphql/wp-graphql/actions/runs/3595866875/jobs/6055873341#step:7:104
- **PASSING TEST:** https://github.com/wp-graphql/wp-graphql/actions/runs/3595869832/jobs/6055878158#step:7:103

Does this close any currently open issues?
------------------------------------------
closes #2641


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

Given the following snippet:

```php
<?php

register_graphql_object_type( 'TestType', [
  'fields' => [
    'field_with_underscore' => [
      'type' => 'String',
      'resolve' => function() use ( $expected ) {
        return $expected;
      }
    ]
  ]
]);

register_graphql_field( 'RootQuery', 'testField', [
  'type' => 'TestType',
    'resolve' => function() {
      return true;
    }
]);
```

**PRE-REGRESSION BEHAVIOR**

![CleanShot 2022-12-01 at 12 24 57](https://user-images.githubusercontent.com/1260765/205141759-dfd2a15d-8184-4da4-932c-a9af3151b74b.png)


**CURRENT BEHAVIOR**

![CleanShot 2022-12-01 at 12 24 23](https://user-images.githubusercontent.com/1260765/205141663-f63e8d8b-81ec-42d2-93a4-bb33f30ee2cd.png)


**AFTER PR**

![CleanShot 2022-12-01 at 12 24 57](https://user-images.githubusercontent.com/1260765/205141759-dfd2a15d-8184-4da4-932c-a9af3151b74b.png)

Any other comments?
-------------------

This regression was [introduced in v1.13.1](https://github.com/wp-graphql/wp-graphql/compare/v1.13.0...v1.13.1#diff-fea80346fad1aa40b8c8872a4d3a8f73a343b677fe4e8410e1224fcfb502a1a5R895)