### PR TITLE
fix: properly register node field on $toType . ConnectionEdge interfaces

### DIFF
--- a/src/Type/WPConnectionType.php
+++ b/src/Type/WPConnectionType.php
@@ -499,10 +499,12 @@ class WPConnectionType {
 
 			$this->type_registry->register_interface_type( $this->to_type . 'ConnectionEdge', [
 				'interfaces'  => [ 'Edge' ],
-				'description' => sprintf( __( 'Edge between a Node and a connected Comment', 'wp-graphql' ), $this->to_type ),
+				'description' => sprintf( __( 'Edge between a Node and a connected %s', 'wp-graphql' ), $this->to_type ),
 				'fields'      => [
-					'type'        => [ 'non_null' => $this->to_type ],
-					'description' => sprintf( __( 'The connected %s Node', 'wp-graphql' ), $this->to_type ),
+					'node' => [
+						'type'        => [ 'non_null' => $this->to_type ],
+						'description' => sprintf( __( 'The connected %s Node', 'wp-graphql' ), $this->to_type ),
+					],
 				],
 			] );
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
The `$toType . ConnectionEdge` Interfaces are being registered without properly defining the `node` field. 

This fixes the `node` field definition.


Does this close any currently open issues?
------------------------------------------
closes #2646 
