### PR TITLE
chore: remove internal usage of deprecated functions

### DIFF
--- a/src/Mutation/CommentCreate.php
+++ b/src/Mutation/CommentCreate.php
@@ -7,7 +7,6 @@ use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
 use WPGraphQL\Data\CommentMutation;
-use WPGraphQL\Data\DataSource;
 
 class CommentCreate {
 	/**
@@ -88,12 +87,12 @@ class CommentCreate {
 			'comment' => [
 				'type'        => 'Comment',
 				'description' => __( 'The comment that was created', 'wp-graphql' ),
-				'resolve'     => function ( $payload, $args, AppContext $context, ResolveInfo $info ) {
+				'resolve'     => function ( $payload, $args, AppContext $context ) {
 					if ( ! isset( $payload['id'] ) || ! absint( $payload['id'] ) ) {
 						return null;
 					}
 
-					return DataSource::resolve_comment( absint( $payload['id'] ), $context );
+					return $context->get_loader( 'comment' )->load_deferred( absint( $payload['id'] ) );
 				},
 			],
 			/**

--- a/src/Mutation/CommentRestore.php
+++ b/src/Mutation/CommentRestore.php
@@ -3,10 +3,8 @@
 namespace WPGraphQL\Mutation;
 
 use GraphQL\Error\UserError;
-use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
-use WPGraphQL\Data\DataSource;
 use WPGraphQL\Utils\Utils;
 
 /**
@@ -66,11 +64,11 @@ class CommentRestore {
 			'comment'    => [
 				'type'        => 'Comment',
 				'description' => __( 'The restored comment object', 'wp-graphql' ),
-				'resolve'     => function ( $payload, $args, AppContext $context, ResolveInfo $info ) {
+				'resolve'     => function ( $payload, $args, AppContext $context ) {
 					if ( ! isset( $payload['commentObject']->comment_ID ) || ! absint( $payload['commentObject']->comment_ID ) ) {
 						return null;
 					}
-					return DataSource::resolve_comment( absint( $payload['commentObject']->comment_ID ), $context );
+					return $context->get_loader( 'comment' )->load_deferred( absint( $payload['commentObject']->comment_ID ) );
 				},
 			],
 		];

--- a/src/Mutation/MediaItemCreate.php
+++ b/src/Mutation/MediaItemCreate.php
@@ -6,7 +6,6 @@ use Exception;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
-use WPGraphQL\Data\DataSource;
 use WPGraphQL\Data\MediaItemMutation;
 use WPGraphQL\Utils\Utils;
 
@@ -108,7 +107,8 @@ class MediaItemCreate {
 					if ( empty( $payload['postObjectId'] ) || ! absint( $payload['postObjectId'] ) ) {
 						return null;
 					}
-					return DataSource::resolve_post_object( $payload['postObjectId'], $context );
+
+					return $context->get_loader( 'post' )->load_deferred( $payload['postObjectId'] );
 				},
 			],
 		];

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -3,8 +3,6 @@
 namespace WPGraphQL\Registry;
 
 use Exception;
-use GraphQL\Type\Definition\ListOfType;
-use GraphQL\Type\Definition\NonNull;
 use GraphQL\Type\Definition\Type;
 use InvalidArgumentException;
 use WPGraphQL\Data\DataSource;

--- a/src/Type/ObjectType/RootQuery.php
+++ b/src/Type/ObjectType/RootQuery.php
@@ -549,8 +549,7 @@ class RootQuery {
 
 							}
 
-							return ! empty( $term_id ) ? DataSource::resolve_term_object( $term_id, $context ) : null;
-
+							return ! empty( $term_id ) ? $context->get_loader( 'term' )->load_deferred( $term_id ) : null;
 						},
 					],
 					'theme'       => [

--- a/tests/wpunit/NodeByUriTest.php
+++ b/tests/wpunit/NodeByUriTest.php
@@ -1652,6 +1652,7 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		]);
 
 		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertNotEmpty( $actual['data']['page'] );
 		$this->assertSame( $page_id, $actual['data']['page']['databaseId'] );
 		$this->assertTrue( $actual['data']['page']['isFrontPage'] );
 		$this->assertSame( '/', $actual['data']['page']['uri'] );

--- a/tests/wpunit/PostObjectQueriesTest.php
+++ b/tests/wpunit/PostObjectQueriesTest.php
@@ -259,7 +259,7 @@ class PostObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase 
 				'toPing'          => null,
 				'pinged'          => null,
 				'modified'        => \WPGraphQL\Utils\Utils::prepare_date_response( get_post( $post_id )->post_modified ),
-				'modifiedGmt'     => \WPGraphQL\Types::prepare_date_response( get_post( $post_id )->post_modified_gmt ),
+				'modifiedGmt'     => \WPGraphQL\Utils\Utils::prepare_date_response( get_post( $post_id )->post_modified_gmt ),
 				'title'           => apply_filters( 'the_title', 'Test Title for PostObjectQueriesTest' ),
 				'guid'            => get_post( $post_id )->guid,
 				'featuredImage'   => [


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Removes the internal usage of several deprecated function calls:
- `DataSource::resolve_comment()`
- `DataSource::resolve_post_object()`
- `DataSource::resolve_term_object()`
- `Types::prepare_date_response()`


Does this close any currently open issues?
------------------------------------------
No


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
As far as I can tell, this removes the last usages of deprecated methods in core. 


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php8.0.26)

**WordPress Version:** 6.2
