### PR TITLE
feat: AbstractConnectionResolver:set_query_class() created

### DIFF
--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -119,6 +119,13 @@ abstract class AbstractConnectionResolver {
 	protected $query_amount;
 
 	/**
+	 * The query class used to fetch the nodes.
+	 *
+	 * @var mixed
+	 */
+	protected $query_class;
+
+	/**
 	 * ConnectionResolver constructor.
 	 *
 	 * @param mixed       $source  source passed down from the resolve tree
@@ -304,6 +311,17 @@ abstract class AbstractConnectionResolver {
 		$this->query_args[ $key ] = $value;
 
 		return $this;
+	}
+
+	/**
+	 * Sets the connection Query class.
+	 *
+	 * @param string $class  Query class name.
+	 *
+	 * @return void
+	 */
+	public function set_query_class( $class ) {
+		$this->query_class = $class;
 	}
 
 	/**

--- a/src/Data/Connection/CommentConnectionResolver.php
+++ b/src/Data/Connection/CommentConnectionResolver.php
@@ -150,13 +150,18 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * Get_query
 	 *
-	 * Return the instance of the WP_Comment_Query
+	 * Return the instance of the Query class defaults to \WP_Comment_Query.
 	 *
-	 * @return \WP_Comment_Query
+	 * @return mixed
 	 * @throws \Exception
 	 */
 	public function get_query() {
-		return new WP_Comment_Query( $this->query_args );
+		// Get query class.
+		$queryClass = ! empty( $this->query_class )
+			? $this->query_class
+			: '\WP_Comment_Query';
+
+		return new $queryClass( $this->query_args );
 	}
 
 	/**

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -68,6 +68,8 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 			$this->post_type = $post_type;
 		}
 
+		$this->query_class = '\WP_Query';
+
 		/**
 		 * Call the parent construct to setup class data
 		 */
@@ -93,10 +95,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	 */
 	public function get_query() {
 		// Get query class.
-		$queryClass = ! empty( $this->context->queryClass )
-			? $this->context->queryClass
-			: '\WP_Query';
-
+		$queryClass = $this->query_class;
 		$query = new $queryClass( $this->query_args );
 
 		if ( isset( $query->query_vars['suppress_filters'] ) && true === $query->query_vars['suppress_filters'] ) {

--- a/src/Data/Connection/TermObjectConnectionResolver.php
+++ b/src/Data/Connection/TermObjectConnectionResolver.php
@@ -40,7 +40,8 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 	 * @throws \Exception
 	 */
 	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info, $taxonomy = null ) {
-		$this->taxonomy = $taxonomy;
+		$this->taxonomy    = $taxonomy;
+		$this->query_class = '\WP_Term_Query';
 		parent::__construct( $source, $args, $context, $info );
 	}
 
@@ -161,13 +162,15 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * Return an instance of WP_Term_Query with the args mapped to the query
+	 * Return an instance of WP_Term_Query or similar class with the args mapped to the query
 	 *
-	 * @return \WP_Term_Query
+	 * @return mixed
 	 * @throws \Exception
 	 */
 	public function get_query() {
-		return new \WP_Term_Query( $this->query_args );
+		// Get query class.
+		$queryClass = $this->query_class;
+		return new $queryClass( $this->query_args );
 	}
 
 	/**

--- a/src/Data/Connection/UserConnectionResolver.php
+++ b/src/Data/Connection/UserConnectionResolver.php
@@ -182,8 +182,8 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 	 */
 	public function get_query() {
 		// Get query class.
-		$queryClass = ! empty( $this->context->queryClass )
-			? $this->context->queryClass
+		$queryClass = ! empty( $this->query_class )
+			? $this->query_class
 			: '\WP_User_Query';
 
 		return new $queryClass( $this->query_args );

--- a/tests/_support/Utils/class-wp-query-custom.php
+++ b/tests/_support/Utils/class-wp-query-custom.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * WP_Query clone for testing
+ *
+ * @package Test\WPGraphQL
+ */
+
+/**
+ * Class WP_Query_Custom
+ */
+class WP_Query_Custom {
+	/**
+	 * Stores query results.
+	 *
+	 * @var \WP_Query
+	 */
+	protected $query;
+
+	/**
+	 * WP_Query_Custom constructor.
+	 *
+	 * @param array $args  Query Arguments.
+	 */
+	public function __construct( $args = [] ) {
+		$this->query = new \WP_Query(
+            array_merge(
+                $args,
+                [ 'posts_per_page' => 3 ]
+            )
+        );
+	}
+
+    /**
+	 * Magic method to re-map the isset check on the child class looking for properties when
+	 * resolving the fields
+	 *
+	 * @param string $key The name of the field you are trying to retrieve
+	 *
+	 * @return bool
+	 */
+	public function __isset( $key ) {
+		return isset( $this->query->$key );
+	}
+
+	/**
+	 * Pass thru for query instance.
+	 *
+	 * @param string $name  WP_Query_Custom member name.
+	 *
+	 * @return mixed
+	 */
+	public function __get( $name ) {
+		return $this->query->$name;
+	}
+
+    /**
+	 * Forwards function calls to WP_Query instance.
+	 *
+	 * @param string $method - function name.
+	 * @param array  $args  - function call arguments.
+	 *
+	 * @return mixed
+	 *
+	 * @throws BadMethodCallException Method not found on WP_Query object.
+	 */
+	public function __call( $method, $args ) {
+		if ( \is_callable( [ $this->query, $method ] ) ) {
+			return $this->query->$method( ...$args );
+		}
+
+		$class = __CLASS__;
+		throw new BadMethodCallException( "Call to undefined method {$method} on the {$class}" );
+	}
+}

--- a/tests/wpunit.suite.dist.yml
+++ b/tests/wpunit.suite.dist.yml
@@ -20,3 +20,4 @@ modules:
         - wp-graphql/wp-graphql.php
       configFile:
         - 'tests/_data/config.php'
+bootstrap: _bootstrap.php

--- a/tests/wpunit/_bootstrap.php
+++ b/tests/wpunit/_bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+require __DIR__ . '/../_support/Utils/class-wp-query-custom.php';


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
- Adds `query_class` and `set_query_class()` to **AbstractConnectionResolver** class.
- Updates **Comment**, **Post**, **User**, and **Term** connection resolver classes to source the `$query_class`.
- Adds `testRegisteringConnectionsWithCustomQueryClasses` to the `ConnectionRegistrationTest` case 
- **WP_Query_Custom** added to `tests/_support/utils/class-wp-query-custom.php` for testing.


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
