### PR TITLE
Replace double negation with true

### DIFF
--- a/packages/graphiql-query-composer/components/AbstractArgView.js
+++ b/packages/graphiql-query-composer/components/AbstractArgView.js
@@ -443,7 +443,7 @@ const AbstractArgView = (props) => {
       >
         {isInputObjectType(argType) ? (
           <span>
-            {!!argValue
+            {argValue
               ? props.styleConfig.arrowOpen
               : props.styleConfig.arrowClosed}
           </span>


### PR DESCRIPTION
Hey there, I found a small issue.

A boolean cast via double negation (!!) is redundant when used as a condition The condition can be written without the extra cast and behave exactly the same.

In other words: `!!true` is `true`.