### PR TITLE
feat: Refactor NodeResolver::resolve_uri() to use WP_Query

### DIFF
--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -50,6 +50,10 @@ class NodeResolver {
 			return $post;
 		}
 
+		/**
+		 * Disabling the following code for now, since add_rewrite_uri() would cause a request to direct to a different valid permalink.
+		 */
+		/* phpcs:disable
 		$permalink    = get_permalink( $post );
 		$parsed_path  = $permalink ? wp_parse_url( $permalink, PHP_URL_PATH ) : null;
 		$trimmed_path = $parsed_path ? rtrim( ltrim( $parsed_path, '/' ), '/' ) : null;
@@ -57,6 +61,7 @@ class NodeResolver {
 		if ( $trimmed_path !== $uri_path ) {
 			return null;
 		}
+		phpcs:enable */
 
 		return $post;
 	}
@@ -151,6 +156,11 @@ class NodeResolver {
 				}
 
 				return ! empty( $post_type_object->name ) ? $this->context->get_loader( 'post_type' )->load_deferred( $post_type_object->name ) : null;
+			}
+
+			// Validate the post before returning it.
+			if ( ! $this->validate_post( $queried_object ) ) {
+				return null;
 			}
 
 			return ! empty( $queried_object->ID ) ? $this->context->get_loader( 'post' )->load_deferred( $queried_object->ID ) : null;

--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -81,29 +81,9 @@ class NodeResolver {
 			return null;
 		}
 
-		// Check if an array has a key that starts with a string.
-		$is_same_term = false;
-
-		$taxonomy = $term->taxonomy;
-
-		// Categories and Tags can use a shorthand in the query vars.
-		if ( 'category' === $taxonomy ) {
-			$taxonomy = 'cat';
-		} elseif ( 'post_tag' === $taxonomy ) {
-			$taxonomy = 'tag';
-		}
-
-		foreach ( array_keys( $this->wp->query_vars ) as $key ) {
-			if ( strpos( $key, $taxonomy ) === 0 ) {
-				$is_same_term = true;
-				break;
-			}
-		}
-
-		if ( ! $is_same_term ) {
+		if ( isset( $this->wp->query_vars['taxonomy'] ) && $term->taxonomy !== $this->wp->query_vars['taxonomy'] ) {
 			return null;
 		}
-
 
 		return $term;
 	}
