### PR TITLE
fix: prevent non-node types from being output in the query analyzer list type keys

### DIFF
--- a/src/Utils/QueryAnalyzer.php
+++ b/src/Utils/QueryAnalyzer.php
@@ -357,11 +357,10 @@ class QueryAnalyzer {
 							// if the Type is not a Node, and has a "node" field,
 							// lets get the named type of the node, not the edge
 							$type_map[] = 'list:' . strtolower( $named_type );
-						} else if ( in_array( 'node', $named_type->getFieldNames(), true ) ) {
+						} elseif ( in_array( 'node', $named_type->getFieldNames(), true ) ) {
 							$named_type = $named_type->getField( 'node' )->getType();
 							$type_map[] = 'list:' . strtolower( $named_type );
-						}
-
+						}                   
 					}
 				}
 
@@ -377,7 +376,7 @@ class QueryAnalyzer {
 								// if the Type is not a Node, and has a "node" field,
 								// lets get the named type of the node, not the edge
 								$type_map[] = 'list:' . strtolower( $possible_type );
-							} else if ( in_array( 'node', $possible_type->getFieldNames(), true ) ) {
+							} elseif ( in_array( 'node', $possible_type->getFieldNames(), true ) ) {
 								$named_type = $named_type->getField( 'node' )->getType();
 								$type_map[] = 'list:' . strtolower( $possible_type );
 							}

