### PR TITLE
…

### DIFF
--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -872,10 +872,8 @@ class TypeRegistry {
 	protected function prepare_field( $field_name, $field_config, $type_name ) {
 
 		if ( ! isset( $field_config['name'] ) ) {
-			$field_config['name'] = $field_name;
+			$field_config['name'] = lcfirst( $field_name );
 		}
-
-		$field_config['name'] = lcfirst( $field_config['name'] );
 
 		if ( ! isset( $field_config['type'] ) ) {
 			graphql_debug( sprintf( __( 'The registered field \'%s\' does not have a Type defined. Make sure to define a type for all fields.', 'wp-graphql' ), $field_name ), [

--- a/src/Type/WPMutationType.php
+++ b/src/Type/WPMutationType.php
@@ -293,7 +293,7 @@ class WPMutationType {
 	protected function register_mutation_field() : void {
 		$this->type_registry->register_field(
 			'rootMutation',
-			$this->mutation_name,
+			Utils::format_field_name( $this->mutation_name ),
 			array_merge( $this->config,
 				[
 					'args'        => [
@@ -308,6 +308,7 @@ class WPMutationType {
 					'isPrivate'   => $this->is_private,
 					'type'        => $this->mutation_name . 'Payload',
 					'resolve'     => $this->resolve_mutation,
+					'name'        => Utils::format_field_name( $this->mutation_name ),
 				]
 			)
 		);

--- a/tests/wpunit/AccessFunctionsTest.php
+++ b/tests/wpunit/AccessFunctionsTest.php
@@ -1642,4 +1642,56 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 	}
 
+	public function testRegisterTypeWithFieldStartingWithUppercaseLetterIsAllowed() {
+
+		register_graphql_object_type( 'TypeWithUcFirstField', [
+			'fields' => [
+				'UC_First' => [
+					'type' => 'String',
+				],
+			],
+		] );
+
+		add_filter( 'graphql_TypeWithUcFirstField_fields', function( $fields ) {
+
+			$fields[] = [
+				'name' => 'UC_Field_2',
+				'type' => 'String'
+			];
+
+			return $fields;
+
+		});
+
+		$query = '
+		query GetType( $name: String! ){
+		  __type(name:$name) {
+		    fields(includeDeprecated:true) { 
+		      name
+		    }
+		  }
+		}
+		';
+
+		$actual = $this->graphql([
+			'query' => $query,
+			'variables' => [
+				'name' => 'TypeWithUcFirstField'
+			]
+		]);
+
+		$this->assertNotContains( 'errors', $actual );
+
+		$this->assertNotEmpty( $actual['data']['__type']['fields'] );
+
+		$field_names = wp_list_pluck( $actual['data']['__type']['fields'], 'name' );
+
+		codecept_debug( $field_names );
+
+		$this->assertContains(  'UC_Field_2', $field_names );
+		$this->assertContains(  'uC_First', $field_names );
+		$this->assertNotContains(  'UC_First', $field_names );
+
+	}
+
 }

--- a/tests/wpunit/CustomPostTypeTest.php
+++ b/tests/wpunit/CustomPostTypeTest.php
@@ -1426,5 +1426,54 @@ class CustomPostTypeTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 	}
 
+	public function testGraphqlSingleNameWithUnderscoresIsAllowed() {
+
+		register_post_type( 'indicator', [
+			'public' => true,
+			'show_in_graphql' => true,
+			'graphql_single_name' => 'indicator',
+			'graphql_plural_name' => 'indicators',
+		] );
+
+		register_taxonomy( 'indicator_category', 'indicator', [
+			'public' => true,
+			'show_in_graphql' => true,
+			'graphql_single_name' => 'indicator_category',
+			'graphql_plural_name' => 'indicator_categories',
+		] );
+
+		$query = '
+		query GetType( $name: String! ){
+		  __type(name:$name) {
+		    fields(includeDeprecated:true) { 
+		      name
+		    }
+		  }
+		}
+		';
+
+		$actual = $this->graphql([
+			'query' => $query,
+			'variables' => [
+				'name' => 'Indicator_category'
+			]
+		]);
+
+		$this->assertNotContains( 'errors', $actual );
+
+		$this->assertNotEmpty( $actual['data']['__type']['fields'] );
+
+		$field_names = wp_list_pluck( $actual['data']['__type']['fields'], 'name' );
+
+		codecept_debug( $field_names );
+
+		// the included field that was not excluded should still remain
+		$this->assertContains(  'indicator_categoryId', $field_names );
+
+		unregister_post_type( 'indicator' );
+		unregister_taxonomy( 'indicator_category' );
+
+	}
+
 
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

- add test for filtering a field with uppercase first letter, and asserting that the schema outputs the field as-is
- add test for registering a post type with an underscore as graphql_single_name and graphql_plural_name, and a taxonomy with graphql_single_name/graphql_plural_name with underscores, ensuring they're not removed in the fields added to the schema
- update WPMutationType to format the name in the mutation type class, instead of centrally in the type registry


Does this close any currently open issues?
------------------------------------------

fixes #2670
fixes #2666 


Any other comments?
-------------------
@todo



