### PR TITLE
release: v1.14.7

### DIFF
--- a/.github/workflows/deploy-docker-image.yml
+++ b/.github/workflows/deploy-docker-image.yml
@@ -32,7 +32,7 @@ jobs:
             wordpress: '6.2'
           # This is a temporary exclusion until a php74 image is released. See #2780
           - php: '7.4'
-          - wordpress: '6.2'
+            wordpress: '6.2'
       fail-fast: false
     name: WordPress ${{ matrix.wordpress }} on PHP ${{ matrix.php }}
     steps:

--- a/.github/workflows/testing-integration.yml
+++ b/.github/workflows/testing-integration.yml
@@ -47,7 +47,7 @@ jobs:
         # This is a temporary exclusion until a php74 image is released. See #2780
         exclude:
           - php: '7.4'
-          - wordpress: '6.2'
+            wordpress: '6.2'
 
     steps:
       - name: Cancel previous runs of this workflow (pull requests only)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.14.7
+
+## Chores / Bugfixes
+
+- [#2851](https://github.com/wp-graphql/wp-graphql/pull/2851): fix: querying posts by slug or uri with non-ascii characters
+- [#2849](https://github.com/wp-graphql/wp-graphql/pull/2849): ci: Indent WP 6.2 in workflow file. Fixes Docker deploys. Thanks @markkelnar!
+- [#2846](https://github.com/wp-graphql/wp-graphql/pull/2846): chore(deps): bump tough-cookie from 4.0.0 to 4.1.3
+
 ## 1.14.6
 
 ## Chores / Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Chores / Bugfixes
 
+- [#2853](https://github.com/wp-graphql/wp-graphql/pull/2853): fix: internal server error when query max depth setting is left empty
 - [#2851](https://github.com/wp-graphql/wp-graphql/pull/2851): fix: querying posts by slug or uri with non-ascii characters
 - [#2849](https://github.com/wp-graphql/wp-graphql/pull/2849): ci: Indent WP 6.2 in workflow file. Fixes Docker deploys. Thanks @markkelnar!
 - [#2846](https://github.com/wp-graphql/wp-graphql/pull/2846): chore(deps): bump tough-cookie from 4.0.0 to 4.1.3

--- a/package-lock.json
+++ b/package-lock.json
@@ -22425,6 +22425,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -26616,14 +26622,15 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
-      "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
       "dev": true,
       "dependencies": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
-        "universalify": "^0.1.2"
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
       },
       "engines": {
         "node": ">=6"
@@ -27309,9 +27316,9 @@
       }
     },
     "node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
       "dev": true,
       "engines": {
         "node": ">= 4.0.0"
@@ -27360,6 +27367,16 @@
         "file-loader": {
           "optional": true
         }
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/use-error-boundary": {
@@ -45358,6 +45375,12 @@
         "strict-uri-encode": "^2.0.0"
       }
     },
+    "querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true
+    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -48540,14 +48563,15 @@
       "dev": true
     },
     "tough-cookie": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
-      "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
       "dev": true,
       "requires": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
-        "universalify": "^0.1.2"
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
       }
     },
     "tr46": {
@@ -49039,9 +49063,9 @@
       }
     },
     "universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
       "dev": true
     },
     "unpipe": {
@@ -49068,6 +49092,16 @@
         "loader-utils": "^2.0.0",
         "mime-types": "^2.1.27",
         "schema-utils": "^3.0.0"
+      }
+    },
+    "url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "requires": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "use-error-boundary": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, JSON, API, Gatsby, Faust, Headless, Decoupled, Svelte, React, Nex
 Requires at least: 5.0
 Tested up to: 6.2
 Requires PHP: 7.1
-Stable tag: 1.14.6
+Stable tag: 1.14.7
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -239,6 +239,15 @@ The `uri` field was non-null on some Types in the Schema but has been changed to
 Composer dependencies are no longer versioned in Github. Recommended install source is WordPress.org or using Composer to get the code from Packagist.org or WPackagist.org.
 
 == Changelog ==
