### PR TITLE
release: v1.14.5

### DIFF
--- a/.github/workflows/deploy-docker-image.yml
+++ b/.github/workflows/deploy-docker-image.yml
@@ -45,14 +45,14 @@ jobs:
         run: echo "tag=$(echo ${GITHUB_REF:11})" >> $GITHUB_OUTPUT
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2.5.0
+        uses: docker/build-push-action@v4
         with:
           context: .
           push: true
@@ -65,7 +65,7 @@ jobs:
             WP_VERSION=${{ matrix.wordpress }}
 
       - name: Build and push Docker testing image
-        uses: docker/build-push-action@v2.5.0
+        uses: docker/build-push-action@v4
         with:
           context: .
           push: true

--- a/.github/workflows/upload-schema-artifact.yml
+++ b/.github/workflows/upload-schema-artifact.yml
@@ -10,7 +10,7 @@ jobs:
     name: Generate and Upload WPGraphQL Schema Artifact
     services:
       mariadb:
-        image: mariadb
+        image: mariadb:10.8.2
         ports:
           - 3306:3306
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.14.5
+
+### Chores / Bugfixes
+
+- [#2834](https://github.com/wp-graphql/wp-graphql/pull/2834): fix: improve how the Query Analyzer tracks list types, only tracking lists from the RootType and not nested lists.
+- [#2828](https://github.com/wp-graphql/wp-graphql/pull/2828): chore: update composer dev-deps to latest. Thanks @justlevine!
+- [#2835](https://github.com/wp-graphql/wp-graphql/pull/2835): ci: update docker deploy workflow to use latest docker actions.
+- [#2836](https://github.com/wp-graphql/wp-graphql/pull/2836): ci: update schema upload workflow to pin mariadb to 10.8.2
+
 ## 1.14.4
 
 ### New Features

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6f917e7ef1190bca26aaac22c3ff7902",
+    "content-hash": "c438cc668a448e1922171b36a34aa624",
     "packages": [
         {
             "name": "appsero/client",

--- a/readme.txt
+++ b/readme.txt
@@ -234,6 +234,16 @@ Composer dependencies are no longer versioned in Github. Recommended install sou
 
 = 1.14.5 =
 
+**Chores / Bugfixes**
+
+- [#2834](https://github.com/wp-graphql/wp-graphql/pull/2834): fix: improve how the Query Analyzer tracks list types, only tracking lists from the RootType and not nested lists.
+- [#2828](https://github.com/wp-graphql/wp-graphql/pull/2828): chore: update composer dev-deps to latest. Thanks @justlevine!
+- [#2835](https://github.com/wp-graphql/wp-graphql/pull/2835): ci: update docker deploy workflow to use latest docker actions.
+- [#2836](https://github.com/wp-graphql/wp-graphql/pull/2836): ci: update schema upload workflow to pin mariadb to 10.8.2
+
+
+= 1.14.4 =
+
 **New Features**
 
 - [#2826](https://github.com/wp-graphql/wp-graphql/pull/2826): feat: pass connection config to connection field

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, JSON, API, Gatsby, Faust, Headless, Decoupled, Svelte, React, Nex
 Requires at least: 5.0
 Tested up to: 6.2
 Requires PHP: 7.1
-Stable tag: 1.14.4
+Stable tag: 1.14.5
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -232,7 +232,7 @@ Composer dependencies are no longer versioned in Github. Recommended install sou
 
 == Changelog ==
 
-= 1.14.4 =
+= 1.14.5 =
 
 **New Features**
 

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -127,7 +127,7 @@ final class WPGraphQL {
 
 		// Plugin version.
 		if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-			define( 'WPGRAPHQL_VERSION', '1.14.4' );
+			define( 'WPGRAPHQL_VERSION', '1.14.5' );
 		}
 
 		// Plugin Folder Path.

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.14.4
+ * Version: 1.14.5
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0


### PR DESCRIPTION
# Release Notes

### Chores / Bugfixes

- [#2834](https://github.com/wp-graphql/wp-graphql/pull/2834): fix: improve how the Query Analyzer tracks list types, only tracking lists from the RootType and not nested lists.
- [#2828](https://github.com/wp-graphql/wp-graphql/pull/2828): chore: update composer dev-deps to latest. Thanks @justlevine!
- [#2835](https://github.com/wp-graphql/wp-graphql/pull/2835): ci: update docker deploy workflow to use latest docker actions.
- [#2836](https://github.com/wp-graphql/wp-graphql/pull/2836): ci: update schema upload workflow to pin mariadb to 10.8.2
