### PR TITLE
fix: deprecation notice

### DIFF
--- a/src/Data/Connection/TermObjectConnectionResolver.php
+++ b/src/Data/Connection/TermObjectConnectionResolver.php
@@ -5,7 +5,6 @@ namespace WPGraphQL\Data\Connection;
 use Exception;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
-use WPGraphQL\Types;
 use WPGraphQL\Utils\Utils;
 
 /**
@@ -235,7 +234,7 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 		/**
 		 * Map and sanitize the input args to the WP_Term_Query compatible args
 		 */
-		$query_args = Types::map_input( $where_args, $arg_mapping );
+		$query_args = Utils::map_input( $where_args, $arg_mapping );
 
 		/**
 		 * Filter the input fields

--- a/src/Data/Connection/UserConnectionResolver.php
+++ b/src/Data/Connection/UserConnectionResolver.php
@@ -5,7 +5,7 @@ namespace WPGraphQL\Data\Connection;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
-use WPGraphQL\Types;
+use WPGraphQL\Utils\Utils;
 
 /**
  * Class UserConnectionResolver
@@ -247,7 +247,7 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 		/**
 		 * Map and sanitize the input args to the WP_User_Query compatible args
 		 */
-		$query_args = Types::map_input( $args, $arg_mapping );
+		$query_args = Utils::map_input( $args, $arg_mapping );
 
 		/**
 		 * Filter the input fields


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [ x] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes a deprecation warning `Function WPGraphQL\Types::map_input is <strong>deprecated</strong> since version 0.6.0! Use WPGraphQL\Utils\Utils::map_input() instead` when querying terms with any kind of condition.


Does this close any currently open issues?
------------------------------------------
fixes https://github.com/wp-graphql/wp-graphql/issues/2717


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
`PHP Deprecated:  Function WPGraphQL\Types::map_input is <strong>deprecated</strong> since version 0.6.0! Use WPGraphQL\Utils\Utils::map_input() instead.`


Any other comments?
-------------------


Where has this been tested?
---------------------------
**Operating System:** Windows 11 (PHP 7.4.33)

**WordPress Version:** 6.1.1
