### PR TITLE
release: v1.13.7

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -6,6 +6,8 @@ on:
       - opened
       - edited
       - synchronize
+  pull_request:
+    types: edited
 
 jobs:
   main:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.13.7
+
+## Chores / Bugfixes
+
+- ([#2661](https://github.com/wp-graphql/wp-graphql/pull/2661)): chore(deps): bump simple-git from 3.10.0 to 3.15.1
+- ([#2665](https://github.com/wp-graphql/wp-graphql/pull/2665)): chore(deps): bump decode-uri-component from 0.2.0 to 0.2.2
+- ([#2668](https://github.com/wp-graphql/wp-graphql/pull/2668)): test: Multiple domain tests. Thanks @markkelnar!
+- ([#2669](https://github.com/wp-graphql/wp-graphql/pull/2669)): ci: Use last working version of xdebug for php7. Thanks @markkelnar!
+- ([#2671](https://github.com/wp-graphql/wp-graphql/pull/2671)): fix: correct regressions to field formatting forcing snake_cace and UcFirst fields to be lcfirst/camelCase
+- ([#2672](https://github.com/wp-graphql/wp-graphql/pull/2672)): chore: update lint-pr workflow
+
 ## 1.13.6
 
 ### New Features

--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -53,16 +53,16 @@ ENV DATA_DUMP_DIR="${PROJECT_DIR}/tests/_data"
 # Remove exec statement from base entrypoint script.
 RUN sed -i '$d' /usr/local/bin/docker-entrypoint.sh
 
-# Set up Apache
+# Set up Apache catch all name
 RUN echo 'ServerName localhost' >> /etc/apache2/apache2.conf
 
 # Custom PHP settings
 RUN echo "upload_max_filesize = 50M" >> /usr/local/etc/php/conf.d/custom.ini \
     ;
 
-# Install XDebug 3
-RUN echo "Installing XDebug 3 (in disabled state)" \
-    && pecl install xdebug \
+# Install XDebug 3. If PHP version 7, use last supported version
+RUN echo "Installing XDebug 3 version $XDEBUG_VERSION (in disabled state)" \
+    && if [[ $PHP_VERSION == 7* ]] ; then pecl install xdebug-3.1.5 ; else pecl install xdebug ; fi \
     && mkdir -p /usr/local/etc/php/conf.d/disabled \
     && echo "zend_extension=xdebug" > /usr/local/etc/php/conf.d/disabled/docker-php-ext-xdebug.ini \
     && echo "xdebug.mode=develop,debug,coverage" >> /usr/local/etc/php/conf.d/disabled/docker-php-ext-xdebug.ini \

--- a/docker/app.setup.sh
+++ b/docker/app.setup.sh
@@ -40,6 +40,10 @@ if ! $( wp core is-installed --allow-root ); then
 		--admin_password="${ADMIN_PASSWORD}" \
 		--admin_email="${ADMIN_EMAIL}" \
 		--allow-root
+else
+    # Set the WP url accordingly. If running the app vs running tests. Tests failing locally if already had app running, vice/versa.
+    wp --allow-root option set SITEURL "${WP_URL}"
+    wp --allow-root option set HOME "${WP_URL}"
 fi
 
 echo "Running WordPress version: $(wp core version --allow-root) at $(wp option get home --allow-root)"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9593,9 +9593,9 @@
       }
     },
     "node_modules/decode-uri-component": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU= sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
       "engines": {
         "node": ">=0.10"
       }
@@ -25263,9 +25263,9 @@
       "dev": true
     },
     "node_modules/simple-git": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.10.0.tgz",
-      "integrity": "sha512-2w35xrS5rVtAW0g67LqtxCZN5cdddz/woQRfS0OJXaljXEoTychZ4jnE+CQgra/wX4ZvHeiChTUMenCwfIYEYw==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.15.1.tgz",
+      "integrity": "sha512-73MVa5984t/JP4JcQt0oZlKGr42ROYWC3BcUZfuHtT3IHKPspIvL0cZBnvPXF7LL3S/qVeVHVdYYmJ3LOTw4Rg==",
       "dev": true,
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
@@ -35828,9 +35828,9 @@
       }
     },
     "decode-uri-component": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU= sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og=="
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ=="
     },
     "decompress-response": {
       "version": "6.0.0",
@@ -47523,9 +47523,9 @@
       "dev": true
     },
     "simple-git": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.10.0.tgz",
-      "integrity": "sha512-2w35xrS5rVtAW0g67LqtxCZN5cdddz/woQRfS0OJXaljXEoTychZ4jnE+CQgra/wX4ZvHeiChTUMenCwfIYEYw==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.15.1.tgz",
+      "integrity": "sha512-73MVa5984t/JP4JcQt0oZlKGr42ROYWC3BcUZfuHtT3IHKPspIvL0cZBnvPXF7LL3S/qVeVHVdYYmJ3LOTw4Rg==",
       "dev": true,
       "requires": {
         "@kwsites/file-exists": "^1.1.1",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, API, Gatsby, Headless, Decoupled, React, Nextjs, Vue, Apollo, RES
 Requires at least: 5.0
 Tested up to: 6.1
 Requires PHP: 7.1
-Stable tag: 1.13.6
+Stable tag: 1.13.7
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -231,6 +231,18 @@ The `uri` field was non-null on some Types in the Schema but has been changed to
 Composer dependencies are no longer versioned in Github. Recommended install source is WordPress.org or using Composer to get the code from Packagist.org or WPackagist.org.
 
 == Changelog ==
+
+= 1.13.7 =
+
+**Chores / Bugfixes**
+
+- ([#2661](https://github.com/wp-graphql/wp-graphql/pull/2661)): chore(deps): bump simple-git from 3.10.0 to 3.15.1
+- ([#2665](https://github.com/wp-graphql/wp-graphql/pull/2665)): chore(deps): bump decode-uri-component from 0.2.0 to 0.2.2
+- ([#2668](https://github.com/wp-graphql/wp-graphql/pull/2668)): test: Multiple domain tests. Thanks @markkelnar!
+- ([#2669](https://github.com/wp-graphql/wp-graphql/pull/2669)): ci: Use last working version of xdebug for php7. Thanks @markkelnar!
+- ([#2671](https://github.com/wp-graphql/wp-graphql/pull/2671)): fix: correct regressions to field formatting forcing snake_cace and UcFirst fields to be lcfirst/camelCase
+- ([#2672](https://github.com/wp-graphql/wp-graphql/pull/2672)): chore: update lint-pr workflow
+
 
 = 1.13.6 =
 

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -872,10 +872,8 @@ class TypeRegistry {
 	protected function prepare_field( $field_name, $field_config, $type_name ) {
 
 		if ( ! isset( $field_config['name'] ) ) {
-			$field_config['name'] = $field_name;
+			$field_config['name'] = lcfirst( $field_name );
 		}
-
-		$field_config['name'] = lcfirst( $field_config['name'] );
 
 		if ( ! isset( $field_config['type'] ) ) {
 			graphql_debug( sprintf( __( 'The registered field \'%s\' does not have a Type defined. Make sure to define a type for all fields.', 'wp-graphql' ), $field_name ), [

--- a/src/Type/WPMutationType.php
+++ b/src/Type/WPMutationType.php
@@ -291,9 +291,10 @@ class WPMutationType {
 	 * Registers the mutation in the Graph.
 	 */
 	protected function register_mutation_field() : void {
+		$field_name = Utils::format_field_name( $this->mutation_name );
 		$this->type_registry->register_field(
 			'rootMutation',
-			$this->mutation_name,
+			$field_name,
 			array_merge( $this->config,
 				[
 					'args'        => [
@@ -308,6 +309,7 @@ class WPMutationType {
 					'isPrivate'   => $this->is_private,
 					'type'        => $this->mutation_name . 'Payload',
 					'resolve'     => $this->resolve_mutation,
+					'name'        => $field_name,
 				]
 			)
 		);

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -130,7 +130,7 @@ final class WPGraphQL {
 
 		// Plugin version.
 		if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-			define( 'WPGRAPHQL_VERSION', '1.13.6' );
+			define( 'WPGRAPHQL_VERSION', '1.13.7' );
 		}
 
 		// Plugin Folder Path.

--- a/tests/acceptance/TwoDomainsSupportedCest.php
+++ b/tests/acceptance/TwoDomainsSupportedCest.php
@@ -1,0 +1,26 @@
+<?php
+
+class DifferentLocalDomainsSupportedCest {
+
+	public function queryDifferentLocalDomainsTest(AcceptanceTester $I)
+    {
+		$domains = [
+			'localhost',
+			'wp.localhost',
+			'wp2.localhost',
+			'foo.bar',
+			'foo.bar.localhost'
+		];
+		foreach( $domains as $hostname ) {
+			$I->haveHttpHeader('Host', $hostname);
+			$I->sendGet('graphql', [ 'query' => '{__typename}' ] );
+			$I->seeResponseCodeIs(200);
+			$I->seeResponseContainsJson([
+				'data' => [
+					'__typename' => 'RootQuery'
+				]
+			]);
+		}
+	}
+
+}

--- a/tests/wpunit/AccessFunctionsTest.php
+++ b/tests/wpunit/AccessFunctionsTest.php
@@ -1642,4 +1642,56 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 	}
 
+	public function testRegisterTypeWithFieldStartingWithUppercaseLetterIsAllowed() {
+
+		register_graphql_object_type( 'TypeWithUcFirstField', [
+			'fields' => [
+				'UC_First' => [
+					'type' => 'String',
+				],
+			],
+		] );
+
+		add_filter( 'graphql_TypeWithUcFirstField_fields', function( $fields ) {
+
+			$fields[] = [
+				'name' => 'UC_Field_2',
+				'type' => 'String'
+			];
+
+			return $fields;
+
+		});
+
+		$query = '
+		query GetType( $name: String! ){
+		  __type(name:$name) {
+		    fields(includeDeprecated:true) { 
+		      name
+		    }
+		  }
+		}
+		';
+
+		$actual = $this->graphql([
+			'query' => $query,
+			'variables' => [
+				'name' => 'TypeWithUcFirstField'
+			]
+		]);
+
+		$this->assertNotContains( 'errors', $actual );
+
+		$this->assertNotEmpty( $actual['data']['__type']['fields'] );
+
+		$field_names = wp_list_pluck( $actual['data']['__type']['fields'], 'name' );
+
+		codecept_debug( $field_names );
+
+		$this->assertContains(  'UC_Field_2', $field_names );
+		$this->assertContains(  'uC_First', $field_names );
+		$this->assertNotContains(  'UC_First', $field_names );
+
+	}
+
 }

--- a/tests/wpunit/CustomPostTypeTest.php
+++ b/tests/wpunit/CustomPostTypeTest.php
@@ -1426,5 +1426,54 @@ class CustomPostTypeTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 	}
 
+	public function testGraphqlSingleNameWithUnderscoresIsAllowed() {
+
+		register_post_type( 'indicator', [
+			'public' => true,
+			'show_in_graphql' => true,
+			'graphql_single_name' => 'indicator',
+			'graphql_plural_name' => 'indicators',
+		] );
+
+		register_taxonomy( 'indicator_category', 'indicator', [
+			'public' => true,
+			'show_in_graphql' => true,
+			'graphql_single_name' => 'indicator_category',
+			'graphql_plural_name' => 'indicator_categories',
+		] );
+
+		$query = '
+		query GetType( $name: String! ){
+		  __type(name:$name) {
+		    fields(includeDeprecated:true) { 
+		      name
+		    }
+		  }
+		}
+		';
+
+		$actual = $this->graphql([
+			'query' => $query,
+			'variables' => [
+				'name' => 'Indicator_category'
+			]
+		]);
+
+		$this->assertNotContains( 'errors', $actual );
+
+		$this->assertNotEmpty( $actual['data']['__type']['fields'] );
+
+		$field_names = wp_list_pluck( $actual['data']['__type']['fields'], 'name' );
+
+		codecept_debug( $field_names );
+
+		// the included field that was not excluded should still remain
+		$this->assertContains(  'indicator_categoryId', $field_names );
+
+		unregister_post_type( 'indicator' );
+		unregister_taxonomy( 'indicator_category' );
+
+	}
+
 
 }

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.13.6
+ * Version: 1.13.7
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.13.6
+ * @version  1.13.7
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
# Release Notes

## Chores / Bugfixes

- ([#2661](https://github.com/wp-graphql/wp-graphql/pull/2661)): chore(deps): bump simple-git from 3.10.0 to 3.15.1
- ([#2665](https://github.com/wp-graphql/wp-graphql/pull/2665)): chore(deps): bump decode-uri-component from 0.2.0 to 0.2.2
- ([#2668](https://github.com/wp-graphql/wp-graphql/pull/2668)): test: Multiple domain tests. Thanks @markkelnar!
- ([#2669](https://github.com/wp-graphql/wp-graphql/pull/2669)): ci: Use last working version of xdebug for php7. Thanks @markkelnar!
- ([#2671](https://github.com/wp-graphql/wp-graphql/pull/2671)): fix: correct regressions to field formatting forcing snake_cace and UcFirst fields to be lcfirst/camelCase
- ([#2672](https://github.com/wp-graphql/wp-graphql/pull/2672)): chore: update lint-pr workflow
