### PR TITLE
release: v1.13.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.13.5
+
+### Chores / Bugfixes
+
+- ([#2647](https://github.com/wp-graphql/wp-graphql/pull/2647)): fix: properly register the node field on ConnectionEdge interfaces
+- ([#2645](https://github.com/wp-graphql/wp-graphql/pull/2645)): fix: regression where fields of an object type were forced to be camelCase. This allows snake_case fields again.
+
 ## 1.13.4
 
 ### Chores / Bugfixes

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, API, Gatsby, Headless, Decoupled, React, Nextjs, Vue, Apollo, RES
 Requires at least: 5.0
 Tested up to: 6.1
 Requires PHP: 7.1
-Stable tag: 1.13.4
+Stable tag: 1.13.5
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -231,6 +231,14 @@ The `uri` field was non-null on some Types in the Schema but has been changed to
 Composer dependencies are no longer versioned in Github. Recommended install source is WordPress.org or using Composer to get the code from Packagist.org or WPackagist.org.
 
 == Changelog ==
+
+= 1.13.5 =
+
+**Chores / Bugfixes**
+
+- ([#2647](https://github.com/wp-graphql/wp-graphql/pull/2647)): fix: properly register the node field on ConnectionEdge interfaces
+- ([#2645](https://github.com/wp-graphql/wp-graphql/pull/2645)): fix: regression where fields of an object type were forced to be camelCase. This allows snake_case fields again.
+
 
 = 1.13.4 =
 

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -875,7 +875,7 @@ class TypeRegistry {
 			$field_config['name'] = $field_name;
 		}
 
-		$field_config['name'] = Utils::format_field_name( $field_config['name'] );
+		$field_config['name'] = lcfirst( $field_config['name'] );
 
 		if ( ! isset( $field_config['type'] ) ) {
 			graphql_debug( sprintf( __( 'The registered field \'%s\' does not have a Type defined. Make sure to define a type for all fields.', 'wp-graphql' ), $field_name ), [

--- a/src/Type/WPConnectionType.php
+++ b/src/Type/WPConnectionType.php
@@ -499,10 +499,12 @@ class WPConnectionType {
 
 			$this->type_registry->register_interface_type( $this->to_type . 'ConnectionEdge', [
 				'interfaces'  => [ 'Edge' ],
-				'description' => sprintf( __( 'Edge between a Node and a connected Comment', 'wp-graphql' ), $this->to_type ),
+				'description' => sprintf( __( 'Edge between a Node and a connected %s', 'wp-graphql' ), $this->to_type ),
 				'fields'      => [
-					'type'        => [ 'non_null' => $this->to_type ],
-					'description' => sprintf( __( 'The connected %s Node', 'wp-graphql' ), $this->to_type ),
+					'node' => [
+						'type'        => [ 'non_null' => $this->to_type ],
+						'description' => sprintf( __( 'The connected %s Node', 'wp-graphql' ), $this->to_type ),
+					],
 				],
 			] );
 

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -130,7 +130,7 @@ final class WPGraphQL {
 
 		// Plugin version.
 		if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-			define( 'WPGRAPHQL_VERSION', '1.13.4' );
+			define( 'WPGRAPHQL_VERSION', '1.13.5' );
 		}
 
 		// Plugin Folder Path.

--- a/tests/wpunit/AccessFunctionsTest.php
+++ b/tests/wpunit/AccessFunctionsTest.php
@@ -1598,4 +1598,48 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 	}
 
+	public function testRegisterObjectTypeWithFieldWithUnderscoreIsAddedAsFormattedField() {
+
+		$expected = uniqid( 'gql', true );
+
+		register_graphql_object_type( 'TestType', [
+			'fields' => [
+				'field_with_underscore' => [
+					'type' => 'String',
+					'resolve' => function() use ( $expected ) {
+						return $expected;
+					}
+				]
+			]
+		]);
+
+		register_graphql_field( 'RootQuery', 'testField', [
+			'type' => 'TestType',
+			'resolve' => function() {
+				return true;
+			}
+		]);
+
+
+
+		$query = '
+		query {
+		  testField {
+		    field_with_underscore
+		  }
+		}
+		';
+
+
+		$actual = $this->graphql([
+			'query' => $query
+		]);
+
+		codecept_debug( $actual );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertSame( $expected, $actual['data']['testField']['field_with_underscore'] );
+
+	}
+
 }

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.13.4
+ * Version: 1.13.5
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.13.4
+ * @version  1.13.5
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
# Release Notes

## Chores / Bugfixes

- ([#2647](https://github.com/wp-graphql/wp-graphql/pull/2647)): fix: properly register the node field on ConnectionEdge interfaces
- ([#2645](https://github.com/wp-graphql/wp-graphql/pull/2645)): fix: regression where fields of an object type were forced to be camelCase. This allows snake_case fields again.
