### PR TITLE
feat: Allow ordering by Name (numeric)

### DIFF
--- a/src/Type/Enum/TermObjectsConnectionOrderbyEnum.php
+++ b/src/Type/Enum/TermObjectsConnectionOrderbyEnum.php
@@ -18,6 +18,10 @@ class TermObjectsConnectionOrderbyEnum {
 						'value'       => 'name',
 						'description' => __( 'Order the connection by name.', 'wp-graphql' ),
 					],
+					'NAME_NUM'        => [
+						'value'       => 'name_num',
+						'description' => __( 'Order the connection by name (numeric).', 'wp-graphql' ),
+					],
 					'SLUG'        => [
 						'value'       => 'slug',
 						'description' => __( 'Order the connection by slug.', 'wp-graphql' ),


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [ ] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds a new `NAME_NUM` order by value to the `TermObjectsConnectionOrderbyEnum` to allow for ordering by name (numeric). Sometime ordering by name results in unexpected results, such as "10" being ordered before "2". This allows for ordering by name (numeric) to avoid this issue.


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

### Example of ordering by `NAME`
![NAME](https://user-images.githubusercontent.com/5116925/214982298-f1f5f1ea-ace4-42eb-a265-59a34a8c6022.jpg)


### Example of ordering by `NAME_NUM`
![NAME_NUM](https://user-images.githubusercontent.com/5116925/214982202-c5d40996-05ac-49ae-ad09-2c62f536bfa9.jpg)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** 6.1.1