--- a/src/Utils/QueryAnalyzer.php
+++ b/src/Utils/QueryAnalyzer.php
@@ -352,13 +352,16 @@ class QueryAnalyzer {
 					// with a double __, then it should be tracked
 					if ( $is_list_type && 0 !== strpos( $named_type, '__' ) ) {
 
-						// if the Type is not a Node, and has a "node" field,
-						// lets get the named type of the node, not the edge
-						if ( in_array( 'node', $named_type->getFieldNames(), true ) && ! in_array( 'Node', array_keys( $named_type->getInterfaces() ), true ) ) {
+						// if the type doesn't apply the node interface
+						if ( array_key_exists( 'Node', $named_type->getInterfaces() ) ) {
+							// if the Type is not a Node, and has a "node" field,
+							// lets get the named type of the node, not the edge
+							$type_map[] = 'list:' . strtolower( $named_type );
+						} else if ( in_array( 'node', $named_type->getFieldNames(), true ) ) {
 							$named_type = $named_type->getField( 'node' )->getType();
+							$type_map[] = 'list:' . strtolower( $named_type );
 						}
 
-						$type_map[] = 'list:' . strtolower( $named_type );
 					}
 				}
 
@@ -369,7 +372,15 @@ class QueryAnalyzer {
 					foreach ( $possible_types as $possible_type ) {
 						// if the type is a list, store it
 						if ( $is_list_type && 0 !== strpos( $possible_type, '__' ) ) {
-							$type_map[] = 'list:' . strtolower( $possible_type );
+							// if the type doesn't apply the node interface
+							if ( array_key_exists( 'Node', $named_type->getInterfaces() ) ) {
+								// if the Type is not a Node, and has a "node" field,
+								// lets get the named type of the node, not the edge
+								$type_map[] = 'list:' . strtolower( $named_type );
+							} else if ( in_array( 'node', $named_type->getFieldNames(), true ) ) {
+								$named_type = $named_type->getField( 'node' )->getType();
+								$type_map[] = 'list:' . strtolower( $named_type );
+							}
 						}
 					}
 				}

--- a/src/Utils/QueryAnalyzer.php
+++ b/src/Utils/QueryAnalyzer.php
@@ -351,16 +351,15 @@ class QueryAnalyzer {
 					// if the type is a list and the named type doesn't start
 					// with a double __, then it should be tracked
 					if ( $is_list_type && 0 !== strpos( $named_type, '__' ) ) {
-
 						// if the type doesn't apply the node interface
-						if ( array_key_exists( 'Node', $named_type->getInterfaces() ) ) {
+						if ( ! empty( $named_type->getInterfaces() ) && array_key_exists( 'Node', $named_type->getInterfaces() ) ) {
 							// if the Type is not a Node, and has a "node" field,
 							// lets get the named type of the node, not the edge
 							$type_map[] = 'list:' . strtolower( $named_type );
 						} elseif ( in_array( 'node', $named_type->getFieldNames(), true ) ) {
 							$named_type = $named_type->getField( 'node' )->getType();
 							$type_map[] = 'list:' . strtolower( $named_type );
-						}                   
+						}
 					}
 				}
 
@@ -372,7 +371,7 @@ class QueryAnalyzer {
 						// if the type is a list, store it
 						if ( $is_list_type && 0 !== strpos( $possible_type, '__' ) ) {
 							// if the type doesn't apply the node interface
-							if ( array_key_exists( 'Node', $possible_type->getInterfaces() ) ) {
+							if ( ! empty( $possible_type->getInterfaces() ) &&  array_key_exists( 'Node', $possible_type->getInterfaces() ) ) {
 								// if the Type is not a Node, and has a "node" field,
 								// lets get the named type of the node, not the edge
 								$type_map[] = 'list:' . strtolower( $possible_type );

--- a/src/Utils/QueryAnalyzer.php
+++ b/src/Utils/QueryAnalyzer.php
@@ -371,7 +371,7 @@ class QueryAnalyzer {
 						// if the type is a list, store it
 						if ( $is_list_type && 0 !== strpos( $possible_type, '__' ) ) {
 							// if the type doesn't apply the node interface
-							if ( ! empty( $possible_type->getInterfaces() ) &&  array_key_exists( 'Node', $possible_type->getInterfaces() ) ) {
+							if ( ! empty( $possible_type->getInterfaces() ) && array_key_exists( 'Node', $possible_type->getInterfaces() ) ) {
 								// if the Type is not a Node, and has a "node" field,
 								// lets get the named type of the node, not the edge
 								$type_map[] = 'list:' . strtolower( $possible_type );

--- a/src/Utils/QueryAnalyzer.php
+++ b/src/Utils/QueryAnalyzer.php
@@ -373,13 +373,13 @@ class QueryAnalyzer {
 						// if the type is a list, store it
 						if ( $is_list_type && 0 !== strpos( $possible_type, '__' ) ) {
 							// if the type doesn't apply the node interface
-							if ( array_key_exists( 'Node', $named_type->getInterfaces() ) ) {
+							if ( array_key_exists( 'Node', $possible_type->getInterfaces() ) ) {
 								// if the Type is not a Node, and has a "node" field,
 								// lets get the named type of the node, not the edge
-								$type_map[] = 'list:' . strtolower( $named_type );
-							} else if ( in_array( 'node', $named_type->getFieldNames(), true ) ) {
+								$type_map[] = 'list:' . strtolower( $possible_type );
+							} else if ( in_array( 'node', $possible_type->getFieldNames(), true ) ) {
 								$named_type = $named_type->getField( 'node' )->getType();
-								$type_map[] = 'list:' . strtolower( $named_type );
+								$type_map[] = 'list:' . strtolower( $possible_type );
 							}
 						}
 					}

--- a/tests/wpunit/QueryAnalyzerTest.php
+++ b/tests/wpunit/QueryAnalyzerTest.php
@@ -11,6 +11,8 @@ class QueryAnalyzerTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 			'post_title' => 'test post'
 		]);
 
+		WPGraphQL::clear_schema();
+
 	}
 
 	public function _tearDown():void {
@@ -77,6 +79,80 @@ class QueryAnalyzerTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$types = $request->get_query_analyzer()->get_query_types();
 		$this->assertEqualSets( [ 'rootquery', 'rootquerytopostconnection', 'post' ], $types );
+	}
+
+	public function testQueryForListOfNonNodeInterfaceTypesDoesntAddKeys() {
+
+		// types that do not implement the "Node" interface shouldn't be tracked as keys
+		// in the Query Analyzer
+
+		add_action( 'graphql_register_types', function() {
+			register_graphql_interface_type( 'TestInterface', [
+				'eagerlyLoadType' => true,
+				'fields'      => [
+					'test' => [
+						'type' => 'String',
+					],
+				],
+				'resolveType' => function () {
+					return 'TestType';
+				},
+			] );
+
+			register_graphql_object_type( 'TestType', [
+				'eagerlyLoadType' => true,
+				'interfaces' => [ 'TestInterface' ],
+				'fields'     => [
+					'test' => [
+						'type' => 'String',
+					],
+				],
+			] );
+
+			register_graphql_field( 'Post', 'testField', [
+				'type'    => [ 'list_of' => 'TestInterface' ],
+				'resolve' => function () {
+					return [
+						[
+							'test' => 'value',
+						],
+						[
+							'test' => 'value',
+						],
+					];
+				},
+			] );
+		} );
+
+
+		$query = '
+		{
+		  posts {
+		    nodes {
+		      testField {
+		        test
+		      }
+		    }
+		  }
+		}
+		';
+
+		$request = graphql([
+			'query' => $query
+		], true );
+
+		$request->execute();
+
+		$list_types = $request->get_query_analyzer()->get_list_types();
+
+		codecept_debug( $list_types );
+		$keys_array = $list_types;
+		codecept_debug( $list_types );
+
+		$this->assertNotContains( 'list:testinterface', $list_types );
+		$this->assertNotContains( 'list:testtype', $list_types );
+		$this->assertContains( 'list:post', $list_types );
+
 	}
 
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

This prevents list types from being returned in the query analyzer if the type isn't a type that implements the `node` interface.

**failing test**: https://github.com/wp-graphql/wp-graphql/actions/runs/3897357240/jobs/6654945889
**passing test**: https://github.com/wp-graphql/wp-graphql/actions/runs/3897472140/jobs/6655191024


Does this close any currently open issues?
------------------------------------------
closes #2690 

