### PR TITLE
ci: Use last working version of xdebug for php7

### DIFF
--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -60,9 +60,9 @@ RUN echo 'ServerName localhost' >> /etc/apache2/apache2.conf
 RUN echo "upload_max_filesize = 50M" >> /usr/local/etc/php/conf.d/custom.ini \
     ;
 
-# Install XDebug 3
-RUN echo "Installing XDebug 3 (in disabled state)" \
-    && pecl install xdebug \
+# Install XDebug 3. If PHP version 7, use last supported version
+RUN echo "Installing XDebug 3 version $XDEBUG_VERSION (in disabled state)" \
+    && if [[ $PHP_VERSION == 7* ]] ; then pecl install xdebug-3.1.5 ; else pecl install xdebug ; fi \
     && mkdir -p /usr/local/etc/php/conf.d/disabled \
     && echo "zend_extension=xdebug" > /usr/local/etc/php/conf.d/disabled/docker-php-ext-xdebug.ini \
     && echo "xdebug.mode=develop,debug,coverage" >> /usr/local/etc/php/conf.d/disabled/docker-php-ext-xdebug.ini \


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [ ] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Building images for PHP version 7 fails because xdebug library dropped support for php 7. This change makes use of the last known working version for PHP 7.*.  Leaving PHP 8 to use latest xdebug library.

This error will be seen in github tests and local develop where a docker image is built.

![Screen Shot 2022-12-08 at 2 22 14 PM](https://user-images.githubusercontent.com/749603/206562035-aba8a978-b9a9-418e-8248-4a4e92b17cb4.png)

[Drop PHP 7.3 and PHP 7.4 support](https://github.com/xdebug/xdebug/pull/849)

Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
