### PR TITLE
ci: Indent WP 6.2 in workflow file

### DIFF
--- a/.github/workflows/deploy-docker-image.yml
+++ b/.github/workflows/deploy-docker-image.yml
@@ -32,7 +32,7 @@ jobs:
             wordpress: '6.2'
           # This is a temporary exclusion until a php74 image is released. See #2780
           - php: '7.4'
-          - wordpress: '6.2'
+            wordpress: '6.2'
       fail-fast: false
     name: WordPress ${{ matrix.wordpress }} on PHP ${{ matrix.php }}
     steps:

--- a/.github/workflows/testing-integration.yml
+++ b/.github/workflows/testing-integration.yml
@@ -47,7 +47,7 @@ jobs:
         # This is a temporary exclusion until a php74 image is released. See #2780
         exclude:
           - php: '7.4'
-          - wordpress: '6.2'
+            wordpress: '6.2'
 
     steps:
       - name: Cancel previous runs of this workflow (pull requests only)


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [ ] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
… The github image build for WP 6.2 are being excluded for all PHP versions instead of just one specific PHP version as intended.  This is a simple fix and should build/deploy images on the next tag/release of this plugin.


Does this close any currently open issues?
------------------------------------------
… Yes https://github.com/wp-graphql/wp-graphql/issues/2848


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