@@ -359,10 +339,8 @@ class NodeResolver {
 		 */
 		global $wp_rewrite;
 
-
 		$this->wp->query_vars = [];
 		$post_type_query_vars = [];
-
 
 		if ( is_array( $extra_query_vars ) ) {
 			$this->wp->query_vars = &$extra_query_vars;
@@ -500,7 +478,6 @@ class NodeResolver {
 		 * @param string[] $public_query_vars The array of allowed query variable names.
 		 */
 		$this->wp->public_query_vars = apply_filters( 'query_vars', $this->wp->public_query_vars );
-
 
 		foreach ( get_post_types( [ 'show_in_graphql' => true ], 'objects' )  as $post_type => $t ) {
 			/** @var \WP_Post_Type $t */

--- a/src/Type/ObjectType/RootQuery.php
+++ b/src/Type/ObjectType/RootQuery.php
@@ -217,7 +217,12 @@ class RootQuery {
 							$idType = $args['idType'] ?? 'global_id';
 							switch ( $idType ) {
 								case 'uri':
-									return $context->node_resolver->resolve_uri( $args['id'] );
+									return $context->node_resolver->resolve_uri(
+										$args['id'],
+										[
+											'nodeType' => 'ContentNode',
+										]
+									);
 								case 'database_id':
 									$post_id = absint( $args['id'] );
 									break;
@@ -527,7 +532,12 @@ class RootQuery {
 
 									break;
 								case 'uri':
-									return $context->node_resolver->resolve_uri( $args['id'] );
+									return $context->node_resolver->resolve_uri(
+										$args['id'],
+										[
+											'nodeType' => 'TermNode',
+										]
+									);
 								case 'global_id':
 								default:
 									$id_components = Relay::fromGlobalId( $args['id'] );
@@ -584,7 +594,12 @@ class RootQuery {
 									$id = absint( $args['id'] );
 									break;
 								case 'uri':
-									return $context->node_resolver->resolve_uri( $args['id'] );
+									return $context->node_resolver->resolve_uri(
+										$args['id'],
+										[
+											'nodeType' => 'User',
+										]
+									);
 								case 'login':
 									$current_user = wp_get_current_user();
 									if ( $current_user->user_login !== $args['id'] ) {
@@ -695,6 +710,7 @@ class RootQuery {
 									[
 										'name'      => $args['id'],
 										'post_type' => $post_type_object->name,
+										'nodeType'  => 'ContentNode',
 									]
 								);
 							case 'uri':
@@ -822,6 +838,7 @@ class RootQuery {
 								[
 									'name'      => $slug,
 									'post_type' => $post_type_object->name,
+									'nodeType'  => 'ContentNode',
 								]
 							);
 
@@ -902,7 +919,12 @@ class RootQuery {
 								$term_id = isset( $term->term_id ) ? absint( $term->term_id ) : null;
 								break;
 							case 'uri':
-								return $context->node_resolver->resolve_uri( $args['id'] );
+								return $context->node_resolver->resolve_uri(
+									$args['id'],
+									[
+										'nodeType' => 'TermNode',
+									]
+								);
 							case 'global_id':
 							default:
 								$id_components = Relay::fromGlobalId( $args['id'] );

--- a/src/Type/ObjectType/RootQuery.php
+++ b/src/Type/ObjectType/RootQuery.php
@@ -923,6 +923,7 @@ class RootQuery {
 									$args['id'],
 									[
 										'nodeType' => 'TermNode',
+										'taxonomy' => $tax_object->name,
 									]
 								);
 							case 'global_id':

--- a/tests/wpunit/ContentNodeInterfaceTest.php
+++ b/tests/wpunit/ContentNodeInterfaceTest.php
@@ -201,9 +201,6 @@ class ContentNodeInterfaceTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 	 * @throws Exception
 	 */
 	public function testContentNodeFieldByUri() {
-
-		$this->set_permalink_structure( '' );
-
 		$page_id = $this->factory()->post->create( [
 			'post_type'   => 'page',
 			'post_status' => 'publish',
@@ -217,28 +214,6 @@ class ContentNodeInterfaceTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 			'post_title'  => 'Test Post for ContentNodeFieldByUri',
 			'post_author' => $this->admin,
 		] );
-
-		$variables = [
-			'postIdType' => 'URI',
-			'postId'     => '/?' . parse_url( get_permalink( $post_id ) )['query'],
-			'pageIdType' => 'URI',
-			'pageId'     => '/?' . parse_url( get_permalink( $page_id ) )['query'],
-		];
-
-		codecept_debug( $variables );
-
-		$actual = $this->graphql( [
-			'query'     => $this->contentNodeQuery(),
-			'variables' => $variables,
-		] );
-
-		$this->assertArrayNotHasKey( 'errors', $actual );
-		$this->assertEquals( 'Post', $actual['data']['post']['__typename'] );
-		$this->assertEquals( 'Page', $actual['data']['page']['__typename'] );
-		$this->assertEquals( $post_id, $actual['data']['post']['postId'] );
-		$this->assertEquals( $page_id, $actual['data']['page']['pageId'] );
-
-		$this->set_permalink_structure( '/%year%/%monthnum%/%day%/%postname%/' );
 
 		$variables = [
 			'postIdType' => 'URI',
@@ -259,6 +234,7 @@ class ContentNodeInterfaceTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 		$this->assertEquals( 'Page', $actual['data']['page']['__typename'] );
 		$this->assertEquals( $post_id, $actual['data']['post']['postId'] );
 		$this->assertEquals( $page_id, $actual['data']['page']['pageId'] );
+
 	}
 
 	/**

--- a/tests/wpunit/NodeByUriTest.php
+++ b/tests/wpunit/NodeByUriTest.php
@@ -182,6 +182,48 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 	}
 
+	public function testPostWithAnchorByUri() {
+		$post_id = $this->factory()->post->create( [
+			'post_type'   => 'post',
+			'post_status' => 'publish',
+			'post_title'  => 'Test postWithAnchorByUri',
+			'post_author' => $this->user,
+		] );
+
+		$query = '
+		query GET_NODE_BY_URI( $uri: String! ) {
+			nodeByUri( uri: $uri ) {
+				__typename
+				...on Post {
+					databaseId
+				}
+				uri
+			}
+		}
+		';
+
+		$uri = wp_make_link_relative( get_permalink( $post_id ) );
+
+
+		// Test with anchor.
+		$uri .= '#test-anchor';
+
+		codecept_debug( $uri );
+
+		$actual = $this->graphql([
+			'query'     => $query,
+			'variables' => [
+				'uri' => $uri,
+			],
+		]);
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertSame( ucfirst( get_post_type_object( 'post' )->graphql_single_name ), $actual['data']['nodeByUri']['__typename'] );
+		$this->assertSame( $post_id, $actual['data']['nodeByUri']['databaseId'] );
+		$this->assertStringStartsWith( $actual['data']['nodeByUri']['uri'], $uri );
+
+	}
+
 	/**
 	 * @throws Exception
 	 */

--- a/tests/wpunit/NodeByUriTest.php
+++ b/tests/wpunit/NodeByUriTest.php
@@ -2141,6 +2141,7 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		codecept_debug( 'Validating URI: ' . $uri );
 
 		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertNotEmpty( $actual['data']['nodeByUri'], 'The nodeByUri data should not be empty' );
 		$this->assertSame( $expected_graphql_type, $actual['data']['nodeByUri']['__typename'], 'The __typename should match the expected type' );
 		$this->assertSame( $expected_database_id, $actual['data']['nodeByUri']['databaseId'], 'The databaseId should match the expected ID' );
 		$this->assertSame( $uri, $actual['data']['nodeByUri']['uri'], 'The uri should match the expected URI' );

--- a/tests/wpunit/NodeByUriTest.php
+++ b/tests/wpunit/NodeByUriTest.php
@@ -493,9 +493,6 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->assertSame( `postFormat`, $actual['data']['nodeByUri']['__typename'] );
 		$this->assertSame( $term->term_id, $actual['data']['nodeByUri']['databaseId'] );
 		$this->assertSame( $uri, $actual['data']['nodeByUri']['uri'] );
-
-
-
 	}
 
 	/**
@@ -709,6 +706,192 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->assertSame( 'User', $actual['data']['nodeByUri']['__typename'] );
 		$this->assertSame( $this->user, $actual['data']['nodeByUri']['databaseId'] );
 		$this->assertSame( $uri, $actual['data']['nodeByUri']['uri'] );
+	}
+
+	public function testDateYearArchiveByUri() {
+		$query = '
+			query GET_NODE_BY_URI( $uri: String! ) {
+				nodeByUri( uri: $uri ) {
+					__typename
+					...on ContentType {
+						name
+					}
+					uri
+				}
+			}
+		';
+
+		// Test year archive
+		$uri = wp_make_link_relative( get_year_link( gmdate( 'Y' ) ) );
+
+		codecept_debug( $uri );
+
+		/**
+		 * NodeResolver::parse_request() generates the following query vars:
+		 * uri => /{year}/
+		 * year => {year}
+		 */
+		$actual = $this->graphql( [
+			'query' => $query,
+			'variables' => [
+				'uri' => $uri,
+			],
+		] );
+
+		$this->markTestIncomplete( 'resolve_uri() doesnt check for `date archives`. See https://github.com/wp-graphql/wp-graphql/issues/2191' );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertSame( 'ContentType', $actual['data']['nodeByUri']['__typename'] );
+		$this->assertSame( 'post', $actual['data']['nodeByUri']['name'] );
+
+		// Test with pretty permalinks disabled
+		$this->set_permalink_structure( '' );
+
+		$uri = wp_make_link_relative( get_year_link( gmdate( 'Y' ) ) );
+
+		codecept_debug( $uri );
+
+		/**
+		 * NodeResolver::parse_request() generates the following query vars:
+		 * uri => m={year}
+		 * m => {year}
+		 */
+		$actual = $this->graphql( [
+			'query' => $query,
+			'variables' => [
+				'uri' => $uri,
+			],
+		] );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertSame( 'ContentType', $actual['data']['nodeByUri']['__typename'] );
+		$this->assertSame( 'post', $actual['data']['nodeByUri']['name'] );
+
+	}
+
+	public function testDateMonthArchiveByUri() {
+		$query = '
+			query GET_NODE_BY_URI( $uri: String! ) {
+				nodeByUri( uri: $uri ) {
+					__typename
+					...on ContentType {
+						name
+					}
+					uri
+				}
+			}
+		';
+
+		// Test month archive
+		$uri = wp_make_link_relative( get_month_link( gmdate( 'Y' ), gmdate( 'm' ) ) );
+
+		codecept_debug( $uri );
+
+		/**
+		 * NodeResolver::parse_request() generates the following query vars:
+		 * uri => /{year}/{month}/
+		 * year => {year}
+		 * monthnum => {month}
+		 */
+		$actual = $this->graphql( [
+			'query' => $query,
+			'variables' => [
+				'uri' => $uri,
+			],
+		] );
+
+		$this->markTestIncomplete( 'resolve_uri() doesnt check for `date archives`. See https://github.com/wp-graphql/wp-graphql/issues/2191' );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertSame( 'ContentType', $actual['data']['nodeByUri']['__typename'] );
+		$this->assertSame( 'post', $actual['data']['nodeByUri']['name'] );
+
+		// Test with pretty permalinks disabled
+		$this->set_permalink_structure( '' );
+
+		$uri = wp_make_link_relative( get_month_link( gmdate( 'Y' ), gmdate( 'm' ) ) );
+
+		codecept_debug( $uri );
+
+		/**
+		 * NodeResolver::parse_request() generates the following query vars:
+		 * uri => m={year}{month}
+		 * m => {year}{month}
+		 */
+		$actual = $this->graphql( [
+			'query' => $query,
+			'variables' => [
+				'uri' => $uri,
+			],
+		] );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertSame( 'ContentType', $actual['data']['nodeByUri']['__typename'] );
+		$this->assertSame( 'post', $actual['data']['nodeByUri']['name'] );
+
+	}
+
+	public function testDateDayArchiveByUri() {
+		$query = '
+			query GET_NODE_BY_URI( $uri: String! ) {
+				nodeByUri( uri: $uri ) {
+					__typename
+					...on ContentType {
+						name
+					}
+					uri
+				}
+			}
+		';
+
+		// Test day archive
+		$uri = wp_make_link_relative( get_day_link( gmdate( 'Y' ), gmdate( 'm' ), gmdate( 'd' ) ) );
+
+		codecept_debug( $uri );
+
+		/**
+		 * NodeResolver::parse_request() generates the following query vars:
+		 * uri => /{year}/{month}/{day}/
+		 * year => {year}
+		 * monthnum => {month}
+		 * day => {day}
+		 */
+		$actual = $this->graphql( [
+			'query' => $query,
+			'variables' => [
+				'uri' => $uri,
+			],
+		] );
+
+		$this->markTestIncomplete( 'resolve_uri() doesnt check for `date archives`. See https://github.com/wp-graphql/wp-graphql/issues/2191' );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertSame( 'ContentType', $actual['data']['nodeByUri']['__typename'] );
+		$this->assertSame( 'post', $actual['data']['nodeByUri']['name'] );
+
+		// Test with pretty permalinks disabled
+		$this->set_permalink_structure( '' );
+
+		$uri = wp_make_link_relative( get_day_link( gmdate( 'Y' ), gmdate( 'm' ), gmdate( 'd' ) ) );
+
+		codecept_debug( $uri );
+
+		/**
+		 * NodeResolver::parse_request() generates the following query vars:
+		 * uri => m={year}{month}{day}
+		 * m => {year}{month}{day}
+		 */
+		$actual = $this->graphql( [
+			'query' => $query,
+			'variables' => [
+				'uri' => $uri,
+			],
+		] );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertSame( 'ContentType', $actual['data']['nodeByUri']['__typename'] );
+		$this->assertSame( 'post', $actual['data']['nodeByUri']['name'] );
+
 	}
 
 	public function testPageQueryWhenPageIsSetToHomePage() {

--- a/tests/wpunit/NodeByUriTest.php
+++ b/tests/wpunit/NodeByUriTest.php
@@ -1967,6 +1967,7 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->assertSame( 'TestHierarchicalType', $actual['data']['nodeByUri']['__typename'] );
 		$this->assertSame( $child_id, $actual['data']['nodeByUri']['databaseId'] );
 
+		unregister_taxonomy( 'test_hierarchical' );
 	}
 
 	public function testExternalUriReturnsNull() {

--- a/tests/wpunit/NodeByUriTest.php
+++ b/tests/wpunit/NodeByUriTest.php
@@ -24,7 +24,6 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 			'show_in_graphql'     => true,
 			'graphql_single_name' => 'CustomTax',
 			'graphql_plural_name' => 'CustomTaxes',
-
 		]);
 
 		flush_rewrite_rules( true );
@@ -1341,12 +1340,14 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$this->assertArrayNotHasKey( 'errors', $actual );
 
+		unregister_taxonomy( 'identical_slugs_tax' );
 		$this->markTestIncomplete( 'NodeResolver::resolver_uri cannot handle taxonomies with hierarchical permalinks' );
 
 		$this->assertSame( 'IdenticalSlugType', $actual['data']['nodeByUri']['__typename'] );
 		$this->assertSame( $identical_slugs_term_2_child_id, $actual['data']['nodeByUri']['databaseId'] );
 		$this->assertSame( $uri, $actual['data']['nodeByUri']['uri'] );
 
+		unregister_taxonomy( 'identical_slugs_tax' );
 	}
 
 	/**
@@ -2102,6 +2103,7 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$this->assertArrayNotHasKey( 'errors', $actual );
 
+		unregister_taxonomy( 'test_hierarchical' );
 		$this->markTestIncomplete( 'NodeResolver::resolver_uri cannot handle taxonomies with hierarchical permalinks' );
 
 		$this->assertSame( $uri, $actual['data']['nodeByUri']['uri'] );

--- a/tests/wpunit/NodeByUriTest.php
+++ b/tests/wpunit/NodeByUriTest.php
@@ -563,9 +563,6 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 			],
 		] );
 
-		$this->markTestIncomplete( 'resolve_uri() doesnt check for `attachment`. See https://github.com/wp-graphql/wp-graphql/issues/2178');
-
-
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertSame( 'MediaItem', $actual['data']['nodeByUri']['__typename'] );
 		$this->assertSame( $attachment_id, $actual['data']['nodeByUri']['databaseId'] );
@@ -674,8 +671,6 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 				'uri' => $uri,
 			],
 		]);
-
-		$this->markTestIncomplete( 'NodeResolver::parse_request() doesnt handle conflicts between CPT/Page slugs' );
 
 		$this->assertValidURIResolution( $uri, 'Page', $page_id, $actual );
 	}
@@ -1105,9 +1100,7 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$this->assertArrayNotHasKey( 'errors', $actual );
 
-		$this->markTestIncomplete( 'PostFormat archives not implemented. See: https://github.com/wp-graphql/wp-graphql/issues/2190' );
 		$this->assertValidURIResolution( $uri, 'PostFormat', $term->term_id, $actual );
-
 	}
 
 	/**
@@ -1259,7 +1252,6 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->assertArrayNotHasKey( 'errors', $actual );
 
 		unregister_taxonomy( 'identical_slugs_tax' );
-		$this->markTestIncomplete( 'NodeResolver::resolver_uri cannot handle taxonomies with hierarchical permalinks' );
 
 		$this->assertValidURIResolution( $uri, 'IdenticalSlugType', $identical_slugs_term_2_child_id, $actual );
 
@@ -1354,7 +1346,6 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->assertArrayNotHasKey( 'errors', $actual );
 
 		unregister_taxonomy( 'test_hierarchical' );
-		$this->markTestIncomplete( 'NodeResolver::resolver_uri cannot handle taxonomies with hierarchical permalinks' );
 
 		$this->assertSame( $uri, $actual['data']['nodeByUri']['uri'] );
 		$this->assertSame( 'TestHierarchicalType', $actual['data']['nodeByUri']['__typename'] );

--- a/tests/wpunit/NodeByUriTest.php
+++ b/tests/wpunit/NodeByUriTest.php
@@ -204,8 +204,7 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$uri = wp_make_link_relative( get_permalink( $post_id ) );
 
-
-		// Test with anchor.
+		// Test with /#anchor.
 		$uri .= '#test-anchor';
 
 		codecept_debug( $uri );
@@ -222,6 +221,62 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->assertSame( $post_id, $actual['data']['nodeByUri']['databaseId'] );
 		$this->assertStringStartsWith( $actual['data']['nodeByUri']['uri'], $uri );
 
+		// Test with #anchor
+		$uri = str_replace( '/#', '#', $uri );
+
+		codecept_debug( $uri );
+
+		$actual = $this->graphql([
+			'query'     => $query,
+			'variables' => [
+				'uri' => $uri,
+			],
+		]);
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertSame( ucfirst( get_post_type_object( 'post' )->graphql_single_name ), $actual['data']['nodeByUri']['__typename'] );
+		$this->assertSame( $post_id, $actual['data']['nodeByUri']['databaseId'] );
+		$this->assertStringStartsWith( rtrim( $actual['data']['nodeByUri']['uri'], '/' ), $uri );
+
+		// Test without pretty permalinks.
+		$this->set_permalink_structure( '' );
+
+		$uri = wp_make_link_relative( get_permalink( $post_id ) );
+		
+		// test with /#anchor
+		$uri .= '/#test-anchor';
+
+		codecept_debug( $uri );
+
+		$actual = $this->graphql([
+			'query'     => $query,
+			'variables' => [
+				'uri' => $uri,
+			],
+		]);
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertSame( ucfirst( get_post_type_object( 'post' )->graphql_single_name ), $actual['data']['nodeByUri']['__typename'] );
+		$this->assertSame( $post_id, $actual['data']['nodeByUri']['databaseId'] );
+		$this->assertStringStartsWith( $actual['data']['nodeByUri']['uri'], $uri );
+
+		// Test with #anchor
+
+		$uri = str_replace( '/#', '#', $uri );
+
+		codecept_debug( $uri );
+
+		$actual = $this->graphql([
+			'query'     => $query,
+			'variables' => [
+				'uri' => $uri,
+			],
+		]);
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertSame( ucfirst( get_post_type_object( 'post' )->graphql_single_name ), $actual['data']['nodeByUri']['__typename'] );
+		$this->assertSame( $post_id, $actual['data']['nodeByUri']['databaseId'] );
+		$this->assertStringStartsWith( rtrim( $actual['data']['nodeByUri']['uri'], '/' ), $uri );
 	}
 
 	/**

--- a/tests/wpunit/NodeByUriTest.php
+++ b/tests/wpunit/NodeByUriTest.php
@@ -787,6 +787,7 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->assertSame( 'TestHierarchical', $actual['data']['nodeByUri']['__typename'] );
 		$this->assertSame( $parent, $actual['data']['nodeByUri']['databaseId'] );
 
+		// cleanup.
 		unregister_post_type( 'test_hierarchical' );
 	}
 
@@ -1251,10 +1252,9 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$this->assertArrayNotHasKey( 'errors', $actual );
 
-		unregister_taxonomy( 'identical_slugs_tax' );
-
 		$this->assertValidURIResolution( $uri, 'IdenticalSlugType', $identical_slugs_term_2_child_id, $actual );
 
+		// cleanup
 		unregister_taxonomy( 'identical_slugs_tax' );
 	}
 
@@ -1345,12 +1345,11 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$this->assertArrayNotHasKey( 'errors', $actual );
 
-		unregister_taxonomy( 'test_hierarchical' );
-
 		$this->assertSame( $uri, $actual['data']['nodeByUri']['uri'] );
 		$this->assertSame( 'TestHierarchicalType', $actual['data']['nodeByUri']['__typename'] );
 		$this->assertSame( $child_id, $actual['data']['nodeByUri']['databaseId'] );
 
+		// cleanup
 		unregister_taxonomy( 'test_hierarchical' );
 	}
 

--- a/tests/wpunit/NodeByUriTest.php
+++ b/tests/wpunit/NodeByUriTest.php
@@ -934,6 +934,7 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		]);
 
 		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertNotEmpty( $actual['data']['nodeByUri'] );
 		$this->assertSame( 'CustomType', $actual['data']['nodeByUri']['__typename'] );
 		$this->assertSame( $post_id, $actual['data']['nodeByUri']['databaseId'] );
 

--- a/tests/wpunit/NodeByUriTest.php
+++ b/tests/wpunit/NodeByUriTest.php
@@ -168,28 +168,8 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$this->assertEquals( $expected, $actual, 'Post with anchor should return the same results as the first page' );
 
-		// Test without pretty permalinks.
-		$this->set_permalink_structure( '' );
-
-		$uri = wp_make_link_relative( get_permalink( $post_id ) );
-
-		/**
-		 * NodeResolver::parse_request() will generate the following query vars:
-		 * uri => p={post_id}
-		 * p => {post_id}
-		 */
-		$actual = $this->graphql([
-			'query'     => $query,
-			'variables' => [
-				'uri' => $uri,
-			],
-		]);
-
-		$this->assertValidURIResolution( $uri, $expected_graphql_type, $post_id, $actual );
-
 		// Test with fixed base.
 		$this->set_permalink_structure( '/blog/%year%/%monthnum%/%day%/%postname%/' );
-
 
 		$uri = wp_make_link_relative( get_permalink( $post_id ) );
 
@@ -325,24 +305,6 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->assertValidURIResolution( $uri, $expected_graphql_type, $page_id, $actual );
 		$this->assertTrue( $actual['data']['nodeByUri']['isContentNode'] );
 		$this->assertFalse( $actual['data']['nodeByUri']['isTermNode'] );
-
-		// Test without pretty permalinks.
-		$this->set_permalink_structure( '' );
-		$uri = wp_make_link_relative( get_permalink( $page_id ) );
-		
-		/**
-		 * NodeResolver::parse_request() will generate the following query vars:
-		 * uri => page_id={page_id}
-		 * page_id => {page_id}
-		 */
-		$actual = $this->graphql([
-			'query'     => $query,
-			'variables' => [
-				'uri' => $uri,
-			],
-		]);
-
-		$this->assertValidURIResolution( $uri, $expected_graphql_type, $page_id, $actual );
 
 		// Test with fixed base.
 		$this->set_permalink_structure( '/blog/%year%/%monthnum%/%day%/%postname%/' );
@@ -566,33 +528,6 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->assertSame( 'MediaItem', $actual['data']['nodeByUri']['__typename'] );
 		$this->assertSame( $attachment_id, $actual['data']['nodeByUri']['databaseId'] );
 		$this->assertSame( $uri, $actual['data']['nodeByUri']['uri'] );
-
-		// Test with pretty permalinks disabled
-
-		$this->set_permalink_structure( '' );
-
-		$uri = wp_make_link_relative( get_permalink( $attachment_id ) );
-
-		codecept_debug( $uri );
-
-		/**
-		 * NodeResolver::parse_request() generates the following query vars:
-		 * uri => attachment_id={attachment_id}
-		 * attachment_id => {attachment_id}
-		 */
-		$actual = $this->graphql( [
-			'query' => $query,
-			'variables' => [
-				'uri' => $uri,
-			],
-		] );
-
-		$this->markTestIncomplete( 'resolve_uri() doesnt check for `attachment_id`.');
-
-		$this->assertArrayNotHasKey( 'errors', $actual );
-		$this->assertSame( 'MediaItem', $actual['data']['nodeByUri']['__typename'] );
-		$this->assertSame( $attachment_id, $actual['data']['nodeByUri']['databaseId'] );
-		$this->assertSame( $uri, $actual['data']['nodeByUri']['uri'] );
 	}
 
 	public function testAttachmentWithParent() {
@@ -635,31 +570,6 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->assertSame( 'MediaItem', $actual['data']['nodeByUri']['__typename'] );
 		$this->assertSame( $attachment_id, $actual['data']['nodeByUri']['databaseId'] );
 		$this->assertSame( $uri, $actual['data']['nodeByUri']['uri'] );
-
-		// Test with pretty permalinks disabled
-
-		$this->set_permalink_structure( '' );
-
-		$uri = wp_make_link_relative( get_permalink( $attachment_id ) );
-
-		codecept_debug( $uri );
-
-		/**
-		 * NodeResolver::parse_request() generates the following query vars:
-		 * uri => attachment_id={attachment_id}
-		 * attachment_id => {attachment_id}
-		 */
-		$actual = $this->graphql( [
-			'query' => $query,
-			'variables' => [
-				'uri' => $uri,
-			],
-		] );
-
-		$this->assertArrayNotHasKey( 'errors', $actual );
-		$this->assertSame( 'MediaItem', $actual['data']['nodeByUri']['__typename'] );
-		$this->assertSame( $attachment_id, $actual['data']['nodeByUri']['databaseId'] );
-		$this->assertSame( $uri, $actual['data']['nodeByUri']['uri'] );
 	}
 
 	/**
@@ -686,27 +596,6 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		 * by_uri_cpt => test-customposttypebyuri,
 		 * post_type => by_uri_cpt,
 		 * name => test-customposttypebyuri,
-		 */
-		$actual = $this->graphql([
-			'query'     => $query,
-			'variables' => [
-				'uri' => $uri,
-			],
-		]);
-
-		$this->assertValidURIResolution( $uri, $expected_graphql_type, $cpt_id, $actual );
-
-		// Test without pretty permalinks.
-		$this->set_permalink_structure( '' );
-
-		$uri = wp_make_link_relative( get_permalink( $cpt_id ) );
-		
-		/**
-		 * NodeResolver::parse_request() will generate the following query vars:
-		 * uri => by_uri_cpt=test-customposttypebyuri
-		 * by_uri_cpt => test-customposttypebyuri
-		 * post_type => by_uri_cpt
-		 * name => test-customposttypebyuri
 		 */
 		$actual = $this->graphql([
 			'query'     => $query,
@@ -1094,25 +983,6 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->assertValidURIResolution( $uri, $expected_graphql_type, $category_id, $actual );
 		$this->assertFalse( $actual['data']['nodeByUri']['isContentNode'] );
 		$this->assertTrue( $actual['data']['nodeByUri']['isTermNode'] );
-
-		// Test without pretty permalinks.
-		$this->set_permalink_structure( '' );
-
-		$uri = wp_make_link_relative( get_category_link( $category_id ));
-
-		/**
-		 * NodeResolver::parse_request() will generate the following query vars:
-		 * uri => cat={category_id}
-		 * cat => {category_id}
-		 */
-		$actual = $this->graphql([
-			'query'     => $query,
-			'variables' => [
-				'uri' => $uri
-			],
-		]);
-
-		$this->assertValidURIResolution( $uri, $expected_graphql_type, $category_id, $actual );
 	}
 
 	public function testUncategorizedCategoryByUri() {
@@ -1152,25 +1022,6 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->assertValidURIResolution( $uri, $expected_graphql_type, $category_id, $actual );
 		$this->assertFalse( $actual['data']['nodeByUri']['isContentNode'] );
 		$this->assertTrue( $actual['data']['nodeByUri']['isTermNode'] );
-
-		// Test without pretty permalinks.
-		$this->set_permalink_structure( '' );
-
-		$uri = wp_make_link_relative( get_category_link( $category_id ));
-
-		/**
-		 * NodeResolver::parse_request() will generate the following query vars:
-		 * uri => cat={category_id}
-		 * cat => {category_id}
-		 */
-		$actual = $this->graphql([
-			'query'     => $query,
-			'variables' => [
-				'uri' => $uri
-			],
-		]);
-
-		$this->assertValidURIResolution( $uri, $expected_graphql_type, $category_id, $actual );
 	}
 
 	/**
@@ -1215,25 +1066,6 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->assertValidURIResolution( $uri, $expected_graphql_type, $tag_id, $actual );
 		$this->assertFalse( $actual['data']['nodeByUri']['isContentNode'] );
 		$this->assertTrue( $actual['data']['nodeByUri']['isTermNode'] );
-
-		// Test without pretty permalinks.
-		$this->set_permalink_structure( '' );
-
-		$uri = wp_make_link_relative( get_term_link( $tag_id ));
-
-		/**
-		 * NodeResolver::parse_request() will generate the following query vars:
-		 * uri => tag={tag_id}
-		 * tag => test-tagbyuri
-		 */
-		$actual = $this->graphql([
-			'query'     => $query,
-			'variables' => [
-				'uri' => $uri
-			],
-		]);
-
-		$this->assertValidURIResolution( $uri, $expected_graphql_type, $tag_id, $actual );
 	}
 
 	/**
@@ -1275,26 +1107,6 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->markTestIncomplete( 'PostFormat archives not implemented. See: https://github.com/wp-graphql/wp-graphql/issues/2190' );
 		$this->assertValidURIResolution( $uri, 'PostFormat', $term->term_id, $actual );
 
-		// Test without pretty permalinks.
-		$this->set_permalink_structure( '' );
-		create_initial_taxonomies();
-
-		$uri = wp_make_link_relative( get_post_format_link( 'aside' ));
-
-		/**
-		 * NodeResolver::parse_request() will generate the following query vars:
-		 * uri => post_format={aside}
-		 * post_format => post-format-aside
-		 * post_type => [ post ]
-		 */
-		$actual = $this->graphql([
-			'query'     => $query,
-			'variables' => [
-				'uri' => $uri
-			],
-		]);
-
-		$this->assertValidURIResolution( $uri, 'PostFormat', $term->term_id, $actual );
 	}
 
 	/**
@@ -1323,25 +1135,6 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		]);
 
 		$this->assertValidURIResolution( $uri, $expected_graphql_type, $term_id, $actual );
-
-		// Test without pretty permalinks.
-		$this->set_permalink_structure( '' );
-
-		$uri = wp_make_link_relative( get_term_link( $term_id ));
-
-		/**
-		 * NodeResolver::parse_request() will generate the following query vars:
-		 * uri => by_uri_tax=default-term
-		 * by_uri_tax => default-term
-		 */
-		$actual = $this->graphql([
-			'query'     => $query,
-			'variables' => [
-				'uri' => $uri
-			],
-		]);
-
-		$this->assertValidURIResolution( $uri, $expected_graphql_type, $term_id, $actual );
 	}
 
 	public function testCustomTaxTermByUri() {
@@ -1359,25 +1152,6 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		/**
 		 * NodeResolver::parse_request() will generate the following query vars:
 		 * uri => /by_uri_tax/test-customtaxtermbyuri/
-		 * by_uri_tax => test-customtaxtermbyuri
-		 */
-		$actual = $this->graphql([
-			'query'     => $query,
-			'variables' => [
-				'uri' => $uri
-			],
-		]);
-
-		$this->assertValidURIResolution( $uri, $expected_graphql_type, $term_id, $actual );
-
-		// Test without pretty permalinks.
-		$this->set_permalink_structure( '' );
-
-		$uri = wp_make_link_relative( get_term_link( $term_id ));
-
-		/**
-		 * NodeResolver::parse_request() will generate the following query vars:
-		 * uri => by_uri_tax={term_id}
 		 * by_uri_tax => test-customtaxtermbyuri
 		 */
 		$actual = $this->graphql([
@@ -1659,27 +1433,6 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		] );
 
 		$this->assertValidURIResolution( $uri, 'User', $this->user, $actual );
-
-		// Test with pretty permalinks disabled
-		$this->set_permalink_structure( '' );
-
-		$uri = wp_make_link_relative( get_author_posts_url( $this->user ) );
-
-		/**
-		 * NodeResolver::parse_request() generates the following query vars:
-		 * uri => /?author={user_id}
-		 * author => {user_id}
-		 */
-		$actual = $this->graphql( [
-			'query' => $query,
-			'variables' => [
-				'uri' => $uri,
-			],
-		] );
-
-		$this->markTestIncomplete( 'resolve_uri() doesnt check for `author`' );
-
-		$this->assertValidURIResolution( $uri, 'User', $this->user, $actual );
 	}
 
 	/**
@@ -1720,30 +1473,6 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertSame( 'ContentType', $actual['data']['nodeByUri']['__typename'] );
 		$this->assertSame( 'post', $actual['data']['nodeByUri']['name'] );
-
-		// Test with pretty permalinks disabled
-		$this->set_permalink_structure( '' );
-
-		$uri = wp_make_link_relative( get_year_link( gmdate( 'Y' ) ) );
-
-		codecept_debug( $uri );
-
-		/**
-		 * NodeResolver::parse_request() generates the following query vars:
-		 * uri => m={year}
-		 * m => {year}
-		 */
-		$actual = $this->graphql( [
-			'query' => $query,
-			'variables' => [
-				'uri' => $uri,
-			],
-		] );
-
-		$this->assertArrayNotHasKey( 'errors', $actual );
-		$this->assertSame( 'ContentType', $actual['data']['nodeByUri']['__typename'] );
-		$this->assertSame( 'post', $actual['data']['nodeByUri']['name'] );
-
 	}
 
 	public function testDateMonthArchiveByUri() {
@@ -1782,30 +1511,6 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertSame( 'ContentType', $actual['data']['nodeByUri']['__typename'] );
 		$this->assertSame( 'post', $actual['data']['nodeByUri']['name'] );
-
-		// Test with pretty permalinks disabled
-		$this->set_permalink_structure( '' );
-
-		$uri = wp_make_link_relative( get_month_link( gmdate( 'Y' ), gmdate( 'm' ) ) );
-
-		codecept_debug( $uri );
-
-		/**
-		 * NodeResolver::parse_request() generates the following query vars:
-		 * uri => m={year}{month}
-		 * m => {year}{month}
-		 */
-		$actual = $this->graphql( [
-			'query' => $query,
-			'variables' => [
-				'uri' => $uri,
-			],
-		] );
-
-		$this->assertArrayNotHasKey( 'errors', $actual );
-		$this->assertSame( 'ContentType', $actual['data']['nodeByUri']['__typename'] );
-		$this->assertSame( 'post', $actual['data']['nodeByUri']['name'] );
-
 	}
 
 	public function testDateDayArchiveByUri() {
@@ -1841,29 +1546,6 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		] );
 
 		$this->markTestIncomplete( 'resolve_uri() doesnt check for `date archives`. See https://github.com/wp-graphql/wp-graphql/issues/2191' );
-
-		$this->assertArrayNotHasKey( 'errors', $actual );
-		$this->assertSame( 'ContentType', $actual['data']['nodeByUri']['__typename'] );
-		$this->assertSame( 'post', $actual['data']['nodeByUri']['name'] );
-
-		// Test with pretty permalinks disabled
-		$this->set_permalink_structure( '' );
-
-		$uri = wp_make_link_relative( get_day_link( gmdate( 'Y' ), gmdate( 'm' ), gmdate( 'd' ) ) );
-
-		codecept_debug( $uri );
-
-		/**
-		 * NodeResolver::parse_request() generates the following query vars:
-		 * uri => m={year}{month}{day}
-		 * m => {year}{month}{day}
-		 */
-		$actual = $this->graphql( [
-			'query' => $query,
-			'variables' => [
-				'uri' => $uri,
-			],
-		] );
 
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertSame( 'ContentType', $actual['data']['nodeByUri']['__typename'] );

--- a/tests/wpunit/NodeByUriTest.php
+++ b/tests/wpunit/NodeByUriTest.php
@@ -2006,6 +2006,7 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		]);
 
 		update_option( 'page_for_posts', $page_id );
