### PR TITLE
feat: allow fields to be registered with underscores

### DIFF
--- a/access-functions.php
+++ b/access-functions.php
@@ -191,12 +191,12 @@ function register_graphql_type( string $type_name, array $config ) {
  * Given a Type Name and a $config array, this adds an Interface Type to the TypeRegistry
  *
  * @param string $type_name The name of the Type to register
- * @param array|callable  $config    The Type config
+ * @param array  $config    The Type config
  *
  * @throws \Exception
  * @return void
  */
-function register_graphql_interface_type( string $type_name, $config ) {
+function register_graphql_interface_type( string $type_name, array $config ) {
 	add_action(
 		get_graphql_register_action(),
 		function ( TypeRegistry $type_registry ) use ( $type_name, $config ) {

--- a/access-functions.php
+++ b/access-functions.php
@@ -190,13 +190,13 @@ function register_graphql_type( string $type_name, array $config ) {
 /**
  * Given a Type Name and a $config array, this adds an Interface Type to the TypeRegistry
  *
- * @param string $type_name The name of the Type to register
- * @param array  $config    The Type config
+ * @param string          $type_name The name of the Type to register
+ * @param array|callable  $config    The Type config
  *
  * @throws \Exception
  * @return void
  */
-function register_graphql_interface_type( string $type_name, array $config ) {
+function register_graphql_interface_type( string $type_name, $config ) {
 	add_action(
 		get_graphql_register_action(),
 		function ( TypeRegistry $type_registry ) use ( $type_name, $config ) {

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -704,7 +704,7 @@ class TypeRegistry {
 	 * Add an Interface Type to the registry
 	 *
 	 * @param string $type_name The name of the type to register
-	 * @param array $config he configuration of the type
+	 * @param array $config The configuration of the type
 	 *
 	 * @throws \Exception
 	 * @return void
@@ -1005,7 +1005,7 @@ class TypeRegistry {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function register_fields( string $type_name, array $fields = [], ?bool $allow_underscores_in_field_names = false ): void {
+	public function register_fields( string $type_name, array $fields = [] ): void {
 		if ( ! empty( $fields ) ) {
 			foreach ( $fields as $field_name => $config ) {
 				if ( is_string( $field_name ) && ! empty( $config ) && is_array( $config ) ) {

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -1034,7 +1034,7 @@ class TypeRegistry {
 			function ( $fields ) use ( $type_name, $field_name, $config ) {
 
 				// Whether the field should be allowed to have underscores in the field name
-				$allow_field_underscores = isset( $config['allow_field_underscores'] ) && true === $config['allow_field_underscores'];
+				$allow_field_underscores = isset( $config['allowFieldUnderscores'] ) && true === $config['allowFieldUnderscores'];
 
 				$field_name = Utils::format_field_name( $field_name, $allow_field_underscores );
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -678,7 +678,6 @@ class Request {
 
 		}
 
-		return [];
 	}
 
 	/**

--- a/src/Request.php
+++ b/src/Request.php
@@ -227,7 +227,7 @@ class Request {
 	 *
 	 * @return mixed|null
 	 */
-	protected function get_root_value() { 
+	protected function get_root_value() {
 		/**
 		 * Set the root value based on what was passed to the request
 		 */
@@ -321,7 +321,7 @@ class Request {
 	 * @return boolean
 	 * @throws \Exception
 	 */
-	protected function has_authentication_errors() { 
+	protected function has_authentication_errors() {
 		/**
 		 * Bail if this is not an HTTP request.
 		 *
@@ -607,10 +607,10 @@ class Request {
 	/**
 	 * Execute an internal request (graphql() function call).
 	 *
-	 * @return array|void
+	 * @return array
 	 * @throws \Exception
 	 */
-	public function execute() { 
+	public function execute(): array {
 		$helper = new WPHelper();
 
 		if ( ! $this->data instanceof OperationParams ) {
@@ -624,7 +624,9 @@ class Request {
 				$this->data = $data;
 				return $this->execute();
 			}, $this->params);
-		} elseif ( $this->params instanceof OperationParams ) {
+		}
+
+		if ( $this->params instanceof OperationParams ) {
 
 			/**
 			 * Initialize the GraphQL Request
@@ -675,6 +677,8 @@ class Request {
 			return $this->after_execute( $response );
 
 		}
+
+		return [];
 	}
 
 	/**
@@ -683,7 +687,7 @@ class Request {
 	 * @return array
 	 * @throws \Exception
 	 */
-	public function execute_http() { 
+	public function execute_http() {
 		/**
 		 * Parse HTTP request.
 		 */
@@ -742,7 +746,7 @@ class Request {
 	 *
 	 * @return bool
 	 */
-	private function is_batch_queries_enabled() { 
+	private function is_batch_queries_enabled() {
 		$batch_queries_enabled = true;
 
 		$batch_queries_setting = get_graphql_setting( 'batch_queries_enabled', 'on' );
@@ -765,7 +769,7 @@ class Request {
 	 *
 	 * @return \GraphQL\Server\StandardServer
 	 */
-	private function get_server() { 
+	private function get_server() {
 		$debug_flag = $this->get_debug_flag();
 
 		$config = new ServerConfig();

--- a/src/Type/WPConnectionType.php
+++ b/src/Type/WPConnectionType.php
@@ -531,7 +531,7 @@ class WPConnectionType {
 					 */
 					return $resolve_connection( $root, $args, $context, $info );
 				},
-				'allow_field_underscores' => isset( $this->config['allow_field_underscores'] ) && true === $this->config['allow_field_underscores'],
+				'allowFieldUnderscores' => isset( $this->config['allowFieldUnderscores'] ) && true === $this->config['allowFieldUnderscores'],
 			]
 		);
 

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -106,11 +106,11 @@ class Utils {
 	 * Given a field name, formats it for GraphQL
 	 *
 	 * @param string $field_name         The field name to format
-	 * @param ?bool   $allow_underscores  Whether the field should be formatted with underscores allowed. Default false.
+	 * @param bool   $allow_underscores  Whether the field should be formatted with underscores allowed. Default false.
 	 *
 	 * @return string
 	 */
-	public static function format_field_name( string $field_name, ?bool $allow_underscores = false ): string {
+	public static function format_field_name( string $field_name, bool $allow_underscores = false ): string {
 
 		$replaced = preg_replace( '[^a-zA-Z0-9 -]', '_', $field_name );
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

**NOTE**: this PR is into the 1.14.0 release branch, replacing [this PR](https://github.com/wp-graphql/wp-graphql/pull/2737) to develop.

This allows fields, connections and mutations to be registered with underscores and have the underscores be preserved when the field is added to the Schema. 


Does this close any currently open issues?
------------------------------------------
closes #2736 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

Given the following snippet: 

```php
register_graphql_object_type( 'TestObject', [
	'eagerlyLoadType' => true,
	'fields' => [
		'test' => [ 'type' => 'String' ],
	]
]);

register_graphql_field( 'TestObject', 'my_field_with_underscores', [
	'type' => 'String',
	'description' => 'Default behavior with underscores stripped',
] );

register_graphql_field( 'TestObject', 'my_field_with_underscores', [
	'type' => 'String',
	'description' => 'Field configured to allow field underscores',
	'allow_field_underscores' => true,
] );
```

We can introspect the `TestObject` and see that both fields have been added, one without underscores (default) and one with underscores (opted-in):


![CleanShot 2023-02-24 at 16 50 37](https://user-images.githubusercontent.com/1260765/221322334-c742db21-e2f1-421f-8e0a-7268aec04ce7.png)


Any other comments?
-------------------
I'd _love_ to solve this in a more central way, but I don't see a good way to do it without breaking a lot of Schemas for a lot of users, something I don't think is worth the tradeoff right now.


Also, this PR was branched of the branch I was working on to prep for the v1.14.0 release, so it might have a bit of extra changes coming for the ride 🤦🏻‍♂️ 