### PR TITLE
chore: Use fully-qualified classnames in PHPDoc annotations

### DIFF
--- a/access-functions.php
+++ b/access-functions.php
@@ -59,8 +59,8 @@ function graphql_format_type_name( $type_name ) {
  * @param array $request_data   The GraphQL request data (query, variables, operation_name).
  * @param bool  $return_request If true, return the Request object, else return the results of the request execution
  *
- * @return array | Request
- * @throws Exception
+ * @return array|\WPGraphQL\Request
+ * @throws \Exception
  * @since  0.2.0
  */
 function graphql( array $request_data = [], bool $return_request = false ) {
@@ -85,8 +85,8 @@ function graphql( array $request_data = [], bool $return_request = false ) {
  * @param array  $variables      Variables to be passed to your GraphQL request
  * @param bool   $return_requst If true, return the Request object, else return the results of the request execution
  *
- * @return array | Request
- * @throws Exception
+ * @return array|\WPGraphQL\Request
+ * @throws \Exception
  * @since  0.0.2
  */
 function do_graphql_request( $query, $operation_name = '', $variables = [], $return_requst = false ) {
@@ -174,7 +174,7 @@ function register_graphql_interfaces_to_types( $interface_names, $type_names ) {
  * @param string $type_name The name of the Type to register
  * @param array  $config    The Type config
  *
- * @throws Exception
+ * @throws \Exception
  * @return void
  */
 function register_graphql_type( string $type_name, array $config ) {
@@ -193,7 +193,7 @@ function register_graphql_type( string $type_name, array $config ) {
  * @param string $type_name The name of the Type to register
  * @param array  $config    The Type config
  *
- * @throws Exception
+ * @throws \Exception
  * @return void
  */
 function register_graphql_interface_type( string $type_name, array $config ) {
@@ -238,7 +238,7 @@ function register_graphql_input_type( string $type_name, array $config ) {
  * @param string $type_name The name of the Type to register
  * @param array  $config    The Type config
  *
- * @throws Exception
+ * @throws \Exception
  *
  * @return void
  */
@@ -423,7 +423,7 @@ function rename_graphql_field( string $type_name, string $field_name, string $ne
  * @param string $new_type_name  The new name to give the Type.
  *
  * @return void
- * @throws Exception
+ * @throws \Exception
  *
  * @since 1.3.4
  */
@@ -459,7 +459,7 @@ function rename_graphql_type( string $type_name, string $new_type_name ) {
  *
  * @param array $config Array to configure the connection
  *
- * @throws Exception
+ * @throws \Exception
  * @return void
  *
  * @since 0.1.0
@@ -480,7 +480,7 @@ function register_graphql_connection( array $config ) {
  * @param string $type_name The name of the Type to register
  * @param array  $config    The config for the scalar type to register
  *
- * @throws Exception
+ * @throws \Exception
  * @return void
  *
  * @since 0.8.4
@@ -566,7 +566,7 @@ function deregister_graphql_field( string $type_name, string $field_name ) {
  * @param string $mutation_name The name of the Mutation to register
  * @param array  $config        The config for the mutation
  *
- * @throws Exception
+ * @throws \Exception
  *
  * @return void
  * @since 0.1.0

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
 		"wp-graphql/wp-graphql-testcase": "~2.3",
 		"phpunit/phpunit": "^9.5",
 		"simpod/php-coveralls-mirror": "^3.0",
-		"phpstan/extension-installer": "^1.1"
+		"phpstan/extension-installer": "^1.1",
+		"slevomat/coding-standard": "^8.8"
 	},
 	"config": {
 		"platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c96042ef3dda42b1f6762baa6665cf78",
+    "content-hash": "72226c34b59b4a645da36090ab9e1d2d",
     "packages": [
         {
             "name": "appsero/client",
@@ -2895,6 +2895,51 @@
             "time": "2020-12-13T13:06:13+00:00"
         },
         {
+            "name": "phpstan/phpdoc-parser",
+            "version": "1.15.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "61800f71a5526081d1b5633766aa88341f1ade76"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/61800f71a5526081d1b5633766aa88341f1ade76",
+                "reference": "61800f71a5526081d1b5633766aa88341f1ade76",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^1.5",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "^9.5",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.15.3"
+            },
+            "time": "2022-12-20T20:56:55+00:00"
+        },
+        {
             "name": "phpstan/phpstan",
             "version": "1.8.8",
             "source": {
@@ -4837,6 +4882,71 @@
                 "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
             },
             "time": "2022-10-05T23:31:46+00:00"
+        },
+        {
+            "name": "slevomat/coding-standard",
+            "version": "8.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "59e25146a4ef0a7b194c5bc55b32dd414345db89"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/59e25146a4ef0a7b194c5bc55b32dd414345db89",
+                "reference": "59e25146a4ef0a7b194c5bc55b32dd414345db89",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.0",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpdoc-parser": ">=1.15.2 <1.16.0",
+                "squizlabs/php_codesniffer": "^3.7.1"
+            },
+            "require-dev": {
+                "phing/phing": "2.17.4",
+                "php-parallel-lint/php-parallel-lint": "1.3.2",
+                "phpstan/phpstan": "1.4.10|1.9.6",
+                "phpstan/phpstan-deprecation-rules": "1.1.1",
+                "phpstan/phpstan-phpunit": "1.0.0|1.3.3",
+                "phpstan/phpstan-strict-rules": "1.4.4",
+                "phpunit/phpunit": "7.5.20|8.5.21|9.5.27"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "keywords": [
+                "dev",
+                "phpcs"
+            ],
+            "support": {
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/8.8.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kukulich",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-01-09T10:46:13+00:00"
         },
         {
             "name": "softcreatr/jsonpath",
@@ -7598,5 +7708,5 @@
     "platform-overrides": {
         "php": "7.3"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -99,4 +99,7 @@
 
 	<!-- Enforce short array syntax -->
 	<rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
+
+	<!-- Use FQCN for PHPDoc types -->
+	<rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameInAnnotation"/>
 </ruleset>

--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -27,7 +27,7 @@ class Admin {
 	protected $graphiql_enabled;
 
 	/**
-	 * @var Settings
+	 * @var \WPGraphQL\Admin\Settings\Settings
 	 */
 	protected $settings;
 

--- a/src/Admin/GraphiQL/GraphiQL.php
+++ b/src/Admin/GraphiQL/GraphiQL.php
@@ -55,7 +55,7 @@ class GraphiQL {
 	/**
 	 * Registers admin bar menu
 	 *
-	 * @param WP_Admin_Bar $admin_bar The Admin Bar Instance
+	 * @param \WP_Admin_Bar $admin_bar The Admin Bar Instance
 	 *
 	 * @return void
 	 */

--- a/src/Admin/Settings/Settings.php
+++ b/src/Admin/Settings/Settings.php
@@ -10,7 +10,7 @@ namespace WPGraphQL\Admin\Settings;
 class Settings {
 
 	/**
-	 * @var SettingsRegistry
+	 * @var \WPGraphQL\Admin\Settings\SettingsRegistry
 	 */
 	public $settings_api;
 

--- a/src/Admin/Settings/SettingsRegistry.php
+++ b/src/Admin/Settings/SettingsRegistry.php
@@ -72,7 +72,7 @@ class SettingsRegistry {
 	 * @param string $slug    Setting Section Slug
 	 * @param array  $section setting section config
 	 *
-	 * @return SettingsRegistry
+	 * @return \WPGraphQL\Admin\Settings\SettingsRegistry
 	 */
 	public function register_section( string $slug, array $section ) {
 		$section['id']                    = $slug;
@@ -87,7 +87,7 @@ class SettingsRegistry {
 	 * @param string $section The slug of the section to register a field to
 	 * @param array  $fields  settings fields array
 	 *
-	 * @return SettingsRegistry
+	 * @return \WPGraphQL\Admin\Settings\SettingsRegistry
 	 */
 	public function register_fields( string $section, array $fields ) {
 		foreach ( $fields as $field ) {
@@ -103,7 +103,7 @@ class SettingsRegistry {
 	 * @param string $section The slug of the section to register a field to
 	 * @param array  $field   The config for the field being registered
 	 *
-	 * @return SettingsRegistry
+	 * @return \WPGraphQL\Admin\Settings\SettingsRegistry
 	 */
 	public function register_field( string $section, array $field ) {
 		$defaults = [

--- a/src/AppContext.php
+++ b/src/AppContext.php
@@ -42,12 +42,12 @@ class AppContext {
 	/**
 	 * Stores the WP_User object of the current user
 	 *
-	 * @var WP_User $viewer
+	 * @var \WP_User $viewer
 	 */
 	public $viewer;
 
 	/**
-	 * @var TypeRegistry
+	 * @var \WPGraphQL\Registry\TypeRegistry
 	 */
 	public $type_registry;
 
@@ -89,7 +89,7 @@ class AppContext {
 	/**
 	 * Instance of the NodeResolver class to resolve nodes by URI
 	 *
-	 * @var NodeResolver
+	 * @var \WPGraphQL\Data\NodeResolver
 	 */
 	public $node_resolver;
 
@@ -130,7 +130,7 @@ class AppContext {
 		/**
 		 * This sets up the NodeResolver to allow nodes to be resolved by URI
 		 *
-		 * @param AppContext $app_context The AppContext instance
+		 * @param \WPGraphQL\AppContext $app_context The AppContext instance
 		 */
 		$this->node_resolver = new NodeResolver( $this );
 

--- a/src/Data/CommentMutation.php
+++ b/src/Data/CommentMutation.php
@@ -24,7 +24,7 @@ class CommentMutation {
 	 * @param bool   $update        Whether it's an update action
 	 *
 	 * @return array $output_args
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public static function prepare_comment_object( array $input, array &$output_args, string $mutation_name, $update = false ) {
 		/**
@@ -120,8 +120,8 @@ class CommentMutation {
 	 * @param int         $comment_id    The ID of the postObject the comment is connected to
 	 * @param array       $input         The input for the mutation
 	 * @param string      $mutation_name The name of the mutation ( ex: create, update, delete )
-	 * @param AppContext  $context       The AppContext passed down to all resolvers
-	 * @param ResolveInfo $info          The ResolveInfo passed down to all resolvers
+	 * @param \WPGraphQL\AppContext $context The AppContext passed down to all resolvers
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down to all resolvers
 	 *
 	 * @return void
 	 */

--- a/src/Data/Config.php
+++ b/src/Data/Config.php
@@ -98,7 +98,7 @@ class Config {
 					 **
 					 *
 					 * @param string        $where The WHERE clause of the query.
-					 * @param WP_User_Query $query The WP_User_Query instance (passed by reference).
+					 * @param \WPGraphQL\Data\WP_User_Query $query The WP_User_Query instance (passed by reference).
 					 */
 					$query->query_where = apply_filters_ref_array( 'graphql_users_where', [
 						$query->query_where,
@@ -109,7 +109,7 @@ class Config {
 					 * Filters the ORDER BY clause of the query.
 					 *
 					 * @param string        $orderby The ORDER BY clause of the query.
-					 * @param WP_User_Query $query   The WP_User_Query instance (passed by reference).
+					 * @param \WPGraphQL\Data\WP_User_Query $query The WP_User_Query instance (passed by reference).
 					 */
 					$query->query_orderby = apply_filters_ref_array( 'graphql_users_orderby', [
 						$query->query_orderby,
@@ -160,7 +160,7 @@ class Config {
 	 * and for their cursors to properly go forward/backward to the proper place in the database.
 	 *
 	 * @param string    $orderby  The ORDER BY clause of the query.
-	 * @param WP_Query $wp_query The WP_Query instance executing
+	 * @param \WP_Query $wp_query The WP_Query instance executing
 	 *
 	 * @return string
 	 */
@@ -191,7 +191,7 @@ class Config {
 	 * after the referenced cursor
 	 *
 	 * @param string   $where The WHERE clause of the query.
-	 * @param WP_Query $query The WP_Query instance (passed by reference).
+	 * @param \WP_Query $query The WP_Query instance (passed by reference).
 	 *
 	 * @return string
 	 */
@@ -313,7 +313,7 @@ class Config {
 	 * is a GraphQL Request and before or after cursors are passed to the query
 	 *
 	 * @param array            $pieces A compacted array of comment query clauses.
-	 * @param WP_Comment_Query $query  Current instance of WP_Comment_Query, passed by reference.
+	 * @param \WP_Comment_Query $query Current instance of WP_Comment_Query, passed by reference.
 	 *
 	 * @return array $pieces
 	 */

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -38,14 +38,14 @@ abstract class AbstractConnectionResolver {
 	/**
 	 * The AppContext for the GraphQL Request
 	 *
-	 * @var AppContext
+	 * @var \WPGraphQL\AppContext
 	 */
 	protected $context;
 
 	/**
 	 * The ResolveInfo for the GraphQL Request
 	 *
-	 * @var ResolveInfo
+	 * @var \GraphQL\Type\Definition\ResolveInfo
 	 */
 	protected $info;
 
@@ -66,7 +66,7 @@ abstract class AbstractConnectionResolver {
 	/**
 	 * The loader the resolver is configured to use.
 	 *
-	 * @var AbstractDataLoader
+	 * @var \WPGraphQL\Data\Loader\AbstractDataLoader
 	 */
 	protected $loader;
 
@@ -124,11 +124,11 @@ abstract class AbstractConnectionResolver {
 	 * @param mixed       $source  source passed down from the resolve tree
 	 * @param array       $args    array of arguments input in the field as part of the GraphQL
 	 *                             query
-	 * @param AppContext  $context Object containing app context that gets passed down the resolve
-	 *                             tree
-	 * @param ResolveInfo $info    Info about fields passed down the resolve tree
+	 * @param \WPGraphQL\AppContext $context Object containing app context that gets passed down the resolve
+ * tree
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info Info about fields passed down the resolve tree
 	 *
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info ) {
 
@@ -167,7 +167,7 @@ abstract class AbstractConnectionResolver {
 		 * Filters the GraphQL args before they are used in get_query_args().
 		 *
 		 * @param array                      $args                The GraphQL args passed to the resolver.
-		 * @param AbstractConnectionResolver $connection_resolver Instance of the ConnectionResolver.
+		 * @param \WPGraphQL\Data\Connection\AbstractConnectionResolver $connection_resolver Instance of the ConnectionResolver.
 		 * @param array                      $unfiltered_args     Array of arguments input in the field as part of the GraphQL query.
 		 *
 		 * @since 1.11.0
@@ -194,7 +194,7 @@ abstract class AbstractConnectionResolver {
 		 *
 		 * @param array                      $query_args          The query args to be used with the executable query to get data.
 		 *                                                        This should take in the GraphQL args and return args for use in fetching the data.
-		 * @param AbstractConnectionResolver $connection_resolver Instance of the ConnectionResolver
+		 * @param \WPGraphQL\Data\Connection\AbstractConnectionResolver $connection_resolver Instance of the ConnectionResolver
 		 * @param array                      $unfiltered_args Array of arguments input in the field as part of the GraphQL query.
 		 */
 		$this->query_args = apply_filters( 'graphql_connection_query_args', $this->get_query_args(), $this, $args );
@@ -213,8 +213,8 @@ abstract class AbstractConnectionResolver {
 	/**
 	 * Get the loader name
 	 *
-	 * @return AbstractDataLoader
-	 * @throws Exception
+	 * @return \WPGraphQL\Data\Loader\AbstractDataLoader
+	 * @throws \Exception
 	 */
 	protected function getLoader() {
 		$name = $this->get_loader_name();
@@ -251,7 +251,7 @@ abstract class AbstractConnectionResolver {
 	/**
 	 * Returns the AppContext of the connection
 	 *
-	 * @return AppContext
+	 * @return \WPGraphQL\AppContext
 	 */
 	public function getContext(): AppContext {
 		return $this->context;
@@ -260,7 +260,7 @@ abstract class AbstractConnectionResolver {
 	/**
 	 * Returns the ResolveInfo of the connection
 	 *
-	 * @return ResolveInfo
+	 * @return \GraphQL\Type\Definition\ResolveInfo
 	 */
 	public function getInfo(): ResolveInfo {
 		return $this->info;
@@ -279,7 +279,7 @@ abstract class AbstractConnectionResolver {
 	 * @param string $key   The key of the query arg to set
 	 * @param mixed  $value The value of the query arg to set
 	 *
-	 * @return AbstractConnectionResolver
+	 * @return \WPGraphQL\Data\Connection\AbstractConnectionResolver
 	 *
 	 * @deprecated 0.3.0
 	 *
@@ -298,7 +298,7 @@ abstract class AbstractConnectionResolver {
 	 * @param string $key   The key of the query arg to set
 	 * @param mixed  $value The value of the query arg to set
 	 *
-	 * @return AbstractConnectionResolver
+	 * @return \WPGraphQL\Data\Connection\AbstractConnectionResolver
 	 */
 	public function set_query_arg( $key, $value ) {
 		$this->query_args[ $key ] = $value;
@@ -309,7 +309,7 @@ abstract class AbstractConnectionResolver {
 	/**
 	 * Whether the connection should resolve as a one-to-one connection.
 	 *
-	 * @return AbstractConnectionResolver
+	 * @return \WPGraphQL\Data\Connection\AbstractConnectionResolver
 	 */
 	public function one_to_one() {
 		$this->one_to_one = true;
@@ -395,7 +395,7 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * @since 1.9.0
 	 *
-	 * @throws Exception if child class forgot to implement this.
+	 * @throws \Exception if child class forgot to implement this.
 	 *
 	 * @return array the array of IDs.
 	 */
@@ -412,8 +412,8 @@ abstract class AbstractConnectionResolver {
 	 * @param mixed $id The ID to identify the object by. Could be a database ID or an in-memory ID
 	 *                  (like post_type name)
 	 *
-	 * @return mixed|Model|null
-	 * @throws Exception
+	 * @return mixed|\WPGraphQL\Model\Model|null
+	 * @throws \Exception
 	 */
 	public function get_node_by_id( $id ) {
 		return $this->loader->load( $id );
@@ -426,7 +426,7 @@ abstract class AbstractConnectionResolver {
 	 * ensure that queries don't exceed unwanted limits when querying data.
 	 *
 	 * @return int
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function get_query_amount() {
 
@@ -439,8 +439,8 @@ abstract class AbstractConnectionResolver {
 		 * @param int         $max_posts  the maximum number of posts per page.
 		 * @param mixed       $source     source passed down from the resolve tree
 		 * @param array       $args       array of arguments input in the field as part of the GraphQL query
-		 * @param AppContext  $context    Object containing app context that gets passed down the resolve tree
-		 * @param ResolveInfo $info       Info about fields passed down the resolve tree
+		 * @param \WPGraphQL\AppContext $context Object containing app context that gets passed down the resolve tree
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info Info about fields passed down the resolve tree
 		 *
 		 * @since 0.0.6
 		 */
@@ -456,7 +456,7 @@ abstract class AbstractConnectionResolver {
 	 * This checks the $args to determine the amount requested, and if
 	 *
 	 * @return int|null
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function get_amount_requested() {
 
@@ -501,7 +501,7 @@ abstract class AbstractConnectionResolver {
 		 * This filter allows to modify the requested connection page size
 		 *
 		 * @param int                        $amount   the requested amount
-		 * @param AbstractConnectionResolver $resolver Instance of the connection resolver class
+		 * @param \WPGraphQL\Data\Connection\AbstractConnectionResolver $resolver Instance of the connection resolver class
 		 */
 		return max( 0, apply_filters( 'graphql_connection_amount_requested', $amount_requested, $this ) );
 
@@ -758,7 +758,7 @@ abstract class AbstractConnectionResolver {
 	 * @uses AbstractConnectionResolver::get_ids_for_nodes()
 	 *
 	 * @return array
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function get_nodes() {
 		$nodes = [];
@@ -830,7 +830,7 @@ abstract class AbstractConnectionResolver {
 			 * Create the edge, pass it through a filter.
 			 *
 			 * @param array                      $edge                The edge within the connection
-			 * @param AbstractConnectionResolver $connection_resolver Instance of the connection resolver class
+			 * @param \WPGraphQL\Data\Connection\AbstractConnectionResolver $connection_resolver Instance of the connection resolver class
 			 */
 			$edge = apply_filters(
 				'graphql_connection_edge',
@@ -901,7 +901,7 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * @return array
 	 *
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function execute_and_get_ids() {
 
@@ -920,7 +920,7 @@ abstract class AbstractConnectionResolver {
 		 * Filter whether the connection should execute.
 		 *
 		 * @param bool                       $should_execute      Whether the connection should execute
-		 * @param AbstractConnectionResolver $connection_resolver Instance of the Connection Resolver
+		 * @param \WPGraphQL\Data\Connection\AbstractConnectionResolver $connection_resolver Instance of the Connection Resolver
 		 */
 		$this->should_execute = apply_filters( 'graphql_connection_should_execute', $should_execute, $this );
 		if ( false === $this->should_execute ) {
@@ -944,7 +944,7 @@ abstract class AbstractConnectionResolver {
 		 * query to that datasource instead.
 		 *
 		 * @param mixed                      $query               Instance of the Query for the resolver
-		 * @param AbstractConnectionResolver $connection_resolver Instance of the Connection Resolver
+		 * @param \WPGraphQL\Data\Connection\AbstractConnectionResolver $connection_resolver Instance of the Connection Resolver
 		 */
 		$this->query = apply_filters( 'graphql_connection_query', $this->get_query(), $this );
 
@@ -952,7 +952,7 @@ abstract class AbstractConnectionResolver {
 		 * Filter the connection IDs
 		 *
 		 * @param array                      $ids                 Array of IDs this connection will be resolving
-		 * @param AbstractConnectionResolver $connection_resolver Instance of the Connection Resolver
+		 * @param \WPGraphQL\Data\Connection\AbstractConnectionResolver $connection_resolver Instance of the Connection Resolver
 		 */
 		$this->ids = apply_filters( 'graphql_connection_ids', $this->get_ids(), $this );
 
@@ -974,9 +974,9 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * Get the connection to return to the Connection Resolver
 	 *
-	 * @return mixed|array|Deferred
+	 * @return mixed|array|\GraphQL\Deferred
 	 *
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function get_connection() {
 
@@ -999,7 +999,7 @@ abstract class AbstractConnectionResolver {
 				 * Filters the nodes in the connection
 				 *
 				 * @param array                      $nodes               The nodes in the connection
-				 * @param AbstractConnectionResolver $connection_resolver Instance of the Connection Resolver
+				 * @param \WPGraphQL\Data\Connection\AbstractConnectionResolver $connection_resolver Instance of the Connection Resolver
 				 */
 				$this->nodes = apply_filters( 'graphql_connection_nodes', $this->get_nodes(), $this );
 
@@ -1007,7 +1007,7 @@ abstract class AbstractConnectionResolver {
 				 * Filters the edges in the connection
 				 *
 				 * @param array                      $nodes               The nodes in the connection
-				 * @param AbstractConnectionResolver $connection_resolver Instance of the Connection Resolver
+				 * @param \WPGraphQL\Data\Connection\AbstractConnectionResolver $connection_resolver Instance of the Connection Resolver
 				 */
 				$this->edges = apply_filters( 'graphql_connection_edges', $this->get_edges(), $this );
 
@@ -1030,7 +1030,7 @@ abstract class AbstractConnectionResolver {
 				 * This filter allows additional fields to be returned to the connection resolver
 				 *
 				 * @param array                      $connection          The connection data being returned
-				 * @param AbstractConnectionResolver $connection_resolver The instance of the connection resolver
+				 * @param \WPGraphQL\Data\Connection\AbstractConnectionResolver $connection_resolver The instance of the connection resolver
 				 */
 				return apply_filters( 'graphql_connection', $connection, $this );
 

--- a/src/Data/Connection/CommentConnectionResolver.php
+++ b/src/Data/Connection/CommentConnectionResolver.php
@@ -19,7 +19,7 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @var WP_Comment_Query
+	 * @var \WP_Comment_Query
 	 */
 	protected $query;
 
@@ -139,8 +139,8 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 		 * @param array       $query_args array of query_args being passed to the
 		 * @param mixed       $source     source passed down from the resolve tree
 		 * @param array       $args       array of arguments input in the field as part of the GraphQL query
-		 * @param AppContext  $context    object passed down the resolve tree
-		 * @param ResolveInfo $info       info about fields passed down the resolve tree
+		 * @param \WPGraphQL\AppContext $context object passed down the resolve tree
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info info about fields passed down the resolve tree
 		 *
 		 * @since 0.0.6
 		 */
@@ -152,8 +152,8 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 	 *
 	 * Return the instance of the WP_Comment_Query
 	 *
-	 * @return WP_Comment_Query
-	 * @throws Exception
+	 * @return \WP_Comment_Query
+	 * @throws \Exception
 	 */
 	public function get_query() {
 		return new WP_Comment_Query( $this->query_args );
@@ -256,7 +256,7 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 		 * Filters the GraphQL args before they are used in get_query_args().
 		 *
 		 * @param array                     $args                The GraphQL args passed to the resolver.
-		 * @param CommentConnectionResolver $connection_resolver Instance of the ConnectionResolver
+		 * @param \WPGraphQL\Data\Connection\CommentConnectionResolver $connection_resolver Instance of the ConnectionResolver
 		 *
 		 * @since 1.11.0
 		 */

--- a/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
@@ -17,10 +17,10 @@ class EnqueuedScriptsConnectionResolver extends AbstractConnectionResolver {
 	 *
 	 * @param mixed       $source     source passed down from the resolve tree
 	 * @param array       $args       array of arguments input in the field as part of the GraphQL query
-	 * @param AppContext  $context    Object containing app context that gets passed down the resolve tree
-	 * @param ResolveInfo $info       Info about fields passed down the resolve tree
+	 * @param \WPGraphQL\AppContext $context Object containing app context that gets passed down the resolve tree
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info Info about fields passed down the resolve tree
 	 *
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info ) {
 

--- a/src/Data/Connection/EnqueuedStylesheetConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedStylesheetConnectionResolver.php
@@ -23,10 +23,10 @@ class EnqueuedStylesheetConnectionResolver extends AbstractConnectionResolver {
 	 *
 	 * @param mixed       $source     source passed down from the resolve tree
 	 * @param array       $args       array of arguments input in the field as part of the GraphQL query
-	 * @param AppContext  $context    Object containing app context that gets passed down the resolve tree
-	 * @param ResolveInfo $info       Info about fields passed down the resolve tree
+	 * @param \WPGraphQL\AppContext $context Object containing app context that gets passed down the resolve tree
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info Info about fields passed down the resolve tree
 	 *
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info ) {
 

--- a/src/Data/Connection/MenuConnectionResolver.php
+++ b/src/Data/Connection/MenuConnectionResolver.php
@@ -15,7 +15,7 @@ class MenuConnectionResolver extends TermObjectConnectionResolver {
 	 * Get the connection args for use in WP_Term_Query to query the menus
 	 *
 	 * @return array
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function get_query_args() {
 		$term_args = [

--- a/src/Data/Connection/MenuItemConnectionResolver.php
+++ b/src/Data/Connection/MenuItemConnectionResolver.php
@@ -19,10 +19,10 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 	 *
 	 * @param mixed       $source     source passed down from the resolve tree
 	 * @param array       $args       array of arguments input in the field as part of the GraphQL query
-	 * @param AppContext  $context    Object containing app context that gets passed down the resolve tree
-	 * @param ResolveInfo $info       Info about fields passed down the resolve tree
+	 * @param \WPGraphQL\AppContext $context Object containing app context that gets passed down the resolve tree
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info Info about fields passed down the resolve tree
 	 *
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info ) {
 		parent::__construct( $source, $args, $context, $info, 'nav_menu_item' );

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -35,12 +35,12 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	 * @param mixed              $source    source passed down from the resolve tree
 	 * @param array              $args      array of arguments input in the field as part of the
 	 *                                      GraphQL query
-	 * @param AppContext         $context   Object containing app context that gets passed down the
-	 *                                      resolve tree
-	 * @param ResolveInfo        $info      Info about fields passed down the resolve tree
+	 * @param \WPGraphQL\AppContext $context Object containing app context that gets passed down the
+ * resolve tree
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info Info about fields passed down the resolve tree
 	 * @param mixed|string|array $post_type The post type to resolve for
 	 *
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info, $post_type = 'any' ) {
 
@@ -89,7 +89,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	 *
 	 * @return \WP_Query|object
 	 *
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function get_query() {
 		// Get query class.
@@ -377,8 +377,8 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		 * @param array       $query_args The args that will be passed to the WP_Query
 		 * @param mixed       $source     The source that's passed down the GraphQL queries
 		 * @param array       $args       The inputArgs on the field
-		 * @param AppContext  $context    The AppContext passed down the GraphQL tree
-		 * @param ResolveInfo $info       The ResolveInfo passed down the GraphQL tree
+		 * @param \WPGraphQL\AppContext $context The AppContext passed down the GraphQL tree
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the GraphQL tree
 		 */
 		return apply_filters( 'graphql_post_object_connection_query_args', $query_args, $this->source, $this->args, $this->context, $this->info );
 
@@ -447,8 +447,8 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		 * @param array              $args       Query "where" args
 		 * @param mixed              $source     The query results for a query calling this
 		 * @param array              $all_args   All of the arguments for the query (not just the "where" args)
-		 * @param AppContext         $context    The AppContext object
-		 * @param ResolveInfo        $info       The ResolveInfo object
+		 * @param \WPGraphQL\AppContext $context The AppContext object
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object
 		 * @param mixed|string|array $post_type  The post type for the query
 		 *
 		 * @return array
@@ -601,7 +601,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		 * Filters the GraphQL args before they are used in get_query_args().
 		 *
 		 * @param array                        $args                The GraphQL args passed to the resolver.
-		 * @param PostObjectConnectionResolver $connection_resolver Instance of the ConnectionResolver.
+		 * @param \WPGraphQL\Data\Connection\PostObjectConnectionResolver $connection_resolver Instance of the ConnectionResolver.
 		 * @param array                        $unfiltered_args     Array of arguments input in the field as part of the GraphQL query.
 		 *
 		 * @since 1.11.0

--- a/src/Data/Connection/TermObjectConnectionResolver.php
+++ b/src/Data/Connection/TermObjectConnectionResolver.php
@@ -34,11 +34,11 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 	 *
 	 * @param mixed       $source     source passed down from the resolve tree
 	 * @param array       $args       array of arguments input in the field as part of the GraphQL query
-	 * @param AppContext  $context    Object containing app context that gets passed down the resolve tree
-	 * @param ResolveInfo $info       Info about fields passed down the resolve tree
+	 * @param \WPGraphQL\AppContext $context Object containing app context that gets passed down the resolve tree
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info Info about fields passed down the resolve tree
 	 * @param mixed|string|null $taxonomy The name of the Taxonomy the resolver is intended to be used for
 	 *
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info, $taxonomy = null ) {
 		$this->taxonomy = $taxonomy;
@@ -142,8 +142,8 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 		 * @param array       $query_args array of query_args being passed to the
 		 * @param mixed       $source     source passed down from the resolve tree
 		 * @param array       $args       array of arguments input in the field as part of the GraphQL query
-		 * @param AppContext  $context    object passed down the resolve tree
-		 * @param ResolveInfo $info       info about fields passed down the resolve tree
+		 * @param \WPGraphQL\AppContext $context object passed down the resolve tree
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info info about fields passed down the resolve tree
 		 *
 		 * @since 0.0.6
 		 */
@@ -156,7 +156,7 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 	 * Return an instance of WP_Term_Query with the args mapped to the query
 	 *
 	 * @return \WP_Term_Query
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function get_query() {
 		return new \WP_Term_Query( $this->query_args );
@@ -247,8 +247,8 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 		 * @param string      $taxonomy   The name of the taxonomy
 		 * @param mixed       $source     The query results
 		 * @param array       $all_args   All of the query arguments (not just the "where" args)
-		 * @param AppContext  $context    The AppContext object
-		 * @param ResolveInfo $info       The ResolveInfo object
+		 * @param \WPGraphQL\AppContext $context The AppContext object
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object
 		 *
 		 * @since 0.0.5
 		 * @return array
@@ -298,7 +298,7 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 		 * Filters the GraphQL args before they are used in get_query_args().
 		 *
 		 * @param array                        $args                The GraphQL args passed to the resolver.
-		 * @param TermObjectConnectionResolver $connection_resolver Instance of the ConnectionResolver
+		 * @param \WPGraphQL\Data\Connection\TermObjectConnectionResolver $connection_resolver Instance of the ConnectionResolver
 		 * @param array                        $unfiltered_args     Array of arguments input in the field as part of the GraphQL query.
 		 *
 		 * @since 1.11.0

--- a/src/Data/Connection/UserConnectionResolver.php
+++ b/src/Data/Connection/UserConnectionResolver.php
@@ -259,8 +259,8 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 		 * @param array       $args       The query "where" args
 		 * @param mixed       $source     The query results of the query calling this relation
 		 * @param array       $all_args   Array of all the query args (not just the "where" args)
-		 * @param AppContext  $context    The AppContext object
-		 * @param ResolveInfo $info       The ResolveInfo object
+		 * @param \WPGraphQL\AppContext $context The AppContext object
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object
 		 *
 		 * @return array
 		 * @since 0.0.5

--- a/src/Data/Cursor/AbstractCursor.php
+++ b/src/Data/Cursor/AbstractCursor.php
@@ -14,12 +14,12 @@ abstract class AbstractCursor {
 		/**
 	 * The global WordPress Database instance
 	 *
-	 * @var wpdb $wpdb
+	 * @var \wpdb $wpdb
 	 */
 	public $wpdb;
 
 	/**
-	 * @var CursorBuilder
+	 * @var \WPGraphQL\Data\Cursor\CursorBuilder
 	 */
 	public $builder;
 

--- a/src/Data/Cursor/CommentObjectCursor.php
+++ b/src/Data/Cursor/CommentObjectCursor.php
@@ -39,7 +39,7 @@ class CommentObjectCursor extends AbstractCursor {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @return ?WP_Comment
+	 * @return ?\WP_Comment
 	 */
 	public function get_cursor_node() {
 		if ( ! $this->cursor_offset ) {

--- a/src/Data/Cursor/CursorBuilder.php
+++ b/src/Data/Cursor/CursorBuilder.php
@@ -52,7 +52,7 @@ class CursorBuilder {
 		 * Filters the field used for ordering when cursors are used for pagination
 		 *
 		 * @param array         $field          The field key, value, type and order
-		 * @param CursorBuilder $cursor_builder The CursorBuilder class
+		 * @param \WPGraphQL\Data\Cursor\CursorBuilder $cursor_builder The CursorBuilder class
 		 * @param ?object        $object_cursor  The Cursor class
 		 */
 		$field = apply_filters(

--- a/src/Data/Cursor/TermObjectCursor.php
+++ b/src/Data/Cursor/TermObjectCursor.php
@@ -6,7 +6,7 @@ use WP_Term;
 class TermObjectCursor extends AbstractCursor {
 
 	/**
-	 * @var ?WP_Term;
+	 * @var ?\WP_Term ;
 	 */
 	public $cursor_node;
 
@@ -33,7 +33,7 @@ class TermObjectCursor extends AbstractCursor {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @return ?WP_Term;
+	 * @return ?\WP_Term ;
 	 */
 	public function get_cursor_node() {
 		if ( ! $this->cursor_offset ) {
@@ -46,7 +46,7 @@ class TermObjectCursor extends AbstractCursor {
 	}
 
 	/**
-	 * @return ?WP_Term;
+	 * @return ?\WP_Term ;
 	 * @deprecated 1.9.0
 	 */
 	public function get_cursor_term() {

--- a/src/Data/Cursor/UserCursor.php
+++ b/src/Data/Cursor/UserCursor.php
@@ -15,7 +15,7 @@ use WP_User_Query;
 class UserCursor extends AbstractCursor {
 
 	/**
-	 * @var ?WP_User
+	 * @var ?\WP_User
 	 */
 	public $cursor_node;
 
@@ -29,7 +29,7 @@ class UserCursor extends AbstractCursor {
 	/**
 	 * UserCursor constructor.
 	 *
-	 * @param array|WP_User_Query $query_vars The query vars to use when building the SQL statement.
+	 * @param array|\WP_User_Query $query_vars The query vars to use when building the SQL statement.
 	 * @param string|null         $cursor     Whether to generate the before or after cursor
 	 *
 	 * @return void
@@ -60,7 +60,7 @@ class UserCursor extends AbstractCursor {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @return ?WP_User
+	 * @return ?\WP_User
 	 */
 	public function get_cursor_node() {
 		if ( ! $this->cursor_offset ) {
@@ -73,7 +73,7 @@ class UserCursor extends AbstractCursor {
 	}
 
 	/**
-	 * @return ?WP_User
+	 * @return ?\WP_User
 	 * @deprecated 1.9.0
 	 */
 	public function get_cursor_user() {

--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -56,11 +56,11 @@ class DataSource {
 	 * Retrieves a WP_Comment object for the id that gets passed
 	 *
 	 * @param int        $id      ID of the comment we want to get the object for.
-	 * @param AppContext $context The context of the request.
+	 * @param \WPGraphQL\AppContext $context The context of the request.
 	 *
-	 * @return Deferred object
-	 * @throws UserError Throws UserError.
-	 * @throws Exception Throws UserError.
+	 * @return \GraphQL\Deferred object
+	 * @throws \GraphQL\Error\UserError Throws UserError.
+	 * @throws \Exception Throws UserError.
 	 *
 	 * @since      0.0.5
 	 *
@@ -77,8 +77,8 @@ class DataSource {
 	 *
 	 * @param int $comment_id The ID of the comment the comment author is associated with.
 	 *
-	 * @return mixed|CommentAuthor|null
-	 * @throws Exception Throws Exception.
+	 * @return mixed|\WPGraphQL\Model\CommentAuthor|null
+	 * @throws \Exception Throws Exception.
 	 */
 	public static function resolve_comment_author( int $comment_id ) {
 
@@ -92,11 +92,11 @@ class DataSource {
 	 *
 	 * @param mixed       $source  The object the connection is coming from
 	 * @param array       $args    Query args to pass to the connection resolver
-	 * @param AppContext  $context The context of the query to pass along
-	 * @param ResolveInfo $info    The ResolveInfo object
+	 * @param \WPGraphQL\AppContext $context The context of the query to pass along
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object
 	 *
 	 * @return mixed
-	 * @throws Exception
+	 * @throws \Exception
 	 * @since 0.0.5
 	 */
 	public static function resolve_comments_connection( $source, array $args, AppContext $context, ResolveInfo $info ) {
@@ -110,11 +110,11 @@ class DataSource {
 	 *
 	 * @param mixed       $source  The object the connection is coming from
 	 * @param array       $args    Array of arguments to pass to resolve method
-	 * @param AppContext  $context AppContext object passed down
-	 * @param ResolveInfo $info    The ResolveInfo object
+	 * @param \WPGraphQL\AppContext $context AppContext object passed down
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object
 	 *
 	 * @return array
-	 * @throws Exception
+	 * @throws \Exception
 	 * @since  0.0.5
 	 */
 	public static function resolve_plugins_connection( $source, array $args, AppContext $context, ResolveInfo $info ) {
@@ -126,12 +126,12 @@ class DataSource {
 	 * Returns the post object for the ID and post type passed
 	 *
 	 * @param int        $id      ID of the post you are trying to retrieve
-	 * @param AppContext $context The context of the GraphQL Request
+	 * @param \WPGraphQL\AppContext $context The context of the GraphQL Request
 	 *
-	 * @return Deferred
+	 * @return \GraphQL\Deferred
 	 *
-	 * @throws UserError
-	 * @throws Exception
+	 * @throws \GraphQL\Error\UserError
+	 * @throws \Exception
 	 *
 	 * @since      0.0.5
 	 * @deprecated Use the Loader passed in $context instead
@@ -143,10 +143,10 @@ class DataSource {
 
 	/**
 	 * @param int        $id      The ID of the menu item to load
-	 * @param AppContext $context The context of the GraphQL request
+	 * @param \WPGraphQL\AppContext $context The context of the GraphQL request
 	 *
-	 * @return Deferred|null
-	 * @throws Exception
+	 * @return \GraphQL\Deferred|null
+	 * @throws \Exception
 	 *
 	 * @deprecated Use the Loader passed in $context instead
 	 */
@@ -160,12 +160,12 @@ class DataSource {
 	 *
 	 * @param mixed              $source    The object the connection is coming from
 	 * @param array              $args      Arguments to pass to the resolve method
-	 * @param AppContext         $context   AppContext object to pass down
-	 * @param ResolveInfo        $info      The ResolveInfo object
+	 * @param \WPGraphQL\AppContext $context AppContext object to pass down
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object
 	 * @param mixed|string|array $post_type Post type of the post we are trying to resolve
 	 *
 	 * @return mixed
-	 * @throws Exception
+	 * @throws \Exception
 	 * @since  0.0.5
 	 */
 	public static function resolve_post_objects_connection( $source, array $args, AppContext $context, ResolveInfo $info, $post_type ) {
@@ -179,8 +179,8 @@ class DataSource {
 	 *
 	 * @param string $taxonomy Name of the taxonomy you want to retrieve the taxonomy object for
 	 *
-	 * @return Taxonomy object
-	 * @throws UserError | Exception
+	 * @return \WPGraphQL\Model\Taxonomy object
+	 * @throws \GraphQL\Error\UserError|\Exception
 	 * @since  0.0.5
 	 */
 	public static function resolve_taxonomy( $taxonomy ) {
@@ -210,10 +210,10 @@ class DataSource {
 	 * Get the term object for a term
 	 *
 	 * @param int        $id      ID of the term you are trying to retrieve the object for
-	 * @param AppContext $context The context of the GraphQL Request
+	 * @param \WPGraphQL\AppContext $context The context of the GraphQL Request
 	 *
 	 * @return mixed
-	 * @throws Exception
+	 * @throws \Exception
 	 * @since      0.0.5
 	 *
 	 * @deprecated Use the Loader passed in $context instead
@@ -228,12 +228,12 @@ class DataSource {
 	 *
 	 * @param mixed       $source   The object the connection is coming from
 	 * @param array       $args     Array of args to be passed to the resolve method
-	 * @param AppContext  $context  The AppContext object to be passed down
-	 * @param ResolveInfo $info     The ResolveInfo object
+	 * @param \WPGraphQL\AppContext $context The AppContext object to be passed down
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object
 	 * @param string      $taxonomy The name of the taxonomy the term belongs to
 	 *
 	 * @return array
-	 * @throws Exception
+	 * @throws \Exception
 	 * @since  0.0.5
 	 */
 	public static function resolve_term_objects_connection( $source, array $args, AppContext $context, ResolveInfo $info, string $taxonomy ) {
@@ -247,9 +247,9 @@ class DataSource {
 	 *
 	 * @param string $stylesheet Directory name for the theme.
 	 *
-	 * @return Theme object
-	 * @throws UserError
-	 * @throws Exception
+	 * @return \WPGraphQL\Model\Theme object
+	 * @throws \GraphQL\Error\UserError
+	 * @throws \Exception
 	 * @since  0.0.5
 	 */
 	public static function resolve_theme( $stylesheet ) {
@@ -266,11 +266,11 @@ class DataSource {
 	 *
 	 * @param mixed       $source  The object the connection is coming from
 	 * @param array       $args    Passes an array of arguments to the resolve method
-	 * @param AppContext  $context The AppContext object to be passed down
-	 * @param ResolveInfo $info    The ResolveInfo object
+	 * @param \WPGraphQL\AppContext $context The AppContext object to be passed down
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object
 	 *
 	 * @return array
-	 * @throws Exception
+	 * @throws \Exception
 	 * @since  0.0.5
 	 */
 	public static function resolve_themes_connection( $source, array $args, AppContext $context, ResolveInfo $info ) {
@@ -282,10 +282,10 @@ class DataSource {
 	 * Gets the user object for the user ID specified
 	 *
 	 * @param int        $id      ID of the user you want the object for
-	 * @param AppContext $context The AppContext
+	 * @param \WPGraphQL\AppContext $context The AppContext
 	 *
-	 * @return Deferred
-	 * @throws Exception
+	 * @return \GraphQL\Deferred
+	 * @throws \Exception
 	 *
 	 * @since      0.0.5
 	 * @deprecated Use the Loader passed in $context instead
@@ -300,11 +300,11 @@ class DataSource {
 	 *
 	 * @param mixed       $source  The object the connection is coming from
 	 * @param array       $args    Array of args to be passed down to the resolve method
-	 * @param AppContext  $context The AppContext object to be passed down
-	 * @param ResolveInfo $info    The ResolveInfo object
+	 * @param \WPGraphQL\AppContext $context The AppContext object to be passed down
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object
 	 *
 	 * @return array
-	 * @throws Exception
+	 * @throws \Exception
 	 * @since  0.0.5
 	 */
 	public static function resolve_users_connection( $source, array $args, AppContext $context, ResolveInfo $info ) {
@@ -319,8 +319,8 @@ class DataSource {
 	 *
 	 * @param string $name Name of the user role you want info for
 	 *
-	 * @return UserRole
-	 * @throws Exception
+	 * @return \WPGraphQL\Model\UserRole
+	 * @throws \Exception
 	 * @since  0.0.30
 	 */
 	public static function resolve_user_role( $name ) {
@@ -346,8 +346,8 @@ class DataSource {
 	 * @param int   $user_id ID of the user to get the avatar data for
 	 * @param array $args    The args to pass to the get_avatar_data function
 	 *
-	 * @return Avatar|null
-	 * @throws Exception
+	 * @return \WPGraphQL\Model\Avatar|null
+	 * @throws \Exception
 	 */
 	public static function resolve_avatar( int $user_id, array $args ) {
 
@@ -367,11 +367,11 @@ class DataSource {
 	 *
 	 * @param array       $source  The Query results
 	 * @param array       $args    The query arguments
-	 * @param AppContext  $context The AppContext passed down to the query
-	 * @param ResolveInfo $info    The ResloveInfo object
+	 * @param \WPGraphQL\AppContext $context The AppContext passed down to the query
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResloveInfo object
 	 *
 	 * @return array
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public static function resolve_user_role_connection( $source, array $args, AppContext $context, ResolveInfo $info ) {
 
@@ -423,7 +423,7 @@ class DataSource {
 	/**
 	 * Get all of the allowed settings by group
 	 *
-	 * @param TypeRegistry $type_registry The WPGraphQL TypeRegistry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The WPGraphQL TypeRegistry
 	 *
 	 * @return array $allowed_settings_by_group
 	 */
@@ -475,7 +475,7 @@ class DataSource {
 	/**
 	 * Get all of the $allowed_settings
 	 *
-	 * @param TypeRegistry $type_registry The WPGraphQL TypeRegistry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The WPGraphQL TypeRegistry
 	 *
 	 * @return array $allowed_settings
 	 */
@@ -538,7 +538,7 @@ class DataSource {
 	 * an object that implements node to its type.
 	 *
 	 * @return array
-	 * @throws UserError
+	 * @throws \GraphQL\Error\UserError
 	 */
 	public static function get_node_definition() {
 
@@ -660,11 +660,11 @@ class DataSource {
 	 * Given the ID of a node, this resolves the data
 	 *
 	 * @param string      $global_id The Global ID of the node
-	 * @param AppContext  $context   The Context of the GraphQL Request
-	 * @param ResolveInfo $info      The ResolveInfo for the GraphQL Request
+	 * @param \WPGraphQL\AppContext $context The Context of the GraphQL Request
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo for the GraphQL Request
 	 *
 	 * @return null|string
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public static function resolve_node( $global_id, AppContext $context, ResolveInfo $info ) {
 
@@ -722,11 +722,11 @@ class DataSource {
 	 * Based largely on the core parse_request function in wp-includes/class-wp.php
 	 *
 	 * @param string      $uri     The URI to fetch a resource from
-	 * @param AppContext  $context The AppContext passed through the GraphQL Resolve Tree
-	 * @param ResolveInfo $info    The ResolveInfo passed through the GraphQL Resolve tree
+	 * @param \WPGraphQL\AppContext $context The AppContext passed through the GraphQL Resolve Tree
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed through the GraphQL Resolve tree
 	 *
 	 * @return mixed
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public static function resolve_resource_by_uri( $uri, $context, $info ) {
 		$node_resolver = new NodeResolver( $context );

--- a/src/Data/Loader/AbstractDataLoader.php
+++ b/src/Data/Loader/AbstractDataLoader.php
@@ -43,14 +43,14 @@ abstract class AbstractDataLoader {
 	/**
 	 * This stores a reference to the AppContext for the loader to make use of
 	 *
-	 * @var AppContext
+	 * @var \WPGraphQL\AppContext
 	 */
 	protected $context;
 
 	/**
 	 * AbstractDataLoader constructor.
 	 *
-	 * @param AppContext $context
+	 * @param \WPGraphQL\AppContext $context
 	 */
 	public function __construct( AppContext $context ) {
 		$this->context = $context;
@@ -62,8 +62,8 @@ abstract class AbstractDataLoader {
 	 * @param mixed|int|string $database_id The database ID for a particular loader to load an
 	 *                                      object
 	 *
-	 * @return Deferred|null
-	 * @throws Exception
+	 * @return \GraphQL\Deferred|null
+	 * @throws \Exception
 	 */
 	public function load_deferred( $database_id ) {
 
@@ -89,7 +89,7 @@ abstract class AbstractDataLoader {
 	 * @param array $keys The keys of the objects to buffer
 	 *
 	 * @return $this
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function buffer( array $keys ) {
 		foreach ( $keys as $index => $key ) {
@@ -114,7 +114,7 @@ abstract class AbstractDataLoader {
 	 * @param mixed $key
 	 *
 	 * @return mixed
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function load( $key ) {
 
@@ -143,7 +143,7 @@ abstract class AbstractDataLoader {
 	 * @param mixed $value
 	 *
 	 * @return $this
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function prime( $key, $value ) {
 		$key = $this->key_to_scalar( $key );
@@ -199,7 +199,7 @@ abstract class AbstractDataLoader {
 	 * invalidations across this particular `DataLoader`. Returns itself for
 	 * method chaining.
 	 *
-	 * @return AbstractDataLoader
+	 * @return \WPGraphQL\Data\Loader\AbstractDataLoader
 	 * @deprecated in favor of clear_all
 	 */
 	public function clearAll() {
@@ -212,7 +212,7 @@ abstract class AbstractDataLoader {
 	 * invalidations across this particular `DataLoader`. Returns itself for
 	 * method chaining.
 	 *
-	 * @return AbstractDataLoader
+	 * @return \WPGraphQL\Data\Loader\AbstractDataLoader
 	 */
 	public function clear_all() {
 		$this->cached = [];
@@ -227,8 +227,8 @@ abstract class AbstractDataLoader {
 	 * @param array $keys
 	 * @param bool  $asArray
 	 *
-	 * @return array|Generator
-	 * @throws Exception
+	 * @return array|\Generator
+	 * @throws \Exception
 	 *
 	 * @deprecated Use load_many instead
 	 */
@@ -244,8 +244,8 @@ abstract class AbstractDataLoader {
 	 * @param array $keys
 	 * @param bool  $asArray
 	 *
-	 * @return array|Generator
-	 * @throws Exception
+	 * @return array|\Generator
+	 * @throws \Exception
 	 */
 	public function load_many( array $keys, $asArray = false ) {
 		if ( empty( $keys ) ) {
@@ -266,7 +266,7 @@ abstract class AbstractDataLoader {
 	 * @param array $keys   The keys to generate results for
 	 * @param array $result The results for all keys
 	 *
-	 * @return Generator
+	 * @return \Generator
 	 */
 	private function generate_many( array $keys, array $result ) {
 		foreach ( $keys as $key ) {
@@ -281,7 +281,7 @@ abstract class AbstractDataLoader {
 	 * to the cache if necessary
 	 *
 	 * @return array
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	private function load_buffered() {
 		// Do not load previously-cached entries:
@@ -370,7 +370,7 @@ abstract class AbstractDataLoader {
 	 * @param mixed $entry The entry loaded from the dataloader to be used to generate a Model
 	 * @param mixed $key   The Key used to identify the loaded entry
 	 *
-	 * @return null|Model
+	 * @return null|\WPGraphQL\Model\Model
 	 */
 	protected function normalize_entry( $entry, $key ) {
 
@@ -385,7 +385,7 @@ abstract class AbstractDataLoader {
 		 * @param null               $model                The filtered model to return. Default null
 		 * @param mixed              $entry                The entry loaded from the dataloader to be used to generate a Model
 		 * @param mixed              $key                  The Key used to identify the loaded entry
-		 * @param AbstractDataLoader $abstract_data_loader The AbstractDataLoader instance
+		 * @param \WPGraphQL\Data\Loader\AbstractDataLoader $abstract_data_loader The AbstractDataLoader instance
 		 */
 		$model         = null;
 		$pre_get_model = apply_filters( 'graphql_dataloader_pre_get_model', $model, $entry, $key, $this );
@@ -409,7 +409,7 @@ abstract class AbstractDataLoader {
 		 * @param mixed              $model  The Model to be returned by the loader
 		 * @param mixed              $entry  The entry loaded by dataloader that was used to create the Model
 		 * @param mixed              $key    The Key that was used to load the entry
-		 * @param AbstractDataLoader $loader The AbstractDataLoader Instance
+		 * @param \WPGraphQL\Data\Loader\AbstractDataLoader $loader The AbstractDataLoader Instance
 		 */
 		return apply_filters( 'graphql_dataloader_get_model', $model, $entry, $key, $this );
 	}
@@ -483,7 +483,7 @@ abstract class AbstractDataLoader {
 	 * @param mixed $entry The User Role object
 	 * @param mixed $key   The Key to identify the user role by
 	 *
-	 * @return Model
+	 * @return \WPGraphQL\Model\Model
 	 */
 	protected function get_model( $entry, $key ) {
 		return $entry;

--- a/src/Data/Loader/CommentAuthorLoader.php
+++ b/src/Data/Loader/CommentAuthorLoader.php
@@ -15,8 +15,8 @@ class CommentAuthorLoader extends AbstractDataLoader {
 	 * @param mixed $entry The User Role object
 	 * @param mixed $key The Key to identify the user role by
 	 *
-	 * @return mixed|CommentAuthor
-	 * @throws Exception
+	 * @return mixed|\WPGraphQL\Model\CommentAuthor
+	 * @throws \Exception
 	 */
 	protected function get_model( $entry, $key ) {
 

--- a/src/Data/Loader/CommentLoader.php
+++ b/src/Data/Loader/CommentLoader.php
@@ -16,8 +16,8 @@ class CommentLoader extends AbstractDataLoader {
 	 * @param mixed $entry The User Role object
 	 * @param mixed $key The Key to identify the user role by
 	 *
-	 * @return mixed|Comment|null
-	 * @throws Exception
+	 * @return mixed|\WPGraphQL\Model\Comment|null
+	 * @throws \Exception
 	 */
 	protected function get_model( $entry, $key ) {
 
@@ -46,7 +46,7 @@ class CommentLoader extends AbstractDataLoader {
 	 * @param array $keys
 	 *
 	 * @return array
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function loadKeys( array $keys = [] ) {
 

--- a/src/Data/Loader/PluginLoader.php
+++ b/src/Data/Loader/PluginLoader.php
@@ -17,8 +17,8 @@ class PluginLoader extends AbstractDataLoader {
 	 * @param mixed $entry The User Role object
 	 * @param mixed $key The Key to identify the user role by
 	 *
-	 * @return Model|Plugin
-	 * @throws Exception
+	 * @return \WPGraphQL\Model\Model|\WPGraphQL\Model\Plugin
+	 * @throws \Exception
 	 */
 	protected function get_model( $entry, $key ) {
 		return new Plugin( $entry );
@@ -30,7 +30,7 @@ class PluginLoader extends AbstractDataLoader {
 	 * @param array $keys
 	 *
 	 * @return array
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function loadKeys( array $keys ) {
 		if ( empty( $keys ) ) {

--- a/src/Data/Loader/PostObjectLoader.php
+++ b/src/Data/Loader/PostObjectLoader.php
@@ -19,8 +19,8 @@ class PostObjectLoader extends AbstractDataLoader {
 	 * @param mixed $entry The User Role object
 	 * @param mixed $key The Key to identify the user role by
 	 *
-	 * @return mixed|Post
-	 * @throws Exception
+	 * @return mixed|\WPGraphQL\Model\Post
+	 * @throws \Exception
 	 */
 	protected function get_model( $entry, $key ) {
 
@@ -71,7 +71,7 @@ class PostObjectLoader extends AbstractDataLoader {
 	 * @param array $keys
 	 *
 	 * @return array
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function loadKeys( array $keys ) {
 

--- a/src/Data/Loader/PostTypeLoader.php
+++ b/src/Data/Loader/PostTypeLoader.php
@@ -15,8 +15,8 @@ class PostTypeLoader extends AbstractDataLoader {
 	 * @param mixed $entry The User Role object
 	 * @param mixed $key The Key to identify the user role by
 	 *
-	 * @return mixed|PostType
-	 * @throws Exception
+	 * @return mixed|\WPGraphQL\Model\PostType
+	 * @throws \Exception
 	 */
 	protected function get_model( $entry, $key ) {
 		return new PostType( $entry );
@@ -26,7 +26,7 @@ class PostTypeLoader extends AbstractDataLoader {
 	 * @param array $keys
 	 *
 	 * @return array
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function loadKeys( array $keys ) {
 		$post_types = \WPGraphQL::get_allowed_post_types( 'objects' );

--- a/src/Data/Loader/TaxonomyLoader.php
+++ b/src/Data/Loader/TaxonomyLoader.php
@@ -15,8 +15,8 @@ class TaxonomyLoader extends AbstractDataLoader {
 	 * @param mixed $entry The User Role object
 	 * @param mixed $key The Key to identify the user role by
 	 *
-	 * @return mixed|Taxonomy
-	 * @throws Exception
+	 * @return mixed|\WPGraphQL\Model\Taxonomy
+	 * @throws \Exception
 	 */
 	protected function get_model( $entry, $key ) {
 		return new Taxonomy( $entry );
@@ -26,7 +26,7 @@ class TaxonomyLoader extends AbstractDataLoader {
 	 * @param array $keys
 	 *
 	 * @return array
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function loadKeys( array $keys ) {
 		$taxonomies = \WPGraphQL::get_allowed_taxonomies( 'objects' );

--- a/src/Data/Loader/TermObjectLoader.php
+++ b/src/Data/Loader/TermObjectLoader.php
@@ -18,8 +18,8 @@ class TermObjectLoader extends AbstractDataLoader {
 	 * @param mixed $entry The User Role object
 	 * @param mixed $key The Key to identify the user role by
 	 *
-	 * @return mixed|Term
-	 * @throws Exception
+	 * @return mixed|\WPGraphQL\Model\Term
+	 * @throws \Exception
 	 */
 	protected function get_model( $entry, $key ) {
 
@@ -62,7 +62,7 @@ class TermObjectLoader extends AbstractDataLoader {
 	 * @param int[] $keys
 	 *
 	 * @return array
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function loadKeys( array $keys ) {
 

--- a/src/Data/Loader/ThemeLoader.php
+++ b/src/Data/Loader/ThemeLoader.php
@@ -16,8 +16,8 @@ class ThemeLoader extends AbstractDataLoader {
 	 * @param mixed $entry The User Role object
 	 * @param mixed $key The Key to identify the user role by
 	 *
-	 * @return Model|Theme
-	 * @throws Exception
+	 * @return \WPGraphQL\Model\Model|\WPGraphQL\Model\Theme
+	 * @throws \Exception
 	 */
 	protected function get_model( $entry, $key ) {
 		return new Theme( $entry );
@@ -27,7 +27,7 @@ class ThemeLoader extends AbstractDataLoader {
 	 * @param array $keys
 	 *
 	 * @return array
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function loadKeys( array $keys ) {
 		$themes = wp_get_themes();

--- a/src/Data/Loader/UserLoader.php
+++ b/src/Data/Loader/UserLoader.php
@@ -15,8 +15,8 @@ class UserLoader extends AbstractDataLoader {
 	 * @param mixed $entry The User Role object
 	 * @param mixed $key The Key to identify the user role by
 	 *
-	 * @return mixed|User
-	 * @throws Exception
+	 * @return mixed|\WPGraphQL\Model\User
+	 * @throws \Exception
 	 */
 	protected function get_model( $entry, $key ) {
 		if ( $entry instanceof \WP_User ) {
@@ -116,7 +116,7 @@ class UserLoader extends AbstractDataLoader {
 	 * @param array $keys
 	 *
 	 * @return array
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function loadKeys( array $keys ) {
 

--- a/src/Data/Loader/UserRoleLoader.php
+++ b/src/Data/Loader/UserRoleLoader.php
@@ -16,8 +16,8 @@ class UserRoleLoader extends AbstractDataLoader {
 	 * @param mixed $entry The User Role object
 	 * @param mixed $key The Key to identify the user role by
 	 *
-	 * @return mixed|UserRole
-	 * @throws Exception
+	 * @return mixed|\WPGraphQL\Model\UserRole
+	 * @throws \Exception
 	 */
 	protected function get_model( $entry, $key ) {
 		return new UserRole( $entry );
@@ -27,7 +27,7 @@ class UserRoleLoader extends AbstractDataLoader {
 	 * @param array $keys
 	 *
 	 * @return array
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function loadKeys( array $keys ) {
 		$wp_roles = wp_roles()->roles;

--- a/src/Data/MediaItemMutation.php
+++ b/src/Data/MediaItemMutation.php
@@ -19,7 +19,7 @@ class MediaItemMutation {
 	 * This prepares the media item for insertion
 	 *
 	 * @param array        $input            The input for the mutation from the GraphQL request
-	 * @param WP_Post_Type $post_type_object The post_type_object for the mediaItem (attachment)
+	 * @param \WP_Post_Type $post_type_object The post_type_object for the mediaItem (attachment)
 	 * @param string       $mutation_name    The name of the mutation being performed (create,
 	 *                                       update, etc.)
 	 * @param mixed        $file             The mediaItem (attachment) file
@@ -100,7 +100,7 @@ class MediaItemMutation {
 		 *
 		 * @param array        $insert_post_args The array of $input_post_args that will be passed to wp_insert_attachment
 		 * @param array        $input            The data that was entered as input for the mutation
-		 * @param WP_Post_Type $post_type_object The post_type_object that the mutation is affecting
+		 * @param \WP_Post_Type $post_type_object The post_type_object that the mutation is affecting
 		 * @param string       $mutation_type    The type of mutation being performed (create, update, delete)
 		 */
 		$insert_post_args = apply_filters( 'graphql_media_item_insert_post_args', $insert_post_args, $input, $post_type_object, $mutation_name );
@@ -113,10 +113,10 @@ class MediaItemMutation {
 	 *
 	 * @param int          $media_item_id    The ID of the media item being mutated
 	 * @param array        $input            The input on the mutation
-	 * @param WP_Post_Type $post_type_object The Post Type Object for the item being mutated
+	 * @param \WP_Post_Type $post_type_object The Post Type Object for the item being mutated
 	 * @param string       $mutation_name    The name of the mutation
-	 * @param AppContext   $context          The AppContext that is passed down the resolve tree
-	 * @param ResolveInfo  $info             The ResolveInfo that is passed down the resolve tree
+	 * @param \WPGraphQL\AppContext $context The AppContext that is passed down the resolve tree
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo that is passed down the resolve tree
 	 *
 	 * @return void
 	 */
@@ -136,10 +136,10 @@ class MediaItemMutation {
 		 *
 		 * @param int          $media_item_id    The ID of the mediaItem being mutated
 		 * @param array        $input            The input for the mutation
-		 * @param WP_Post_Type $post_type_object The Post Type Object for the type of post being mutated
+		 * @param \WP_Post_Type $post_type_object The Post Type Object for the type of post being mutated
 		 * @param string       $mutation_name    The name of the mutation (ex: create, update, delete)
-		 * @param AppContext   $context          The AppContext that is passed down the resolve tree
-		 * @param ResolveInfo  $info             The ResolveInfo that is passed down the resolve tree
+		 * @param \WPGraphQL\AppContext $context The AppContext that is passed down the resolve tree
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo that is passed down the resolve tree
 		 */
 		do_action( 'graphql_media_item_mutation_update_additional_data', $media_item_id, $input, $post_type_object, $mutation_name, $context, $info );
 

--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -11,19 +11,19 @@ use WPGraphQL\Model\Post;
 class NodeResolver {
 
 	/**
-	 * @var WP
+	 * @var \WP
 	 */
 	protected $wp;
 
 	/**
-	 * @var AppContext
+	 * @var \WPGraphQL\AppContext
 	 */
 	protected $context;
 
 	/**
 	 * NodeResolver constructor.
 	 *
-	 * @param AppContext $context
+	 * @param \WPGraphQL\AppContext $context
 	 *
 	 * @return void
 	 */
@@ -36,9 +36,9 @@ class NodeResolver {
 	/**
 	 * Given a Post object, validates it before returning it.
 	 *
-	 * @param WP_Post $post
+	 * @param \WP_Post $post
 	 *
-	 * @return WP_Post|null
+	 * @return \WP_Post|null
 	 */
 	public function validate_post( WP_Post $post ) {
 
@@ -70,7 +70,7 @@ class NodeResolver {
 	 * @param mixed|array|string $extra_query_vars Any extra query vars to consider
 	 *
 	 * @return mixed
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function resolve_uri( string $uri, $extra_query_vars = '' ) {
 
@@ -83,8 +83,8 @@ class NodeResolver {
 		 *
 		 * @param mixed|null $node The node, defaults to nothing.
 		 * @param string $uri The uri being searched.
-		 * @param AppContext $content The app context.
-		 * @param WP $wp WP object.
+		 * @param \WPGraphQL\AppContext $content The app context.
+		 * @param \WP $wp WP object.
 		 * @param mixed|array|string $extra_query_vars Any extra query vars to consider.
 		 */
 		$node = apply_filters( 'graphql_pre_resolve_uri', null, $uri, $this->context, $this->wp, $extra_query_vars );

--- a/src/Data/PostObjectMutation.php
+++ b/src/Data/PostObjectMutation.php
@@ -19,8 +19,8 @@ class PostObjectMutation {
 	 * This handles inserting the post object
 	 *
 	 * @param array        $input             The input for the mutation
-	 * @param WP_Post_Type $post_type_object  The post_type_object for the type of post being
-	 *                                        mutated
+	 * @param \WP_Post_Type $post_type_object The post_type_object for the type of post being
+ * mutated
 	 * @param string       $mutation_name     The name of the mutation being performed
 	 *
 	 * @return array $insert_post_args
@@ -108,7 +108,7 @@ class PostObjectMutation {
 		 *
 		 * @param array        $insert_post_args The array of $input_post_args that will be passed to wp_insert_post
 		 * @param array        $input            The data that was entered as input for the mutation
-		 * @param WP_Post_Type $post_type_object The post_type_object that the mutation is affecting
+		 * @param \WP_Post_Type $post_type_object The post_type_object that the mutation is affecting
 		 * @param string       $mutation_type    The type of mutation being performed (create, edit, etc)
 		 */
 		$insert_post_args = apply_filters( 'graphql_post_object_insert_post_args', $insert_post_args, $input, $post_type_object, $mutation_name );
@@ -127,12 +127,12 @@ class PostObjectMutation {
 	 * @param int          $post_id               $post_id      The ID of the postObject being
 	 *                                            mutated
 	 * @param array        $input                 The input for the mutation
-	 * @param WP_Post_Type $post_type_object      The Post Type Object for the type of post being
-	 *                                            mutated
+	 * @param \WP_Post_Type $post_type_object The Post Type Object for the type of post being
+ * mutated
 	 * @param string       $mutation_name         The name of the mutation (ex: create, update,
 	 *                                            delete)
-	 * @param AppContext   $context               The AppContext passed down to all resolvers
-	 * @param ResolveInfo  $info                  The ResolveInfo passed down to all resolvers
+	 * @param \WPGraphQL\AppContext $context The AppContext passed down to all resolvers
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down to all resolvers
 	 * @param string       $intended_post_status  The intended post_status the post should have
 	 *                                            according to the mutation input
 	 * @param string       $default_post_status   The default status posts should use if an
@@ -148,10 +148,10 @@ class PostObjectMutation {
 		 * @param bool         $is_locked            Whether the post is locked
 		 * @param int          $post_id              The ID of the postObject being mutated
 		 * @param array        $input                The input for the mutation
-		 * @param WP_Post_Type $post_type_object     The Post Type Object for the type of post being mutated
+		 * @param \WP_Post_Type $post_type_object The Post Type Object for the type of post being mutated
 		 * @param string       $mutation_name        The name of the mutation (ex: create, update, delete)
-		 * @param AppContext   $context              The AppContext passed down to all resolvers
-		 * @param ResolveInfo  $info                 The ResolveInfo passed down to all resolvers
+		 * @param \WPGraphQL\AppContext $context The AppContext passed down to all resolvers
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down to all resolvers
 		 * @param ?string      $intended_post_status The intended post_status the post should have according to the mutation input
 		 * @param ?string      $default_post_status  The default status posts should use if an intended status wasn't set
 		 *
@@ -181,7 +181,7 @@ class PostObjectMutation {
 		 *
 		 * @param int          $post_id          The ID of the postObject being mutated
 		 * @param array        $input            The input for the mutation
-		 * @param WP_Post_Type $post_type_object The Post Type Object for the type of post being mutated
+		 * @param \WP_Post_Type $post_type_object The Post Type Object for the type of post being mutated
 		 * @param string       $mutation_name    The name of the mutation (ex: create, update, delete)
 		 */
 		self::set_object_terms( $post_id, $input, $post_type_object, $mutation_name );
@@ -193,10 +193,10 @@ class PostObjectMutation {
 		 *
 		 * @param int          $post_id              The ID of the postObject being mutated
 		 * @param array        $input                The input for the mutation
-		 * @param WP_Post_Type $post_type_object     The Post Type Object for the type of post being mutated
+		 * @param \WP_Post_Type $post_type_object The Post Type Object for the type of post being mutated
 		 * @param string       $mutation_name        The name of the mutation (ex: create, update, delete)
-		 * @param AppContext   $context              The AppContext passed down to all resolvers
-		 * @param ResolveInfo  $info                 The ResolveInfo passed down to all resolvers
+		 * @param \WPGraphQL\AppContext $context The AppContext passed down to all resolvers
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down to all resolvers
 		 * @param ?string      $intended_post_status The intended post_status the post should have according to the mutation input
 		 * @param ?string      $default_post_status  The default status posts should use if an intended status wasn't set
 		 */
@@ -208,10 +208,10 @@ class PostObjectMutation {
 		 * @param bool         $is_locked            Whether the post is locked.
 		 * @param int          $post_id              The ID of the postObject being mutated
 		 * @param array        $input                The input for the mutation
-		 * @param WP_Post_Type $post_type_object     The Post Type Object for the type of post being mutated
+		 * @param \WP_Post_Type $post_type_object The Post Type Object for the type of post being mutated
 		 * @param string       $mutation_name        The name of the mutation (ex: create, update, delete)
-		 * @param AppContext   $context              The AppContext passed down to all resolvers
-		 * @param ResolveInfo  $info                 The ResolveInfo passed down to all resolvers
+		 * @param \WPGraphQL\AppContext $context The AppContext passed down to all resolvers
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down to all resolvers
 		 * @param ?string      $intended_post_status The intended post_status the post should have according to the mutation input
 		 * @param ?string      $default_post_status  The default status posts should use if an intended status wasn't set
 		 *
@@ -232,8 +232,8 @@ class PostObjectMutation {
 	 *
 	 * @param int          $post_id           The ID of the postObject being mutated
 	 * @param array        $input             The input for the mutation
-	 * @param WP_Post_Type $post_type_object  The Post Type Object for the type of post being
-	 *                                        mutated
+	 * @param \WP_Post_Type $post_type_object The Post Type Object for the type of post being
+ * mutated
 	 * @param string       $mutation_name     The name of the mutation (ex: create, update, delete)
 	 *
 	 * @return void
@@ -247,7 +247,7 @@ class PostObjectMutation {
 		 *
 		 * @param int          $post_id          The ID of the postObject being mutated
 		 * @param array        $input            The input for the mutation
-		 * @param WP_Post_Type $post_type_object The Post Type Object for the type of post being mutated
+		 * @param \WP_Post_Type $post_type_object The Post Type Object for the type of post being mutated
 		 * @param string       $mutation_name    The name of the mutation (ex: create, update, delete)
 		 */
 		do_action( 'graphql_post_object_mutation_set_object_terms', $post_id, $input, $post_type_object, $mutation_name );

--- a/src/Data/TermObjectMutation.php
+++ b/src/Data/TermObjectMutation.php
@@ -12,10 +12,10 @@ class TermObjectMutation {
 	 * This prepares the object to be mutated - ensures data is safe to be saved,
 	 * and mapped from input args to WordPress $args
 	 *
-	 * @throws UserError User error for invalid term.
+	 * @throws \GraphQL\Error\UserError User error for invalid term.
 	 * 
 	 * @param array        $input         The input from the GraphQL Request
-	 * @param WP_Taxonomy  $taxonomy      The Taxonomy object for the type of term being mutated
+	 * @param \WP_Taxonomy $taxonomy The Taxonomy object for the type of term being mutated
 	 * @param string       $mutation_name The name of the mutation (create, update, etc)
 	 *
 	 * @return mixed
@@ -80,7 +80,7 @@ class TermObjectMutation {
 		 *
 		 * @param array $insert_args The array of input args that will be passed to the functions that insert terms
 		 * @param array $input The data that was entered as input for the mutation
-		 * @param WP_Taxonomy $taxonomy The taxonomy object of the term being mutated
+		 * @param \WP_Taxonomy $taxonomy The taxonomy object of the term being mutated
 		 * @param string $mutation_name The name of the mutation being performed (create, edit, etc)
 		 */
 		return apply_filters( 'graphql_term_object_insert_term_args', $insert_args, $input, $taxonomy, $mutation_name );

--- a/src/Data/UserMutation.php
+++ b/src/Data/UserMutation.php
@@ -214,11 +214,11 @@ class UserMutation {
 	 * @param int         $user_id       The ID of the user being mutated
 	 * @param array       $input         The input data from the GraphQL query
 	 * @param string      $mutation_name Name of the mutation currently being run
-	 * @param AppContext  $context       The AppContext passed down the resolve tree
-	 * @param ResolveInfo $info          The ResolveInfo passed down the Resolve Tree
+	 * @param \WPGraphQL\AppContext $context The AppContext passed down the resolve tree
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the Resolve Tree
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public static function update_additional_user_object_data( $user_id, $input, $mutation_name, AppContext $context, ResolveInfo $info ) {
 
@@ -233,8 +233,8 @@ class UserMutation {
 		 * @param int         $user_id       The ID of the user being mutated
 		 * @param array       $input         The input for the mutation
 		 * @param string      $mutation_name The name of the mutation (ex: create, update, delete)
-		 * @param AppContext  $context       The AppContext passed down the resolve tree
-		 * @param ResolveInfo $info          The ResolveInfo passed down the Resolve Tree
+		 * @param \WPGraphQL\AppContext $context The AppContext passed down the resolve tree
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the Resolve Tree
 		 */
 		do_action( 'graphql_user_object_mutation_update_additional_data', $user_id, $input, $mutation_name, $context, $info );
 
@@ -247,7 +247,7 @@ class UserMutation {
 	 * @param array $roles   List of roles that need to get added to the user
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	private static function add_user_roles( $user_id, $roles ) {
 

--- a/src/Model/Avatar.php
+++ b/src/Model/Avatar.php
@@ -34,7 +34,7 @@ class Avatar extends Model {
 	 *
 	 * @param array $avatar The incoming avatar to be modeled
 	 *
-	 * @throws Exception Throws Exception.
+	 * @throws \Exception Throws Exception.
 	 */
 	public function __construct( array $avatar ) {
 		$this->data = $avatar;

--- a/src/Model/Comment.php
+++ b/src/Model/Comment.php
@@ -36,16 +36,16 @@ class Comment extends Model {
 	/**
 	 * Stores the incoming WP_Comment object to be modeled
 	 *
-	 * @var WP_Comment $data
+	 * @var \WP_Comment $data
 	 */
 	protected $data;
 
 	/**
 	 * Comment constructor.
 	 *
-	 * @param WP_Comment $comment The incoming WP_Comment to be modeled
+	 * @param \WP_Comment $comment The incoming WP_Comment to be modeled
 	 *
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function __construct( WP_Comment $comment ) {
 
@@ -80,7 +80,7 @@ class Comment extends Model {
 	 * Method for determining if the data should be considered private or not
 	 *
 	 * @return bool
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	protected function is_private() {
 

--- a/src/Model/CommentAuthor.php
+++ b/src/Model/CommentAuthor.php
@@ -22,16 +22,16 @@ class CommentAuthor extends Model {
 	/**
 	 * Stores the comment author to be modeled
 	 *
-	 * @var WP_Comment $data The raw data passed to he model
+	 * @var \WP_Comment $data The raw data passed to he model
 	 */
 	protected $data;
 
 	/**
 	 * CommentAuthor constructor.
 	 *
-	 * @param WP_Comment $comment_author The incoming comment author array to be modeled
+	 * @param \WP_Comment $comment_author The incoming comment author array to be modeled
 	 *
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function __construct( WP_Comment $comment_author ) {
 		$this->data = $comment_author;

--- a/src/Model/MenuItem.php
+++ b/src/Model/MenuItem.php
@@ -39,10 +39,10 @@ class MenuItem extends Model {
 	/**
 	 * MenuItem constructor.
 	 *
-	 * @param WP_Post $post The incoming WP_Post object that needs modeling
+	 * @param \WP_Post $post The incoming WP_Post object that needs modeling
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function __construct( WP_Post $post ) {
 		$this->data = wp_setup_nav_menu_item( $post );
@@ -56,7 +56,7 @@ class MenuItem extends Model {
 	 * it's not considered a public node
 	 *
 	 * @return bool
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function is_private() {
 

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -51,7 +51,7 @@ abstract class Model {
 	/**
 	 * Stores the WP_User object for the current user in the session
 	 *
-	 * @var WP_User $current_user
+	 * @var \WP_User $current_user
 	 */
 	protected $current_user;
 
@@ -80,7 +80,7 @@ abstract class Model {
 	 *                                            data to compare with the current user ID
 	 *
 	 * @return void
-	 * @throws Exception Throws Exception.
+	 * @throws \Exception Throws Exception.
 	 */
 	protected function __construct( $restricted_cap = '', $allowed_restricted_fields = [], $owner = null ) {
 
@@ -216,7 +216,7 @@ abstract class Model {
 			 * @param mixed       $data           The un-modeled incoming data
 			 * @param string|null $visibility     The visibility that has currently been set for the data at this point
 			 * @param null|int    $owner          The user ID for the owner of this piece of data
-			 * @param WP_User     $current_user   The current user for the session
+			 * @param \WP_User $current_user The current user for the session
 			 *
 			 * @return string
 			 */
@@ -231,7 +231,7 @@ abstract class Model {
 			 * @param mixed       $data         The un-modeled incoming data
 			 * @param string|null $visibility   The visibility that has currently been set for the data at this point
 			 * @param null|int    $owner        The user ID for the owner of this piece of data
-			 * @param WP_User     $current_user The current user for the session
+			 * @param \WP_User $current_user The current user for the session
 			 *
 			 * @return bool|null
 			 */
@@ -253,7 +253,7 @@ abstract class Model {
 			 * @param mixed       $data         The un-modeled incoming data
 			 * @param string|null $visibility   The visibility that has currently been set for the data at this point
 			 * @param null|int    $owner        The user ID for the owner of this piece of data
-			 * @param WP_User     $current_user The current user for the session
+			 * @param \WP_User $current_user The current user for the session
 			 *
 			 * @return bool
 			 */
@@ -277,7 +277,7 @@ abstract class Model {
 		 * @param string      $model_name   Name of the model the filter is currently being executed in
 		 * @param mixed       $data         The un-modeled incoming data
 		 * @param null|int    $owner        The user ID for the owner of this piece of data
-		 * @param WP_User     $current_user The current user for the session
+		 * @param \WP_User $current_user The current user for the session
 		 *
 		 * @return string
 		 */
@@ -325,7 +325,7 @@ abstract class Model {
 			 * @param mixed       $data                      The un-modeled incoming data
 			 * @param string|null $visibility                The visibility that has currently been set for the data at this point
 			 * @param null|int    $owner                     The user ID for the owner of this piece of data
-			 * @param WP_User     $current_user              The current user for the session
+			 * @param \WP_User $current_user The current user for the session
 			 *
 			 * @return array
 			 */
@@ -362,7 +362,7 @@ abstract class Model {
 					 * @param mixed    $data         The un-modeled incoming data
 					 * @param string   $visibility   The visibility setting for this piece of data
 					 * @param null|int $owner        The user ID for the owner of this piece of data
-					 * @param WP_User  $current_user The current user for the session
+					 * @param \WP_User $current_user The current user for the session
 					 *
 					 * @return string
 					 */
@@ -387,7 +387,7 @@ abstract class Model {
 				 * @param mixed    $data         The un-modeled incoming data
 				 * @param string   $visibility   The visibility setting for this piece of data
 				 * @param null|int $owner        The user ID for the owner of this piece of data
-				 * @param WP_User  $current_user The current user for the session
+				 * @param \WP_User $current_user The current user for the session
 				 *
 				 * @return null|callable|int|string|array|mixed
 				 */
@@ -413,7 +413,7 @@ abstract class Model {
 					 * @param mixed    $data         The un-modeled incoming data
 					 * @param string   $visibility   The visibility setting for this piece of data
 					 * @param null|int $owner        The user ID for the owner of this piece of data
-					 * @param WP_User  $current_user The current user for the session
+					 * @param \WP_User $current_user The current user for the session
 					 *
 					 * @return mixed
 					 */
@@ -429,7 +429,7 @@ abstract class Model {
 				 * @param mixed    $data         The un-modeled incoming data
 				 * @param string   $visibility   The visibility setting for this piece of data
 				 * @param null|int $owner        The user ID for the owner of this piece of data
-				 * @param WP_User  $current_user The current user for the session
+				 * @param \WP_User $current_user The current user for the session
 				 */
 				do_action( 'graphql_after_return_field_from_model', $result, $key, $this->get_model_name(), $this->data, $this->visibility, $this->owner, $this->current_user );
 
@@ -481,7 +481,7 @@ abstract class Model {
 		 * @param string   $model_name   Name of the model the filter is currently being executed in
 		 * @param string   $visibility   The visibility setting for this piece of data
 		 * @param null|int $owner        The user ID for the owner of this piece of data
-		 * @param WP_User  $current_user The current user for the session
+		 * @param \WP_User $current_user The current user for the session
 		 *
 		 * @return array
 		 *
@@ -497,7 +497,7 @@ abstract class Model {
 		 * @param mixed    $data         The un-modeled incoming data
 		 * @param string   $visibility   The visibility setting for this piece of data
 		 * @param null|int $owner        The user ID for the owner of this piece of data
-		 * @param WP_User  $current_user The current user for the session
+		 * @param \WP_User $current_user The current user for the session
 		 *
 		 * @return array
 		 */

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -80,38 +80,38 @@ class Post extends Model {
 	/**
 	 * Stores the incoming post data
 	 *
-	 * @var WP_Post $data
+	 * @var \WP_Post $data
 	 */
 	protected $data;
 
 	/**
 	 * Store the global post to reset during model tear down
 	 *
-	 * @var WP_Post
+	 * @var \WP_Post
 	 */
 	protected $global_post;
 
 	/**
 	 * Stores the incoming post type object for the post being modeled
 	 *
-	 * @var null|WP_Post_Type $post_type_object
+	 * @var null|\WP_Post_Type $post_type_object
 	 */
 	protected $post_type_object;
 
 	/**
 	 * Store the instance of the WP_Query
 	 *
-	 * @var WP_Query
+	 * @var \WP_Query
 	 */
 	protected $wp_query;
 
 	/**
 	 * Post constructor.
 	 *
-	 * @param WP_Post $post The incoming WP_Post object that needs modeling.
+	 * @param \WP_Post $post The incoming WP_Post object that needs modeling.
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function __construct( WP_Post $post ) {
 
@@ -338,7 +338,7 @@ class Post extends Model {
 	/**
 	 * Method for determining if the data should be considered private or not
 	 *
-	 * @param WP_Post $post_object The object of the post we need to verify permissions for
+	 * @param \WP_Post $post_object The object of the post we need to verify permissions for
 	 *
 	 * @return bool
 	 */

--- a/src/Model/Term.php
+++ b/src/Model/Term.php
@@ -33,31 +33,31 @@ class Term extends Model {
 	/**
 	 * Stores the incoming WP_Term object
 	 *
-	 * @var WP_Term $data
+	 * @var \WP_Term $data
 	 */
 	protected $data;
 
 	/**
 	 * Stores the taxonomy object for the term being modeled
 	 *
-	 * @var null|WP_Taxonomy $taxonomy_object
+	 * @var null|\WP_Taxonomy $taxonomy_object
 	 */
 	protected $taxonomy_object;
 
 	/**
 	 * The global Post instance
 	 *
-	 * @var WP_Post
+	 * @var \WP_Post
 	 */
 	protected $global_post;
 
 	/**
 	 * Term constructor.
 	 *
-	 * @param WP_Term $term The incoming WP_Term object that needs modeling
+	 * @param \WP_Term $term The incoming WP_Term object that needs modeling
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function __construct( WP_Term $term ) {
 		$this->data            = $term;

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -40,31 +40,31 @@ class User extends Model {
 	/**
 	 * Stores the WP_User object for the incoming data
 	 *
-	 * @var WP_User $data
+	 * @var \WP_User $data
 	 */
 	protected $data;
 
 	/**
 	 * The Global Post at time of Model generation
 	 *
-	 * @var WP_Post
+	 * @var \WP_Post
 	 */
 	protected $global_post;
 
 	/**
 	 * The global authordata at time of Model generation
 	 *
-	 * @var WP_User
+	 * @var \WP_User
 	 */
 	protected $global_authordata;
 
 	/**
 	 * User constructor.
 	 *
-	 * @param WP_User $user The incoming WP_User object that needs modeling
+	 * @param \WP_User $user The incoming WP_User object that needs modeling
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function __construct( WP_User $user ) {
 

--- a/src/Mutation/CommentCreate.php
+++ b/src/Mutation/CommentCreate.php
@@ -14,7 +14,7 @@ class CommentCreate {
 	 * Registers the CommentCreate mutation.
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public static function register_mutation() {
 		register_graphql_mutation(

--- a/src/Mutation/CommentDelete.php
+++ b/src/Mutation/CommentDelete.php
@@ -15,7 +15,7 @@ class CommentDelete {
 	 * Registers the CommentDelete mutation.
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public static function register_mutation() {
 		register_graphql_mutation(

--- a/src/Mutation/CommentUpdate.php
+++ b/src/Mutation/CommentUpdate.php
@@ -20,7 +20,7 @@ class CommentUpdate {
 	 * Registers the CommentUpdate mutation.
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public static function register_mutation() {
 		register_graphql_mutation(

--- a/src/Mutation/MediaItemCreate.php
+++ b/src/Mutation/MediaItemCreate.php
@@ -15,7 +15,7 @@ class MediaItemCreate {
 	 * Registers the MediaItemCreate mutation.
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public static function register_mutation() {
 		register_graphql_mutation(

--- a/src/Mutation/MediaItemDelete.php
+++ b/src/Mutation/MediaItemDelete.php
@@ -12,7 +12,7 @@ class MediaItemDelete {
 	 * Registers the MediaItemDelete mutation.
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public static function register_mutation() {
 		register_graphql_mutation(
@@ -65,7 +65,7 @@ class MediaItemDelete {
 				'type'        => 'MediaItem',
 				'description' => __( 'The mediaItem before it was deleted', 'wp-graphql' ),
 				'resolve'     => function ( $payload ) {
-					/** @var Post $deleted */
+					/** @var \WPGraphQL\Model\Post $deleted */
 					$deleted = $payload['mediaItemObject'];
 
 					return ! empty( $deleted->ID ) ? $deleted : null;

--- a/src/Mutation/MediaItemUpdate.php
+++ b/src/Mutation/MediaItemUpdate.php
@@ -16,7 +16,7 @@ class MediaItemUpdate {
 	 * Registers the MediaItemUpdate mutation.
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public static function register_mutation() {
 		register_graphql_mutation(
@@ -35,7 +35,7 @@ class MediaItemUpdate {
 	 * @return array
 	 */
 	public static function get_input_fields() {
-		/** @var WP_Post_Type $post_type_object */
+		/** @var \WP_Post_Type $post_type_object */
 		$post_type_object = get_post_type_object( 'attachment' );
 		return array_merge(
 			MediaItemCreate::get_input_fields(),

--- a/src/Mutation/PostObjectCreate.php
+++ b/src/Mutation/PostObjectCreate.php
@@ -18,7 +18,7 @@ class PostObjectCreate {
 	/**
 	 * Registers the PostObjectCreate mutation.
 	 *
-	 * @param WP_Post_Type $post_type_object The post type of the mutation.
+	 * @param \WP_Post_Type $post_type_object The post type of the mutation.
 	 *
 	 * @return void
 	 */
@@ -38,7 +38,7 @@ class PostObjectCreate {
 	/**
 	 * Defines the mutation input field configuration.
 	 *
-	 * @param WP_Post_Type $post_type_object The post type of the mutation.
+	 * @param \WP_Post_Type $post_type_object The post type of the mutation.
 	 *
 	 * @return array
 	 */
@@ -159,7 +159,7 @@ class PostObjectCreate {
 	/**
 	 * Defines the mutation output field configuration.
 	 *
-	 * @param WP_Post_Type $post_type_object The post type of the mutation.
+	 * @param \WP_Post_Type $post_type_object The post type of the mutation.
 	 *
 	 * @return array
 	 */
@@ -183,7 +183,7 @@ class PostObjectCreate {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @param WP_Post_Type $post_type_object The post type of the mutation.
+	 * @param \WP_Post_Type $post_type_object The post type of the mutation.
 	 * @param string       $mutation_name    The mutation name.
 	 *
 	 * @return callable
@@ -243,7 +243,7 @@ class PostObjectCreate {
 			 * customizing stati or various E-commerce plugins that make heavy use of custom stati)
 			 *
 			 * @param string       $default_status   The default status to be used when the post is initially inserted
-			 * @param WP_Post_Type $post_type_object The Post Type that is being inserted
+			 * @param \WP_Post_Type $post_type_object The Post Type that is being inserted
 			 * @param string       $mutation_name    The name of the mutation currently in progress
 			 */
 			$default_post_status = apply_filters( 'graphql_post_object_create_default_post_status', 'draft', $post_type_object, $mutation_name );
@@ -316,10 +316,10 @@ class PostObjectCreate {
 			 * the $intended_status.
 			 *
 			 * @param boolean      $should_set_intended_status Whether to set the intended post_status or not. Default true.
-			 * @param WP_Post_Type $post_type_object           The Post Type Object for the post being mutated
+			 * @param \WP_Post_Type $post_type_object The Post Type Object for the post being mutated
 			 * @param string       $mutation_name              The name of the mutation currently in progress
-			 * @param AppContext   $context                    The AppContext passed down to all resolvers
-			 * @param ResolveInfo  $info                       The ResolveInfo passed down to all resolvers
+			 * @param \WPGraphQL\AppContext $context The AppContext passed down to all resolvers
+			 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down to all resolvers
 			 * @param string       $intended_post_status       The intended post_status the post should have according to the mutation input
 			 * @param string       $default_post_status        The default status posts should use if an intended status wasn't set
 			 */

--- a/src/Mutation/PostObjectDelete.php
+++ b/src/Mutation/PostObjectDelete.php
@@ -13,10 +13,10 @@ class PostObjectDelete {
 	/**
 	 * Registers the PostObjectDelete mutation.
 	 *
-	 * @param WP_Post_Type $post_type_object The post type of the mutation.
+	 * @param \WP_Post_Type $post_type_object The post type of the mutation.
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public static function register_mutation( WP_Post_Type $post_type_object ) {
 		$mutation_name = 'delete' . ucwords( $post_type_object->graphql_single_name );
@@ -34,7 +34,7 @@ class PostObjectDelete {
 	/**
 	 * Defines the mutation input field configuration.
 	 *
-	 * @param WP_Post_Type $post_type_object The post type of the mutation.
+	 * @param \WP_Post_Type $post_type_object The post type of the mutation.
 	 *
 	 * @return array
 	 */
@@ -57,7 +57,7 @@ class PostObjectDelete {
 	/**
 	 * Defines the mutation output field configuration.
 	 *
-	 * @param WP_Post_Type $post_type_object The post type of the mutation.
+	 * @param \WP_Post_Type $post_type_object The post type of the mutation.
 	 *
 	 * @return array
 	 */
@@ -67,7 +67,7 @@ class PostObjectDelete {
 				'type'        => 'ID',
 				'description' => __( 'The ID of the deleted object', 'wp-graphql' ),
 				'resolve'     => function ( $payload ) {
-					/** @var Post $deleted */
+					/** @var \WPGraphQL\Model\Post $deleted */
 					$deleted = $payload['postObject'];
 
 					return ! empty( $deleted->ID ) ? Relay::toGlobalId( 'post', (string) $deleted->ID ) : null;
@@ -77,7 +77,7 @@ class PostObjectDelete {
 				'type'        => $post_type_object->graphql_single_name,
 				'description' => __( 'The object before it was deleted', 'wp-graphql' ),
 				'resolve'     => function ( $payload ) {
-					/** @var Post $deleted */
+					/** @var \WPGraphQL\Model\Post $deleted */
 					$deleted = $payload['postObject'];
 
 					return ! empty( $deleted->ID ) ? $deleted : null;
@@ -89,7 +89,7 @@ class PostObjectDelete {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @param WP_Post_Type $post_type_object The post type of the mutation.
+	 * @param \WP_Post_Type $post_type_object The post type of the mutation.
 	 * @param string       $mutation_name    The mutation name.
 	 *
 	 * @return callable

--- a/src/Mutation/PostObjectUpdate.php
+++ b/src/Mutation/PostObjectUpdate.php
@@ -14,10 +14,10 @@ class PostObjectUpdate {
 	/**
 	 * Registers the PostObjectUpdate mutation.
 	 *
-	 * @param WP_Post_Type $post_type_object The post type of the mutation.
+	 * @param \WP_Post_Type $post_type_object The post type of the mutation.
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public static function register_mutation( WP_Post_Type $post_type_object ) {
 		$mutation_name = 'update' . ucwords( $post_type_object->graphql_single_name );
@@ -35,7 +35,7 @@ class PostObjectUpdate {
 	/**
 	 * Defines the mutation input field configuration.
 	 *
-	 * @param WP_Post_Type $post_type_object   The post type of the mutation.
+	 * @param \WP_Post_Type $post_type_object The post type of the mutation.
 	 *
 	 * @return array
 	 */
@@ -57,7 +57,7 @@ class PostObjectUpdate {
 	/**
 	 * Defines the mutation output field configuration.
 	 *
-	 * @param WP_Post_Type $post_type_object   The post type of the mutation.
+	 * @param \WP_Post_Type $post_type_object The post type of the mutation.
 	 *
 	 * @return array
 	 */
@@ -68,7 +68,7 @@ class PostObjectUpdate {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @param WP_Post_Type $post_type_object   The post type of the mutation.
+	 * @param \WP_Post_Type $post_type_object The post type of the mutation.
 	 * @param string        $mutation_name      The mutation name.
 	 *
 	 * @return callable
@@ -175,7 +175,7 @@ class PostObjectUpdate {
 			 * The dynamic portion of the hook name, `$taxonomy->name` refers to the taxonomy of the term being mutated
 			 *
 			 * @param int    $post_id       Inserted post ID
-			 * @param WP_Post_Type $post_type_object The Post Type object for the post being mutated
+			 * @param \WP_Post_Type $post_type_object The Post Type object for the post being mutated
 			 * @param array  $args          The args used to insert the term
 			 * @param string $mutation_name The name of the mutation being performed
 			 */

--- a/src/Mutation/SendPasswordResetEmail.php
+++ b/src/Mutation/SendPasswordResetEmail.php
@@ -14,7 +14,7 @@ class SendPasswordResetEmail {
 	 * Registers the sendPasswordResetEmail Mutation
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public static function register_mutation() {
 		register_graphql_mutation(
@@ -144,7 +144,7 @@ class SendPasswordResetEmail {
 	 *
 	 * @param  string $username The user's username or email address.
 	 *
-	 * @return WP_User|false WP_User object on success, false on failure.
+	 * @return \WP_User|false WP_User object on success, false on failure.
 	 */
 	private static function get_user_data( $username ) {
 		if ( self::is_email_address( $username ) ) {
@@ -190,7 +190,7 @@ class SendPasswordResetEmail {
 	/**
 	 * Get the subject of the password reset email
 	 *
-	 * @param WP_User $user_data User data
+	 * @param \WP_User $user_data User data
 	 *
 	 * @return string
 	 */
@@ -203,7 +203,7 @@ class SendPasswordResetEmail {
 		 *
 		 * @param string   $title      Default email title.
 		 * @param string   $user_login The username for the user.
-		 * @param WP_User $user_data  WP_User object.
+		 * @param \WP_User $user_data WP_User object.
 		 */
 		return apply_filters( 'retrieve_password_title', $title, $user_data->user_login, $user_data );
 	}
@@ -232,7 +232,7 @@ class SendPasswordResetEmail {
 	/**
 	 * Get the message body of the password reset email
 	 *
-	 * @param WP_User $user_data User data
+	 * @param \WP_User $user_data User data
 	 * @param string   $key       Password reset key
 	 *
 	 * @return string
@@ -255,7 +255,7 @@ class SendPasswordResetEmail {
 		 * @param string   $message    Default mail message.
 		 * @param string   $key        The activation key.
 		 * @param string   $user_login The username for the user.
-		 * @param WP_User $user_data  WP_User object.
+		 * @param \WP_User $user_data WP_User object.
 		 */
 		return apply_filters( 'retrieve_password_message', $message, $key, $user_data->user_login, $user_data );
 	}

--- a/src/Mutation/TermObjectCreate.php
+++ b/src/Mutation/TermObjectCreate.php
@@ -12,7 +12,7 @@ class TermObjectCreate {
 	/**
 	 * Registers the TermObjectCreate mutation.
 	 *
-	 * @param WP_Taxonomy $taxonomy The taxonomy type of the mutation.
+	 * @param \WP_Taxonomy $taxonomy The taxonomy type of the mutation.
 	 *
 	 * @return void
 	 */
@@ -43,7 +43,7 @@ class TermObjectCreate {
 	/**
 	 * Defines the mutation input field configuration.
 	 *
-	 * @param WP_Taxonomy $taxonomy The taxonomy type of the mutation.
+	 * @param \WP_Taxonomy $taxonomy The taxonomy type of the mutation.
 	 *
 	 * @return array
 	 */
@@ -82,7 +82,7 @@ class TermObjectCreate {
 	/**
 	 * Defines the mutation output field configuration.
 	 *
-	 * @param WP_Taxonomy $taxonomy The taxonomy type of the mutation.
+	 * @param \WP_Taxonomy $taxonomy The taxonomy type of the mutation.
 	 *
 	 * @return array
 	 */
@@ -105,7 +105,7 @@ class TermObjectCreate {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @param WP_Taxonomy $taxonomy      The taxonomy type of the mutation.
+	 * @param \WP_Taxonomy $taxonomy The taxonomy type of the mutation.
 	 * @param string      $mutation_name The name of the mutation.
 	 *
 	 * @return callable
@@ -168,11 +168,11 @@ class TermObjectCreate {
 			 * Fires after a single term is created or updated via a GraphQL mutation
 			 *
 			 * @param int         $term_id       Inserted term object
-			 * @param WP_Taxonomy $taxonomy      The taxonomy of the term being updated
+			 * @param \WP_Taxonomy $taxonomy The taxonomy of the term being updated
 			 * @param array       $args          The args used to insert the term
 			 * @param string      $mutation_name The name of the mutation being performed
-			 * @param AppContext  $context       The AppContext passed down the resolve tree
-			 * @param ResolveInfo $info          The ResolveInfo passed down the resolve tree
+			 * @param \WPGraphQL\AppContext $context The AppContext passed down the resolve tree
+			 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the resolve tree
 			 */
 			do_action( 'graphql_insert_term', $term['term_id'], $taxonomy, $args, $mutation_name, $context, $info );
 
@@ -184,8 +184,8 @@ class TermObjectCreate {
 			 * @param int         $term_id       Inserted term object
 			 * @param array       $args          The args used to insert the term
 			 * @param string      $mutation_name The name of the mutation being performed
-			 * @param AppContext  $context       The AppContext passed down the resolve tree
-			 * @param ResolveInfo $info          The ResolveInfo passed down the resolve tree
+			 * @param \WPGraphQL\AppContext $context The AppContext passed down the resolve tree
+			 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the resolve tree
 			 */
 			do_action( "graphql_insert_{$taxonomy->name}", $term['term_id'], $args, $mutation_name, $context, $info );
 

--- a/src/Mutation/TermObjectDelete.php
+++ b/src/Mutation/TermObjectDelete.php
@@ -17,7 +17,7 @@ class TermObjectDelete {
 	/**
 	 * Registers the TermObjectDelete mutation.
 	 *
-	 * @param WP_Taxonomy $taxonomy The taxonomy type of the mutation.
+	 * @param \WP_Taxonomy $taxonomy The taxonomy type of the mutation.
 	 *
 	 * @return void
 	 */
@@ -37,7 +37,7 @@ class TermObjectDelete {
 	/**
 	 * Defines the mutation input field configuration.
 	 *
-	 * @param WP_Taxonomy $taxonomy The taxonomy type of the mutation.
+	 * @param \WP_Taxonomy $taxonomy The taxonomy type of the mutation.
 	 *
 	 * @return array
 	 */
@@ -56,7 +56,7 @@ class TermObjectDelete {
 	/**
 	 * Defines the mutation output field configuration.
 	 *
-	 * @param WP_Taxonomy $taxonomy The taxonomy type of the mutation.
+	 * @param \WP_Taxonomy $taxonomy The taxonomy type of the mutation.
 	 *
 	 * @return array
 	 */
@@ -84,7 +84,7 @@ class TermObjectDelete {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @param WP_Taxonomy $taxonomy      The taxonomy type of the mutation.
+	 * @param \WP_Taxonomy $taxonomy The taxonomy type of the mutation.
 	 * @param string      $mutation_name The name of the mutation.
 	 *
 	 * @return callable

--- a/src/Mutation/TermObjectUpdate.php
+++ b/src/Mutation/TermObjectUpdate.php
@@ -18,7 +18,7 @@ class TermObjectUpdate {
 	/**
 	 * Registers the TermObjectUpdate mutation.
 	 *
-	 * @param WP_Taxonomy $taxonomy The Taxonomy the mutation is registered for.
+	 * @param \WP_Taxonomy $taxonomy The Taxonomy the mutation is registered for.
 	 *
 	 * @return void
 	 */
@@ -37,7 +37,7 @@ class TermObjectUpdate {
 	/**
 	 * Defines the mutation input field configuration.
 	 *
-	 * @param WP_Taxonomy $taxonomy    The taxonomy type of the mutation.
+	 * @param \WP_Taxonomy $taxonomy The taxonomy type of the mutation.
 	 *
 	 * @return array
 	 */
@@ -64,7 +64,7 @@ class TermObjectUpdate {
 	/**
 	 * Defines the mutation output field configuration.
 	 *
-	 * @param WP_Taxonomy $taxonomy    The taxonomy type of the mutation.
+	 * @param \WP_Taxonomy $taxonomy The taxonomy type of the mutation.
 	 *
 	 * @return array
 	 */
@@ -75,7 +75,7 @@ class TermObjectUpdate {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @param WP_Taxonomy $taxonomy       The taxonomy type of the mutation.
+	 * @param \WP_Taxonomy $taxonomy The taxonomy type of the mutation.
 	 * @param string       $mutation_name  The name of the mutation.
 	 *
 	 * @return callable
@@ -153,11 +153,11 @@ class TermObjectUpdate {
 			 * Fires an action when a term is updated via a GraphQL Mutation
 			 *
 			 * @param int         $term_id       The ID of the term object that was mutated
-			 * @param WP_Taxonomy $taxonomy     The taxonomy of the term being updated
+			 * @param \WP_Taxonomy $taxonomy The taxonomy of the term being updated
 			 * @param array       $args          The args used to update the term
 			 * @param string      $mutation_name The name of the mutation being performed (create, update, delete, etc)
-			 * @param AppContext  $context       The AppContext passed down the resolve tree
-			 * @param ResolveInfo $info          The ResolveInfo passed down the resolve tree
+			 * @param \WPGraphQL\AppContext $context The AppContext passed down the resolve tree
+			 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the resolve tree
 			 */
 			do_action( 'graphql_update_term', $existing_term->term_id, $taxonomy, $args, $mutation_name, $context, $info );
 
@@ -167,8 +167,8 @@ class TermObjectUpdate {
 			 * @param int         $term_id       The ID of the term object that was mutated
 			 * @param array       $args          The args used to update the term
 			 * @param string      $mutation_name The name of the mutation being performed (create, update, delete, etc)
-			 * @param AppContext  $context       The AppContext passed down the resolve tree
-			 * @param ResolveInfo $info          The ResolveInfo passed down the resolve tree
+			 * @param \WPGraphQL\AppContext $context The AppContext passed down the resolve tree
+			 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the resolve tree
 			 */
 			do_action( "graphql_update_{$taxonomy->name}", $existing_term->term_id, $args, $mutation_name, $context, $info );
 

--- a/src/Mutation/UpdateSettings.php
+++ b/src/Mutation/UpdateSettings.php
@@ -18,7 +18,7 @@ class UpdateSettings {
 	/**
 	 * Registers the CommentCreate mutation.
 	 *
-	 * @param TypeRegistry $type_registry The WPGraphQL TypeRegistry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The WPGraphQL TypeRegistry
 	 *
 	 * @return void
 	 */
@@ -45,7 +45,7 @@ class UpdateSettings {
 	/**
 	 * Defines the mutation input field configuration.
 	 *
-	 * @param TypeRegistry $type_registry The WPGraphQL TypeRegistry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The WPGraphQL TypeRegistry
 	 *
 	 * @return array
 	 */
@@ -105,7 +105,7 @@ class UpdateSettings {
 	/**
 	 * Defines the mutation output field configuration.
 	 *
-	 * @param TypeRegistry $type_registry The WPGraphQL TypeRegistry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The WPGraphQL TypeRegistry
 	 *
 	 * @return array
 	 */
@@ -152,11 +152,11 @@ class UpdateSettings {
 	 * Defines the mutation data modification closure.
 	 *
 	 * @param array $input The mutation input
-	 * @param TypeRegistry $type_registry The WPGraphQL TypeRegistry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The WPGraphQL TypeRegistry
 	 *
 	 * @return array
 	 *
-	 * @throws UserError
+	 * @throws \GraphQL\Error\UserError
 	 */
 	public static function mutate_and_get_payload( array $input, TypeRegistry $type_registry ): array {
 		/**

--- a/src/Mutation/UserUpdate.php
+++ b/src/Mutation/UserUpdate.php
@@ -13,7 +13,7 @@ class UserUpdate {
 	 * Registers the CommentCreate mutation.
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public static function register_mutation() {
 		register_graphql_mutation(

--- a/src/Registry/SchemaRegistry.php
+++ b/src/Registry/SchemaRegistry.php
@@ -14,14 +14,14 @@ use WPGraphQL\WPSchema;
 class SchemaRegistry {
 
 	/**
-	 * @var TypeRegistry
+	 * @var \WPGraphQL\Registry\TypeRegistry
 	 */
 	protected $type_registry;
 
 	/**
 	 * SchemaRegistry constructor.
 	 *
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function __construct() {
 		$this->type_registry = \WPGraphQL::get_type_registry();
@@ -30,8 +30,8 @@ class SchemaRegistry {
 	/**
 	 * Returns the Schema to use for execution of the GraphQL Request
 	 *
-	 * @return WPSchema
-	 * @throws Exception
+	 * @return \WPGraphQL\WPSchema
+	 * @throws \Exception
 	 */
 	public function get_schema() {
 
@@ -53,8 +53,8 @@ class SchemaRegistry {
 		/**
 		 * Filter the Schema
 		 *
-		 * @param WPSchema       $schema   The generated Schema
-		 * @param SchemaRegistry $registry The Schema Registry Instance
+		 * @param \WPGraphQL\WPSchema $schema The generated Schema
+		 * @param \WPGraphQL\Registry\SchemaRegistry $registry The Schema Registry Instance
 		 */
 		return apply_filters( 'graphql_schema', $schema, $this );
 

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -218,7 +218,7 @@ class TypeRegistry {
 	/**
 	 * Initialize the TypeRegistry
 	 *
-	 * @throws Exception
+	 * @throws \Exception
 	 *
 	 * @return void
 	 */
@@ -241,7 +241,7 @@ class TypeRegistry {
 		/**
 		 * Fire an action as the Type registry is being initiated
 		 *
-		 * @param TypeRegistry $registry Instance of the TypeRegistry
+		 * @param \WPGraphQL\Registry\TypeRegistry $registry Instance of the TypeRegistry
 		 */
 		do_action( 'init_graphql_type_registry', $this );
 
@@ -250,10 +250,10 @@ class TypeRegistry {
 	/**
 	 * Initialize the Type Registry
 	 *
-	 * @param TypeRegistry $type_registry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function init_type_registry( TypeRegistry $type_registry ) {
 
@@ -261,7 +261,7 @@ class TypeRegistry {
 		 * Fire an action as the type registry is initialized. This executes
 		 * before the `graphql_register_types` action to allow for earlier hooking
 		 *
-		 * @param TypeRegistry $registry Instance of the TypeRegistry
+		 * @param \WPGraphQL\Registry\TypeRegistry $registry Instance of the TypeRegistry
 		 */
 		do_action( 'graphql_register_initial_types', $type_registry );
 
@@ -543,7 +543,7 @@ class TypeRegistry {
 		 * Fire an action as the type registry is initialized. This executes
 		 * before the `graphql_register_types` action to allow for earlier hooking
 		 *
-		 * @param TypeRegistry $registry Instance of the TypeRegistry
+		 * @param \WPGraphQL\Registry\TypeRegistry $registry Instance of the TypeRegistry
 		 */
 		do_action( 'graphql_register_types', $type_registry );
 
@@ -551,7 +551,7 @@ class TypeRegistry {
 		 * Fire an action as the type registry is initialized. This executes
 		 * during the `graphql_register_types` action to allow for earlier hooking
 		 *
-		 * @param TypeRegistry $registry Instance of the TypeRegistry
+		 * @param \WPGraphQL\Registry\TypeRegistry $registry Instance of the TypeRegistry
 		 */
 		do_action( 'graphql_register_types_late', $type_registry );
 
@@ -563,7 +563,7 @@ class TypeRegistry {
 	 * @param string $type_name The name of the Type to register
 	 * @param array  $config    The config for the scalar type to register
 	 *
-	 * @throws Exception
+	 * @throws \Exception
 	 *
 	 * @return void
 	 */
@@ -579,7 +579,7 @@ class TypeRegistry {
 	 *
 	 * @return void
 	 *
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	protected function register_connections_from_config( array $config ) {
 
@@ -607,9 +607,9 @@ class TypeRegistry {
 	 * Add a Type to the Registry
 	 *
 	 * @param string $type_name The name of the type to register
-	 * @param mixed|array|Type $config The config for the type
+	 * @param mixed|array|\GraphQL\Type\Definition\Type $config The config for the type
 	 *
-	 * @throws Exception
+	 * @throws \Exception
 	 *
 	 * @return void
 	 */
@@ -671,7 +671,7 @@ class TypeRegistry {
 	 * @param string $type_name The name of the type to register
 	 * @param array $config The configuration of the type
 	 *
-	 * @throws Exception
+	 * @throws \Exception
 	 * @return void
 	 */
 	public function register_object_type( string $type_name, array $config ) {
@@ -685,7 +685,7 @@ class TypeRegistry {
 	 * @param string $type_name The name of the type to register
 	 * @param array $config he configuration of the type
 	 *
-	 * @throws Exception
+	 * @throws \Exception
 	 * @return void
 	 */
 	public function register_interface_type( string $type_name, array $config ) {
@@ -700,7 +700,7 @@ class TypeRegistry {
 	 * @param array $config he configuration of the type
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function register_enum_type( string $type_name, array $config ) {
 		$config['kind'] = 'enum';
@@ -714,7 +714,7 @@ class TypeRegistry {
 	 * @param array $config he configuration of the type
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function register_input_type( string $type_name, array $config ) {
 		$config['kind'] = 'input';
@@ -729,7 +729,7 @@ class TypeRegistry {
 	 *
 	 * @return void
 	 *
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function register_union_type( string $type_name, array $config ) {
 		$config['kind'] = 'union';
@@ -738,10 +738,10 @@ class TypeRegistry {
 
 	/**
 	 * @param string $type_name The name of the type to register
-	 * @param mixed|array|Type $config he configuration of the type
+	 * @param mixed|array|\GraphQL\Type\Definition\Type $config he configuration of the type
 	 *
-	 * @return mixed|array|Type|null
-	 * @throws Exception
+	 * @return mixed|array|\GraphQL\Type\Definition\Type|null
+	 * @throws \Exception
 	 */
 	public function prepare_type( string $type_name, $config ) {
 		/**
@@ -841,7 +841,7 @@ class TypeRegistry {
 	 * @param string $type_name Name of the Type to register the fields to
 	 *
 	 * @return array
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function prepare_fields( array $fields, string $type_name ) {
 		$prepared_fields = [];
@@ -867,7 +867,7 @@ class TypeRegistry {
 	 * @param string $type_name    Name of the type to prepare the field for
 	 *
 	 * @return array|null
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	protected function prepare_field( $field_name, $field_config, $type_name ) {
 
@@ -952,7 +952,7 @@ class TypeRegistry {
 	 * @param mixed|string|array $type The type definition
 	 *
 	 * @return mixed
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function setup_type_modifiers( $type ) {
 		if ( ! is_array( $type ) ) {
@@ -1080,8 +1080,8 @@ class TypeRegistry {
 	 * @param array $config The info about the connection being registered
 	 *
 	 * @return void
-	 * @throws InvalidArgumentException
-	 * @throws Exception
+	 * @throws \InvalidArgumentException
+	 * @throws \Exception
 	 */
 	public function register_connection( array $config ) {
 		new WPConnectionType( $config, $this );
@@ -1094,7 +1094,7 @@ class TypeRegistry {
 	 * @param array  $config        Info about the mutation being registered
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function register_mutation( string $mutation_name, array $config ) {
 		$config['name'] = $mutation_name;
@@ -1106,7 +1106,7 @@ class TypeRegistry {
 	 *
 	 * @param mixed $type The Type being wrapped
 	 *
-	 * @return NonNull
+	 * @return \GraphQL\Type\Definition\NonNull
 	 */
 	public function non_null( $type ) {
 		if ( is_string( $type ) ) {
@@ -1123,7 +1123,7 @@ class TypeRegistry {
 	 *
 	 * @param mixed $type The Type being wrapped
 	 *
-	 * @return ListOfType
+	 * @return \GraphQL\Type\Definition\ListOfType
 	 */
 	public function list_of( $type ) {
 		if ( is_string( $type ) ) {

--- a/src/Registry/Utils/PostObject.php
+++ b/src/Registry/Utils/PostObject.php
@@ -26,10 +26,10 @@ class PostObject {
 	/**
 	 * Registers a post_type type to the schema as either a GraphQL object, interface, or union.
 	 *
-	 * @param WP_Post_Type $post_type_object Post type.
+	 * @param \WP_Post_Type $post_type_object Post type.
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public static function register_types( WP_Post_Type $post_type_object ) {
 		$single_name = $post_type_object->graphql_single_name;
@@ -103,7 +103,7 @@ class PostObject {
 	/**
 	 * Gets all the connections for the given post type.
 	 *
-	 * @param WP_Post_Type $post_type_object
+	 * @param \WP_Post_Type $post_type_object
 	 *
 	 * @return array
 	 */
@@ -251,7 +251,7 @@ class PostObject {
 	/**
 	 * Gets all the interfaces for the given post type.
 	 *
-	 * @param WP_Post_Type $post_type_object Post type.
+	 * @param \WP_Post_Type $post_type_object Post type.
 	 *
 	 * @return array
 	 */
@@ -334,7 +334,7 @@ class PostObject {
 	/**
 	 * Registers common post type fields on schema type corresponding to provided post type object.
 	 *
-	 * @param WP_Post_Type $post_type_object Post type.
+	 * @param \WP_Post_Type $post_type_object Post type.
 	 *
 	 * @return array
 	 * @todo make protected after \Type\ObjectType\PostObject::get_fields() is removed.

--- a/src/Registry/Utils/TermObject.php
+++ b/src/Registry/Utils/TermObject.php
@@ -25,10 +25,10 @@ class TermObject {
 	/**
 	 * Registers a taxonomy type to the schema as either a GraphQL object, interface, or union.
 	 *
-	 * @param WP_Taxonomy $tax_object Taxonomy.
+	 * @param \WP_Taxonomy $tax_object Taxonomy.
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public static function register_types( WP_Taxonomy $tax_object ) {
 		$single_name = $tax_object->graphql_single_name;
@@ -96,7 +96,7 @@ class TermObject {
 	/**
 	 * Gets all the connections for the given post type.
 	 *
-	 * @param WP_Taxonomy $tax_object
+	 * @param \WP_Taxonomy $tax_object
 	 *
 	 * @return array
 	 */
@@ -254,7 +254,7 @@ class TermObject {
 	/**
 	 * Gets all the interfaces for the given Taxonomy.
 	 *
-	 * @param WP_Taxonomy $tax_object Taxonomy.
+	 * @param \WP_Taxonomy $tax_object Taxonomy.
 	 *
 	 * @return array
 	 */
@@ -289,7 +289,7 @@ class TermObject {
 	/**
 	 * Registers common Taxonomy fields on schema type corresponding to provided Taxonomy object.
 	 *
-	 * @param WP_Taxonomy $tax_object Taxonomy.
+	 * @param \WP_Taxonomy $tax_object Taxonomy.
 	 *
 	 * @return array
 	 */

--- a/src/Request.php
+++ b/src/Request.php
@@ -31,28 +31,28 @@ class Request {
 	/**
 	 * App context for this request.
 	 *
-	 * @var AppContext
+	 * @var \WPGraphQL\AppContext
 	 */
 	public $app_context;
 
 	/**
 	 * Request data.
 	 *
-	 * @var mixed|array|OperationParams
+	 * @var mixed|array|\GraphQL\Server\OperationParams
 	 */
 	public $data;
 
 	/**
 	 * Cached global post.
 	 *
-	 * @var ?WP_Post
+	 * @var ?\WP_Post
 	 */
 	public $global_post;
 
 	/**
 	 * Cached global wp_the_query.
 	 *
-	 * @var ?WP_Query
+	 * @var ?\WP_Query
 	 */
 	private $global_wp_the_query;
 
@@ -60,28 +60,28 @@ class Request {
 	 * GraphQL operation parameters for this request. Can also be an array of
 	 * OperationParams.
 	 *
-	 * @var mixed|array|OperationParams|OperationParams[]
+	 * @var mixed|array|\GraphQL\Server\OperationParams|\GraphQL\Server\OperationParams[]
 	 */
 	public $params;
 
 	/**
 	 * Schema for this request.
 	 *
-	 * @var WPSchema
+	 * @var \WPGraphQL\WPSchema
 	 */
 	public $schema;
 
 	/**
 	 * Debug log for WPGraphQL Requests
 	 *
-	 * @var DebugLog
+	 * @var \WPGraphQL\Utils\DebugLog
 	 */
 	public $debug_log;
 
 	/**
 	 * The Type Registry the Schema is built with
 	 *
-	 * @var Registry\TypeRegistry
+	 * @var \WPGraphQL\Registry\TypeRegistry
 	 */
 	public $type_registry;
 
@@ -107,7 +107,7 @@ class Request {
 	protected $root_value;
 
 	/**
-	 * @var QueryAnalyzer
+	 * @var \WPGraphQL\Utils\QueryAnalyzer
 	 */
 	protected $query_analyzer;
 
@@ -118,7 +118,7 @@ class Request {
 	 *
 	 * @return void
 	 *
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function __construct( array $data = [] ) {
 
@@ -185,7 +185,7 @@ class Request {
 	}
 
 	/**
-	 * @return QueryAnalyzer
+	 * @return \WPGraphQL\Utils\QueryAnalyzer
 	 */
 	public function get_query_analyzer(): QueryAnalyzer {
 		return $this->query_analyzer;
@@ -215,7 +215,7 @@ class Request {
 		 * Return the validation rules to use in the request
 		 *
 		 * @param array   $validation_rules The validation rules to use in the request
-		 * @param Request $request          The Request instance
+		 * @param \WPGraphQL\Request $request The Request instance
 		 */
 		return apply_filters( 'graphql_validation_rules', $validation_rules, $this );
 
@@ -237,7 +237,7 @@ class Request {
 		 * Return the filtered root value
 		 *
 		 * @param mixed   $root_value The root value the Schema should use to resolve with. Default null.
-		 * @param Request $request    The Request instance
+		 * @param \WPGraphQL\Request $request The Request instance
 		 */
 		return apply_filters( 'graphql_root_value', $root_value, $this );
 	}
@@ -246,7 +246,7 @@ class Request {
 	 * Apply filters and do actions before GraphQL execution
 	 *
 	 * @return void
-	 * @throws Error
+	 * @throws \GraphQL\Error\Error
 	 */
 	private function before_execute(): void {
 
@@ -289,7 +289,7 @@ class Request {
 			/**
 			 * Execute batch queries
 			 *
-			 * @param OperationParams[] $params The operation params of the batch request
+			 * @param \GraphQL\Server\OperationParams[] $params The operation params of the batch request
 			 */
 			do_action( 'graphql_execute_batch_queries', $this->params );
 
@@ -303,7 +303,7 @@ class Request {
 		/**
 		 * This action runs before execution of a GraphQL request (regardless if it's a single or batch request)
 		 *
-		 * @param Request $request The instance of the Request being executed
+		 * @param \WPGraphQL\Request $request The instance of the Request being executed
 		 */
 		do_action( 'graphql_before_execute', $this );
 
@@ -319,7 +319,7 @@ class Request {
 	 * request.
 	 *
 	 * @return boolean
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	protected function has_authentication_errors() {
 
@@ -406,7 +406,7 @@ class Request {
 		 * GraphQL request will be prevented and an error will be thrown.
 		 *
 		 * @param boolean $authentication_errors Whether there are authentication errors with the request
-		 * @param Request $request               Instance of the Request
+		 * @param \WPGraphQL\Request $request Instance of the Request
 		 */
 		return apply_filters( 'graphql_authentication_errors', $authentication_errors, $this );
 	}
@@ -419,7 +419,7 @@ class Request {
 	 *
 	 * @return array
 	 *
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	private function after_execute( $response ) {
 
@@ -470,7 +470,7 @@ class Request {
 		 * Run an action after GraphQL Execution
 		 *
 		 * @param array   $filtered_response The response of the entire operation. Could be a single operation or a batch operation
-		 * @param Request $request           Instance of the Request being executed
+		 * @param \WPGraphQL\Request $request Instance of the Request being executed
 		 */
 		do_action( 'graphql_after_execute', $filtered_response, $this );
 
@@ -515,11 +515,11 @@ class Request {
 		 * Run an action. This is a good place for debug tools to hook in to log things, etc.
 		 *
 		 * @param mixed|array $response  The response your GraphQL request
-		 * @param WPSchema    $schema    The schema object for the root request
+		 * @param \WPGraphQL\WPSchema $schema The schema object for the root request
 		 * @param mixed|string|null      $operation The name of the operation
 		 * @param string      $query     The query that GraphQL executed
 		 * @param array|null  $variables Variables to passed to your GraphQL query
-		 * @param Request     $request   Instance of the Request
+		 * @param \WPGraphQL\Request $request Instance of the Request
 		 *
 		 * @since 0.0.4
 		 */
@@ -551,11 +551,11 @@ class Request {
 		 * to be hooked in and included in the $response.
 		 *
 		 * @param array      $response  The response for your GraphQL query
-		 * @param WPSchema   $schema    The schema object for the root query
+		 * @param \WPGraphQL\WPSchema $schema The schema object for the root query
 		 * @param string     $operation The name of the operation
 		 * @param string     $query     The query that GraphQL executed
 		 * @param array|null $variables Variables to passed to your GraphQL request
-		 * @param Request    $request   Instance of the Request
+		 * @param \WPGraphQL\Request $request Instance of the Request
 		 * @param string|null $query_id The query id that GraphQL executed
 		 *
 		 * @since 0.0.5
@@ -568,11 +568,11 @@ class Request {
 		 *
 		 * @param array      $filtered_response The filtered response for the GraphQL request
 		 * @param array      $response          The response for your GraphQL request
-		 * @param WPSchema   $schema            The schema object for the root request
+		 * @param \WPGraphQL\WPSchema $schema The schema object for the root request
 		 * @param string     $operation         The name of the operation
 		 * @param string     $query             The query that GraphQL executed
 		 * @param array|null $variables         Variables to passed to your GraphQL query
-		 * @param Request    $request           Instance of the Request
+		 * @param \WPGraphQL\Request $request Instance of the Request
 		 * @param string|null $query_id          The query id that GraphQL executed
 		 */
 		do_action( 'graphql_return_response', $filtered_response, $response, $this->schema, $operation, $query, $variables, $this, $query_id );
@@ -588,7 +588,7 @@ class Request {
 	/**
 	 * Run action for a request.
 	 *
-	 * @param OperationParams $params OperationParams for the request.
+	 * @param \GraphQL\Server\OperationParams $params OperationParams for the request.
 	 *
 	 * @return void
 	 */
@@ -600,7 +600,7 @@ class Request {
 		 * @param ?string          $query     The GraphQL query
 		 * @param ?string          $operation The name of the operation
 		 * @param ?array          $variables Variables to be passed to your GraphQL request
-		 * @param OperationParams $params    The Operation Params. This includes any extra params, such as extenions or any other modifications to the request body
+		 * @param \GraphQL\Server\OperationParams $params The Operation Params. This includes any extra params, such as extenions or any other modifications to the request body
 		 */
 		do_action( 'do_graphql_request', $params->query, $params->operation, $params->variables, $params );
 	}
@@ -609,7 +609,7 @@ class Request {
 	 * Execute an internal request (graphql() function call).
 	 *
 	 * @return array
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function execute() {
 
@@ -685,7 +685,7 @@ class Request {
 	 * Execute an HTTP request.
 	 *
 	 * @return array
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function execute_http() {
 
@@ -719,7 +719,7 @@ class Request {
 	/**
 	 * Get the operation params for the request.
 	 *
-	 * @return OperationParams|OperationParams[]
+	 * @return \GraphQL\Server\OperationParams|\GraphQL\Server\OperationParams[]
 	 */
 	public function get_params() {
 		return $this->params;
@@ -760,7 +760,7 @@ class Request {
 		 * Filter whether batch queries are supported or not
 		 *
 		 * @param boolean         $batch_queries_enabled Whether Batch Queries should be enabled
-		 * @param OperationParams $params                Request operation params
+		 * @param \GraphQL\Server\OperationParams $params Request operation params
 		 */
 		return apply_filters( 'graphql_is_batch_queries_enabled', $batch_queries_enabled, $this->params );
 
@@ -769,7 +769,7 @@ class Request {
 	/**
 	 * Create the GraphQL server that will process the request.
 	 *
-	 * @return StandardServer
+	 * @return \GraphQL\Server\StandardServer
 	 */
 	private function get_server() {
 
@@ -796,8 +796,8 @@ class Request {
 		 * upon directly to override default values or implement new features, e.g.,
 		 * $config->setValidationRules().
 		 *
-		 * @param ServerConfig    $config Server config
-		 * @param OperationParams $params Request operation params
+		 * @param \GraphQL\Server\ServerConfig $config Server config
+		 * @param \GraphQL\Server\OperationParams $params Request operation params
 		 *
 		 * @since 0.2.0
 		 */

--- a/src/Router.php
+++ b/src/Router.php
@@ -39,7 +39,7 @@ class Router {
 	public static $http_status_code = 200;
 
 	/**
-	 * @var Request
+	 * @var \WPGraphQL\Request
 	 */
 	protected static $request;
 
@@ -47,7 +47,7 @@ class Router {
 	 * Initialize the WPGraphQL Router
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function init() {
 
@@ -85,7 +85,7 @@ class Router {
 	/**
 	 * Returns the GraphQL Request being executed
 	 *
-	 * @return Request
+	 * @return \WPGraphQL\Request
 	 */
 	public static function get_request() {
 		return self::$request;
@@ -237,7 +237,7 @@ class Router {
 	 * Loading process
 	 *
 	 * @return void
-	 * @throws Exception Throws exception.
+	 * @throws \Exception Throws exception.
 	 * @throws \Throwable Throws exception.
 	 * @since  0.0.1
 	 */
@@ -427,7 +427,7 @@ class Router {
 	 * This processes the graphql requests that come into the /graphql endpoint via an HTTP request
 	 *
 	 * @return mixed
-	 * @throws Exception Throws Exception.
+	 * @throws \Exception Throws Exception.
 	 * @throws \Throwable Throws Exception.
 	 * @global WP_User $current_user The currently authenticated user.
 	 * @since  0.0.1
@@ -500,7 +500,7 @@ class Router {
 			 * Filter thrown GraphQL errors
 			 *
 			 * @param array               $errors   Formatted errors object.
-			 * @param Exception          $error    Thrown error.
+			 * @param \Exception $error Thrown error.
 			 * @param \WPGraphQL\Request  $request  WPGraphQL Request object.
 			 */
 			$response['errors'] = apply_filters(
@@ -545,14 +545,14 @@ class Router {
 	/**
 	 * Prepare headers for response
 	 *
-	 * @param mixed|array|ExecutionResult $response        The response of the GraphQL Request.
-	 * @param mixed|array|ExecutionResult $graphql_results The results of the GraphQL execution.
+	 * @param mixed|array|\GraphQL\Executor\ExecutionResult $response The response of the GraphQL Request.
+	 * @param mixed|array|\GraphQL\Executor\ExecutionResult $graphql_results The results of the GraphQL execution.
 	 * @param string                      $query           The GraphQL query.
 	 * @param string                      $operation_name  The operation name of the GraphQL
 	 *                                                     Request.
 	 * @param mixed|array|null            $variables       The variables applied to the GraphQL
 	 *                                                     Request.
-	 * @param mixed|WP_User|null          $user            The current user object.
+	 * @param mixed|\WP_User|null $user The current user object.
 	 *
 	 * @return void
 	 */
@@ -567,7 +567,7 @@ class Router {
 		 * @param string  $query           The GraphQL query
 		 * @param string  $operation_name  The operation name of the GraphQL Request
 		 * @param array   $variables       The variables applied to the GraphQL Request
-		 * @param WP_User $user            The current user object
+		 * @param \WP_User $user The current user object
 		 */
 		self::$http_status_code = apply_filters( 'graphql_response_status_code', self::$http_status_code, $response, $graphql_results, $query, $operation_name, $variables, $user );
 

--- a/src/Server/ValidationRules/QueryDepth.php
+++ b/src/Server/ValidationRules/QueryDepth.php
@@ -35,7 +35,7 @@ class QueryDepth extends QuerySecurityRule {
 	}
 
 	/**
-	 * @param ValidationContext $context
+	 * @param \GraphQL\Validator\ValidationContext $context
 	 *
 	 * @return callable[]|mixed[]
 	 */
@@ -83,7 +83,7 @@ class QueryDepth extends QuerySecurityRule {
 	/**
 	 * Determine node depth
 	 *
-	 * @param Node $node The node being analyzed in the operation
+	 * @param \GraphQL\Language\AST\Node $node The node being analyzed in the operation
 	 * @param int  $depth The depth of the operation
 	 * @param int  $maxDepth The Max Depth of the operation
 	 *

--- a/src/Server/ValidationRules/RequireAuthentication.php
+++ b/src/Server/ValidationRules/RequireAuthentication.php
@@ -59,7 +59,7 @@ class RequireAuthentication extends QuerySecurityRule {
 	}
 
 	/**
-	 * @param ValidationContext $context
+	 * @param \GraphQL\Validator\ValidationContext $context
 	 *
 	 * @return callable[]|mixed[]
 	 */
@@ -71,7 +71,7 @@ class RequireAuthentication extends QuerySecurityRule {
 		 * Filters the allowed
 		 *
 		 * @param array             $allowed_root_fields The Root fields allowed to be requested without authentication
-		 * @param ValidationContext $context             The Validation context of the field being executed.
+		 * @param \GraphQL\Validator\ValidationContext $context The Validation context of the field being executed.
 		 */
 		$allowed_root_fields = apply_filters( 'graphql_require_authentication_allowed_fields', $allowed_root_fields, $context );
 

--- a/src/Server/WPHelper.php
+++ b/src/Server/WPHelper.php
@@ -20,8 +20,8 @@ class WPHelper extends Helper {
 	 * @param string $method The method of the request (GET, POST, etc).
 	 * @param array  $bodyParams The params passed to the body of the request.
 	 * @param array  $queryParams The query params passed to the request.
-	 * @return OperationParams|OperationParams[]
-	 * @throws RequestError Throws RequestError.
+	 * @return \GraphQL\Server\OperationParams|\GraphQL\Server\OperationParams[]
+	 * @throws \GraphQL\Server\RequestError Throws RequestError.
 	 */
 	public function parseRequestParams( $method, array $bodyParams, array $queryParams ) {
 		// Apply wp_unslash to query (GET) variables to undo wp_magic_quotes. We

--- a/src/Type/Connection/Comments.php
+++ b/src/Type/Connection/Comments.php
@@ -23,7 +23,7 @@ class Comments {
 	 * Connections from Post Objects to Comments are handled in \Registry\Utils\PostObject.
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public static function register_connections() {
 

--- a/src/Type/Connection/MenuItems.php
+++ b/src/Type/Connection/MenuItems.php
@@ -22,7 +22,7 @@ class MenuItems {
 	 * Register connections to MenuItems
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public static function register_connections() {
 

--- a/src/Type/Connection/PostObjects.php
+++ b/src/Type/Connection/PostObjects.php
@@ -28,7 +28,7 @@ class PostObjects {
 	 * Registers the various connections from other Types to PostObjects
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public static function register_connections() {
 
@@ -224,8 +224,8 @@ class PostObjects {
 	 * Given the Post Type Object and an array of args, this returns an array of args for use in
 	 * registering a connection.
 	 *
-	 * @param mixed|WP_Post_Type|WP_Taxonomy $graphql_object The post type object for the post_type having a
-	 *                                        connection registered to it
+	 * @param mixed|\WP_Post_Type|\WP_Taxonomy $graphql_object The post type object for the post_type having a
+ * connection registered to it
 	 * @param array                          $args           The custom args to modify the connection registration
 	 *
 	 * @return array
@@ -258,7 +258,7 @@ class PostObjects {
 	 * Given an optional array of args, this returns the args to be used in the connection
 	 *
 	 * @param array         $args             The args to modify the defaults
-	 * @param mixed|WP_Post_Type|WP_Taxonomy $post_type_object The post type the connection is going to
+	 * @param mixed|\WP_Post_Type|\WP_Taxonomy $post_type_object The post type the connection is going to
 	 *
 	 * @return array
 	 */

--- a/src/Type/InterfaceType/Commenter.php
+++ b/src/Type/InterfaceType/Commenter.php
@@ -15,7 +15,7 @@ class Commenter {
 	/**
 	 * Register the Commenter Interface
 	 *
-	 * @param TypeRegistry $type_registry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
 	 * @return void
 	 */

--- a/src/Type/InterfaceType/Connection.php
+++ b/src/Type/InterfaceType/Connection.php
@@ -9,10 +9,10 @@ class Connection {
 	/**
 	 * Register the Connection Interface
 	 *
-	 * @param TypeRegistry $type_registry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public static function register_type( TypeRegistry $type_registry ): void {
 

--- a/src/Type/InterfaceType/ContentNode.php
+++ b/src/Type/InterfaceType/ContentNode.php
@@ -13,10 +13,10 @@ class ContentNode {
 	/**
 	 * Adds the ContentNode Type to the WPGraphQL Registry
 	 *
-	 * @param TypeRegistry $type_registry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public static function register_type( TypeRegistry $type_registry ) {
 

--- a/src/Type/InterfaceType/Edge.php
+++ b/src/Type/InterfaceType/Edge.php
@@ -9,10 +9,10 @@ class Edge {
 	/**
 	 * Register the Connection Interface
 	 *
-	 * @param TypeRegistry $type_registry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public static function register_type( TypeRegistry $type_registry ): void {
 

--- a/src/Type/InterfaceType/EnqueuedAsset.php
+++ b/src/Type/InterfaceType/EnqueuedAsset.php
@@ -13,7 +13,7 @@ class EnqueuedAsset {
 	/**
 	 * Register the Enqueued Script Type
 	 *
-	 * @param TypeRegistry $type_registry The WPGraphQL Type Registry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The WPGraphQL Type Registry
 	 *
 	 * @return void
 	 */

--- a/src/Type/InterfaceType/HierarchicalContentNode.php
+++ b/src/Type/InterfaceType/HierarchicalContentNode.php
@@ -14,10 +14,10 @@ class HierarchicalContentNode {
 	/**
 	 * Register the HierarchicalContentNode Interface Type
 	 *
-	 * @param TypeRegistry $type_registry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public static function register_type( TypeRegistry $type_registry ): void {
 		register_graphql_interface_type(

--- a/src/Type/InterfaceType/HierarchicalNode.php
+++ b/src/Type/InterfaceType/HierarchicalNode.php
@@ -15,10 +15,10 @@ class HierarchicalNode {
 	/**
 	 * Register the HierarchicalNode Interface Type
 	 *
-	 * @param TypeRegistry $type_registry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public static function register_type( TypeRegistry $type_registry ):void {
 

--- a/src/Type/InterfaceType/HierarchicalTermNode.php
+++ b/src/Type/InterfaceType/HierarchicalTermNode.php
@@ -14,10 +14,10 @@ class HierarchicalTermNode {
 	/**
 	 * Register the HierarchicalTermNode Interface Type
 	 *
-	 * @param TypeRegistry $type_registry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public static function register_type( TypeRegistry $type_registry ): void {
 

--- a/src/Type/InterfaceType/MenuItemLinkable.php
+++ b/src/Type/InterfaceType/MenuItemLinkable.php
@@ -13,10 +13,10 @@ class MenuItemLinkable {
 	/**
 	 * Registers the MenuItemLinkable Interface Type
 	 *
-	 * @param TypeRegistry $type_registry Instance of the WPGraphQL Type Registry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry Instance of the WPGraphQL Type Registry
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public static function register_type( TypeRegistry $type_registry ): void {
 

--- a/src/Type/InterfaceType/NodeWithAuthor.php
+++ b/src/Type/InterfaceType/NodeWithAuthor.php
@@ -11,7 +11,7 @@ class NodeWithAuthor {
 	/**
 	 * Registers the NodeWithAuthor Type to the Schema
 	 *
-	 * @param TypeRegistry $type_registry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
 	 * @return void
 	 */

--- a/src/Type/InterfaceType/NodeWithComments.php
+++ b/src/Type/InterfaceType/NodeWithComments.php
@@ -7,7 +7,7 @@ class NodeWithComments {
 	/**
 	 * Registers the NodeWithComments Type to the Schema
 	 *
-	 * @param TypeRegistry $type_registry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
 	 * @return void
 	 */

--- a/src/Type/InterfaceType/NodeWithContentEditor.php
+++ b/src/Type/InterfaceType/NodeWithContentEditor.php
@@ -7,7 +7,7 @@ class NodeWithContentEditor {
 	/**
 	 * Registers the NodeWithContentEditor Type to the Schema
 	 *
-	 * @param TypeRegistry $type_registry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
 	 * @return void
 	 */

--- a/src/Type/InterfaceType/NodeWithExcerpt.php
+++ b/src/Type/InterfaceType/NodeWithExcerpt.php
@@ -8,7 +8,7 @@ class NodeWithExcerpt {
 	/**
 	 * Registers the NodeWithExcerpt Type to the Schema
 	 *
-	 * @param TypeRegistry $type_registry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
 	 * @return void
 	 */

--- a/src/Type/InterfaceType/NodeWithFeaturedImage.php
+++ b/src/Type/InterfaceType/NodeWithFeaturedImage.php
@@ -13,10 +13,10 @@ class NodeWithFeaturedImage {
 	/**
 	 * Registers the NodeWithFeaturedImage Type to the Schema
 	 *
-	 * @param TypeRegistry $type_registry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public static function register_type( TypeRegistry $type_registry ) {
 

--- a/src/Type/InterfaceType/NodeWithPageAttributes.php
+++ b/src/Type/InterfaceType/NodeWithPageAttributes.php
@@ -8,7 +8,7 @@ class NodeWithPageAttributes {
 	/**
 	 * Registers the NodeWithPageAttributes Type to the Schema
 	 *
-	 * @param TypeRegistry $type_registry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
 	 * @return void
 	 */

--- a/src/Type/InterfaceType/NodeWithRevisions.php
+++ b/src/Type/InterfaceType/NodeWithRevisions.php
@@ -8,7 +8,7 @@ class NodeWithRevisions {
 	/**
 	 * Registers the NodeWithRevisions Type to the Schema
 	 *
-	 * @param TypeRegistry $type_registry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
 	 * @return void
 	 */

--- a/src/Type/InterfaceType/NodeWithTemplate.php
+++ b/src/Type/InterfaceType/NodeWithTemplate.php
@@ -8,7 +8,7 @@ class NodeWithTemplate {
 	/**
 	 * Registers the NodeWithTemplate Type to the Schema
 	 *
-	 * @param TypeRegistry $type_registry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
 	 * @return void
 	 */

--- a/src/Type/InterfaceType/NodeWithTitle.php
+++ b/src/Type/InterfaceType/NodeWithTitle.php
@@ -12,7 +12,7 @@ class NodeWithTitle {
 	/**
 	 * Registers the NodeWithTitle Type to the Schema
 	 *
-	 * @param TypeRegistry $type_registry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
 	 * @return void
 	 */

--- a/src/Type/InterfaceType/NodeWithTrackbacks.php
+++ b/src/Type/InterfaceType/NodeWithTrackbacks.php
@@ -8,7 +8,7 @@ class NodeWithTrackbacks {
 	/**
 	 * Registers the NodeWithTrackbacks Type to the Schema
 	 *
-	 * @param TypeRegistry $type_registry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
 	 * @return void
 	 */

--- a/src/Type/InterfaceType/OneToOneConnection.php
+++ b/src/Type/InterfaceType/OneToOneConnection.php
@@ -9,10 +9,10 @@ class OneToOneConnection {
 	/**
 	 * Register the Connection Interface
 	 *
-	 * @param TypeRegistry $type_registry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public static function register_type( TypeRegistry $type_registry ): void {
 

--- a/src/Type/InterfaceType/PageInfo.php
+++ b/src/Type/InterfaceType/PageInfo.php
@@ -9,10 +9,10 @@ class PageInfo {
 	/**
 	 * Register the PageInfo Interface
 	 *
-	 * @param TypeRegistry $type_registry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public static function register_type( TypeRegistry $type_registry ): void {
 

--- a/src/Type/InterfaceType/Previewable.php
+++ b/src/Type/InterfaceType/Previewable.php
@@ -11,10 +11,10 @@ class Previewable {
 	/**
 	 * Adds the Previewable Type to the WPGraphQL Registry
 	 *
-	 * @param TypeRegistry $type_registry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public static function register_type( TypeRegistry $type_registry ): void {
 		register_graphql_interface_type(

--- a/src/Type/InterfaceType/TermNode.php
+++ b/src/Type/InterfaceType/TermNode.php
@@ -14,10 +14,10 @@ class TermNode {
 	/**
 	 * Register the TermNode Interface
 	 *
-	 * @param TypeRegistry $type_registry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public static function register_type( TypeRegistry $type_registry ) {
 

--- a/src/Type/InterfaceType/UniformResourceIdentifiable.php
+++ b/src/Type/InterfaceType/UniformResourceIdentifiable.php
@@ -15,7 +15,7 @@ class UniformResourceIdentifiable {
 	/**
 	 * Registers the UniformResourceIdentifiable Interface to the Schema.
 	 *
-	 * @param TypeRegistry $type_registry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 * @return void
 	 */
 	public static function register_type( TypeRegistry $type_registry ) {
@@ -52,12 +52,12 @@ class UniformResourceIdentifiable {
 
 					switch ( true ) {
 						case $node instanceof Post:
-							/** @var WP_Post_Type $post_type_object */
+							/** @var \WP_Post_Type $post_type_object */
 							$post_type_object = get_post_type_object( $node->post_type );
 							$type             = $type_registry->get_type( $post_type_object->graphql_single_name );
 							break;
 						case $node instanceof Term:
-							/** @var WP_Taxonomy $tax_object */
+							/** @var \WP_Taxonomy $tax_object */
 							$tax_object = get_taxonomy( $node->taxonomyName );
 							$type       = $type_registry->get_type( $tax_object->graphql_single_name );
 							break;

--- a/src/Type/ObjectType/MenuItem.php
+++ b/src/Type/ObjectType/MenuItem.php
@@ -176,8 +176,8 @@ class MenuItem {
 							 *
 							 * @param \WP_Post|\WP_Term $resolved_object Post or term connected to MenuItem
 							 * @param array             $args            Array of arguments input in the field as part of the GraphQL query
-							 * @param AppContext        $context         Object containing app context that gets passed down the resolve tree
-							 * @param ResolveInfo       $info            Info about fields passed down the resolve tree
+							 * @param \WPGraphQL\AppContext $context Object containing app context that gets passed down the resolve tree
+							 * @param \GraphQL\Type\Definition\ResolveInfo $info Info about fields passed down the resolve tree
 							 * @param int               $object_id       Post or term ID of connected object
 							 * @param string            $object_type     Type of connected object ("post_type" or "taxonomy")
 							 *

--- a/src/Type/ObjectType/PostObject.php
+++ b/src/Type/ObjectType/PostObject.php
@@ -17,11 +17,11 @@ class PostObject {
 	/**
 	 * Registers a post_type WPObject type to the schema.
 	 *
-	 * @param WP_Post_Type $post_type_object Post type.
-	 * @param TypeRegistry $type_registry    The Type Registry
+	 * @param \WP_Post_Type $post_type_object Post type.
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The Type Registry
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 * @deprecated 1.12.0
 	 */
 	public static function register_post_object_types( WP_Post_Type $post_type_object, TypeRegistry $type_registry ) {
@@ -35,8 +35,8 @@ class PostObject {
 	/**
 	 * Registers common post type fields on schema type corresponding to provided post type object.
 	 *
-	 * @param WP_Post_Type $post_type_object Post type.
-	 * @param TypeRegistry $type_registry    The Type Registry
+	 * @param \WP_Post_Type $post_type_object Post type.
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The Type Registry
 	 *
 	 * @deprecated 1.12.0
 	 *

--- a/src/Type/ObjectType/SettingGroup.php
+++ b/src/Type/ObjectType/SettingGroup.php
@@ -14,10 +14,10 @@ class SettingGroup {
 	 *
 	 * @param string       $group_name    The name of the setting group
 	 * @param string       $group         The settings group config
-	 * @param TypeRegistry $type_registry The WPGraphQL TypeRegistry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The WPGraphQL TypeRegistry
 	 *
 	 * @return string|null
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public static function register_settings_group( string $group_name, string $group, TypeRegistry $type_registry ) {
 
@@ -47,7 +47,7 @@ class SettingGroup {
 	 *
 	 * @param string $group_name Name of the settings group to retrieve fields for
 	 * @param string $group      The settings group config
-	 * @param TypeRegistry $type_registry The WPGraphQL TypeRegistry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The WPGraphQL TypeRegistry
 	 *
 	 * @return array
 	 */

--- a/src/Type/ObjectType/Settings.php
+++ b/src/Type/ObjectType/Settings.php
@@ -17,7 +17,7 @@ class Settings {
 	 * Registers a Settings Type with fields for all settings based on settings
 	 * registered using the core register_setting API
 	 *
-	 * @param TypeRegistry $type_registry The WPGraphQL TypeRegistry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The WPGraphQL TypeRegistry
 	 *
 	 * @return void
 	 */
@@ -42,7 +42,7 @@ class Settings {
 	/**
 	 * Returns an array of fields for all settings based on the `register_setting` WordPress API
 	 *
-	 * @param TypeRegistry $type_registry The WPGraphQL TypeRegistry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The WPGraphQL TypeRegistry
 	 *
 	 * @return array
 	 */

--- a/src/Type/ObjectType/TermObject.php
+++ b/src/Type/ObjectType/TermObject.php
@@ -16,10 +16,10 @@ class TermObject {
 	/**
 	 * Register the Type for each kind of Taxonomy
 	 *
-	 * @param WP_Taxonomy $tax_object The taxonomy being registered
+	 * @param \WP_Taxonomy $tax_object The taxonomy being registered
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 * @deprecated 1.12.0
 	 */
 	public static function register_taxonomy_object_type( WP_Taxonomy $tax_object ) {

--- a/src/Type/Union/MenuItemObjectUnion.php
+++ b/src/Type/Union/MenuItemObjectUnion.php
@@ -18,10 +18,10 @@ class MenuItemObjectUnion {
 	/**
 	 * Registers the Type
 	 *
-	 * @param TypeRegistry $type_registry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public static function register_type( TypeRegistry $type_registry ) {
 

--- a/src/Type/Union/PostObjectUnion.php
+++ b/src/Type/Union/PostObjectUnion.php
@@ -16,10 +16,10 @@ class PostObjectUnion {
 	/**
 	 * Registers the Type
 	 *
-	 * @param TypeRegistry $type_registry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public static function register_type( TypeRegistry $type_registry ): void {
 		register_graphql_union_type(

--- a/src/Type/Union/TermObjectUnion.php
+++ b/src/Type/Union/TermObjectUnion.php
@@ -15,10 +15,10 @@ class TermObjectUnion {
 	/**
 	 * Registers the Type
 	 *
-	 * @param TypeRegistry $type_registry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public static function register_type( TypeRegistry $type_registry ): void {
 		register_graphql_union_type(

--- a/src/Type/WPConnectionType.php
+++ b/src/Type/WPConnectionType.php
@@ -93,7 +93,7 @@ class WPConnectionType {
 	/**
 	 * The resolver function to resolve the connection
 	 *
-	 * @var callable|Closure
+	 * @var callable|\Closure
 	 */
 	protected $resolve_connection;
 
@@ -119,7 +119,7 @@ class WPConnectionType {
 	/**
 	 * The WPGraphQL TypeRegistry
 	 *
-	 * @var TypeRegistry
+	 * @var \WPGraphQL\Registry\TypeRegistry
 	 */
 	protected $type_registry;
 
@@ -134,7 +134,7 @@ class WPConnectionType {
 	 * WPConnectionType constructor.
 	 *
 	 * @param array        $config The config array for the connection
-	 * @param TypeRegistry $type_registry Instance of the WPGraphQL Type Registry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry Instance of the WPGraphQL Type Registry
 	 */
 	public function __construct( array $config, TypeRegistry $type_registry ) {
 
@@ -144,7 +144,7 @@ class WPConnectionType {
 		 * Filter the config of WPConnectionType
 		 *
 		 * @param array        $config         Array of configuration options passed to the WPConnectionType when instantiating a new type
-		 * @param WPConnectionType $wp_connection_type The instance of the WPConnectionType class
+		 * @param \WPGraphQL\Type\WPConnectionType $wp_connection_type The instance of the WPConnectionType class
 		 */
 		$config = apply_filters( 'graphql_wp_connection_type_config', $config, $this );
 
@@ -181,7 +181,7 @@ class WPConnectionType {
 		 * Run an action when the WPConnectionType is instantiating.
 		 *
 		 * @param array        $config         Array of configuration options passed to the WPObjectType when instantiating a new type
-		 * @param WPConnectionType $wp_connection_type The instance of the WPConnectionType class
+		 * @param \WPGraphQL\Type\WPConnectionType $wp_connection_type The instance of the WPConnectionType class
 		 *
 		 * @since 1.13.0
 		 */
@@ -266,7 +266,7 @@ class WPConnectionType {
 	 *
 	 * @return void
 	 *
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	protected function register_connection_input() {
 
@@ -304,7 +304,7 @@ class WPConnectionType {
 	 *
 	 * @return void
 	 *
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	protected function register_one_to_one_connection_edge_type(): void {
 
@@ -344,7 +344,7 @@ class WPConnectionType {
 	 *
 	 * @return void
 	 *
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function register_connection_page_info_type(): void {
 
@@ -365,7 +365,7 @@ class WPConnectionType {
 	 *
 	 * @return void
 	 *
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	protected function register_connection_edge_type(): void {
 
@@ -409,7 +409,7 @@ class WPConnectionType {
 	 *
 	 * @return void
 	 *
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	protected function register_connection_type(): void {
 
@@ -535,7 +535,7 @@ class WPConnectionType {
 
 	/**
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function register_connection_interfaces(): void {
 
@@ -591,7 +591,7 @@ class WPConnectionType {
 	 *
 	 * @return void
 	 *
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function register_connection(): void {
 

--- a/src/Type/WPInputObjectType.php
+++ b/src/Type/WPInputObjectType.php
@@ -50,7 +50,7 @@ class WPInputObjectType extends InputObjectType {
 	 * @param array        $fields
 	 * @param string       $type_name
 	 * @param array        $config
-	 * @param TypeRegistry $type_registry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 * @return mixed
 	 * @since 0.0.5
 	 */
@@ -66,7 +66,7 @@ class WPInputObjectType extends InputObjectType {
 		 * @param string $type_name The name of the object type
 		 * @param array  $config    The type config
 		 *
-		 * @param TypeRegistry $type_registry The TypeRegistry instance
+		 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The TypeRegistry instance
 		 */
 		$fields = apply_filters( 'graphql_input_fields', $fields, $type_name, $config, $type_registry );
 
@@ -83,7 +83,7 @@ class WPInputObjectType extends InputObjectType {
 		 * more specific overrides
 		 *
 		 * @param array $fields The array of fields for the object config
-		 * @param TypeRegistry $type_registry The TypeRegistry instance
+		 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The TypeRegistry instance
 		 */
 		$fields = apply_filters( "graphql_{$lc_type_name}_fields", $fields, $type_registry );
 
@@ -94,7 +94,7 @@ class WPInputObjectType extends InputObjectType {
 		 * more specific overrides
 		 *
 		 * @param array $fields The array of fields for the object config
-		 * @param TypeRegistry $type_registry The TypeRegistry instance
+		 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The TypeRegistry instance
 		 */
 		$fields = apply_filters( "graphql_{$uc_type_name}_fields", $fields, $type_registry );
 

--- a/src/Type/WPInterfaceTrait.php
+++ b/src/Type/WPInterfaceTrait.php
@@ -32,7 +32,7 @@ trait WPInterfaceTrait {
 		 *
 		 * @param array        $interfaces     List of interfaces applied to the Object Type
 		 * @param array        $config         The config for the Object Type
-		 * @param mixed|WPInterfaceType|WPObjectType $type The Type instance
+		 * @param mixed|\WPGraphQL\Type\WPInterfaceType|\WPGraphQL\Type\WPObjectType $type The Type instance
 		 */
 		$interfaces = apply_filters( 'graphql_type_interfaces', $interfaces, $this->config, $this );
 

--- a/src/Type/WPInterfaceType.php
+++ b/src/Type/WPInterfaceType.php
@@ -13,7 +13,7 @@ class WPInterfaceType extends InterfaceType {
 	/**
 	 * Instance of the TypeRegistry as an Interface needs knowledge of available Types
 	 *
-	 * @var TypeRegistry
+	 * @var \WPGraphQL\Registry\TypeRegistry
 	 */
 	public $type_registry;
 
@@ -26,9 +26,9 @@ class WPInterfaceType extends InterfaceType {
 	 * WPInterfaceType constructor.
 	 *
 	 * @param array        $config
-	 * @param TypeRegistry $type_registry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function __construct( array $config, TypeRegistry $type_registry ) {
 
@@ -94,7 +94,7 @@ class WPInterfaceType extends InterfaceType {
 			 *
 			 * @param mixed           $type   The Type to resolve to, based on the object being resolved.
 			 * @param mixed           $object The Object being resolved.
-			 * @param WPInterfaceType $wp_interface_type   The WPInterfaceType instance.
+			 * @param \WPGraphQL\Type\WPInterfaceType $wp_interface_type The WPInterfaceType instance.
 			 */
 			return apply_filters( 'graphql_interface_resolve_type', $type, $object, $this );
 		};
@@ -103,7 +103,7 @@ class WPInterfaceType extends InterfaceType {
 		 * Filter the config of WPInterfaceType
 		 *
 		 * @param array           $config Array of configuration options passed to the WPInterfaceType when instantiating a new type
-		 * @param WPInterfaceType $wp_interface_type   The instance of the WPInterfaceType class
+		 * @param \WPGraphQL\Type\WPInterfaceType $wp_interface_type The instance of the WPInterfaceType class
 		 */
 		$config = apply_filters( 'graphql_wp_interface_type_config', $config, $this );
 

--- a/src/Type/WPMutationType.php
+++ b/src/Type/WPMutationType.php
@@ -60,14 +60,14 @@ class WPMutationType {
 	/**
 	 * The resolver function to resole the connection
 	 *
-	 * @var callable|Closure
+	 * @var callable|\Closure
 	 */
 	protected $resolve_mutation;
 
 	/**
 	 * The WPGraphQL TypeRegistry
 	 *
-	 * @var TypeRegistry
+	 * @var \WPGraphQL\Registry\TypeRegistry
 	 */
 	protected $type_registry;
 
@@ -75,9 +75,9 @@ class WPMutationType {
 	 * WPMutationType constructor.
 	 *
 	 * @param array        $config        The config array for the mutation
-	 * @param TypeRegistry $type_registry Instance of the WPGraphQL Type Registry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry Instance of the WPGraphQL Type Registry
 	 *
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function __construct( array $config, TypeRegistry $type_registry ) {
 
@@ -85,7 +85,7 @@ class WPMutationType {
 		 * Filter the config of WPMutationType
 		 *
 		 * @param array        $config         Array of configuration options passed to the WPMutationType when instantiating a new type
-		 * @param WPMutationType $wp_mutation_type The instance of the WPMutationType class
+		 * @param \WPGraphQL\Type\WPMutationType $wp_mutation_type The instance of the WPMutationType class
 		 *
 		 * @since 1.13.0
 		 */
@@ -108,7 +108,7 @@ class WPMutationType {
 		 * Run an action when the WPMutationType is instantiating.
 		 *
 		 * @param array        $config         Array of configuration options passed to the WPObjectType when instantiating a new type
-		 * @param WPMutationType $wp_mutation_type The instance of the WPMutationType class
+		 * @param \WPGraphQL\Type\WPMutationType $wp_mutation_type The instance of the WPMutationType class
 		 *
 		 * @since 1.13.0
 		 */
@@ -192,8 +192,8 @@ class WPMutationType {
 			 * Filters the mutation input before it's passed to the `mutateAndGetPayload` callback.
 			 *
 			 * @param array $input The mutation input args.
-			 * @param AppContext $context The AppContext object.
-			 * @param ResolveInfo $info The ResolveInfo object.
+			 * @param \WPGraphQL\AppContext $context The AppContext object.
+			 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object.
 			 * @param string $mutation_name The name of the mutation field.
 			 */
 			$input = apply_filters( 'graphql_mutation_input', $unfiltered_input, $context, $info, $this->mutation_name );
@@ -205,10 +205,10 @@ class WPMutationType {
 			 *
 			 * @param array|callable|null $payload. The payload returned from the callback. Null by default.
 			 * @param string $mutation_name The name of the mutation field.
-			 * @param callable|Closure $mutateAndGetPayload The callback for the mutation.
+			 * @param callable|\Closure $mutateAndGetPayload The callback for the mutation.
 			 * @param array $input The mutation input args.
-			 * @param AppContext $context The AppContext object.
-			 * @param ResolveInfo $info The ResolveInfo object.
+			 * @param \WPGraphQL\AppContext $context The AppContext object.
+			 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object.
 			 */
 			$pre = apply_filters( 'graphql_pre_mutate_and_get_payload', null, $this->mutation_name, $this->config['mutateAndGetPayload'], $input, $context, $info );
 
@@ -223,8 +223,8 @@ class WPMutationType {
 				 * @param array $payload The payload returned from the callback.
 				 * @param string $mutation_name The name of the mutation field.
 				 * @param array $input The mutation input args.
-				 * @param AppContext $context The AppContext object.
-				 * @param ResolveInfo $info The ResolveInfo object.
+				 * @param \WPGraphQL\AppContext $context The AppContext object.
+				 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object.
 				 */
 				$payload = apply_filters( 'graphql_mutation_payload', $payload, $this->mutation_name, $input, $context, $info );
 			}
@@ -235,8 +235,8 @@ class WPMutationType {
 			 * @param array $payload The Payload returned from the mutation.
 			 * @param array $input The mutation input args, after being filtered by 'graphql_mutation_input'.
 			 * @param array $unfiltered_input The unfiltered input args of the mutation
-			 * @param AppContext $context The AppContext object.
-			 * @param ResolveInfo $info The ResolveInfo object.
+			 * @param \WPGraphQL\AppContext $context The AppContext object.
+			 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object.
 			 * @param string $mutation_name The name of the mutation field.
 			 */
 			do_action( 'graphql_mutation_response', $payload, $input, $unfiltered_input, $context, $info, $this->mutation_name );
@@ -318,7 +318,7 @@ class WPMutationType {
 	/**
 	 * Registers the Mutation Types and field to the Schema.
 	 *
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	protected function register_mutation() :void {
 		$this->register_mutation_payload();

--- a/src/Type/WPObjectType.php
+++ b/src/Type/WPObjectType.php
@@ -26,7 +26,7 @@ class WPObjectType extends ObjectType {
 	 * to easily define themselves as a node type by implementing
 	 * self::$node_interface
 	 *
-	 * @var array|Node $node_interface
+	 * @var array|\WPGraphQL\Type\InterfaceType\Node $node_interface
 	 * @since 0.0.5
 	 */
 	private static $node_interface;
@@ -34,7 +34,7 @@ class WPObjectType extends ObjectType {
 	/**
 	 * Instance of the Type Registry
 	 *
-	 * @var TypeRegistry
+	 * @var \WPGraphQL\Registry\TypeRegistry
 	 */
 	public $type_registry;
 
@@ -47,7 +47,7 @@ class WPObjectType extends ObjectType {
 	 * WPObjectType constructor.
 	 *
 	 * @param array        $config
-	 * @param TypeRegistry $type_registry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
 	 * @throws \Exception
 	 * @since 0.0.5
@@ -63,7 +63,7 @@ class WPObjectType extends ObjectType {
 		 * Filter the config of WPObjectType
 		 *
 		 * @param array        $config         Array of configuration options passed to the WPObjectType when instantiating a new type
-		 * @param WPObjectType $wp_object_type The instance of the WPObjectType class
+		 * @param \WPGraphQL\Type\WPObjectType $wp_object_type The instance of the WPObjectType class
 		 */
 		$config = apply_filters( 'graphql_wp_object_type_config', $config, $this );
 
@@ -129,7 +129,7 @@ class WPObjectType extends ObjectType {
 		 * Run an action when the WPObjectType is instantiating
 		 *
 		 * @param array        $config         Array of configuration options passed to the WPObjectType when instantiating a new type
-		 * @param WPObjectType $wp_object_type The instance of the WPObjectType class
+		 * @param \WPGraphQL\Type\WPObjectType $wp_object_type The instance of the WPObjectType class
 		 */
 		do_action( 'graphql_wp_object_type', $config, $this );
 
@@ -151,7 +151,7 @@ class WPObjectType extends ObjectType {
 	 * This returns the node_interface definition allowing
 	 * WPObjectTypes to easily implement the node_interface
 	 *
-	 * @return array|Node
+	 * @return array|\WPGraphQL\Type\InterfaceType\Node
 	 * @since 0.0.5
 	 */
 	public static function node_interface() {
@@ -186,8 +186,8 @@ class WPObjectType extends ObjectType {
 		 *
 		 * @param array        $fields         The array of fields for the object config
 		 * @param string       $type_name      The name of the object type
-		 * @param WPObjectType $wp_object_type The WPObjectType Class
-		 * @param TypeRegistry $type_registry  The Type Registry
+		 * @param \WPGraphQL\Type\WPObjectType $wp_object_type The WPObjectType Class
+		 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The Type Registry
 		 */
 		$fields = apply_filters( 'graphql_object_fields', $fields, $type_name, $this, $this->type_registry );
 
@@ -204,8 +204,8 @@ class WPObjectType extends ObjectType {
 		 * more specific overrides
 		 *
 		 * @param array        $fields         The array of fields for the object config
-		 * @param WPObjectType $wp_object_type The WPObjectType Class
-		 * @param TypeRegistry $type_registry  The Type Registry
+		 * @param \WPGraphQL\Type\WPObjectType $wp_object_type The WPObjectType Class
+		 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The Type Registry
 		 */
 		$fields = apply_filters( "graphql_{$lc_type_name}_fields", $fields, $this, $this->type_registry );
 
@@ -216,8 +216,8 @@ class WPObjectType extends ObjectType {
 		 * more specific overrides
 		 *
 		 * @param array        $fields         The array of fields for the object config
-		 * @param WPObjectType $wp_object_type The WPObjectType Class
-		 * @param TypeRegistry $type_registry  The Type Registry
+		 * @param \WPGraphQL\Type\WPObjectType $wp_object_type The WPObjectType Class
+		 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The Type Registry
 		 */
 		$fields = apply_filters( "graphql_{$uc_type_name}_fields", $fields, $this, $this->type_registry );
 

--- a/src/Type/WPScalar.php
+++ b/src/Type/WPScalar.php
@@ -15,7 +15,7 @@ class WPScalar extends CustomScalarType {
 	 * WPScalar constructor.
 	 *
 	 * @param array        $config
-	 * @param TypeRegistry $type_registry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 */
 	public function __construct( array $config, TypeRegistry $type_registry ) {
 

--- a/src/Type/WPUnionType.php
+++ b/src/Type/WPUnionType.php
@@ -17,7 +17,7 @@ use WPGraphQL\Registry\TypeRegistry;
 class WPUnionType extends UnionType {
 
 	/**
-	 * @var TypeRegistry
+	 * @var \WPGraphQL\Registry\TypeRegistry
 	 */
 	public $type_registry;
 
@@ -25,7 +25,7 @@ class WPUnionType extends UnionType {
 	 * WPUnionType constructor.
 	 *
 	 * @param array        $config The Config to setup a Union Type
-	 * @param TypeRegistry $type_registry
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
 	 * @since 0.0.30
 	 */
@@ -69,7 +69,7 @@ class WPUnionType extends UnionType {
 			 *
 			 * @param mixed       $type          The Type to resolve to, based on the object being resolved
 			 * @param mixed       $object        The Object being resolved
-			 * @param WPUnionType $wp_union_type The WPUnionType instance
+			 * @param \WPGraphQL\Type\WPUnionType $wp_union_type The WPUnionType instance
 			 */
 			return apply_filters( 'graphql_union_resolve_type', $type, $object, $this );
 		};
@@ -79,7 +79,7 @@ class WPUnionType extends UnionType {
 		 *
 		 * @param mixed       $types         The possible types for the Union
 		 * @param array       $config        The config for the Union Type
-		 * @param WPUnionType $wp_union_type The WPUnionType instance
+		 * @param \WPGraphQL\Type\WPUnionType $wp_union_type The WPUnionType instance
 		 *
 		 * @return mixed|array
 		 */
@@ -89,7 +89,7 @@ class WPUnionType extends UnionType {
 		 * Filter the config of WPUnionType
 		 *
 		 * @param array       $config        Array of configuration options passed to the WPUnionType when instantiating a new type
-		 * @param WPUnionType $wp_union_type The instance of the WPUnionType class
+		 * @param \WPGraphQL\Type\WPUnionType $wp_union_type The instance of the WPUnionType class
 		 *
 		 * @since 0.0.30
 		 */
@@ -99,7 +99,7 @@ class WPUnionType extends UnionType {
 		 * Run an action when the WPUnionType is instantiating
 		 *
 		 * @param array       $config        Array of configuration options passed to the WPUnionType when instantiating a new type
-		 * @param WPUnionType $wp_union_type The instance of the WPUnionType class
+		 * @param \WPGraphQL\Type\WPUnionType $wp_union_type The instance of the WPUnionType class
 		 */
 		do_action( 'graphql_wp_union_type', $config, $this );
 

--- a/src/Utils/DebugLog.php
+++ b/src/Utils/DebugLog.php
@@ -35,7 +35,7 @@ class DebugLog {
 		 * Filters whether GraphQL Debug is enabled enabled. Serves as the default state for enabling debug logs.
 		 *
 		 * @param bool $enabled Whether logs are enabled or not
-		 * @param DebugLog $debug_log The DebugLog class instance
+		 * @param \WPGraphQL\Utils\DebugLog $debug_log The DebugLog class instance
 		 */
 		$this->logs_enabled = apply_filters( 'graphql_debug_logs_enabled', $enabled, $this );
 	}
@@ -105,7 +105,7 @@ class DebugLog {
 		/**
 		 * Init the debug logger
 		 *
-		 * @param DebugLog $instance The DebugLog instance
+		 * @param \WPGraphQL\Utils\DebugLog $instance The DebugLog instance
 		 */
 		do_action( 'graphql_get_debug_log', $this );
 
@@ -123,7 +123,7 @@ class DebugLog {
 		 * Return the filtered debug log
 		 *
 		 * @param array    $logs     The logs to be output with the request
-		 * @param DebugLog $instance The Debug Log class
+		 * @param \WPGraphQL\Utils\DebugLog $instance The Debug Log class
 		 */
 		return apply_filters( 'graphql_debug_log', array_values( $this->logs ), $this );
 	}

--- a/src/Utils/InstrumentSchema.php
+++ b/src/Utils/InstrumentSchema.php
@@ -18,10 +18,10 @@ use WPGraphQL\AppContext;
 class InstrumentSchema {
 
 	/**
-	 * @param Type $type Instance of the Schema.
+	 * @param \GraphQL\Type\Definition\Type $type Instance of the Schema.
 	 * @param string $type_name Name of the Type
 	 *
-	 * @return Type
+	 * @return \GraphQL\Type\Definition\Type
 	 */
 	public static function instrument_resolvers( Type $type, string $type_name ): Type {
 
@@ -62,7 +62,7 @@ class InstrumentSchema {
 			/**
 			 * Filter the field definition
 			 *
-			 * @param FieldDefinition $field     The field definition
+			 * @param \GraphQL\Type\Definition\FieldDefinition $field The field definition
 			 * @param string          $type_name The name of the Type the field belongs to
 			 */
 			$field = apply_filters( 'graphql_field_definition', $field, $type_name );
@@ -90,11 +90,11 @@ class InstrumentSchema {
 			 *
 			 * @param mixed       $source  The source passed down the Resolve Tree
 			 * @param array       $args    The args for the field
-			 * @param AppContext  $context The AppContext passed down the ResolveTree
-			 * @param ResolveInfo $info    The ResolveInfo passed down the ResolveTree
+			 * @param \WPGraphQL\AppContext $context The AppContext passed down the ResolveTree
+			 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the ResolveTree
 			 *
 			 * @return mixed
-			 * @throws Exception
+			 * @throws \Exception
 			 * @since 0.0.1
 			 */
 			$field->resolveFn = static function ( $source, array $args, AppContext $context, ResolveInfo $info ) use ( $field_resolver, $type_name, $field_key, $field ) {
@@ -104,12 +104,12 @@ class InstrumentSchema {
 				 *
 				 * @param mixed           $source         The source passed down the Resolve Tree
 				 * @param array           $args           The args for the field
-				 * @param AppContext      $context        The AppContext passed down the ResolveTree
-				 * @param ResolveInfo     $info           The ResolveInfo passed down the ResolveTree
+				 * @param \WPGraphQL\AppContext $context The AppContext passed down the ResolveTree
+				 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the ResolveTree
 				 * @param ?callable       $field_resolver The Resolve function for the field
 				 * @param string          $type_name      The name of the type the fields belong to
 				 * @param string          $field_key      The name of the field
-				 * @param FieldDefinition $field          The Field Definition for the resolving field
+				 * @param \GraphQL\Type\Definition\FieldDefinition $field The Field Definition for the resolving field
 				 */
 				do_action( 'graphql_before_resolve_field', $source, $args, $context, $info, $field_resolver, $type_name, $field_key, $field );
 
@@ -128,11 +128,11 @@ class InstrumentSchema {
 				 * @param mixed           $nil            Unique nil value
 				 * @param mixed           $source         The source passed down the Resolve Tree
 				 * @param array           $args           The args for the field
-				 * @param AppContext      $context        The AppContext passed down the ResolveTree
-				 * @param ResolveInfo     $info           The ResolveInfo passed down the ResolveTree
+				 * @param \WPGraphQL\AppContext $context The AppContext passed down the ResolveTree
+				 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the ResolveTree
 				 * @param string          $type_name      The name of the type the fields belong to
 				 * @param string          $field_key      The name of the field
-				 * @param FieldDefinition $field          The Field Definition for the resolving field
+				 * @param \GraphQL\Type\Definition\FieldDefinition $field The Field Definition for the resolving field
 				 * @param mixed           $field_resolver The default field resolver
 				 */
 				$result = apply_filters( 'graphql_pre_resolve_field', $nil, $source, $args, $context, $info, $type_name, $field_key, $field, $field_resolver );
@@ -159,11 +159,11 @@ class InstrumentSchema {
 				 * @param mixed           $result         The result of the field resolution
 				 * @param mixed           $source         The source passed down the Resolve Tree
 				 * @param array           $args           The args for the field
-				 * @param AppContext      $context        The AppContext passed down the ResolveTree
-				 * @param ResolveInfo     $info           The ResolveInfo passed down the ResolveTree
+				 * @param \WPGraphQL\AppContext $context The AppContext passed down the ResolveTree
+				 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the ResolveTree
 				 * @param string          $type_name      The name of the type the fields belong to
 				 * @param string          $field_key      The name of the field
-				 * @param FieldDefinition $field          The Field Definition for the resolving field
+				 * @param \GraphQL\Type\Definition\FieldDefinition $field The Field Definition for the resolving field
 				 * @param mixed           $field_resolver The default field resolver
 				 */
 				$result = apply_filters( 'graphql_resolve_field', $result, $source, $args, $context, $info, $type_name, $field_key, $field, $field_resolver );
@@ -173,12 +173,12 @@ class InstrumentSchema {
 				 *
 				 * @param mixed           $source         The source passed down the Resolve Tree
 				 * @param array           $args           The args for the field
-				 * @param AppContext      $context        The AppContext passed down the ResolveTree
-				 * @param ResolveInfo     $info           The ResolveInfo passed down the ResolveTree
+				 * @param \WPGraphQL\AppContext $context The AppContext passed down the ResolveTree
+				 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the ResolveTree
 				 * @param ?callable        $field_resolver The Resolve function for the field
 				 * @param string          $type_name      The name of the type the fields belong to
 				 * @param string          $field_key      The name of the field
-				 * @param FieldDefinition $field          The Field Definition for the resolving field
+				 * @param \GraphQL\Type\Definition\FieldDefinition $field The Field Definition for the resolving field
 				 * @param mixed           $result         The result of the field resolver
 				 */
 				do_action( 'graphql_after_resolve_field', $source, $args, $context, $info, $field_resolver, $type_name, $field_key, $field, $result );
@@ -202,12 +202,12 @@ class InstrumentSchema {
 	 *
 	 * @param mixed                 $source         The source passed down the Resolve Tree
 	 * @param array                 $args           The args for the field
-	 * @param AppContext            $context        The AppContext passed down the ResolveTree
-	 * @param ResolveInfo           $info           The ResolveInfo passed down the ResolveTree
+	 * @param \WPGraphQL\AppContext $context The AppContext passed down the ResolveTree
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the ResolveTree
 	 * @param mixed|callable|string $field_resolver The Resolve function for the field
 	 * @param string                $type_name      The name of the type the fields belong to
 	 * @param string                $field_key      The name of the field
-	 * @param FieldDefinition       $field          The Field Definition for the resolving field
+	 * @param \GraphQL\Type\Definition\FieldDefinition $field The Field Definition for the resolving field
 	 *
 	 * @return bool|mixed
 	 */

--- a/src/Utils/QueryAnalyzer.php
+++ b/src/Utils/QueryAnalyzer.php
@@ -32,7 +32,7 @@ use WPGraphQL\WPSchema;
 class QueryAnalyzer {
 
 	/**
-	 * @var Schema
+	 * @var \GraphQL\Type\Schema
 	 */
 	protected $schema;
 
@@ -78,7 +78,7 @@ class QueryAnalyzer {
 	protected $query_id;
 
 	/**
-	 * @var Request
+	 * @var \WPGraphQL\Request
 	 */
 	protected $request;
 
@@ -98,7 +98,7 @@ class QueryAnalyzer {
 	protected $graphql_keys = [];
 
 	/**
-	 * @param Request $request The GraphQL request being executed
+	 * @param \WPGraphQL\Request $request The GraphQL request being executed
 	 */
 	public function __construct( Request $request ) {
 		$this->request       = $request;
@@ -110,7 +110,7 @@ class QueryAnalyzer {
 	}
 
 	/**
-	 * @return Request
+	 * @return \WPGraphQL\Request
 	 */
 	public function get_request(): Request {
 		return $this->request;
@@ -125,7 +125,7 @@ class QueryAnalyzer {
 		 * Filters whether to analyze queries or not
 		 *
 		 * @param bool          $should_analyze_queries Whether to analyze queries or not. Default true
-		 * @param QueryAnalyzer $query_analyzer         The QueryAnalyzer instance
+		 * @param \WPGraphQL\Utils\QueryAnalyzer $query_analyzer The QueryAnalyzer instance
 		 */
 		$should_analyze_queries = apply_filters( 'graphql_should_analyze_queries', true, $this );
 
@@ -178,12 +178,12 @@ class QueryAnalyzer {
 	 * @param ?string         $query     The GraphQL query
 	 * @param ?string         $operation The name of the operation
 	 * @param ?array          $variables Variables to be passed to your GraphQL request
-	 * @param OperationParams $params    The Operation Params. This includes any extra params, such
-	 *                                   as extenions or any other modifications to the request
-	 *                                   body
+	 * @param \GraphQL\Server\OperationParams $params The Operation Params. This includes any extra params, such
+ * as extenions or any other modifications to the request
+ * body
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function determine_graphql_keys( ?string $query, ?string $operation, ?array $variables, OperationParams $params ): void {
 
@@ -208,7 +208,7 @@ class QueryAnalyzer {
 		$this->models        = $this->set_query_models( $this->schema, $query );
 
 		/**
-		 * @param QueryAnalyzer $query_analyzer The instance of the query analyzer
+		 * @param \WPGraphQL\Utils\QueryAnalyzer $query_analyzer The instance of the query analyzer
 		 * @param string        $query          The query string being executed
 		 */
 		do_action( 'graphql_determine_graphql_keys', $this, $query );
@@ -294,17 +294,17 @@ class QueryAnalyzer {
 	 * Given the Schema and a query string, return a list of GraphQL Types that are being asked for
 	 * by the query.
 	 *
-	 * @param ?Schema $schema The WPGraphQL Schema
+	 * @param ?\GraphQL\Type\Schema $schema The WPGraphQL Schema
 	 * @param ?string $query  The query string
 	 *
 	 * @return array
-	 * @throws SyntaxError|Exception
+	 * @throws \GraphQL\Error\SyntaxError|\Exception
 	 */
 	public function set_list_types( ?Schema $schema, ?string $query ): array {
 
 		/**
 		 * @param array|null $null   Default value for the filter
-		 * @param ?Schema    $schema The WPGraphQL Schema for the current request
+		 * @param ?\GraphQL\Type\Schema $schema The WPGraphQL Schema for the current request
 		 * @param ?string    $query  The query string being requested
 		 */
 		$null               = null;
@@ -399,17 +399,17 @@ class QueryAnalyzer {
 	 * Given the Schema and a query string, return a list of GraphQL Types that are being asked for
 	 * by the query.
 	 *
-	 * @param ?Schema $schema The WPGraphQL Schema
+	 * @param ?\GraphQL\Type\Schema $schema The WPGraphQL Schema
 	 * @param ?string $query  The query string
 	 *
 	 * @return array
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function set_query_types( ?Schema $schema, ?string $query ): array {
 
 		/**
 		 * @param array|null $null   Default value for the filter
-		 * @param ?Schema    $schema The WPGraphQL Schema for the current request
+		 * @param ?\GraphQL\Type\Schema $schema The WPGraphQL Schema for the current request
 		 * @param ?string    $query  The query string being requested
 		 */
 		$null                = null;
@@ -479,17 +479,17 @@ class QueryAnalyzer {
 	 * Given the Schema and a query string, return a list of GraphQL model names that are being
 	 * asked for by the query.
 	 *
-	 * @param ?Schema $schema The WPGraphQL Schema
+	 * @param ?\GraphQL\Type\Schema $schema The WPGraphQL Schema
 	 * @param ?string $query  The query string
 	 *
 	 * @return array
-	 * @throws SyntaxError|Exception
+	 * @throws \GraphQL\Error\SyntaxError|\Exception
 	 */
 	public function set_query_models( ?Schema $schema, ?string $query ): array {
 
 		/**
 		 * @param array|null $null   Default value for the filter
-		 * @param ?Schema    $schema The WPGraphQL Schema for the current request
+		 * @param ?\GraphQL\Type\Schema $schema The WPGraphQL Schema for the current request
 		 * @param ?string    $query  The query string being requested
 		 */
 		$null           = null;
@@ -707,7 +707,7 @@ class QueryAnalyzer {
 	 * Outputs Query Analyzer data in the extensions response
 	 *
 	 * @param mixed       $response
-	 * @param WPSchema    $schema         The WPGraphQL Schema
+	 * @param \WPGraphQL\WPSchema $schema The WPGraphQL Schema
 	 * @param string|null $operation_name The operation name being executed
 	 * @param string|null $request        The GraphQL Request being made
 	 * @param array|null  $variables      The variables sent with the request
@@ -721,7 +721,7 @@ class QueryAnalyzer {
 		/**
 		 * @param bool        $should         Whether the query analyzer output should be displayed in the Extensions output. Default to the value of WPGraphQL Debug.
 		 * @param mixed       $response       The response of the WPGraphQL Request being executed
-		 * @param WPSchema    $schema         The WPGraphQL Schema
+		 * @param \WPGraphQL\WPSchema $schema The WPGraphQL Schema
 		 * @param string|null $operation_name The operation name being executed
 		 * @param string|null      $request        The GraphQL Request being made
 		 * @param array|null  $variables      The variables sent with the request

--- a/src/Utils/QueryLog.php
+++ b/src/Utils/QueryLog.php
@@ -101,7 +101,7 @@ class QueryLog {
 	 * Filter the results of the GraphQL Response to include the Query Log
 	 *
 	 * @param mixed    $response
-	 * @param WPSchema $schema         The WPGraphQL Schema
+	 * @param \WPGraphQL\WPSchema $schema The WPGraphQL Schema
 	 * @param string   $operation_name The operation name being executed
 	 * @param string   $request        The GraphQL Request being made
 	 * @param array    $variables      The variables sent with the request
@@ -166,7 +166,7 @@ class QueryLog {
 		 * Filter the trace
 		 *
 		 * @param array    $trace     The trace to return
-		 * @param QueryLog $instance  The QueryLog class instance
+		 * @param \WPGraphQL\Utils\QueryLog $instance The QueryLog class instance
 		 */
 		return apply_filters( 'graphql_tracing_response', $trace, $this );
 

--- a/src/Utils/Tracing.php
+++ b/src/Utils/Tracing.php
@@ -134,8 +134,8 @@ class Tracing {
 	 *
 	 * @param mixed               $source         The source passed down the Resolve Tree
 	 * @param array               $args           The args for the field
-	 * @param AppContext          $context        The AppContext passed down the ResolveTree
-	 * @param ResolveInfo         $info           The ResolveInfo passed down the ResolveTree
+	 * @param \WPGraphQL\AppContext $context The AppContext passed down the ResolveTree
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the ResolveTree
 	 *
 	 * @return void
 	 */
@@ -355,7 +355,7 @@ class Tracing {
 		 * Filter the trace
 		 *
 		 * @param array   $trace     The trace to return
-		 * @param Tracing $instance  The Tracing class instance
+		 * @param \WPGraphQL\Utils\Tracing $instance The Tracing class instance
 		 */
 		return apply_filters( 'graphql_tracing_response', (array) $trace, $this );
 	}

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -26,7 +26,7 @@ final class WPGraphQL {
 	/**
 	 * Stores the instance of the WPGraphQL class
 	 *
-	 * @var ?WPGraphQL The one true WPGraphQL
+	 * @var ?\WPGraphQL The one true WPGraphQL
 	 * @since  0.0.1
 	 */
 	private static $instance;
@@ -34,21 +34,21 @@ final class WPGraphQL {
 	/**
 	 * Holds the Schema def
 	 *
-	 * @var mixed|null|WPSchema $schema The Schema used for the GraphQL API
+	 * @var mixed|null|\WPGraphQL\WPSchema $schema The Schema used for the GraphQL API
 	 */
 	protected static $schema;
 
 	/**
 	 * Holds the TypeRegistry instance
 	 *
-	 * @var mixed|null|TypeRegistry $type_registry The registry that holds all GraphQL Types
+	 * @var mixed|null|\WPGraphQL\Registry\TypeRegistry $type_registry The registry that holds all GraphQL Types
 	 */
 	protected static $type_registry;
 
 	/**
 	 * Stores an array of allowed post types
 	 *
-	 * @var ?WP_Post_Type[] allowed_post_types
+	 * @var ?\WP_Post_Type[] allowed_post_types
 	 * @since  0.0.5
 	 */
 	protected static $allowed_post_types;
@@ -56,7 +56,7 @@ final class WPGraphQL {
 	/**
 	 * Stores an array of allowed taxonomies
 	 *
-	 * @var ?WP_Taxonomy[] allowed_taxonomies
+	 * @var ?\WP_Taxonomy[] allowed_taxonomies
 	 * @since  0.0.5
 	 */
 	protected static $allowed_taxonomies;
@@ -69,7 +69,7 @@ final class WPGraphQL {
 	/**
 	 * The instance of the WPGraphQL object
 	 *
-	 * @return WPGraphQL - The one true WPGraphQL
+	 * @return \WPGraphQL - The one true WPGraphQL
 	 * @since  0.0.1
 	 */
 	public static function instance() {
@@ -253,7 +253,7 @@ final class WPGraphQL {
 				/**
 				 * Fire off init action
 				 *
-				 * @param WPGraphQL $instance The instance of the WPGraphQL class
+				 * @param \WPGraphQL $instance The instance of the WPGraphQL class
 				 */
 				do_action( 'graphql_init', $instance );
 			}
@@ -310,7 +310,7 @@ final class WPGraphQL {
 	 * further execution.
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public function min_php_version_check() {
 
@@ -401,7 +401,7 @@ final class WPGraphQL {
 				 *
 				 * @param array                              $interfaces List of interfaces applied to the Object Type
 				 * @param array                              $config     The config for the Object Type
-				 * @param mixed|WPInterfaceType|WPObjectType $type       The Type instance
+				 * @param mixed|\WPGraphQL\Type\WPInterfaceType|\WPGraphQL\Type\WPObjectType $type The Type instance
 				 */
 				return apply_filters_deprecated( 'graphql_object_type_interfaces', [ $interfaces, $config, $type ], '1.4.1', 'graphql_type_interfaces' );
 			}
@@ -499,7 +499,7 @@ final class WPGraphQL {
 	 * @param string $post_type_name The name of the post type being registered
 	 *
 	 * @return array
-	 * @throws Exception
+	 * @throws \Exception
 	 * @since 1.12.0
 	 */
 	public static function register_graphql_post_type_args( array $args, string $post_type_name ) {
@@ -529,7 +529,7 @@ final class WPGraphQL {
 	 * @param string $taxonomy_name The name of the taxonomy being registered
 	 *
 	 * @return array
-	 * @throws Exception
+	 * @throws \Exception
 	 * @since 1.12.0
 	 */
 	public static function register_graphql_taxonomy_args( array $args, string $taxonomy_name ) {
@@ -696,7 +696,7 @@ final class WPGraphQL {
 			/**
 			 * Get all post types objects.
 			 *
-			 * @var WP_Taxonomy[] $tax_objects
+			 * @var \WP_Taxonomy[] $tax_objects
 			 */
 			$tax_objects = get_taxonomies(
 				[ 'show_in_graphql' => true ],
@@ -782,9 +782,9 @@ final class WPGraphQL {
 	 * Returns the Schema as defined by static registrations throughout
 	 * the WP Load.
 	 *
-	 * @return WPSchema
+	 * @return \WPGraphQL\WPSchema
 	 *
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public static function get_schema() {
 
@@ -796,9 +796,9 @@ final class WPGraphQL {
 			/**
 			 * Generate & Filter the schema.
 			 *
-			 * @param WPSchema   $schema                 The executable Schema that GraphQL executes against
-			 * @param AppContext $app_context            Object The AppContext object containing all of the
-			 *                                           information about the context we know at this point
+			 * @param \WPGraphQL\WPSchema $schema The executable Schema that GraphQL executes against
+			 * @param \WPGraphQL\AppContext $app_context Object The AppContext object containing all of the
+ * information about the context we know at this point
 			 *
 			 * @since 0.0.5
 			 */
@@ -839,9 +839,9 @@ final class WPGraphQL {
 	 * Returns the Schema as defined by static registrations throughout
 	 * the WP Load.
 	 *
-	 * @return TypeRegistry
+	 * @return \WPGraphQL\Registry\TypeRegistry
 	 *
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public static function get_type_registry() {
 
@@ -852,9 +852,9 @@ final class WPGraphQL {
 			/**
 			 * Generate & Filter the schema.
 			 *
-			 * @param TypeRegistry $type_registry          The TypeRegistry for the API
-			 * @param AppContext   $app_context            Object The AppContext object containing all of the
-			 *                                             information about the context we know at this point
+			 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The TypeRegistry for the API
+			 * @param \WPGraphQL\AppContext $app_context Object The AppContext object containing all of the
+ * information about the context we know at this point
 			 *
 			 * @since 0.0.5
 			 */
@@ -890,7 +890,7 @@ final class WPGraphQL {
 	/**
 	 * Get the AppContext for use in passing down the Resolve Tree
 	 *
-	 * @return AppContext
+	 * @return \WPGraphQL\AppContext
 	 */
 	public static function get_app_context() {
 

--- a/src/WPSchema.php
+++ b/src/WPSchema.php
@@ -16,7 +16,7 @@ use WPGraphQL\Registry\TypeRegistry;
 class WPSchema extends Schema {
 
 	/**
-	 * @var SchemaConfig
+	 * @var \GraphQL\Type\SchemaConfig
 	 */
 	public $config;
 
@@ -24,7 +24,7 @@ class WPSchema extends Schema {
 	 * Holds the $filterable_config which allows WordPress access to modifying the
 	 * $config that gets passed down to the Executable Schema
 	 *
-	 * @var SchemaConfig|null
+	 * @var \GraphQL\Type\SchemaConfig|null
 	 * @since 0.0.9
 	 */
 	public $filterable_config;
@@ -32,8 +32,8 @@ class WPSchema extends Schema {
 	/**
 	 * WPSchema constructor.
 	 *
-	 * @param SchemaConfig $config The config for the Schema.
-	 * @param TypeRegistry $type_registry
+	 * @param \GraphQL\Type\SchemaConfig $config The config for the Schema.
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
 	 * @since 0.0.9
 	 */
@@ -44,8 +44,8 @@ class WPSchema extends Schema {
 		/**
 		 * Set the $filterable_config as the $config that was passed to the WPSchema when instantiated
 		 *
-		 * @param SchemaConfig $config The config for the Schema.
-		 * @param TypeRegistry $type_registry The WPGraphQL type registry.
+		 * @param \GraphQL\Type\SchemaConfig $config The config for the Schema.
+		 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The WPGraphQL type registry.
 		 *
 		 * @since 0.0.9
 		 */


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR fixes all usages of class names in PHPDocs to be their fully-qualified version. This ensures PHPDoc types are unambiguous.

Uses (and adds to the dev-dependencies / phpcs ruleset ) [`SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameInAnnotation`](https://github.com/slevomat/coding-standard/blob/master/doc/namespaces.md#slevomatcodingstandardnamespacesfullyqualifiedclassnameinannotation-)

Does this close any currently open issues?
------------------------------------------
closes #2588


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
`SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameInAnnotation` also includes phpcbf support.

Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php 8.0.26 )

**WordPress Version:** 6.1.1
