### PR TITLE
fix: Allow post types and taxonomies to be registered without graphql_plural_name

### DIFF
--- a/src/Type/ObjectType/RootQuery.php
+++ b/src/Type/ObjectType/RootQuery.php
@@ -677,6 +677,7 @@ class RootQuery {
 		$allowed_post_types = \WPGraphQL::get_allowed_post_types( 'objects', [ 'graphql_register_root_field' => true ] );
 
 		foreach ( $allowed_post_types as $post_type_object ) {
+
 			register_graphql_field(
 				'RootQuery',
 				$post_type_object->graphql_single_name,

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -608,6 +608,13 @@ final class WPGraphQL {
 			$post_type_names = [];
 
 			foreach ( $post_type_objects as $post_type_object ) {
+
+				// if the graphql_single_name was provided, but not the plural name
+				// use the single name as the plural name
+				if ( empty( $post_type_object->graphql_plural_name ) && ! empty( $post_type_object->graphql_single_name ) ) {
+					$post_type_object->graphql_plural_name = $post_type_object->graphql_single_name;
+				}
+
 				/**
 				 * Validate that the post_types have a graphql_single_name and graphql_plural_name
 				 */
@@ -698,6 +705,13 @@ final class WPGraphQL {
 			$tax_names = [];
 
 			foreach ( $tax_objects as $tax_object ) {
+
+				// if the graphql_single_name was provided, but not the plural name
+				// use the single name as the plural name
+				if ( empty( $tax_object->graphql_plural_name ) && ! empty( $tax_object->graphql_single_name ) ) {
+					$tax_object->graphql_plural_name = $tax_object->graphql_single_name;
+				}
+
 				/**
 				 * Validate that the taxonomies have a graphql_single_name and graphql_plural_name
 				 */

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -621,12 +621,8 @@ final class WPGraphQL {
 			 */
 			$allowed_post_type_names = apply_filters( 'graphql_post_entities_allowed_post_types', $post_type_names, $post_type_objects );
 
-			// Maybe they're just out of order.
-			sort( $post_type_names );
-			sort( $allowed_post_type_names );
-
 			// Filter the post type objects if the list of allowed types have changed.
-			$post_type_objects = array_filter($post_type_objects, static function ( $obj ) use ( $allowed_post_type_names ) {
+			$post_type_objects = array_filter( $post_type_objects, static function ( $obj ) use ( $allowed_post_type_names ) {
 
 				if ( empty( $obj->graphql_plural_name ) && ! empty( $obj->graphql_single_name ) ) {
 					$obj->graphql_plural_name = $obj->graphql_single_name;
@@ -709,10 +705,7 @@ final class WPGraphQL {
 			 */
 			$allowed_tax_names = apply_filters( 'graphql_term_entities_allowed_taxonomies', $tax_names, $tax_objects );
 
-			sort( $tax_names );
-			sort( $allowed_tax_names );
-
-			$tax_objects = array_filter($tax_objects, static function ( $obj ) use ( $allowed_tax_names ) {
+			$tax_objects = array_filter( $tax_objects, static function ( $obj ) use ( $allowed_tax_names ) {
 
 				if ( empty( $obj->graphql_plural_name ) && ! empty( $obj->graphql_single_name ) ) {
 					$obj->graphql_plural_name = $obj->graphql_single_name;

--- a/tests/wpunit/CustomPostTypeTest.php
+++ b/tests/wpunit/CustomPostTypeTest.php
@@ -1555,7 +1555,7 @@ class CustomPostTypeTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$request = new \WPGraphQL\Request();
 		$request->schema->assertValid();
 
-		unregister_taxonomy( 'cpt_no_single_plural' );
+		unregister_post_type( 'cpt_no_single_plural' );
 
 	}
 

--- a/tests/wpunit/CustomPostTypeTest.php
+++ b/tests/wpunit/CustomPostTypeTest.php
@@ -1531,11 +1531,31 @@ class CustomPostTypeTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 			'query' => $query
 		]);
 
+		$request = new \WPGraphQL\Request();
+		$request->schema->assertValid();
+
 		self::assertQuerySuccessful( $actual, [
 			$this->expectedField( 'allNoPlural.nodes', self::IS_FALSY )
 		]);
 
 		unregister_post_type( 'cpt_no_plural' );
+
+	}
+
+	public function testRegisterPostTypeWithoutGraphqlSingleOrPluralNameDoesntInvalidateSchema() {
+
+		register_post_type( 'cpt_no_single_plural', [
+			'show_in_graphql' => true,
+			// no graphql_single_name
+			// no graphql_plural_name
+		]);
+
+		// assert that the schema is still valid, even though the tax
+		// didn't provide the single/plural name (it will be left out of the schema)
+		$request = new \WPGraphQL\Request();
+		$request->schema->assertValid();
+
+		unregister_taxonomy( 'cpt_no_single_plural' );
 
 	}
 

--- a/tests/wpunit/CustomPostTypeTest.php
+++ b/tests/wpunit/CustomPostTypeTest.php
@@ -1508,5 +1508,36 @@ class CustomPostTypeTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 	}
 
+	public function testRegisterPostTypeWithoutGraphqlPluralNameIsValid() {
+
+		register_post_type( 'cpt_no_plural', [
+			'show_in_graphql' => true,
+			'graphql_single_name' => 'noPlural'
+		]);
+
+		$this->clearSchema();
+
+		$query = '
+		{
+		  allNoPlural {
+		    nodes {
+		      id
+		    }
+		  }
+		}
+		';
+
+		$actual = $this->graphql([
+			'query' => $query
+		]);
+
+		self::assertQuerySuccessful( $actual, [
+			$this->expectedField( 'allNoPlural.nodes', self::IS_FALSY )
+		]);
+
+		unregister_post_type( 'cpt_no_plural' );
+
+	}
+
 
 }

--- a/tests/wpunit/CustomTaxonomyTest.php
+++ b/tests/wpunit/CustomTaxonomyTest.php
@@ -1070,4 +1070,35 @@ class CustomTaxonomyTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 	}
 
+	public function testRegisterTaxonomyWithoutGraphqlPluralNameIsValid() {
+
+		register_taxonomy( 'tax_no_plural', 'post',[
+			'show_in_graphql' => true,
+			'graphql_single_name' => 'taxNoPlural'
+		]);
+
+		$this->clearSchema();
+
+		$query = '
+		{
+		  allTaxNoPlural {
+		    nodes {
+		      id
+		    }
+		  }
+		}
+		';
+
+		$actual = $this->graphql([
+			'query' => $query
+		]);
+
+		self::assertQuerySuccessful( $actual, [
+			$this->expectedField( 'allTaxNoPlural.nodes', self::IS_FALSY )
+		]);
+
+		unregister_taxonomy( 'tax_no_plural' );
+
+	}
+
 }

--- a/tests/wpunit/CustomTaxonomyTest.php
+++ b/tests/wpunit/CustomTaxonomyTest.php
@@ -1077,7 +1077,8 @@ class CustomTaxonomyTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 			'graphql_single_name' => 'taxNoPlural'
 		]);
 
-		$this->clearSchema();
+		$request = new \WPGraphQL\Request();
+		$request->schema->assertValid();
 
 		$query = '
 		{
@@ -1098,6 +1099,23 @@ class CustomTaxonomyTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		]);
 
 		unregister_taxonomy( 'tax_no_plural' );
+
+	}
+
+	public function testRegisterTaxonomyWithoutGraphqlSingleOrPluralNameDoesntInvalidateSchema() {
+
+		register_taxonomy( 'tax_no_single_plural', 'post',[
+			'show_in_graphql' => true,
+			// no graphql_single_name
+			// no graphql_plural_name
+		]);
+
+		// assert that the schema is still valid, even though the tax
+		// didn't provide the single/plural name (it will be left out of the schema)
+		$request = new \WPGraphQL\Request();
+		$request->schema->assertValid();
+
+		unregister_taxonomy( 'tax_no_single_plural' );
 
 	}
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This allows post types/taxonomies to be registered to show_in_graphql without requiring `graphql_plural_name` (graphql_single_name) is still required.

Does this close any currently open issues?
------------------------------------------
closes #2754 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

Registering a post type like so: 

```php
add_action( 'init', function() {
	register_post_type( 'test_type', [
		'label' => 'Test Type',
		'public' => true,
		'show_in_graphql' => true,
		'graphql_single_name' => 'testType',
	]);
});
```

## Before

![CleanShot 2023-03-08 at 13 39 20](https://user-images.githubusercontent.com/1260765/223844497-0d6b40b5-20d9-4f0d-95c4-4c7542ccbe0a.png)


## After

![CleanShot 2023-03-08 at 13 41 47](https://user-images.githubusercontent.com/1260765/223845020-32bce628-3292-446b-9204-1db07a81f495.png)


Any other comments?
-------------------
This PR also converts the hard UserError that's thrown and changes it to a `graphql_debug()` message. 

This allows the Schema to still generate even if a post type is registered with `show_in_graphql => true`, but is missing a graphql_single_name. 

ex: 

```php
add_action( 'init', function() {
	register_post_type( 'test_type', [
		'label' => 'Test Type',
		'public' => true,
		'show_in_graphql' => true,
		// oops, forgot to add a graphql_single_name
	]);
});
```

Results in the Schema loading in GraphiQL, but a debug message being output:


![CleanShot 2023-03-08 at 14 45 46](https://user-images.githubusercontent.com/1260765/223857617-c3c32480-054d-4496-b77b-12c312442af1.png)

Previously this would've prevented the Schema / GraphiQL from loading.
