### PR TITLE
fix: issue #2774 multiple taxonomy support when supplying multiple taxonomies

### DIFF
--- a/src/Data/Connection/TermObjectConnectionResolver.php
+++ b/src/Data/Connection/TermObjectConnectionResolver.php
@@ -49,15 +49,21 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 	 */
 	public function get_query_args() {
 
-		/**
-		 * Set the taxonomy for the $args
-		 */
-		$all_taxonomies = \WPGraphQL::get_allowed_taxonomies();
-		$requested_taxonomies = isset( $this->args['where']['taxonomies'] ) ? $this->args['where']['taxonomies'] : [ $this->taxonomy ];
-		$valid_taxonomies = array_intersect( $all_taxonomies, $requested_taxonomies );
+
+		$all_taxonomies       = \WPGraphQL::get_allowed_taxonomies();
+		$taxonomy = ! empty( $this->taxonomy ) && in_array( $this->taxonomy, $all_taxonomies, true ) ? [ $this->taxonomy ] : $all_taxonomies;
+
+		if ( ! empty( $this->args['where']['taxonomies'] ) ) {
+			/**
+			 * Set the taxonomy for the $args
+			 */
+			$requested_taxonomies = $this->args['where']['taxonomies'];
+			$taxonomy             = array_intersect( $all_taxonomies, $requested_taxonomies );
+		}
+
 
 		$query_args = [
-			'taxonomy' => !empty($valid_taxonomies) ? $valid_taxonomies : $all_taxonomies,
+			'taxonomy' => $taxonomy,
 		];
 
 		/**


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x ] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [ x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [ x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Addresses issue #2774. It correctly parses multiple taxonomy terms now and maintains support for a single taxonomy term.


Does this close any currently open issues?
------------------------------------------
Issue #2774 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Mac OSX 12.5

**WordPress Version:** 6.1.1
