### PR TITLE
fix: missing apostrophe after escape

### DIFF
--- a/src/Type/Enum/UsersConnectionSearchColumnEnum.php
+++ b/src/Type/Enum/UsersConnectionSearchColumnEnum.php
@@ -33,7 +33,7 @@ class UsersConnectionSearchColumnEnum {
 					],
 					'URL'      => [
 						'value'       => 'url',
-						'description' => __( 'The URL of the user\s website.', 'wp-graphql' ),
+						'description' => __( 'The URL of the user\'s website.', 'wp-graphql' ),
 					],
 				],
 			]


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [ ] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
…
Fixes a missing apostrophe to correct use an escape character. This breaks instropecting the schema.

Does this close any currently open issues?
------------------------------------------

closes https://github.com/wp-graphql/wp-graphql/issues/2703

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)
```
      Failed to load schema from kb.graphql:
      Syntax Error: Invalid character escape sequence: "\s".
      GraphQLError: Syntax Error: Invalid character escape sequence: "\s".
```

Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Linux

**WordPress Version:** n/a - need to fix the comment only!
