### PR TITLE
ci: test against WordPress v6.2

### DIFF
--- a/.github/workflows/deploy-docker-image.yml
+++ b/.github/workflows/deploy-docker-image.yml
@@ -14,14 +14,7 @@ jobs:
     strategy:
       matrix:
         php: [ '8.1', '8.0', '7.4', '7.3' ]
-        wordpress: [ '6.0', '5.9', '5.8', '5.7.2', '5.6', '5.5.3' ]
-        include:
-          - php: '8.1'
-            wordpress: '6.1'
-          - php: '8.0'
-            wordpress: '6.1'
-          - php: '7.4'
-            wordpress: '6.1'
+        wordpress: [ '6.2', '6.1', '6.0', '5.9', '5.8', '5.7.2', '5.6', '5.5.3' ]
         exclude:
           - php: '8.0'
             wordpress: '5.5.3'
@@ -33,6 +26,10 @@ jobs:
             wordpress: '5.7.2'
           - php: '7.3'
             wordpress: '6.0'
+          - php: '7.3'
+            wordpress: '6.1'
+          - php: '7.3'
+            wordpress: '6.2'
       fail-fast: false
     name: WordPress ${{ matrix.wordpress }} on PHP ${{ matrix.php }}
     steps:

--- a/.github/workflows/deploy-docker-image.yml
+++ b/.github/workflows/deploy-docker-image.yml
@@ -30,6 +30,9 @@ jobs:
             wordpress: '6.1'
           - php: '7.3'
             wordpress: '6.2'
+          # This is a temporary exclusion until a php74 image is released. See #2780
+          - php: '7.4'
+          - wordpress: '6.2'
       fail-fast: false
     name: WordPress ${{ matrix.wordpress }} on PHP ${{ matrix.php }}
     steps:

--- a/.github/workflows/testing-integration.yml
+++ b/.github/workflows/testing-integration.yml
@@ -21,15 +21,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.0', '7.4', ]
-        wordpress: [ '6.1', '6.0', '5.9', '5.8', '5.7', '5.6' ]
+        php: [ '8.0', '7.4' ]
+        wordpress: [ '6.2', '6.1', '6.0', '5.9', '5.8', '5.7', '5.6' ]
         include:
           - php: '8.1'
-            wordpress: '6.1'
+            wordpress: '6.2'
             multisite: true
           - php: '8.1'
-            wordpress: '6.0'
+            wordpress: '6.2'
             coverage: 1
+          - php: '8.1'
+            wordpress: '6.1'
+          - php: '8.1'
+            wordpress: '6.0'
           - php: '8.1'
             wordpress: '5.9'
           - php: '7.3'

--- a/.github/workflows/testing-integration.yml
+++ b/.github/workflows/testing-integration.yml
@@ -44,6 +44,10 @@ jobs:
             wordpress: '5.7'
           - php: '7.3'
             wordpress: '5.6'
+        # This is a temporary exclusion until a php74 image is released. See #2780
+        exclude:
+          - php: '7.4'
+          - wordpress: '6.2'
 
     steps:
       - name: Checkout

--- a/bin/run-docker.sh
+++ b/bin/run-docker.sh
@@ -16,11 +16,11 @@ print_usage_instructions() {
     echo "  composer build-app";
     echo "  composer run-app";
     echo "";
-    echo "  WP_VERSION=6.1 PHP_VERSION=8.1 composer build-app";
-    echo "  WP_VERSION=6.1 PHP_VERSION=8.1 composer run-app";
+    echo "  WP_VERSION=6.2 PHP_VERSION=8.1 composer build-app";
+    echo "  WP_VERSION=6.2 PHP_VERSION=8.1 composer run-app";
     echo "";
-    echo "  WP_VERSION=6.1 PHP_VERSION=8.1  bin/run-docker.sh build -a";
-    echo "  WP_VERSION=6.1 PHP_VERSION=8.1  bin/run-docker.sh run -a";
+    echo "  WP_VERSION=6.2 PHP_VERSION=8.1  bin/run-docker.sh build -a";
+    echo "  WP_VERSION=6.2 PHP_VERSION=8.1  bin/run-docker.sh run -a";
     exit 1
 }
 
