### PR TITLE
fix: Prevent truncation of query name inside the GraphiQL Query composer explorer tab.

### DIFF
--- a/packages/graphiql-query-composer/components/RootView.js
+++ b/packages/graphiql-query-composer/components/RootView.js
@@ -239,7 +239,7 @@ const RootView = (props) => {
               style={{
                 textOverflow: `ellipsis`,
                 display: `inline-block`,
-                maxWidth: `65%`,
+                maxWidth: `100%`,
                 whiteSpace: `nowrap`,
                 overflow: `hidden`,
                 verticalAlign: `middle`,


### PR DESCRIPTION


What does this implement/fix? Explain your changes.
---------------------------------------------------
This fixes the truncation issue that was hiding the query name on the various queries/fragments in the explorer tab of the GraphiQL Query composer.

before fix:
![chrome_vwj8CEFTOc](https://github.com/wp-graphql/wp-graphql/assets/45132430/c4c26554-d6f0-4d60-8f5d-8f07778f1894)

after fix:
![chrome_yCLRO6kI8k](https://github.com/wp-graphql/wp-graphql/assets/45132430/e207ac7d-ce5f-44d8-978f-207021feecc5)


Does this close any currently open issues?
------------------------------------------
Not that I am aware of.

Where has this been tested?
---------------------------
**Operating System:**
Windows 11 64 bit

**Browsers**
Google Chrome 114.0.5735.199 (Official Build) (64-bit)
Firefox Browser 113.0.1 (64-bit)
Microsoft Edge Version 114.0.1823.82 (Official build) (64-bit)

**WordPress Version:**
6.2.2