### PR TITLE
fix: internal server error when query max depth setting is left empty

### DIFF
--- a/src/Admin/Settings/Settings.php
+++ b/src/Admin/Settings/Settings.php
@@ -150,11 +150,11 @@ class Settings {
 				'type'              => 'number',
 				'default'           => 10,
 				'sanitize_callback' => static function ( $value ) {
-				    // if the entered value is not a positive integer, default to 10
-				    if ( ! absint( $value ) ) {
-				        $value = 10;
-				    }
-				    return absint( $value );
+					// if the entered value is not a positive integer, default to 10
+					if ( ! absint( $value ) ) {
+						$value = 10;
+					}
+					return absint( $value );
 				},
 			],
 			[

--- a/src/Admin/Settings/Settings.php
+++ b/src/Admin/Settings/Settings.php
@@ -149,11 +149,11 @@ class Settings {
 				'desc'              => __( 'If Query Depth limiting is enabled, this is the number of levels WPGraphQL will allow. Queries with deeper nesting will be rejected. Must be a positive integer value. Default 10.', 'wp-graphql' ),
 				'type'              => 'number',
 				'default'           => 10,
-                'sanitize_callback' => static function( $value ) {
-                    // if the entered value is not a positive integer, default to 10
-                    if ( ! absint( $value ) ) {
-                        $value = 10;
-                    }
+				'sanitize_callback' => static function( $value ) {
+				    // if the entered value is not a positive integer, default to 10
+				    if ( ! absint( $value ) ) {
+				        $value = 10;
+				    }
                     return absint( $value );
                 }
 			],

--- a/src/Admin/Settings/Settings.php
+++ b/src/Admin/Settings/Settings.php
@@ -149,13 +149,13 @@ class Settings {
 				'desc'              => __( 'If Query Depth limiting is enabled, this is the number of levels WPGraphQL will allow. Queries with deeper nesting will be rejected. Must be a positive integer value. Default 10.', 'wp-graphql' ),
 				'type'              => 'number',
 				'default'           => 10,
-				'sanitize_callback' => static function( $value ) {
+				'sanitize_callback' => static function ( $value ) {
 				    // if the entered value is not a positive integer, default to 10
 				    if ( ! absint( $value ) ) {
 				        $value = 10;
 				    }
-                    return absint( $value );
-                }
+				    return absint( $value );
+				},
 			],
 			[
 				'name'    => 'graphiql_enabled',

--- a/src/Admin/Settings/Settings.php
+++ b/src/Admin/Settings/Settings.php
@@ -144,13 +144,12 @@ class Settings {
 				'default' => 'off',
 			],
 			[
-				'name'    => 'query_depth_max',
-				'label'   => __( 'Max Depth to allow for GraphQL Queries', 'wp-graphql' ),
-				'desc'    => __( 'If Query Depth limiting is enabled, this is the number of levels WPGraphQL will allow. Queries with deeper nesting will be rejected. Must be a positive integer value. Default 10.', 'wp-graphql' ),
-				'type'    => 'number',
-				'default' => 10,
+				'name'              => 'query_depth_max',
+				'label'             => __( 'Max Depth to allow for GraphQL Queries', 'wp-graphql' ),
+				'desc'              => __( 'If Query Depth limiting is enabled, this is the number of levels WPGraphQL will allow. Queries with deeper nesting will be rejected. Must be a positive integer value. Default 10.', 'wp-graphql' ),
+				'type'              => 'number',
+				'default'           => 10,
                 'sanitize_callback' => static function( $value ) {
-
                     // if the entered value is not a positive integer, default to 10
                     if ( ! absint( $value ) ) {
                         $value = 10;

--- a/src/Admin/Settings/Settings.php
+++ b/src/Admin/Settings/Settings.php
@@ -146,9 +146,15 @@ class Settings {
 			[
 				'name'    => 'query_depth_max',
 				'label'   => __( 'Max Depth to allow for GraphQL Queries', 'wp-graphql' ),
-				'desc'    => __( 'If Query Depth limiting is enabled, this is the number of levels WPGraphQL will allow. Queries with deeper nesting will be rejected. Must be a positive integer value.', 'wp-graphql' ),
+				'desc'    => __( 'If Query Depth limiting is enabled, this is the number of levels WPGraphQL will allow. Queries with deeper nesting will be rejected. Must be a positive integer value. Default 10.', 'wp-graphql' ),
 				'type'    => 'number',
 				'default' => 10,
+                'sanitize_callback' => static function( $value ) {
+                    if ( ! absint( $value ) ) {
+                        $value = 10;
+                    }
+                    return absint( $value );
+                }
 			],
 			[
 				'name'    => 'graphiql_enabled',

--- a/src/Admin/Settings/Settings.php
+++ b/src/Admin/Settings/Settings.php
@@ -150,6 +150,8 @@ class Settings {
 				'type'    => 'number',
 				'default' => 10,
                 'sanitize_callback' => static function( $value ) {
+
+                    // if the entered value is not a positive integer, default to 10
                     if ( ! absint( $value ) ) {
                         $value = 10;
                     }

--- a/src/Server/ValidationRules/QueryDepth.php
+++ b/src/Server/ValidationRules/QueryDepth.php
@@ -31,6 +31,7 @@ class QueryDepth extends QuerySecurityRule {
 	 */
 	public function __construct() {
 		$max_query_depth = get_graphql_setting( 'query_depth_max', 10 );
+		$max_query_depth = absint( $max_query_depth ) ?? 10;
 		$this->setMaxQueryDepth( $max_query_depth );
 	}
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

This fixes a bug that occurs when leaving the "Max Depth to allow for GraphQL Queries" value empty in the GraphQL > Settings page. 

Does this close any currently open issues?
------------------------------------------
closes #2809


Any other comments?
-------------------
If the value entered in the "Max Depth" setting is a non-positive integer, the default value of 10 will be saved. If a non-positive integer is already stored for the setting value, the default of 10 will be used.
