### PR TITLE
fix: Remove space from plugin name

### DIFF
--- a/tests/wpunit/PluginConnectionQueriesTest.php
+++ b/tests/wpunit/PluginConnectionQueriesTest.php
@@ -336,7 +336,7 @@ class PluginConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTes
 	public function testPluginsQueryWithWhereArgs() {
 		$query = $this->getQuery();
 
-		$active_plugin   = 'WP GraphQL';
+		$active_plugin   = 'WPGraphQL';
 		$inactive_plugin = 'Akismet Anti-Spam';
 
 		wp_set_current_user( $this->admin );

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -72,7 +72,7 @@ function graphql_init_appsero_telemetry() {
 		return;
 	}
 
-	$client   = new Appsero\Client( 'cd0d1172-95a0-4460-a36a-2c303807c9ef', 'WP GraphQL', __FILE__ );
+	$client   = new Appsero\Client( 'cd0d1172-95a0-4460-a36a-2c303807c9ef', 'WPGraphQL', __FILE__ );
 	$insights = $client->insights();
 
 	// If the Appsero client has the add_plugin_data method, use it

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: WP GraphQL
+ * Plugin Name: WPGraphQL
  * Plugin URI: https://github.com/wp-graphql/wp-graphql
  * GitHub Plugin URI: https://github.com/wp-graphql/wp-graphql
  * Description: GraphQL API for WordPress


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

This WordPress plugin's header currently has the [Plugin Name set as **WP GraphQL**](https://github.com/wp-graphql/wp-graphql/blob/develop/wp-graphql.php#L3) (w/space),
with mostly all other references reading as **WPGraphQL** (w/o space).

These changes **ONLY** update the Plugin Name within the plugin's [header fields](https://developer.wordpress.org/plugins/plugin-basics/header-requirements/#header-fields) (+  Appsero),
which will be displayed in the Plugins list in the WordPress Admin.

<img width="810" alt="currently" src="https://user-images.githubusercontent.com/6676674/222262902-4be6013a-6606-4478-9a56-7e5dea5f8754.png">

<img width="819" alt="proposed" src="https://user-images.githubusercontent.com/6676674/222262907-ea2026be-d0c7-430d-af7e-ee9b1fd49780.png">

Note that this name is returned when using the WordPress core function [get_plugin_data()](https://developer.wordpress.org/reference/functions/get_plugin_data/),
however I did not find any use of that internally within this plugin.

If a 3rd party plugin is using the plugin name, they should be encouraged to use a more reliable field for a unique identifier, such as "Text Domain", which is traditionally the same as the plugin directory.


Where has this been tested?
---------------------------
**Operating System:**
macOS v13.2.1

**WordPress Version:**
v6.1
