### PR TITLE
fix: uri field is null when querying the page for posts uri

### DIFF
--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -201,8 +201,7 @@ class NodeResolver {
 					return null;
 				}
 
-				/** @todo resolve to an Archive Type. */
-				$post_type_object = get_post_type_object( $queried_object->post_type );
+				$post_type_object = get_post_type_object( 'post' );
 
 				if ( ! $post_type_object ) {
 					return null;


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

This fixes a bug in the NodeResolver where querying the posts page prevents the node from fully resolving properly. 

failing test: https://github.com/wp-graphql/wp-graphql/actions/runs/4745816863/jobs/8428653391?pr=2792#step:8:816
passing test: https://github.com/wp-graphql/wp-graphql/actions/runs/4745911977/jobs/8428890823?pr=2792#step:8:813

Does this close any currently open issues?
------------------------------------------
closes #2791


Any other comments?
-------------------

**BEFORE**

I can query a node by URI and get the node back, but the node returns `null` for the uri field 🤔. This is a bug. If a node can be identified by a uri, the node has a uri. 

![CleanShot 2023-04-19 at 10 43 30](https://user-images.githubusercontent.com/1260765/233143712-c0c77136-e388-4424-802f-5263d33797a6.png)

**AFTER**

The uri field is output as expected 👏🏻 

![CleanShot 2023-04-19 at 10 44 28](https://user-images.githubusercontent.com/1260765/233143956-80c40808-e40b-46e3-b5b7-6055e0b07dc4.png)
