### PR TITLE
chore: remove deprecated use of `WPGraphQL\Data\DataSource::resolve_user()`

### DIFF
--- a/src/Type/ObjectType/RootQuery.php
+++ b/src/Type/ObjectType/RootQuery.php
@@ -618,7 +618,7 @@ class RootQuery {
 									break;
 							}
 
-							return ! empty( $id ) ? DataSource::resolve_user( $id, $context ) : null;
+							return ! empty( $id ) ? $context->get_loader( 'user' )->load_deferred( $id ) : null;
 						},
 					],
 					'userRole'    => [


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [ ] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------

> Unexpected deprecation notice for WPGraphQL\Data\DataSource::resolve_user.
Function WPGraphQL\Data\DataSource::resolve_user is deprecated since version 0.8.4! Use Use $context->get_loader( 'user' )->load_deferred( $id ) instead. instead.
Failed asserting that an array is empty.


Does this close any currently open issues?
------------------------------------------
No!


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
This is currently failing unit tests from the BP extension.


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
