### PR TITLE
feat: allow fields to be registered with underscores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,23 @@
 # Changelog
 
+## 1.14.0
+
+## New Features
+
+
+
+## Chores / Bugfixes
+
+
 ## 1.13.8
+
+### Chores / Bugfixes
 
 - [#2712](https://github.com/wp-graphql/wp-graphql/pull/2712): fix: query analyzer outputting unexpected list types
 
 ## 1.13.7
 
-## Chores / Bugfixes
+### Chores / Bugfixes
 
 - ([#2661](https://github.com/wp-graphql/wp-graphql/pull/2661)): chore(deps): bump simple-git from 3.10.0 to 3.15.1
 - ([#2665](https://github.com/wp-graphql/wp-graphql/pull/2665)): chore(deps): bump decode-uri-component from 0.2.0 to 0.2.2

--- a/access-functions.php
+++ b/access-functions.php
@@ -191,12 +191,12 @@ function register_graphql_type( string $type_name, array $config ) {
  * Given a Type Name and a $config array, this adds an Interface Type to the TypeRegistry
  *
  * @param string $type_name The name of the Type to register
- * @param array|callable  $config    The Type config
+ * @param array  $config    The Type config
  *
  * @throws \Exception
  * @return void
  */
-function register_graphql_interface_type( string $type_name, $config ) {
+function register_graphql_interface_type( string $type_name, array $config ) {
 	add_action(
 		get_graphql_register_action(),
 		function ( TypeRegistry $type_registry ) use ( $type_name, $config ) {

--- a/access-functions.php
+++ b/access-functions.php
@@ -191,12 +191,12 @@ function register_graphql_type( string $type_name, array $config ) {
  * Given a Type Name and a $config array, this adds an Interface Type to the TypeRegistry
  *
  * @param string $type_name The name of the Type to register
- * @param array  $config    The Type config
+ * @param array|callable  $config    The Type config
  *
  * @throws \Exception
  * @return void
  */
-function register_graphql_interface_type( string $type_name, array $config ) {
+function register_graphql_interface_type( string $type_name, $config ) {
 	add_action(
 		get_graphql_register_action(),
 		function ( TypeRegistry $type_registry ) use ( $type_name, $config ) {

--- a/access-functions.php
+++ b/access-functions.php
@@ -190,13 +190,13 @@ function register_graphql_type( string $type_name, array $config ) {
 /**
  * Given a Type Name and a $config array, this adds an Interface Type to the TypeRegistry
  *
- * @param string $type_name The name of the Type to register
- * @param array  $config    The Type config
+ * @param string          $type_name The name of the Type to register
+ * @param array|callable  $config    The Type config
  *
  * @throws \Exception
  * @return void
  */
-function register_graphql_interface_type( string $type_name, array $config ) {
+function register_graphql_interface_type( string $type_name, $config ) {
 	add_action(
 		get_graphql_register_action(),
 		function ( TypeRegistry $type_registry ) use ( $type_name, $config ) {

--- a/access-functions.php
+++ b/access-functions.php
@@ -271,14 +271,16 @@ function register_graphql_enum_type( string $type_name, array $config ) {
  * Given a Type Name, Field Name, and a $config array, this adds a Field to a registered Type in
  * the TypeRegistry
  *
- * @param string $type_name  The name of the Type to add the field to
- * @param string $field_name The name of the Field to add to the Type
- * @param array  $config     The Type config
+ * @param string $type_name                       The name of the Type to add the field to
+ * @param string $field_name                      The name of the Field to add to the Type
+ * @param array  $config                          The Type config
  *
  * @return void
+ * @throws \Exception
  * @since 0.1.0
  */
 function register_graphql_field( string $type_name, string $field_name, array $config ) {
+
 	add_action(
 		get_graphql_register_action(),
 		function ( TypeRegistry $type_registry ) use ( $type_name, $field_name, $config ) {
@@ -296,6 +298,7 @@ function register_graphql_field( string $type_name, string $field_name, array $c
  * @param array  $fields    An array of field configs
  *
  * @return void
+ * @throws \Exception
  * @since 0.1.0
  */
 function register_graphql_fields( string $type_name, array $fields ) {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, API, Gatsby, Headless, Decoupled, React, Nextjs, Vue, Apollo, RES
 Requires at least: 5.0
 Tested up to: 6.1
 Requires PHP: 7.1
-Stable tag: 1.13.8
+Stable tag: 1.14.0
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -231,6 +231,12 @@ The `uri` field was non-null on some Types in the Schema but has been changed to
 Composer dependencies are no longer versioned in Github. Recommended install source is WordPress.org or using Composer to get the code from Packagist.org or WPackagist.org.
 
 == Changelog ==
+
+= 1.14.0 =
+
+**New Features**
+
+**Chores / Bugfixes**
 
 = 1.13.8 =
 

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -704,7 +704,7 @@ class TypeRegistry {
 	 * Add an Interface Type to the registry
 	 *
 	 * @param string $type_name The name of the type to register
-	 * @param array $config he configuration of the type
+	 * @param array $config The configuration of the type
 	 *
 	 * @throws \Exception
 	 * @return void
@@ -1005,7 +1005,7 @@ class TypeRegistry {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function register_fields( string $type_name, array $fields = [], ?bool $allow_underscores_in_field_names = false ): void {
+	public function register_fields( string $type_name, array $fields = [] ): void {
 		if ( ! empty( $fields ) ) {
 			foreach ( $fields as $field_name => $config ) {
 				if ( is_string( $field_name ) && ! empty( $config ) && is_array( $config ) ) {

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -634,7 +634,7 @@ class TypeRegistry {
 	 *
 	 * @return void
 	 */
-	public function register_type( string $type_name, $config ) {
+	public function register_type( string $type_name, $config ): void {
 		/**
 		 * If the type should be excluded from the schema, skip it.
 		 */
@@ -695,7 +695,7 @@ class TypeRegistry {
 	 * @throws \Exception
 	 * @return void
 	 */
-	public function register_object_type( string $type_name, array $config ) {
+	public function register_object_type( string $type_name, array $config ): void {
 		$config['kind'] = 'object';
 		$this->register_type( $type_name, $config );
 	}
@@ -709,7 +709,7 @@ class TypeRegistry {
 	 * @throws \Exception
 	 * @return void
 	 */
-	public function register_interface_type( string $type_name, array $config ) {
+	public function register_interface_type( string $type_name, array $config ): void {
 		$config['kind'] = 'interface';
 		$this->register_type( $type_name, $config );
 	}
@@ -723,7 +723,7 @@ class TypeRegistry {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function register_enum_type( string $type_name, array $config ) {
+	public function register_enum_type( string $type_name, array $config ): void {
 		$config['kind'] = 'enum';
 		$this->register_type( $type_name, $config );
 	}
@@ -737,7 +737,7 @@ class TypeRegistry {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function register_input_type( string $type_name, array $config ) {
+	public function register_input_type( string $type_name, array $config ): void {
 		$config['kind'] = 'input';
 		$this->register_type( $type_name, $config );
 	}
@@ -752,7 +752,7 @@ class TypeRegistry {
 	 *
 	 * @throws \Exception
 	 */
-	public function register_union_type( string $type_name, array $config ) {
+	public function register_union_type( string $type_name, array $config ): void {
 		$config['kind'] = 'union';
 		$this->register_type( $type_name, $config );
 	}
@@ -836,7 +836,7 @@ class TypeRegistry {
 	 *
 	 * @return bool
 	 */
-	public function has_type( string $type_name ) {
+	public function has_type( string $type_name ): bool {
 		return isset( $this->type_loaders[ $this->format_key( $type_name ) ] );
 	}
 
@@ -845,7 +845,7 @@ class TypeRegistry {
 	 *
 	 * @return array
 	 */
-	public function get_types() {
+	public function get_types(): array {
 
 		// The full map of types is merged with eager types to support the
 		// rename_graphql_type API.
@@ -864,7 +864,7 @@ class TypeRegistry {
 	 * @return array
 	 * @throws \Exception
 	 */
-	public function prepare_fields( array $fields, string $type_name ) {
+	public function prepare_fields( array $fields, string $type_name ): array {
 		$prepared_fields = [];
 		if ( ! empty( $fields ) && is_array( $fields ) ) {
 			foreach ( $fields as $field_name => $field_config ) {
@@ -890,7 +890,7 @@ class TypeRegistry {
 	 * @return array|null
 	 * @throws \Exception
 	 */
-	protected function prepare_field( $field_name, $field_config, $type_name ) {
+	protected function prepare_field( string $field_name, array $field_config, string $type_name ): ?array {
 
 		if ( ! isset( $field_config['name'] ) ) {
 			$field_config['name'] = lcfirst( $field_name );
@@ -984,7 +984,9 @@ class TypeRegistry {
 			return $this->non_null(
 				$this->setup_type_modifiers( $type['non_null'] )
 			);
-		} elseif ( isset( $type['list_of'] ) ) {
+		}
+
+		if ( isset( $type['list_of'] ) ) {
 			return $this->list_of(
 				$this->setup_type_modifiers( $type['list_of'] )
 			);
@@ -1001,8 +1003,9 @@ class TypeRegistry {
 	 * @param array  $fields    Fields to register
 	 *
 	 * @return void
+	 * @throws \Exception
 	 */
-	public function register_fields( string $type_name, array $fields = [] ) {
+	public function register_fields( string $type_name, array $fields = [], ?bool $allow_underscores_in_field_names = false ): void {
 		if ( ! empty( $fields ) ) {
 			foreach ( $fields as $field_name => $config ) {
 				if ( is_string( $field_name ) && ! empty( $config ) && is_array( $config ) ) {
@@ -1015,18 +1018,25 @@ class TypeRegistry {
 	/**
 	 * Add a field to a Type in the Type Registry
 	 *
-	 * @param string $type_name  Name of the type in the Type Registry to add the fields to
-	 * @param string $field_name Name of the field to add to the type
-	 * @param array  $config     Info about the field to register to the type
+	 * @param string $type_name                       Name of the type in the Type Registry to add
+	 *                                                the fields to
+	 * @param string $field_name                      Name of the field to add to the type
+	 * @param array  $config                          Info about the field to register to the type
 	 *
 	 * @return void
+	 * @throws \Exception
 	 */
-	public function register_field( string $type_name, string $field_name, array $config ) {
+	public function register_field( string $type_name, string $field_name, array $config ): void {
+
+
 		add_filter(
 			'graphql_' . $type_name . '_fields',
 			function ( $fields ) use ( $type_name, $field_name, $config ) {
 
-				$field_name = Utils::format_field_name( $field_name );
+				// Whether the field should be allowed to have underscores in the field name
+				$allow_field_underscores = isset( $config['allow_field_underscores'] ) && true === $config['allow_field_underscores'];
+
+				$field_name = Utils::format_field_name( $field_name, $allow_field_underscores );
 
 				if ( preg_match( '/^\d/', $field_name ) ) {
 					graphql_debug(
@@ -1104,7 +1114,7 @@ class TypeRegistry {
 	 * @throws \InvalidArgumentException
 	 * @throws \Exception
 	 */
-	public function register_connection( array $config ) {
+	public function register_connection( array $config ): void {
 		new WPConnectionType( $config, $this );
 	}
 
@@ -1117,7 +1127,7 @@ class TypeRegistry {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function register_mutation( string $mutation_name, array $config ) {
+	public function register_mutation( string $mutation_name, array $config ): void {
 		// Bail if the mutation has been excluded from the schema.
 		if ( in_array( strtolower( $mutation_name ), $this->get_excluded_mutations(), true ) ) {
 			return;
@@ -1135,7 +1145,7 @@ class TypeRegistry {
 	 * @uses 'graphql_excluded_mutations' filter.
 	 *
 	 * @param string $mutation_name Name of the mutation to remove from the schema.
-	 * 
+	 *
 	 * @since 1.14.0
 	 */
 	public function deregister_mutation( string $mutation_name ) : void {

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -1034,7 +1034,7 @@ class TypeRegistry {
 			function ( $fields ) use ( $type_name, $field_name, $config ) {
 
 				// Whether the field should be allowed to have underscores in the field name
-				$allow_field_underscores = isset( $config['allow_field_underscores'] ) && true === $config['allow_field_underscores'];
+				$allow_field_underscores = isset( $config['allowFieldUnderscores'] ) && true === $config['allowFieldUnderscores'];
 
 				$field_name = Utils::format_field_name( $field_name, $allow_field_underscores );
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -26,8 +26,8 @@ use WPGraphQL\Utils\QueryAnalyzer;
  *
  * @package WPGraphQL
  */
-class Request
-{
+class Request {
+
 
 	/**
 	 * App context for this request.
@@ -121,22 +121,21 @@ class Request
 	 *
 	 * @throws \Exception
 	 */
-	public function __construct(array $data = [])
-	{
+	public function __construct( array $data = [] ) {
 
 		/**
 		 * Whether it's a GraphQL Request (http or internal)
 		 *
 		 * @since 0.0.5
 		 */
-		if (!defined('GRAPHQL_REQUEST')) {
-			define('GRAPHQL_REQUEST', true);
+		if ( ! defined( 'GRAPHQL_REQUEST' ) ) {
+			define( 'GRAPHQL_REQUEST', true );
 		}
 
 		/**
 		 * Filter "is_graphql_request" to return true
 		 */
-		\WPGraphQL::set_is_graphql_request(true);
+		\WPGraphQL::set_is_graphql_request( true );
 
 		/**
 		 * Action – intentionally with no context – to indicate a GraphQL Request has started.
@@ -144,7 +143,7 @@ class Request
 		 * occur in the context of a GraphQL Request. The base class hooks into this action to
 		 * kick off the schema creation, so types are not set up until this action has run!
 		 */
-		do_action('init_graphql_request');
+		do_action( 'init_graphql_request' );
 
 		// Start tracking debug log messages
 		$this->debug_log = new DebugLog();
@@ -161,23 +160,23 @@ class Request
 		// Get the App Context
 		$this->app_context = \WPGraphQL::get_app_context();
 
-		$this->root_value = $this->get_root_value();
+		$this->root_value       = $this->get_root_value();
 		$this->validation_rules = $this->get_validation_rules();
-		$this->field_resolver = $this->get_field_resolver();
+		$this->field_resolver   = $this->get_field_resolver();
 
 		/**
 		 * Configure the app_context which gets passed down to all the resolvers.
 		 *
 		 * @since 0.0.4
 		 */
-		$app_context = new AppContext();
-		$app_context->viewer = wp_get_current_user();
-		$app_context->root_url = get_bloginfo('url');
+		$app_context                = new AppContext();
+		$app_context->viewer        = wp_get_current_user();
+		$app_context->root_url      = get_bloginfo( 'url' );
 		$app_context->request = !empty($_REQUEST) ? $_REQUEST : null; // phpcs:ignore
 		$app_context->type_registry = $this->type_registry;
-		$this->app_context = $app_context;
+		$this->app_context          = $app_context;
 
-		$this->query_analyzer = new QueryAnalyzer($this);
+		$this->query_analyzer = new QueryAnalyzer( $this );
 
 		// The query analyzer tracks nodes, models, list types and more
 		// to return in headers and debug messages to help developers understand
@@ -189,16 +188,14 @@ class Request
 	/**
 	 * @return \WPGraphQL\Utils\QueryAnalyzer
 	 */
-	public function get_query_analyzer(): QueryAnalyzer
-	{
+	public function get_query_analyzer(): QueryAnalyzer {
 		return $this->query_analyzer;
 	}
 
 	/**
 	 * @return mixed
 	 */
-	protected function get_field_resolver()
-	{
+	protected function get_field_resolver() {
 		return $this->field_resolver;
 	}
 
@@ -207,14 +204,13 @@ class Request
 	 *
 	 * @return array
 	 */
-	protected function get_validation_rules(): array
-	{
+	protected function get_validation_rules(): array {
 
 		$validation_rules = GraphQL::getStandardValidationRules();
 
 		$validation_rules['require_authentication'] = new RequireAuthentication();
-		$validation_rules['disable_introspection'] = new DisableIntrospection();
-		$validation_rules['query_depth'] = new QueryDepth();
+		$validation_rules['disable_introspection']  = new DisableIntrospection();
+		$validation_rules['query_depth']            = new QueryDepth();
 
 		/**
 		 * Return the validation rules to use in the request
@@ -222,7 +218,7 @@ class Request
 		 * @param array   $validation_rules The validation rules to use in the request
 		 * @param \WPGraphQL\Request $request The Request instance
 		 */
-		return apply_filters('graphql_validation_rules', $validation_rules, $this);
+		return apply_filters( 'graphql_validation_rules', $validation_rules, $this );
 
 	}
 
@@ -231,13 +227,11 @@ class Request
 	 *
 	 * @return mixed|null
 	 */
-	protected function get_root_value()
-	{
-
+	protected function get_root_value() { 
 		/**
 		 * Set the root value based on what was passed to the request
 		 */
-		$root_value = isset($this->data['root_value']) && !empty($this->data['root_value']) ? $this->data['root_value'] : null;
+		$root_value = isset( $this->data['root_value'] ) && ! empty( $this->data['root_value'] ) ? $this->data['root_value'] : null;
 
 		/**
 		 * Return the filtered root value
@@ -245,7 +239,7 @@ class Request
 		 * @param mixed   $root_value The root value the Schema should use to resolve with. Default null.
 		 * @param \WPGraphQL\Request $request The Request instance
 		 */
-		return apply_filters('graphql_root_value', $root_value, $this);
+		return apply_filters( 'graphql_root_value', $root_value, $this );
 	}
 
 	/**
@@ -254,8 +248,7 @@ class Request
 	 * @return void
 	 * @throws \GraphQL\Error\Error
 	 */
-	private function before_execute(): void
-	{
+	private function before_execute(): void {
 
 		/**
 		 * Store the global post so that it can be reset after GraphQL execution
@@ -264,33 +257,33 @@ class Request
 		 * without disrupting the flow of the post as the global POST before and after GraphQL execution will be
 		 * the same.
 		 */
-		if (!empty($GLOBALS['post'])) {
+		if ( ! empty( $GLOBALS['post'] ) ) {
 			$this->global_post = $GLOBALS['post'];
 		}
 
-		if (!empty($GLOBALS['wp_query'])) {
+		if ( ! empty( $GLOBALS['wp_query'] ) ) {
 			$this->global_wp_the_query = clone $GLOBALS['wp_the_query'];
 		}
 
 		/**
 		 * If the request is a batch request it will come back as an array
 		 */
-		if (is_array($this->params)) {
+		if ( is_array( $this->params ) ) {
 
 			// If the request is a batch request, but batch requests are disabled,
 			// bail early
-			if (!$this->is_batch_queries_enabled()) {
-				throw new Error(__('Batch Queries are not supported', 'wp-graphql'));
+			if ( ! $this->is_batch_queries_enabled() ) {
+				throw new Error( __( 'Batch Queries are not supported', 'wp-graphql' ) );
 			}
 
-			$batch_limit = get_graphql_setting('batch_limit', 10);
-			$batch_limit = absint($batch_limit) ? absint($batch_limit) : 10;
+			$batch_limit = get_graphql_setting( 'batch_limit', 10 );
+			$batch_limit = absint( $batch_limit ) ? absint( $batch_limit ) : 10;
 
 			// If batch requests are enabled, but a limit is set and the request exceeds the limit
 			// fail now
-			if ($batch_limit < count($this->params)) {
+			if ( $batch_limit < count( $this->params ) ) {
 				// translators: First placeholder is the max number of batch operations allowed in a GraphQL request. The 2nd placeholder is the number of operations requested in the current request.
-				throw new Error(sprintf(__('Batch requests are limited to %1$d operations. This request contained %2$d', 'wp-graphql'), absint($batch_limit), count($this->params)));
+				throw new Error( sprintf( __( 'Batch requests are limited to %1$d operations. This request contained %2$d', 'wp-graphql' ), absint( $batch_limit ), count( $this->params ) ) );
 			}
 
 			/**
@@ -298,13 +291,13 @@ class Request
 			 *
 			 * @param \GraphQL\Server\OperationParams[] $params The operation params of the batch request
 			 */
-			do_action('graphql_execute_batch_queries', $this->params);
+			do_action( 'graphql_execute_batch_queries', $this->params );
 
 			// Process the batched requests
-			array_walk($this->params, [$this, 'do_action']);
+			array_walk( $this->params, [ $this, 'do_action' ] );
 
 		} else {
-			$this->do_action($this->params);
+			$this->do_action( $this->params );
 		}
 
 		/**
@@ -312,7 +305,7 @@ class Request
 		 *
 		 * @param \WPGraphQL\Request $request The instance of the Request being executed
 		 */
-		do_action('graphql_before_execute', $this);
+		do_action( 'graphql_before_execute', $this );
 
 	}
 
@@ -328,16 +321,14 @@ class Request
 	 * @return boolean
 	 * @throws \Exception
 	 */
-	protected function has_authentication_errors()
-	{
-
+	protected function has_authentication_errors() { 
 		/**
 		 * Bail if this is not an HTTP request.
 		 *
 		 * Auth for internal requests will happen
 		 * via WordPress internals.
 		 */
-		if (!is_graphql_http_request()) {
+		if ( ! is_graphql_http_request() ) {
 			return false;
 		}
 
@@ -357,12 +348,12 @@ class Request
 		 * If we get an auth error, but the user is still logged in, another auth mechanism
 		 * (JWT, oAuth, etc) must have been used.
 		 */
-		if (true !== $wp_rest_auth_cookie && is_user_logged_in()) {
+		if ( true !== $wp_rest_auth_cookie && is_user_logged_in() ) {
 
 			/**
 			 * Return filtered authentication errors
 			 */
-			return $this->filtered_authentication_errors($authentication_errors);
+			return $this->filtered_authentication_errors( $authentication_errors );
 
 			/**
 			 * If the user is not logged in, determine if there's a nonce
@@ -371,31 +362,31 @@ class Request
 
 			$nonce = null;
 
-			if (isset($_REQUEST['_wpnonce'])) {
+			if ( isset( $_REQUEST['_wpnonce'] ) ) {
 				$nonce = $_REQUEST['_wpnonce']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			} elseif (isset($_SERVER['HTTP_X_WP_NONCE'])) {
+			} elseif ( isset( $_SERVER['HTTP_X_WP_NONCE'] ) ) {
 				$nonce = $_SERVER['HTTP_X_WP_NONCE']; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			}
 
-			if (null === $nonce) {
+			if ( null === $nonce ) {
 				// No nonce at all, so act as if it's an unauthenticated request.
-				wp_set_current_user(0);
+				wp_set_current_user( 0 );
 
-				return $this->filtered_authentication_errors($authentication_errors);
+				return $this->filtered_authentication_errors( $authentication_errors );
 			}
 
 			// Check the nonce.
-			$result = wp_verify_nonce($nonce, 'wp_rest');
+			$result = wp_verify_nonce( $nonce, 'wp_rest' );
 
-			if (!$result) {
-				throw new Exception(__('Cookie nonce is invalid', 'wp-graphql'));
+			if ( ! $result ) {
+				throw new Exception( __( 'Cookie nonce is invalid', 'wp-graphql' ) );
 			}
 		}
 
 		/**
 		 * Return the filtered authentication errors
 		 */
-		return $this->filtered_authentication_errors($authentication_errors);
+		return $this->filtered_authentication_errors( $authentication_errors );
 	}
 
 	/**
@@ -407,8 +398,7 @@ class Request
 	 *
 	 * @return boolean
 	 */
-	protected function filtered_authentication_errors($authentication_errors = false)
-	{
+	protected function filtered_authentication_errors( $authentication_errors = false ) {
 
 		/**
 		 * If false, there are no authentication errors. If true, execution of the
@@ -417,7 +407,7 @@ class Request
 		 * @param boolean $authentication_errors Whether there are authentication errors with the request
 		 * @param \WPGraphQL\Request $request Instance of the Request
 		 */
-		return apply_filters('graphql_authentication_errors', $authentication_errors, $this);
+		return apply_filters( 'graphql_authentication_errors', $authentication_errors, $this );
 	}
 
 	/**
@@ -430,14 +420,13 @@ class Request
 	 *
 	 * @throws \Exception
 	 */
-	private function after_execute($response)
-	{
+	private function after_execute( $response ) {
 
 		/**
 		 * If there are authentication errors, prevent execution and throw an exception.
 		 */
-		if (false !== $this->has_authentication_errors()) {
-			throw new Exception(__('Authentication Error', 'wp-graphql'));
+		if ( false !== $this->has_authentication_errors() ) {
+			throw new Exception( __( 'Authentication Error', 'wp-graphql' ) );
 		}
 
 		/**
@@ -445,13 +434,13 @@ class Request
 		 * treat this as a batch request and map over the array to apply the
 		 * after_execute_actions, otherwise apply them to the current response
 		 */
-		if (is_array($this->params) && is_array($response)) {
+		if ( is_array( $this->params ) && is_array( $response ) ) {
 			$filtered_response = [];
-			foreach ($response as $key => $resp) {
-				$filtered_response[] = $this->after_execute_actions($resp, (int) $key);
+			foreach ( $response as $key => $resp ) {
+				$filtered_response[] = $this->after_execute_actions( $resp, (int) $key );
 			}
 		} else {
-			$filtered_response = $this->after_execute_actions($response, null);
+			$filtered_response = $this->after_execute_actions( $response, null );
 		}
 
 		/**
@@ -466,14 +455,14 @@ class Request
 		 * post with setup_postdata we cached before this request.
 		 */
 
-		if (!empty($this->global_wp_the_query)) {
+		if ( ! empty( $this->global_wp_the_query ) ) {
 			$GLOBALS['wp_the_query'] = $this->global_wp_the_query; // phpcs:ignore WordPress.WP.GlobalVariablesOverride
 			wp_reset_query(); // phpcs:ignore WordPress.WP.DiscouragedFunctions.wp_reset_query_wp_reset_query
 		}
 
-		if (!empty($this->global_post)) {
+		if ( ! empty( $this->global_post ) ) {
 			$GLOBALS['post'] = $this->global_post; // phpcs:ignore WordPress.WP.GlobalVariablesOverride
-			setup_postdata($this->global_post);
+			setup_postdata( $this->global_post );
 		}
 
 		/**
@@ -482,7 +471,7 @@ class Request
 		 * @param array   $filtered_response The response of the entire operation. Could be a single operation or a batch operation
 		 * @param \WPGraphQL\Request $request Instance of the Request being executed
 		 */
-		do_action('graphql_after_execute', $filtered_response, $this);
+		do_action( 'graphql_after_execute', $filtered_response, $this );
 
 		/**
 		 * Return the filtered response
@@ -499,27 +488,26 @@ class Request
 	 *
 	 * @return array
 	 */
-	private function after_execute_actions($response, $key = null)
-	{
+	private function after_execute_actions( $response, $key = null ) {
 
 		/**
 		 * Determine which params (batch or single request) to use when passing through to the actions
 		 */
-		$query = null;
+		$query     = null;
 		$operation = null;
 		$variables = null;
-		$query_id = null;
+		$query_id  = null;
 
-		if ($this->params instanceof OperationParams) {
+		if ( $this->params instanceof OperationParams ) {
 			$operation = $this->params->operation;
-			$query = $this->params->query;
-			$query_id = $this->params->queryId;
+			$query     = $this->params->query;
+			$query_id  = $this->params->queryId;
 			$variables = $this->params->variables;
-		} elseif (is_array($this->params)) {
-			$operation = $this->params[$key]->operation ?? '';
-			$query = $this->params[$key]->query ?? '';
-			$query_id = $this->params[$key]->queryId ?? null;
-			$variables = $this->params[$key]->variables ?? null;
+		} elseif ( is_array( $this->params ) ) {
+			$operation = $this->params[ $key ]->operation ?? '';
+			$query     = $this->params[ $key ]->query ?? '';
+			$query_id  = $this->params[ $key ]->queryId ?? null;
+			$variables = $this->params[ $key ]->variables ?? null;
 		}
 
 		/**
@@ -534,13 +522,13 @@ class Request
 		 *
 		 * @since 0.0.4
 		 */
-		do_action('graphql_execute', $response, $this->schema, $operation, $query, $variables, $this);
+		do_action( 'graphql_execute', $response, $this->schema, $operation, $query, $variables, $this );
 
 		/**
 		 * Add the debug log to the request
 		 */
-		if (!empty($response)) {
-			if (is_array($response)) {
+		if ( ! empty( $response ) ) {
+			if ( is_array( $response ) ) {
 				$response['extensions']['debug'] = $this->debug_log->get_logs();
 			} else {
 				$response->extensions['debug'] = $this->debug_log->get_logs();
@@ -571,7 +559,7 @@ class Request
 		 *
 		 * @since 0.0.5
 		 */
-		$filtered_response = apply_filters('graphql_request_results', $response, $this->schema, $operation, $query, $variables, $this, $query_id);
+		$filtered_response = apply_filters( 'graphql_request_results', $response, $this->schema, $operation, $query, $variables, $this, $query_id );
 
 		/**
 		 * Run an action after the response has been filtered, as the response is being returned.
@@ -586,12 +574,12 @@ class Request
 		 * @param \WPGraphQL\Request $request Instance of the Request
 		 * @param string|null $query_id          The query id that GraphQL executed
 		 */
-		do_action('graphql_return_response', $filtered_response, $response, $this->schema, $operation, $query, $variables, $this, $query_id);
+		do_action( 'graphql_return_response', $filtered_response, $response, $this->schema, $operation, $query, $variables, $this, $query_id );
 
 		/**
 		 * Filter "is_graphql_request" back to false.
 		 */
-		\WPGraphQL::set_is_graphql_request(false);
+		\WPGraphQL::set_is_graphql_request( false );
 
 		return $filtered_response;
 	}
@@ -603,8 +591,7 @@ class Request
 	 *
 	 * @return void
 	 */
-	private function do_action(OperationParams $params)
-	{
+	private function do_action( OperationParams $params ) {
 
 		/**
 		 * Run an action for each request.
@@ -614,7 +601,7 @@ class Request
 		 * @param ?array          $variables Variables to be passed to your GraphQL request
 		 * @param \GraphQL\Server\OperationParams $params The Operation Params. This includes any extra params, such as extenions or any other modifications to the request body
 		 */
-		do_action('do_graphql_request', $params->query, $params->operation, $params->variables, $params);
+		do_action( 'do_graphql_request', $params->query, $params->operation, $params->variables, $params );
 	}
 
 	/**
@@ -623,38 +610,36 @@ class Request
 	 * @return array|void
 	 * @throws \Exception
 	 */
-	public function execute()
-	{
-
+	public function execute() { 
 		$helper = new WPHelper();
 
-		if (!$this->data instanceof OperationParams) {
-			$this->params = $helper->parseRequestParams('POST', $this->data, []);
+		if ( ! $this->data instanceof OperationParams ) {
+			$this->params = $helper->parseRequestParams( 'POST', $this->data, [] );
 		} else {
 			$this->params = $this->data;
 		}
 
-		if (is_array($this->params)) {
-			return array_map(function ($data) {
+		if ( is_array( $this->params ) ) {
+			return array_map(function ( $data ) {
 				$this->data = $data;
 				return $this->execute();
 			}, $this->params);
-		} elseif ($this->params instanceof OperationParams) {
+		} elseif ( $this->params instanceof OperationParams ) {
 
 			/**
 			 * Initialize the GraphQL Request
 			 */
 			$this->before_execute();
-			$response = apply_filters('pre_graphql_execute_request', null, $this);
+			$response = apply_filters( 'pre_graphql_execute_request', null, $this );
 
-			if (null === $response) {
+			if ( null === $response ) {
 
 				/**
 				 * Allow the query string to be determined by a filter. Ex, when params->queryId is present, query can be retrieved.
 				 */
 				$query = apply_filters(
 					'graphql_execute_query_params',
-					isset($this->params->query) ? $this->params->query : '',
+					isset( $this->params->query ) ? $this->params->query : '',
 					$this->params
 				);
 
@@ -663,8 +648,8 @@ class Request
 					$query,
 					$this->root_value,
 					$this->app_context,
-					isset($this->params->variables) ? $this->params->variables : null,
-					isset($this->params->operation) ? $this->params->operation : null,
+					isset( $this->params->variables ) ? $this->params->variables : null,
+					isset( $this->params->operation ) ? $this->params->operation : null,
 					$this->field_resolver,
 					$this->validation_rules
 				);
@@ -672,22 +657,22 @@ class Request
 				/**
 				 * Return the result of the request
 				 */
-				$response = $result->toArray($this->get_debug_flag());
+				$response = $result->toArray( $this->get_debug_flag() );
 			}
 
 			/**
 			 * Ensure the response is returned as a proper, populated array. Otherwise add an error.
 			 */
-			if (empty($response) || !is_array($response)) {
+			if ( empty( $response ) || ! is_array( $response ) ) {
 				$response = [
-					'errors' => __('The GraphQL request returned an invalid response', 'wp-graphql'),
+					'errors' => __( 'The GraphQL request returned an invalid response', 'wp-graphql' ),
 				];
 			}
 
 			/**
 			 * If the request is a batch request it will come back as an array
 			 */
-			return $this->after_execute($response);
+			return $this->after_execute( $response );
 
 		}
 	}
@@ -698,13 +683,11 @@ class Request
 	 * @return array
 	 * @throws \Exception
 	 */
-	public function execute_http()
-	{
-
+	public function execute_http() { 
 		/**
 		 * Parse HTTP request.
 		 */
-		$helper = new WPHelper();
+		$helper       = new WPHelper();
 		$this->params = $helper->parseHttpRequest();
 
 		/**
@@ -715,17 +698,17 @@ class Request
 		/**
 		 * Get the response.
 		 */
-		$response = apply_filters('pre_graphql_execute_request', null, $this);
+		$response = apply_filters( 'pre_graphql_execute_request', null, $this );
 
 		/**
 		 * If no cached response, execute the query
 		 */
-		if (null === $response) {
-			$server = $this->get_server();
-			$response = $server->executeRequest($this->params);
+		if ( null === $response ) {
+			$server   = $this->get_server();
+			$response = $server->executeRequest( $this->params );
 		}
 
-		return $this->after_execute($response);
+		return $this->after_execute( $response );
 	}
 
 	/**
@@ -733,8 +716,7 @@ class Request
 	 *
 	 * @return \GraphQL\Server\OperationParams|\GraphQL\Server\OperationParams[]
 	 */
-	public function get_params()
-	{
+	public function get_params() {
 		return $this->params;
 	}
 
@@ -743,10 +725,9 @@ class Request
 	 *
 	 * @return int
 	 */
-	public function get_debug_flag()
-	{
+	public function get_debug_flag() {
 		$flag = DebugFlag::INCLUDE_DEBUG_MESSAGE;
-		if (0 !== get_current_user_id()) {
+		if ( 0 !== get_current_user_id() ) {
 			// Flag 2 shows the trace data, which should require user to be logged in to see by default
 			$flag = DebugFlag::INCLUDE_DEBUG_MESSAGE | DebugFlag::INCLUDE_TRACE;
 		}
@@ -761,13 +742,11 @@ class Request
 	 *
 	 * @return bool
 	 */
-	private function is_batch_queries_enabled()
-	{
-
+	private function is_batch_queries_enabled() { 
 		$batch_queries_enabled = true;
 
-		$batch_queries_setting = get_graphql_setting('batch_queries_enabled', 'on');
-		if ('off' === $batch_queries_setting) {
+		$batch_queries_setting = get_graphql_setting( 'batch_queries_enabled', 'on' );
+		if ( 'off' === $batch_queries_setting ) {
 			$batch_queries_enabled = false;
 		}
 
@@ -777,7 +756,7 @@ class Request
 		 * @param boolean         $batch_queries_enabled Whether Batch Queries should be enabled
 		 * @param \GraphQL\Server\OperationParams $params Request operation params
 		 */
-		return apply_filters('graphql_is_batch_queries_enabled', $batch_queries_enabled, $this->params);
+		return apply_filters( 'graphql_is_batch_queries_enabled', $batch_queries_enabled, $this->params );
 
 	}
 
@@ -786,25 +765,23 @@ class Request
 	 *
 	 * @return \GraphQL\Server\StandardServer
 	 */
-	private function get_server()
-	{
-
+	private function get_server() { 
 		$debug_flag = $this->get_debug_flag();
 
 		$config = new ServerConfig();
 		$config
-			->setDebugFlag($debug_flag)
-			->setSchema($this->schema)
-			->setContext($this->app_context)
-			->setValidationRules($this->validation_rules)
-			->setQueryBatching($this->is_batch_queries_enabled());
+			->setDebugFlag( $debug_flag )
+			->setSchema( $this->schema )
+			->setContext( $this->app_context )
+			->setValidationRules( $this->validation_rules )
+			->setQueryBatching( $this->is_batch_queries_enabled() );
 
-		if (!empty($this->root_value)) {
-			$config->setFieldResolver($this->root_value);
+		if ( ! empty( $this->root_value ) ) {
+			$config->setFieldResolver( $this->root_value );
 		}
 
-		if (!empty($this->field_resolver)) {
-			$config->setFieldResolver($this->field_resolver);
+		if ( ! empty( $this->field_resolver ) ) {
+			$config->setFieldResolver( $this->field_resolver );
 		}
 
 		/**
@@ -817,9 +794,9 @@ class Request
 		 *
 		 * @since 0.2.0
 		 */
-		do_action('graphql_server_config', $config, $this->params);
+		do_action( 'graphql_server_config', $config, $this->params );
 
-		return new StandardServer($config);
+		return new StandardServer( $config );
 
 	}
 }

--- a/src/Request.php
+++ b/src/Request.php
@@ -26,7 +26,8 @@ use WPGraphQL\Utils\QueryAnalyzer;
  *
  * @package WPGraphQL
  */
-class Request {
+class Request
+{
 
 	/**
 	 * App context for this request.
@@ -120,21 +121,22 @@ class Request {
 	 *
 	 * @throws \Exception
 	 */
-	public function __construct( array $data = [] ) {
+	public function __construct(array $data = [])
+	{
 
 		/**
 		 * Whether it's a GraphQL Request (http or internal)
 		 *
 		 * @since 0.0.5
 		 */
-		if ( ! defined( 'GRAPHQL_REQUEST' ) ) {
-			define( 'GRAPHQL_REQUEST', true );
+		if (!defined('GRAPHQL_REQUEST')) {
+			define('GRAPHQL_REQUEST', true);
 		}
 
 		/**
 		 * Filter "is_graphql_request" to return true
 		 */
-		\WPGraphQL::set_is_graphql_request( true );
+		\WPGraphQL::set_is_graphql_request(true);
 
 		/**
 		 * Action – intentionally with no context – to indicate a GraphQL Request has started.
@@ -142,7 +144,7 @@ class Request {
 		 * occur in the context of a GraphQL Request. The base class hooks into this action to
 		 * kick off the schema creation, so types are not set up until this action has run!
 		 */
-		do_action( 'init_graphql_request' );
+		do_action('init_graphql_request');
 
 		// Start tracking debug log messages
 		$this->debug_log = new DebugLog();
@@ -159,23 +161,23 @@ class Request {
 		// Get the App Context
 		$this->app_context = \WPGraphQL::get_app_context();
 
-		$this->root_value       = $this->get_root_value();
+		$this->root_value = $this->get_root_value();
 		$this->validation_rules = $this->get_validation_rules();
-		$this->field_resolver   = $this->get_field_resolver();
+		$this->field_resolver = $this->get_field_resolver();
 
 		/**
 		 * Configure the app_context which gets passed down to all the resolvers.
 		 *
 		 * @since 0.0.4
 		 */
-		$app_context                = new AppContext();
-		$app_context->viewer        = wp_get_current_user();
-		$app_context->root_url      = get_bloginfo( 'url' );
-		$app_context->request       = ! empty( $_REQUEST ) ? $_REQUEST : null; // phpcs:ignore
+		$app_context = new AppContext();
+		$app_context->viewer = wp_get_current_user();
+		$app_context->root_url = get_bloginfo('url');
+		$app_context->request = !empty($_REQUEST) ? $_REQUEST : null; // phpcs:ignore
 		$app_context->type_registry = $this->type_registry;
-		$this->app_context          = $app_context;
+		$this->app_context = $app_context;
 
-		$this->query_analyzer = new QueryAnalyzer( $this );
+		$this->query_analyzer = new QueryAnalyzer($this);
 
 		// The query analyzer tracks nodes, models, list types and more
 		// to return in headers and debug messages to help developers understand
@@ -187,14 +189,16 @@ class Request {
 	/**
 	 * @return \WPGraphQL\Utils\QueryAnalyzer
 	 */
-	public function get_query_analyzer(): QueryAnalyzer {
+	public function get_query_analyzer(): QueryAnalyzer
+	{
 		return $this->query_analyzer;
 	}
 
 	/**
 	 * @return mixed
 	 */
-	protected function get_field_resolver() {
+	protected function get_field_resolver()
+	{
 		return $this->field_resolver;
 	}
 
@@ -203,13 +207,14 @@ class Request {
 	 *
 	 * @return array
 	 */
-	protected function get_validation_rules(): array {
+	protected function get_validation_rules(): array
+	{
 
 		$validation_rules = GraphQL::getStandardValidationRules();
 
 		$validation_rules['require_authentication'] = new RequireAuthentication();
-		$validation_rules['disable_introspection']  = new DisableIntrospection();
-		$validation_rules['query_depth']            = new QueryDepth();
+		$validation_rules['disable_introspection'] = new DisableIntrospection();
+		$validation_rules['query_depth'] = new QueryDepth();
 
 		/**
 		 * Return the validation rules to use in the request
@@ -217,7 +222,7 @@ class Request {
 		 * @param array   $validation_rules The validation rules to use in the request
 		 * @param \WPGraphQL\Request $request The Request instance
 		 */
-		return apply_filters( 'graphql_validation_rules', $validation_rules, $this );
+		return apply_filters('graphql_validation_rules', $validation_rules, $this);
 
 	}
 
@@ -226,12 +231,13 @@ class Request {
 	 *
 	 * @return mixed|null
 	 */
-	protected function get_root_value() {
+	protected function get_root_value()
+	{
 
 		/**
 		 * Set the root value based on what was passed to the request
 		 */
-		$root_value = isset( $this->data['root_value'] ) && ! empty( $this->data['root_value'] ) ? $this->data['root_value'] : null;
+		$root_value = isset($this->data['root_value']) && !empty($this->data['root_value']) ? $this->data['root_value'] : null;
 
 		/**
 		 * Return the filtered root value
@@ -239,7 +245,7 @@ class Request {
 		 * @param mixed   $root_value The root value the Schema should use to resolve with. Default null.
 		 * @param \WPGraphQL\Request $request The Request instance
 		 */
-		return apply_filters( 'graphql_root_value', $root_value, $this );
+		return apply_filters('graphql_root_value', $root_value, $this);
 	}
 
 	/**
@@ -248,7 +254,8 @@ class Request {
 	 * @return void
 	 * @throws \GraphQL\Error\Error
 	 */
-	private function before_execute(): void {
+	private function before_execute(): void
+	{
 
 		/**
 		 * Store the global post so that it can be reset after GraphQL execution
@@ -257,33 +264,33 @@ class Request {
 		 * without disrupting the flow of the post as the global POST before and after GraphQL execution will be
 		 * the same.
 		 */
-		if ( ! empty( $GLOBALS['post'] ) ) {
+		if (!empty($GLOBALS['post'])) {
 			$this->global_post = $GLOBALS['post'];
 		}
 
-		if ( ! empty( $GLOBALS['wp_query'] ) ) {
+		if (!empty($GLOBALS['wp_query'])) {
 			$this->global_wp_the_query = clone $GLOBALS['wp_the_query'];
 		}
 
 		/**
 		 * If the request is a batch request it will come back as an array
 		 */
-		if ( is_array( $this->params ) ) {
+		if (is_array($this->params)) {
 
 			// If the request is a batch request, but batch requests are disabled,
 			// bail early
-			if ( ! $this->is_batch_queries_enabled() ) {
-				throw new Error( __( 'Batch Queries are not supported', 'wp-graphql' ) );
+			if (!$this->is_batch_queries_enabled()) {
+				throw new Error(__('Batch Queries are not supported', 'wp-graphql'));
 			}
 
-			$batch_limit = get_graphql_setting( 'batch_limit', 10 );
-			$batch_limit = absint( $batch_limit ) ? absint( $batch_limit ) : 10;
+			$batch_limit = get_graphql_setting('batch_limit', 10);
+			$batch_limit = absint($batch_limit) ? absint($batch_limit) : 10;
 
 			// If batch requests are enabled, but a limit is set and the request exceeds the limit
 			// fail now
-			if ( $batch_limit < count( $this->params ) ) {
+			if ($batch_limit < count($this->params)) {
 				// translators: First placeholder is the max number of batch operations allowed in a GraphQL request. The 2nd placeholder is the number of operations requested in the current request.
-				throw new Error( sprintf( __( 'Batch requests are limited to %1$d operations. This request contained %2$d', 'wp-graphql' ), absint( $batch_limit ), count( $this->params ) ) );
+				throw new Error(sprintf(__('Batch requests are limited to %1$d operations. This request contained %2$d', 'wp-graphql'), absint($batch_limit), count($this->params)));
 			}
 
 			/**
@@ -291,13 +298,13 @@ class Request {
 			 *
 			 * @param \GraphQL\Server\OperationParams[] $params The operation params of the batch request
 			 */
-			do_action( 'graphql_execute_batch_queries', $this->params );
+			do_action('graphql_execute_batch_queries', $this->params);
 
 			// Process the batched requests
-			array_walk( $this->params, [ $this, 'do_action' ] );
+			array_walk($this->params, [$this, 'do_action']);
 
 		} else {
-			$this->do_action( $this->params );
+			$this->do_action($this->params);
 		}
 
 		/**
@@ -305,7 +312,7 @@ class Request {
 		 *
 		 * @param \WPGraphQL\Request $request The instance of the Request being executed
 		 */
-		do_action( 'graphql_before_execute', $this );
+		do_action('graphql_before_execute', $this);
 
 	}
 
@@ -321,7 +328,8 @@ class Request {
 	 * @return boolean
 	 * @throws \Exception
 	 */
-	protected function has_authentication_errors() {
+	protected function has_authentication_errors()
+	{
 
 		/**
 		 * Bail if this is not an HTTP request.
@@ -329,7 +337,7 @@ class Request {
 		 * Auth for internal requests will happen
 		 * via WordPress internals.
 		 */
-		if ( ! is_graphql_http_request() ) {
+		if (!is_graphql_http_request()) {
 			return false;
 		}
 
@@ -349,12 +357,12 @@ class Request {
 		 * If we get an auth error, but the user is still logged in, another auth mechanism
 		 * (JWT, oAuth, etc) must have been used.
 		 */
-		if ( true !== $wp_rest_auth_cookie && is_user_logged_in() ) {
+		if (true !== $wp_rest_auth_cookie && is_user_logged_in()) {
 
 			/**
 			 * Return filtered authentication errors
 			 */
-			return $this->filtered_authentication_errors( $authentication_errors );
+			return $this->filtered_authentication_errors($authentication_errors);
 
 			/**
 			 * If the user is not logged in, determine if there's a nonce
@@ -363,31 +371,31 @@ class Request {
 
 			$nonce = null;
 
-			if ( isset( $_REQUEST['_wpnonce'] ) ) {
+			if (isset($_REQUEST['_wpnonce'])) {
 				$nonce = $_REQUEST['_wpnonce']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			} elseif ( isset( $_SERVER['HTTP_X_WP_NONCE'] ) ) {
+			} elseif (isset($_SERVER['HTTP_X_WP_NONCE'])) {
 				$nonce = $_SERVER['HTTP_X_WP_NONCE']; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			}
 
-			if ( null === $nonce ) {
+			if (null === $nonce) {
 				// No nonce at all, so act as if it's an unauthenticated request.
-				wp_set_current_user( 0 );
+				wp_set_current_user(0);
 
-				return $this->filtered_authentication_errors( $authentication_errors );
+				return $this->filtered_authentication_errors($authentication_errors);
 			}
 
 			// Check the nonce.
-			$result = wp_verify_nonce( $nonce, 'wp_rest' );
+			$result = wp_verify_nonce($nonce, 'wp_rest');
 
-			if ( ! $result ) {
-				throw new Exception( __( 'Cookie nonce is invalid', 'wp-graphql' ) );
+			if (!$result) {
+				throw new Exception(__('Cookie nonce is invalid', 'wp-graphql'));
 			}
 		}
 
 		/**
 		 * Return the filtered authentication errors
 		 */
-		return $this->filtered_authentication_errors( $authentication_errors );
+		return $this->filtered_authentication_errors($authentication_errors);
 	}
 
 	/**
@@ -399,7 +407,8 @@ class Request {
 	 *
 	 * @return boolean
 	 */
-	protected function filtered_authentication_errors( $authentication_errors = false ) {
+	protected function filtered_authentication_errors($authentication_errors = false)
+	{
 
 		/**
 		 * If false, there are no authentication errors. If true, execution of the
@@ -408,7 +417,7 @@ class Request {
 		 * @param boolean $authentication_errors Whether there are authentication errors with the request
 		 * @param \WPGraphQL\Request $request Instance of the Request
 		 */
-		return apply_filters( 'graphql_authentication_errors', $authentication_errors, $this );
+		return apply_filters('graphql_authentication_errors', $authentication_errors, $this);
 	}
 
 	/**
@@ -421,13 +430,14 @@ class Request {
 	 *
 	 * @throws \Exception
 	 */
-	private function after_execute( $response ) {
+	private function after_execute($response)
+	{
 
 		/**
 		 * If there are authentication errors, prevent execution and throw an exception.
 		 */
-		if ( false !== $this->has_authentication_errors() ) {
-			throw new Exception( __( 'Authentication Error', 'wp-graphql' ) );
+		if (false !== $this->has_authentication_errors()) {
+			throw new Exception(__('Authentication Error', 'wp-graphql'));
 		}
 
 		/**
@@ -435,13 +445,13 @@ class Request {
 		 * treat this as a batch request and map over the array to apply the
 		 * after_execute_actions, otherwise apply them to the current response
 		 */
-		if ( is_array( $this->params ) && is_array( $response ) ) {
+		if (is_array($this->params) && is_array($response)) {
 			$filtered_response = [];
-			foreach ( $response as $key => $resp ) {
-				$filtered_response[] = $this->after_execute_actions( $resp, (int) $key );
+			foreach ($response as $key => $resp) {
+				$filtered_response[] = $this->after_execute_actions($resp, (int) $key);
 			}
 		} else {
-			$filtered_response = $this->after_execute_actions( $response, null );
+			$filtered_response = $this->after_execute_actions($response, null);
 		}
 
 		/**
@@ -456,14 +466,14 @@ class Request {
 		 * post with setup_postdata we cached before this request.
 		 */
 
-		if ( ! empty( $this->global_wp_the_query ) ) {
+		if (!empty($this->global_wp_the_query)) {
 			$GLOBALS['wp_the_query'] = $this->global_wp_the_query; // phpcs:ignore WordPress.WP.GlobalVariablesOverride
 			wp_reset_query(); // phpcs:ignore WordPress.WP.DiscouragedFunctions.wp_reset_query_wp_reset_query
 		}
 
-		if ( ! empty( $this->global_post ) ) {
+		if (!empty($this->global_post)) {
 			$GLOBALS['post'] = $this->global_post; // phpcs:ignore WordPress.WP.GlobalVariablesOverride
-			setup_postdata( $this->global_post );
+			setup_postdata($this->global_post);
 		}
 
 		/**
@@ -472,7 +482,7 @@ class Request {
 		 * @param array   $filtered_response The response of the entire operation. Could be a single operation or a batch operation
 		 * @param \WPGraphQL\Request $request Instance of the Request being executed
 		 */
-		do_action( 'graphql_after_execute', $filtered_response, $this );
+		do_action('graphql_after_execute', $filtered_response, $this);
 
 		/**
 		 * Return the filtered response
@@ -485,30 +495,31 @@ class Request {
 	 * Apply filters and do actions after GraphQL execution
 	 *
 	 * @param mixed|array|object $response The response for your GraphQL request
-	 * @param mixed|Int|null     $key      The array key of the params for batch requests
+	 * @param mixed|int|null     $key      The array key of the params for batch requests
 	 *
 	 * @return array
 	 */
-	private function after_execute_actions( $response, $key = null ) {
+	private function after_execute_actions($response, $key = null)
+	{
 
 		/**
 		 * Determine which params (batch or single request) to use when passing through to the actions
 		 */
-		$query     = null;
+		$query = null;
 		$operation = null;
 		$variables = null;
-		$query_id  = null;
+		$query_id = null;
 
-		if ( $this->params instanceof OperationParams ) {
+		if ($this->params instanceof OperationParams) {
 			$operation = $this->params->operation;
-			$query     = $this->params->query;
-			$query_id  = $this->params->queryId;
+			$query = $this->params->query;
+			$query_id = $this->params->queryId;
 			$variables = $this->params->variables;
-		} elseif ( is_array( $this->params ) ) {
-			$operation = $this->params[ $key ]->operation ?? '';
-			$query     = $this->params[ $key ]->query ?? '';
-			$query_id  = $this->params[ $key ]->queryId ?? null;
-			$variables = $this->params[ $key ]->variables ?? null;
+		} elseif (is_array($this->params)) {
+			$operation = $this->params[$key]->operation ?? '';
+			$query = $this->params[$key]->query ?? '';
+			$query_id = $this->params[$key]->queryId ?? null;
+			$variables = $this->params[$key]->variables ?? null;
 		}
 
 		/**
@@ -523,13 +534,13 @@ class Request {
 		 *
 		 * @since 0.0.4
 		 */
-		do_action( 'graphql_execute', $response, $this->schema, $operation, $query, $variables, $this );
+		do_action('graphql_execute', $response, $this->schema, $operation, $query, $variables, $this);
 
 		/**
 		 * Add the debug log to the request
 		 */
-		if ( ! empty( $response ) ) {
-			if ( is_array( $response ) ) {
+		if (!empty($response)) {
+			if (is_array($response)) {
 				$response['extensions']['debug'] = $this->debug_log->get_logs();
 			} else {
 				$response->extensions['debug'] = $this->debug_log->get_logs();
@@ -560,7 +571,7 @@ class Request {
 		 *
 		 * @since 0.0.5
 		 */
-		$filtered_response = apply_filters( 'graphql_request_results', $response, $this->schema, $operation, $query, $variables, $this, $query_id );
+		$filtered_response = apply_filters('graphql_request_results', $response, $this->schema, $operation, $query, $variables, $this, $query_id);
 
 		/**
 		 * Run an action after the response has been filtered, as the response is being returned.
@@ -575,12 +586,12 @@ class Request {
 		 * @param \WPGraphQL\Request $request Instance of the Request
 		 * @param string|null $query_id          The query id that GraphQL executed
 		 */
-		do_action( 'graphql_return_response', $filtered_response, $response, $this->schema, $operation, $query, $variables, $this, $query_id );
+		do_action('graphql_return_response', $filtered_response, $response, $this->schema, $operation, $query, $variables, $this, $query_id);
 
 		/**
 		 * Filter "is_graphql_request" back to false.
 		 */
-		\WPGraphQL::set_is_graphql_request( false );
+		\WPGraphQL::set_is_graphql_request(false);
 
 		return $filtered_response;
 	}
@@ -592,7 +603,8 @@ class Request {
 	 *
 	 * @return void
 	 */
-	private function do_action( OperationParams $params ) {
+	private function do_action(OperationParams $params)
+	{
 
 		/**
 		 * Run an action for each request.
@@ -602,56 +614,57 @@ class Request {
 		 * @param ?array          $variables Variables to be passed to your GraphQL request
 		 * @param \GraphQL\Server\OperationParams $params The Operation Params. This includes any extra params, such as extenions or any other modifications to the request body
 		 */
-		do_action( 'do_graphql_request', $params->query, $params->operation, $params->variables, $params );
+		do_action('do_graphql_request', $params->query, $params->operation, $params->variables, $params);
 	}
 
 	/**
 	 * Execute an internal request (graphql() function call).
 	 *
-	 * @return array
+	 * @return array|void
 	 * @throws \Exception
 	 */
-	public function execute() {
+	public function execute()
+	{
 
 		$helper = new WPHelper();
 
-		if ( ! $this->data instanceof OperationParams ) {
-			$this->params = $helper->parseRequestParams( 'POST', $this->data, [] );
+		if (!$this->data instanceof OperationParams) {
+			$this->params = $helper->parseRequestParams('POST', $this->data, []);
 		} else {
 			$this->params = $this->data;
 		}
 
-		if ( is_array( $this->params ) ) {
-			return array_map( function ( $data ) {
+		if (is_array($this->params)) {
+			return array_map(function ($data) {
 				$this->data = $data;
 				return $this->execute();
-			}, $this->params );
-		} elseif ( $this->params instanceof OperationParams ) {
+			}, $this->params);
+		} elseif ($this->params instanceof OperationParams) {
 
 			/**
 			 * Initialize the GraphQL Request
 			 */
 			$this->before_execute();
-			$response = apply_filters( 'pre_graphql_execute_request', null, $this );
+			$response = apply_filters('pre_graphql_execute_request', null, $this);
 
-			if ( null === $response ) {
+			if (null === $response) {
 
 				/**
 				 * Allow the query string to be determined by a filter. Ex, when params->queryId is present, query can be retrieved.
 				 */
 				$query = apply_filters(
 					'graphql_execute_query_params',
-					isset( $this->params->query ) ? $this->params->query : '',
+					isset($this->params->query) ? $this->params->query : '',
 					$this->params
 				);
 
-				$result = \GraphQL\GraphQL::executeQuery(
+				$result = GraphQL::executeQuery(
 					$this->schema,
 					$query,
 					$this->root_value,
 					$this->app_context,
-					isset( $this->params->variables ) ? $this->params->variables : null,
-					isset( $this->params->operation ) ? $this->params->operation : null,
+					isset($this->params->variables) ? $this->params->variables : null,
+					isset($this->params->operation) ? $this->params->operation : null,
 					$this->field_resolver,
 					$this->validation_rules
 				);
@@ -659,22 +672,22 @@ class Request {
 				/**
 				 * Return the result of the request
 				 */
-				$response = $result->toArray( $this->get_debug_flag() );
+				$response = $result->toArray($this->get_debug_flag());
 			}
 
 			/**
 			 * Ensure the response is returned as a proper, populated array. Otherwise add an error.
 			 */
-			if ( empty( $response ) || ! is_array( $response ) ) {
+			if (empty($response) || !is_array($response)) {
 				$response = [
-					'errors' => __( 'The GraphQL request returned an invalid response', 'wp-graphql' ),
+					'errors' => __('The GraphQL request returned an invalid response', 'wp-graphql'),
 				];
 			}
 
 			/**
 			 * If the request is a batch request it will come back as an array
 			 */
-			return $this->after_execute( $response );
+			return $this->after_execute($response);
 
 		}
 	}
@@ -685,12 +698,13 @@ class Request {
 	 * @return array
 	 * @throws \Exception
 	 */
-	public function execute_http() {
+	public function execute_http()
+	{
 
 		/**
 		 * Parse HTTP request.
 		 */
-		$helper       = new WPHelper();
+		$helper = new WPHelper();
 		$this->params = $helper->parseHttpRequest();
 
 		/**
@@ -701,17 +715,17 @@ class Request {
 		/**
 		 * Get the response.
 		 */
-		$response = apply_filters( 'pre_graphql_execute_request', null, $this );
+		$response = apply_filters('pre_graphql_execute_request', null, $this);
 
 		/**
 		 * If no cached response, execute the query
 		 */
-		if ( null === $response ) {
-			$server   = $this->get_server();
-			$response = $server->executeRequest( $this->params );
+		if (null === $response) {
+			$server = $this->get_server();
+			$response = $server->executeRequest($this->params);
 		}
 
-		return $this->after_execute( $response );
+		return $this->after_execute($response);
 	}
 
 	/**
@@ -719,7 +733,8 @@ class Request {
 	 *
 	 * @return \GraphQL\Server\OperationParams|\GraphQL\Server\OperationParams[]
 	 */
-	public function get_params() {
+	public function get_params()
+	{
 		return $this->params;
 	}
 
@@ -728,9 +743,10 @@ class Request {
 	 *
 	 * @return int
 	 */
-	public function get_debug_flag() {
+	public function get_debug_flag()
+	{
 		$flag = DebugFlag::INCLUDE_DEBUG_MESSAGE;
-		if ( 0 !== get_current_user_id() ) {
+		if (0 !== get_current_user_id()) {
 			// Flag 2 shows the trace data, which should require user to be logged in to see by default
 			$flag = DebugFlag::INCLUDE_DEBUG_MESSAGE | DebugFlag::INCLUDE_TRACE;
 		}
@@ -745,12 +761,13 @@ class Request {
 	 *
 	 * @return bool
 	 */
-	private function is_batch_queries_enabled() {
+	private function is_batch_queries_enabled()
+	{
 
 		$batch_queries_enabled = true;
 
-		$batch_queries_setting = get_graphql_setting( 'batch_queries_enabled', 'on' );
-		if ( 'off' === $batch_queries_setting ) {
+		$batch_queries_setting = get_graphql_setting('batch_queries_enabled', 'on');
+		if ('off' === $batch_queries_setting) {
 			$batch_queries_enabled = false;
 		}
 
@@ -760,7 +777,7 @@ class Request {
 		 * @param boolean         $batch_queries_enabled Whether Batch Queries should be enabled
 		 * @param \GraphQL\Server\OperationParams $params Request operation params
 		 */
-		return apply_filters( 'graphql_is_batch_queries_enabled', $batch_queries_enabled, $this->params );
+		return apply_filters('graphql_is_batch_queries_enabled', $batch_queries_enabled, $this->params);
 
 	}
 
@@ -769,24 +786,25 @@ class Request {
 	 *
 	 * @return \GraphQL\Server\StandardServer
 	 */
-	private function get_server() {
+	private function get_server()
+	{
 
 		$debug_flag = $this->get_debug_flag();
 
 		$config = new ServerConfig();
 		$config
-			->setDebugFlag( $debug_flag )
-			->setSchema( $this->schema )
-			->setContext( $this->app_context )
-			->setValidationRules( $this->validation_rules )
-			->setQueryBatching( $this->is_batch_queries_enabled() );
+			->setDebugFlag($debug_flag)
+			->setSchema($this->schema)
+			->setContext($this->app_context)
+			->setValidationRules($this->validation_rules)
+			->setQueryBatching($this->is_batch_queries_enabled());
 
-		if ( ! empty( $this->root_value ) ) {
-			$config->setFieldResolver( $this->root_value );
+		if (!empty($this->root_value)) {
+			$config->setFieldResolver($this->root_value);
 		}
 
-		if ( ! empty( $this->field_resolver ) ) {
-			$config->setFieldResolver( $this->field_resolver );
+		if (!empty($this->field_resolver)) {
+			$config->setFieldResolver($this->field_resolver);
 		}
 
 		/**
@@ -799,9 +817,9 @@ class Request {
 		 *
 		 * @since 0.2.0
 		 */
-		do_action( 'graphql_server_config', $config, $this->params );
+		do_action('graphql_server_config', $config, $this->params);
 
-		return new StandardServer( $config );
+		return new StandardServer($config);
 
 	}
 }

--- a/src/Request.php
+++ b/src/Request.php
@@ -678,7 +678,6 @@ class Request {
 
 		}
 
-		return [];
 	}
 
 	/**

--- a/src/Request.php
+++ b/src/Request.php
@@ -227,7 +227,7 @@ class Request {
 	 *
 	 * @return mixed|null
 	 */
-	protected function get_root_value() { 
+	protected function get_root_value() {
 		/**
 		 * Set the root value based on what was passed to the request
 		 */
@@ -321,7 +321,7 @@ class Request {
 	 * @return boolean
 	 * @throws \Exception
 	 */
-	protected function has_authentication_errors() { 
+	protected function has_authentication_errors() {
 		/**
 		 * Bail if this is not an HTTP request.
 		 *
@@ -607,10 +607,10 @@ class Request {
 	/**
 	 * Execute an internal request (graphql() function call).
 	 *
-	 * @return array|void
+	 * @return array
 	 * @throws \Exception
 	 */
-	public function execute() { 
+	public function execute(): array {
 		$helper = new WPHelper();
 
 		if ( ! $this->data instanceof OperationParams ) {
@@ -624,7 +624,9 @@ class Request {
 				$this->data = $data;
 				return $this->execute();
 			}, $this->params);
-		} elseif ( $this->params instanceof OperationParams ) {
+		}
+
+		if ( $this->params instanceof OperationParams ) {
 
 			/**
 			 * Initialize the GraphQL Request
@@ -675,6 +677,8 @@ class Request {
 			return $this->after_execute( $response );
 
 		}
+
+		return [];
 	}
 
 	/**
@@ -683,7 +687,7 @@ class Request {
 	 * @return array
 	 * @throws \Exception
 	 */
-	public function execute_http() { 
+	public function execute_http() {
 		/**
 		 * Parse HTTP request.
 		 */
@@ -742,7 +746,7 @@ class Request {
 	 *
 	 * @return bool
 	 */
-	private function is_batch_queries_enabled() { 
+	private function is_batch_queries_enabled() {
 		$batch_queries_enabled = true;
 
 		$batch_queries_setting = get_graphql_setting( 'batch_queries_enabled', 'on' );
@@ -765,7 +769,7 @@ class Request {
 	 *
 	 * @return \GraphQL\Server\StandardServer
 	 */
-	private function get_server() { 
+	private function get_server() {
 		$debug_flag = $this->get_debug_flag();
 
 		$config = new ServerConfig();

--- a/src/Type/WPConnectionType.php
+++ b/src/Type/WPConnectionType.php
@@ -133,8 +133,11 @@ class WPConnectionType {
 	/**
 	 * WPConnectionType constructor.
 	 *
-	 * @param array        $config The config array for the connection
-	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry Instance of the WPGraphQL Type Registry
+	 * @param array                            $config        The config array for the connection
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry Instance of the WPGraphQL Type
+	 *                                                        Registry
+	 *
+	 * @throws \Exception
 	 */
 	public function __construct( array $config, TypeRegistry $type_registry ) {
 
@@ -514,12 +517,12 @@ class WPConnectionType {
 			$this->from_type,
 			$this->from_field_name,
 			[
-				'type'              => true === $this->one_to_one ? $this->connection_name . 'Edge' : $this->connection_name,
-				'args'              => array_merge( $this->get_pagination_args(), $this->where_args ),
-				'auth'              => $this->auth,
-				'deprecationReason' => ! empty( $this->config['deprecationReason'] ) ? $this->config['deprecationReason'] : null,
-				'description'       => ! empty( $this->config['description'] ) ? $this->config['description'] : sprintf( __( 'Connection between the %1$s type and the %2$s type', 'wp-graphql' ), $this->from_type, $this->to_type ),
-				'resolve'           => function ( $root, $args, $context, $info ) {
+				'type'                    => true === $this->one_to_one ? $this->connection_name . 'Edge' : $this->connection_name,
+				'args'                    => array_merge( $this->get_pagination_args(), $this->where_args ),
+				'auth'                    => $this->auth,
+				'deprecationReason'       => ! empty( $this->config['deprecationReason'] ) ? $this->config['deprecationReason'] : null,
+				'description'             => ! empty( $this->config['description'] ) ? $this->config['description'] : sprintf( __( 'Connection between the %1$s type and the %2$s type', 'wp-graphql' ), $this->from_type, $this->to_type ),
+				'resolve'                 => function ( $root, $args, $context, $info ) {
 					$context->connection_query_class = $this->query_class;
 					$resolve_connection              = $this->resolve_connection;
 
@@ -528,6 +531,7 @@ class WPConnectionType {
 					 */
 					return $resolve_connection( $root, $args, $context, $info );
 				},
+				'allow_field_underscores' => isset( $this->config['allow_field_underscores'] ) && true === $this->config['allow_field_underscores'],
 			]
 		);
 

--- a/src/Type/WPConnectionType.php
+++ b/src/Type/WPConnectionType.php
@@ -531,7 +531,7 @@ class WPConnectionType {
 					 */
 					return $resolve_connection( $root, $args, $context, $info );
 				},
-				'allow_field_underscores' => isset( $this->config['allow_field_underscores'] ) && true === $this->config['allow_field_underscores'],
+				'allowFieldUnderscores' => isset( $this->config['allowFieldUnderscores'] ) && true === $this->config['allowFieldUnderscores'],
 			]
 		);
 

--- a/src/Type/WPMutationType.php
+++ b/src/Type/WPMutationType.php
@@ -294,29 +294,33 @@ class WPMutationType {
 
 	/**
 	 * Registers the mutation in the Graph.
+	 *
+	 * @throws \Exception
 	 */
 	protected function register_mutation_field() : void {
-		$field_name = Utils::format_field_name( $this->mutation_name );
-		$this->type_registry->register_field(
-			'rootMutation',
-			$field_name,
-			array_merge( $this->config,
-				[
-					'args'        => [
-						'input' => [
-							'type'              => [ 'non_null' => $this->mutation_name . 'Input' ],
-							'description'       => sprintf( __( 'Input for the %s mutation', 'wp-graphql' ), $this->mutation_name ),
-							'deprecationReason' => ! empty( $this->config['deprecationReason'] ) ? $this->config['deprecationReason'] : null,
-						],
+
+		$field_config = array_merge( $this->config,
+			[
+				'args'        => [
+					'input' => [
+						'type'              => [ 'non_null' => $this->mutation_name . 'Input' ],
+						'description'       => sprintf( __( 'Input for the %s mutation', 'wp-graphql' ), $this->mutation_name ),
+						'deprecationReason' => ! empty( $this->config['deprecationReason'] ) ? $this->config['deprecationReason'] : null,
 					],
-					'auth'        => $this->auth,
-					'description' => ! empty( $this->config['description'] ) ? $this->config['description'] : sprintf( __( 'The %s mutation', 'wp-graphql' ), $this->mutation_name ),
-					'isPrivate'   => $this->is_private,
-					'type'        => $this->mutation_name . 'Payload',
-					'resolve'     => $this->resolve_mutation,
-					'name'        => $field_name,
-				]
-			)
+				],
+				'auth'        => $this->auth,
+				'description' => ! empty( $this->config['description'] ) ? $this->config['description'] : sprintf( __( 'The %s mutation', 'wp-graphql' ), $this->mutation_name ),
+				'isPrivate'   => $this->is_private,
+				'type'        => $this->mutation_name . 'Payload',
+				'resolve'     => $this->resolve_mutation,
+				'name'        => lcfirst( $this->mutation_name ),
+			]
+		);
+
+		$this->type_registry->register_field(
+			'RootMutation',
+			lcfirst( $this->mutation_name ),
+			$field_config
 		);
 	}
 

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -106,11 +106,11 @@ class Utils {
 	 * Given a field name, formats it for GraphQL
 	 *
 	 * @param string $field_name         The field name to format
-	 * @param ?bool   $allow_underscores  Whether the field should be formatted with underscores allowed. Default false.
+	 * @param bool   $allow_underscores  Whether the field should be formatted with underscores allowed. Default false.
 	 *
 	 * @return string
 	 */
-	public static function format_field_name( string $field_name, ?bool $allow_underscores = false ): string {
+	public static function format_field_name( string $field_name, bool $allow_underscores = false ): string {
 
 		$replaced = preg_replace( '[^a-zA-Z0-9 -]', '_', $field_name );
 

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -105,11 +105,12 @@ class Utils {
 	/**
 	 * Given a field name, formats it for GraphQL
 	 *
-	 * @param string $field_name The field name to format
+	 * @param string $field_name         The field name to format
+	 * @param ?bool   $allow_underscores  Whether the field should be formatted with underscores allowed. Default false.
 	 *
 	 * @return string
 	 */
-	public static function format_field_name( string $field_name ) {
+	public static function format_field_name( string $field_name, ?bool $allow_underscores = false ): string {
 
 		$replaced = preg_replace( '[^a-zA-Z0-9 -]', '_', $field_name );
 
@@ -118,12 +119,24 @@ class Utils {
 			$field_name = $replaced;
 		}
 
-		$field_name = lcfirst( $field_name );
-		$field_name = lcfirst( str_replace( '_', ' ', ucwords( $field_name, '_' ) ) );
-		$field_name = lcfirst( str_replace( '-', ' ', ucwords( $field_name, '_' ) ) );
-		$field_name = lcfirst( str_replace( ' ', '', ucwords( $field_name, ' ' ) ) );
+		$formatted_field_name = lcfirst( $field_name );
 
-		return $field_name;
+
+		// underscores are allowed by GraphQL, but WPGraphQL has historically
+		// stripped them when formatting field names.
+		// The $allow_underscores argument allows functions to opt-in to allowing underscores
+		if ( true !== $allow_underscores ) {
+			// uppercase words separated by an underscore, then replace the underscores with a space
+			$formatted_field_name = lcfirst( str_replace( '_', ' ', ucwords( $formatted_field_name, '_' ) ) );
+		}
+
+		// uppercase words separated by a dash, then replace the dashes with a space
+		$formatted_field_name = lcfirst( str_replace( '-', ' ', ucwords( $formatted_field_name, '-' ) ) );
+
+		// uppercace words separated by a space, and replace spaces with no space
+		$formatted_field_name = lcfirst( str_replace( ' ', '', ucwords( $formatted_field_name, ' ' ) ) );
+
+		return lcfirst( $formatted_field_name );
 	}
 
 	/**

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -21,8 +21,8 @@ use WPGraphQL\WPSchema;
  *
  * @package WPGraphQL
  */
-final class WPGraphQL
-{
+final class WPGraphQL {
+
 
 	/**
 	 * Stores the instance of the WPGraphQL class
@@ -73,13 +73,11 @@ final class WPGraphQL
 	 * @return \WPGraphQL - The one true WPGraphQL
 	 * @since  0.0.1
 	 */
-	public static function instance()
-	{
-
-		if (!isset(self::$instance) || !(self::$instance instanceof self)) {
+	public static function instance() {
+		if ( ! isset( self::$instance ) || ! ( self::$instance instanceof self ) ) {
 			self::$instance = new self();
 			self::$instance->setup_constants();
-			if (self::$instance->includes()) {
+			if ( self::$instance->includes() ) {
 				self::$instance->actions();
 				self::$instance->filters();
 			}
@@ -99,11 +97,9 @@ final class WPGraphQL
 	 * @return void
 	 * @since  0.0.1
 	 */
-	public function __clone()
-	{
-
+	public function __clone() {
 		// Cloning instances of the class is forbidden.
-		_doing_it_wrong(__FUNCTION__, esc_html__('The WPGraphQL class should not be cloned.', 'wp-graphql'), '0.0.1');
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'The WPGraphQL class should not be cloned.', 'wp-graphql' ), '0.0.1' );
 
 	}
 
@@ -113,11 +109,9 @@ final class WPGraphQL
 	 * @return void
 	 * @since  0.0.1
 	 */
-	public function __wakeup()
-	{
-
+	public function __wakeup() {
 		// De-serializing instances of the class is forbidden.
-		_doing_it_wrong(__FUNCTION__, esc_html__('De-serializing instances of the WPGraphQL class is not allowed', 'wp-graphql'), '0.0.1');
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'De-serializing instances of the WPGraphQL class is not allowed', 'wp-graphql' ), '0.0.1' );
 
 	}
 
@@ -127,35 +121,33 @@ final class WPGraphQL
 	 * @return void
 	 * @since  0.0.1
 	 */
-	private function setup_constants()
-	{
-
+	private function setup_constants() {
 		// Set main file path.
-		$main_file_path = dirname(__DIR__) . '/wp-graphql.php';
+		$main_file_path = dirname( __DIR__ ) . '/wp-graphql.php';
 
 		// Plugin version.
-		if (!defined('WPGRAPHQL_VERSION')) {
-			define('WPGRAPHQL_VERSION', '1.14.0');
+		if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
+			define( 'WPGRAPHQL_VERSION', '1.14.0' );
 		}
 
 		// Plugin Folder Path.
-		if (!defined('WPGRAPHQL_PLUGIN_DIR')) {
-			define('WPGRAPHQL_PLUGIN_DIR', plugin_dir_path($main_file_path));
+		if ( ! defined( 'WPGRAPHQL_PLUGIN_DIR' ) ) {
+			define( 'WPGRAPHQL_PLUGIN_DIR', plugin_dir_path( $main_file_path ) );
 		}
 
 		// Plugin Root File.
-		if (!defined('WPGRAPHQL_PLUGIN_FILE')) {
-			define('WPGRAPHQL_PLUGIN_FILE', $main_file_path);
+		if ( ! defined( 'WPGRAPHQL_PLUGIN_FILE' ) ) {
+			define( 'WPGRAPHQL_PLUGIN_FILE', $main_file_path );
 		}
 
 		// Whether to autoload the files or not.
-		if (!defined('WPGRAPHQL_AUTOLOAD')) {
-			define('WPGRAPHQL_AUTOLOAD', true);
+		if ( ! defined( 'WPGRAPHQL_AUTOLOAD' ) ) {
+			define( 'WPGRAPHQL_AUTOLOAD', true );
 		}
 
 		// The minimum version of PHP this plugin requires to work properly
-		if (!defined('GRAPHQL_MIN_PHP_VERSION')) {
-			define('GRAPHQL_MIN_PHP_VERSION', '7.1');
+		if ( ! defined( 'GRAPHQL_MIN_PHP_VERSION' ) ) {
+			define( 'GRAPHQL_MIN_PHP_VERSION', '7.1' );
 		}
 
 	}
@@ -167,9 +159,7 @@ final class WPGraphQL
 	 * @return bool
 	 * @since  0.0.1
 	 */
-	private function includes()
-	{
-
+	private function includes() {
 		/**
 		 * WPGRAPHQL_AUTOLOAD can be set to "false" to prevent the autoloader from running.
 		 * In most cases, this is not something that should be disabled, but some environments
@@ -179,9 +169,9 @@ final class WPGraphQL
 		 * The codeception tests are an example of an environment where adding the autoloader again causes issues
 		 * so this is set to false for tests.
 		 */
-		if (defined('WPGRAPHQL_AUTOLOAD') && true === WPGRAPHQL_AUTOLOAD) {
+		if ( defined( 'WPGRAPHQL_AUTOLOAD' ) && true === WPGRAPHQL_AUTOLOAD ) {
 
-			if (file_exists(WPGRAPHQL_PLUGIN_DIR . 'vendor/autoload.php')) {
+			if ( file_exists( WPGRAPHQL_PLUGIN_DIR . 'vendor/autoload.php' ) ) {
 				// Autoload Required Classes.
 				require_once WPGRAPHQL_PLUGIN_DIR . 'vendor/autoload.php';
 			}
@@ -189,13 +179,13 @@ final class WPGraphQL
 			// If GraphQL class doesn't exist, then dependencies cannot be
 			// detected. This likely means the user cloned the repo from Github
 			// but did not run `composer install`
-			if (!class_exists('GraphQL\GraphQL')) {
+			if ( ! class_exists( 'GraphQL\GraphQL' ) ) {
 
 				add_action(
 					'admin_notices',
 					function () {
 
-						if (!current_user_can('manage_options')) {
+						if ( ! current_user_can( 'manage_options' ) ) {
 							return;
 						}
 
@@ -203,7 +193,7 @@ final class WPGraphQL
 							'<div class="notice notice-error">' .
 							'<p>%s</p>' .
 							'</div>',
-							esc_html__('WPGraphQL appears to have been installed without it\'s dependencies. It will not work properly until dependencies are installed. This likely means you have cloned WPGraphQL from Github and need to run the command `composer install`.', 'wp-graphql')
+							esc_html__( 'WPGraphQL appears to have been installed without it\'s dependencies. It will not work properly until dependencies are installed. This likely means you have cloned WPGraphQL from Github and need to run the command `composer install`.', 'wp-graphql' )
 						);
 					}
 				);
@@ -223,16 +213,14 @@ final class WPGraphQL
 	 *
 	 * @return void
 	 */
-	public static function set_is_graphql_request($is_graphql_request = false)
-	{
+	public static function set_is_graphql_request( $is_graphql_request = false ) {
 		self::$is_graphql_request = $is_graphql_request;
 	}
 
 	/**
 	 * @return bool
 	 */
-	public static function is_graphql_request()
-	{
+	public static function is_graphql_request() {
 		return self::$is_graphql_request;
 	}
 
@@ -242,9 +230,7 @@ final class WPGraphQL
 	 *
 	 * @return void
 	 */
-	private function actions()
-	{
-
+	private function actions() {
 		/**
 		 * Init WPGraphQL after themes have been setup,
 		 * allowing for both plugins and themes to register
@@ -264,21 +250,21 @@ final class WPGraphQL
 				 *
 				 * @param \WPGraphQL $instance The instance of the WPGraphQL class
 				 */
-				do_action('graphql_init', $instance);
+				do_action( 'graphql_init', $instance );
 			}
 		);
 
 		// Initialize the plugin url constant
 		// see: https://developer.wordpress.org/reference/functions/plugins_url/#more-information
-		add_action('init', [$this, 'setup_plugin_url']);
+		add_action( 'init', [ $this, 'setup_plugin_url' ] );
 
 		// Prevent WPGraphQL Insights from running
-		remove_action('init', '\WPGraphQL\Extensions\graphql_insights_init');
+		remove_action( 'init', '\WPGraphQL\Extensions\graphql_insights_init' );
 
 		/**
 		 * Flush permalinks if the registered GraphQL endpoint has not yet been registered.
 		 */
-		add_action('wp_loaded', [$this, 'maybe_flush_permalinks']);
+		add_action( 'wp_loaded', [ $this, 'maybe_flush_permalinks' ] );
 
 		/**
 		 * Hook in before fields resolve to check field permissions
@@ -294,13 +280,13 @@ final class WPGraphQL
 		);
 
 		// Determine what to show in graphql
-		add_action('init_graphql_request', 'register_initial_settings', 10);
+		add_action( 'init_graphql_request', 'register_initial_settings', 10 );
 
 		// Throw an exception
-		add_action('do_graphql_request', [$this, 'min_php_version_check']);
+		add_action( 'do_graphql_request', [ $this, 'min_php_version_check' ] );
 
 		// Initialize Admin functionality
-		add_action('after_setup_theme', [$this, 'init_admin']);
+		add_action( 'after_setup_theme', [ $this, 'init_admin' ] );
 
 		add_action('init_graphql_request', function () {
 			$tracing = new \WPGraphQL\Utils\Tracing();
@@ -321,11 +307,9 @@ final class WPGraphQL
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function min_php_version_check()
-	{
-
-		if (defined('GRAPHQL_MIN_PHP_VERSION') && version_compare(PHP_VERSION, GRAPHQL_MIN_PHP_VERSION, '<')) {
-			throw new \Exception(sprintf(__('The server\'s current PHP version %1$s is lower than the WPGraphQL minimum required version: %2$s', 'wp-graphql'), PHP_VERSION, GRAPHQL_MIN_PHP_VERSION));
+	public function min_php_version_check() {
+		if ( defined( 'GRAPHQL_MIN_PHP_VERSION' ) && version_compare( PHP_VERSION, GRAPHQL_MIN_PHP_VERSION, '<' ) ) {
+			throw new \Exception( sprintf( __( 'The server\'s current PHP version %1$s is lower than the WPGraphQL minimum required version: %2$s', 'wp-graphql' ), PHP_VERSION, GRAPHQL_MIN_PHP_VERSION ) );
 		}
 
 	}
@@ -335,12 +319,10 @@ final class WPGraphQL
 	 *
 	 * @return void
 	 */
-	public function setup_plugin_url()
-	{
-
+	public function setup_plugin_url() {
 		// Plugin Folder URL.
-		if (!defined('WPGRAPHQL_PLUGIN_URL')) {
-			define('WPGRAPHQL_PLUGIN_URL', plugin_dir_url(dirname(__DIR__) . '/wp-graphql.php'));
+		if ( ! defined( 'WPGRAPHQL_PLUGIN_URL' ) ) {
+			define( 'WPGRAPHQL_PLUGIN_URL', plugin_dir_url( dirname( __DIR__ ) . '/wp-graphql.php' ) );
 		}
 
 	}
@@ -350,9 +332,7 @@ final class WPGraphQL
 	 *
 	 * @return void
 	 */
-	public function setup_types()
-	{
-
+	public function setup_types() {
 		/**
 		 * Setup the settings, post_types and taxonomies to show_in_graphql
 		 */
@@ -364,10 +344,9 @@ final class WPGraphQL
 	 *
 	 * @return void
 	 */
-	public function maybe_flush_permalinks()
-	{
-		$rules = get_option('rewrite_rules');
-		if (!isset($rules[graphql_get_endpoint() . '/?$'])) {
+	public function maybe_flush_permalinks() {
+		$rules = get_option( 'rewrite_rules' );
+		if ( ! isset( $rules[ graphql_get_endpoint() . '/?$' ] ) ) {
 			flush_rewrite_rules(); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.flush_rewrite_rules_flush_rewrite_rules
 		}
 	}
@@ -377,9 +356,7 @@ final class WPGraphQL
 	 *
 	 * @return void
 	 */
-	private function filters()
-	{
-
+	private function filters() {
 		// Filter the post_types and taxonomies to show in the GraphQL Schema
 		$this->setup_types();
 
@@ -408,9 +385,9 @@ final class WPGraphQL
 		 *
 		 * @deprecated
 		 */
-		add_filter('graphql_type_interfaces', function ($interfaces, $config, $type) {
+		add_filter('graphql_type_interfaces', function ( $interfaces, $config, $type ) {
 
-			if ($type instanceof WPObjectType) {
+			if ( $type instanceof WPObjectType ) {
 				/**
 				 * Filters the interfaces applied to an object type
 				 *
@@ -418,7 +395,7 @@ final class WPGraphQL
 				 * @param array                              $config     The config for the Object Type
 				 * @param mixed|\WPGraphQL\Type\WPInterfaceType|\WPGraphQL\Type\WPObjectType $type The Type instance
 				 */
-				return apply_filters_deprecated('graphql_object_type_interfaces', [$interfaces, $config, $type], '1.4.1', 'graphql_type_interfaces');
+				return apply_filters_deprecated( 'graphql_object_type_interfaces', [ $interfaces, $config, $type ], '1.4.1', 'graphql_type_interfaces' );
 			}
 
 			return $interfaces;
@@ -432,8 +409,7 @@ final class WPGraphQL
 	 *
 	 * @return void
 	 */
-	public function init_admin()
-	{
+	public function init_admin() {
 		$admin = new Admin();
 		$admin->init();
 	}
@@ -444,14 +420,13 @@ final class WPGraphQL
 	 * @return void
 	 * @since  0.0.2
 	 */
-	public static function show_in_graphql()
-	{
-		add_filter('register_post_type_args', [__CLASS__, 'setup_default_post_types'], 10, 2);
-		add_filter('register_taxonomy_args', [__CLASS__, 'setup_default_taxonomies'], 10, 2);
+	public static function show_in_graphql() {
+		add_filter( 'register_post_type_args', [ __CLASS__, 'setup_default_post_types' ], 10, 2 );
+		add_filter( 'register_taxonomy_args', [ __CLASS__, 'setup_default_taxonomies' ], 10, 2 );
 
 		// Run late so the user can filter the args themselves.
-		add_filter('register_post_type_args', [__CLASS__, 'register_graphql_post_type_args'], 99, 2);
-		add_filter('register_taxonomy_args', [__CLASS__, 'register_graphql_taxonomy_args'], 99, 2);
+		add_filter( 'register_post_type_args', [ __CLASS__, 'register_graphql_post_type_args' ], 99, 2 );
+		add_filter( 'register_taxonomy_args', [ __CLASS__, 'register_graphql_taxonomy_args' ], 99, 2 );
 	}
 
 	/**
@@ -462,19 +437,18 @@ final class WPGraphQL
 	 *
 	 * @return array
 	 */
-	public static function setup_default_post_types($args, $post_type)
-	{
+	public static function setup_default_post_types( $args, $post_type ) {
 		// Adds GraphQL support for attachments.
-		if ('attachment' === $post_type) {
-			$args['show_in_graphql'] = true;
+		if ( 'attachment' === $post_type ) {
+			$args['show_in_graphql']     = true;
 			$args['graphql_single_name'] = 'mediaItem';
 			$args['graphql_plural_name'] = 'mediaItems';
-		} elseif ('page' === $post_type) { // Adds GraphQL support for pages.
-			$args['show_in_graphql'] = true;
+		} elseif ( 'page' === $post_type ) { // Adds GraphQL support for pages.
+			$args['show_in_graphql']     = true;
 			$args['graphql_single_name'] = 'page';
 			$args['graphql_plural_name'] = 'pages';
-		} elseif ('post' === $post_type) { // Adds GraphQL support for posts.
-			$args['show_in_graphql'] = true;
+		} elseif ( 'post' === $post_type ) { // Adds GraphQL support for posts.
+			$args['show_in_graphql']     = true;
 			$args['graphql_single_name'] = 'post';
 			$args['graphql_plural_name'] = 'posts';
 		}
@@ -491,19 +465,18 @@ final class WPGraphQL
 	 * @return array
 	 * @since 1.12.0
 	 */
-	public static function setup_default_taxonomies($args, $taxonomy)
-	{
+	public static function setup_default_taxonomies( $args, $taxonomy ) {
 		// Adds GraphQL support for categories.
-		if ('category' === $taxonomy) {
-			$args['show_in_graphql'] = true;
+		if ( 'category' === $taxonomy ) {
+			$args['show_in_graphql']     = true;
 			$args['graphql_single_name'] = 'category';
 			$args['graphql_plural_name'] = 'categories';
-		} elseif ('post_tag' === $taxonomy) { // Adds GraphQL support for tags.
-			$args['show_in_graphql'] = true;
+		} elseif ( 'post_tag' === $taxonomy ) { // Adds GraphQL support for tags.
+			$args['show_in_graphql']     = true;
 			$args['graphql_single_name'] = 'tag';
 			$args['graphql_plural_name'] = 'tags';
-		} elseif ('post_format' === $taxonomy) { // Adds GraphQL support for post formats.
-			$args['show_in_graphql'] = true;
+		} elseif ( 'post_format' === $taxonomy ) { // Adds GraphQL support for post formats.
+			$args['show_in_graphql']     = true;
 			$args['graphql_single_name'] = 'postFormat';
 			$args['graphql_plural_name'] = 'postFormats';
 		}
@@ -521,10 +494,9 @@ final class WPGraphQL
 	 * @throws \Exception
 	 * @since 1.12.0
 	 */
-	public static function register_graphql_post_type_args(array $args, string $post_type_name)
-	{
+	public static function register_graphql_post_type_args( array $args, string $post_type_name ) {
 		// Bail early if the post type is hidden from the WPGraphQL schema.
-		if (empty($args['show_in_graphql'])) {
+		if ( empty( $args['show_in_graphql'] ) ) {
 			return $args;
 		}
 
@@ -536,9 +508,9 @@ final class WPGraphQL
 		 * @param array  $args           The graphql specific args for the post type
 		 * @param string $post_type_name The name of the post type being registered
 		 */
-		$graphql_args = apply_filters('register_graphql_post_type_args', $graphql_args, $post_type_name);
+		$graphql_args = apply_filters( 'register_graphql_post_type_args', $graphql_args, $post_type_name );
 
-		return wp_parse_args($args, $graphql_args);
+		return wp_parse_args( $args, $graphql_args );
 
 	}
 
@@ -552,10 +524,9 @@ final class WPGraphQL
 	 * @throws \Exception
 	 * @since 1.12.0
 	 */
-	public static function register_graphql_taxonomy_args(array $args, string $taxonomy_name)
-	{
+	public static function register_graphql_taxonomy_args( array $args, string $taxonomy_name ) {
 		// Bail early if the taxonomy  is hidden from the WPGraphQL schema.
-		if (empty($args['show_in_graphql'])) {
+		if ( empty( $args['show_in_graphql'] ) ) {
 			return $args;
 		}
 
@@ -567,9 +538,9 @@ final class WPGraphQL
 		 * @param array  $args          The graphql specific args for the taxonomy
 		 * @param string $taxonomy_name The name of the taxonomy being registered
 		 */
-		$graphql_args = apply_filters('register_graphql_taxonomy_args', $graphql_args, $taxonomy_name);
+		$graphql_args = apply_filters( 'register_graphql_taxonomy_args', $graphql_args, $taxonomy_name );
 
-		return wp_parse_args($args, $graphql_args);
+		return wp_parse_args( $args, $graphql_args );
 
 	}
 
@@ -578,26 +549,25 @@ final class WPGraphQL
 	 *
 	 * @since 1.12.0
 	 */
-	public static function get_default_graphql_type_args(): array
-	{
+	public static function get_default_graphql_type_args(): array {
 
 		return [
 			// The "kind" of GraphQL type to register. Can be `interface`, `object`, or `union`.
-			'graphql_kind' => 'object',
+			'graphql_kind'                     => 'object',
 			// The callback used to resolve the type. Only used if `graphql_kind` is an `interface` or `union`.
-			'graphql_resolve_type' => null,
+			'graphql_resolve_type'             => null,
 			// An array of custom interfaces the type should implement.
-			'graphql_interfaces' => [],
+			'graphql_interfaces'               => [],
 			// An array of default interfaces the type should exclude.
-			'graphql_exclude_interfaces' => [],
+			'graphql_exclude_interfaces'       => [],
 			// An array of custom connections the type should implement.
-			'graphql_connections' => [],
+			'graphql_connections'              => [],
 			// An array of default connection field names the type should exclude.
-			'graphql_exclude_connections' => [],
+			'graphql_exclude_connections'      => [],
 			// An array of possible type the union can resolve to. Only used if `graphql_kind` is a `union`.
-			'graphql_union_types' => [],
+			'graphql_union_types'              => [],
 			// Whether to register default connections to the schema.
-			'graphql_register_root_field' => true,
+			'graphql_register_root_field'      => true,
 			'graphql_register_root_connection' => true,
 		];
 	}
@@ -615,39 +585,38 @@ final class WPGraphQL
 	 * @since  0.0.4
 	 * @since  1.8.1 adds $output as first param, and stores post type objects in class property.
 	 */
-	public static function get_allowed_post_types($output = 'names', $args = [])
-	{
+	public static function get_allowed_post_types( $output = 'names', $args = [] ) {
 		// Support deprecated param order.
-		if (is_array($output)) {
-			_deprecated_argument(__METHOD__, '1.8.1', '$args should be passed as the second parameter.');
-			$args = $output;
+		if ( is_array( $output ) ) {
+			_deprecated_argument( __METHOD__, '1.8.1', '$args should be passed as the second parameter.' );
+			$args   = $output;
 			$output = 'names';
 		}
 
 		// Initialize array of allowed post type objects.
-		if (empty(self::$allowed_post_types)) {
+		if ( empty( self::$allowed_post_types ) ) {
 			/**
 			 * Get all post types objects.
 			 *
 			 * @var \WP_Post_Type[] $post_type_objects
 			 */
 			$post_type_objects = get_post_types(
-				['show_in_graphql' => true],
+				[ 'show_in_graphql' => true ],
 				'objects'
 			);
 
 			$post_type_names = [];
 
-			foreach ($post_type_objects as $post_type_object) {
+			foreach ( $post_type_objects as $post_type_object ) {
 				/**
 				 * Validate that the post_types have a graphql_single_name and graphql_plural_name
 				 */
-				if (empty($post_type_object->graphql_single_name) || empty($post_type_object->graphql_plural_name)) {
+				if ( empty( $post_type_object->graphql_single_name ) || empty( $post_type_object->graphql_plural_name ) ) {
 					throw new UserError(
 						sprintf(
 							/* translators: %s will replaced with the registered type */
-							__('The %s post_type isn\'t configured properly to show in GraphQL. It needs a "graphql_single_name" and a "graphql_plural_name"', 'wp-graphql'),
-								$post_type_object->name
+							__( 'The %s post_type isn\'t configured properly to show in GraphQL. It needs a "graphql_single_name" and a "graphql_plural_name"', 'wp-graphql' ),
+							$post_type_object->name
 						)
 					);
 				}
@@ -668,17 +637,17 @@ final class WPGraphQL
 			 *
 			 * @since 0.0.2
 			 */
-			$allowed_post_type_names = apply_filters('graphql_post_entities_allowed_post_types', $post_type_names, $post_type_objects);
+			$allowed_post_type_names = apply_filters( 'graphql_post_entities_allowed_post_types', $post_type_names, $post_type_objects );
 
 			// Filter the post type objects if the list of allowed types have changed.
-			if ($post_type_names !== $allowed_post_type_names) {
+			if ( $post_type_names !== $allowed_post_type_names ) {
 				// Maybe they're just out of order.
-				sort($post_type_names);
-				sort($allowed_post_type_names);
+				sort( $post_type_names );
+				sort( $allowed_post_type_names );
 
-				if ($post_type_names !== $allowed_post_type_names) {
-					$post_type_objects = array_filter($post_type_objects, function ($obj) use ($allowed_post_type_names) {
-						return in_array($obj->name, $allowed_post_type_names, true);
+				if ( $post_type_names !== $allowed_post_type_names ) {
+					$post_type_objects = array_filter($post_type_objects, function ( $obj ) use ( $allowed_post_type_names ) {
+						return in_array( $obj->name, $allowed_post_type_names, true );
 					});
 				}
 			}
@@ -691,10 +660,10 @@ final class WPGraphQL
 		/**
 		 * Filter the list of allowed post types either by the provided args or to only return an array of names.
 		 */
-		if (!empty($args) || 'names' === $output) {
+		if ( ! empty( $args ) || 'names' === $output ) {
 			$field = 'names' === $output ? 'name' : false;
 
-			$post_types = wp_filter_object_list($post_types, $args, 'and', $field);
+			$post_types = wp_filter_object_list( $post_types, $args, 'and', $field );
 		}
 
 		return $post_types;
@@ -712,33 +681,32 @@ final class WPGraphQL
 	 * @return array
 	 * @since  0.0.4
 	 */
-	public static function get_allowed_taxonomies($output = 'names', $args = [])
-	{
+	public static function get_allowed_taxonomies( $output = 'names', $args = [] ) {
 
 		// Initialize array of allowed post type objects.
-		if (empty(self::$allowed_taxonomies)) {
+		if ( empty( self::$allowed_taxonomies ) ) {
 			/**
 			 * Get all post types objects.
 			 *
 			 * @var \WP_Taxonomy[] $tax_objects
 			 */
 			$tax_objects = get_taxonomies(
-				['show_in_graphql' => true],
+				[ 'show_in_graphql' => true ],
 				'objects'
 			);
 
 			$tax_names = [];
 
-			foreach ($tax_objects as $tax_object) {
+			foreach ( $tax_objects as $tax_object ) {
 				/**
 				 * Validate that the taxonomies have a graphql_single_name and graphql_plural_name
 				 */
-				if (empty($tax_object->graphql_single_name) || empty($tax_object->graphql_plural_name)) {
+				if ( empty( $tax_object->graphql_single_name ) || empty( $tax_object->graphql_plural_name ) ) {
 					throw new UserError(
 						sprintf(
 							/* translators: %s will replaced with the registered taxonomty */
-							__('The %s taxonomy isn\'t configured properly to show in GraphQL. It needs a "graphql_single_name" and a "graphql_plural_name"', 'wp-graphql'),
-								$tax_object->name
+							__( 'The %s taxonomy isn\'t configured properly to show in GraphQL. It needs a "graphql_single_name" and a "graphql_plural_name"', 'wp-graphql' ),
+							$tax_object->name
 						)
 					);
 				}
@@ -759,17 +727,17 @@ final class WPGraphQL
 			 *
 			 * @since 0.0.2
 			 */
-			$allowed_tax_names = apply_filters('graphql_term_entities_allowed_taxonomies', $tax_names, $tax_objects);
+			$allowed_tax_names = apply_filters( 'graphql_term_entities_allowed_taxonomies', $tax_names, $tax_objects );
 
 			// Filter the taxonomy objects if the list of allowed types have changed.
-			if ($tax_names !== $allowed_tax_names) {
+			if ( $tax_names !== $allowed_tax_names ) {
 				// Maybe they're just out of order.
-				sort($tax_names);
-				sort($allowed_tax_names);
+				sort( $tax_names );
+				sort( $allowed_tax_names );
 
-				if ($tax_names !== $allowed_tax_names) {
-					$tax_objects = array_filter($tax_objects, function ($obj) use ($allowed_tax_names) {
-						return in_array($obj->name, $allowed_tax_names, true);
+				if ( $tax_names !== $allowed_tax_names ) {
+					$tax_objects = array_filter($tax_objects, function ( $obj ) use ( $allowed_tax_names ) {
+						return in_array( $obj->name, $allowed_tax_names, true );
 					});
 				}
 			}
@@ -781,10 +749,10 @@ final class WPGraphQL
 		/**
 		 * Filter the list of allowed taxonomies either by the provided args or to only return an array of names.
 		 */
-		if (!empty($args) || 'names' === $output) {
+		if ( ! empty( $args ) || 'names' === $output ) {
 			$field = 'names' === $output ? 'name' : false;
 
-			$taxonomies = wp_filter_object_list($taxonomies, $args, 'and', $field);
+			$taxonomies = wp_filter_object_list( $taxonomies, $args, 'and', $field );
 		}
 
 		return $taxonomies;
@@ -795,10 +763,9 @@ final class WPGraphQL
 	 *
 	 * @return void
 	 */
-	public static function clear_schema()
-	{
-		self::$type_registry = null;
-		self::$schema = null;
+	public static function clear_schema() {
+		self::$type_registry      = null;
+		self::$schema             = null;
 		self::$allowed_post_types = null;
 		self::$allowed_taxonomies = null;
 	}
@@ -811,13 +778,11 @@ final class WPGraphQL
 	 *
 	 * @throws \Exception
 	 */
-	public static function get_schema()
-	{
-
-		if (null === self::$schema) {
+	public static function get_schema() {
+		if ( null === self::$schema ) {
 
 			$schema_registry = new SchemaRegistry();
-			$schema = $schema_registry->get_schema();
+			$schema          = $schema_registry->get_schema();
 
 			/**
 			 * Generate & Filter the schema.
@@ -828,18 +793,18 @@ final class WPGraphQL
 			 *
 			 * @since 0.0.5
 			 */
-			self::$schema = apply_filters('graphql_schema', $schema, self::get_app_context());
+			self::$schema = apply_filters( 'graphql_schema', $schema, self::get_app_context() );
 		}
 
 		/**
 		 * Fire an action when the Schema is returned
 		 */
-		do_action('graphql_get_schema', self::$schema);
+		do_action( 'graphql_get_schema', self::$schema );
 
 		/**
 		 * Return the Schema after applying filters
 		 */
-		return !empty(self::$schema) ? self::$schema : null;
+		return ! empty( self::$schema ) ? self::$schema : null;
 	}
 
 	/**
@@ -847,19 +812,18 @@ final class WPGraphQL
 	 *
 	 * @return bool
 	 */
-	public static function debug(): bool
-	{
-		if (defined('GRAPHQL_DEBUG')) {
+	public static function debug(): bool {
+		if ( defined( 'GRAPHQL_DEBUG' ) ) {
 			$enabled = (bool) GRAPHQL_DEBUG;
 		} else {
-			$enabled = get_graphql_setting('debug_mode_enabled', 'off');
+			$enabled = get_graphql_setting( 'debug_mode_enabled', 'off' );
 			$enabled = 'on' === $enabled;
 		}
 
 		/**
 		 * @param bool $enabled Whether GraphQL Debug is enabled or not
 		 */
-		return (bool) apply_filters('graphql_debug_enabled', $enabled);
+		return (bool) apply_filters( 'graphql_debug_enabled', $enabled );
 	}
 
 	/**
@@ -870,10 +834,8 @@ final class WPGraphQL
 	 *
 	 * @throws \Exception
 	 */
-	public static function get_type_registry()
-	{
-
-		if (null === self::$type_registry) {
+	public static function get_type_registry() {
+		if ( null === self::$type_registry ) {
 
 			$type_registry = new TypeRegistry();
 
@@ -886,18 +848,18 @@ final class WPGraphQL
 			 *
 			 * @since 0.0.5
 			 */
-			self::$type_registry = apply_filters('graphql_type_registry', $type_registry, self::get_app_context());
+			self::$type_registry = apply_filters( 'graphql_type_registry', $type_registry, self::get_app_context() );
 		}
 
 		/**
 		 * Fire an action when the Type Registry is returned
 		 */
-		do_action('graphql_get_type_registry', self::$type_registry);
+		do_action( 'graphql_get_type_registry', self::$type_registry );
 
 		/**
 		 * Return the Schema after applying filters
 		 */
-		return !empty(self::$type_registry) ? self::$type_registry : null;
+		return ! empty( self::$type_registry ) ? self::$type_registry : null;
 
 	}
 
@@ -906,8 +868,7 @@ final class WPGraphQL
 	 *
 	 * @return null|string
 	 */
-	public static function get_static_schema()
-	{
+	public static function get_static_schema() {
 		$schema = null;
 		if (file_exists(WPGRAPHQL_PLUGIN_DIR . 'schema.graphql') && !empty(file_get_contents(WPGRAPHQL_PLUGIN_DIR . 'schema.graphql'))) { // phpcs:ignore
 			$schema = file_get_contents(WPGRAPHQL_PLUGIN_DIR . 'schema.graphql'); // phpcs:ignore
@@ -921,17 +882,15 @@ final class WPGraphQL
 	 *
 	 * @return \WPGraphQL\AppContext
 	 */
-	public static function get_app_context()
-	{
-
+	public static function get_app_context() {
 		/**
 		 * Configure the app_context which gets passed down to all the resolvers.
 		 *
 		 * @since 0.0.4
 		 */
-		$app_context = new AppContext();
-		$app_context->viewer = wp_get_current_user();
-		$app_context->root_url = get_bloginfo('url');
+		$app_context           = new AppContext();
+		$app_context->viewer   = wp_get_current_user();
+		$app_context->root_url = get_bloginfo( 'url' );
 		$app_context->request = !empty($_REQUEST) ? $_REQUEST : null; // phpcs:ignore
 
 		return $app_context;

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -130,7 +130,7 @@ final class WPGraphQL {
 
 		// Plugin version.
 		if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-			define( 'WPGRAPHQL_VERSION', '1.13.8' );
+			define( 'WPGRAPHQL_VERSION', '1.14.0' );
 		}
 
 		// Plugin Folder Path.

--- a/tests/wpunit/AccessFunctionsTest.php
+++ b/tests/wpunit/AccessFunctionsTest.php
@@ -1756,4 +1756,184 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 	}
 
+	public function testRegisterGraphqlFieldWithAllowedUndercores() {
+
+		$expected_value = uniqid( 'test value: ', true );
+
+		$config = [
+			'type' => 'String',
+			'resolve' => function() use ( $expected_value ) {
+				return $expected_value;
+			},
+			'allow_field_underscores' => true,
+		];
+
+		register_graphql_field( 'RootQuery', 'underscore_test_field', $config, true );
+
+		$query = '
+		{
+		  underscore_test_field
+		}
+		';
+
+		$actual = $this->graphql([
+			'query' => $query,
+		]);
+
+		self::assertQuerySuccessful( $actual, [
+			$this->expectedField( 'underscore_test_field', $expected_value )
+		]);
+
+	}
+
+	public function testDeRegisterGraphqlFieldWithAllowedUndercores() {
+
+		$expected_value = uniqid( 'test value: ', true );
+
+		$config = [
+			'type' => 'String',
+			'resolve' => function() use ( $expected_value ) {
+				return $expected_value;
+			},
+			'allow_field_underscores' => true,
+		];
+
+		deregister_graphql_field( 'RootQuery', 'underscore_test_field' );
+		register_graphql_field( 'RootQuery', 'underscore_test_field', $config, true );
+
+		$query = '
+		{
+		  underscore_test_field
+		}
+		';
+
+		$actual = $this->graphql([
+			'query' => $query,
+		]);
+
+		self::assertQueryError( $actual, []);
+
+
+	}
+
+	public function testRegisterConnectionWithUnderscores() {
+
+		register_graphql_connection([
+			'fromType' => 'RootQuery',
+			'toType' => 'Post',
+			'fromFieldName' => 'test_field_with_underscores',
+			'allow_field_underscores' => true,
+		]);
+
+		$actual = $this->graphql([
+			'query' => '
+			{
+			  test_field_with_underscores(first:1) {
+			    nodes {
+			      id
+			    }
+			  }
+			}
+			'
+		]);
+
+		self::assertQuerySuccessful( $actual, [
+			$this->expectedField( 'test_field_with_underscores', self::IS_FALSY )
+		]);
+
+	}
+
+	public function testDeRegisterConnectionWithUnderscores() {
+
+		deregister_graphql_connection( 'test_field_with_underscores' );
+
+		register_graphql_connection([
+			'fromType' => 'RootQuery',
+			'toType' => 'Post',
+			'fromFieldName' => 'test_field_with_underscores',
+			'allow_field_underscores' => true,
+		]);
+
+		$actual = $this->graphql([
+			'query' => '
+			{
+			  test_field_with_underscores(first:1) {
+			    nodes {
+			      id
+			    }
+			  }
+			}
+			'
+		]);
+
+		// query should error because the connection was deregistered
+		self::assertQueryError( $actual, []);
+
+	}
+
+	public function testRegisterMutationWithUnderscores() {
+
+		$expected = 'test';
+
+		register_graphql_mutation( 'test_mutation_with_underscores', [
+			'inputFields'         => [],
+			'outputFields'        => [
+				'test' => [
+					'type' => 'String',
+				],
+			],
+			'mutateAndGetPayload' => function () use ( $expected ) {
+				return [
+					'test' => $expected,
+				];
+			},
+			'allow_field_underscores' => true,
+		]);
+
+		$actual = $this->graphql([
+			'query' => '
+			mutation WithUnderscores {
+			  test_mutation_with_underscores(input: { clientMutationId: "test" }) {
+			    test
+			  }
+			}
+			'
+		]);
+
+		self::assertQuerySuccessful( $actual, [
+			$this->expectedField( 'test_mutation_with_underscores.test', $expected )
+		]);
+
+	}
+
+	public function testDeRegisterMutationWithUnderscores() {
+
+		deregister_graphql_mutation( 'test_mutation_with_underscores' );
+
+		register_graphql_mutation( 'test_mutation_with_underscores', [
+			'inputFields'         => [],
+			'outputFields'        => [
+				'test' => [
+					'type' => 'String',
+				],
+			],
+			'mutateAndGetPayload' => function () {  return null; },
+			'allow_field_underscores' => true,
+		]);
+
+		$actual = $this->graphql([
+			'query' => '
+			mutation WithUnderscores {
+			  test_mutation_with_underscores(input: { clientMutationId: "test" }) {
+			    test
+			  }
+			}
+			'
+		]);
+
+		// query should error because the mutation was deregistered
+		self::assertQueryError( $actual, []);
+
+	}
+
 }

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.13.8
+ * Version: 1.14.0
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.13.8
+ * @version  1.14.0
  */
 
 // Exit if accessed directly.
@@ -86,3 +86,4 @@ function graphql_init_appsero_telemetry() {
 }
 
 graphql_init_appsero_telemetry();
+

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -22,33 +22,32 @@
  */
 
 // Exit if accessed directly.
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 // If the codeception remote coverage file exists, require it.
 // This file should only exist locally or when CI bootstraps the environment for testing
-if (file_exists(__DIR__ . '/c3.php')) {
+if ( file_exists( __DIR__ . '/c3.php' ) ) {
 	require_once __DIR__ . '/c3.php';
 }
 
 // Run this function when WPGraphQL is de-activated
-register_deactivation_hook(__FILE__, 'graphql_deactivation_callback');
-register_activation_hook(__FILE__, 'graphql_activation_callback');
+register_deactivation_hook( __FILE__, 'graphql_deactivation_callback' );
+register_activation_hook( __FILE__, 'graphql_activation_callback' );
 
 // Bootstrap the plugin
-if (!class_exists('WPGraphQL')) {
+if ( ! class_exists( 'WPGraphQL' ) ) {
 	require_once __DIR__ . '/src/WPGraphQL.php';
 }
 
-if (!function_exists('graphql_init')) {
+if ( ! function_exists( 'graphql_init' ) ) {
 	/**
 	 * Function that instantiates the plugins main class
 	 *
 	 * @return object
 	 */
-	function graphql_init()
-	{
+	function graphql_init() {
 		/**
 		 * Return an instance of the action
 		 */
@@ -57,8 +56,8 @@ if (!function_exists('graphql_init')) {
 }
 graphql_init();
 
-if (defined('WP_CLI') && WP_CLI) {
-	require_once plugin_dir_path(__FILE__) . 'cli/wp-cli.php';
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	require_once plugin_dir_path( __FILE__ ) . 'cli/wp-cli.php';
 }
 
 /**
@@ -66,19 +65,17 @@ if (defined('WP_CLI') && WP_CLI) {
  *
  * @return void
  */
-function graphql_init_appsero_telemetry()
-{
-
+function graphql_init_appsero_telemetry() {
 	// If the class doesn't exist, or code is being scanned by PHPSTAN, move on.
-	if (!class_exists('Appsero\Client') || defined('PHPSTAN')) {
+	if ( ! class_exists( 'Appsero\Client' ) || defined( 'PHPSTAN' ) ) {
 		return;
 	}
 
-	$client = new Appsero\Client('cd0d1172-95a0-4460-a36a-2c303807c9ef', 'WP GraphQL', __FILE__);
+	$client   = new Appsero\Client( 'cd0d1172-95a0-4460-a36a-2c303807c9ef', 'WP GraphQL', __FILE__ );
 	$insights = $client->insights();
 
 	// If the Appsero client has the add_plugin_data method, use it
-	if (method_exists($insights, 'add_plugin_data')) {
+	if ( method_exists( $insights, 'add_plugin_data' ) ) {
 		// @phpstan-ignore-next-line
 		$insights->add_plugin_data();
 	}


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This allows fields, connections and mutations to be registered with underscores and have the underscores be preserved when the field is added to the Schema. 


Does this close any currently open issues?
------------------------------------------
closes #2736 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

Given the following snippet: 

```php
register_graphql_object_type( 'TestObject', [
	'eagerlyLoadType' => true,
	'fields' => [
		'test' => [ 'type' => 'String' ],
	]
]);

register_graphql_field( 'TestObject', 'my_field_with_underscores', [
	'type' => 'String',
	'description' => 'Default behavior with underscores stripped',
] );

register_graphql_field( 'TestObject', 'my_field_with_underscores', [
	'type' => 'String',
	'description' => 'Field configured to allow field underscores',
	'allow_field_underscores' => true,
] );
```

We can introspect the `TestObject` and see that both fields have been added, one without underscores (default) and one with underscores (opted-in):


![CleanShot 2023-02-24 at 16 50 37](https://user-images.githubusercontent.com/1260765/221322334-c742db21-e2f1-421f-8e0a-7268aec04ce7.png)


Any other comments?
-------------------
I'd _love_ to solve this in a more central way, but I don't see a good way to do it without breaking a lot of Schemas for a lot of users, something I don't think is worth the tradeoff right now.


Also, this PR was branched of the branch I was working on to prep for the v1.14.0 release, so it might have a bit of extra changes coming for the ride 🤦🏻‍♂️ 