### PR TITLE
test: Multiple domain tests

### DIFF
--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -53,7 +53,7 @@ ENV DATA_DUMP_DIR="${PROJECT_DIR}/tests/_data"
 # Remove exec statement from base entrypoint script.
 RUN sed -i '$d' /usr/local/bin/docker-entrypoint.sh
 
-# Set up Apache
+# Set up Apache catch all name
 RUN echo 'ServerName localhost' >> /etc/apache2/apache2.conf
 
 # Custom PHP settings

--- a/docker/app.setup.sh
+++ b/docker/app.setup.sh
@@ -40,6 +40,10 @@ if ! $( wp core is-installed --allow-root ); then
 		--admin_password="${ADMIN_PASSWORD}" \
 		--admin_email="${ADMIN_EMAIL}" \
 		--allow-root
+else
+    # Set the WP url accordingly. If running the app vs running tests. Tests failing locally if already had app running, vice/versa.
+    wp --allow-root option set SITEURL "${WP_URL}"
+    wp --allow-root option set HOME "${WP_URL}"
 fi
 
 echo "Running WordPress version: $(wp core version --allow-root) at $(wp option get home --allow-root)"

--- a/tests/acceptance/TwoDomainsSupportedCest.php
+++ b/tests/acceptance/TwoDomainsSupportedCest.php
@@ -1,0 +1,26 @@
+<?php
+
+class DifferentLocalDomainsSupportedCest {
+
+	public function queryDifferentLocalDomainsTest(AcceptanceTester $I)
+    {
+		$domains = [
+			'localhost',
+			'wp.localhost',
+			'wp2.localhost',
+			'foo.bar',
+			'foo.bar.localhost'
+		];
+		foreach( $domains as $hostname ) {
+			$I->haveHttpHeader('Host', $hostname);
+			$I->sendGet('graphql', [ 'query' => '{__typename}' ] );
+			$I->seeResponseCodeIs(200);
+			$I->seeResponseContainsJson([
+				'data' => [
+					'__typename' => 'RootQuery'
+				]
+			]);
+		}
+	}
+
+}


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Add tests to verify the router changes in this [PR](https://github.com/wp-graphql/wp-graphql/pull/2182) are tested.


Does this close any currently open issues?
------------------------------------------
closes #2187 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
I tested the version of the router.php code and these tests before that change in #2182 and these tests failed.

At this point a apache <VirtualHost> entry is not needed in the docker setup because the Apache ServerName localhost acts as a catchall for requests. And the one <virttualhost> config that is in /etc/apache2/sites.enabled/000-default.conf is the catch all and routes to /var/www/html for any domain, from my understanding of how it works.

Conclusion, for now, go with this until it fails and maybe need a more specific /etc/apache2/sites-enabled/localhost.conf

Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
