### PR TITLE
feat: `original_args` parameter added to `graphql_post_object_connection_args` hook

### DIFF
--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -168,14 +168,11 @@ abstract class AbstractConnectionResolver {
 		 *
 		 * @param array                      $args                The GraphQL args passed to the resolver.
 		 * @param AbstractConnectionResolver $connection_resolver Instance of the ConnectionResolver.
-		 * @param mixed                      $source              Source passed down from the resolve tree.
-		 * @param array                      $all_args            Array of arguments input in the field as part of the GraphQL query.
-		 * @param AppContext                 $context             Object containing app context that gets passed down the resolve tree.
-		 * @param ResolveInfo                $info                Info about fields passed down the resolve tree.
+		 * @param array                      $unfiltered_args     Array of arguments input in the field as part of the GraphQL query.
 		 *
 		 * @since 1.11.0
 		 */
-		$this->args = apply_filters( 'graphql_connection_args', $this->get_args(), $this, $this->source, $this->args, $this->context, $this->info );
+		$this->args = apply_filters( 'graphql_connection_args', $this->get_args(), $this, $args );
 
 		/**
 		 * Determine the query amount for the resolver.

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -167,11 +167,15 @@ abstract class AbstractConnectionResolver {
 		 * Filters the GraphQL args before they are used in get_query_args().
 		 *
 		 * @param array                      $args                The GraphQL args passed to the resolver.
-		 * @param AbstractConnectionResolver $connection_resolver Instance of the ConnectionResolver
+		 * @param AbstractConnectionResolver $connection_resolver Instance of the ConnectionResolver.
+		 * @param mixed                      $source              Source passed down from the resolve tree.
+		 * @param array                      $all_args            Array of arguments input in the field as part of the GraphQL query.
+		 * @param AppContext                 $context             Object containing app context that gets passed down the resolve tree.
+		 * @param ResolveInfo                $info                Info about fields passed down the resolve tree.
 		 *
 		 * @since 1.11.0
 		 */
-		$this->args = apply_filters( 'graphql_connection_args', $this->get_args(), $this );
+		$this->args = apply_filters( 'graphql_connection_args', $this->get_args(), $this, $this->source, $this->args, $this->context, $this->info );
 
 		/**
 		 * Determine the query amount for the resolver.
@@ -191,11 +195,15 @@ abstract class AbstractConnectionResolver {
 		 *
 		 * Filters the args
 		 *
-		 * @param array                      $query_args                   The query args to be used with the executable query to get data.
-		 *                                                                 This should take in the GraphQL args and return args for use in fetching the data.
-		 * @param AbstractConnectionResolver $connection_resolver          Instance of the ConnectionResolver
+		 * @param array                      $query_args          The query args to be used with the executable query to get data.
+		 *                                                        This should take in the GraphQL args and return args for use in fetching the data.
+		 * @param AbstractConnectionResolver $connection_resolver Instance of the ConnectionResolver
+		 * @param mixed                      $source              Source passed down from the resolve tree.
+		 * @param array                      $all_args            Array of arguments input in the field as part of the GraphQL query.
+		 * @param AppContext                 $context             Object containing app context that gets passed down the resolve tree.
+		 * @param ResolveInfo                $info                Info about fields passed down the resolve tree.
 		 */
-		$this->query_args = apply_filters( 'graphql_connection_query_args', $this->get_query_args(), $this );
+		$this->query_args = apply_filters( 'graphql_connection_query_args', $this->get_query_args(), $this, $this->source, $this->args, $this->context, $this->info );
 
 	}
 

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -197,7 +197,7 @@ abstract class AbstractConnectionResolver {
 		 * @param AbstractConnectionResolver $connection_resolver Instance of the ConnectionResolver
 		 * @param array                      $unfiltered_args Array of arguments input in the field as part of the GraphQL query.
 		 */
-		$this->query_args = apply_filters( 'graphql_connection_query_args', $this->get_query_args(), $this, $this->source, $this->args, $this->context, $this->info );
+		$this->query_args = apply_filters( 'graphql_connection_query_args', $this->get_query_args(), $this, $args );
 
 	}
 

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -195,10 +195,7 @@ abstract class AbstractConnectionResolver {
 		 * @param array                      $query_args          The query args to be used with the executable query to get data.
 		 *                                                        This should take in the GraphQL args and return args for use in fetching the data.
 		 * @param AbstractConnectionResolver $connection_resolver Instance of the ConnectionResolver
-		 * @param mixed                      $source              Source passed down from the resolve tree.
-		 * @param array                      $all_args            Array of arguments input in the field as part of the GraphQL query.
-		 * @param AppContext                 $context             Object containing app context that gets passed down the resolve tree.
-		 * @param ResolveInfo                $info                Info about fields passed down the resolve tree.
+		 * @param array                      $unfiltered_args Array of arguments input in the field as part of the GraphQL query.
 		 */
 		$this->query_args = apply_filters( 'graphql_connection_query_args', $this->get_query_args(), $this, $this->source, $this->args, $this->context, $this->info );
 

--- a/src/Data/Connection/MenuItemConnectionResolver.php
+++ b/src/Data/Connection/MenuItemConnectionResolver.php
@@ -118,15 +118,12 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 		 *
 		 * Filters the GraphQL args before they are used in get_query_args().
 		 *
-		 * @param array       $args      The GraphQL args passed to the resolver.
-		 * @param mixed       $source    Source passed down from the resolve tree.
-		 * @param array       $all_args  Array of arguments input in the field as part of the GraphQL query.
-		 * @param AppContext  $context   Object containing app context that gets passed down the resolve tree.
-		 * @param ResolveInfo $info      Info about fields passed down the resolve tree.
+		 * @param array $args            The GraphQL args passed to the resolver.
+		 * @param array $unfiltered_args Array of arguments input in the field as part of the GraphQL query.
 		 *
 		 * @since 1.11.0
 		 */
-		return apply_filters( 'graphql_menu_item_connection_args', $args, $this->source, $this->args, $this->context, $this->info );
+		return apply_filters( 'graphql_menu_item_connection_args', $args, $this->args );
 	}
 
 }

