### PR TITLE
release: v1.13.10

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,8 +1,8 @@
 # Number of days of inactivity before an issue becomes stale
 daysUntilStale: 90
-# Stalebot will close issues marked "stale?" if they have not been triaged after 90 days. 
+# Stalebot will close issues marked "stale?" if they have not been triaged after 90 days.
 # See https://github.com/wp-graphql/wp-graphql/issues/2494
-daysUntilClose: 90
+daysUntilClose: false
 # Issues with these labels will never be considered stale
 exemptLabels:
   - "not stale"
@@ -10,19 +10,12 @@ exemptLabels:
   - "Ready for Review"
   - "Release"
   - "Target: v2.0"
-  - "Work in Progress"
-  - "status: assigned"
   - "status: blocked"
 # Stalebot will mark issues as stale? after 90 days
-# If stale? issues haven't been triaged after another 90 days, they will be closed. 
+# If stale? issues haven't been triaged after another 90 days, they will be closed.
 # See: https://github.com/wp-graphql/wp-graphql/issues/2494
 staleLabel: "stale?"
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs. Thank you
-  for your contributions.
-# Comment to post when closing a stale issue. Set to `false` to disable
-closeComment: >
-  This issue has been automatically closed because it has not had recent activity. 
-  If you believe this issue is still valid, please open a new issue and mark this as a related issue.
+  recent activity. You can help keep it active by commenting with additional information or even just confirming the issue still exists. We thank you for your contributions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,27 @@
 # Changelog
 
+## 1.13.10
+
+### Chores / Bugfixes
+
+- [#2741](https://github.com/wp-graphql/wp-graphql/pull/2741): Change the plugin name from "WP GraphQL" to "WPGraphQL". Thanks @josephfusco!
+- [#2742](https://github.com/wp-graphql/wp-graphql/pull/2742): Update Stalebot rules. Thanks @justlevine!
+
 ## 1.13.9
+
+### Chores / Bugfixes
 
 - [#2726](https://github.com/wp-graphql/wp-graphql/pull/2726): fix: invalid schema when custom post types and custom taxonomies are registered with underscores in the "graphql_single_name" / "graphql_plural_name"
 
 ## 1.13.8
 
+### Chores / Bugfixes
+
 - [#2712](https://github.com/wp-graphql/wp-graphql/pull/2712): fix: query analyzer outputting unexpected list types
 
 ## 1.13.7
 
-## Chores / Bugfixes
+### Chores / Bugfixes
 
 - ([#2661](https://github.com/wp-graphql/wp-graphql/pull/2661)): chore(deps): bump simple-git from 3.10.0 to 3.15.1
 - ([#2665](https://github.com/wp-graphql/wp-graphql/pull/2665)): chore(deps): bump decode-uri-component from 0.2.0 to 0.2.2

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, API, Gatsby, Headless, Decoupled, React, Nextjs, Vue, Apollo, RES
 Requires at least: 5.0
 Tested up to: 6.1
 Requires PHP: 7.1
-Stable tag: 1.13.8
+Stable tag: 1.13.10
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -231,6 +231,14 @@ The `uri` field was non-null on some Types in the Schema but has been changed to
 Composer dependencies are no longer versioned in Github. Recommended install source is WordPress.org or using Composer to get the code from Packagist.org or WPackagist.org.
 
 == Changelog ==
+
+= 1.13.10 =
+
+**Chores / Bugfixes**
+
+- [#2741](https://github.com/wp-graphql/wp-graphql/pull/2741): Change the plugin name from "WP GraphQL" to "WPGraphQL". Thanks @josephfusco!
+- [#2742](https://github.com/wp-graphql/wp-graphql/pull/2742): Update Stalebot rules. Thanks @justlevine!
+
 
 = 1.13.9 =
 

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -130,7 +130,7 @@ final class WPGraphQL {
 
 		// Plugin version.
 		if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-			define( 'WPGRAPHQL_VERSION', '1.13.9' );
+			define( 'WPGRAPHQL_VERSION', '1.13.10' );
 		}
 
 		// Plugin Folder Path.

--- a/tests/wpunit/PluginConnectionQueriesTest.php
+++ b/tests/wpunit/PluginConnectionQueriesTest.php
@@ -336,7 +336,7 @@ class PluginConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTes
 	public function testPluginsQueryWithWhereArgs() {
 		$query = $this->getQuery();
 
-		$active_plugin   = 'WP GraphQL';
+		$active_plugin   = 'WPGraphQL';
 		$inactive_plugin = 'Akismet Anti-Spam';
 
 		wp_set_current_user( $this->admin );

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.13.9
+ * Version: 1.13.10
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.13.9
+ * @version  1.13.10
  */
 
 // Exit if accessed directly.

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: WP GraphQL
+ * Plugin Name: WPGraphQL
  * Plugin URI: https://github.com/wp-graphql/wp-graphql
  * GitHub Plugin URI: https://github.com/wp-graphql/wp-graphql
  * Description: GraphQL API for WordPress
@@ -72,7 +72,7 @@ function graphql_init_appsero_telemetry() {
 		return;
 	}
 
-	$client   = new Appsero\Client( 'cd0d1172-95a0-4460-a36a-2c303807c9ef', 'WP GraphQL', __FILE__ );
+	$client   = new Appsero\Client( 'cd0d1172-95a0-4460-a36a-2c303807c9ef', 'WPGraphQL', __FILE__ );
 	$insights = $client->insights();
 
 	// If the Appsero client has the add_plugin_data method, use it


### PR DESCRIPTION
# Release Notes

### Chores / Bugfixes

- [#2741](https://github.com/wp-graphql/wp-graphql/pull/2741): Change the plugin name from "WP GraphQL" to "WPGraphQL". Thanks @josephfusco!
- [#2742](https://github.com/wp-graphql/wp-graphql/pull/2742): Update Stalebot rules. Thanks @justlevine!