+		update_option( 'show_on_front', 'page' );
 
 		$query = $this->getQuery();
 

--- a/tests/wpunit/PageByUriTest.php
+++ b/tests/wpunit/PageByUriTest.php
@@ -97,6 +97,8 @@ class PageByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		// set the page as the page_for_posts
 		update_option( 'page_for_posts', $this->page );
+		update_option( 'show_on_front', 'page' );
+
 
 		$actual = $this->graphql([
 			'query' => $query,

--- a/tests/wpunit/PostObjectQueriesTest.php
+++ b/tests/wpunit/PostObjectQueriesTest.php
@@ -12,8 +12,11 @@ class PostObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase 
 		// before
 		parent::setUp();
 
-		$this->clearSchema();
 		$this->set_permalink_structure( '/%year%/%monthnum%/%day%/%postname%/' );
+		create_initial_post_types();
+		$this->clearSchema();
+
+
 		$this->current_time     = strtotime( '- 1 day' );
 		$this->current_date     = date( 'Y-m-d H:i:s', $this->current_time );
 		$this->current_date_gmt = gmdate( 'Y-m-d H:i:s', $this->current_time );
@@ -1827,11 +1830,12 @@ class PostObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase 
 			'post_title'  => 'Test for QueryPostUsingIDType',
 		]);
 
