### PR TITLE
fix: Explicitly check for DEBUG enabled value for tests

### DIFF
--- a/docker/testing.entrypoint.sh
+++ b/docker/testing.entrypoint.sh
@@ -7,7 +7,8 @@ run_tests() {
     if [[ -n "$COVERAGE" ]]; then
         local coverage="--coverage --coverage-xml"
     fi
-    if [[ -n "$DEBUG" ]]; then
+    if [[ "1" -eq "$DEBUG" || "true" == "$DEBUG" ]]; then
+        echo "Debug enabled"
         local debug="--debug"
     fi
 


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [ ] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
When running tests, specifying any value for DEBUG env variable, enables codeception debug mode.  Allow DEBUG=0 to not enable debug mode for tests.  Actually, only enable debug when DEBUG=1 or DEBUG=true.


Does this close any currently open issues?
------------------------------------------
…[issue](https://github.com/wp-graphql/wp-graphql/issues/2734)


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
