### PR TITLE
fix: handle 404s in node resolver [WIP]

### DIFF
--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -356,10 +356,9 @@ class NodeResolver {
 		// Fetch the rewrite rules.
 		$rewrite = $wp_rewrite->wp_rewrite_rules();
 
-		$error = '404';
 		if ( ! empty( $rewrite ) ) {
 			// If we match a rewrite rule, this will be cleared.
-			$error                   = null;
+			$error                   = '404';
 			$this->wp->did_permalink = true;
 
 			$pathinfo         = ! empty( $uri ) ? $uri : '';
@@ -460,9 +459,16 @@ class NodeResolver {
 				// Substitute the substring matches into the query.
 				$query = addslashes( \WP_MatchesMapRegex::apply( $query, $matches ) ); // @phpstan-ignore-line
 
+				$this->wp->matched_query = $query;
+
 				// Parse the query.
 				parse_str( $query, $perma_query_vars );
 
+				// If we're processing a 404 request, clear the error var since we found something.
+				// @phpstan-ignore-next-line
+				if ( '404' == $error ) { // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
+					unset( $error );
+				}
 			}
 		}
 


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
When we refactored `NodeResolver` to use `WP_Query`, we didnt revisit our shimmed `parse_request()` method for parity with `WP::parse_request()`

Currently, this PR addresses a discrepancy that was causing unmatched URLs to return the home page. However there may be additional discrepancies that cause similar side effects as #2751.

Note: there is still an issue with the NodeResolver properties not getting cleared between requests: 

![image](https://user-images.githubusercontent.com/29322304/223283688-e95fdc3d-a017-4b90-8505-74e6e08d1284.png)


Does this close any currently open issues?
------------------------------------------
Part of #2751 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