+		$post = get_post( $post_id );
+
 		$global_id = \GraphQLRelay\Relay::toGlobalId( 'post', absint( $post_id ) );
-		$slug      = get_post( $post_id )->post_name;
-		$uri       = get_page_uri( $post_id );
+		$slug      = $post->post_name;
+		$uri       = wp_make_link_relative( get_permalink( $post_id ) );
 		$title     = get_post( $post_id )->post_title;
-		$permalink = get_permalink( $post_id );
 
 		codecept_debug( $uri );
 
@@ -1839,7 +1843,7 @@ class PostObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase 
 			'id'     => $global_id,
 			'postId' => $post_id,
 			'title'  => $title,
-			'uri'    => str_ireplace( home_url(), '', $permalink ),
+			'uri'    => $uri,
 			'slug'   => $slug,
 		];
 

--- a/tests/wpunit/TermNodeTest.php
+++ b/tests/wpunit/TermNodeTest.php
@@ -4,6 +4,10 @@ class TermNodeTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 	public function setUp(): void {
 		parent::setUp();
+		$this->set_permalink_structure( '/%postname%/' );
+		create_initial_taxonomies();
+		flush_rewrite_rules( true );
+
 		$this->clearSchema();
 	}
 	public function tearDown(): void {


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This pr refactors `NodeResolver::resolve_uri()` to use `WP_Query`, instead of the current approach where we try to replicate the class logic locally.

This brings the resolution process more in line with `WP::main()`, mitigating edge cases and reducing code complexity.

In addition, it adds the following WP filters to the method:
- `graphql_resolve_uri_query_class` . Used to swap out WP_Query with a specialized class, e.g. `WC_Query` from woo.
- `graphql_resolve_uri` . Used to short-circuit `resolve_uri()` after the query has been run, but before our own attempts to resolve it to a WPGraphQL `node`, e.g. if we want a CPT to use a special dataloader.
- `graphql_post_resolve_uri`. Used to provide a WPGraphQL `node` if `resolve_uri()` is unable to do so, e.g. a plugin-specific Edge case.

Does this close any currently open issues?
------------------------------------------
fixes #2178
fixes #2190
closes #1910 
(possibly others)

Part of #2366 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
- This PR includes #2659, which should be merged first. 
- Since we're no longer routing via our own conditionals, `$extra_query_vars['nodeType']` and `$extra_query_vars['taxonomy']` are now set in more places to let us validate the type we're receiving is compatible with the GraphQL type we resolve to.
- I removed `nodeByUri` tests for when pretty permalinks are disabled _for now_. The reason is that `parse_request()` (from before this PR) marks those as a 404, which we were able to ignore when we were using our own logic before calling WP_Query, but no longer. I _believe_ this is a quirk with Codeception, and not an issue with the code itself, and I am looking into workarounds to reinstate those tests.
- Before merging, we should test with popular WPGraphQL Extensions, just in case they're doing something funky to work around the existing bugs.
- While I dont expect there to be any performance hits (if anything, maybe a small perf improvement because `WP_Query` results are usually cached, and we're hitting it earlier in the lifecycle), but we should do some profiling to be 100% sure. This is beyond my skillset.
- Date archives _still_ resolve null, since without #2491 we have nowhere to resolve them to. We _could_ put a `graphql_debug()` saying theyre not currently supported, and fallback to the `ContentType`, but there isnt precedent for that in the codebase.

Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php8.0.19)

**WordPress Version:** 6.1.1
