### PR TITLE
fix: early return for HTTP OPTIONS requests

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -39,7 +39,7 @@ class Router {
 	public static $http_status_code = 200;
 
 	/**
-	 * @var \WPGraphQL\Request
+	 * @var \WPGraphQL\Request | null
 	 */
 	protected static $request;
 
@@ -85,9 +85,9 @@ class Router {
 	/**
 	 * Returns the GraphQL Request being executed
 	 *
-	 * @return \WPGraphQL\Request
+	 * @return \WPGraphQL\Request | null
 	 */
-	public static function get_request() {
+	public static function get_request(): ?Request {
 		return self::$request;
 	}
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This returns early for HTTP OPTIONS requests, before the WPGraphQL\Request() is instantiated and execution begins. 


Does this close any currently open issues?
------------------------------------------
closes #2785 

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

## BEFORE:

OPTIONS request takes 2.23s:

![CleanShot 2023-04-11 at 10 13 46](https://user-images.githubusercontent.com/1260765/231224721-7614b4b5-89cd-4ca6-bf41-a5f5b7ac02bc.png)


## AFTER:

OPTIONS request takes 244ms:

![CleanShot 2023-04-11 at 10 13 06](https://user-images.githubusercontent.com/1260765/231224551-7a102759-1760-42bb-ac7d-4a196535ff0a.png)
