### PR TITLE
test: add tests for #2751 / #2752 (master/v1.13.10, should pass)

### DIFF
--- a/tests/wpunit/NodeByUriTest.php
+++ b/tests/wpunit/NodeByUriTest.php
@@ -722,4 +722,80 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 	}
 
+	/**
+	 * @see: https://github.com/wp-graphql/wp-graphql/issues/2751
+	 */
+	public function testNodeByUriWithCustomPermalinkStructure() {
+
+		$this->set_permalink_structure( '/posts/%postname%/' );
+
+		$query = '
+		query NodeByUri($uri:String!) {
+		  nodeByUri( uri: $uri ) {
+		    __typename
+		    uri
+		  }
+		}
+		';
+
+		$actual = $this->graphql([
+			'query' => $query,
+			'variables' => [
+				'uri' => '/whatever (something non-existing)'
+			]
+		]);
+
+		// The query should succeed
+		self::assertQuerySuccessful( $actual, [
+			// the query should return a null value as the uri
+			// cannot be found
+			$this->expectedField( 'nodeByUri', self::IS_NULL ),
+		] );
+
+	}
+
+	/**
+	 * @see: https://github.com/wp-graphql/wp-graphql/issues/2751
+	 */
+	public function testNodeByUriWithCustomPermalinkStructureAndFrontPageSet() {
+
+		$page_id = $this->factory()->post->create([
+			'post_type'   => 'page',
+			'post_status' => 'publish',
+		]);
+
+		update_option( 'page_on_front', $page_id );
+		update_option( 'show_on_front', 'page' );
+
+		$this->set_permalink_structure( '/posts/%postname%/' );
+
+		$query = '
+		query NodeByUri($uri:String!) {
+		  nodeByUri( uri: $uri ) {
+		    __typename
+		    uri
+		  }
+		}
+		';
+
+		$actual = $this->graphql([
+			'query' => $query,
+			'variables' => [
+				'uri' => '/whatever (something non-existing)'
+			]
+		]);
+
+		// The query should succeed
+		self::assertQuerySuccessful( $actual, [
+			// the query should return a null value as the uri
+			// cannot be found
+			$this->expectedField( 'nodeByUri', self::IS_NULL ),
+		] );
+
+		// cleanup
+		update_option( 'page_on_front', 0 );
+		update_option( 'show_on_front', 0 );
+
+	}
+
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

This adds tests for the issue described in #2751 and fixed in #2752

Ideally, the tests should pass against 1.13.10, fail against 1.14.0 release branch and pass again against #2752 branch.

- 1.13.10: (passing: https://github.com/wp-graphql/wp-graphql/actions/runs/4366526843/jobs/7636653735)
- 1.14.0: (failing: https://github.com/wp-graphql/wp-graphql/actions/runs/4366438525/jobs/7636452522#step:7:801)
- 2752 branch: (passing: https://github.com/wp-graphql/wp-graphql/actions/runs/4366609438)


Does this close any currently open issues?
------------------------------------------
assists #2752 in closing #2751 