### PR TITLE
release: v1.13.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.13.9
+
+- [#2726](https://github.com/wp-graphql/wp-graphql/pull/2726): fix: invalid schema when custom post types and custom taxonomies are registered with underscores in the "graphql_single_name" / "graphql_plural_name"
+
 ## 1.13.8
 
 - [#2712](https://github.com/wp-graphql/wp-graphql/pull/2712): fix: query analyzer outputting unexpected list types

--- a/readme.txt
+++ b/readme.txt
@@ -232,6 +232,12 @@ Composer dependencies are no longer versioned in Github. Recommended install sou
 
 == Changelog ==
 
+= 1.13.9 =
+
+**Chores / Bugfixes**
+
+- [#2726](https://github.com/wp-graphql/wp-graphql/pull/2726): fix: invalid schema when custom post types and custom taxonomies are registered with underscores in the "graphql_single_name" / "graphql_plural_name"
+
 = 1.13.8 =
 
 **Chores / Bugfixes**

--- a/src/Type/WPConnectionType.php
+++ b/src/Type/WPConnectionType.php
@@ -518,9 +518,11 @@ class WPConnectionType {
 	 */
 	public function register_connection_interfaces(): void {
 
-		if ( ! $this->type_registry->has_type( $this->to_type . 'ConnectionEdge' ) ) {
+		$connection_edge_type = Utils::format_type_name( $this->to_type . 'ConnectionEdge' );
 
-			$this->type_registry->register_interface_type( $this->to_type . 'ConnectionEdge', [
+		if ( ! $this->type_registry->has_type( $connection_edge_type ) ) {
+
+			$this->type_registry->register_interface_type( $connection_edge_type, [
 				'interfaces'  => [ 'Edge' ],
 				'description' => sprintf( __( 'Edge between a Node and a connected %s', 'wp-graphql' ), $this->to_type ),
 				'fields'      => [
@@ -539,7 +541,7 @@ class WPConnectionType {
 				'description' => sprintf( __( 'Connection to %s Nodes', 'wp-graphql' ), $this->to_type ),
 				'fields'      => [
 					'edges' => [
-						'type'        => [ 'non_null' => [ 'list_of' => [ 'non_null' => $this->to_type . 'ConnectionEdge' ] ] ],
+						'type'        => [ 'non_null' => [ 'list_of' => [ 'non_null' => $connection_edge_type ] ] ],
 						'description' => sprintf( __( 'A list of edges (relational context) between %1$s and connected %2$s Nodes', 'wp-graphql' ), $this->from_type, $this->to_type ),
 					],
 					'nodes' => [

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -130,7 +130,7 @@ final class WPGraphQL {
 
 		// Plugin version.
 		if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-			define( 'WPGRAPHQL_VERSION', '1.13.8' );
+			define( 'WPGRAPHQL_VERSION', '1.13.9' );
 		}
 
 		// Plugin Folder Path.

--- a/tests/wpunit/CustomPostTypeTest.php
+++ b/tests/wpunit/CustomPostTypeTest.php
@@ -1475,5 +1475,38 @@ class CustomPostTypeTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 	}
 
+	public function testRegisterCustomPostTypeWithUnderscoresInGraphqlNameHasValidSchema() {
+
+			$args = [
+				'public'              => true,
+				'show_in_rest'        => true,
+				'hierarchical'        => true,
+				'show_ui'             => true,
+				'show_in_graphql'     => true,
+				'graphql_single_name' => 'with_underscore',
+				'graphql_plural_name' => 'with_underscore',
+				'has_archive'         => true,
+				'query_var'           => true,
+				'rewrite'             => [ 'slug' => 'casinos' ],
+				'supports'            => [ 'editor', 'thumbnail', 'title' ],
+				'label'               => _( 'With Underscores' ),
+				'map_meta_cap'        => true
+			];
+
+			// register the post type with underscore in the graphql_single_name / graphql_plural_name
+			register_post_type( 'with_underscore', $args );
+
+			$request = new \WPGraphQL\Request();
+
+			// clean up
+			unregister_post_type( 'with_underscore' );
+
+			$request->schema->assertValid();
+
+			// Assert true upon success.
+			$this->assertTrue( true );
+
+	}
+
 
 }

--- a/tests/wpunit/CustomTaxonomyTest.php
+++ b/tests/wpunit/CustomTaxonomyTest.php
@@ -1044,4 +1044,30 @@ class CustomTaxonomyTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 	}
 
+	public function testRegisterCustomPostTypeWithUnderscoresInGraphqlNameHasValidSchema() {
+
+		$args = [
+			'public'              => true,
+			'hierarchical'        => true,
+			'show_ui'             => true,
+			'graphql_single_name' => 'tax_with_underscore',
+			'graphql_plural_name' => 'tax_with_underscores',
+			'show_in_graphql'     => true,
+			'label'               => 'Taxonomy with Underscores',
+		];
+
+		// register the taxonomy with underscore in the graphql_single_name / graphql_plural_name
+		register_taxonomy( 'with_underscore', [ 'post' ], $args );
+
+		$request = new \WPGraphQL\Request();
+
+		unregister_taxonomy( 'with_underscore' );
+
+		$request->schema->assertValid();
+
+		// Assert true upon success.
+		$this->assertTrue( true );
+
+	}
+
 }

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.13.8
+ * Version: 1.13.9
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.13.8
+ * @version  1.13.9
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
# Release Notes

## Chores / Bugfixes

- [#2726](https://github.com/wp-graphql/wp-graphql/pull/2726): fix: invalid schema when custom post types and custom taxonomies are registered with underscores in the "graphql_single_name" / "graphql_plural_name"