@@ -29,7 +29,7 @@ if [ $# -eq 0 ]; then
 fi
 
 TAG=${TAG-latest}
-WP_VERSION=${WP_VERSION-6.1}
+WP_VERSION=${WP_VERSION-6.2}
 PHP_VERSION=${PHP_VERSION-8.1}
 
 BUILD_NO_CACHE=${BUILD_NO_CACHE-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   app:
     depends_on:
       - app_db
-    image: wp-graphql:latest-wp${WP_VERSION-6.1}-php${PHP_VERSION-8.1}
+    image: wp-graphql:latest-wp${WP_VERSION-6.2}-php${PHP_VERSION-8.1}
     volumes:
       - '.:/var/www/html/wp-content/plugins/wp-graphql'
       - './.log/app:/var/log/apache2'
@@ -34,7 +34,7 @@ services:
   testing:
     depends_on:
       - app_db
-    image: wp-graphql-testing:latest-wp${WP_VERSION-6.1}-php${PHP_VERSION-8.1}
+    image: wp-graphql-testing:latest-wp${WP_VERSION-6.2}-php${PHP_VERSION-8.1}
     volumes:
       - '.:/var/www/html/wp-content/plugins/wp-graphql'
       - './.log/testing:/var/log/apache2'

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -191,7 +191,7 @@ PHP_VERSION=7.4 composer build-test
 Build the environment with specific version of WordPress:
 
 ```shell
-WP_VERSION=6.1 composer build-test
+WP_VERSION=6.2 composer build-test
 ```
 
 ```shell

--- a/tests/_data/config.php
+++ b/tests/_data/config.php
@@ -5,6 +5,8 @@
  * fatal errors when the autoloader is loaded twice
  */
 define( 'GRAPHQL_DEBUG', true );
+define( 'WP_DEBUG', true );
+define( 'WP_DEBUG_LOG', true );
 define( 'WPGRAPHQL_AUTOLOAD', false );
 define( 'WP_AUTO_UPDATE_CORE', false );
 define( 'AUTOMATIC_UPDATER_DISABLED', true );

--- a/tests/_data/config.php
+++ b/tests/_data/config.php
@@ -5,8 +5,6 @@
  * fatal errors when the autoloader is loaded twice
  */
 define( 'GRAPHQL_DEBUG', true );
-define( 'WP_DEBUG', true );
-define( 'WP_DEBUG_LOG', true );
 define( 'WPGRAPHQL_AUTOLOAD', false );
 define( 'WP_AUTO_UPDATE_CORE', false );
 define( 'AUTOMATIC_UPDATER_DISABLED', true );

--- a/tests/wpunit/CustomPostTypeTest.php
+++ b/tests/wpunit/CustomPostTypeTest.php
@@ -1519,11 +1519,11 @@ class CustomPostTypeTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$query = '
 		{
-		  allNoPlural {
-		    nodes {
-		      id
-		    }
-		  }
+			allNoPlural {
+				nodes {
+					id
+				}
+			}
 		}
 		';
 
@@ -1538,8 +1538,9 @@ class CustomPostTypeTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 			$this->expectedField( 'allNoPlural.nodes', self::IS_FALSY )
 		]);
 
+		// Cleanup.
 		unregister_post_type( 'cpt_no_plural' );
-
+		$this->clearSchema();
 	}
 
 	public function testRegisterPostTypeWithoutGraphqlSingleOrPluralNameDoesntInvalidateSchema() {
@@ -1555,9 +1556,9 @@ class CustomPostTypeTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$request = new \WPGraphQL\Request();
 		$request->schema->assertValid();
 
+		// Cleanup
 		unregister_post_type( 'cpt_no_single_plural' );
-
+		$this->clearSchema();
 	}
-
 
 }

--- a/tests/wpunit/EnqueuedScriptsTest.php
+++ b/tests/wpunit/EnqueuedScriptsTest.php
@@ -81,7 +81,7 @@ class EnqueuedScriptsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 			'post_excerpt'  => 'Test excerpt',
 		] );
 
-		$filename       = ( WPGRAPHQL_PLUGIN_DIR . '/tests/_data/images/test.png' );
+		$filename       = ( WPGRAPHQL_PLUGIN_DIR . 'tests/_data/images/test.png' );
 		$this->media_id = $this->factory()->attachment->create_upload_object( $filename, $this->post_id );
 
 		$this->custom_post_id = $this->factory()->post->create( [

--- a/tests/wpunit/EnqueuedStylesheetsTest.php
+++ b/tests/wpunit/EnqueuedStylesheetsTest.php
@@ -81,7 +81,7 @@ class EnqueuedStylesheetsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCas
 			'post_excerpt'  => 'Test excerpt',
 		] );
 
-		$filename       = ( WPGRAPHQL_PLUGIN_DIR . '/tests/_data/images/test.png' );
+		$filename       = ( WPGRAPHQL_PLUGIN_DIR . 'tests/_data/images/test.png' );
 		$this->media_id = $this->factory()->attachment->create_upload_object( $filename, $this->post_id );
 
 		$this->custom_post_id = $this->factory()->post->create( [

--- a/tests/wpunit/MediaItemQueriesTest.php
+++ b/tests/wpunit/MediaItemQueriesTest.php
@@ -337,7 +337,7 @@ class MediaItemQueriesTest  extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase 
 	 */
 	public function testMediaItemImageUrl() {
 
-		$filename      = ( WPGRAPHQL_PLUGIN_DIR . '/tests/_data/images/test.png' );
+		$filename      = ( WPGRAPHQL_PLUGIN_DIR . 'tests/_data/images/test.png' );
 		$attachment_id = $this->factory()->attachment->create_upload_object( $filename );
 
 		$expected_filesize = filesize( $filename );
@@ -366,10 +366,10 @@ class MediaItemQueriesTest  extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase 
 
 	public function testQueryMediaItemsByMimeType() {
 		
-		$png_filename      = ( WPGRAPHQL_PLUGIN_DIR . '/tests/_data/images/test.png' );
+		$png_filename      = ( WPGRAPHQL_PLUGIN_DIR . 'tests/_data/images/test.png' );
 		$png_attachment_id = $this->factory()->attachment->create_upload_object( $png_filename );
 
-		$pdf_filename      = ( WPGRAPHQL_PLUGIN_DIR . '/tests/_data/media/test.pdf' );
+		$pdf_filename      = ( WPGRAPHQL_PLUGIN_DIR . 'tests/_data/media/test.pdf' );
 		$pdf_attachment_id = $this->factory()->attachment->create_upload_object( $pdf_filename );
 
 		$query = '
@@ -416,7 +416,7 @@ class MediaItemQueriesTest  extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase 
 	 */
 	public function testQueryMediaItemBySourceUrl() {
 
-		$filename          = ( WPGRAPHQL_PLUGIN_DIR . '/tests/_data/images/test.png' );
+		$filename          = ( WPGRAPHQL_PLUGIN_DIR . 'tests/_data/images/test.png' );
 		$attachment_id     = $this->factory()->attachment->create_upload_object( $filename );
 		$expected_filesize = filesize( $filename );
 
@@ -539,7 +539,7 @@ class MediaItemQueriesTest  extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase 
 		/**
 		 * Upload a medium size attachment
 		 */
-		$filename      = ( WPGRAPHQL_PLUGIN_DIR . '/tests/_data/images/test-medium.png' );
+		$filename      = ( WPGRAPHQL_PLUGIN_DIR . 'tests/_data/images/test-medium.png' );
 		$attachment_id = $this->factory()->attachment->create_upload_object( $filename );
 
 		/**
@@ -592,7 +592,7 @@ class MediaItemQueriesTest  extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase 
 		/**
 		 * Upload a medium size attachment
 		 */
-		$filename      = ( WPGRAPHQL_PLUGIN_DIR . '/tests/_data/images/test.png' );
+		$filename      = ( WPGRAPHQL_PLUGIN_DIR . 'tests/_data/images/test.png' );
 		$attachment_id = $this->factory()->attachment->create_upload_object( $filename );
 
 		/**

--- a/tests/wpunit/PostObjectQueriesTest.php
+++ b/tests/wpunit/PostObjectQueriesTest.php
@@ -160,7 +160,7 @@ class PostObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase 
 		/**
 		 * Create a featured image and attach it to the post
 		 */
-		$filename          = ( WPGRAPHQL_PLUGIN_DIR . '/tests/_data/images/test.png' );
+		$filename          = ( WPGRAPHQL_PLUGIN_DIR . 'tests/_data/images/test.png' );
 		$featured_image_id = $this->factory()->attachment->create_upload_object( $filename );
 		update_post_meta( $post_id, '_thumbnail_id', $featured_image_id );
 

--- a/tests/wpunit/PreviewTest.php
+++ b/tests/wpunit/PreviewTest.php
@@ -34,7 +34,7 @@ class PreviewTest extends \Codeception\TestCase\WPTestCase {
 
 		wp_set_object_terms( $this->post, $this->category, 'category', false );
 
-		$filename             = ( WPGRAPHQL_PLUGIN_DIR . '/tests/_data/images/test.png' );
+		$filename             = ( WPGRAPHQL_PLUGIN_DIR . 'tests/_data/images/test.png' );
 		$this->featured_image = $this->factory()->attachment->create_upload_object( $filename );
 		update_post_meta( $this->post, '_thumbnail_id', $this->featured_image );
 

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -10,7 +10,7 @@
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
- * Tested up to: 6.1
+ * Tested up to: 6.2
  * Requires PHP: 7.1
  * License: GPL-3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR updates the various ci matrices to test against WordPress 6.2

It also fixes two WPUnit test issues that were causing codeception to fail locally:
- tests: Cleans up schema after `testRegisterPostTypeWithoutGraphqlPluralNameIsValid()`, to prevent a `GraphQL\UserError` when running later tests.
- tests: Removed extraneous `/` when concatenating paths with the `WPGraphQL_PLUGIN_DIR` constant.


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
Excludes WP6.2 on PHP7.4, due to a missing docker image. Tracking in #2780 


Where has this been tested?
---------------------------
**Operating System:** N/A

**WordPress Version:** N/A
