### PR TITLE
chore: call `_doing_it_wrong()` when using deprecated `{PostObject|TermObject}Union`

### DIFF
--- a/src/Type/Union/PostObjectUnion.php
+++ b/src/Type/Union/PostObjectUnion.php
@@ -29,6 +29,7 @@ class PostObjectUnion {
 				'typeNames'   => self::get_possible_types(),
 				'description' => __( 'Union between the post, page and media item types', 'wp-graphql' ),
 				'resolveType' => function ( $value ) use ( $type_registry ) {
+					_doing_it_wrong( 'PostObjectUnion', esc_attr__( 'The PostObjectUnion GraphQL type is deprecated. Use the ContentNode interface instead.', 'wp-graphql' ), '@todo' );
 
 					$type = null;
 					if ( isset( $value->post_type ) ) {

--- a/src/Type/Union/TermObjectUnion.php
+++ b/src/Type/Union/TermObjectUnion.php
@@ -28,6 +28,7 @@ class TermObjectUnion {
 				'typeNames'   => self::get_possible_types(),
 				'description' => __( 'Union between the Category, Tag and PostFormatPost types', 'wp-graphql' ),
 				'resolveType' => function ( $value ) use ( $type_registry ) {
+					_doing_it_wrong( 'TermObjectUnion', esc_attr__( 'The TermObjectUnion GraphQL type is deprecated. Use the TermNode interface instead.', 'wp-graphql' ), '@todo' );
 
 					$type = null;
 					if ( isset( $value->taxonomyName ) ) {


### PR DESCRIPTION
…

<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR calls `_doing_it_wrong()` when using the deprecated `PostObjectUnion`/`TermObjectUnion` GraphQL types.

These type earned a `@deprecated` tag in #2617 


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------

As far as I can tell, beyond the `@deprecated` tag, no other indications that these types were deprecated are in the codebase, nor was it mentioned in the release notes. As such, I'm conflicted whether we should backdate the notice to `1.13.x`, or consider this PR the actual type deprecation and mark it for the next *minor* release (v1.15.x).
@jasonbahl your call. 

For now, the version is marked `@todo`.


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php8.0.26)

**WordPress Version:** 6.2
