### PR TITLE
fix: wrong order in term and post ancestors.

### DIFF
--- a/src/Registry/Utils/TermObject.php
+++ b/src/Registry/Utils/TermObject.php
@@ -177,6 +177,7 @@ class TermObject {
 
 					$resolver = new TermObjectConnectionResolver( $term, $args, $context, $info, $tax_object->name );
 					$resolver->set_query_arg( 'include', $ancestor_ids );
+					$resolver->set_query_arg( 'orderby', 'include' );
 
 					return $resolver->get_connection();
 				},

--- a/src/Type/Connection/PostObjects.php
+++ b/src/Type/Connection/PostObjects.php
@@ -159,6 +159,7 @@ class PostObjects {
 				}
 				$resolver = new PostObjectConnectionResolver( $post, $args, $context, $info );
 				$resolver->set_query_arg( 'post__in', $ancestors );
+				$resolver->set_query_arg( 'orderby', 'post__in' );
 
 				return $resolver->get_connection();
 			},


### PR DESCRIPTION
<!--🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [X] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [X] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [X] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!
-->
What does this implement/fix? Explain your changes.
---------------------------------------------------

This PR fixes the wrong order in the ancestor's resolvers for terms and posts.

- Terms: The default order in [TermObjectConnectionResolver](https://github.com/wp-graphql/wp-graphql/blob/develop/src/Data/Connection/TermObjectConnectionResolver.php#L79) is `$query_args['orderby'] = 'name';`. The [ancestors resolver](https://github.com/wp-graphql/wp-graphql/blob/develop/src/Registry/Utils/TermObject.php#L179) uses `$resolver->set_query_arg( 'include', $ancestor_ids );` that requires `$resolver->set_query_arg( 'orderby', 'include' );` in other to preserve the [initial order from](https://developer.wordpress.org/reference/functions/get_ancestors/) `get_ancestors` function.

- Post: The default order in [PostObjectConnectionResolver](https://github.com/wp-graphql/wp-graphql/blob/44fbc682ec0d62e011447941c38cb74d1ef591de/src/Type/Connection/PostObjects.php#L140) is `$resolver->set_query_arg( 'orderby', 'post__in' );`. The [ancestors resolver](https://github.com/wp-graphql/wp-graphql/pull/2770/files#diff-eae106d899fe458092e3a45740f6a69b7a99f259222c25dfb1d4d67ae45b3356R161) uses `$resolver->set_query_arg( 'post__in', $ancestors );` that requires `$resolver->set_query_arg( 'orderby', 'post__in' );` in other to preserve the [initial order from](https://developer.wordpress.org/reference/functions/get_ancestors/) `get_ancestors` function.


Props to @italodr for identifying the bug.