### PR TITLE
ci: keep the develop branch in sync with master

### DIFF
--- a/.github/workflows/sync-develop-with-master.yml
+++ b/.github/workflows/sync-develop-with-master.yml
@@ -1,0 +1,25 @@
+name: Keep develop in sync with master
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  merge-master-back-to-develop:
+    timeout-minutes: 2
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set Git config
+        run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "Github Actions"
+
+      - name: Merge master back to develop
+        run: |
+          git fetch --unshallow
+          git checkout develop
+          git pull
+          git merge --no-ff origin/master -m "Auto-merge master back to develop"
+          git push


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- add workflow to keep develop in sync with master after a push to master

Does this close any currently open issues?
------------------------------------------
closes #2674 
