### PR TITLE
fix: querying posts by slug or uri when the post name is non-ascii

### DIFF
--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -74,9 +74,9 @@ class NodeResolver {
 			return $post;
 		}
 
-		// if the uri doesn't have the post's name or ID in it, we must've found something we didn't expect
+		// if the uri doesn't have the post's urlencoded name or ID in it, we must've found something we didn't expect
 		// so we will return null
-		if ( false === strpos( $this->wp->query_vars['uri'], $post->post_name ) && false === strpos( $this->wp->query_vars['uri'], (string) $post->ID ) ) {
+		if ( false === strpos( $this->wp->query_vars['uri'], (string) $post->ID ) && false === strpos( $this->wp->query_vars['uri'], urldecode( sanitize_title( $post->post_name ) ) ) ) {
 			return null;
 		}
 
@@ -210,6 +210,7 @@ class NodeResolver {
 			return $node;
 		}
 
+
 		// Resolve Post Objects.
 		if ( $queried_object instanceof WP_Post ) {
 			// If Page for Posts is set, we need to return the Page archive, not the page.
@@ -230,6 +231,7 @@ class NodeResolver {
 
 			// Validate the post before returning it.
 			if ( ! $this->validate_post( $queried_object ) ) {
+
 				return null;
 			}
 

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -527,7 +527,7 @@ class Post extends Model {
 					return ! empty( $this->data->ping_status ) ? $this->data->ping_status : null;
 				},
 				'slug'                      => function () {
-					return ! empty( $this->data->post_name ) ? $this->data->post_name : null;
+					return ! empty( $this->data->post_name ) ? urldecode( $this->data->post_name ) : null;
 				},
 				'template'                  => function () {
 
@@ -683,7 +683,7 @@ class Post extends Model {
 						$link = get_permalink( $this->data->ID );
 					}
 
-					return ! empty( $link ) ? $link : null;
+					return ! empty( $link ) ? urldecode( $link ) : null;
 				},
 				'uri'                       => function () {
 					$uri = $this->link;

--- a/tests/wpunit/PostObjectQueriesTest.php
+++ b/tests/wpunit/PostObjectQueriesTest.php
@@ -2243,6 +2243,56 @@ class PostObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase 
 		$this->assertNull( $actual['data']['post'] );
 	}
 
+	// create a post using emoji
+	public function testQueryPostBySlugWithEmojiSlug() {
+
+		$raw_title = '🍌';
+
+		// the $encoded_slug will have a dash between words i.e. 'سلا-دنیا'
+		$encoded_slug = urldecode( sanitize_title( $raw_title ) );
+
+		$non_ascii_post = $this->factory()->post->create_and_get([
+			'post_title' => $raw_title,
+			'post_status' => 'publish',
+			'post_author' => $this->admin,
+		]);
+
+		codecept_debug( [
+			'$non_ascii_string' => $raw_title,
+			'$encoded_slug' => $encoded_slug,
+			'$post_name' => $non_ascii_post->post_name,
+			'post' => $non_ascii_post,
+		]);
+
+		$query = '
+		query getPostBySlug( $id: ID! ) {
+		  post( id: $id idType: SLUG ) {
+		    __typename
+		    title
+		    slug
+		    databaseId
+		  }
+		}
+		';
+
+		// query the post by (encoded) slug
+		$actual = $this->graphql([
+			'query' => $query,
+			'variables' => [
+				'id' => $encoded_slug, // سلام-دنیا //
+			]
+		]);
+
+		// assert that the response is what we expect
+		self::assertQuerySuccessful($actual, [
+			$this->expectedField( 'post.__typename', 'Post' ),
+			$this->expectedField( 'post.title', $raw_title ),
+			$this->expectedField( 'post.slug', $encoded_slug ),
+			$this->expectedField( 'post.databaseId', $non_ascii_post->ID ),
+		]);
+
+	}
+
 	// create a post using unicode
 	public function testQueryPostBySlugWithNonAsciiSlug() {
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This fixes a bug where querying posts by slug or uri was returning null when the post's name (slug) included non-ascii characters.  

Failing Tests: https://github.com/wp-graphql/wp-graphql/actions/runs/5521919716/jobs/10070736088?pr=2851
Passing Tests: https://github.com/wp-graphql/wp-graphql/actions/runs/5522008949/jobs/10070950056?pr=2851


Does this close any currently open issues?
------------------------------------------

- closes #2847 
- closes #2804


Any other comments?
-------------------

I've created 2 posts with the following titles: 

- (Persian) `سلام-دنیا`
- (Emoji) `🍌`

![CleanShot 2023-07-11 at 09 18 01](https://github.com/wp-graphql/wp-graphql/assets/1260765/abaf5ab9-2bf2-4a45-ae3a-86f6955e52d8)

This gives me posts visible at the following URLs: 

- `/blog/2023/07/11/🍌/`
- `/blog/2023/07/10/سلام-دنیا/`

### Before:

Querying these posts by their slugs / uri would return null:

![CleanShot 2023-07-11 at 09 27 43](https://github.com/wp-graphql/wp-graphql/assets/1260765/0d4a5e8a-f76a-4b1f-994f-054628b337d6)


### After:

Querying these posts by their slugs / uri returns the expected nodes: 

![CleanShot 2023-07-11 at 09 28 35](https://github.com/wp-graphql/wp-graphql/assets/1260765/91491e1a-274b-454c-ad4a-aec353e4cddb)
