### PR TITLE
fix: Add test for the graphql all query key in headers

### DIFF
--- a/tests/functional/GraphQLHeadersCept.php
+++ b/tests/functional/GraphQLHeadersCept.php
@@ -30,6 +30,7 @@ $x_graphql_url = $I->grabHttpHeader( 'X-GraphQL-URL' );
 
 $I->assertNotEmpty( $x_graphql_keys );
 
+$I->assertContains( 'graphql:Query', explode( ' ', $x_graphql_keys ) );
 $I->assertContains( 'operation:GetPosts', explode( ' ', $x_graphql_keys ) );
 
 $I->assertNotEmpty( $x_graphql_url );


### PR DESCRIPTION

What does this implement/fix? Explain your changes.
---------------------------------------------------
As part of query cache headers/keys, test that the top level graphql query key is present on request.


Does this close any currently open issues?
------------------------------------------
… related to this [issue](https://github.com/wp-graphql/wp-graphql-smart-cache/issues/193) in smart cache.


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
