### PR TITLE
fix: output `list:$type` keys for Root fields that return a listOf Nodes

### DIFF
--- a/src/Utils/QueryAnalyzer.php
+++ b/src/Utils/QueryAnalyzer.php
@@ -303,12 +303,12 @@ class QueryAnalyzer {
 
 
 	/**
-	 * @param Type $type The Type of field
-	 * @param FieldDefinition $field_def The field definition the type is for
+	 * @param \GraphQL\Type\Definition\Type $type The Type of field
+	 * @param \GraphQL\Type\Definition\FieldDefinition $field_def The field definition the type is for
 	 * @param mixed $parent_type The Parent Type
 	 * @param bool $is_list_type Whether the field is a list type field
 	 *
-	 * @return Type|String|null
+	 * @return  \GraphQL\Type\Definition\Type|String|null
 	 */
 	public function get_wrapped_field_type( Type $type, FieldDefinition $field_def, $parent_type, bool $is_list_type = false ) {
 
@@ -328,8 +328,8 @@ class QueryAnalyzer {
 		// Determine if we're dealing with a connection
 		if ( $type instanceof ObjectType || $type instanceof InterfaceType ) {
 
-			$interfaces = method_exists( $type, 'getInterfaces' ) ? $type->getInterfaces() : [];
-			$interface_names = ! empty( $interfaces ) ? array_map( static function( InterfaceType $interface ) {
+			$interfaces      = method_exists( $type, 'getInterfaces' ) ? $type->getInterfaces() : [];
+			$interface_names = ! empty( $interfaces ) ? array_map( static function ( InterfaceType $interface ) {
 				return $interface->name;
 			}, $interfaces ) : [];
 

--- a/tests/wpunit/QueryAnalyzerTest.php
+++ b/tests/wpunit/QueryAnalyzerTest.php
@@ -316,8 +316,70 @@ class QueryAnalyzerTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$this->assertSame( [ 'list:page' ], $types );
 
+	}
 
+	public function testNonNullListOfNonNullPostMapsToListOfPosts() {
+
+		register_graphql_field( 'RootQuery', 'listOfThing', [
+			'type' => [
+				'non_null' => [
+					'list_of' => [
+						'non_null' => 'Post'
+					],
+				],
+			],
+		]);
+
+		$query = '
+		{
+		  listOfThing {
+		    __typename
+		  }
+		}
+		';
+
+		$request = graphql([
+			'query' => $query,
+		], true );
+
+		$request->execute();
+
+		$types = $request->get_query_analyzer()->get_list_types();
+
+		$this->assertContains( 'list:post', $types );
 
 	}
+
+	public function testListOfNonNullPostMapsToListOfPosts() {
+
+		register_graphql_field( 'RootQuery', 'listOfThing', [
+			'type' => [
+				'list_of' => [
+					'non_null' => 'Post'
+				],
+			],
+		]);
+
+		$query = '
+		{
+		  listOfThing {
+		    __typename
+		  }
+		}
+		';
+
+		$request = graphql([
+			'query' => $query,
+		], true );
+
+		$request->execute();
+
+		$types = $request->get_query_analyzer()->get_list_types();
+
+		$this->assertContains( 'list:post', $types );
+
+	}
+
+
 
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This fixes a regression to the 1.14.5 release where `list:$type` keys are no longer being output for RootQuery fields that return a listOf Nodes. 

- failing tests: https://github.com/wp-graphql/wp-graphql/actions/runs/5593265358/jobs/10226719111#step:8:588
- passing tests: https://github.com/wp-graphql/wp-graphql/actions/runs/5593270930/jobs/10226731070#step:8:588

Does this close any currently open issues?
------------------------------------------
closes #2860 

related: https://github.com/wp-graphql/wp-graphql-smart-cache/issues/228


Any other comments?
-------------------

Given the following snippet: 

```php
add_action( 'graphql_register_types', function() {

	register_graphql_field( 'RootQuery', 'testListOfPosts', [
		'type' => [
			'non_null' => [
				'list_of' => [
					'non_null' => 'Post'
				],
			],
		],
		'resolve' => function() {
			$posts = new \WP_Query([ 'posts_per_page' => 10 ]);
			return array_map( function( $post ) { return new Post( $post ); }, $posts->posts );
		}
	]);

});
```

I could query for `testListOfPosts`:

## Before

We do not see `list:post` in the keys

![CleanShot 2023-07-18 at 17 04 56](https://github.com/wp-graphql/wp-graphql/assets/1260765/ecb8ab21-a9c6-4e98-b680-ca92d53b54b3)


## After

We DO see `list:post` in the keys

![CleanShot 2023-07-18 at 17 05 06](https://github.com/wp-graphql/wp-graphql/assets/1260765/6ff3ad04-759c-4359-8e05-7d7581b6ebea)