--- a/src/Data/Connection/MenuItemConnectionResolver.php
+++ b/src/Data/Connection/MenuItemConnectionResolver.php
@@ -118,11 +118,15 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 		 *
 		 * Filters the GraphQL args before they are used in get_query_args().
 		 *
-		 * @param array $args The GraphQL args passed to the resolver.
+		 * @param array       $args      The GraphQL args passed to the resolver.
+		 * @param mixed       $source    Source passed down from the resolve tree.
+		 * @param array       $all_args  Array of arguments input in the field as part of the GraphQL query.
+		 * @param AppContext  $context   Object containing app context that gets passed down the resolve tree.
+		 * @param ResolveInfo $info      Info about fields passed down the resolve tree.
 		 *
 		 * @since 1.11.0
 		 */
-		return apply_filters( 'graphql_menu_item_connection_args', $args );
+		return apply_filters( 'graphql_menu_item_connection_args', $args, $this->source, $this->args, $this->context, $this->info );
 	}
 
 }

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -602,14 +602,11 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		 *
 		 * @param array                        $args                The GraphQL args passed to the resolver.
 		 * @param PostObjectConnectionResolver $connection_resolver Instance of the ConnectionResolver.
-		 * @param mixed                        $source              Source passed down from the resolve tree.
-		 * @param array                        $all_args            Array of arguments input in the field as part of the GraphQL query.
-		 * @param AppContext                   $context             Object containing app context that gets passed down the resolve tree.
-		 * @param ResolveInfo                  $info                Info about fields passed down the resolve tree.
+		 * @param array                        $unfiltered_args     Array of arguments input in the field as part of the GraphQL query.
 		 *
 		 * @since 1.11.0
 		 */
