### PR TITLE
fix: prevent infinite recursion when an interface implements itself 

### DIFF
--- a/src/Type/WPInterfaceTrait.php
+++ b/src/Type/WPInterfaceTrait.php
@@ -43,7 +43,7 @@ trait WPInterfaceTrait {
 		// check if an interface is attempting to implement itself, and if so unset it
 		$key = array_search( strtolower( $this->config['name'] ), array_map( 'strtolower', $interfaces ), true );
 		if ( false !== $key ) {
-			graphql_debug( sprintf( __( 'The "%1$s" Interface attempted to implement the "%2$s" Interface, which is not allowed', 'wp-graphql' ), $interfaces[ $key ], $interfaces[ $key ] ) );
+			graphql_debug( sprintf( __( 'The "%s" Interface attempted to implement itself, which is not allowed', 'wp-graphql' ), $interfaces[ $key ] ) );
 			unset( $interfaces[ $key ] );
 		}
 

--- a/src/Type/WPInterfaceTrait.php
+++ b/src/Type/WPInterfaceTrait.php
@@ -44,8 +44,13 @@ trait WPInterfaceTrait {
 
 		foreach ( $interfaces as $interface ) {
 
+			if ( $interface instanceof InterfaceType && $interface->name !== $this->name ) {
+				$new_interfaces[ $interface->name ] = $interface;
+				continue;
+			}
+
 			// surface when interfaces are trying to be registered with invalid configuration
-			if ( ! is_string( $interface ) && ! $interface instanceof InterfaceType ) {
+			if ( ! is_string( $interface ) ) {
 				graphql_debug( sprintf( __( 'Invalid Interface registered to the "%s" Type. Interfaces can only be registered with an interface name or a valid instance of an InterfaceType', 'wp-graphql' ), $this->name ), [ 'invalid_interface' => $interface ] );
 				continue;
 			}

--- a/src/Type/WPInterfaceTrait.php
+++ b/src/Type/WPInterfaceTrait.php
@@ -40,22 +40,25 @@ trait WPInterfaceTrait {
 			return $interfaces;
 		}
 
-		// check if an interface is attempting to implement itself, and if so unset it
-		$key = array_search( strtolower( $this->config['name'] ), array_map( 'strtolower', $interfaces ), true );
-		if ( false !== $key ) {
-			graphql_debug( sprintf( __( 'The "%s" Interface attempted to implement itself, which is not allowed', 'wp-graphql' ), $interfaces[ $key ] ) );
-			unset( $interfaces[ $key ] );
-		}
-
 		$new_interfaces = [];
 
 		foreach ( $interfaces as $interface ) {
-			if ( ! is_string( $interface ) ) {
+
+			// surface when interfaces are trying to be registered with invalid configuration
+			if ( ! is_string( $interface ) && ! $interface instanceof InterfaceType ) {
+				graphql_debug( sprintf( __( 'Invalid Interface registered to the "%s" Type. Interfaces can only be registered with an interface name or a valid instance of an InterfaceType', 'wp-graphql' ), $this->name ), [ 'invalid_interface' => $interface ] );
+				continue;
+			}
+
+			// Prevent an interface from implementing itself
+			if ( strtolower( $this->config['name'] ) === strtolower( $interface ) ) {
+				graphql_debug( sprintf( __( 'The "%s" Interface attempted to implement itself, which is not allowed', 'wp-graphql' ), $interface ) );
 				continue;
 			}
 
 			$interface_type = $this->type_registry->get_type( $interface );
 			if ( ! $interface_type instanceof InterfaceType ) {
+				graphql_debug( sprintf( __( '"%1$s" is not a valid Interface Type and cannot be implemented as an Interface on the "%2$s" Type', 'wp-graphql' ), $interface, $this->name ) );
 				continue;
 			}
 

--- a/tests/wpunit/InterfaceTest.php
+++ b/tests/wpunit/InterfaceTest.php
@@ -409,4 +409,28 @@ class InterfaceTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertTrue( in_array( 'test', $fields ) );
 	}
 
+	public function testInterfaceImplementingItselfDoesNotCauseInfiniteRecursion() {
+
+		// here we implement the interface on the interface itself.
+		// this will cause infinite recursion and a failed test.
+		// the fix should prevent the interface from being implemented on itself,
+		// even if the code attempts to do it.
+		register_graphql_interface_type( 'InterfaceA', [
+			'interfaces' => [ 'Node', 'InterfaceA' ],
+			'fields' => [ 'fieldA' => [ 'type' => 'String' ] ],
+			'resolveType' => function() {
+				return 'Post';
+			}
+		]);
+
+		register_graphql_interfaces_to_types( [ 'InterfaceA' ], [ 'Post' ] );
+
+		$actual = graphql([
+			'query' => '{ posts { nodes { id, title } } }'
+		]);
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+
+	}
+
 }

--- a/tests/wpunit/InterfaceTest.php
+++ b/tests/wpunit/InterfaceTest.php
@@ -411,12 +411,12 @@ class InterfaceTest extends \Codeception\TestCase\WPTestCase {
 
 	public function testInterfaceImplementingItselfDoesNotCauseInfiniteRecursion() {
 
-		// here we implement the interface on the interface itself.
+		// here we implement the interface on the interface itself (multiple times with different cases).
 		// this will cause infinite recursion and a failed test.
 		// the fix should prevent the interface from being implemented on itself,
 		// even if the code attempts to do it.
 		register_graphql_interface_type( 'InterfaceA', [
-			'interfaces' => [ 'Node', 'InterfaceA' ],
+			'interfaces' => [ 'Node', 'InterfaceA', 'interfaceA', 'interfacea' ],
 			'fields' => [ 'fieldA' => [ 'type' => 'String' ] ],
 			'resolveType' => function() {
 				return 'Post';


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- prevent the interface being registered from implementing itself
- **Failing Test**: https://github.com/wp-graphql/wp-graphql/actions/runs/3894753346/jobs/6649175397
- **Passing Test**: https://github.com/wp-graphql/wp-graphql/actions/runs/3894832627/jobs/6649360575

Does this close any currently open issues?
------------------------------------------
closes #2687 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

With the following code in place:

```php
add_action( 'graphql_register_types', function () {

	register_graphql_interface_type( 'InterfaceA', [
		'interfaces' => [ 'Node', 'InterfaceA' ],
		'fields' => [ 'fieldA' => [ 'type' => 'String' ] ],
		'resolveType' => function() {
			return 'Post';
		}
	]);

	register_graphql_interfaces_to_types( [ 'InterfaceA' ], [ 'Post' ] );

});
```

## Before

When trying to open the GraphiQL IDE, we get infinite recursion leading to max nested function errors, and the Schema never loads:

![CleanShot 2023-01-11 at 09 45 51](https://user-images.githubusercontent.com/1260765/211865802-9ef3d9f9-b8e4-421f-b2cf-4a6377fccb0e.png)

## After

Schema loads fine and we can use GraphiQL:

![CleanShot 2023-01-11 at 09 48 10](https://user-images.githubusercontent.com/1260765/211866276-40b31496-4d03-4d7f-bd2d-47b0dedfe129.png)


Any other comments?
-------------------

We're outputting a `graphql_debug` message informing the user that the interface attempted to implement itself, but we don't throw an error, as that would break existing queries that were working.