### PR TITLE
fix: querying posts by slug fails when custom permalinks are set

### DIFF
--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -506,7 +506,7 @@ class NodeResolver {
 				if ( isset( $post_type_query_vars[ $wpvar ] ) ) {
 					$this->wp->query_vars['post_type'] = $post_type_query_vars[ $wpvar ];
 					$this->wp->query_vars['name']      = $this->wp->query_vars[ $wpvar ];
-				}           
+				}
 			}
 		}
 

--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -506,8 +506,7 @@ class NodeResolver {
 				if ( isset( $post_type_query_vars[ $wpvar ] ) ) {
 					$this->wp->query_vars['post_type'] = $post_type_query_vars[ $wpvar ];
 					$this->wp->query_vars['name']      = $this->wp->query_vars[ $wpvar ];
-				}
-
+				}           
 			}
 		}
 

--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -2,12 +2,11 @@
 
 namespace WPGraphQL\Data;
 
-use Exception;
 use GraphQL\Deferred;
-use WP;
 use WP_Post;
 use WPGraphQL\AppContext;
 use GraphQL\Error\UserError;
+use WPGraphQL\Router;
 
 class NodeResolver {
 
@@ -30,8 +29,9 @@ class NodeResolver {
 	 */
 	public function __construct( AppContext $context ) {
 		global $wp;
-		$this->wp      = $wp;
-		$this->context = $context;
+		$this->wp               = $wp;
+		$this->wp->matched_rule = Router::$route . '/?$';
+		$this->context          = $context;
 	}
 
 	/**
@@ -435,6 +435,7 @@ class NodeResolver {
 			}
 
 			if ( ! empty( $this->wp->matched_rule ) ) {
+
 				// Trim the query of everything up to the '?'.
 				$query = preg_replace( '!^.+\?!', '', $query );
 
@@ -506,6 +507,7 @@ class NodeResolver {
 					$this->wp->query_vars['post_type'] = $post_type_query_vars[ $wpvar ];
 					$this->wp->query_vars['name']      = $this->wp->query_vars[ $wpvar ];
 				}
+
 			}
 		}
 

--- a/tests/wpunit/NodeByUriTest.php
+++ b/tests/wpunit/NodeByUriTest.php
@@ -322,10 +322,6 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertNull( $actual['data']['nodeByUri'] );
 
-		codecept_debug( [
-			'invalidBase' => '/blog' . $uri
-		]);
-
 		//Test with unwanted base.
 		$actual = $this->graphql([
 			'query'     => $query,

--- a/tests/wpunit/NodeByUriTest.php
+++ b/tests/wpunit/NodeByUriTest.php
@@ -322,6 +322,10 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertNull( $actual['data']['nodeByUri'] );
 
+		codecept_debug( [
+			'invalidBase' => '/blog' . $uri
+		]);
+
 		//Test with unwanted base.
 		$actual = $this->graphql([
 			'query'     => $query,
@@ -1945,6 +1949,47 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 			$this->expectedField( 'nodeByUri.__typename', 'ContentType' ),
 			$this->expectedField( 'nodeByUri.uri', $uri ),
 		] );
+
+	}
+
+	public function testQueryPostBySlugWhenPermalinksAreSetCustom() {
+
+		$this->set_permalink_structure( '/articles/%postname%/' );
+
+		$slug = 'test-slug';
+
+		$postId = $this->factory()->post->create([
+			'post_type'   => 'post',
+			'post_status' => 'publish',
+			'post_name' => $slug,
+			'post_title' => 'post-title'
+ 		]);
+		codecept_debug( [
+			'slug' => $slug,
+			'link' => get_permalink( $postId )
+		]);
+
+
+		$query = '
+		query GetPostsBySlug( $id: ID! ) {
+		  post(id: $id, idType: SLUG) {
+		    __typename
+		    slug
+		  }
+		}
+		';
+
+		$actual = $this->graphql([
+			'query' => $query,
+			'variables' => [
+				'id' => $slug,
+			]
+		]);
+
+		self::assertQuerySuccessful( $actual, [
+			$this->expectedField( 'post.__typename', 'Post' ),
+			$this->expectedField( 'post.slug', $slug ),
+		]);
 
 	}
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

This fixes a bug where querying for posts (of a non-hierarchical post type) by Slug would return null when the site had custom permalinks set. 


Does this close any currently open issues?
------------------------------------------
closes #2798 2798


Any other comments?
-------------------

**BEFORE**

![CleanShot 2023-04-24 at 17 07 04](https://user-images.githubusercontent.com/1260765/234134775-90dae1cb-4b70-4b34-8c5f-48173a70e8a2.png)

**AFTER**

![CleanShot 2023-04-24 at 17 15 10](https://user-images.githubusercontent.com/1260765/234135541-9aa66a10-e187-4758-98eb-c364d5b03fdc.png)

Notes for future reference (written at 2:30AM by @justlevine):
------------------------------------------

- The original issue only occurs when querying via the non-pretty url (index.php?graphql) like in GraphiQL, not the pretty permalink (/graphql).
- The root cause is that unlike WP native's routing, our parse_request() doesn't match slugs (since the rewrite rules are now prefixed with a custom base), leaving $query_vars['error'] set to true.
- The reason that it only affects non-pretty urls is because our parse_request() matches requests via the pretty permalink to the pretty permalink, instead of our query. This is because we're reusing the $wp global instead of creating a new one. This is a bug
- The 'fix' in this PR works by employing that bug to our advantage. We pretend we matched the /graphql rewrite rules, essentially bypassing the rule matching in parse_request() so there's no difference in handling between requests to the prettied/naked urls.
- An actual fix in the long term would be reviewing the differences between our parse_request() and native WP's, so we're accurately able to match and rely on WP's rewrite rules. (Or alternatively to ditch more parts of parse_request() that are seemingly unnecessary).

