### PR TITLE
chore: add missing translator comments

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -81,9 +81,6 @@
 		<exclude name="WordPress.PHP.DisallowShortTernary.Found"/>
 		<exclude name="WordPress.CodeAnalysis.AssignmentInCondition.Found"/>
 
-		<!-- Should maybe Add Back Later -->
-		<exclude name="WordPress.WP.I18n.MissingTranslatorsComment"/>
-		
 		<!-- Should probably not be added back -->
 		<exclude name="WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid"/>
 		<exclude name="WordPress.DateTime.RestrictedFunctions.date_date"/>

--- a/src/Admin/Settings/Settings.php
+++ b/src/Admin/Settings/Settings.php
@@ -97,7 +97,12 @@ class Settings {
 			[
 				'name'              => 'graphql_endpoint',
 				'label'             => __( 'GraphQL Endpoint', 'wp-graphql' ),
-				'desc'              => sprintf( __( 'The endpoint (path) for the GraphQL API on the site. <a target="_blank" href="%1$s/%2$s">%1$s/%2$s</a>. <br/><strong>Note:</strong> Changing the endpoint to something other than "graphql" <em>could</em> have an affect on tooling in the GraphQL ecosystem', 'wp-graphql' ), site_url(), get_graphql_setting( 'graphql_endpoint', 'graphql' ) ),
+				'desc'              => sprintf(
+					// translators: %1$s is the site url, %2$s is the default endpoint
+					__( 'The endpoint (path) for the GraphQL API on the site. <a target="_blank" href="%1$s/%2$s">%1$s/%2$s</a>. <br/><strong>Note:</strong> Changing the endpoint to something other than "graphql" <em>could</em> have an affect on tooling in the GraphQL ecosystem', 'wp-graphql' ),
+					site_url(),
+					get_graphql_setting( 'graphql_endpoint', 'graphql' )
+				),
 				'type'              => 'text',
 				'value'             => ! empty( $custom_endpoint ) ? $custom_endpoint : null,
 				'default'           => ! empty( $custom_endpoint ) ? $custom_endpoint : 'graphql',
@@ -181,7 +186,10 @@ class Settings {
 			[
 				'name'     => 'debug_mode_enabled',
 				'label'    => __( 'Enable GraphQL Debug Mode', 'wp-graphql' ),
-				'desc'     => defined( 'GRAPHQL_DEBUG' ) ? sprintf( __( 'This setting is disabled. "GRAPHQL_DEBUG" has been set to "%s" with code', 'wp-graphql' ), GRAPHQL_DEBUG ? 'true' : 'false' ) : __( 'Whether GraphQL requests should execute in "debug" mode. This setting is disabled if <strong>GRAPHQL_DEBUG</strong> is defined in wp-config.php. <br/>This will provide more information in GraphQL errors but can leak server implementation details so this setting is <strong>NOT RECOMMENDED FOR PRODUCTION ENVIRONMENTS</strong>.', 'wp-graphql' ),
+				'desc'     => defined( 'GRAPHQL_DEBUG' )
+					// translators: %s is the value of the GRAPHQL_DEBUG constant
+					? sprintf( __( 'This setting is disabled. "GRAPHQL_DEBUG" has been set to "%s" with code', 'wp-graphql' ), GRAPHQL_DEBUG ? 'true' : 'false' )
+					: __( 'Whether GraphQL requests should execute in "debug" mode. This setting is disabled if <strong>GRAPHQL_DEBUG</strong> is defined in wp-config.php. <br/>This will provide more information in GraphQL errors but can leak server implementation details so this setting is <strong>NOT RECOMMENDED FOR PRODUCTION ENVIRONMENTS</strong>.', 'wp-graphql' ),
 				'type'     => 'checkbox',
 				'value'    => true === \WPGraphQL::debug() ? 'on' : get_graphql_setting( 'debug_mode_enabled', 'off' ),
 				'disabled' => defined( 'GRAPHQL_DEBUG' ) ? true : false,
@@ -217,7 +225,11 @@ class Settings {
 			[
 				'name'     => 'public_introspection_enabled',
 				'label'    => __( 'Enable Public Introspection', 'wp-graphql' ),
-				'desc'     => sprintf( __( 'GraphQL Introspection is a feature that allows the GraphQL Schema to be queried. For Production and Staging environments, WPGraphQL will by default limit introspection queries to authenticated requests. Checking this enables Introspection for public requests, regardless of environment. %s ', 'wp-graphql' ), true === \WPGraphQL::debug() ? '<strong>' . __( 'NOTE: This setting is force enabled because GraphQL Debug Mode is enabled. ', 'wp-graphql' ) . '</strong>' : null ),
+				'desc'     => sprintf(
+					// translators: %s is either empty or a string with a note about debug mode.
+					__( 'GraphQL Introspection is a feature that allows the GraphQL Schema to be queried. For Production and Staging environments, WPGraphQL will by default limit introspection queries to authenticated requests. Checking this enables Introspection for public requests, regardless of environment. %s ', 'wp-graphql' ),
+					true === \WPGraphQL::debug() ? '<strong>' . __( 'NOTE: This setting is force enabled because GraphQL Debug Mode is enabled. ', 'wp-graphql' ) . '</strong>' : ''
+				),
 				'type'     => 'checkbox',
 				'default'  => ( 'local' === $this->get_wp_environment() || 'development' === $this->get_wp_environment() ) ? 'on' : 'off',
 				'value'    => true === \WPGraphQL::debug() ? 'on' : get_graphql_setting( 'public_introspection_enabled', 'off' ),

--- a/src/AppContext.php
+++ b/src/AppContext.php
@@ -168,6 +168,7 @@ class AppContext {
 	 */
 	public function get_loader( $key ) {
 		if ( ! array_key_exists( $key, $this->loaders ) ) {
+			// translators: %s is the key of the loader that was not found.
 			throw new UserError( sprintf( __( 'No loader assigned to the key %s', 'wp-graphql' ), $key ) );
 		}
 

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -400,10 +400,13 @@ abstract class AbstractConnectionResolver {
 	 * @return array the array of IDs.
 	 */
 	public function get_ids_from_query() {
-		throw new Exception( sprintf(
-			__( 'Class %s does not implement a valid method `get_ids_from_query()`.', 'wp-graphql' ),
-			get_class( $this )
-		) );
+		throw new Exception(
+			sprintf(
+				// translators: %s is the name of the connection resolver class.
+				__( 'Class %s does not implement a valid method `get_ids_from_query()`.', 'wp-graphql' ),
+				get_class( $this )
+			)
+		);
 	}
 
 	/**

--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -193,12 +193,14 @@ class DataSource {
 		$allowed_taxonomies = \WPGraphQL::get_allowed_taxonomies();
 
 		if ( ! in_array( $taxonomy, $allowed_taxonomies, true ) ) {
+			// translators: %s is the name of the taxonomy.
 			throw new UserError( sprintf( __( 'No taxonomy was found with the name %s', 'wp-graphql' ), $taxonomy ) );
 		}
 
 		$tax_object = get_taxonomy( $taxonomy );
 
 		if ( ! $tax_object instanceof \WP_Taxonomy ) {
+			// translators: %s is the name of the taxonomy.
 			throw new UserError( sprintf( __( 'No taxonomy was found with the name %s', 'wp-graphql' ), $taxonomy ) );
 		}
 
@@ -257,6 +259,7 @@ class DataSource {
 		if ( $theme->exists() ) {
 			return new Theme( $theme );
 		} else {
+			// translators: %s is the name of the theme stylesheet.
 			throw new UserError( sprintf( __( 'No theme was found with the stylesheet: %s', 'wp-graphql' ), $stylesheet ) );
 		}
 	}
@@ -328,6 +331,7 @@ class DataSource {
 		$role = isset( wp_roles()->roles[ $name ] ) ? wp_roles()->roles[ $name ] : null;
 
 		if ( null === $role ) {
+			// translators: %s is the name of the user role.
 			throw new UserError( sprintf( __( 'No user role was found with the name %s', 'wp-graphql' ), $name ) );
 		} else {
 			$role                = (array) $role;
@@ -701,6 +705,7 @@ class DataSource {
 			return null;
 
 		} else {
+			// translators: %s is the global ID.
 			throw new UserError( sprintf( __( 'The global ID isn\'t recognized ID: %s', 'wp-graphql' ), $global_id ) );
 		}
 	}

--- a/src/Model/MenuItem.php
+++ b/src/Model/MenuItem.php
@@ -83,8 +83,10 @@ class MenuItem extends Model {
 		}
 
 		if ( is_wp_error( $menus ) ) {
+			// translators: %s is the menu item ID.
 			throw new Exception( sprintf( __( 'No menus could be found for menu item %s', 'wp-graphql' ), $this->data->ID ) );
 		}
+
 		$menu_id = $menus[0];
 		if ( empty( $location_ids ) || ! in_array( $menu_id, $location_ids, true ) ) {
 			return true;

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -85,6 +85,7 @@ abstract class Model {
 	protected function __construct( $restricted_cap = '', $allowed_restricted_fields = [], $owner = null ) {
 
 		if ( empty( $this->data ) ) {
+			// translators: %s is the name of the model.
 			throw new Exception( sprintf( __( 'An empty data set was used to initialize the modeling of this %s object', 'wp-graphql' ), $this->get_model_name() ) );
 		}
 

--- a/src/Mutation/MediaItemCreate.php
+++ b/src/Mutation/MediaItemCreate.php
@@ -160,6 +160,7 @@ class MediaItemCreate {
 
 			// if the file doesn't pass the check, throw an error
 			if ( ! $check_file['ext'] || ! $check_file['type'] || ! wp_http_validate_url( $uploaded_file_url ) ) {
+				// translators: %s is the file path.
 				throw new UserError( sprintf( __( 'Invalid filePath "%s"', 'wp-graphql' ), $input['filePath'] ) );
 			}
 
@@ -180,7 +181,14 @@ class MediaItemCreate {
 			$allowed_protocols = apply_filters( 'graphql_media_item_create_allowed_protocols', $allowed_protocols, $protocol, $input, $context, $info );
 
 			if ( ! in_array( $protocol, $allowed_protocols, true ) ) {
-				throw new UserError( sprintf( __( 'Invalid protocol. "%1$s". Only "%2$s" allowed.', 'wp-graphql' ), $protocol, implode( '", "', $allowed_protocols ) ) );
+				throw new UserError(
+					sprintf(
+						// translators: %1$s is the protocol, %2$s is the list of allowed protocols.
+						__( 'Invalid protocol. "%1$s". Only "%2$s" allowed.', 'wp-graphql' ),
+						$protocol,
+						implode( '", "', $allowed_protocols )
+					)
+				);
 			}
 
 			/**

--- a/src/Mutation/MediaItemDelete.php
+++ b/src/Mutation/MediaItemDelete.php
@@ -96,6 +96,7 @@ class MediaItemDelete {
 
 			// Stop now if the post isn't a mediaItem.
 			if ( 'attachment' !== $existing_media_item->post_type ) {
+				// Translators: the placeholder is the post_type of the object being deleted
 				throw new UserError( sprintf( __( 'Sorry, the item you are trying to delete is a %1%s, not a mediaItem', 'wp-graphql' ), $existing_media_item->post_type ) );
 			}
 
@@ -118,7 +119,7 @@ class MediaItemDelete {
 			 * don't remove from the trash
 			 */
 			if ( 'trash' === $existing_media_item->post_status && true !== $force_delete ) {
-				// Translators: the first placeholder is the post_type of the object being deleted and the second placeholder is the unique ID of that object
+				// translators: the first placeholder is the post_type of the object being deleted and the second placeholder is the unique ID of that object
 				throw new UserError( sprintf( __( 'The mediaItem with id %1$s is already in the trash. To remove from the trash, use the forceDelete input', 'wp-graphql' ), $input['id'] ) );
 			}
 

--- a/src/Mutation/PostObjectCreate.php
+++ b/src/Mutation/PostObjectCreate.php
@@ -147,7 +147,12 @@ class PostObjectCreate {
 			// If the taxonomy is in the array of taxonomies registered to the post_type
 			if ( in_array( $tax_object->name, get_object_taxonomies( $post_type_object->name ), true ) ) {
 				$fields[ $tax_object->graphql_plural_name ] = [
-					'description' => sprintf( __( 'Set connections between the %1$s and %2$s', 'wp-graphql' ), $post_type_object->graphql_single_name, $tax_object->graphql_plural_name ),
+					'description' => sprintf(
+						// translators: %1$s is the post type GraphQL name, %2$s is the taxonomy GraphQL name.
+						__( 'Set connections between the %1$s and %2$s', 'wp-graphql' ),
+						$post_type_object->graphql_single_name,
+						$tax_object->graphql_plural_name
+					),
 					'type'        => ucfirst( $post_type_object->graphql_single_name ) . ucfirst( $tax_object->graphql_plural_name ) . 'Input',
 				];
 			}
@@ -336,7 +341,7 @@ class PostObjectCreate {
 				 * don't proceed.
 				 */
 				if ( ! $new_post = get_post( $post_id ) ) {
-					throw new UserError( sprintf( __( 'The status of the post could not be set', 'wp-graphql' ) ) );
+					throw new UserError( __( 'The status of the post could not be set', 'wp-graphql' ) );
 				}
 
 				/**

--- a/src/Mutation/TermObjectCreate.php
+++ b/src/Mutation/TermObjectCreate.php
@@ -29,7 +29,7 @@ class TermObjectCreate {
 							'type'        => [
 								'non_null' => 'String',
 							],
-							// Translators: The placeholder is the name of the taxonomy for the object being mutated
+							// translators: The placeholder is the name of the taxonomy for the object being mutated
 							'description' => sprintf( __( 'The name of the %1$s object to mutate', 'wp-graphql' ), $taxonomy->name ),
 						],
 					]
@@ -51,12 +51,12 @@ class TermObjectCreate {
 		$fields = [
 			'aliasOf'     => [
 				'type'        => 'String',
-				// Translators: The placeholder is the name of the taxonomy for the object being mutated
+				// translators: The placeholder is the name of the taxonomy for the object being mutated
 				'description' => sprintf( __( 'The slug that the %1$s will be an alias of', 'wp-graphql' ), $taxonomy->name ),
 			],
 			'description' => [
 				'type'        => 'String',
-				// Translators: The placeholder is the name of the taxonomy for the object being mutated
+				// translators: The placeholder is the name of the taxonomy for the object being mutated
 				'description' => sprintf( __( 'The description of the %1$s object', 'wp-graphql' ), $taxonomy->name ),
 			],
 			'slug'        => [
@@ -71,7 +71,7 @@ class TermObjectCreate {
 		if ( true === $taxonomy->hierarchical ) {
 			$fields['parentId'] = [
 				'type'        => 'ID',
-				// Translators: The placeholder is the name of the taxonomy for the object being mutated
+				// translators: The placeholder is the name of the taxonomy for the object being mutated
 				'description' => sprintf( __( 'The ID of the %1$s that should be set as the parent', 'wp-graphql' ), $taxonomy->name ),
 			];
 		}
@@ -130,13 +130,14 @@ class TermObjectCreate {
 			 * Ensure a name was provided
 			 */
 			if ( empty( $args['name'] ) ) {
-				// Translators: The placeholder is the name of the taxonomy of the term being mutated
+				// translators: The placeholder is the name of the taxonomy of the term being mutated
 				throw new UserError( sprintf( __( 'A name is required to create a %1$s', 'wp-graphql' ), $taxonomy->name ) );
 			}
 
 			$term_name = wp_slash( $args['name'] );
 
 			if ( ! is_string( $term_name ) ) {
+				// translators: The placeholder is the name of the taxonomy of the term being mutated
 				throw new UserError( sprintf( __( 'A valid name is required to create a %1$s', 'wp-graphql' ), $taxonomy->name ) );
 			}
 

--- a/src/Mutation/UpdateSettings.php
+++ b/src/Mutation/UpdateSettings.php
@@ -137,6 +137,7 @@ class UpdateSettings {
 
 				$output_fields[ Utils::format_field_name( $setting_type_name ) ] = [
 					'type'        => $setting_type_name,
+					// translators: %s is the setting type name
 					'description' => sprintf( __( 'Update the %s setting.', 'wp-graphql' ), $setting_type_name ),
 					'resolve'     => function () use ( $setting_type_name ) {
 						return $setting_type_name;

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -450,23 +450,45 @@ class TypeRegistry {
 					register_graphql_input_type(
 						$post_type_object->graphql_single_name . ucfirst( $tax_object->graphql_plural_name ) . 'NodeInput',
 						[
-							'description' => sprintf( __( 'List of %1$s to connect the %2$s to. If an ID is set, it will be used to create the connection. If not, it will look for a slug. If neither are valid existing terms, and the site is configured to allow terms to be created during post mutations, a term will be created using the Name if it exists in the input, then fallback to the slug if it exists.', 'wp-graphql' ), $tax_object->graphql_plural_name, $post_type_object->graphql_single_name ),
+							'description' => sprintf(
+								// translators: %1$s is the GraphQL plural name of the taxonomy, %2$s is the GraphQL singular name of the post type.
+								__( 'List of %1$s to connect the %2$s to. If an ID is set, it will be used to create the connection. If not, it will look for a slug. If neither are valid existing terms, and the site is configured to allow terms to be created during post mutations, a term will be created using the Name if it exists in the input, then fallback to the slug if it exists.', 'wp-graphql' ),
+								$tax_object->graphql_plural_name,
+								$post_type_object->graphql_single_name
+							),
 							'fields'      => [
 								'id'          => [
 									'type'        => 'Id',
-									'description' => sprintf( __( 'The ID of the %1$s. If present, this will be used to connect to the %2$s. If no existing %1$s exists with this ID, no connection will be made.', 'wp-graphql' ), $tax_object->graphql_single_name, $post_type_object->graphql_single_name ),
+									'description' => sprintf(
+										// translators: %1$s is the GraphQL name of the taxonomy, %2$s is the GraphQL name of the post type.
+										__( 'The ID of the %1$s. If present, this will be used to connect to the %2$s. If no existing %1$s exists with this ID, no connection will be made.', 'wp-graphql' ),
+										$tax_object->graphql_single_name,
+										$post_type_object->graphql_single_name
+									),
 								],
 								'slug'        => [
 									'type'        => 'String',
-									'description' => sprintf( __( 'The slug of the %1$s. If no ID is present, this field will be used to make a connection. If no existing term exists with this slug, this field will be used as a fallback to the Name field when creating a new term to connect to, if term creation is enabled as a nested mutation.', 'wp-graphql' ), $tax_object->graphql_single_name ),
+									'description' => sprintf(
+										// translators: %1$s is the GraphQL name of the taxonomy.
+										__( 'The slug of the %1$s. If no ID is present, this field will be used to make a connection. If no existing term exists with this slug, this field will be used as a fallback to the Name field when creating a new term to connect to, if term creation is enabled as a nested mutation.', 'wp-graphql' ),
+										$tax_object->graphql_single_name
+									),
 								],
 								'description' => [
 									'type'        => 'String',
-									'description' => sprintf( __( 'The description of the %1$s. This field is used to set a description of the %1$s if a new one is created during the mutation.', 'wp-graphql' ), $tax_object->graphql_single_name ),
+									'description' => sprintf(
+										// translators: %1$s is the GraphQL name of the taxonomy.
+										__( 'The description of the %1$s. This field is used to set a description of the %1$s if a new one is created during the mutation.', 'wp-graphql' ),
+										$tax_object->graphql_single_name
+									),
 								],
 								'name'        => [
 									'type'        => 'String',
-									'description' => sprintf( __( 'The name of the %1$s. This field is used to create a new term, if term creation is enabled in nested mutations, and if one does not already exist with the provided slug or ID or if a slug or ID is not provided. If no name is included and a term is created, the creation will fallback to the slug field.', 'wp-graphql' ), $tax_object->graphql_single_name ),
+									'description' => sprintf(
+											// translators: %1$s is the GraphQL name of the taxonomy.
+										__( 'The name of the %1$s. This field is used to create a new term, if term creation is enabled in nested mutations, and if one does not already exist with the provided slug or ID or if a slug or ID is not provided. If no name is included and a term is created, the creation will fallback to the slug field.', 'wp-graphql' ),
+										$tax_object->graphql_single_name
+									),
 								],
 							],
 						]
@@ -475,11 +497,20 @@ class TypeRegistry {
 					register_graphql_input_type(
 						ucfirst( $post_type_object->graphql_single_name ) . ucfirst( $tax_object->graphql_plural_name ) . 'Input',
 						[
-							'description' => sprintf( __( 'Set relationships between the %1$s to %2$s', 'wp-graphql' ), $post_type_object->graphql_single_name, $tax_object->graphql_plural_name ),
+							'description' => sprintf(
+								// translators: %1$s is the GraphQL name of the post type, %2$s is the plural GraphQL name of the taxonomy.
+								__( 'Set relationships between the %1$s to %2$s', 'wp-graphql' ),
+								$post_type_object->graphql_single_name,
+								$tax_object->graphql_plural_name
+							),
 							'fields'      => [
 								'append' => [
 									'type'        => 'Boolean',
-									'description' => sprintf( __( 'If true, this will append the %1$s to existing related %2$s. If false, this will replace existing relationships. Default true.', 'wp-graphql' ), $tax_object->graphql_single_name, $tax_object->graphql_plural_name ),
+									'description' => sprintf(
+										// translators: %1$s is the GraphQL name of the taxonomy, %2$s is the plural GraphQL name of the taxonomy.
+										__( 'If true, this will append the %1$s to existing related %2$s. If false, this will replace existing relationships. Default true.', 'wp-graphql' ), $tax_object->graphql_single_name,
+										$tax_object->graphql_plural_name
+									),
 								],
 								'nodes'  => [
 									'type'        => [
@@ -549,7 +580,11 @@ class TypeRegistry {
 					Utils::format_field_name( $type_name ),
 					[
 						'type'        => $type_name,
-						'description' => sprintf( __( "Fields of the '%s' settings group", 'wp-graphql' ), ucfirst( $group_name ) . 'Settings' ),
+						'description' => sprintf(
+							// translators: %s is the GraphQL name of the settings group.
+							__( "Fields of the '%s' settings group", 'wp-graphql' ),
+							ucfirst( $group_name ) . 'Settings'
+						),
 						'resolve'     => function () use ( $setting_type ) {
 							return $setting_type;
 						},
@@ -644,7 +679,11 @@ class TypeRegistry {
 		 */
 		if ( ! is_valid_graphql_name( $type_name ) ) {
 			graphql_debug(
-				sprintf( __( 'The Type name \'%1$s\' is invalid and has not been added to the GraphQL Schema.', 'wp-graphql' ), $type_name ),
+				sprintf(
+					// translators: %s is the name of the type.
+					__( 'The Type name \'%1$s\' is invalid and has not been added to the GraphQL Schema.', 'wp-graphql' ),
+					$type_name
+				),
 				[
 					'type'      => 'INVALID_TYPE_NAME',
 					'type_name' => $type_name,
@@ -658,7 +697,11 @@ class TypeRegistry {
 		 */
 		if ( isset( $this->types[ $this->format_key( $type_name ) ] ) || isset( $this->type_loaders[ $this->format_key( $type_name ) ] ) ) {
 			graphql_debug(
-				sprintf( __( 'You cannot register duplicate Types to the Schema. The Type \'%1$s\' already exists in the Schema. Make sure to give new Types a unique name.', 'wp-graphql' ), $type_name ),
+				sprintf(
+					// translators: %s is the name of the type.
+					__( 'You cannot register duplicate Types to the Schema. The Type \'%1$s\' already exists in the Schema. Make sure to give new Types a unique name.', 'wp-graphql' ),
+					$type_name
+				),
 				[
 					'type'      => 'DUPLICATE_TYPE',
 					'type_name' => $type_name,
@@ -895,11 +938,18 @@ class TypeRegistry {
 		}
 
 		if ( ! isset( $field_config['type'] ) ) {
-			graphql_debug( sprintf( __( 'The registered field \'%s\' does not have a Type defined. Make sure to define a type for all fields.', 'wp-graphql' ), $field_name ), [
-				'type'       => 'INVALID_FIELD_TYPE',
-				'type_name'  => $type_name,
-				'field_name' => $field_name,
-			] );
+			graphql_debug(
+				sprintf(
+					/* translators: %s is the Field name. */
+					__( 'The registered field \'%s\' does not have a Type defined. Make sure to define a type for all fields.', 'wp-graphql' ),
+					$field_name
+				),
+				[
+					'type'       => 'INVALID_FIELD_TYPE',
+					'type_name'  => $type_name,
+					'field_name' => $field_name,
+				]
+			);
 			return null;
 		}
 
@@ -1038,7 +1088,12 @@ class TypeRegistry {
 
 				if ( preg_match( '/^\d/', $field_name ) ) {
 					graphql_debug(
-						sprintf( __( 'The field \'%1$s\' on Type \'%2$s\' is invalid. Field names cannot start with a number.', 'wp-graphql' ), $field_name, $type_name ),
+						sprintf(
+							// translators: %1$s is the field name, %2$s is the type name.
+							__( 'The field \'%1$s\' on Type \'%2$s\' is invalid. Field names cannot start with a number.', 'wp-graphql' ),
+							$field_name,
+							$type_name
+						),
 						[
 							'type'       => 'INVALID_FIELD_NAME',
 							'field_name' => $field_name,
@@ -1050,7 +1105,12 @@ class TypeRegistry {
 
 				if ( isset( $fields[ $field_name ] ) ) {
 					graphql_debug(
-						sprintf( __( 'You cannot register duplicate fields on the same Type. The field \'%1$s\' already exists on the type \'%2$s\'. Make sure to give the field a unique name.', 'wp-graphql' ), $field_name, $type_name ),
+						sprintf(
+							// translators: %1$s is the field name, %2$s is the type name.
+							__( 'You cannot register duplicate fields on the same Type. The field \'%1$s\' already exists on the type \'%2$s\'. Make sure to give the field a unique name.', 'wp-graphql' ),
+							$field_name,
+							$type_name
+						),
 						[
 							'type'       => 'DUPLICATE_FIELD',
 							'field_name' => $field_name,

--- a/src/Registry/Utils/PostObject.php
+++ b/src/Registry/Utils/PostObject.php
@@ -65,6 +65,7 @@ class PostObject {
 		if ( empty( $post_type_object->graphql_resolve_type ) || ! is_callable( $post_type_object->graphql_resolve_type ) ) {
 			graphql_debug(
 				sprintf(
+					// translators: %1$s is the post type name, %2$s is the graphql kind.
 					__( '%1$s is registered as a GraphQL %2$s, but has no way to resolve the type. Ensure "graphql_resolve_type" is a valid callback function', 'wp-graphql' ),
 					$single_name,
 					$post_type_object->graphql_kind
@@ -136,7 +137,11 @@ class PostObject {
 				'toType'             => $post_type_object->graphql_single_name,
 				'connectionTypeName' => ucfirst( $post_type_object->graphql_single_name ) . 'ToPreviewConnection',
 				'oneToOne'           => true,
-				'deprecationReason'  => ( true === $post_type_object->publicly_queryable || true === $post_type_object->public ) ? null : sprintf( __( 'The "%s" Type is not publicly queryable and does not support previews. This field will be removed in the future.', 'wp-graphql' ), WPGraphQL\Utils\Utils::format_type_name( $post_type_object->graphql_single_name ) ),
+				'deprecationReason'  => ( true === $post_type_object->publicly_queryable || true === $post_type_object->public ) ? null
+					: sprintf(
+						// translators: %s is the post type's GraphQL name.
+						__( 'The "%s" Type is not publicly queryable and does not support previews. This field will be removed in the future.', 'wp-graphql' ), WPGraphQL\Utils\Utils::format_type_name( $post_type_object->graphql_single_name )
+					),
 				'resolve'            => function ( Post $post, $args, AppContext $context, ResolveInfo $info ) {
 					if ( $post->isRevision ) {
 						return null;

--- a/src/Registry/Utils/TermObject.php
+++ b/src/Registry/Utils/TermObject.php
@@ -34,8 +34,11 @@ class TermObject {
 		$single_name = $tax_object->graphql_single_name;
 
 		$config = [
-			/* translators: post object singular name w/ description */
-			'description' => sprintf( __( 'The %s type', 'wp-graphql' ), $single_name ),
+			'description' => sprintf(
+				// translators: %s is the term object singular name.
+				__( 'The %s type', 'wp-graphql' ),
+				$single_name
+			),
 			'connections' => static::get_connections( $tax_object ),
 			'interfaces'  => static::get_interfaces( $tax_object ),
 			'fields'      => static::get_fields( $tax_object ),
@@ -58,6 +61,7 @@ class TermObject {
 		if ( empty( $tax_object->graphql_resolve_type ) || ! is_callable( $tax_object->graphql_resolve_type ) ) {
 			graphql_debug(
 				sprintf(
+					// translators: %1$s is the term object singular name, %2$s is the graphql kind.
 					__( '%1$s is registered as a GraphQL %2$s, but has no way to resolve the type. Ensure "graphql_resolve_type" is a valid callback function', 'wp-graphql' ),
 					$single_name,
 					$tax_object->graphql_kind
@@ -123,6 +127,7 @@ class TermObject {
 			$connections['children'] = [
 				'toType'         => $tax_object->graphql_single_name,
 				'description'    => sprintf(
+					// translators: %1$s is the term object singular name, %2$s is the term object plural name.
 					__( 'Connection between the %1$s type and its children %2$s.', 'wp-graphql' ),
 					$tax_object->graphql_single_name,
 					$tax_object->graphql_plural_name
@@ -142,6 +147,7 @@ class TermObject {
 			$connections['parent'] = [
 				'toType'             => $tax_object->graphql_single_name,
 				'description'        => sprintf(
+					// translators: %s is the term object singular name.
 					__( 'Connection between the %1$s type and its parent %1$s.', 'wp-graphql' ),
 					$tax_object->graphql_single_name
 				),

--- a/src/Server/ValidationRules/RequireAuthentication.php
+++ b/src/Server/ValidationRules/RequireAuthentication.php
@@ -94,6 +94,7 @@ class RequireAuthentication extends QuerySecurityRule {
 						$context->reportError(
 							new Error(
 								sprintf(
+									// translators: %s is the field name
 									__( 'The field "%s" cannot be accessed without authentication.', 'wp-graphql' ),
 									$context->getParentType() . '.' . $node->name->value
 								),

--- a/src/Type/Enum/CommentStatusEnum.php
+++ b/src/Type/Enum/CommentStatusEnum.php
@@ -22,6 +22,7 @@ class CommentStatusEnum {
 		foreach ( $stati as $status => $name ) {
 
 			$values[ WPEnumType::get_safe_name( $status ) ] = [
+				// translators: %s is the name of the comment status
 				'description' => sprintf( __( 'Comments with the %1$s status', 'wp-graphql' ), $name ),
 				'value'       => $status,
 			];

--- a/src/Type/Enum/ContentTypeEnum.php
+++ b/src/Type/Enum/ContentTypeEnum.php
@@ -71,7 +71,11 @@ class ContentTypeEnum {
 				register_graphql_enum_type(
 					'ContentTypesOf' . Utils::format_type_name( $tax_object->graphql_single_name ) . 'Enum',
 					[
-						'description' => sprintf( __( 'Allowed Content Types of the %s taxonomy.', 'wp-graphql' ), Utils::format_type_name( $tax_object->graphql_single_name ) ),
+						'description' => sprintf(
+							// translators: %s is the taxonomy's GraphQL name.
+							__( 'Allowed Content Types of the %s taxonomy.', 'wp-graphql' ),
+							Utils::format_type_name( $tax_object->graphql_single_name )
+						),
 						'values'      => $taxonomy_values,
 					]
 				);

--- a/src/Type/Enum/MediaItemSizeEnum.php
+++ b/src/Type/Enum/MediaItemSizeEnum.php
@@ -31,7 +31,11 @@ class MediaItemSizeEnum {
 		 */
 		foreach ( $image_sizes as $image_size ) {
 			$values[ WPEnumType::get_safe_name( $image_size ) ] = [
-				'description' => sprintf( __( 'MediaItem with the %1$s size', 'wp-graphql' ), $image_size ),
+				'description' => sprintf(
+					// translators: %1$s is the image size.
+					__( 'MediaItem with the %1$s size', 'wp-graphql' ),
+					$image_size
+				),
 				'value'       => $image_size,
 			];
 		}

--- a/src/Type/Enum/MediaItemStatusEnum.php
+++ b/src/Type/Enum/MediaItemStatusEnum.php
@@ -27,7 +27,11 @@ class MediaItemStatusEnum {
 		foreach ( $post_stati as $status ) {
 
 			$values[ WPEnumType::get_safe_name( $status ) ] = [
-				'description' => sprintf( __( 'Objects with the %1$s status', 'wp-graphql' ), $status ),
+				'description' => sprintf(
+					// translators: %1$s is the post status.
+					__( 'Objects with the %1$s status', 'wp-graphql' ),
+					$status
+				),
 				'value'       => $status,
 			];
 		}

--- a/src/Type/Enum/MenuLocationEnum.php
+++ b/src/Type/Enum/MenuLocationEnum.php
@@ -20,7 +20,11 @@ class MenuLocationEnum {
 			foreach ( $locations as $location ) {
 				$values[ WPEnumType::get_safe_name( $location ) ] = [
 					'value'       => $location,
-					'description' => sprintf( __( 'Put the menu in the %s location', 'wp-graphql' ), $location ),
+					'description' => sprintf(
+						// translators: %s is the menu location name.
+						__( 'Put the menu in the %s location', 'wp-graphql' ),
+						$location
+					),
 				];
 			}
 		}

--- a/src/Type/Enum/MimeTypeEnum.php
+++ b/src/Type/Enum/MimeTypeEnum.php
@@ -26,7 +26,11 @@ class MimeTypeEnum {
 			foreach ( $allowed_mime_types as $mime_type ) {
 				$values[ WPEnumType::get_safe_name( $mime_type ) ] = [
 					'value'       => $mime_type,
-					'description' => sprintf( __( 'MimeType %s', 'wp-graphql' ), $mime_type ),
+					'description' => sprintf(
+						// translators: %s is the mime type.
+						__( '%s mime type.', 'wp-graphql' ),
+						$mime_type
+					),
 				];
 			}
 		}

--- a/src/Type/Enum/PostStatusEnum.php
+++ b/src/Type/Enum/PostStatusEnum.php
@@ -34,7 +34,11 @@ class PostStatusEnum {
 				}
 
 				$post_status_enum_values[ WPEnumType::get_safe_name( $status ) ] = [
-					'description' => sprintf( __( 'Objects with the %1$s status', 'wp-graphql' ), $status ),
+					'description' => sprintf(
+						// translators: %1$s is the post status.
+						__( 'Objects with the %1$s status', 'wp-graphql' ),
+						$status
+					),
 					'value'       => $status,
 				];
 			}

--- a/src/Type/Enum/TaxonomyEnum.php
+++ b/src/Type/Enum/TaxonomyEnum.php
@@ -26,7 +26,11 @@ class TaxonomyEnum {
 			if ( ! isset( $values[ WPEnumType::get_safe_name( $tax_object->graphql_single_name ) ] ) ) {
 				$values[ WPEnumType::get_safe_name( $tax_object->graphql_single_name ) ] = [
 					'value'       => $tax_object->name,
-					'description' => sprintf( __( 'Taxonomy enum %s', 'wp-graphql' ), $tax_object->name ),
+					'description' => sprintf(
+						// translators: %s is the taxonomy name.
+						__( 'Taxonomy enum %s', 'wp-graphql' ),
+						$tax_object->name
+					),
 				];
 			}
 		}

--- a/src/Type/Enum/TimezoneEnum.php
+++ b/src/Type/Enum/TimezoneEnum.php
@@ -182,7 +182,11 @@ class TimezoneEnum {
 			// Intentionally avoid WPEnumType::get_safe_name here for specific timezone formatting
 			$enum_values[ WPEnumType::get_safe_name( $offset_name ) ] = [
 				'value'       => $offset_value,
-				'description' => sprintf( __( 'UTC offset: %s', 'wp-graphql' ), $offset_name ),
+				'description' => sprintf(
+					// translators: %s is the UTC offset.
+					__( 'UTC offset: %s', 'wp-graphql' ),
+					$offset_name
+				),
 			];
 
 		}

--- a/src/Type/ObjectType/RootQuery.php
+++ b/src/Type/ObjectType/RootQuery.php
@@ -682,7 +682,12 @@ class RootQuery {
 				$post_type_object->graphql_single_name,
 				[
 					'type'        => $post_type_object->graphql_single_name,
-					'description' => sprintf( __( 'An object of the %1$s Type. %2$s', 'wp-graphql' ), $post_type_object->graphql_single_name, $post_type_object->description ),
+					'description' => sprintf(
+						// translators: %1$s is the post type GraphQL name, %2$s is the post type description
+						__( 'An object of the %1$s Type. %2$s', 'wp-graphql' ),
+						$post_type_object->graphql_single_name,
+						$post_type_object->description
+					),
 					'args'        => [
 						'id'        => [
 							'type'        => [
@@ -779,21 +784,37 @@ class RootQuery {
 			$post_by_args = [
 				'id'  => [
 					'type'        => 'ID',
-					'description' => sprintf( __( 'Get the object by its global ID', 'wp-graphql' ), $post_type_object->graphql_single_name ),
+					'description' => sprintf(
+						// translators: %s is the post type's GraphQL name.
+						__( 'Get the %s object by its global ID', 'wp-graphql' ),
+						$post_type_object->graphql_single_name
+					),
 				],
 				$post_type_object->graphql_single_name . 'Id' => [
 					'type'        => 'Int',
-					'description' => sprintf( __( 'Get the %s by its database ID', 'wp-graphql' ), $post_type_object->graphql_single_name ),
+					'description' => sprintf(
+						// translators: %s is the post type's GraphQL name.
+						__( 'Get the %s by its database ID', 'wp-graphql' ),
+						$post_type_object->graphql_single_name
+					),
 				],
 				'uri' => [
 					'type'        => 'String',
-					'description' => sprintf( __( 'Get the %s by its uri', 'wp-graphql' ), $post_type_object->graphql_single_name ),
+					'description' => sprintf(
+						// translators: %s is the post type's GraphQL name.
+						__( 'Get the %s by its uri', 'wp-graphql' ),
+						$post_type_object->graphql_single_name
+					),
 				],
 			];
 			if ( false === $post_type_object->hierarchical ) {
 				$post_by_args['slug'] = [
 					'type'        => 'String',
-					'description' => sprintf( __( 'Get the %s by its slug (only available for non-hierarchical types)', 'wp-graphql' ), $post_type_object->graphql_single_name ),
+					'description' => sprintf(
+						// translators: %s is the post type's GraphQL name.
+						__( 'Get the %s by its slug (only available for non-hierarchical types)', 'wp-graphql' ),
+						$post_type_object->graphql_single_name
+					),
 				];
 			}
 
@@ -806,7 +827,11 @@ class RootQuery {
 				[
 					'type'              => $post_type_object->graphql_single_name,
 					'deprecationReason' => __( 'Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: "" ), use post(id: "" idType: "")', 'wp-graphql' ),
-					'description'       => sprintf( __( 'A %s object', 'wp-graphql' ), $post_type_object->graphql_single_name ),
+					'description'       => sprintf(
+						// translators: %s is the post type's GraphQL name.
+						__( 'A %s object', 'wp-graphql' ),
+						$post_type_object->graphql_single_name
+					),
 					'args'              => $post_by_args,
 					'resolve'           => function ( $source, array $args, $context ) use ( $post_type_object ) {
 						$post_object = null;
@@ -890,7 +915,11 @@ class RootQuery {
 				$tax_object->graphql_single_name,
 				[
 					'type'        => $tax_object->graphql_single_name,
-					'description' => sprintf( __( 'A % object', 'wp-graphql' ), $tax_object->graphql_single_name ),
+					'description' => sprintf(
+						// translators: %s is the taxonomys' GraphQL name.
+						__( 'A % object', 'wp-graphql' ),
+						$tax_object->graphql_single_name
+					),
 					'args'        => [
 						'id'     => [
 							'type'        => [

--- a/src/Type/ObjectType/SettingGroup.php
+++ b/src/Type/ObjectType/SettingGroup.php
@@ -33,6 +33,7 @@ class SettingGroup {
 		register_graphql_object_type(
 			ucfirst( $group_name ) . 'Settings',
 			[
+				// translators: %s is the name of the setting group.
 				'description' => sprintf( __( 'The %s setting type', 'wp-graphql' ), $group_name ),
 				'fields'      => $fields,
 			]
@@ -88,6 +89,7 @@ class SettingGroup {
 					 */
 					$fields[ $field_key ] = [
 						'type'        => $type_registry->get_type( $setting_field['type'] ),
+						// translators: %s is the name of the setting group.
 						'description' => isset( $setting_field['description'] ) && ! empty( $setting_field['description'] ) ? $setting_field['description'] : sprintf( __( 'The %s Settings Group', 'wp-graphql' ), $setting_field['type'] ),
 						'resolve'     => function ( $root, array $args, $context, $info ) use ( $setting_field ) {
 

--- a/src/Type/ObjectType/Settings.php
+++ b/src/Type/ObjectType/Settings.php
@@ -91,6 +91,7 @@ class Settings {
 					 */
 					$fields[ $field_key ] = [
 						'type'        => $setting_field['type'],
+						// translators: %s is the name of the setting group.
 						'description' => sprintf( __( 'Settings of the the %s Settings Group', 'wp-graphql' ), $setting_field['type'] ),
 						'resolve'     => function ( $root, $args, $context, $info ) use ( $setting_field, $key ) {
 							/**

--- a/src/Type/WPConnectionType.php
+++ b/src/Type/WPConnectionType.php
@@ -284,8 +284,11 @@ class WPConnectionType {
 		$this->type_registry->register_input_type(
 			$input_name,
 			[
-				// Translators: Placeholder is the name of the connection
-				'description' => sprintf( __( 'Arguments for filtering the %s connection', 'wp-graphql' ), $this->connection_name ),
+				'description' => sprintf(
+					// translators: %s is the name of the connection
+					__( 'Arguments for filtering the %s connection', 'wp-graphql' ),
+					$this->connection_name
+				),
 				'fields'      => $this->connection_args,
 				'queryClass'  => $this->query_class,
 			]
@@ -324,8 +327,12 @@ class WPConnectionType {
 			$this->connection_name . 'Edge',
 			[
 				'interfaces'  => $interfaces,
-				// Translators: Placeholders are for the name of the Type the connection is coming from and the name of the Type the connection is going to
-				'description' => sprintf( __( 'Connection between the %1$s type and the %2$s type', 'wp-graphql' ), $this->from_type, $this->to_type ),
+				'description' => sprintf(
+					// translators: Placeholders are for the name of the Type the connection is coming from and the name of the Type the connection is going to
+					__( 'Connection between the %1$s type and the %2$s type', 'wp-graphql' ),
+					$this->from_type,
+					$this->to_type
+				),
 				'fields'      => array_merge(
 					[
 						'node' => [
@@ -355,7 +362,11 @@ class WPConnectionType {
 
 		$this->type_registry->register_object_type( $this->connection_name . 'PageInfo', [
 			'interfaces'  => [ $this->to_type . 'ConnectionPageInfo' ],
-			'description' => sprintf( __( 'Page Info on the "%s"', 'wp-graphql' ), $this->connection_name ),
+			'description' => sprintf(
+				// translators: %s is the name of the connection.
+				__( 'Page Info on the "%s"', 'wp-graphql' ),
+				$this->connection_name
+			),
 			'fields'      => PageInfo::get_fields(),
 		] );
 
@@ -429,8 +440,12 @@ class WPConnectionType {
 		$this->type_registry->register_object_type(
 			$this->connection_name,
 			[
-				// Translators: the placeholders are the name of the Types the connection is between.
-				'description'       => sprintf( __( 'Connection between the %1$s type and the %2$s type', 'wp-graphql' ), $this->from_type, $this->to_type ),
+				'description'       => sprintf(
+					// translators: the placeholders are the name of the Types the connection is between.
+					__( 'Connection between the %1$s type and the %2$s type', 'wp-graphql' ),
+					$this->from_type,
+					$this->to_type
+				),
 				'interfaces'        => $interfaces,
 				'connection_config' => $this->config,
 				'fields'            => $this->get_connection_fields(),
@@ -454,7 +469,7 @@ class WPConnectionType {
 				],
 				'edges'    => [
 					'type'        => [ 'non_null' => [ 'list_of' => [ 'non_null' => $this->connection_name . 'Edge' ] ] ],
-					// Translators: Placeholder is the name of the connection
+					// translators: %s is the name of the connection.
 					'description' => sprintf( __( 'Edges for the %s connection', 'wp-graphql' ), $this->connection_name ),
 				],
 				'nodes'    => [
@@ -519,7 +534,14 @@ class WPConnectionType {
 			'args'                  => array_merge( $this->get_pagination_args(), $this->where_args ),
 			'auth'                  => $this->auth,
 			'deprecationReason'     => ! empty( $this->config['deprecationReason'] ) ? $this->config['deprecationReason'] : null,
-			'description'           => ! empty( $this->config['description'] ) ? $this->config['description'] : sprintf( __( 'Connection between the %1$s type and the %2$s type', 'wp-graphql' ), $this->from_type, $this->to_type ),
+			'description'           => ! empty( $this->config['description'] ) 
+				? $this->config['description']
+				: sprintf(
+					// translators: the placeholders are the name of the Types the connection is between.
+					__( 'Connection between the %1$s type and the %2$s type', 'wp-graphql' ),
+					$this->from_type,
+					$this->to_type
+				),
 			'resolve'               => function ( $root, $args, $context, $info ) {
 				$context->connection_query_class = $this->query_class;
 				$resolve_connection              = $this->resolve_connection;
@@ -551,6 +573,7 @@ class WPConnectionType {
 		if ( ! $this->type_registry->has_type( $this->to_type . 'ConnectionPageInfo' ) ) {
 			$this->type_registry->register_interface_type( $this->to_type . 'ConnectionPageInfo', [
 				'interfaces'  => [ 'WPPageInfo' ],
+				// translators: %s is the name of the connection edge.
 				'description' => sprintf( __( 'Page Info on the connected %s', 'wp-graphql' ), $connection_edge_type ),
 				'fields'      => PageInfo::get_fields(),
 			] );
@@ -561,10 +584,12 @@ class WPConnectionType {
 
 			$this->type_registry->register_interface_type( $connection_edge_type, [
 				'interfaces'  => [ 'Edge' ],
+				// translators: %s is the name of the type the connection edge is to.
 				'description' => sprintf( __( 'Edge between a Node and a connected %s', 'wp-graphql' ), $this->to_type ),
 				'fields'      => [
 					'node' => [
 						'type'        => [ 'non_null' => $this->to_type ],
+						// translators: %s is the name of the type the connection edge is to.
 						'description' => sprintf( __( 'The connected %s Node', 'wp-graphql' ), $this->to_type ),
 					],
 				],
@@ -575,17 +600,24 @@ class WPConnectionType {
 		if ( ! $this->one_to_one && ! $this->type_registry->has_type( $this->to_type . 'Connection' ) ) {
 			$this->type_registry->register_interface_type( $this->to_type . 'Connection', [
 				'interfaces'  => [ 'Connection' ],
+				// translators: %s is the name of the type the connection is to.
 				'description' => sprintf( __( 'Connection to %s Nodes', 'wp-graphql' ), $this->to_type ),
 				'fields'      => [
 					'edges'    => [
 						'type'        => [ 'non_null' => [ 'list_of' => [ 'non_null' => $connection_edge_type ] ] ],
-						'description' => sprintf( __( 'A list of edges (relational context) between %1$s and connected %2$s Nodes', 'wp-graphql' ), $this->from_type, $this->to_type ),
+						'description' => sprintf(
+							// translators: %1$s is the name of the type the connection is from, %2$s is the name of the type the connection is to.
+							__( 'A list of edges (relational context) between %1$s and connected %2$s Nodes', 'wp-graphql' ),
+							$this->from_type,
+							$this->to_type
+						),
 					],
 					'pageInfo' => [
 						'type' => [ 'non_null' => $this->to_type . 'ConnectionPageInfo' ],
 					],
 					'nodes'    => [
 						'type'        => [ 'non_null' => [ 'list_of' => [ 'non_null' => $this->to_type ] ] ],
+						// translators: %s is the name of the type the connection is to.
 						'description' => sprintf( __( 'A list of connected %s Nodes', 'wp-graphql' ), $this->to_type ),
 					],
 				],

--- a/src/Type/WPInterfaceTrait.php
+++ b/src/Type/WPInterfaceTrait.php
@@ -51,19 +51,39 @@ trait WPInterfaceTrait {
 
 			// surface when interfaces are trying to be registered with invalid configuration
 			if ( ! is_string( $interface ) ) {
-				graphql_debug( sprintf( __( 'Invalid Interface registered to the "%s" Type. Interfaces can only be registered with an interface name or a valid instance of an InterfaceType', 'wp-graphql' ), $this->name ), [ 'invalid_interface' => $interface ] );
+				graphql_debug(
+					sprintf(
+						// translators: %s is the name of the GraphQL type.
+						__( 'Invalid Interface registered to the "%s" Type. Interfaces can only be registered with an interface name or a valid instance of an InterfaceType', 'wp-graphql' ),
+						$this->name
+					),
+					[ 'invalid_interface' => $interface ]
+				);
 				continue;
 			}
 
 			// Prevent an interface from implementing itself
 			if ( strtolower( $this->config['name'] ) === strtolower( $interface ) ) {
-				graphql_debug( sprintf( __( 'The "%s" Interface attempted to implement itself, which is not allowed', 'wp-graphql' ), $interface ) );
+				graphql_debug(
+					sprintf(
+						// translators: %s is the name of the interface.
+						__( 'The "%s" Interface attempted to implement itself, which is not allowed', 'wp-graphql' ),
+						$interface
+					)
+				);
 				continue;
 			}
 
 			$interface_type = $this->type_registry->get_type( $interface );
 			if ( ! $interface_type instanceof InterfaceType ) {
-				graphql_debug( sprintf( __( '"%1$s" is not a valid Interface Type and cannot be implemented as an Interface on the "%2$s" Type', 'wp-graphql' ), $interface, $this->name ) );
+				graphql_debug(
+					sprintf(
+						// translators: %1$s is the name of the interface, %2$s is the name of the type.
+						__( '"%1$s" is not a valid Interface Type and cannot be implemented as an Interface on the "%2$s" Type', 'wp-graphql' ),
+						$interface,
+						$this->name
+					)
+				);
 				continue;
 			}
 

--- a/src/Type/WPMutationType.php
+++ b/src/Type/WPMutationType.php
@@ -266,6 +266,7 @@ class WPMutationType {
 		$this->type_registry->register_input_type(
 			$input_name,
 			[
+				// translators: %s is the name of the mutation.
 				'description'       => sprintf( __( 'Input for the %1$s mutation.', 'wp-graphql' ), $this->mutation_name ),
 				'fields'            => $this->input_fields,
 				'deprecationReason' => ! empty( $this->config['deprecationReason'] ) ? $this->config['deprecationReason'] : null,
@@ -283,6 +284,7 @@ class WPMutationType {
 		$this->type_registry->register_object_type(
 			$object_name,
 			[
+				// translators: %s is the name of the mutation.
 				'description'       => sprintf( __( 'The payload for the %s mutation.', 'wp-graphql' ), $this->mutation_name ),
 				'fields'            => $this->output_fields,
 				'deprecationReason' => ! empty( $this->config['deprecationReason'] ) ? $this->config['deprecationReason'] : null,
@@ -302,11 +304,13 @@ class WPMutationType {
 				'args'        => [
 					'input' => [
 						'type'              => [ 'non_null' => $this->mutation_name . 'Input' ],
+						// translators: %s is the name of the mutation.
 						'description'       => sprintf( __( 'Input for the %s mutation', 'wp-graphql' ), $this->mutation_name ),
 						'deprecationReason' => ! empty( $this->config['deprecationReason'] ) ? $this->config['deprecationReason'] : null,
 					],
 				],
 				'auth'        => $this->auth,
+				// translators: %s is the name of the mutation.
 				'description' => ! empty( $this->config['description'] ) ? $this->config['description'] : sprintf( __( 'The %s mutation', 'wp-graphql' ), $this->mutation_name ),
 				'isPrivate'   => $this->is_private,
 				'type'        => $this->mutation_name . 'Payload',

--- a/src/Utils/QueryLog.php
+++ b/src/Utils/QueryLog.php
@@ -139,7 +139,11 @@ class QueryLog {
 		global $wpdb;
 
 		$save_queries_value = defined( 'SAVEQUERIES' ) && true === SAVEQUERIES ? 'true' : 'false';
-		$default_message    = sprintf( __( 'Query Logging has been disabled. The \'SAVEQUERIES\' Constant is set to \'%s\' on your server.', 'wp-graphql' ), $save_queries_value );
+		$default_message    = sprintf(
+			// translators: %s is the value of the SAVEQUERIES constant
+			__( 'Query Logging has been disabled. The \'SAVEQUERIES\' Constant is set to \'%s\' on your server.', 'wp-graphql' ),
+			$save_queries_value
+		);
 
 		// Default message
 		$trace = [ $default_message ];

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -309,7 +309,14 @@ final class WPGraphQL {
 	 */
 	public function min_php_version_check() {
 		if ( defined( 'GRAPHQL_MIN_PHP_VERSION' ) && version_compare( PHP_VERSION, GRAPHQL_MIN_PHP_VERSION, '<' ) ) {
-			throw new \Exception( sprintf( __( 'The server\'s current PHP version %1$s is lower than the WPGraphQL minimum required version: %2$s', 'wp-graphql' ), PHP_VERSION, GRAPHQL_MIN_PHP_VERSION ) );
+			throw new \Exception(
+				sprintf(
+					// translators: %1$s is the current PHP version, %2$s is the minimum required PHP version.
+					__( 'The server\'s current PHP version %1$s is lower than the WPGraphQL minimum required version: %2$s', 'wp-graphql' ),
+					PHP_VERSION,
+					GRAPHQL_MIN_PHP_VERSION
+				)
+			);
 		}
 
 	}


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.

- [x] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR reinstates the `WordPress.WP.I18n.MissingTranslatorsComment` PHPCS sniff, and adds all missing `\\ translators:` comments to the codebase.  


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php 8.0.26)

**WordPress Version:** 6.2.2