-		return apply_filters( 'graphql_post_object_connection_args', $args, $this, $this->source, $this->args, $this->context, $this->info );
+		return apply_filters( 'graphql_post_object_connection_args', $args, $this, $this->args );
 	}
 
 	/**

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -601,11 +601,12 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		 * Filters the GraphQL args before they are used in get_query_args().
 		 *
 		 * @param array                        $args                The GraphQL args passed to the resolver.
+		 * @param array                        $original_args       Unsanitized args passed to the resolver.
 		 * @param PostObjectConnectionResolver $connection_resolver Instance of the ConnectionResolver
 		 *
 		 * @since 1.11.0
 		 */
-		return apply_filters( 'graphql_post_object_connection_args', $args, $this );
+		return apply_filters( 'graphql_post_object_connection_args', $args, $this->args, $this );
 	}
 
 	/**

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -601,11 +601,11 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		 * Filters the GraphQL args before they are used in get_query_args().
 		 *
 		 * @param array                        $args                The GraphQL args passed to the resolver.
-		 * @param PostObjectConnectionResolver $connection_resolver Instance of the ConnectionResolver
-		 * @param mixed                        $source              Source passed down from the resolve tree
-		 * @param array                        $all_args            Array of arguments input in the field as part of the GraphQL query
-		 * @param AppContext                   $context             Object containing app context that gets passed down the resolve tree
-		 * @param ResolveInfo                  $info                Info about fields passed down the resolve tree
+		 * @param PostObjectConnectionResolver $connection_resolver Instance of the ConnectionResolver.
+		 * @param mixed                        $source              Source passed down from the resolve tree.
+		 * @param array                        $all_args            Array of arguments input in the field as part of the GraphQL query.
+		 * @param AppContext                   $context             Object containing app context that gets passed down the resolve tree.
+		 * @param ResolveInfo                  $info                Info about fields passed down the resolve tree.
 		 *
 		 * @since 1.11.0
 		 */

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -601,12 +601,15 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		 * Filters the GraphQL args before they are used in get_query_args().
 		 *
 		 * @param array                        $args                The GraphQL args passed to the resolver.
-		 * @param array                        $original_args       Unsanitized args passed to the resolver.
 		 * @param PostObjectConnectionResolver $connection_resolver Instance of the ConnectionResolver
+		 * @param mixed                        $source              Source passed down from the resolve tree
+		 * @param array                        $all_args            Array of arguments input in the field as part of the GraphQL query
+		 * @param AppContext                   $context             Object containing app context that gets passed down the resolve tree
+		 * @param ResolveInfo                  $info                Info about fields passed down the resolve tree
 		 *
 		 * @since 1.11.0
 		 */
-		return apply_filters( 'graphql_post_object_connection_args', $args, $this->args, $this );
+		return apply_filters( 'graphql_post_object_connection_args', $args, $this, $this->source, $this->args, $this->context, $this->info );
 	}
 
 	/**

--- a/src/Data/Connection/TermObjectConnectionResolver.php
+++ b/src/Data/Connection/TermObjectConnectionResolver.php
@@ -297,12 +297,13 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 		 *
 		 * Filters the GraphQL args before they are used in get_query_args().
 		 *
-		 * @param array                     $args                The GraphQL args passed to the resolver.
+		 * @param array                        $args                The GraphQL args passed to the resolver.
 		 * @param TermObjectConnectionResolver $connection_resolver Instance of the ConnectionResolver
+		 * @param array                        $unfiltered_args     Array of arguments input in the field as part of the GraphQL query.
 		 *
 		 * @since 1.11.0
 		 */
-		return apply_filters( 'graphql_term_object_connection_args', $args, $this );
+		return apply_filters( 'graphql_term_object_connection_args', $args, $this, $this->args );
 	}
 
 	/**


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds `original_args` parameter to hook for bypassing WP_Query argument sanitation.


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