+
+= 1.14.7 =
+
+**Chores / Bugfixes**
+
+- [#2851](https://github.com/wp-graphql/wp-graphql/pull/2851): fix: querying posts by slug or uri with non-ascii characters
+- [#2849](https://github.com/wp-graphql/wp-graphql/pull/2849): ci: Indent WP 6.2 in workflow file. Fixes Docker deploys. Thanks @markkelnar!
+- [#2846](https://github.com/wp-graphql/wp-graphql/pull/2846): chore(deps): bump tough-cookie from 4.0.0 to 4.1.3
+
 
 = 1.14.6 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -244,6 +244,7 @@ Composer dependencies are no longer versioned in Github. Recommended install sou
 
 **Chores / Bugfixes**
 
+- [#2853](https://github.com/wp-graphql/wp-graphql/pull/2853): fix: internal server error when query max depth setting is left empty
 - [#2851](https://github.com/wp-graphql/wp-graphql/pull/2851): fix: querying posts by slug or uri with non-ascii characters
 - [#2849](https://github.com/wp-graphql/wp-graphql/pull/2849): ci: Indent WP 6.2 in workflow file. Fixes Docker deploys. Thanks @markkelnar!
 - [#2846](https://github.com/wp-graphql/wp-graphql/pull/2846): chore(deps): bump tough-cookie from 4.0.0 to 4.1.3

--- a/src/Admin/Settings/Settings.php
+++ b/src/Admin/Settings/Settings.php
@@ -144,11 +144,18 @@ class Settings {
 				'default' => 'off',
 			],
 			[
-				'name'    => 'query_depth_max',
-				'label'   => __( 'Max Depth to allow for GraphQL Queries', 'wp-graphql' ),
-				'desc'    => __( 'If Query Depth limiting is enabled, this is the number of levels WPGraphQL will allow. Queries with deeper nesting will be rejected. Must be a positive integer value.', 'wp-graphql' ),
-				'type'    => 'number',
-				'default' => 10,
+				'name'              => 'query_depth_max',
+				'label'             => __( 'Max Depth to allow for GraphQL Queries', 'wp-graphql' ),
+				'desc'              => __( 'If Query Depth limiting is enabled, this is the number of levels WPGraphQL will allow. Queries with deeper nesting will be rejected. Must be a positive integer value. Default 10.', 'wp-graphql' ),
+				'type'              => 'number',
+				'default'           => 10,
+				'sanitize_callback' => static function ( $value ) {
+					// if the entered value is not a positive integer, default to 10
+					if ( ! absint( $value ) ) {
+						$value = 10;
+					}
+					return absint( $value );
+				},
 			],
 			[
 				'name'    => 'graphiql_enabled',

--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -74,9 +74,9 @@ class NodeResolver {
 			return $post;
 		}
 
-		// if the uri doesn't have the post's name or ID in it, we must've found something we didn't expect
+		// if the uri doesn't have the post's urlencoded name or ID in it, we must've found something we didn't expect
 		// so we will return null
-		if ( false === strpos( $this->wp->query_vars['uri'], $post->post_name ) && false === strpos( $this->wp->query_vars['uri'], (string) $post->ID ) ) {
+		if ( false === strpos( $this->wp->query_vars['uri'], (string) $post->ID ) && false === strpos( $this->wp->query_vars['uri'], urldecode( sanitize_title( $post->post_name ) ) ) ) {
 			return null;
 		}
 
@@ -210,6 +210,7 @@ class NodeResolver {
 			return $node;
 		}
 
+
 		// Resolve Post Objects.
 		if ( $queried_object instanceof WP_Post ) {
 			// If Page for Posts is set, we need to return the Page archive, not the page.
@@ -230,6 +231,7 @@ class NodeResolver {
 
 			// Validate the post before returning it.
 			if ( ! $this->validate_post( $queried_object ) ) {
+
 				return null;
 			}
 

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -527,7 +527,7 @@ class Post extends Model {
 					return ! empty( $this->data->ping_status ) ? $this->data->ping_status : null;
 				},
 				'slug'                      => function () {
-					return ! empty( $this->data->post_name ) ? $this->data->post_name : null;
+					return ! empty( $this->data->post_name ) ? urldecode( $this->data->post_name ) : null;
 				},
 				'template'                  => function () {
 
@@ -683,7 +683,7 @@ class Post extends Model {
 						$link = get_permalink( $this->data->ID );
 					}
 
-					return ! empty( $link ) ? $link : null;
+					return ! empty( $link ) ? urldecode( $link ) : null;
 				},
 				'uri'                       => function () {
 					$uri = $this->link;

--- a/src/Server/ValidationRules/QueryDepth.php
+++ b/src/Server/ValidationRules/QueryDepth.php
@@ -31,6 +31,7 @@ class QueryDepth extends QuerySecurityRule {
 	 */
 	public function __construct() {
 		$max_query_depth = get_graphql_setting( 'query_depth_max', 10 );
+		$max_query_depth = absint( $max_query_depth ) ?? 10;
 		$this->setMaxQueryDepth( $max_query_depth );
 	}
 

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -127,7 +127,7 @@ final class WPGraphQL {
 
 		// Plugin version.
 		if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-			define( 'WPGRAPHQL_VERSION', '1.14.6' );
+			define( 'WPGRAPHQL_VERSION', '1.14.7' );
 		}
 
 		// Plugin Folder Path.

--- a/tests/wpunit/PostObjectQueriesTest.php
+++ b/tests/wpunit/PostObjectQueriesTest.php
@@ -2243,4 +2243,104 @@ class PostObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase 
 		$this->assertNull( $actual['data']['post'] );
 	}
 
+	// create a post using emoji
+	public function testQueryPostBySlugWithEmojiSlug() {
+
+		$raw_title = '🍌';
+
+		// the $encoded_slug will have a dash between words i.e. 'سلا-دنیا'
+		$encoded_slug = urldecode( sanitize_title( $raw_title ) );
+
+		$non_ascii_post = $this->factory()->post->create_and_get([
+			'post_title' => $raw_title,
+			'post_status' => 'publish',
+			'post_author' => $this->admin,
+		]);
+
+		codecept_debug( [
+			'$non_ascii_string' => $raw_title,
+			'$encoded_slug' => $encoded_slug,
+			'$post_name' => $non_ascii_post->post_name,
+			'post' => $non_ascii_post,
+		]);
+
+		$query = '
+		query getPostBySlug( $id: ID! ) {
+		  post( id: $id idType: SLUG ) {
+		    __typename
+		    title
+		    slug
+		    databaseId
+		  }
+		}
+		';
+
+		// query the post by (encoded) slug
+		$actual = $this->graphql([
+			'query' => $query,
+			'variables' => [
+				'id' => $encoded_slug, // سلام-دنیا //
+			]
+		]);
+
+		// assert that the response is what we expect
+		self::assertQuerySuccessful($actual, [
+			$this->expectedField( 'post.__typename', 'Post' ),
+			$this->expectedField( 'post.title', $raw_title ),
+			$this->expectedField( 'post.slug', $encoded_slug ),
+			$this->expectedField( 'post.databaseId', $non_ascii_post->ID ),
+		]);
+
+	}
+
+	// create a post using unicode
+	public function testQueryPostBySlugWithNonAsciiSlug() {
+
+		$raw_title = 'سلام دنیا';
+
+		// the $encoded_slug will have a dash between words i.e. 'سلا-دنیا'
+		$encoded_slug = urldecode( sanitize_title( $raw_title ) );
+
+		$non_ascii_post = $this->factory()->post->create_and_get([
+			'post_title' => $raw_title,
+			'post_status' => 'publish',
+			'post_author' => $this->admin,
+		]);
+
+		codecept_debug( [
+			'$non_ascii_string' => $raw_title,
+			'$encoded_slug' => $encoded_slug,
+			'$post_name' => $non_ascii_post->post_name,
+			'post' => $non_ascii_post,
+		]);
+
+		$query = '
+		query getPostBySlug( $id: ID! ) {
+		  post( id: $id idType: SLUG ) {
+		    __typename
+		    title
+		    slug
+		    databaseId
+		  }
+		}
+		';
+
+		// query the post by (encoded) slug
+		$actual = $this->graphql([
+			'query' => $query,
+			'variables' => [
+				'id' => $encoded_slug, // سلام-دنیا //
+			]
+		]);
+
+		// assert that the response is what we expect
+		self::assertQuerySuccessful($actual, [
+			$this->expectedField( 'post.__typename', 'Post' ),
+			$this->expectedField( 'post.title', $raw_title ),
+			$this->expectedField( 'post.slug', $encoded_slug ),
+			$this->expectedField( 'post.databaseId', $non_ascii_post->ID ),
+		]);
+
+	}
+
 }

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.14.6
+ * Version: 1.14.7
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0


### PR DESCRIPTION
# Release Notes

## Chores / Bugfixes

- [#2853](https://github.com/wp-graphql/wp-graphql/pull/2853): fix: internal server error when query max depth setting is left empty
- [#2851](https://github.com/wp-graphql/wp-graphql/pull/2851): fix: querying posts by slug or uri with non-ascii characters
- [#2849](https://github.com/wp-graphql/wp-graphql/pull/2849): ci: Indent WP 6.2 in workflow file. Fixes Docker deploys. Thanks @markkelnar!
- [#2846](https://github.com/wp-graphql/wp-graphql/pull/2846): chore(deps): bump tough-cookie from 4.0.0 to 4.1.3
