### PR TITLE
fix: Conflict Between Custom Post Type and Media Slugs

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1965,16 +1965,16 @@
         },
         {
             "name": "lucatume/wp-browser",
-            "version": "3.1.8",
+            "version": "3.1.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lucatume/wp-browser.git",
-                "reference": "161bf51aea475f86fb124aad1642c845b5379444"
+                "reference": "38e15758d2960d31ce6347bff843574f147d2630"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lucatume/wp-browser/zipball/161bf51aea475f86fb124aad1642c845b5379444",
-                "reference": "161bf51aea475f86fb124aad1642c845b5379444",
+                "url": "https://api.github.com/repos/lucatume/wp-browser/zipball/38e15758d2960d31ce6347bff843574f147d2630",
+                "reference": "38e15758d2960d31ce6347bff843574f147d2630",
                 "shasum": ""
             },
             "require": {
@@ -2058,7 +2058,7 @@
             ],
             "support": {
                 "issues": "https://github.com/lucatume/wp-browser/issues",
-                "source": "https://github.com/lucatume/wp-browser/tree/3.1.8"
+                "source": "https://github.com/lucatume/wp-browser/tree/3.1.9"
             },
             "funding": [
                 {
@@ -2066,20 +2066,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-24T15:10:07+00:00"
+            "time": "2023-04-11T07:42:24+00:00"
         },
         {
             "name": "mikehaertl/php-shellcommand",
-            "version": "1.6.4",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mikehaertl/php-shellcommand.git",
-                "reference": "3488d7803df1e8f1a343d3d0ca452d527ad8d5e5"
+                "reference": "e79ea528be155ffdec6f3bf1a4a46307bb49e545"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mikehaertl/php-shellcommand/zipball/3488d7803df1e8f1a343d3d0ca452d527ad8d5e5",
-                "reference": "3488d7803df1e8f1a343d3d0ca452d527ad8d5e5",
+                "url": "https://api.github.com/repos/mikehaertl/php-shellcommand/zipball/e79ea528be155ffdec6f3bf1a4a46307bb49e545",
+                "reference": "e79ea528be155ffdec6f3bf1a4a46307bb49e545",
                 "shasum": ""
             },
             "require": {
@@ -2110,9 +2110,9 @@
             ],
             "support": {
                 "issues": "https://github.com/mikehaertl/php-shellcommand/issues",
-                "source": "https://github.com/mikehaertl/php-shellcommand/tree/1.6.4"
+                "source": "https://github.com/mikehaertl/php-shellcommand/tree/1.7.0"
             },
-            "time": "2021-03-17T06:54:33+00:00"
+            "time": "2023-04-19T08:25:22+00:00"
         },
         {
             "name": "mikemclin/laravel-wp-password",
@@ -2843,16 +2843,16 @@
         },
         {
             "name": "phpstan/extension-installer",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/extension-installer.git",
-                "reference": "f06dbb052ddc394e7896fcd1cfcd533f9f6ace40"
+                "reference": "f5e02d40f277d28513001976f444d9ff1dc15e9a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/extension-installer/zipball/f06dbb052ddc394e7896fcd1cfcd533f9f6ace40",
-                "reference": "f06dbb052ddc394e7896fcd1cfcd533f9f6ace40",
+                "url": "https://api.github.com/repos/phpstan/extension-installer/zipball/f5e02d40f277d28513001976f444d9ff1dc15e9a",
+                "reference": "f5e02d40f277d28513001976f444d9ff1dc15e9a",
                 "shasum": ""
             },
             "require": {
@@ -2867,7 +2867,12 @@
             },
             "type": "composer-plugin",
             "extra": {
-                "class": "PHPStan\\ExtensionInstaller\\Plugin"
+                "class": "PHPStan\\ExtensionInstaller\\Plugin",
+                "phpstan/extension-installer": {
+                    "ignore": [
+                        "phpstan/phpstan-phpunit"
+                    ]
+                }
             },
             "autoload": {
                 "psr-4": {
@@ -2881,22 +2886,22 @@
             "description": "Composer plugin for automatic installation of PHPStan extensions",
             "support": {
                 "issues": "https://github.com/phpstan/extension-installer/issues",
-                "source": "https://github.com/phpstan/extension-installer/tree/1.2.0"
+                "source": "https://github.com/phpstan/extension-installer/tree/1.3.0"
             },
-            "time": "2022-10-17T12:59:16+00:00"
+            "time": "2023-04-18T13:08:02+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.17.1",
+            "version": "1.20.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "d3753fcb3abc6f78f5de6f72153d4b9c99c72dee"
+                "reference": "6c04009f6cae6eda2f040745b6b846080ef069c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/d3753fcb3abc6f78f5de6f72153d4b9c99c72dee",
-                "reference": "d3753fcb3abc6f78f5de6f72153d4b9c99c72dee",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/6c04009f6cae6eda2f040745b6b846080ef069c2",
+                "reference": "6c04009f6cae6eda2f040745b6b846080ef069c2",
                 "shasum": ""
             },
             "require": {
@@ -2926,22 +2931,22 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.17.1"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.20.3"
             },
-            "time": "2023-04-04T11:11:22+00:00"
+            "time": "2023-04-25T09:01:03+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.11",
+            "version": "1.10.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "8aa62e6ea8b58ffb650e02940e55a788cbc3fe21"
+                "reference": "d232901b09e67538e5c86a724be841bea5768a7c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/8aa62e6ea8b58ffb650e02940e55a788cbc3fe21",
-                "reference": "8aa62e6ea8b58ffb650e02940e55a788cbc3fe21",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d232901b09e67538e5c86a724be841bea5768a7c",
+                "reference": "d232901b09e67538e5c86a724be841bea5768a7c",
                 "shasum": ""
             },
             "require": {
@@ -2990,7 +2995,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-04T19:17:42+00:00"
+            "time": "2023-04-19T13:47:27+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3312,16 +3317,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.6",
+            "version": "9.6.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "b65d59a059d3004a040c16a82e07bbdf6cfdd115"
+                "reference": "c993f0d3b0489ffc42ee2fe0bd645af1538a63b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b65d59a059d3004a040c16a82e07bbdf6cfdd115",
-                "reference": "b65d59a059d3004a040c16a82e07bbdf6cfdd115",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c993f0d3b0489ffc42ee2fe0bd645af1538a63b2",
+                "reference": "c993f0d3b0489ffc42ee2fe0bd645af1538a63b2",
                 "shasum": ""
             },
             "require": {
@@ -3395,7 +3400,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.6"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.7"
             },
             "funding": [
                 {
@@ -3411,7 +3416,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-27T11:43:46+00:00"
+            "time": "2023-04-14T08:58:40+00:00"
         },
         {
             "name": "psr/container",
@@ -4880,32 +4885,32 @@
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "8.9.2",
+            "version": "8.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "c9b39061ebd5c58b71ecae26042eb7b054c380dd"
+                "reference": "af87461316b257e46e15bb041dca6fca3796d822"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/c9b39061ebd5c58b71ecae26042eb7b054c380dd",
-                "reference": "c9b39061ebd5c58b71ecae26042eb7b054c380dd",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/af87461316b257e46e15bb041dca6fca3796d822",
+                "reference": "af87461316b257e46e15bb041dca6fca3796d822",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.0",
                 "php": "^7.2 || ^8.0",
-                "phpstan/phpdoc-parser": ">=1.16.0 <1.18.0",
+                "phpstan/phpdoc-parser": ">=1.20.0 <1.21.0",
                 "squizlabs/php_codesniffer": "^3.7.1"
             },
             "require-dev": {
                 "phing/phing": "2.17.4",
                 "php-parallel-lint/php-parallel-lint": "1.3.2",
-                "phpstan/phpstan": "1.4.10|1.10.11",
+                "phpstan/phpstan": "1.10.14",
                 "phpstan/phpstan-deprecation-rules": "1.1.3",
-                "phpstan/phpstan-phpunit": "1.0.0|1.3.11",
+                "phpstan/phpstan-phpunit": "1.3.11",
                 "phpstan/phpstan-strict-rules": "1.5.1",
-                "phpunit/phpunit": "7.5.20|8.5.21|9.6.6"
+                "phpunit/phpunit": "7.5.20|8.5.21|9.6.6|10.1.1"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -4929,7 +4934,7 @@
             ],
             "support": {
                 "issues": "https://github.com/slevomat/coding-standard/issues",
-                "source": "https://github.com/slevomat/coding-standard/tree/8.9.2"
+                "source": "https://github.com/slevomat/coding-standard/tree/8.11.1"
             },
             "funding": [
                 {
@@ -4941,7 +4946,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-05T06:23:58+00:00"
+            "time": "2023-04-24T08:19:01+00:00"
         },
         {
             "name": "softcreatr/jsonpath",

--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -2,7 +2,9 @@
 
 namespace WPGraphQL\Data;
 
+use Exception;
 use GraphQL\Deferred;
+use WP;
 use WP_Post;
 use WPGraphQL\AppContext;
 use GraphQL\Error\UserError;
@@ -43,6 +45,7 @@ class NodeResolver {
 	 */
 	public function validate_post( WP_Post $post ) {
 
+
 		if ( isset( $this->wp->query_vars['post_type'] ) && ( $post->post_type !== $this->wp->query_vars['post_type'] ) ) {
 			return null;
 		}
@@ -66,6 +69,16 @@ class NodeResolver {
 			return null;
 		}
 		phpcs:enable */
+
+		if ( ! isset( $this->wp->query_vars['uri'] ) ) {
+			return $post;
+		}
+
+		// if the uri doesn't have the post's name or ID in it, we must've found something we didn't expect
+		// so we will return null
+		if ( false === stripos( $this->wp->query_vars['uri'], $post->post_name, 0 ) && stripos( $this->wp->query_vars['uri'], $post->ID, 0 ) ) {
+			return null;
+		}
 
 		return $post;
 	}
@@ -157,7 +170,7 @@ class NodeResolver {
 		if ( ! class_exists( $query_class ) ) {
 			throw new UserError(
 				sprintf(
-					/* translators: %s: The query class used to resolve the URI */
+				/* translators: %s: The query class used to resolve the URI */
 					__( 'The query class %s used to resolve the URI does not exist.', 'wp-graphql' ),
 					$query_class
 				)
@@ -167,7 +180,12 @@ class NodeResolver {
 		/** @var \WP_Query $query */
 		$query = new $query_class( $this->wp->query_vars );
 
-		$queried_object = $query->get_queried_object();
+		// is the query is an archive
+		if ( isset( $query->posts[0] ) && $query->posts[0] instanceof WP_Post && ! $query->is_archive() ) {
+			$queried_object = $query->posts[0];
+		} else {
+			$queried_object = $query->get_queried_object();
+		}
 
 		/**
 		 * When this filter return anything other than null, it will be used as a resolved node
@@ -230,10 +248,13 @@ class NodeResolver {
 
 		// Resolve Post Types.
 		if ( $queried_object instanceof \WP_Post_Type ) {
+
 			// Bail if we're explictly requesting a different GraphQL type.
 			if ( ! $this->is_valid_node_type( 'ContentType' ) ) {
 				return null;
 			}
+
+
 
 			return ! empty( $queried_object->name ) ? $this->context->get_loader( 'post_type' )->load_deferred( $queried_object->name ) : null;
 		}
@@ -435,7 +456,6 @@ class NodeResolver {
 			}
 
 			if ( ! empty( $this->wp->matched_rule ) ) {
-
 				// Trim the query of everything up to the '?'.
 				$query = preg_replace( '!^.+\?!', '', $query );
 

--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -70,13 +70,13 @@ class NodeResolver {
 		}
 		phpcs:enable */
 
-		if ( ! isset( $this->wp->query_vars['uri'] ) ) {
+		if ( empty( $this->wp->query_vars['uri'] ) ) {
 			return $post;
 		}
 
 		// if the uri doesn't have the post's name or ID in it, we must've found something we didn't expect
 		// so we will return null
-		if ( false === stripos( $this->wp->query_vars['uri'], $post->post_name, 0 ) && false === stripos( $this->wp->query_vars['uri'], $post->ID, 0 ) ) {
+		if ( false === strpos( $this->wp->query_vars['uri'], $post->post_name ) && false === strpos( $this->wp->query_vars['uri'], (string) $post->ID ) ) {
 			return null;
 		}
 

--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -76,7 +76,7 @@ class NodeResolver {
 
 		// if the uri doesn't have the post's name or ID in it, we must've found something we didn't expect
 		// so we will return null
-		if ( false === stripos( $this->wp->query_vars['uri'], $post->post_name, 0 ) && stripos( $this->wp->query_vars['uri'], $post->ID, 0 ) ) {
+		if ( false === stripos( $this->wp->query_vars['uri'], $post->post_name, 0 ) && false === stripos( $this->wp->query_vars['uri'], '=' . $post->ID, 0 ) ) {
 			return null;
 		}
 

--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -76,7 +76,7 @@ class NodeResolver {
 
 		// if the uri doesn't have the post's name or ID in it, we must've found something we didn't expect
 		// so we will return null
-		if ( false === stripos( $this->wp->query_vars['uri'], $post->post_name, 0 ) && false === stripos( $this->wp->query_vars['uri'], '=' . $post->ID, 0 ) ) {
+		if ( false === stripos( $this->wp->query_vars['uri'], $post->post_name, 0 ) && false === stripos( $this->wp->query_vars['uri'], $post->ID, 0 ) ) {
 			return null;
 		}
 

--- a/tests/wpunit/PageByUriTest.php
+++ b/tests/wpunit/PageByUriTest.php
@@ -52,7 +52,6 @@ class PageByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		';
 
 		flush_rewrite_rules( true );
-		wp_reset_postdata();
 		$actual = $this->graphql([
 			'query'     => $query,
 			'variables' => [


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

This fixes a bug in the NodeResolver for when there are valid duplicate slugs in different post types. 

Does this close any currently open issues?
------------------------------------------
closes #2800 


Any other comments?
-------------------
Following the steps to reproduce mentioned [here](https://github.com/wp-graphql/wp-graphql/issues/2800#issuecomment-1522393911). 

## BEFORE:

![CleanShot 2023-04-25 at 15 08 12](https://user-images.githubusercontent.com/1260765/234404278-15dc9adc-7399-45b6-a0a0-1a3ad85b9bd3.png)


## AFTER:

![CleanShot 2023-04-25 at 15 08 38](https://user-images.githubusercontent.com/1260765/234404378-a022fd87-2296-4b26-af56-df6977f5795c.png)
