### PR TITLE
release: v1.14.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.14.8
+
+## Chores / Bugfixes
+
+- [#2855](https://github.com/wp-graphql/wp-graphql/pull/2855): perf: enforce static closures when possible (PHPCS). Thanks @justlevine!
+- [#2857](https://github.com/wp-graphql/wp-graphql/pull/2857): fix: Prevent truncation of query name inside the GraphiQL Query composer explorer tab. Thanks @LarsEjaas!
+- [#2856](https://github.com/wp-graphql/wp-graphql/pull/2856): chore: add missing translator comments. Thanks @justlevine!
+- [#2862](https://github.com/wp-graphql/wp-graphql/pull/2862): chore(deps-dev): bump word-wrap from 1.2.3 to 1.2.4
+- [#2861](https://github.com/wp-graphql/wp-graphql/pull/2861): fix: output `list:$type` keys for Root fields that return a list of nodes
+
 ## 1.14.7
 
 ## Chores / Bugfixes

--- a/access-functions.php
+++ b/access-functions.php
@@ -150,7 +150,7 @@ function register_graphql_interfaces_to_types( $interface_names, $type_names ) {
 			// Filter the GraphQL Object Type Interface to apply the interface
 			add_filter(
 				'graphql_type_interfaces',
-				function ( $interfaces, $config ) use ( $type_name, $interface_names ) {
+				static function ( $interfaces, $config ) use ( $type_name, $interface_names ) {
 
 					$interfaces = is_array( $interfaces ) ? $interfaces : [];
 
@@ -180,7 +180,7 @@ function register_graphql_interfaces_to_types( $interface_names, $type_names ) {
 function register_graphql_type( string $type_name, array $config ) {
 	add_action(
 		get_graphql_register_action(),
-		function ( TypeRegistry $type_registry ) use ( $type_name, $config ) {
+		static function ( TypeRegistry $type_registry ) use ( $type_name, $config ) {
 			$type_registry->register_type( $type_name, $config );
 		},
 		10
@@ -199,7 +199,7 @@ function register_graphql_type( string $type_name, array $config ) {
 function register_graphql_interface_type( string $type_name, $config ) {
 	add_action(
 		get_graphql_register_action(),
-		function ( TypeRegistry $type_registry ) use ( $type_name, $config ) {
+		static function ( TypeRegistry $type_registry ) use ( $type_name, $config ) {
 			$type_registry->register_interface_type( $type_name, $config );
 		},
 		10
@@ -246,7 +246,7 @@ function register_graphql_union_type( string $type_name, array $config ) {
 
 	add_action(
 		get_graphql_register_action(),
-		function ( TypeRegistry $type_registry ) use ( $type_name, $config ) {
+		static function ( TypeRegistry $type_registry ) use ( $type_name, $config ) {
 			$config['kind'] = 'union';
 			$type_registry->register_type( $type_name, $config );
 		},
@@ -283,7 +283,7 @@ function register_graphql_field( string $type_name, string $field_name, array $c
 
 	add_action(
 		get_graphql_register_action(),
-		function ( TypeRegistry $type_registry ) use ( $type_name, $field_name, $config ) {
+		static function ( TypeRegistry $type_registry ) use ( $type_name, $field_name, $config ) {
 			$type_registry->register_field( $type_name, $field_name, $config );
 		},
 		10
@@ -304,7 +304,7 @@ function register_graphql_field( string $type_name, string $field_name, array $c
 function register_graphql_fields( string $type_name, array $fields ) {
 	add_action(
 		get_graphql_register_action(),
-		function ( TypeRegistry $type_registry ) use ( $type_name, $fields ) {
+		static function ( TypeRegistry $type_registry ) use ( $type_name, $fields ) {
 			$type_registry->register_fields( $type_name, $fields );
 		},
 		10
@@ -326,7 +326,7 @@ function register_graphql_edge_field( string $from_type, string $to_type, string
 
 	add_action(
 		get_graphql_register_action(),
-		function ( TypeRegistry $type_registry ) use ( $connection_name, $field_name, $config ) {
+		static function ( TypeRegistry $type_registry ) use ( $connection_name, $field_name, $config ) {
 			$type_registry->register_field( $connection_name, $field_name, $config );
 		},
 		10
@@ -347,7 +347,7 @@ function register_graphql_edge_fields( string $from_type, string $to_type, array
 
 	add_action(
 		get_graphql_register_action(),
-		function ( TypeRegistry $type_registry ) use ( $connection_name, $fields ) {
+		static function ( TypeRegistry $type_registry ) use ( $connection_name, $fields ) {
 			$type_registry->register_fields( $connection_name, $fields );
 		},
 		10
@@ -369,7 +369,7 @@ function register_graphql_connection_where_arg( string $from_type, string $to_ty
 
 	add_action(
 		get_graphql_register_action(),
-		function ( TypeRegistry $type_registry ) use ( $connection_name, $field_name, $config ) {
+		static function ( TypeRegistry $type_registry ) use ( $connection_name, $field_name, $config ) {
 			$type_registry->register_field( $connection_name, $field_name, $config );
 		},
 		10
@@ -390,7 +390,7 @@ function register_graphql_connection_where_args( string $from_type, string $to_t
 
 	add_action(
 		get_graphql_register_action(),
-		function ( TypeRegistry $type_registry ) use ( $connection_name, $fields ) {
+		static function ( TypeRegistry $type_registry ) use ( $connection_name, $fields ) {
 			$type_registry->register_fields( $connection_name, $fields );
 		},
 		10
@@ -410,7 +410,7 @@ function register_graphql_connection_where_args( string $from_type, string $to_t
 function rename_graphql_field( string $type_name, string $field_name, string $new_field_name ) {
 	add_filter(
 		"graphql_{$type_name}_fields",
-		function ( $fields ) use ( $field_name, $new_field_name ) {
+		static function ( $fields ) use ( $field_name, $new_field_name ) {
 			$fields[ $new_field_name ] = $fields[ $field_name ];
 			unset( $fields[ $field_name ] );
 
@@ -433,7 +433,7 @@ function rename_graphql_field( string $type_name, string $field_name, string $ne
 function rename_graphql_type( string $type_name, string $new_type_name ) {
 	add_filter(
 		'graphql_type_name',
-		function ( $name ) use ( $type_name, $new_type_name ) {
+		static function ( $name ) use ( $type_name, $new_type_name ) {
 			if ( $name === $type_name ) {
 				return $new_type_name;
 			}
@@ -446,7 +446,7 @@ function rename_graphql_type( string $type_name, string $new_type_name ) {
 	// referenced as the type when registering fields.
 	add_action(
 		'graphql_register_types_late',
-		function ( TypeRegistry $type_registry ) use ( $type_name, $new_type_name ) {
+		static function ( TypeRegistry $type_registry ) use ( $type_name, $new_type_name ) {
 			$type = $type_registry->get_type( $type_name );
 			if ( ! $type instanceof Type ) {
 				return;
@@ -470,7 +470,7 @@ function rename_graphql_type( string $type_name, string $new_type_name ) {
 function register_graphql_connection( array $config ) {
 	add_action(
 		get_graphql_register_action(),
-		function ( TypeRegistry $type_registry ) use ( $config ) {
+		static function ( TypeRegistry $type_registry ) use ( $config ) {
 			$type_registry->register_connection( $config );
 		},
 		20
@@ -491,7 +491,7 @@ function register_graphql_connection( array $config ) {
 function register_graphql_mutation( string $mutation_name, array $config ) {
 	add_action(
 		get_graphql_register_action(),
-		function ( TypeRegistry $type_registry ) use ( $mutation_name, $config ) {
+		static function ( TypeRegistry $type_registry ) use ( $mutation_name, $config ) {
 			$type_registry->register_mutation( $mutation_name, $config );
 		},
 		10
@@ -512,7 +512,7 @@ function register_graphql_mutation( string $mutation_name, array $config ) {
 function register_graphql_scalar( string $type_name, array $config ) {
 	add_action(
 		get_graphql_register_action(),
-		function ( TypeRegistry $type_registry ) use ( $type_name, $config ) {
+		static function ( TypeRegistry $type_registry ) use ( $type_name, $config ) {
 			$type_registry->register_scalar( $type_name, $config );
 		},
 		10
@@ -530,7 +530,7 @@ function deregister_graphql_type( string $type_name ) : void {
 	// Prevent the type from being registered to the scheme directly.
 	add_filter(
 		'graphql_excluded_types',
-		function ( $excluded_types ) use ( $type_name ) : array {
+		static function ( $excluded_types ) use ( $type_name ) : array {
 			// Normalize the types to prevent case sensitivity issues.
 			$type_name = strtolower( $type_name );
 			// If the type isn't already excluded, add it to the array.
@@ -546,7 +546,7 @@ function deregister_graphql_type( string $type_name ) : void {
 	// Prevent the type from being inherited as an interface.
 	add_filter(
 		'graphql_type_interfaces',
-		function ( $interfaces ) use ( $type_name ) : array {
+		static function ( $interfaces ) use ( $type_name ) : array {
 			// Normalize the needle and haystack to prevent case sensitivity issues.
 			$key = array_search(
 				strtolower( $type_name ),
@@ -577,7 +577,7 @@ function deregister_graphql_type( string $type_name ) : void {
 function deregister_graphql_field( string $type_name, string $field_name ) {
 	add_action(
 		get_graphql_register_action(),
-		function ( TypeRegistry $type_registry ) use ( $type_name, $field_name ) {
+		static function ( TypeRegistry $type_registry ) use ( $type_name, $field_name ) {
 			$type_registry->deregister_field( $type_name, $field_name );
 		},
 		10
@@ -595,7 +595,7 @@ function deregister_graphql_field( string $type_name, string $field_name ) {
 function deregister_graphql_connection( string $connection_name ) : void {
 	add_action(
 		get_graphql_register_action(),
-		function ( TypeRegistry $type_registry ) use ( $connection_name ) {
+		static function ( TypeRegistry $type_registry ) use ( $connection_name ) {
 			$type_registry->deregister_connection( $connection_name );
 		},
 		10
@@ -612,7 +612,7 @@ function deregister_graphql_connection( string $connection_name ) : void {
 function deregister_graphql_mutation( string $mutation_name ) : void {
 	add_action(
 		get_graphql_register_action(),
-		function ( TypeRegistry $type_registry ) use ( $mutation_name ) {
+		static function ( TypeRegistry $type_registry ) use ( $mutation_name ) {
 			$type_registry->deregister_mutation( $mutation_name );
 		},
 		10
@@ -665,7 +665,7 @@ function is_graphql_http_request() {
 function register_graphql_settings_section( string $slug, array $config ) {
 	add_action(
 		'graphql_init_settings',
-		function ( \WPGraphQL\Admin\Settings\SettingsRegistry $registry ) use ( $slug, $config ) {
+		static function ( \WPGraphQL\Admin\Settings\SettingsRegistry $registry ) use ( $slug, $config ) {
 			$registry->register_section( $slug, $config );
 		}
 	);
@@ -683,7 +683,7 @@ function register_graphql_settings_section( string $slug, array $config ) {
 function register_graphql_settings_field( string $group, array $config ) {
 	add_action(
 		'graphql_init_settings',
-		function ( \WPGraphQL\Admin\Settings\SettingsRegistry $registry ) use ( $group, $config ) {
+		static function ( \WPGraphQL\Admin\Settings\SettingsRegistry $registry ) use ( $group, $config ) {
 			$registry->register_field( $group, $config );
 		}
 	);
@@ -714,7 +714,7 @@ function graphql_debug( $message, $config = [] ) {
 				},
 				array_filter( // Filter out steps without files
 					$debug_backtrace,
-					function ( $step ) {
+					static function ( $step ) {
 						return ! empty( $step['file'] );
 					}
 				)
@@ -725,7 +725,7 @@ function graphql_debug( $message, $config = [] ) {
 
 	add_action(
 		'graphql_get_debug_log',
-		function ( \WPGraphQL\Utils\DebugLog $debug_log ) use ( $message, $config ) {
+		static function ( \WPGraphQL\Utils\DebugLog $debug_log ) use ( $message, $config ) {
 			$debug_log->add_log_entry( $message, $config );
 		}
 	);
@@ -759,7 +759,7 @@ function is_valid_graphql_name( string $type_name ) {
 function register_graphql_settings_fields( string $group, array $fields ) {
 	add_action(
 		'graphql_init_settings',
-		function ( \WPGraphQL\Admin\Settings\SettingsRegistry $registry ) use ( $group, $fields ) {
+		static function ( \WPGraphQL\Admin\Settings\SettingsRegistry $registry ) use ( $group, $fields ) {
 			$registry->register_fields( $group, $fields );
 		}
 	);

--- a/package-lock.json
+++ b/package-lock.json
@@ -28429,9 +28429,9 @@
       "dev": true
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.4.tgz",
+      "integrity": "sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -49852,9 +49852,9 @@
       "dev": true
     },
     "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.4.tgz",
+      "integrity": "sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA==",
       "dev": true
     },
     "wrap-ansi": {

--- a/packages/graphiql-query-composer/components/RootView.js
+++ b/packages/graphiql-query-composer/components/RootView.js
@@ -239,7 +239,7 @@ const RootView = (props) => {
               style={{
                 textOverflow: `ellipsis`,
                 display: `inline-block`,
-                maxWidth: `65%`,
+                maxWidth: `100%`,
                 whiteSpace: `nowrap`,
                 overflow: `hidden`,
                 verticalAlign: `middle`,

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -81,9 +81,6 @@
 		<exclude name="WordPress.PHP.DisallowShortTernary.Found"/>
 		<exclude name="WordPress.CodeAnalysis.AssignmentInCondition.Found"/>
 
-		<!-- Should maybe Add Back Later -->
-		<exclude name="WordPress.WP.I18n.MissingTranslatorsComment"/>
-		
 		<!-- Should probably not be added back -->
 		<exclude name="WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid"/>
 		<exclude name="WordPress.DateTime.RestrictedFunctions.date_date"/>
@@ -102,4 +99,7 @@
 
 	<!-- Use FQCN for PHPDoc types -->
 	<rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameInAnnotation"/>
+	<!-- Enforce static closures -->
+	<rule ref="SlevomatCodingStandard.Functions.StaticClosure" />
+
 </ruleset>

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, JSON, API, Gatsby, Faust, Headless, Decoupled, Svelte, React, Nex
 Requires at least: 5.0
 Tested up to: 6.2
 Requires PHP: 7.1
-Stable tag: 1.14.7
+Stable tag: 1.14.8
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -239,6 +239,17 @@ The `uri` field was non-null on some Types in the Schema but has been changed to
 Composer dependencies are no longer versioned in Github. Recommended install source is WordPress.org or using Composer to get the code from Packagist.org or WPackagist.org.
 
 == Changelog ==
+
+= 1.14.8 =
+
+**Chores / Bugfixes**
+
+- [#2855](https://github.com/wp-graphql/wp-graphql/pull/2855): perf: enforce static closures when possible (PHPCS). Thanks @justlevine!
+- [#2857](https://github.com/wp-graphql/wp-graphql/pull/2857): fix: Prevent truncation of query name inside the GraphiQL Query composer explorer tab. Thanks @LarsEjaas!
+- [#2856](https://github.com/wp-graphql/wp-graphql/pull/2856): chore: add missing translator comments. Thanks @justlevine!
+- [#2862](https://github.com/wp-graphql/wp-graphql/pull/2862): chore(deps-dev): bump word-wrap from 1.2.3 to 1.2.4
+- [#2861](https://github.com/wp-graphql/wp-graphql/pull/2861): fix: output `list:$type` keys for Root fields that return a list of nodes
+
 
 = 1.14.7 =
 

--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -45,7 +45,7 @@ class Admin {
 
 		// This removes the menu page for WPGraphiQL as it's now built into WPGraphQL
 		if ( $this->graphiql_enabled ) {
-			add_action( 'admin_menu', function () {
+			add_action( 'admin_menu', static function () {
 				remove_menu_page( 'wp-graphiql/wp-graphiql.php' );
 			} );
 		}

--- a/src/Admin/Settings/Settings.php
+++ b/src/Admin/Settings/Settings.php
@@ -97,12 +97,17 @@ class Settings {
 			[
 				'name'              => 'graphql_endpoint',
 				'label'             => __( 'GraphQL Endpoint', 'wp-graphql' ),
-				'desc'              => sprintf( __( 'The endpoint (path) for the GraphQL API on the site. <a target="_blank" href="%1$s/%2$s">%1$s/%2$s</a>. <br/><strong>Note:</strong> Changing the endpoint to something other than "graphql" <em>could</em> have an affect on tooling in the GraphQL ecosystem', 'wp-graphql' ), site_url(), get_graphql_setting( 'graphql_endpoint', 'graphql' ) ),
+				'desc'              => sprintf(
+					// translators: %1$s is the site url, %2$s is the default endpoint
+					__( 'The endpoint (path) for the GraphQL API on the site. <a target="_blank" href="%1$s/%2$s">%1$s/%2$s</a>. <br/><strong>Note:</strong> Changing the endpoint to something other than "graphql" <em>could</em> have an affect on tooling in the GraphQL ecosystem', 'wp-graphql' ),
+					site_url(),
+					get_graphql_setting( 'graphql_endpoint', 'graphql' )
+				),
 				'type'              => 'text',
 				'value'             => ! empty( $custom_endpoint ) ? $custom_endpoint : null,
 				'default'           => ! empty( $custom_endpoint ) ? $custom_endpoint : 'graphql',
 				'disabled'          => ! empty( $custom_endpoint ) ? true : false,
-				'sanitize_callback' => function ( $value ) {
+				'sanitize_callback' => static function ( $value ) {
 					if ( empty( $value ) ) {
 						add_settings_error( 'graphql_endpoint', 'required', __( 'The "GraphQL Endpoint" field is required and cannot be blank. The default endpoint is "graphql"', 'wp-graphql' ), 'error' );
 
@@ -181,7 +186,10 @@ class Settings {
 			[
 				'name'     => 'debug_mode_enabled',
 				'label'    => __( 'Enable GraphQL Debug Mode', 'wp-graphql' ),
-				'desc'     => defined( 'GRAPHQL_DEBUG' ) ? sprintf( __( 'This setting is disabled. "GRAPHQL_DEBUG" has been set to "%s" with code', 'wp-graphql' ), GRAPHQL_DEBUG ? 'true' : 'false' ) : __( 'Whether GraphQL requests should execute in "debug" mode. This setting is disabled if <strong>GRAPHQL_DEBUG</strong> is defined in wp-config.php. <br/>This will provide more information in GraphQL errors but can leak server implementation details so this setting is <strong>NOT RECOMMENDED FOR PRODUCTION ENVIRONMENTS</strong>.', 'wp-graphql' ),
+				'desc'     => defined( 'GRAPHQL_DEBUG' )
+					// translators: %s is the value of the GRAPHQL_DEBUG constant
+					? sprintf( __( 'This setting is disabled. "GRAPHQL_DEBUG" has been set to "%s" with code', 'wp-graphql' ), GRAPHQL_DEBUG ? 'true' : 'false' )
+					: __( 'Whether GraphQL requests should execute in "debug" mode. This setting is disabled if <strong>GRAPHQL_DEBUG</strong> is defined in wp-config.php. <br/>This will provide more information in GraphQL errors but can leak server implementation details so this setting is <strong>NOT RECOMMENDED FOR PRODUCTION ENVIRONMENTS</strong>.', 'wp-graphql' ),
 				'type'     => 'checkbox',
 				'value'    => true === \WPGraphQL::debug() ? 'on' : get_graphql_setting( 'debug_mode_enabled', 'off' ),
 				'disabled' => defined( 'GRAPHQL_DEBUG' ) ? true : false,
@@ -217,7 +225,11 @@ class Settings {
 			[
 				'name'     => 'public_introspection_enabled',
 				'label'    => __( 'Enable Public Introspection', 'wp-graphql' ),
-				'desc'     => sprintf( __( 'GraphQL Introspection is a feature that allows the GraphQL Schema to be queried. For Production and Staging environments, WPGraphQL will by default limit introspection queries to authenticated requests. Checking this enables Introspection for public requests, regardless of environment. %s ', 'wp-graphql' ), true === \WPGraphQL::debug() ? '<strong>' . __( 'NOTE: This setting is force enabled because GraphQL Debug Mode is enabled. ', 'wp-graphql' ) . '</strong>' : null ),
+				'desc'     => sprintf(
+					// translators: %s is either empty or a string with a note about debug mode.
+					__( 'GraphQL Introspection is a feature that allows the GraphQL Schema to be queried. For Production and Staging environments, WPGraphQL will by default limit introspection queries to authenticated requests. Checking this enables Introspection for public requests, regardless of environment. %s ', 'wp-graphql' ),
+					true === \WPGraphQL::debug() ? '<strong>' . __( 'NOTE: This setting is force enabled because GraphQL Debug Mode is enabled. ', 'wp-graphql' ) . '</strong>' : ''
+				),
 				'type'     => 'checkbox',
 				'default'  => ( 'local' === $this->get_wp_environment() || 'development' === $this->get_wp_environment() ) ? 'on' : 'off',
 				'value'    => true === \WPGraphQL::debug() ? 'on' : get_graphql_setting( 'public_introspection_enabled', 'off' ),

--- a/src/Admin/Settings/SettingsRegistry.php
+++ b/src/Admin/Settings/SettingsRegistry.php
@@ -167,7 +167,7 @@ class SettingsRegistry {
 
 			if ( isset( $section['desc'] ) && ! empty( $section['desc'] ) ) {
 				$section['desc'] = '<div class="inside">' . $section['desc'] . '</div>';
-				$callback        = function () use ( $section ) {
+				$callback        = static function () use ( $section ) {
 					echo wp_kses( str_replace( '"', '\"', $section['desc'] ), Utils::get_allowed_wp_kses_html() );
 				};
 			} elseif ( isset( $section['callback'] ) ) {

--- a/src/AppContext.php
+++ b/src/AppContext.php
@@ -168,6 +168,7 @@ class AppContext {
 	 */
 	public function get_loader( $key ) {
 		if ( ! array_key_exists( $key, $this->loaders ) ) {
+			// translators: %s is the key of the loader that was not found.
 			throw new UserError( sprintf( __( 'No loader assigned to the key %s', 'wp-graphql' ), $key ) );
 		}
 

--- a/src/Data/Config.php
+++ b/src/Data/Config.php
@@ -83,7 +83,7 @@ class Config {
 		 */
 		add_filter(
 			'pre_user_query',
-			function ( $query ) {
+			static function ( $query ) {
 
 				if ( ! $query->get( 'suppress_filters' ) ) {
 					$query->set( 'suppress_filters', 0 );

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -400,10 +400,13 @@ abstract class AbstractConnectionResolver {
 	 * @return array the array of IDs.
 	 */
 	public function get_ids_from_query() {
-		throw new Exception( sprintf(
-			__( 'Class %s does not implement a valid method `get_ids_from_query()`.', 'wp-graphql' ),
-			get_class( $this )
-		) );
+		throw new Exception(
+			sprintf(
+				// translators: %s is the name of the connection resolver class.
+				__( 'Class %s does not implement a valid method `get_ids_from_query()`.', 'wp-graphql' ),
+				get_class( $this )
+			)
+		);
 	}
 
 	/**

--- a/src/Data/Connection/CommentConnectionResolver.php
+++ b/src/Data/Connection/CommentConnectionResolver.php
@@ -228,7 +228,7 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 					case 'contentAuthor':
 					case 'userId':
 						if ( is_array( $input_value ) ) {
-							$args['where'][ $input_key ] = array_map( function ( $id ) {
+							$args['where'][ $input_key ] = array_map( static function ( $id ) {
 								return Utils::get_database_id_from_id( $id );
 							}, $input_value );
 							break;
@@ -239,7 +239,7 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 						if ( is_string( $input_value ) ) {
 							$input_value = [ $input_value ];
 						}
-						$args['where'][ $input_key ] = array_map( function ( $id ) {
+						$args['where'][ $input_key ] = array_map( static function ( $id ) {
 							if ( is_email( $id ) ) {
 								return $id;
 							}

--- a/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
@@ -27,7 +27,7 @@ class EnqueuedScriptsConnectionResolver extends AbstractConnectionResolver {
 		/**
 		 * Filter the query amount to be 1000 for
 		 */
-		add_filter( 'graphql_connection_max_query_amount', function ( $max, $source, $args, $context, ResolveInfo $info ) {
+		add_filter( 'graphql_connection_max_query_amount', static function ( $max, $source, $args, $context, ResolveInfo $info ) {
 			if ( 'enqueuedScripts' === $info->fieldName || 'registeredScripts' === $info->fieldName ) {
 				return 1000;
 			}

--- a/src/Data/Connection/EnqueuedStylesheetConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedStylesheetConnectionResolver.php
@@ -33,7 +33,7 @@ class EnqueuedStylesheetConnectionResolver extends AbstractConnectionResolver {
 		/**
 		 * Filter the query amount to be 1000 for
 		 */
-		add_filter( 'graphql_connection_max_query_amount', function ( $max, $source, $args, $context, ResolveInfo $info ) {
+		add_filter( 'graphql_connection_max_query_amount', static function ( $max, $source, $args, $context, ResolveInfo $info ) {
 			if ( 'enqueuedStylesheets' === $info->fieldName || 'registeredStylesheets' === $info->fieldName ) {
 				return 1000;
 			}

--- a/src/Data/Connection/PluginConnectionResolver.php
+++ b/src/Data/Connection/PluginConnectionResolver.php
@@ -200,7 +200,7 @@ class PluginConnectionResolver extends AbstractConnectionResolver {
 			$matches = array_keys(
 				array_filter(
 					$all_plugins,
-					function ( $plugin ) use ( $s ) {
+					static function ( $plugin ) use ( $s ) {
 						foreach ( $plugin as $value ) {
 							if ( is_string( $value ) && false !== stripos( wp_strip_all_tags( $value ), $s ) ) {
 								return true;

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -511,7 +511,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		 */
 		$allowed_statuses = array_filter(
 			array_map(
-				function ( $status ) use ( $post_type_objects ) {
+				static function ( $status ) use ( $post_type_objects ) {
 					foreach ( $post_type_objects as $post_type_object ) {
 						if ( 'publish' === $status ) {
 							return $status;
@@ -586,7 +586,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 					case 'tagIn':
 					case 'tagNotIn':
 						if ( is_array( $input_value ) ) {
-							$args['where'][ $input_key ] = array_map( function ( $id ) {
+							$args['where'][ $input_key ] = array_map( static function ( $id ) {
 								return Utils::get_database_id_from_id( $id );
 							}, $input_value );
 							break;

--- a/src/Data/Connection/TermObjectConnectionResolver.php
+++ b/src/Data/Connection/TermObjectConnectionResolver.php
@@ -289,7 +289,7 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 					case 'termTaxonomId':
 					case 'termTaxonomyId':
 						if ( is_array( $input_value ) ) {
-							$args['where'][ $input_key ] = array_map( function ( $id ) {
+							$args['where'][ $input_key ] = array_map( static function ( $id ) {
 								return Utils::get_database_id_from_id( $id );
 							}, $input_value );
 							break;

--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -193,12 +193,14 @@ class DataSource {
 		$allowed_taxonomies = \WPGraphQL::get_allowed_taxonomies();
 
 		if ( ! in_array( $taxonomy, $allowed_taxonomies, true ) ) {
+			// translators: %s is the name of the taxonomy.
 			throw new UserError( sprintf( __( 'No taxonomy was found with the name %s', 'wp-graphql' ), $taxonomy ) );
 		}
 
 		$tax_object = get_taxonomy( $taxonomy );
 
 		if ( ! $tax_object instanceof \WP_Taxonomy ) {
+			// translators: %s is the name of the taxonomy.
 			throw new UserError( sprintf( __( 'No taxonomy was found with the name %s', 'wp-graphql' ), $taxonomy ) );
 		}
 
@@ -257,6 +259,7 @@ class DataSource {
 		if ( $theme->exists() ) {
 			return new Theme( $theme );
 		} else {
+			// translators: %s is the name of the theme stylesheet.
 			throw new UserError( sprintf( __( 'No theme was found with the stylesheet: %s', 'wp-graphql' ), $stylesheet ) );
 		}
 	}
@@ -328,6 +331,7 @@ class DataSource {
 		$role = isset( wp_roles()->roles[ $name ] ) ? wp_roles()->roles[ $name ] : null;
 
 		if ( null === $role ) {
+			// translators: %s is the name of the user role.
 			throw new UserError( sprintf( __( 'No user role was found with the name %s', 'wp-graphql' ), $name ) );
 		} else {
 			$role                = (array) $role;
@@ -546,11 +550,11 @@ class DataSource {
 
 			$node_definition = Relay::nodeDefinitions(
 			// The ID fetcher definition
-				function ( $global_id, AppContext $context, ResolveInfo $info ) {
+				static function ( $global_id, AppContext $context, ResolveInfo $info ) {
 					self::resolve_node( $global_id, $context, $info );
 				},
 				// Type resolver
-				function ( $node ) {
+				static function ( $node ) {
 					self::resolve_node_type( $node );
 				}
 			);
@@ -701,6 +705,7 @@ class DataSource {
 			return null;
 
 		} else {
+			// translators: %s is the global ID.
 			throw new UserError( sprintf( __( 'The global ID isn\'t recognized ID: %s', 'wp-graphql' ), $global_id ) );
 		}
 	}

--- a/src/Data/Loader/PostObjectLoader.php
+++ b/src/Data/Loader/PostObjectLoader.php
@@ -105,7 +105,7 @@ class PostObjectLoader extends AbstractDataLoader {
 		 */
 		add_filter(
 			'split_the_query',
-			function ( $split, \WP_Query $query ) {
+			static function ( $split, \WP_Query $query ) {
 				if ( false === $query->get( 'split_the_query' ) ) {
 					return false;
 				}

--- a/src/Data/Loader/UserLoader.php
+++ b/src/Data/Loader/UserLoader.php
@@ -157,7 +157,7 @@ class UserLoader extends AbstractDataLoader {
 		 */
 		return array_reduce(
 			$keys,
-			function ( $carry, $key ) use ( $public_users ) {
+			static function ( $carry, $key ) use ( $public_users ) {
 				$user = get_user_by( 'id', $key ); // Cached via previous WP_User_Query.
 
 				if ( $user instanceof \WP_User ) {

--- a/src/Model/MenuItem.php
+++ b/src/Model/MenuItem.php
@@ -83,8 +83,10 @@ class MenuItem extends Model {
 		}
 
 		if ( is_wp_error( $menus ) ) {
+			// translators: %s is the menu item ID.
 			throw new Exception( sprintf( __( 'No menus could be found for menu item %s', 'wp-graphql' ), $this->data->ID ) );
 		}
+
 		$menu_id = $menus[0];
 		if ( empty( $location_ids ) || ! in_array( $menu_id, $location_ids, true ) ) {
 			return true;

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -85,6 +85,7 @@ abstract class Model {
 	protected function __construct( $restricted_cap = '', $allowed_restricted_fields = [], $owner = null ) {
 
 		if ( empty( $this->data ) ) {
+			// translators: %s is the name of the model.
 			throw new Exception( sprintf( __( 'An empty data set was used to initialize the modeling of this %s object', 'wp-graphql' ), $this->get_model_name() ) );
 		}
 

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -727,7 +727,7 @@ class Post extends Model {
 					},
 					'capability' => isset( $this->post_type_object->cap->edit_others_posts ) ?: 'edit_others_posts',
 				],
-				'enqueuedScriptsQueue'      => function () {
+				'enqueuedScriptsQueue'      => static function () {
 					global $wp_scripts;
 					do_action( 'wp_enqueue_scripts' );
 					$queue = $wp_scripts->queue;
@@ -736,7 +736,7 @@ class Post extends Model {
 
 					return $queue;
 				},
-				'enqueuedStylesheetsQueue'  => function () {
+				'enqueuedStylesheetsQueue'  => static function () {
 					global $wp_styles;
 					do_action( 'wp_enqueue_scripts' );
 					$queue = $wp_styles->queue;

--- a/src/Model/Term.php
+++ b/src/Model/Term.php
@@ -172,7 +172,7 @@ class Term extends Model {
 				'parentDatabaseId'         => function () {
 					return ! empty( $this->data->parent ) ? $this->data->parent : null;
 				},
-				'enqueuedScriptsQueue'     => function () {
+				'enqueuedScriptsQueue'     => static function () {
 					global $wp_scripts;
 					$wp_scripts->reset();
 					do_action( 'wp_enqueue_scripts' );
@@ -182,7 +182,7 @@ class Term extends Model {
 
 					return $queue;
 				},
-				'enqueuedStylesheetsQueue' => function () {
+				'enqueuedStylesheetsQueue' => static function () {
 					global $wp_styles;
 					do_action( 'wp_enqueue_scripts' );
 					$queue = $wp_styles->queue;

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -185,7 +185,7 @@ class User extends Model {
 						$capabilities = array_keys(
 							array_filter(
 								$this->data->allcaps,
-								function ( $cap ) {
+								static function ( $cap ) {
 									return true === $cap;
 								}
 							)
@@ -255,7 +255,7 @@ class User extends Model {
 
 					return ! empty( $user_profile_url ) ? str_ireplace( home_url(), '', $user_profile_url ) : '';
 				},
-				'enqueuedScriptsQueue'     => function () {
+				'enqueuedScriptsQueue'     => static function () {
 					global $wp_scripts;
 					do_action( 'wp_enqueue_scripts' );
 					$queue = $wp_scripts->queue;
@@ -264,7 +264,7 @@ class User extends Model {
 
 					return $queue;
 				},
-				'enqueuedStylesheetsQueue' => function () {
+				'enqueuedStylesheetsQueue' => static function () {
 					global $wp_styles;
 					do_action( 'wp_enqueue_scripts' );
 					$queue = $wp_styles->queue;

--- a/src/Mutation/CommentCreate.php
+++ b/src/Mutation/CommentCreate.php
@@ -87,7 +87,7 @@ class CommentCreate {
 			'comment' => [
 				'type'        => 'Comment',
 				'description' => __( 'The comment that was created', 'wp-graphql' ),
-				'resolve'     => function ( $payload, $args, AppContext $context ) {
+				'resolve'     => static function ( $payload, $args, AppContext $context ) {
 					if ( ! isset( $payload['id'] ) || ! absint( $payload['id'] ) ) {
 						return null;
 					}
@@ -121,7 +121,7 @@ class CommentCreate {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload() {
-		return function ( $input, AppContext $context, ResolveInfo $info ) {
+		return static function ( $input, AppContext $context, ResolveInfo $info ) {
 
 			/**
 			 * Throw an exception if there's no input

--- a/src/Mutation/CommentDelete.php
+++ b/src/Mutation/CommentDelete.php
@@ -58,7 +58,7 @@ class CommentDelete {
 			'deletedId' => [
 				'type'        => 'Id',
 				'description' => __( 'The deleted comment ID', 'wp-graphql' ),
-				'resolve'     => function ( $payload ) {
+				'resolve'     => static function ( $payload ) {
 					$deleted = (object) $payload['commentObject'];
 
 					return ! empty( $deleted->comment_ID ) ? Relay::toGlobalId( 'comment', $deleted->comment_ID ) : null;
@@ -67,7 +67,7 @@ class CommentDelete {
 			'comment'   => [
 				'type'        => 'Comment',
 				'description' => __( 'The deleted comment object', 'wp-graphql' ),
-				'resolve'     => function ( $payload, $args, AppContext $context, ResolveInfo $info ) {
+				'resolve'     => static function ( $payload, $args, AppContext $context, ResolveInfo $info ) {
 					return $payload['commentObject'] ? $payload['commentObject'] : null;
 				},
 			],
@@ -80,7 +80,7 @@ class CommentDelete {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload() {
-		return function ( $input ) {
+		return static function ( $input ) {
 			// Get the database ID for the comment.
 			$comment_id = Utils::get_database_id_from_id( $input['id'] );
 

--- a/src/Mutation/CommentRestore.php
+++ b/src/Mutation/CommentRestore.php
@@ -55,7 +55,7 @@ class CommentRestore {
 			'restoredId' => [
 				'type'        => 'Id',
 				'description' => __( 'The ID of the restored comment', 'wp-graphql' ),
-				'resolve'     => function ( $payload ) {
+				'resolve'     => static function ( $payload ) {
 					$restore = (object) $payload['commentObject'];
 
 					return ! empty( $restore->comment_ID ) ? Relay::toGlobalId( 'comment', $restore->comment_ID ) : null;
@@ -64,7 +64,7 @@ class CommentRestore {
 			'comment'    => [
 				'type'        => 'Comment',
 				'description' => __( 'The restored comment object', 'wp-graphql' ),
-				'resolve'     => function ( $payload, $args, AppContext $context ) {
+				'resolve'     => static function ( $payload, $args, AppContext $context ) {
 					if ( ! isset( $payload['commentObject']->comment_ID ) || ! absint( $payload['commentObject']->comment_ID ) ) {
 						return null;
 					}
@@ -80,7 +80,7 @@ class CommentRestore {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload() {
-		return function ( $input ) {
+		return static function ( $input ) {
 			// Stop now if a user isn't allowed to delete the comment.
 			if ( ! current_user_can( 'moderate_comments' ) ) {
 				throw new UserError( __( 'Sorry, you are not allowed to restore this comment.', 'wp-graphql' ) );

--- a/src/Mutation/CommentUpdate.php
+++ b/src/Mutation/CommentUpdate.php
@@ -67,7 +67,7 @@ class CommentUpdate {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload() {
-		return function ( $input, AppContext $context, ResolveInfo $info ) {
+		return static function ( $input, AppContext $context, ResolveInfo $info ) {
 			// Get the database ID for the comment.
 			$comment_id = ! empty( $input['id'] ) ? Utils::get_database_id_from_id( $input['id'] ) : null;
 

--- a/src/Mutation/MediaItemCreate.php
+++ b/src/Mutation/MediaItemCreate.php
@@ -103,7 +103,7 @@ class MediaItemCreate {
 			'mediaItem' => [
 				'type'        => 'MediaItem',
 				'description' => __( 'The MediaItem object mutation type.', 'wp-graphql' ),
-				'resolve'     => function ( $payload, $args, AppContext $context ) {
+				'resolve'     => static function ( $payload, $args, AppContext $context ) {
 					if ( empty( $payload['postObjectId'] ) || ! absint( $payload['postObjectId'] ) ) {
 						return null;
 					}
@@ -120,7 +120,7 @@ class MediaItemCreate {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload() {
-		return function ( $input, AppContext $context, ResolveInfo $info ) {
+		return static function ( $input, AppContext $context, ResolveInfo $info ) {
 			/**
 			 * Stop now if a user isn't allowed to upload a mediaItem
 			 */
@@ -160,6 +160,7 @@ class MediaItemCreate {
 
 			// if the file doesn't pass the check, throw an error
 			if ( ! $check_file['ext'] || ! $check_file['type'] || ! wp_http_validate_url( $uploaded_file_url ) ) {
+				// translators: %s is the file path.
 				throw new UserError( sprintf( __( 'Invalid filePath "%s"', 'wp-graphql' ), $input['filePath'] ) );
 			}
 
@@ -180,7 +181,14 @@ class MediaItemCreate {
 			$allowed_protocols = apply_filters( 'graphql_media_item_create_allowed_protocols', $allowed_protocols, $protocol, $input, $context, $info );
 
 			if ( ! in_array( $protocol, $allowed_protocols, true ) ) {
-				throw new UserError( sprintf( __( 'Invalid protocol. "%1$s". Only "%2$s" allowed.', 'wp-graphql' ), $protocol, implode( '", "', $allowed_protocols ) ) );
+				throw new UserError(
+					sprintf(
+						// translators: %1$s is the protocol, %2$s is the list of allowed protocols.
+						__( 'Invalid protocol. "%1$s". Only "%2$s" allowed.', 'wp-graphql' ),
+						$protocol,
+						implode( '", "', $allowed_protocols )
+					)
+				);
 			}
 
 			/**

--- a/src/Mutation/MediaItemDelete.php
+++ b/src/Mutation/MediaItemDelete.php
@@ -55,7 +55,7 @@ class MediaItemDelete {
 			'deletedId' => [
 				'type'        => 'ID',
 				'description' => __( 'The ID of the deleted mediaItem', 'wp-graphql' ),
-				'resolve'     => function ( $payload ) {
+				'resolve'     => static function ( $payload ) {
 					$deleted = (object) $payload['mediaItemObject'];
 
 					return ! empty( $deleted->ID ) ? Relay::toGlobalId( 'post', $deleted->ID ) : null;
@@ -64,7 +64,7 @@ class MediaItemDelete {
 			'mediaItem' => [
 				'type'        => 'MediaItem',
 				'description' => __( 'The mediaItem before it was deleted', 'wp-graphql' ),
-				'resolve'     => function ( $payload ) {
+				'resolve'     => static function ( $payload ) {
 					/** @var \WPGraphQL\Model\Post $deleted */
 					$deleted = $payload['mediaItemObject'];
 
@@ -80,7 +80,7 @@ class MediaItemDelete {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload() {
-		return function ( $input ) {
+		return static function ( $input ) {
 			// Get the database ID for the comment.
 			$media_item_id = Utils::get_database_id_from_id( $input['id'] );
 
@@ -96,6 +96,7 @@ class MediaItemDelete {
 
 			// Stop now if the post isn't a mediaItem.
 			if ( 'attachment' !== $existing_media_item->post_type ) {
+				// Translators: the placeholder is the post_type of the object being deleted
 				throw new UserError( sprintf( __( 'Sorry, the item you are trying to delete is a %1%s, not a mediaItem', 'wp-graphql' ), $existing_media_item->post_type ) );
 			}
 
@@ -118,7 +119,7 @@ class MediaItemDelete {
 			 * don't remove from the trash
 			 */
 			if ( 'trash' === $existing_media_item->post_status && true !== $force_delete ) {
-				// Translators: the first placeholder is the post_type of the object being deleted and the second placeholder is the unique ID of that object
+				// translators: the first placeholder is the post_type of the object being deleted and the second placeholder is the unique ID of that object
 				throw new UserError( sprintf( __( 'The mediaItem with id %1$s is already in the trash. To remove from the trash, use the forceDelete input', 'wp-graphql' ), $input['id'] ) );
 			}
 

--- a/src/Mutation/MediaItemUpdate.php
+++ b/src/Mutation/MediaItemUpdate.php
@@ -66,7 +66,7 @@ class MediaItemUpdate {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload() {
-		return function ( $input, AppContext $context, ResolveInfo $info ) {
+		return static function ( $input, AppContext $context, ResolveInfo $info ) {
 			$post_type_object = get_post_type_object( 'attachment' );
 
 			if ( empty( $post_type_object ) ) {

--- a/src/Mutation/PostObjectCreate.php
+++ b/src/Mutation/PostObjectCreate.php
@@ -147,7 +147,12 @@ class PostObjectCreate {
 			// If the taxonomy is in the array of taxonomies registered to the post_type
 			if ( in_array( $tax_object->name, get_object_taxonomies( $post_type_object->name ), true ) ) {
 				$fields[ $tax_object->graphql_plural_name ] = [
-					'description' => sprintf( __( 'Set connections between the %1$s and %2$s', 'wp-graphql' ), $post_type_object->graphql_single_name, $tax_object->graphql_plural_name ),
+					'description' => sprintf(
+						// translators: %1$s is the post type GraphQL name, %2$s is the taxonomy GraphQL name.
+						__( 'Set connections between the %1$s and %2$s', 'wp-graphql' ),
+						$post_type_object->graphql_single_name,
+						$tax_object->graphql_plural_name
+					),
 					'type'        => ucfirst( $post_type_object->graphql_single_name ) . ucfirst( $tax_object->graphql_plural_name ) . 'Input',
 				];
 			}
@@ -168,7 +173,7 @@ class PostObjectCreate {
 			$post_type_object->graphql_single_name => [
 				'type'        => $post_type_object->graphql_single_name,
 				'description' => __( 'The Post object mutation type.', 'wp-graphql' ),
-				'resolve'     => function ( $payload, $args, AppContext $context, ResolveInfo $info ) {
+				'resolve'     => static function ( $payload, $args, AppContext $context, ResolveInfo $info ) {
 
 					if ( empty( $payload['postObjectId'] ) || ! absint( $payload['postObjectId'] ) ) {
 						return null;
@@ -189,7 +194,7 @@ class PostObjectCreate {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload( $post_type_object, $mutation_name ) {
-		return function ( $input, AppContext $context, ResolveInfo $info ) use ( $post_type_object, $mutation_name ) {
+		return static function ( $input, AppContext $context, ResolveInfo $info ) use ( $post_type_object, $mutation_name ) {
 
 			/**
 			 * Throw an exception if there's no input
@@ -336,7 +341,7 @@ class PostObjectCreate {
 				 * don't proceed.
 				 */
 				if ( ! $new_post = get_post( $post_id ) ) {
-					throw new UserError( sprintf( __( 'The status of the post could not be set', 'wp-graphql' ) ) );
+					throw new UserError( __( 'The status of the post could not be set', 'wp-graphql' ) );
 				}
 
 				/**

--- a/src/Mutation/PostObjectDelete.php
+++ b/src/Mutation/PostObjectDelete.php
@@ -72,7 +72,7 @@ class PostObjectDelete {
 			'deletedId'                            => [
 				'type'        => 'ID',
 				'description' => __( 'The ID of the deleted object', 'wp-graphql' ),
-				'resolve'     => function ( $payload ) {
+				'resolve'     => static function ( $payload ) {
 					/** @var \WPGraphQL\Model\Post $deleted */
 					$deleted = $payload['postObject'];
 
@@ -82,7 +82,7 @@ class PostObjectDelete {
 			$post_type_object->graphql_single_name => [
 				'type'        => $post_type_object->graphql_single_name,
 				'description' => __( 'The object before it was deleted', 'wp-graphql' ),
-				'resolve'     => function ( $payload ) {
+				'resolve'     => static function ( $payload ) {
 					/** @var \WPGraphQL\Model\Post $deleted */
 					$deleted = $payload['postObject'];
 
@@ -101,7 +101,7 @@ class PostObjectDelete {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload( WP_Post_Type $post_type_object, string $mutation_name ) {
-		return function ( $input ) use ( $post_type_object ) {
+		return static function ( $input ) use ( $post_type_object ) {
 			// Get the database ID for the post.
 			$post_id = Utils::get_database_id_from_id( $input['id'] );
 

--- a/src/Mutation/PostObjectUpdate.php
+++ b/src/Mutation/PostObjectUpdate.php
@@ -78,7 +78,7 @@ class PostObjectUpdate {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload( $post_type_object, $mutation_name ) {
-		return function ( $input, AppContext $context, ResolveInfo $info ) use ( $post_type_object, $mutation_name ) {
+		return static function ( $input, AppContext $context, ResolveInfo $info ) use ( $post_type_object, $mutation_name ) {
 			// Get the database ID for the comment.
 			$post_id       = Utils::get_database_id_from_id( $input['id'] );
 			$existing_post = ! empty( $post_id ) ? get_post( $post_id ) : null;

--- a/src/Mutation/ResetUserPassword.php
+++ b/src/Mutation/ResetUserPassword.php
@@ -60,7 +60,7 @@ class ResetUserPassword {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload() {
-		return function ( $input, AppContext $context, ResolveInfo $info ) {
+		return static function ( $input, AppContext $context, ResolveInfo $info ) {
 
 			if ( empty( $input['key'] ) ) {
 				throw new UserError( __( 'A password reset key is required.', 'wp-graphql' ) );

--- a/src/Mutation/SendPasswordResetEmail.php
+++ b/src/Mutation/SendPasswordResetEmail.php
@@ -55,7 +55,7 @@ class SendPasswordResetEmail {
 				'type'              => 'User',
 				'description'       => __( 'The user that the password reset email was sent to', 'wp-graphql' ),
 				'deprecationReason' => __( 'This field will be removed in a future version of WPGraphQL', 'wp-graphql' ),
-				'resolve'           => function ( $payload, $args, AppContext $context ) {
+				'resolve'           => static function ( $payload, $args, AppContext $context ) {
 					return ! empty( $payload['id'] ) ? $context->get_loader( 'user' )->load_deferred( $payload['id'] ) : null;
 				},
 			],
@@ -72,7 +72,7 @@ class SendPasswordResetEmail {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload() : callable {
-		return function ( $input ) {
+		return static function ( $input ) {
 			if ( ! self::was_username_provided( $input ) ) {
 				throw new UserError( __( 'Enter a username or email address.', 'wp-graphql' ) );
 			}

--- a/src/Mutation/TermObjectCreate.php
+++ b/src/Mutation/TermObjectCreate.php
@@ -29,7 +29,7 @@ class TermObjectCreate {
 							'type'        => [
 								'non_null' => 'String',
 							],
-							// Translators: The placeholder is the name of the taxonomy for the object being mutated
+							// translators: The placeholder is the name of the taxonomy for the object being mutated
 							'description' => sprintf( __( 'The name of the %1$s object to mutate', 'wp-graphql' ), $taxonomy->name ),
 						],
 					]
@@ -51,12 +51,12 @@ class TermObjectCreate {
 		$fields = [
 			'aliasOf'     => [
 				'type'        => 'String',
-				// Translators: The placeholder is the name of the taxonomy for the object being mutated
+				// translators: The placeholder is the name of the taxonomy for the object being mutated
 				'description' => sprintf( __( 'The slug that the %1$s will be an alias of', 'wp-graphql' ), $taxonomy->name ),
 			],
 			'description' => [
 				'type'        => 'String',
-				// Translators: The placeholder is the name of the taxonomy for the object being mutated
+				// translators: The placeholder is the name of the taxonomy for the object being mutated
 				'description' => sprintf( __( 'The description of the %1$s object', 'wp-graphql' ), $taxonomy->name ),
 			],
 			'slug'        => [
@@ -71,7 +71,7 @@ class TermObjectCreate {
 		if ( true === $taxonomy->hierarchical ) {
 			$fields['parentId'] = [
 				'type'        => 'ID',
-				// Translators: The placeholder is the name of the taxonomy for the object being mutated
+				// translators: The placeholder is the name of the taxonomy for the object being mutated
 				'description' => sprintf( __( 'The ID of the %1$s that should be set as the parent', 'wp-graphql' ), $taxonomy->name ),
 			];
 		}
@@ -92,7 +92,7 @@ class TermObjectCreate {
 				'type'        => $taxonomy->graphql_single_name,
 				// translators: Placeholder is the name of the taxonomy
 				'description' => sprintf( __( 'The created %s', 'wp-graphql' ), $taxonomy->name ),
-				'resolve'     => function ( $payload, $args, AppContext $context, ResolveInfo $info ) {
+				'resolve'     => static function ( $payload, $args, AppContext $context, ResolveInfo $info ) {
 					$id = isset( $payload['termId'] ) ? absint( $payload['termId'] ) : null;
 
 					return $context->get_loader( 'term' )->load_deferred( $id );
@@ -111,7 +111,7 @@ class TermObjectCreate {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload( WP_Taxonomy $taxonomy, string $mutation_name ) {
-		return function ( $input, AppContext $context, ResolveInfo $info ) use ( $taxonomy, $mutation_name ) {
+		return static function ( $input, AppContext $context, ResolveInfo $info ) use ( $taxonomy, $mutation_name ) {
 
 			/**
 			 * Ensure the user can edit_terms
@@ -130,13 +130,14 @@ class TermObjectCreate {
 			 * Ensure a name was provided
 			 */
 			if ( empty( $args['name'] ) ) {
-				// Translators: The placeholder is the name of the taxonomy of the term being mutated
+				// translators: The placeholder is the name of the taxonomy of the term being mutated
 				throw new UserError( sprintf( __( 'A name is required to create a %1$s', 'wp-graphql' ), $taxonomy->name ) );
 			}
 
 			$term_name = wp_slash( $args['name'] );
 
 			if ( ! is_string( $term_name ) ) {
+				// translators: The placeholder is the name of the taxonomy of the term being mutated
 				throw new UserError( sprintf( __( 'A valid name is required to create a %1$s', 'wp-graphql' ), $taxonomy->name ) );
 			}
 

--- a/src/Mutation/TermObjectDelete.php
+++ b/src/Mutation/TermObjectDelete.php
@@ -65,7 +65,7 @@ class TermObjectDelete {
 			'deletedId'                    => [
 				'type'        => 'ID',
 				'description' => __( 'The ID of the deleted object', 'wp-graphql' ),
-				'resolve'     => function ( $payload ) {
+				'resolve'     => static function ( $payload ) {
 					$deleted = (object) $payload['termObject'];
 
 					return ! empty( $deleted->term_id ) ? Relay::toGlobalId( 'term', $deleted->term_id ) : null;
@@ -74,7 +74,7 @@ class TermObjectDelete {
 			$taxonomy->graphql_single_name => [
 				'type'        => $taxonomy->graphql_single_name,
 				'description' => __( 'The deteted term object', 'wp-graphql' ),
-				'resolve'     => function ( $payload ) {
+				'resolve'     => static function ( $payload ) {
 					return new Term( $payload['termObject'] );
 				},
 			],
@@ -90,7 +90,7 @@ class TermObjectDelete {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload( WP_Taxonomy $taxonomy, string $mutation_name ) {
-		return function ( $input ) use ( $taxonomy ) {
+		return static function ( $input ) use ( $taxonomy ) {
 			// Get the database ID for the comment.
 			$term_id = Utils::get_database_id_from_id( $input['id'] );
 

--- a/src/Mutation/TermObjectUpdate.php
+++ b/src/Mutation/TermObjectUpdate.php
@@ -81,7 +81,7 @@ class TermObjectUpdate {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload( WP_Taxonomy $taxonomy, $mutation_name ) {
-		return function ( $input, AppContext $context, ResolveInfo $info ) use ( $taxonomy, $mutation_name ) {
+		return static function ( $input, AppContext $context, ResolveInfo $info ) use ( $taxonomy, $mutation_name ) {
 			$term_id = Utils::get_database_id_from_id( $input['id'] );
 
 			/**

--- a/src/Mutation/UpdateSettings.php
+++ b/src/Mutation/UpdateSettings.php
@@ -35,7 +35,7 @@ class UpdateSettings {
 			[
 				'inputFields'         => $input_fields,
 				'outputFields'        => $output_fields,
-				'mutateAndGetPayload' => function ( $input ) use ( $type_registry ) {
+				'mutateAndGetPayload' => static function ( $input ) use ( $type_registry ) {
 					return self::mutate_and_get_payload( $input, $type_registry );
 				},
 			]
@@ -124,7 +124,7 @@ class UpdateSettings {
 		$output_fields['allSettings'] = [
 			'type'        => 'Settings',
 			'description' => __( 'Update all settings.', 'wp-graphql' ),
-			'resolve'     => function () {
+			'resolve'     => static function () {
 				return true;
 			},
 		];
@@ -137,8 +137,9 @@ class UpdateSettings {
 
 				$output_fields[ Utils::format_field_name( $setting_type_name ) ] = [
 					'type'        => $setting_type_name,
+					// translators: %s is the setting type name
 					'description' => sprintf( __( 'Update the %s setting.', 'wp-graphql' ), $setting_type_name ),
-					'resolve'     => function () use ( $setting_type_name ) {
+					'resolve'     => static function () use ( $setting_type_name ) {
 						return $setting_type_name;
 					},
 				];

--- a/src/Mutation/UserCreate.php
+++ b/src/Mutation/UserCreate.php
@@ -137,7 +137,7 @@ class UserCreate {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload() {
-		return function ( $input, AppContext $context, ResolveInfo $info ) {
+		return static function ( $input, AppContext $context, ResolveInfo $info ) {
 			if ( ! current_user_can( 'create_users' ) ) {
 				throw new UserError( __( 'Sorry, you are not allowed to create a new user.', 'wp-graphql' ) );
 			}

--- a/src/Mutation/UserDelete.php
+++ b/src/Mutation/UserDelete.php
@@ -59,7 +59,7 @@ class UserDelete {
 			'deletedId' => [
 				'type'        => 'ID',
 				'description' => __( 'The ID of the user that you just deleted', 'wp-graphql' ),
-				'resolve'     => function ( $payload ) {
+				'resolve'     => static function ( $payload ) {
 					$deleted = (object) $payload['user'];
 					return ( ! empty( $deleted->ID ) ) ? Relay::toGlobalId( 'user', $deleted->ID ) : null;
 				},
@@ -67,7 +67,7 @@ class UserDelete {
 			'user'      => [
 				'type'        => 'User',
 				'description' => __( 'The deleted user object', 'wp-graphql' ),
-				'resolve'     => function ( $payload ) {
+				'resolve'     => static function ( $payload ) {
 					return new User( $payload['user'] );
 				},
 			],

--- a/src/Mutation/UserRegister.php
+++ b/src/Mutation/UserRegister.php
@@ -71,7 +71,7 @@ class UserRegister {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload() {
-		return function ( $input, AppContext $context, ResolveInfo $info ) {
+		return static function ( $input, AppContext $context, ResolveInfo $info ) {
 
 			if ( ! get_option( 'users_can_register' ) ) {
 				throw new UserError( __( 'User registration is currently not allowed.', 'wp-graphql' ) );

--- a/src/Mutation/UserUpdate.php
+++ b/src/Mutation/UserUpdate.php
@@ -61,7 +61,7 @@ class UserUpdate {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload() {
-		return function ( $input, AppContext $context, ResolveInfo $info ) {
+		return static function ( $input, AppContext $context, ResolveInfo $info ) {
 			// Get the user ID.
 			$user_id = Utils::get_database_id_from_id( $input['id'] );
 

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -450,23 +450,45 @@ class TypeRegistry {
 					register_graphql_input_type(
 						$post_type_object->graphql_single_name . ucfirst( $tax_object->graphql_plural_name ) . 'NodeInput',
 						[
-							'description' => sprintf( __( 'List of %1$s to connect the %2$s to. If an ID is set, it will be used to create the connection. If not, it will look for a slug. If neither are valid existing terms, and the site is configured to allow terms to be created during post mutations, a term will be created using the Name if it exists in the input, then fallback to the slug if it exists.', 'wp-graphql' ), $tax_object->graphql_plural_name, $post_type_object->graphql_single_name ),
+							'description' => sprintf(
+								// translators: %1$s is the GraphQL plural name of the taxonomy, %2$s is the GraphQL singular name of the post type.
+								__( 'List of %1$s to connect the %2$s to. If an ID is set, it will be used to create the connection. If not, it will look for a slug. If neither are valid existing terms, and the site is configured to allow terms to be created during post mutations, a term will be created using the Name if it exists in the input, then fallback to the slug if it exists.', 'wp-graphql' ),
+								$tax_object->graphql_plural_name,
+								$post_type_object->graphql_single_name
+							),
 							'fields'      => [
 								'id'          => [
 									'type'        => 'Id',
-									'description' => sprintf( __( 'The ID of the %1$s. If present, this will be used to connect to the %2$s. If no existing %1$s exists with this ID, no connection will be made.', 'wp-graphql' ), $tax_object->graphql_single_name, $post_type_object->graphql_single_name ),
+									'description' => sprintf(
+										// translators: %1$s is the GraphQL name of the taxonomy, %2$s is the GraphQL name of the post type.
+										__( 'The ID of the %1$s. If present, this will be used to connect to the %2$s. If no existing %1$s exists with this ID, no connection will be made.', 'wp-graphql' ),
+										$tax_object->graphql_single_name,
+										$post_type_object->graphql_single_name
+									),
 								],
 								'slug'        => [
 									'type'        => 'String',
-									'description' => sprintf( __( 'The slug of the %1$s. If no ID is present, this field will be used to make a connection. If no existing term exists with this slug, this field will be used as a fallback to the Name field when creating a new term to connect to, if term creation is enabled as a nested mutation.', 'wp-graphql' ), $tax_object->graphql_single_name ),
+									'description' => sprintf(
+										// translators: %1$s is the GraphQL name of the taxonomy.
+										__( 'The slug of the %1$s. If no ID is present, this field will be used to make a connection. If no existing term exists with this slug, this field will be used as a fallback to the Name field when creating a new term to connect to, if term creation is enabled as a nested mutation.', 'wp-graphql' ),
+										$tax_object->graphql_single_name
+									),
 								],
 								'description' => [
 									'type'        => 'String',
-									'description' => sprintf( __( 'The description of the %1$s. This field is used to set a description of the %1$s if a new one is created during the mutation.', 'wp-graphql' ), $tax_object->graphql_single_name ),
+									'description' => sprintf(
+										// translators: %1$s is the GraphQL name of the taxonomy.
+										__( 'The description of the %1$s. This field is used to set a description of the %1$s if a new one is created during the mutation.', 'wp-graphql' ),
+										$tax_object->graphql_single_name
+									),
 								],
 								'name'        => [
 									'type'        => 'String',
-									'description' => sprintf( __( 'The name of the %1$s. This field is used to create a new term, if term creation is enabled in nested mutations, and if one does not already exist with the provided slug or ID or if a slug or ID is not provided. If no name is included and a term is created, the creation will fallback to the slug field.', 'wp-graphql' ), $tax_object->graphql_single_name ),
+									'description' => sprintf(
+											// translators: %1$s is the GraphQL name of the taxonomy.
+										__( 'The name of the %1$s. This field is used to create a new term, if term creation is enabled in nested mutations, and if one does not already exist with the provided slug or ID or if a slug or ID is not provided. If no name is included and a term is created, the creation will fallback to the slug field.', 'wp-graphql' ),
+										$tax_object->graphql_single_name
+									),
 								],
 							],
 						]
@@ -475,11 +497,20 @@ class TypeRegistry {
 					register_graphql_input_type(
 						ucfirst( $post_type_object->graphql_single_name ) . ucfirst( $tax_object->graphql_plural_name ) . 'Input',
 						[
-							'description' => sprintf( __( 'Set relationships between the %1$s to %2$s', 'wp-graphql' ), $post_type_object->graphql_single_name, $tax_object->graphql_plural_name ),
+							'description' => sprintf(
+								// translators: %1$s is the GraphQL name of the post type, %2$s is the plural GraphQL name of the taxonomy.
+								__( 'Set relationships between the %1$s to %2$s', 'wp-graphql' ),
+								$post_type_object->graphql_single_name,
+								$tax_object->graphql_plural_name
+							),
 							'fields'      => [
 								'append' => [
 									'type'        => 'Boolean',
-									'description' => sprintf( __( 'If true, this will append the %1$s to existing related %2$s. If false, this will replace existing relationships. Default true.', 'wp-graphql' ), $tax_object->graphql_single_name, $tax_object->graphql_plural_name ),
+									'description' => sprintf(
+										// translators: %1$s is the GraphQL name of the taxonomy, %2$s is the plural GraphQL name of the taxonomy.
+										__( 'If true, this will append the %1$s to existing related %2$s. If false, this will replace existing relationships. Default true.', 'wp-graphql' ), $tax_object->graphql_single_name,
+										$tax_object->graphql_plural_name
+									),
 								],
 								'nodes'  => [
 									'type'        => [
@@ -527,7 +558,7 @@ class TypeRegistry {
 			$this->register_field( 'GeneralSettings', 'url', [
 				'type'        => 'String',
 				'description' => __( 'Site URL.', 'wp-graphql' ),
-				'resolve'     => function () {
+				'resolve'     => static function () {
 					return get_site_url();
 				},
 			] );
@@ -549,8 +580,12 @@ class TypeRegistry {
 					Utils::format_field_name( $type_name ),
 					[
 						'type'        => $type_name,
-						'description' => sprintf( __( "Fields of the '%s' settings group", 'wp-graphql' ), ucfirst( $group_name ) . 'Settings' ),
-						'resolve'     => function () use ( $setting_type ) {
+						'description' => sprintf(
+							// translators: %s is the GraphQL name of the settings group.
+							__( "Fields of the '%s' settings group", 'wp-graphql' ),
+							ucfirst( $group_name ) . 'Settings'
+						),
+						'resolve'     => static function () use ( $setting_type ) {
 							return $setting_type;
 						},
 					]
@@ -644,7 +679,11 @@ class TypeRegistry {
 		 */
 		if ( ! is_valid_graphql_name( $type_name ) ) {
 			graphql_debug(
-				sprintf( __( 'The Type name \'%1$s\' is invalid and has not been added to the GraphQL Schema.', 'wp-graphql' ), $type_name ),
+				sprintf(
+					// translators: %s is the name of the type.
+					__( 'The Type name \'%1$s\' is invalid and has not been added to the GraphQL Schema.', 'wp-graphql' ),
+					$type_name
+				),
 				[
 					'type'      => 'INVALID_TYPE_NAME',
 					'type_name' => $type_name,
@@ -658,7 +697,11 @@ class TypeRegistry {
 		 */
 		if ( isset( $this->types[ $this->format_key( $type_name ) ] ) || isset( $this->type_loaders[ $this->format_key( $type_name ) ] ) ) {
 			graphql_debug(
-				sprintf( __( 'You cannot register duplicate Types to the Schema. The Type \'%1$s\' already exists in the Schema. Make sure to give new Types a unique name.', 'wp-graphql' ), $type_name ),
+				sprintf(
+					// translators: %s is the name of the type.
+					__( 'You cannot register duplicate Types to the Schema. The Type \'%1$s\' already exists in the Schema. Make sure to give new Types a unique name.', 'wp-graphql' ),
+					$type_name
+				),
 				[
 					'type'      => 'DUPLICATE_TYPE',
 					'type_name' => $type_name,
@@ -895,11 +938,18 @@ class TypeRegistry {
 		}
 
 		if ( ! isset( $field_config['type'] ) ) {
-			graphql_debug( sprintf( __( 'The registered field \'%s\' does not have a Type defined. Make sure to define a type for all fields.', 'wp-graphql' ), $field_name ), [
-				'type'       => 'INVALID_FIELD_TYPE',
-				'type_name'  => $type_name,
-				'field_name' => $field_name,
-			] );
+			graphql_debug(
+				sprintf(
+					/* translators: %s is the Field name. */
+					__( 'The registered field \'%s\' does not have a Type defined. Make sure to define a type for all fields.', 'wp-graphql' ),
+					$field_name
+				),
+				[
+					'type'       => 'INVALID_FIELD_TYPE',
+					'type_name'  => $type_name,
+					'field_name' => $field_name,
+				]
+			);
 			return null;
 		}
 
@@ -1038,7 +1088,12 @@ class TypeRegistry {
 
 				if ( preg_match( '/^\d/', $field_name ) ) {
 					graphql_debug(
-						sprintf( __( 'The field \'%1$s\' on Type \'%2$s\' is invalid. Field names cannot start with a number.', 'wp-graphql' ), $field_name, $type_name ),
+						sprintf(
+							// translators: %1$s is the field name, %2$s is the type name.
+							__( 'The field \'%1$s\' on Type \'%2$s\' is invalid. Field names cannot start with a number.', 'wp-graphql' ),
+							$field_name,
+							$type_name
+						),
 						[
 							'type'       => 'INVALID_FIELD_NAME',
 							'field_name' => $field_name,
@@ -1050,7 +1105,12 @@ class TypeRegistry {
 
 				if ( isset( $fields[ $field_name ] ) ) {
 					graphql_debug(
-						sprintf( __( 'You cannot register duplicate fields on the same Type. The field \'%1$s\' already exists on the type \'%2$s\'. Make sure to give the field a unique name.', 'wp-graphql' ), $field_name, $type_name ),
+						sprintf(
+							// translators: %1$s is the field name, %2$s is the type name.
+							__( 'You cannot register duplicate fields on the same Type. The field \'%1$s\' already exists on the type \'%2$s\'. Make sure to give the field a unique name.', 'wp-graphql' ),
+							$field_name,
+							$type_name
+						),
 						[
 							'type'       => 'DUPLICATE_FIELD',
 							'field_name' => $field_name,
@@ -1090,7 +1150,7 @@ class TypeRegistry {
 
 		add_filter(
 			'graphql_' . $type_name . '_fields',
-			function ( $fields ) use ( $field_name ) {
+			static function ( $fields ) use ( $field_name ) {
 
 				if ( isset( $fields[ $field_name ] ) ) {
 					unset( $fields[ $field_name ] );
@@ -1150,7 +1210,7 @@ class TypeRegistry {
 		// Prevent the mutation from being registered to the scheme directly.
 		add_filter(
 			'graphql_excluded_mutations',
-			function ( $excluded_mutations ) use ( $mutation_name ) : array {
+			static function ( $excluded_mutations ) use ( $mutation_name ) : array {
 				// Normalize the types to prevent case sensitivity issues.
 				$mutation_name = strtolower( $mutation_name );
 				// If the type isn't already excluded, add it to the array.
@@ -1176,7 +1236,7 @@ class TypeRegistry {
 	public function deregister_connection( string $connection_name ) : void {
 		add_filter(
 			'graphql_excluded_connections',
-			function ( $excluded_connections ) use ( $connection_name ) {
+			static function ( $excluded_connections ) use ( $connection_name ) {
 
 				$connection_name = strtolower( $connection_name );
 

--- a/src/Registry/Utils/PostObject.php
+++ b/src/Registry/Utils/PostObject.php
@@ -65,6 +65,7 @@ class PostObject {
 		if ( empty( $post_type_object->graphql_resolve_type ) || ! is_callable( $post_type_object->graphql_resolve_type ) ) {
 			graphql_debug(
 				sprintf(
+					// translators: %1$s is the post type name, %2$s is the graphql kind.
 					__( '%1$s is registered as a GraphQL %2$s, but has no way to resolve the type. Ensure "graphql_resolve_type" is a valid callback function', 'wp-graphql' ),
 					$single_name,
 					$post_type_object->graphql_kind
@@ -115,7 +116,7 @@ class PostObject {
 			$connections['comments'] = [
 				'toType'         => 'Comment',
 				'connectionArgs' => Comments::get_connection_args(),
-				'resolve'        => function ( Post $post, $args, $context, $info ) {
+				'resolve'        => static function ( Post $post, $args, $context, $info ) {
 
 					if ( $post->isRevision ) {
 						$id = $post->parentDatabaseId;
@@ -136,8 +137,12 @@ class PostObject {
 				'toType'             => $post_type_object->graphql_single_name,
 				'connectionTypeName' => ucfirst( $post_type_object->graphql_single_name ) . 'ToPreviewConnection',
 				'oneToOne'           => true,
-				'deprecationReason'  => ( true === $post_type_object->publicly_queryable || true === $post_type_object->public ) ? null : sprintf( __( 'The "%s" Type is not publicly queryable and does not support previews. This field will be removed in the future.', 'wp-graphql' ), WPGraphQL\Utils\Utils::format_type_name( $post_type_object->graphql_single_name ) ),
-				'resolve'            => function ( Post $post, $args, AppContext $context, ResolveInfo $info ) {
+				'deprecationReason'  => ( true === $post_type_object->publicly_queryable || true === $post_type_object->public ) ? null
+					: sprintf(
+						// translators: %s is the post type's GraphQL name.
+						__( 'The "%s" Type is not publicly queryable and does not support previews. This field will be removed in the future.', 'wp-graphql' ), WPGraphQL\Utils\Utils::format_type_name( $post_type_object->graphql_single_name )
+					),
+				'resolve'            => static function ( Post $post, $args, AppContext $context, ResolveInfo $info ) {
 					if ( $post->isRevision ) {
 						return null;
 					}
@@ -161,7 +166,7 @@ class PostObject {
 				'toType'             => $post_type_object->graphql_single_name,
 				'queryClass'         => 'WP_Query',
 				'connectionArgs'     => PostObjects::get_connection_args( [], $post_type_object ),
-				'resolve'            => function ( Post $post, $args, $context, $info ) {
+				'resolve'            => static function ( Post $post, $args, $context, $info ) {
 					$resolver = new PostObjectConnectionResolver( $post, $args, $context, $info, 'revision' );
 					$resolver->set_query_arg( 'post_parent', $post->ID );
 
@@ -193,7 +198,7 @@ class PostObject {
 							],
 						]
 					),
-					'resolve'        => function ( Post $post, $args, AppContext $context, ResolveInfo $info ) {
+					'resolve'        => static function ( Post $post, $args, AppContext $context, ResolveInfo $info ) {
 						$taxonomies = \WPGraphQL::get_allowed_taxonomies();
 						$terms      = wp_get_post_terms( $post->ID, $taxonomies, [ 'fields' => 'ids' ] );
 
@@ -216,7 +221,7 @@ class PostObject {
 				'toType'         => $tax_object->graphql_single_name,
 				'queryClass'     => 'WP_Term_Query',
 				'connectionArgs' => TermObjects::get_connection_args(),
-				'resolve'        => function ( Post $post, $args, AppContext $context, $info ) use ( $tax_object ) {
+				'resolve'        => static function ( Post $post, $args, AppContext $context, $info ) use ( $tax_object ) {
 
 					$object_id = true === $post->isPreview && ! empty( $post->parentDatabaseId ) ? $post->parentDatabaseId : $post->ID;
 
@@ -355,7 +360,7 @@ class PostObject {
 				],
 				'deprecationReason' => __( 'Deprecated in favor of the databaseId field', 'wp-graphql' ),
 				'description'       => __( 'The id field matches the WP_Post->ID field.', 'wp-graphql' ),
-				'resolve'           => function ( Post $post, $args, $context, $info ) {
+				'resolve'           => static function ( Post $post, $args, $context, $info ) {
 					return absint( $post->ID );
 				},
 			],
@@ -435,7 +440,7 @@ class PostObject {
 							'description' => __( 'Format of the field output', 'wp-graphql' ),
 						],
 					],
-					'resolve'     => function ( $source, $args ) {
+					'resolve'     => static function ( $source, $args ) {
 						if ( isset( $args['format'] ) && 'raw' === $args['format'] ) {
 							// @codingStandardsIgnoreLine.
 							return $source->captionRaw;
@@ -458,7 +463,7 @@ class PostObject {
 						],
 					],
 					'description' => __( 'The srcset attribute specifies the URL of the image to use in different situations. It is a comma separated string of urls and their widths.', 'wp-graphql' ),
-					'resolve'     => function ( $source, $args ) {
+					'resolve'     => static function ( $source, $args ) {
 						$size = 'medium';
 						if ( ! empty( $args['size'] ) ) {
 							$size = $args['size'];
@@ -478,7 +483,7 @@ class PostObject {
 						],
 					],
 					'description' => __( 'The sizes attribute value for an image.', 'wp-graphql' ),
-					'resolve'     => function ( $source, $args ) {
+					'resolve'     => static function ( $source, $args ) {
 						$size = 'medium';
 						if ( ! empty( $args['size'] ) ) {
 							$size = $args['size'];
@@ -507,7 +512,7 @@ class PostObject {
 							'description' => __( 'Format of the field output', 'wp-graphql' ),
 						],
 					],
-					'resolve'     => function ( $source, $args ) {
+					'resolve'     => static function ( $source, $args ) {
 						if ( isset( $args['format'] ) && 'raw' === $args['format'] ) {
 							// @codingStandardsIgnoreLine.
 							return $source->descriptionRaw;
@@ -534,7 +539,7 @@ class PostObject {
 							'description' => __( 'Size of the MediaItem to return', 'wp-graphql' ),
 						],
 					],
-					'resolve'     => function ( $image, $args, $context, $info ) {
+					'resolve'     => static function ( $image, $args, $context, $info ) {
 						// @codingStandardsIgnoreLine.
 						$size = null;
 						if ( isset( $args['size'] ) ) {
@@ -553,7 +558,7 @@ class PostObject {
 							'description' => __( 'Size of the MediaItem to return', 'wp-graphql' ),
 						],
 					],
-					'resolve'     => function ( $image, $args, $context, $info ) {
+					'resolve'     => static function ( $image, $args, $context, $info ) {
 
 						// @codingStandardsIgnoreLine.
 						$size = null;

--- a/src/Registry/Utils/TermObject.php
+++ b/src/Registry/Utils/TermObject.php
@@ -34,8 +34,11 @@ class TermObject {
 		$single_name = $tax_object->graphql_single_name;
 
 		$config = [
-			/* translators: post object singular name w/ description */
-			'description' => sprintf( __( 'The %s type', 'wp-graphql' ), $single_name ),
+			'description' => sprintf(
+				// translators: %s is the term object singular name.
+				__( 'The %s type', 'wp-graphql' ),
+				$single_name
+			),
 			'connections' => static::get_connections( $tax_object ),
 			'interfaces'  => static::get_interfaces( $tax_object ),
 			'fields'      => static::get_fields( $tax_object ),
@@ -58,6 +61,7 @@ class TermObject {
 		if ( empty( $tax_object->graphql_resolve_type ) || ! is_callable( $tax_object->graphql_resolve_type ) ) {
 			graphql_debug(
 				sprintf(
+					// translators: %1$s is the term object singular name, %2$s is the graphql kind.
 					__( '%1$s is registered as a GraphQL %2$s, but has no way to resolve the type. Ensure "graphql_resolve_type" is a valid callback function', 'wp-graphql' ),
 					$single_name,
 					$tax_object->graphql_kind
@@ -108,7 +112,7 @@ class TermObject {
 		$connections['taxonomy'] = [
 			'toType'   => 'Taxonomy',
 			'oneToOne' => true,
-			'resolve'  => function ( Term $source, $args, $context, $info ) {
+			'resolve'  => static function ( Term $source, $args, $context, $info ) {
 				if ( empty( $source->taxonomyName ) ) {
 					return null;
 				}
@@ -123,13 +127,14 @@ class TermObject {
 			$connections['children'] = [
 				'toType'         => $tax_object->graphql_single_name,
 				'description'    => sprintf(
+					// translators: %1$s is the term object singular name, %2$s is the term object plural name.
 					__( 'Connection between the %1$s type and its children %2$s.', 'wp-graphql' ),
 					$tax_object->graphql_single_name,
 					$tax_object->graphql_plural_name
 				),
 				'connectionArgs' => TermObjects::get_connection_args(),
 				'queryClass'     => 'WP_Term_Query',
-				'resolve'        => function ( Term $term, $args, AppContext $context, $info ) {
+				'resolve'        => static function ( Term $term, $args, AppContext $context, $info ) {
 					$resolver = new TermObjectConnectionResolver( $term, $args, $context, $info );
 					$resolver->set_query_arg( 'parent', $term->term_id );
 
@@ -142,12 +147,13 @@ class TermObject {
 			$connections['parent'] = [
 				'toType'             => $tax_object->graphql_single_name,
 				'description'        => sprintf(
+					// translators: %s is the term object singular name.
 					__( 'Connection between the %1$s type and its parent %1$s.', 'wp-graphql' ),
 					$tax_object->graphql_single_name
 				),
 				'connectionTypeName' => ucfirst( $tax_object->graphql_single_name ) . 'ToParent' . ucfirst( $tax_object->graphql_single_name ) . 'Connection',
 				'oneToOne'           => true,
-				'resolve'            => function ( Term $term, $args, AppContext $context, $info ) use ( $tax_object ) {
+				'resolve'            => static function ( Term $term, $args, AppContext $context, $info ) use ( $tax_object ) {
 					if ( ! isset( $term->parentDatabaseId ) || empty( $term->parentDatabaseId ) ) {
 						return null;
 					}
@@ -164,7 +170,7 @@ class TermObject {
 				'toType'             => $tax_object->graphql_single_name,
 				'description'        => __( 'The ancestors of the node. Default ordered as lowest (closest to the child) to highest (closest to the root).', 'wp-graphql' ),
 				'connectionTypeName' => ucfirst( $tax_object->graphql_single_name ) . 'ToAncestors' . ucfirst( $tax_object->graphql_single_name ) . 'Connection',
-				'resolve'            => function ( Term $term, $args, AppContext $context, $info ) use ( $tax_object ) {
+				'resolve'            => static function ( Term $term, $args, AppContext $context, $info ) use ( $tax_object ) {
 					if ( ! $tax_object instanceof WP_Taxonomy ) {
 						return null;
 					}
@@ -199,7 +205,7 @@ class TermObject {
 
 				$connections['contentNodes'] = PostObjects::get_connection_config( $tax_object, [
 					'toType'  => 'ContentNode',
-					'resolve' => function ( Term $term, $args, $context, $info ) {
+					'resolve' => static function ( Term $term, $args, $context, $info ) {
 						$resolver = new PostObjectConnectionResolver( $term, $args, $context, $info, 'any' );
 						$resolver->set_query_arg( 'tax_query', [
 							[
@@ -222,7 +228,7 @@ class TermObject {
 			$connections[ $post_type_object->graphql_plural_name ] = PostObjects::get_connection_config( $post_type_object, [
 				'toType'     => $post_type_object->graphql_single_name,
 				'queryClass' => 'WP_Query',
-				'resolve'    => function ( Term $term, $args, AppContext $context, ResolveInfo $info ) use ( $post_type_object ) {
+				'resolve'    => static function ( Term $term, $args, AppContext $context, ResolveInfo $info ) use ( $post_type_object ) {
 					$resolver = new PostObjectConnectionResolver( $term, $args, $context, $info, $post_type_object->name );
 					$resolver->set_query_arg( 'tax_query', [
 						[
@@ -301,12 +307,12 @@ class TermObject {
 				'type'              => 'Int',
 				'deprecationReason' => __( 'Deprecated in favor of databaseId', 'wp-graphql' ),
 				'description'       => __( 'The id field matches the WP_Post->ID field.', 'wp-graphql' ),
-				'resolve'           => function ( Term $term, $args, $context, $info ) {
+				'resolve'           => static function ( Term $term, $args, $context, $info ) {
 					return absint( $term->term_id );
 				},
 			],
 			'uri'               => [
-				'resolve' => function ( $term, $args, $context, $info ) {
+				'resolve' => static function ( $term, $args, $context, $info ) {
 					$url = $term->link;
 					if ( ! empty( $url ) ) {
 						$parsed = wp_parse_url( $url );

--- a/src/Server/ValidationRules/RequireAuthentication.php
+++ b/src/Server/ValidationRules/RequireAuthentication.php
@@ -94,6 +94,7 @@ class RequireAuthentication extends QuerySecurityRule {
 						$context->reportError(
 							new Error(
 								sprintf(
+									// translators: %s is the field name
 									__( 'The field "%s" cannot be accessed without authentication.', 'wp-graphql' ),
 									$context->getParentType() . '.' . $node->name->value
 								),

--- a/src/Type/Connection/Comments.php
+++ b/src/Type/Connection/Comments.php
@@ -37,7 +37,7 @@ class Comments {
 		 */
 		register_graphql_connection( self::get_connection_config( [
 			'fromType' => 'User',
-			'resolve'  => function ( User $user, $args, $context, $info ) {
+			'resolve'  => static function ( User $user, $args, $context, $info ) {
 				$resolver = new CommentConnectionResolver( $user, $args, $context, $info );
 
 				return $resolver->set_query_arg( 'user_id', absint( $user->userId ) )->get_connection();
@@ -51,7 +51,7 @@ class Comments {
 			'fromFieldName'      => 'parent',
 			'connectionTypeName' => 'CommentToParentCommentConnection',
 			'oneToOne'           => true,
-			'resolve'            => function ( Comment $comment, $args, $context, $info ) {
+			'resolve'            => static function ( Comment $comment, $args, $context, $info ) {
 				$resolver = new CommentConnectionResolver( $comment, $args, $context, $info );
 
 				return ! empty( $comment->comment_parent_id ) ? $resolver->one_to_one()->set_query_arg( 'comment__in', [ $comment->comment_parent_id ] )->get_connection() : null;
@@ -66,7 +66,7 @@ class Comments {
 				[
 					'fromType'      => 'Comment',
 					'fromFieldName' => 'replies',
-					'resolve'       => function ( Comment $comment, $args, $context, $info ) {
+					'resolve'       => static function ( Comment $comment, $args, $context, $info ) {
 						$resolver = new CommentConnectionResolver( $comment, $args, $context, $info );
 
 						return $resolver->set_query_arg( 'parent', absint( $comment->commentId ) )->get_connection();
@@ -90,7 +90,7 @@ class Comments {
 			'toType'         => 'Comment',
 			'fromFieldName'  => 'comments',
 			'connectionArgs' => self::get_connection_args(),
-			'resolve'        => function ( $root, $args, $context, $info ) {
+			'resolve'        => static function ( $root, $args, $context, $info ) {
 				return DataSource::resolve_comments_connection( $root, $args, $context, $info );
 			},
 		];

--- a/src/Type/Connection/MenuItems.php
+++ b/src/Type/Connection/MenuItems.php
@@ -40,7 +40,7 @@ class MenuItems {
 				[
 					'fromType'      => 'MenuItem',
 					'fromFieldName' => 'childItems',
-					'resolve'       => function ( MenuItem $menu_item, $args, AppContext $context, ResolveInfo $info ) {
+					'resolve'       => static function ( MenuItem $menu_item, $args, AppContext $context, ResolveInfo $info ) {
 
 						if ( empty( $menu_item->menuId ) || empty( $menu_item->databaseId ) ) {
 							return null;
@@ -65,7 +65,7 @@ class MenuItems {
 				[
 					'fromType' => 'Menu',
 					'toType'   => 'MenuItem',
-					'resolve'  => function ( Menu $menu, $args, AppContext $context, ResolveInfo $info ) {
+					'resolve'  => static function ( Menu $menu, $args, AppContext $context, ResolveInfo $info ) {
 
 						$resolver = new MenuItemConnectionResolver( $menu, $args, $context, $info );
 						$resolver->set_query_arg( 'tax_query', [
@@ -117,7 +117,7 @@ class MenuItems {
 						'description' => __( 'The database ID of the parent menu object', 'wp-graphql' ),
 					],
 				],
-				'resolve'        => function ( $source, $args, $context, $info ) {
+				'resolve'        => static function ( $source, $args, $context, $info ) {
 					$resolver   = new MenuItemConnectionResolver( $source, $args, $context, $info );
 					$connection = $resolver->get_connection();
 

--- a/src/Type/Connection/PostObjects.php
+++ b/src/Type/Connection/PostObjects.php
@@ -38,7 +38,7 @@ class PostObjects {
 			'fromFieldName'  => 'contentNodes',
 			'connectionArgs' => self::get_connection_args(),
 			'queryClass'     => 'WP_Query',
-			'resolve'        => function ( PostType $post_type, $args, AppContext $context, ResolveInfo $info ) {
+			'resolve'        => static function ( PostType $post_type, $args, AppContext $context, ResolveInfo $info ) {
 
 				$resolver = new PostObjectConnectionResolver( $post_type, $args, $context, $info );
 				$resolver->set_query_arg( 'post_type', $post_type->name );
@@ -54,7 +54,7 @@ class PostObjects {
 			'queryClass'    => 'WP_Query',
 			'oneToOne'      => true,
 			'fromFieldName' => 'commentedOn',
-			'resolve'       => function ( Comment $comment, $args, AppContext $context, ResolveInfo $info ) {
+			'resolve'       => static function ( Comment $comment, $args, AppContext $context, ResolveInfo $info ) {
 				if ( empty( $comment->comment_post_ID ) || ! absint( $comment->comment_post_ID ) ) {
 					return null;
 				}
@@ -71,7 +71,7 @@ class PostObjects {
 			'fromFieldName' => 'revisionOf',
 			'description'   => __( 'If the current node is a revision, this field exposes the node this is a revision of. Returns null if the node is not a revision of another node.', 'wp-graphql' ),
 			'oneToOne'      => true,
-			'resolve'       => function ( Post $post, $args, AppContext $context, ResolveInfo $info ) {
+			'resolve'       => static function ( Post $post, $args, AppContext $context, ResolveInfo $info ) {
 
 				if ( ! $post->isRevision || ! isset( $post->parentDatabaseId ) || ! absint( $post->parentDatabaseId ) ) {
 					return null;
@@ -92,7 +92,7 @@ class PostObjects {
 				'queryClass'     => 'WP_Query',
 				'fromFieldName'  => 'contentNodes',
 				'connectionArgs' => self::get_connection_args(),
-				'resolve'        => function ( $source, $args, $context, $info ) {
+				'resolve'        => static function ( $source, $args, $context, $info ) {
 					$post_types = isset( $args['where']['contentTypes'] ) && is_array( $args['where']['contentTypes'] ) ? $args['where']['contentTypes'] : \WPGraphQL::get_allowed_post_types();
 
 					return DataSource::resolve_post_objects_connection( $source, $args, $context, $info, $post_types );
@@ -107,7 +107,7 @@ class PostObjects {
 			'connectionTypeName' => 'HierarchicalContentNodeToParentContentNodeConnection',
 			'description'        => __( 'The parent of the node. The parent object can be of various types', 'wp-graphql' ),
 			'oneToOne'           => true,
-			'resolve'            => function ( Post $post, $args, AppContext $context, ResolveInfo $info ) {
+			'resolve'            => static function ( Post $post, $args, AppContext $context, ResolveInfo $info ) {
 
 				if ( ! isset( $post->parentDatabaseId ) || ! absint( $post->parentDatabaseId ) ) {
 					return null;
@@ -128,7 +128,7 @@ class PostObjects {
 			'connectionTypeName' => 'HierarchicalContentNodeToContentNodeChildrenConnection',
 			'connectionArgs'     => self::get_connection_args(),
 			'queryClass'         => 'WP_Query',
-			'resolve'            => function ( Post $post, $args, $context, $info ) {
+			'resolve'            => static function ( Post $post, $args, $context, $info ) {
 
 				if ( $post->isRevision ) {
 					$id = $post->parentDatabaseId;
@@ -152,7 +152,7 @@ class PostObjects {
 			'connectionTypeName' => 'HierarchicalContentNodeToContentNodeAncestorsConnection',
 			'queryClass'         => 'WP_Query',
 			'description'        => __( 'Returns ancestors of the node. Default ordered as lowest (closest to the child) to highest (closest to the root).', 'wp-graphql' ),
-			'resolve'            => function ( Post $post, $args, $context, $info ) {
+			'resolve'            => static function ( Post $post, $args, $context, $info ) {
 				$ancestors = get_ancestors( $post->ID, '', 'post_type' );
 				if ( empty( $ancestors ) || ! is_array( $ancestors ) ) {
 					return null;
@@ -208,7 +208,7 @@ class PostObjects {
 						$post_type_object,
 						[
 							'fromType' => 'User',
-							'resolve'  => function ( User $user, $args, AppContext $context, ResolveInfo $info ) use ( $post_type_object ) {
+							'resolve'  => static function ( User $user, $args, AppContext $context, ResolveInfo $info ) use ( $post_type_object ) {
 								$resolver = new PostObjectConnectionResolver( $user, $args, $context, $info, $post_type_object->name );
 								$resolver->set_query_arg( 'author', $user->userId );
 
@@ -247,7 +247,7 @@ class PostObjects {
 				'queryClass'     => 'WP_Query',
 				'fromFieldName'  => lcfirst( $graphql_object->graphql_plural_name ),
 				'connectionArgs' => $connection_args,
-				'resolve'        => function ( $root, $args, $context, $info ) use ( $graphql_object ) {
+				'resolve'        => static function ( $root, $args, $context, $info ) use ( $graphql_object ) {
 					return DataSource::resolve_post_objects_connection( $root, $args, $context, $info, $graphql_object->name );
 				},
 			],

--- a/src/Type/Connection/Taxonomies.php
+++ b/src/Type/Connection/Taxonomies.php
@@ -19,7 +19,7 @@ class Taxonomies {
 				'fromType'      => 'RootQuery',
 				'toType'        => 'Taxonomy',
 				'fromFieldName' => 'taxonomies',
-				'resolve'       => function ( $source, $args, $context, $info ) {
+				'resolve'       => static function ( $source, $args, $context, $info ) {
 					$resolver = new TaxonomyConnectionResolver( $source, $args, $context, $info );
 					return $resolver->get_connection();
 				},
@@ -31,7 +31,7 @@ class Taxonomies {
 				'fromType'      => 'ContentType',
 				'toType'        => 'Taxonomy',
 				'fromFieldName' => 'connectedTaxonomies',
-				'resolve'       => function ( PostType $source, $args, $context, $info ) {
+				'resolve'       => static function ( PostType $source, $args, $context, $info ) {
 					if ( empty( $source->taxonomies ) ) {
 						return null;
 					}

--- a/src/Type/Connection/TermObjects.php
+++ b/src/Type/Connection/TermObjects.php
@@ -36,7 +36,7 @@ class TermObjects {
 						],
 					]
 				),
-				'resolve'        => function ( $source, $args, $context, $info ) {
+				'resolve'        => static function ( $source, $args, $context, $info ) {
 					$taxonomies = isset( $args['where']['taxonomies'] ) && is_array( $args['where']['taxonomies'] ) ? $args['where']['taxonomies'] : \WPGraphQL::get_allowed_taxonomies();
 					$resolver   = new TermObjectConnectionResolver( $source, $args, $context, $info, array_values( $taxonomies ) );
 					$connection = $resolver->get_connection();
@@ -96,7 +96,7 @@ class TermObjects {
 			'toType'         => $tax_object->graphql_single_name,
 			'fromFieldName'  => $tax_object->graphql_plural_name,
 			'connectionArgs' => self::get_connection_args(),
-			'resolve'        => function ( $root, $args, $context, $info ) use ( $tax_object ) {
+			'resolve'        => static function ( $root, $args, $context, $info ) use ( $tax_object ) {
 				return DataSource::resolve_term_objects_connection( $root, $args, $context, $info, $tax_object->name );
 			},
 		];

--- a/src/Type/Connection/Users.php
+++ b/src/Type/Connection/Users.php
@@ -32,7 +32,7 @@ class Users {
 				'fromType'       => 'RootQuery',
 				'toType'         => 'User',
 				'fromFieldName'  => 'users',
-				'resolve'        => function ( $source, $args, $context, $info ) {
+				'resolve'        => static function ( $source, $args, $context, $info ) {
 					return DataSource::resolve_users_connection( $source, $args, $context, $info );
 				},
 				'connectionArgs' => self::get_connection_args(),
@@ -47,7 +47,7 @@ class Users {
 				'lockTimestamp' => [
 					'type'        => 'String',
 					'description' => __( 'The timestamp for when the node was last edited', 'wp-graphql' ),
-					'resolve'     => function ( $edge, $args, $context, $info ) {
+					'resolve'     => static function ( $edge, $args, $context, $info ) {
 						if ( isset( $edge['source'] ) && ( $edge['source'] instanceof Post ) ) {
 							$edit_lock = $edge['source']->editLock;
 							$time      = ( is_array( $edit_lock ) && ! empty( $edit_lock[0] ) ) ? $edit_lock[0] : null;
@@ -60,7 +60,7 @@ class Users {
 			'fromFieldName'      => 'editingLockedBy',
 			'description'        => __( 'If a user has edited the node within the past 15 seconds, this will return the user that last edited. Null if the edit lock doesn\'t exist or is greater than 15 seconds', 'wp-graphql' ),
 			'oneToOne'           => true,
-			'resolve'            => function ( Post $source, $args, $context, $info ) {
+			'resolve'            => static function ( Post $source, $args, $context, $info ) {
 
 				if ( ! isset( $source->editLock[1] ) || ! absint( $source->editLock[1] ) ) {
 					return null;
@@ -81,7 +81,7 @@ class Users {
 			'connectionTypeName' => 'ContentNodeToEditLastConnection',
 			'description'        => __( 'The user that most recently edited the node', 'wp-graphql' ),
 			'oneToOne'           => true,
-			'resolve'            => function ( Post $source, $args, $context, $info ) {
+			'resolve'            => static function ( Post $source, $args, $context, $info ) {
 
 				if ( empty( $source->editLastId ) ) {
 					return null;
@@ -99,7 +99,7 @@ class Users {
 			'toType'        => 'User',
 			'fromFieldName' => 'author',
 			'oneToOne'      => true,
-			'resolve'       => function ( Post $post, $args, AppContext $context, ResolveInfo $info ) {
+			'resolve'       => static function ( Post $post, $args, AppContext $context, ResolveInfo $info ) {
 
 				if ( empty( $post->authorDatabaseId ) ) {
 					return null;

--- a/src/Type/Enum/CommentStatusEnum.php
+++ b/src/Type/Enum/CommentStatusEnum.php
@@ -22,6 +22,7 @@ class CommentStatusEnum {
 		foreach ( $stati as $status => $name ) {
 
 			$values[ WPEnumType::get_safe_name( $status ) ] = [
+				// translators: %s is the name of the comment status
 				'description' => sprintf( __( 'Comments with the %1$s status', 'wp-graphql' ), $name ),
 				'value'       => $status,
 			];

--- a/src/Type/Enum/ContentTypeEnum.php
+++ b/src/Type/Enum/ContentTypeEnum.php
@@ -71,7 +71,11 @@ class ContentTypeEnum {
 				register_graphql_enum_type(
 					'ContentTypesOf' . Utils::format_type_name( $tax_object->graphql_single_name ) . 'Enum',
 					[
-						'description' => sprintf( __( 'Allowed Content Types of the %s taxonomy.', 'wp-graphql' ), Utils::format_type_name( $tax_object->graphql_single_name ) ),
+						'description' => sprintf(
+							// translators: %s is the taxonomy's GraphQL name.
+							__( 'Allowed Content Types of the %s taxonomy.', 'wp-graphql' ),
+							Utils::format_type_name( $tax_object->graphql_single_name )
+						),
 						'values'      => $taxonomy_values,
 					]
 				);

--- a/src/Type/Enum/MediaItemSizeEnum.php
+++ b/src/Type/Enum/MediaItemSizeEnum.php
@@ -31,7 +31,11 @@ class MediaItemSizeEnum {
 		 */
 		foreach ( $image_sizes as $image_size ) {
 			$values[ WPEnumType::get_safe_name( $image_size ) ] = [
-				'description' => sprintf( __( 'MediaItem with the %1$s size', 'wp-graphql' ), $image_size ),
+				'description' => sprintf(
+					// translators: %1$s is the image size.
+					__( 'MediaItem with the %1$s size', 'wp-graphql' ),
+					$image_size
+				),
 				'value'       => $image_size,
 			];
 		}

--- a/src/Type/Enum/MediaItemStatusEnum.php
+++ b/src/Type/Enum/MediaItemStatusEnum.php
@@ -27,7 +27,11 @@ class MediaItemStatusEnum {
 		foreach ( $post_stati as $status ) {
 
 			$values[ WPEnumType::get_safe_name( $status ) ] = [
-				'description' => sprintf( __( 'Objects with the %1$s status', 'wp-graphql' ), $status ),
+				'description' => sprintf(
+					// translators: %1$s is the post status.
+					__( 'Objects with the %1$s status', 'wp-graphql' ),
+					$status
+				),
 				'value'       => $status,
 			];
 		}

--- a/src/Type/Enum/MenuLocationEnum.php
+++ b/src/Type/Enum/MenuLocationEnum.php
@@ -20,7 +20,11 @@ class MenuLocationEnum {
 			foreach ( $locations as $location ) {
 				$values[ WPEnumType::get_safe_name( $location ) ] = [
 					'value'       => $location,
-					'description' => sprintf( __( 'Put the menu in the %s location', 'wp-graphql' ), $location ),
+					'description' => sprintf(
+						// translators: %s is the menu location name.
+						__( 'Put the menu in the %s location', 'wp-graphql' ),
+						$location
+					),
 				];
 			}
 		}

--- a/src/Type/Enum/MimeTypeEnum.php
+++ b/src/Type/Enum/MimeTypeEnum.php
@@ -26,7 +26,11 @@ class MimeTypeEnum {
 			foreach ( $allowed_mime_types as $mime_type ) {
 				$values[ WPEnumType::get_safe_name( $mime_type ) ] = [
 					'value'       => $mime_type,
-					'description' => sprintf( __( 'MimeType %s', 'wp-graphql' ), $mime_type ),
+					'description' => sprintf(
+						// translators: %s is the mime type.
+						__( '%s mime type.', 'wp-graphql' ),
+						$mime_type
+					),
 				];
 			}
 		}

--- a/src/Type/Enum/PostStatusEnum.php
+++ b/src/Type/Enum/PostStatusEnum.php
@@ -34,7 +34,11 @@ class PostStatusEnum {
 				}
 
 				$post_status_enum_values[ WPEnumType::get_safe_name( $status ) ] = [
-					'description' => sprintf( __( 'Objects with the %1$s status', 'wp-graphql' ), $status ),
+					'description' => sprintf(
+						// translators: %1$s is the post status.
+						__( 'Objects with the %1$s status', 'wp-graphql' ),
+						$status
+					),
 					'value'       => $status,
 				];
 			}

--- a/src/Type/Enum/TaxonomyEnum.php
+++ b/src/Type/Enum/TaxonomyEnum.php
@@ -26,7 +26,11 @@ class TaxonomyEnum {
 			if ( ! isset( $values[ WPEnumType::get_safe_name( $tax_object->graphql_single_name ) ] ) ) {
 				$values[ WPEnumType::get_safe_name( $tax_object->graphql_single_name ) ] = [
 					'value'       => $tax_object->name,
-					'description' => sprintf( __( 'Taxonomy enum %s', 'wp-graphql' ), $tax_object->name ),
+					'description' => sprintf(
+						// translators: %s is the taxonomy name.
+						__( 'Taxonomy enum %s', 'wp-graphql' ),
+						$tax_object->name
+					),
 				];
 			}
 		}

--- a/src/Type/Enum/TimezoneEnum.php
+++ b/src/Type/Enum/TimezoneEnum.php
@@ -182,7 +182,11 @@ class TimezoneEnum {
 			// Intentionally avoid WPEnumType::get_safe_name here for specific timezone formatting
 			$enum_values[ WPEnumType::get_safe_name( $offset_name ) ] = [
 				'value'       => $offset_value,
-				'description' => sprintf( __( 'UTC offset: %s', 'wp-graphql' ), $offset_name ),
+				'description' => sprintf(
+					// translators: %s is the UTC offset.
+					__( 'UTC offset: %s', 'wp-graphql' ),
+					$offset_name
+				),
 			];
 
 		}

--- a/src/Type/InterfaceType/Commenter.php
+++ b/src/Type/InterfaceType/Commenter.php
@@ -24,7 +24,7 @@ class Commenter {
 		register_graphql_interface_type( 'Commenter', [
 			'description' => __( 'The author of a comment', 'wp-graphql' ),
 			'interfaces'  => [ 'Node', 'DatabaseIdentifier' ],
-			'resolveType' => function ( $comment_author ) use ( $type_registry ) {
+			'resolveType' => static function ( $comment_author ) use ( $type_registry ) {
 				if ( $comment_author instanceof User ) {
 					$type = $type_registry->get_type( 'User' );
 				} else {

--- a/src/Type/InterfaceType/ContentNode.php
+++ b/src/Type/InterfaceType/ContentNode.php
@@ -32,7 +32,7 @@ class ContentNode {
 				'connections' => [
 					'contentType'         => [
 						'toType'   => 'ContentType',
-						'resolve'  => function ( Post $source, $args, $context, $info ) {
+						'resolve'  => static function ( Post $source, $args, $context, $info ) {
 
 							if ( $source->isRevision ) {
 								$parent    = get_post( $source->parentDatabaseId );
@@ -53,7 +53,7 @@ class ContentNode {
 					],
 					'enqueuedScripts'     => [
 						'toType'  => 'EnqueuedScript',
-						'resolve' => function ( $source, $args, $context, $info ) {
+						'resolve' => static function ( $source, $args, $context, $info ) {
 							$resolver = new EnqueuedScriptsConnectionResolver( $source, $args, $context, $info );
 
 							return $resolver->get_connection();
@@ -61,13 +61,13 @@ class ContentNode {
 					],
 					'enqueuedStylesheets' => [
 						'toType'  => 'EnqueuedStylesheet',
-						'resolve' => function ( $source, $args, $context, $info ) {
+						'resolve' => static function ( $source, $args, $context, $info ) {
 							$resolver = new EnqueuedStylesheetConnectionResolver( $source, $args, $context, $info );
 							return $resolver->get_connection();
 						},
 					],
 				],
-				'resolveType' => function ( Post $post ) use ( $type_registry ) {
+				'resolveType' => static function ( Post $post ) use ( $type_registry ) {
 
 					/**
 					 * The resolveType callback is used at runtime to determine what Type an object
@@ -100,7 +100,7 @@ class ContentNode {
 					'contentTypeName'           => [
 						'type'        => [ 'non_null' => 'String' ],
 						'description' => __( 'The name of the Content Type the node belongs to', 'wp-graphql' ),
-						'resolve'     => function ( $node ) {
+						'resolve'     => static function ( $node ) {
 							return $node->post_type;
 						},
 					],

--- a/src/Type/InterfaceType/ContentTemplate.php
+++ b/src/Type/InterfaceType/ContentTemplate.php
@@ -20,7 +20,7 @@ class ContentTemplate {
 						'description' => __( 'The name of the template', 'wp-graphql' ),
 					],
 				],
-				'resolveType' => function ( $value ) {
+				'resolveType' => static function ( $value ) {
 					return isset( $value['__typename'] ) ? $value['__typename'] : 'DefaultTemplate';
 				},
 			]
@@ -68,7 +68,7 @@ class ContentTemplate {
 					'description'     => __( 'The template assigned to the node', 'wp-graphql' ),
 					'fields'          => [
 						'templateName' => [
-							'resolve' => function ( $template ) {
+							'resolve' => static function ( $template ) {
 								return isset( $template['templateName'] ) ? $template['templateName'] : null;
 							},
 						],

--- a/src/Type/InterfaceType/EnqueuedAsset.php
+++ b/src/Type/InterfaceType/EnqueuedAsset.php
@@ -21,7 +21,7 @@ class EnqueuedAsset {
 
 		register_graphql_interface_type( 'EnqueuedAsset', [
 			'description' => __( 'Asset enqueued by the CMS', 'wp-graphql' ),
-			'resolveType' => function ( $asset ) use ( $type_registry ) {
+			'resolveType' => static function ( $asset ) use ( $type_registry ) {
 
 				/**
 				 * The resolveType callback is used at runtime to determine what Type an object
@@ -72,7 +72,7 @@ class EnqueuedAsset {
 				'extra'        => [
 					'type'        => 'String',
 					'description' => __( 'Extra information needed for the script', 'wp-graphql' ),
-					'resolve'     => function ( $asset ) {
+					'resolve'     => static function ( $asset ) {
 						return isset( $asset->extra['data'] ) ? $asset->extra['data'] : null;
 					},
 				],

--- a/src/Type/InterfaceType/MenuItemLinkable.php
+++ b/src/Type/InterfaceType/MenuItemLinkable.php
@@ -24,7 +24,7 @@ class MenuItemLinkable {
 			'description' => __( 'Nodes that can be linked to as Menu Items', 'wp-graphql' ),
 			'interfaces'  => [ 'Node', 'UniformResourceIdentifiable', 'DatabaseIdentifier' ],
 			'fields'      => [],
-			'resolveType' => function ( $node ) use ( $type_registry ) {
+			'resolveType' => static function ( $node ) use ( $type_registry ) {
 
 				switch ( true ) {
 					case $node instanceof Post:

--- a/src/Type/InterfaceType/Node.php
+++ b/src/Type/InterfaceType/Node.php
@@ -21,7 +21,7 @@ class Node {
 						'description' => __( 'The globally unique ID for the object', 'wp-graphql' ),
 					],
 				],
-				'resolveType' => function ( $node ) {
+				'resolveType' => static function ( $node ) {
 					return DataSource::resolve_node_type( $node );
 				},
 			]

--- a/src/Type/InterfaceType/NodeWithContentEditor.php
+++ b/src/Type/InterfaceType/NodeWithContentEditor.php
@@ -27,7 +27,7 @@ class NodeWithContentEditor {
 								'description' => __( 'Format of the field output', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function ( $source, $args ) {
+						'resolve'     => static function ( $source, $args ) {
 							if ( isset( $args['format'] ) && 'raw' === $args['format'] ) {
 								// @codingStandardsIgnoreLine.
 								return $source->contentRaw;

--- a/src/Type/InterfaceType/NodeWithExcerpt.php
+++ b/src/Type/InterfaceType/NodeWithExcerpt.php
@@ -28,7 +28,7 @@ class NodeWithExcerpt {
 								'description' => __( 'Format of the field output', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function ( $source, $args ) {
+						'resolve'     => static function ( $source, $args ) {
 							if ( isset( $args['format'] ) && 'raw' === $args['format'] ) {
 								// @codingStandardsIgnoreLine.
 								return $source->excerptRaw;

--- a/src/Type/InterfaceType/NodeWithFeaturedImage.php
+++ b/src/Type/InterfaceType/NodeWithFeaturedImage.php
@@ -29,7 +29,7 @@ class NodeWithFeaturedImage {
 					'featuredImage' => [
 						'toType'   => 'MediaItem',
 						'oneToOne' => true,
-						'resolve'  => function ( Post $post, $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'  => static function ( Post $post, $args, AppContext $context, ResolveInfo $info ) {
 
 							if ( empty( $post->featuredImageDatabaseId ) ) {
 								return null;

--- a/src/Type/InterfaceType/NodeWithTitle.php
+++ b/src/Type/InterfaceType/NodeWithTitle.php
@@ -33,7 +33,7 @@ class NodeWithTitle {
 								'description' => __( 'Format of the field output', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function ( $source, $args ) {
+						'resolve'     => static function ( $source, $args ) {
 							if ( isset( $args['format'] ) && 'raw' === $args['format'] ) {
 								// @codingStandardsIgnoreLine.
 								return $source->titleRaw;

--- a/src/Type/InterfaceType/Previewable.php
+++ b/src/Type/InterfaceType/Previewable.php
@@ -35,7 +35,7 @@ class Previewable {
 						'description' => __( 'Whether the object is a node in the preview state', 'wp-graphql' ),
 					],
 				],
-				'resolveType' => function ( Post $post ) use ( $type_registry ) {
+				'resolveType' => static function ( Post $post ) use ( $type_registry ) {
 
 					$type = 'Post';
 

--- a/src/Type/InterfaceType/TermNode.php
+++ b/src/Type/InterfaceType/TermNode.php
@@ -28,7 +28,7 @@ class TermNode {
 				'connections' => [
 					'enqueuedScripts'     => [
 						'toType'  => 'EnqueuedScript',
-						'resolve' => function ( $source, $args, $context, $info ) {
+						'resolve' => static function ( $source, $args, $context, $info ) {
 							$resolver = new EnqueuedScriptsConnectionResolver( $source, $args, $context, $info );
 
 							return $resolver->get_connection();
@@ -36,14 +36,14 @@ class TermNode {
 					],
 					'enqueuedStylesheets' => [
 						'toType'  => 'EnqueuedStylesheet',
-						'resolve' => function ( $source, $args, $context, $info ) {
+						'resolve' => static function ( $source, $args, $context, $info ) {
 							$resolver = new EnqueuedStylesheetConnectionResolver( $source, $args, $context, $info );
 							return $resolver->get_connection();
 						},
 					],
 				],
 				'description' => __( 'Terms are nodes within a Taxonomy, used to group and relate other nodes.', 'wp-graphql' ),
-				'resolveType' => function ( $term ) use ( $type_registry ) {
+				'resolveType' => static function ( $term ) use ( $type_registry ) {
 
 					/**
 					 * The resolveType callback is used at runtime to determine what Type an object
@@ -69,7 +69,7 @@ class TermNode {
 					'databaseId'     => [
 						'type'        => [ 'non_null' => 'Int' ],
 						'description' => __( 'Identifies the primary key from the database.', 'wp-graphql' ),
-						'resolve'     => function ( Term $term, $args, $context, $info ) {
+						'resolve'     => static function ( Term $term, $args, $context, $info ) {
 							return absint( $term->term_id );
 						},
 					],

--- a/src/Type/InterfaceType/UniformResourceIdentifiable.php
+++ b/src/Type/InterfaceType/UniformResourceIdentifiable.php
@@ -36,19 +36,19 @@ class UniformResourceIdentifiable {
 					'isContentNode' => [
 						'type'        => [ 'non_null' => 'Boolean' ],
 						'description' => __( 'Whether the node is a Content Node', 'wp-graphql' ),
-						'resolve'     => function ( $node ) {
+						'resolve'     => static function ( $node ) {
 							return $node instanceof Post;
 						},
 					],
 					'isTermNode'    => [
 						'type'        => [ 'non_null' => 'Boolean' ],
 						'description' => __( 'Whether the node is a Term', 'wp-graphql' ),
-						'resolve'     => function ( $node ) {
+						'resolve'     => static function ( $node ) {
 							return $node instanceof Term;
 						},
 					],
 				],
-				'resolveType' => function ( $node ) use ( $type_registry ) {
+				'resolveType' => static function ( $node ) use ( $type_registry ) {
 
 					switch ( true ) {
 						case $node instanceof Post:

--- a/src/Type/ObjectType/Comment.php
+++ b/src/Type/ObjectType/Comment.php
@@ -30,7 +30,7 @@ class Comment {
 						'toType'      => 'Commenter',
 						'description' => __( 'The author of the comment', 'wp-graphql' ),
 						'oneToOne'    => true,
-						'resolve'     => function ( $comment, $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => static function ( $comment, $args, AppContext $context, ResolveInfo $info ) {
 
 							$node = null;
 
@@ -62,7 +62,7 @@ class Comment {
 						'type'              => 'Boolean',
 						'description'       => __( 'The approval status of the comment. This field is equivalent to WP_Comment->comment_approved and the value matching the "comment_approved" column in SQL.', 'wp-graphql' ),
 						'deprecationReason' => __( 'Deprecated in favor of the `status` field', 'wp-graphql' ),
-						'resolve'           => function ( $comment, $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'           => static function ( $comment, $args, AppContext $context, ResolveInfo $info ) {
 							return 'approve' === $comment->status;
 						},
 					],
@@ -84,7 +84,7 @@ class Comment {
 								'description' => __( 'Format of the field output', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function ( \WPGraphQL\Model\Comment $comment, $args ) {
+						'resolve'     => static function ( \WPGraphQL\Model\Comment $comment, $args ) {
 							if ( isset( $args['format'] ) && 'raw' === $args['format'] ) {
 								return isset( $comment->contentRaw ) ? $comment->contentRaw : null;
 							} else {

--- a/src/Type/ObjectType/CommentAuthor.php
+++ b/src/Type/ObjectType/CommentAuthor.php
@@ -56,7 +56,7 @@ class CommentAuthor {
 							],
 
 						],
-						'resolve' => function ( $comment_author, $args, $context, $info ) {
+						'resolve' => static function ( $comment_author, $args, $context, $info ) {
 							/**
 							 * If the $comment_author is a user, the User model only returns the email address if the requesting user is authenticated.
 							 * But, to resolve the Avatar we need a valid email, even for unauthenticated requests.

--- a/src/Type/ObjectType/EnqueuedScript.php
+++ b/src/Type/ObjectType/EnqueuedScript.php
@@ -25,17 +25,17 @@ class EnqueuedScript {
 					'type'    => [
 						'non_null' => 'ID',
 					],
-					'resolve' => function ( $asset ) {
+					'resolve' => static function ( $asset ) {
 						return isset( $asset->handle ) ? Relay::toGlobalId( 'enqueued_script', $asset->handle ) : null;
 					},
 				],
 				'src'     => [
-					'resolve' => function ( \_WP_Dependency $script ) {
+					'resolve' => static function ( \_WP_Dependency $script ) {
 						return ! empty( $script->src ) && is_string( $script->src ) ? $script->src : null;
 					},
 				],
 				'version' => [
-					'resolve' => function ( \_WP_Dependency $script ) {
+					'resolve' => static function ( \_WP_Dependency $script ) {
 						global $wp_scripts;
 
 						return ! empty( $script->ver ) && is_string( $script->ver ) ? (string) $script->ver : $wp_scripts->default_version;

--- a/src/Type/ObjectType/EnqueuedStylesheet.php
+++ b/src/Type/ObjectType/EnqueuedStylesheet.php
@@ -25,17 +25,17 @@ class EnqueuedStylesheet {
 					'type'    => [
 						'non_null' => 'ID',
 					],
-					'resolve' => function ( $asset ) {
+					'resolve' => static function ( $asset ) {
 						return isset( $asset->handle ) ? Relay::toGlobalId( 'enqueued_stylesheet', $asset->handle ) : null;
 					},
 				],
 				'src'     => [
-					'resolve' => function ( \_WP_Dependency $stylesheet ) {
+					'resolve' => static function ( \_WP_Dependency $stylesheet ) {
 						return ! empty( $stylesheet->src ) && is_string( $stylesheet->src ) ? $stylesheet->src : null;
 					},
 				],
 				'version' => [
-					'resolve' => function ( \_WP_Dependency $stylesheet ) {
+					'resolve' => static function ( \_WP_Dependency $stylesheet ) {
 						global $wp_styles;
 
 						return ! empty( $stylesheet->ver ) && is_string( $stylesheet->ver ) ? $stylesheet->ver : $wp_styles->default_version;

--- a/src/Type/ObjectType/MediaDetails.php
+++ b/src/Type/ObjectType/MediaDetails.php
@@ -42,7 +42,7 @@ class MediaDetails {
 							],
 						],
 						'description' => __( 'The available sizes of the mediaItem', 'wp-graphql' ),
-						'resolve'     => function ( $media_details, array $args ) {
+						'resolve'     => static function ( $media_details, array $args ) {
 							// Bail early.
 							if ( empty( $media_details['sizes'] ) ) {
 								return null;
@@ -72,7 +72,7 @@ class MediaDetails {
 					'meta'   => [
 						'type'        => 'MediaItemMeta',
 						'description' => __( 'Meta information associated with the mediaItem', 'wp-graphql' ),
-						'resolve'     => function ( $media_details ) {
+						'resolve'     => static function ( $media_details ) {
 							return ! empty( $media_details['image_meta'] ) ? $media_details['image_meta'] : null;
 						},
 					],

--- a/src/Type/ObjectType/MediaItemMeta.php
+++ b/src/Type/ObjectType/MediaItemMeta.php
@@ -39,7 +39,7 @@ class MediaItemMeta {
 					'createdTimestamp' => [
 						'type'        => 'Int',
 						'description' => __( 'The date/time when the media was created.', 'wp-graphql' ),
-						'resolve'     => function ( $meta, $args, $context, $info ) {
+						'resolve'     => static function ( $meta, $args, $context, $info ) {
 							return ! empty( $meta['created_timestamp'] ) ? $meta['created_timestamp'] : null;
 						},
 					],
@@ -50,7 +50,7 @@ class MediaItemMeta {
 					'focalLength'      => [
 						'type'        => 'Float',
 						'description' => __( 'The focal length value of the media item.', 'wp-graphql' ),
-						'resolve'     => function ( $meta, $args, $context, $info ) {
+						'resolve'     => static function ( $meta, $args, $context, $info ) {
 							return ! empty( $meta['focal_length'] ) ? $meta['focal_length'] : null;
 						},
 					],
@@ -61,7 +61,7 @@ class MediaItemMeta {
 					'shutterSpeed'     => [
 						'type'        => 'Float',
 						'description' => __( 'The shutter speed information of the media item.', 'wp-graphql' ),
-						'resolve'     => function ( $meta, $args, $context, $info ) {
+						'resolve'     => static function ( $meta, $args, $context, $info ) {
 							return ! empty( $meta['shutter_speed'] ) ? $meta['shutter_speed'] : null;
 						},
 					],

--- a/src/Type/ObjectType/MediaSize.php
+++ b/src/Type/ObjectType/MediaSize.php
@@ -34,14 +34,14 @@ class MediaSize {
 					'mimeType'  => [
 						'type'        => 'String',
 						'description' => __( 'The mime type of the referenced size', 'wp-graphql' ),
-						'resolve'     => function ( $image, $args, $context, $info ) {
+						'resolve'     => static function ( $image, $args, $context, $info ) {
 							return ! empty( $image['mime-type'] ) ? $image['mime-type'] : null;
 						},
 					],
 					'fileSize'  => [
 						'type'        => 'Int',
 						'description' => __( 'The filesize of the resource', 'wp-graphql' ),
-						'resolve'     => function ( $image, $args, $context, $info ) {
+						'resolve'     => static function ( $image, $args, $context, $info ) {
 
 							$src_url = null;
 
@@ -58,7 +58,7 @@ class MediaSize {
 					'sourceUrl' => [
 						'type'        => 'String',
 						'description' => __( 'The url of the referenced size', 'wp-graphql' ),
-						'resolve'     => function ( $image, $args, $context, $info ) {
+						'resolve'     => static function ( $image, $args, $context, $info ) {
 
 							$src_url = null;
 

--- a/src/Type/ObjectType/MenuItem.php
+++ b/src/Type/ObjectType/MenuItem.php
@@ -28,7 +28,7 @@ class MenuItem {
 						'toType'      => 'MenuItemLinkable',
 						'description' => __( 'Connection from MenuItem to it\'s connected node', 'wp-graphql' ),
 						'oneToOne'    => true,
-						'resolve'     => function ( MenuItemModel $menu_item, $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => static function ( MenuItemModel $menu_item, $args, AppContext $context, ResolveInfo $info ) {
 
 							if ( ! isset( $menu_item->databaseId ) ) {
 								return null;
@@ -65,7 +65,7 @@ class MenuItem {
 						'toType'      => 'Menu',
 						'description' => __( 'The Menu a MenuItem is part of', 'wp-graphql' ),
 						'oneToOne'    => true,
-						'resolve'     => function ( MenuItemModel $menu_item, $args, $context, $info ) {
+						'resolve'     => static function ( MenuItemModel $menu_item, $args, $context, $info ) {
 							$resolver = new MenuConnectionResolver( $menu_item, $args, $context, $info );
 							$resolver->set_query_arg( 'include', $menu_item->menuDatabaseId );
 
@@ -148,7 +148,7 @@ class MenuItem {
 						'type'              => 'MenuItemObjectUnion',
 						'deprecationReason' => __( 'Deprecated in favor of the connectedNode field', 'wp-graphql' ),
 						'description'       => __( 'The object connected to this menu item.', 'wp-graphql' ),
-						'resolve'           => function ( $menu_item, array $args, AppContext $context, $info ) {
+						'resolve'           => static function ( $menu_item, array $args, AppContext $context, $info ) {
 
 							$object_id   = intval( get_post_meta( $menu_item->menuItemId, '_menu_item_object_id', true ) );
 							$object_type = get_post_meta( $menu_item->menuItemId, '_menu_item_type', true );

--- a/src/Type/ObjectType/PostTypeLabelDetails.php
+++ b/src/Type/ObjectType/PostTypeLabelDetails.php
@@ -27,84 +27,84 @@ class PostTypeLabelDetails {
 					'singularName'        => [
 						'type'        => 'String',
 						'description' => __( 'Name for one object of this post type.', 'wp-graphql' ),
-						'resolve'     => function ( $labels ) {
+						'resolve'     => static function ( $labels ) {
 							return ! empty( $labels->singular_name ) ? $labels->singular_name : null;
 						},
 					],
 					'addNew'              => [
 						'type'        => 'String',
 						'description' => __( 'Default is ‘Add New’ for both hierarchical and non-hierarchical types.', 'wp-graphql' ),
-						'resolve'     => function ( $labels ) {
+						'resolve'     => static function ( $labels ) {
 							return ! empty( $labels->add_new ) ? $labels->add_new : null;
 						},
 					],
 					'addNewItem'          => [
 						'type'        => 'String',
 						'description' => __( 'Label for adding a new singular item.', 'wp-graphql' ),
-						'resolve'     => function ( $labels ) {
+						'resolve'     => static function ( $labels ) {
 							return ! empty( $labels->add_new_item ) ? $labels->add_new_item : null;
 						},
 					],
 					'editItem'            => [
 						'type'        => 'String',
 						'description' => __( 'Label for editing a singular item.', 'wp-graphql' ),
-						'resolve'     => function ( $labels ) {
+						'resolve'     => static function ( $labels ) {
 							return ! empty( $labels->edit_item ) ? $labels->edit_item : null;
 						},
 					],
 					'newItem'             => [
 						'type'        => 'String',
 						'description' => __( 'Label for the new item page title.', 'wp-graphql' ),
-						'resolve'     => function ( $labels ) {
+						'resolve'     => static function ( $labels ) {
 							return ! empty( $labels->new_item ) ? $labels->new_item : null;
 						},
 					],
 					'viewItem'            => [
 						'type'        => 'String',
 						'description' => __( 'Label for viewing a singular item.', 'wp-graphql' ),
-						'resolve'     => function ( $labels ) {
+						'resolve'     => static function ( $labels ) {
 							return ! empty( $labels->view_item ) ? $labels->view_item : null;
 						},
 					],
 					'viewItems'           => [
 						'type'        => 'String',
 						'description' => __( 'Label for viewing post type archives.', 'wp-graphql' ),
-						'resolve'     => function ( $labels ) {
+						'resolve'     => static function ( $labels ) {
 							return ! empty( $labels->view_items ) ? $labels->view_items : null;
 						},
 					],
 					'searchItems'         => [
 						'type'        => 'String',
 						'description' => __( 'Label for searching plural items.', 'wp-graphql' ),
-						'resolve'     => function ( $labels ) {
+						'resolve'     => static function ( $labels ) {
 							return ! empty( $labels->search_items ) ? $labels->search_items : null;
 						},
 					],
 					'notFound'            => [
 						'type'        => 'String',
 						'description' => __( 'Label used when no items are found.', 'wp-graphql' ),
-						'resolve'     => function ( $labels ) {
+						'resolve'     => static function ( $labels ) {
 							return ! empty( $labels->not_found ) ? $labels->not_found : null;
 						},
 					],
 					'notFoundInTrash'     => [
 						'type'        => 'String',
 						'description' => __( 'Label used when no items are in the trash.', 'wp-graphql' ),
-						'resolve'     => function ( $labels ) {
+						'resolve'     => static function ( $labels ) {
 							return ! empty( $labels->not_found_in_trash ) ? $labels->not_found_in_trash : null;
 						},
 					],
 					'parentItemColon'     => [
 						'type'        => 'String',
 						'description' => __( 'Label used to prefix parents of hierarchical items.', 'wp-graphql' ),
-						'resolve'     => function ( $labels ) {
+						'resolve'     => static function ( $labels ) {
 							return ! empty( $labels->parent_item_colon ) ? $labels->parent_item_colon : null;
 						},
 					],
 					'allItems'            => [
 						'type'        => 'String',
 						'description' => __( 'Label to signify all items in a submenu link.', 'wp-graphql' ),
-						'resolve'     => function ( $labels ) {
+						'resolve'     => static function ( $labels ) {
 							return ! empty( $labels->all_items ) ? $labels->all_items : null;
 						},
 					],
@@ -119,70 +119,70 @@ class PostTypeLabelDetails {
 					'insertIntoItem'      => [
 						'type'        => 'String',
 						'description' => __( 'Label for the media frame button.', 'wp-graphql' ),
-						'resolve'     => function ( $labels ) {
+						'resolve'     => static function ( $labels ) {
 							return ! empty( $labels->insert_into_item ) ? $labels->insert_into_item : null;
 						},
 					],
 					'uploadedToThisItem'  => [
 						'type'        => 'String',
 						'description' => __( 'Label for the media frame filter.', 'wp-graphql' ),
-						'resolve'     => function ( $labels ) {
+						'resolve'     => static function ( $labels ) {
 							return ! empty( $labels->uploaded_to_this_item ) ? $labels->uploaded_to_this_item : null;
 						},
 					],
 					'featuredImage'       => [
 						'type'        => 'String',
 						'description' => __( 'Label for the Featured Image meta box title.', 'wp-graphql' ),
-						'resolve'     => function ( $labels ) {
+						'resolve'     => static function ( $labels ) {
 							return ! empty( $labels->featured_image ) ? $labels->featured_image : null;
 						},
 					],
 					'setFeaturedImage'    => [
 						'type'        => 'String',
 						'description' => __( 'Label for setting the featured image.', 'wp-graphql' ),
-						'resolve'     => function ( $labels ) {
+						'resolve'     => static function ( $labels ) {
 							return ! empty( $labels->set_featured_image ) ? $labels->set_featured_image : null;
 						},
 					],
 					'removeFeaturedImage' => [
 						'type'        => 'String',
 						'description' => __( 'Label for removing the featured image.', 'wp-graphql' ),
-						'resolve'     => function ( $labels ) {
+						'resolve'     => static function ( $labels ) {
 							return ! empty( $labels->remove_featured_image ) ? $labels->remove_featured_image : null;
 						},
 					],
 					'useFeaturedImage'    => [
 						'type'        => 'String',
 						'description' => __( 'Label in the media frame for using a featured image.', 'wp-graphql' ),
-						'resolve'     => function ( $labels ) {
+						'resolve'     => static function ( $labels ) {
 							return ! empty( $labels->use_featured_item ) ? $labels->use_featured_item : null;
 						},
 					],
 					'menuName'            => [
 						'type'        => 'String',
 						'description' => __( 'Label for the menu name.', 'wp-graphql' ),
-						'resolve'     => function ( $labels ) {
+						'resolve'     => static function ( $labels ) {
 							return ! empty( $labels->menu_name ) ? $labels->menu_name : null;
 						},
 					],
 					'filterItemsList'     => [
 						'type'        => 'String',
 						'description' => __( 'Label for the table views hidden heading.', 'wp-graphql' ),
-						'resolve'     => function ( $labels ) {
+						'resolve'     => static function ( $labels ) {
 							return ! empty( $labels->filter_items_list ) ? $labels->filter_items_list : null;
 						},
 					],
 					'itemsListNavigation' => [
 						'type'        => 'String',
 						'description' => __( 'Label for the table pagination hidden heading.', 'wp-graphql' ),
-						'resolve'     => function ( $labels ) {
+						'resolve'     => static function ( $labels ) {
 							return ! empty( $labels->items_list_navigation ) ? $labels->items_list_navigation : null;
 						},
 					],
 					'itemsList'           => [
 						'type'        => 'String',
 						'description' => __( 'Label for the table hidden heading.', 'wp-graphql' ),
-						'resolve'     => function ( $labels ) {
+						'resolve'     => static function ( $labels ) {
 							return ! empty( $labels->items_list ) ? $labels->items_list : null;
 						},
 					],

--- a/src/Type/ObjectType/RootMutation.php
+++ b/src/Type/ObjectType/RootMutation.php
@@ -25,7 +25,7 @@ class RootMutation {
 								'description' => __( 'The count to increase', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function ( $root, $args ) {
+						'resolve'     => static function ( $root, $args ) {
 							return isset( $args['count'] ) ? absint( $args['count'] ) + 1 : null;
 						},
 					],

--- a/src/Type/ObjectType/RootQuery.php
+++ b/src/Type/ObjectType/RootQuery.php
@@ -37,7 +37,7 @@ class RootQuery {
 				'connections' => [
 					'contentTypes'          => [
 						'toType'  => 'ContentType',
-						'resolve' => function ( $source, $args, $context, $info ) {
+						'resolve' => static function ( $source, $args, $context, $info ) {
 							$resolver = new ContentTypeConnectionResolver( $source, $args, $context, $info );
 
 							return $resolver->get_connection();
@@ -59,7 +59,7 @@ class RootQuery {
 								'description' => __( 'The slug of the menu to query items for', 'wp-graphql' ),
 							],
 						],
-						'resolve'        => function ( $source, $args, $context, $info ) {
+						'resolve'        => static function ( $source, $args, $context, $info ) {
 							$resolver = new MenuConnectionResolver( $source, $args, $context, $info, 'nav_menu' );
 
 							return $resolver->get_connection();
@@ -82,13 +82,13 @@ class RootQuery {
 								'description' => __( 'Retrieve plugins where plugin status is in an array.', 'wp-graphql' ),
 							],
 						],
-						'resolve'        => function ( $root, $args, $context, $info ) {
+						'resolve'        => static function ( $root, $args, $context, $info ) {
 							return DataSource::resolve_plugins_connection( $root, $args, $context, $info );
 						},
 					],
 					'registeredScripts'     => [
 						'toType'  => 'EnqueuedScript',
-						'resolve' => function ( $source, $args, $context, $info ) {
+						'resolve' => static function ( $source, $args, $context, $info ) {
 
 							// The connection resolver expects the source to include
 							// enqueuedScriptsQueue
@@ -104,7 +104,7 @@ class RootQuery {
 					],
 					'registeredStylesheets' => [
 						'toType'  => 'EnqueuedStylesheet',
-						'resolve' => function ( $source, $args, $context, $info ) {
+						'resolve' => static function ( $source, $args, $context, $info ) {
 
 							// The connection resolver expects the source to include
 							// enqueuedStylesheetsQueue
@@ -120,7 +120,7 @@ class RootQuery {
 					],
 					'themes'                => [
 						'toType'  => 'Theme',
-						'resolve' => function ( $root, $args, $context, $info ) {
+						'resolve' => static function ( $root, $args, $context, $info ) {
 							$resolver = new ThemeConnectionResolver( $root, $args, $context, $info );
 
 							return $resolver->get_connection();
@@ -130,7 +130,7 @@ class RootQuery {
 						'toType'         => 'ContentNode',
 						'queryClass'     => 'WP_Query',
 						'connectionArgs' => PostObjects::get_connection_args(),
-						'resolve'        => function ( $root, $args, $context, $info ) {
+						'resolve'        => static function ( $root, $args, $context, $info ) {
 							$resolver = new PostObjectConnectionResolver( $root, $args, $context, $info, 'revision' );
 
 							return $resolver->get_connection();
@@ -139,7 +139,7 @@ class RootQuery {
 					'userRoles'             => [
 						'toType'        => 'UserRole',
 						'fromFieldName' => 'userRoles',
-						'resolve'       => function ( $user, $args, $context, $info ) {
+						'resolve'       => static function ( $user, $args, $context, $info ) {
 							$resolver = new UserRoleConnectionResolver( $user, $args, $context, $info );
 
 							return $resolver->get_connection();
@@ -150,7 +150,7 @@ class RootQuery {
 					'allSettings' => [
 						'type'        => 'Settings',
 						'description' => __( 'Entry point to get all settings for the site', 'wp-graphql' ),
-						'resolve'     => function () {
+						'resolve'     => static function () {
 							return true;
 						},
 					],
@@ -169,7 +169,7 @@ class RootQuery {
 								'description' => __( 'Type of unique identifier to fetch a comment by. Default is Global ID', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function ( $source, array $args, AppContext $context, $info ) {
+						'resolve'     => static function ( $source, array $args, AppContext $context, $info ) {
 							$id_type = isset( $args['idType'] ) ? $args['idType'] : 'id';
 
 							switch ( $id_type ) {
@@ -212,7 +212,7 @@ class RootQuery {
 								'description' => __( 'Whether to return the node as a preview instance', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function ( $root, $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => static function ( $root, $args, AppContext $context, ResolveInfo $info ) {
 
 							$idType = $args['idType'] ?? 'global_id';
 							switch ( $idType ) {
@@ -252,7 +252,7 @@ class RootQuery {
 							$allowed_post_types[] = 'revision';
 
 							return absint( $post_id ) ? $context->get_loader( 'post' )->load_deferred( $post_id )->then(
-								function ( $post ) use ( $allowed_post_types ) {
+								static function ( $post ) use ( $allowed_post_types ) {
 
 									// if the post isn't an instance of a Post model, return
 									if ( ! $post instanceof Post ) {
@@ -282,7 +282,7 @@ class RootQuery {
 								'description' => __( 'Type of unique identifier to fetch a content type by. Default is Global ID', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function ( $root, $args, $context, $info ) {
+						'resolve'     => static function ( $root, $args, $context, $info ) {
 
 							$id_type = isset( $args['idType'] ) ? $args['idType'] : 'id';
 
@@ -316,7 +316,7 @@ class RootQuery {
 								'description' => __( 'Type of unique identifier to fetch a taxonomy by. Default is Global ID', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function ( $root, $args, $context, $info ) {
+						'resolve'     => static function ( $root, $args, $context, $info ) {
 
 							$id_type = isset( $args['idType'] ) ? $args['idType'] : 'id';
 
@@ -346,7 +346,7 @@ class RootQuery {
 								'description' => __( 'The unique identifier of the node', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function ( $root, $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => static function ( $root, $args, AppContext $context, ResolveInfo $info ) {
 							return ! empty( $args['id'] ) ? DataSource::resolve_node( $args['id'], $context, $info ) : null;
 						},
 					],
@@ -359,7 +359,7 @@ class RootQuery {
 								'description' => __( 'Unique Resource Identifier in the form of a path or permalink for a node. Ex: "/hello-world"', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function ( $root, $args, AppContext $context ) {
+						'resolve'     => static function ( $root, $args, AppContext $context ) {
 							return ! empty( $args['uri'] ) ? $context->node_resolver->resolve_uri( $args['uri'] ) : null;
 						},
 					],
@@ -378,7 +378,7 @@ class RootQuery {
 								'description' => __( 'Type of unique identifier to fetch a menu by. Default is Global ID', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function ( $source, array $args, AppContext $context ) {
+						'resolve'     => static function ( $source, array $args, AppContext $context ) {
 
 							$id_type = isset( $args['idType'] ) ? $args['idType'] : 'id';
 
@@ -447,7 +447,7 @@ class RootQuery {
 								'description' => __( 'Type of unique identifier to fetch a menu item by. Default is Global ID', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function ( $source, array $args, AppContext $context ) {
+						'resolve'     => static function ( $source, array $args, AppContext $context ) {
 							$id_type = isset( $args['idType'] ) ? $args['idType'] : 'id';
 
 							switch ( $id_type ) {
@@ -478,7 +478,7 @@ class RootQuery {
 								'description' => __( 'The globally unique identifier of the plugin.', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function ( $source, array $args, AppContext $context ) {
+						'resolve'     => static function ( $source, array $args, AppContext $context ) {
 							$id_components = Relay::fromGlobalId( $args['id'] );
 
 							return ! empty( $id_components['id'] ) ? $context->get_loader( 'plugin' )->load_deferred( $id_components['id'] ) : null;
@@ -503,7 +503,7 @@ class RootQuery {
 								'description' => __( 'The taxonomy of the tern node. Required when idType is set to "name" or "slug"', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function ( $root, $args, AppContext $context ) {
+						'resolve'     => static function ( $root, $args, AppContext $context ) {
 
 							$idType  = isset( $args['idType'] ) ? $args['idType'] : 'global_id';
 							$term_id = null;
@@ -563,7 +563,7 @@ class RootQuery {
 								'description' => __( 'The globally unique identifier of the theme.', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function ( $source, array $args ) {
+						'resolve'     => static function ( $source, array $args ) {
 							$id_components = Relay::fromGlobalId( $args['id'] );
 
 							return DataSource::resolve_theme( $id_components['id'] );
@@ -584,7 +584,7 @@ class RootQuery {
 								'description' => __( 'Type of unique identifier to fetch a user by. Default is Global ID', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function ( $source, array $args, $context ) {
+						'resolve'     => static function ( $source, array $args, $context ) {
 
 							$idType = isset( $args['idType'] ) ? $args['idType'] : 'id';
 
@@ -646,7 +646,7 @@ class RootQuery {
 								'description' => __( 'The globally unique identifier of the user object.', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => function ( $source, array $args ) {
+						'resolve'     => static function ( $source, array $args ) {
 
 							$id_components = Relay::fromGlobalId( $args['id'] );
 
@@ -657,7 +657,7 @@ class RootQuery {
 					'viewer'      => [
 						'type'        => 'User',
 						'description' => __( 'Returns the current user', 'wp-graphql' ),
-						'resolve'     => function ( $source, array $args, AppContext $context ) {
+						'resolve'     => static function ( $source, array $args, AppContext $context ) {
 							return ! empty( $context->viewer->ID ) ? $context->get_loader( 'user' )->load_deferred( $context->viewer->ID ) : null;
 						},
 					],
@@ -682,7 +682,12 @@ class RootQuery {
 				$post_type_object->graphql_single_name,
 				[
 					'type'        => $post_type_object->graphql_single_name,
-					'description' => sprintf( __( 'An object of the %1$s Type. %2$s', 'wp-graphql' ), $post_type_object->graphql_single_name, $post_type_object->description ),
+					'description' => sprintf(
+						// translators: %1$s is the post type GraphQL name, %2$s is the post type description
+						__( 'An object of the %1$s Type. %2$s', 'wp-graphql' ),
+						$post_type_object->graphql_single_name,
+						$post_type_object->description
+					),
 					'args'        => [
 						'id'        => [
 							'type'        => [
@@ -699,7 +704,7 @@ class RootQuery {
 							'description' => __( 'Whether to return the node as a preview instance', 'wp-graphql' ),
 						],
 					],
-					'resolve'     => function ( $source, array $args, AppContext $context ) use ( $post_type_object ) {
+					'resolve'     => static function ( $source, array $args, AppContext $context ) use ( $post_type_object ) {
 
 						$idType  = isset( $args['idType'] ) ? $args['idType'] : 'global_id';
 						$post_id = null;
@@ -756,7 +761,7 @@ class RootQuery {
 						}
 
 						return absint( $post_id ) ? $context->get_loader( 'post' )->load_deferred( $post_id )->then(
-							function ( $post ) use ( $post_type_object ) {
+							static function ( $post ) use ( $post_type_object ) {
 
 								// if the post isn't an instance of a Post model, return
 								if ( ! $post instanceof Post ) {
@@ -779,21 +784,37 @@ class RootQuery {
 			$post_by_args = [
 				'id'  => [
 					'type'        => 'ID',
-					'description' => sprintf( __( 'Get the object by its global ID', 'wp-graphql' ), $post_type_object->graphql_single_name ),
+					'description' => sprintf(
+						// translators: %s is the post type's GraphQL name.
+						__( 'Get the %s object by its global ID', 'wp-graphql' ),
+						$post_type_object->graphql_single_name
+					),
 				],
 				$post_type_object->graphql_single_name . 'Id' => [
 					'type'        => 'Int',
-					'description' => sprintf( __( 'Get the %s by its database ID', 'wp-graphql' ), $post_type_object->graphql_single_name ),
+					'description' => sprintf(
+						// translators: %s is the post type's GraphQL name.
+						__( 'Get the %s by its database ID', 'wp-graphql' ),
+						$post_type_object->graphql_single_name
+					),
 				],
 				'uri' => [
 					'type'        => 'String',
-					'description' => sprintf( __( 'Get the %s by its uri', 'wp-graphql' ), $post_type_object->graphql_single_name ),
+					'description' => sprintf(
+						// translators: %s is the post type's GraphQL name.
+						__( 'Get the %s by its uri', 'wp-graphql' ),
+						$post_type_object->graphql_single_name
+					),
 				],
 			];
 			if ( false === $post_type_object->hierarchical ) {
 				$post_by_args['slug'] = [
 					'type'        => 'String',
-					'description' => sprintf( __( 'Get the %s by its slug (only available for non-hierarchical types)', 'wp-graphql' ), $post_type_object->graphql_single_name ),
+					'description' => sprintf(
+						// translators: %s is the post type's GraphQL name.
+						__( 'Get the %s by its slug (only available for non-hierarchical types)', 'wp-graphql' ),
+						$post_type_object->graphql_single_name
+					),
 				];
 			}
 
@@ -806,9 +827,13 @@ class RootQuery {
 				[
 					'type'              => $post_type_object->graphql_single_name,
 					'deprecationReason' => __( 'Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: "" ), use post(id: "" idType: "")', 'wp-graphql' ),
-					'description'       => sprintf( __( 'A %s object', 'wp-graphql' ), $post_type_object->graphql_single_name ),
+					'description'       => sprintf(
+						// translators: %s is the post type's GraphQL name.
+						__( 'A %s object', 'wp-graphql' ),
+						$post_type_object->graphql_single_name
+					),
 					'args'              => $post_by_args,
-					'resolve'           => function ( $source, array $args, $context ) use ( $post_type_object ) {
+					'resolve'           => static function ( $source, array $args, $context ) use ( $post_type_object ) {
 						$post_object = null;
 						$post_id     = 0;
 						if ( ! empty( $args['id'] ) ) {
@@ -845,7 +870,7 @@ class RootQuery {
 						}
 
 						return $context->get_loader( 'post' )->load_deferred( $post_id )->then(
-							function ( $post ) use ( $post_type_object ) {
+							static function ( $post ) use ( $post_type_object ) {
 
 								// if the post type object isn't an instance of WP_Post_Type, return
 								if ( ! $post_type_object instanceof \WP_Post_Type ) {
@@ -890,7 +915,11 @@ class RootQuery {
 				$tax_object->graphql_single_name,
 				[
 					'type'        => $tax_object->graphql_single_name,
-					'description' => sprintf( __( 'A % object', 'wp-graphql' ), $tax_object->graphql_single_name ),
+					'description' => sprintf(
+						// translators: %s is the taxonomys' GraphQL name.
+						__( 'A % object', 'wp-graphql' ),
+						$tax_object->graphql_single_name
+					),
 					'args'        => [
 						'id'     => [
 							'type'        => [
@@ -903,7 +932,7 @@ class RootQuery {
 							'description' => __( 'Type of unique identifier to fetch by. Default is Global ID', 'wp-graphql' ),
 						],
 					],
-					'resolve'     => function ( $source, array $args, $context, $info ) use ( $tax_object ) {
+					'resolve'     => static function ( $source, array $args, $context, $info ) use ( $tax_object ) {
 
 						$idType  = isset( $args['idType'] ) ? $args['idType'] : 'global_id';
 						$term_id = null;

--- a/src/Type/ObjectType/SettingGroup.php
+++ b/src/Type/ObjectType/SettingGroup.php
@@ -33,6 +33,7 @@ class SettingGroup {
 		register_graphql_object_type(
 			ucfirst( $group_name ) . 'Settings',
 			[
+				// translators: %s is the name of the setting group.
 				'description' => sprintf( __( 'The %s setting type', 'wp-graphql' ), $group_name ),
 				'fields'      => $fields,
 			]
@@ -88,8 +89,9 @@ class SettingGroup {
 					 */
 					$fields[ $field_key ] = [
 						'type'        => $type_registry->get_type( $setting_field['type'] ),
+						// translators: %s is the name of the setting group.
 						'description' => isset( $setting_field['description'] ) && ! empty( $setting_field['description'] ) ? $setting_field['description'] : sprintf( __( 'The %s Settings Group', 'wp-graphql' ), $setting_field['type'] ),
-						'resolve'     => function ( $root, array $args, $context, $info ) use ( $setting_field ) {
+						'resolve'     => static function ( $root, array $args, $context, $info ) use ( $setting_field ) {
 
 							/**
 							 * Check to see if the user querying the email field has the 'manage_options' capability

--- a/src/Type/ObjectType/Settings.php
+++ b/src/Type/ObjectType/Settings.php
@@ -91,8 +91,9 @@ class Settings {
 					 */
 					$fields[ $field_key ] = [
 						'type'        => $setting_field['type'],
+						// translators: %s is the name of the setting group.
 						'description' => sprintf( __( 'Settings of the the %s Settings Group', 'wp-graphql' ), $setting_field['type'] ),
-						'resolve'     => function ( $root, $args, $context, $info ) use ( $setting_field, $key ) {
+						'resolve'     => static function ( $root, $args, $context, $info ) use ( $setting_field, $key ) {
 							/**
 							 * Check to see if the user querying the email field has the 'manage_options' capability
 							 * All other options should be public by default

--- a/src/Type/ObjectType/Taxonomy.php
+++ b/src/Type/ObjectType/Taxonomy.php
@@ -26,7 +26,7 @@ class Taxonomy {
 					'connectedContentTypes' => [
 						'toType'      => 'ContentType',
 						'description' => __( 'List of Content Types associated with the Taxonomy', 'wp-graphql' ),
-						'resolve'     => function ( TaxonomyModel $taxonomy, $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => static function ( TaxonomyModel $taxonomy, $args, AppContext $context, ResolveInfo $info ) {
 
 							$connected_post_types = ! empty( $taxonomy->object_type ) ? $taxonomy->object_type : [];
 							$resolver             = new ContentTypeConnectionResolver( $taxonomy, $args, $context, $info );

--- a/src/Type/ObjectType/User.php
+++ b/src/Type/ObjectType/User.php
@@ -32,7 +32,7 @@ class User {
 				'connections' => [
 					'enqueuedScripts'     => [
 						'toType'  => 'EnqueuedScript',
-						'resolve' => function ( $source, $args, $context, $info ) {
+						'resolve' => static function ( $source, $args, $context, $info ) {
 							$resolver = new EnqueuedScriptsConnectionResolver( $source, $args, $context, $info );
 
 							return $resolver->get_connection();
@@ -40,7 +40,7 @@ class User {
 					],
 					'enqueuedStylesheets' => [
 						'toType'  => 'EnqueuedStylesheet',
-						'resolve' => function ( $source, $args, $context, $info ) {
+						'resolve' => static function ( $source, $args, $context, $info ) {
 							$resolver = new EnqueuedStylesheetConnectionResolver( $source, $args, $context, $info );
 
 							return $resolver->get_connection();
@@ -52,7 +52,7 @@ class User {
 						'queryClass'         => 'WP_Query',
 						'description'        => __( 'Connection between the User and Revisions authored by the user', 'wp-graphql' ),
 						'connectionArgs'     => PostObjects::get_connection_args(),
-						'resolve'            => function ( $root, $args, $context, $info ) {
+						'resolve'            => static function ( $root, $args, $context, $info ) {
 							$resolver = new PostObjectConnectionResolver( $root, $args, $context, $info, 'revision' );
 
 							return $resolver->get_connection();
@@ -61,7 +61,7 @@ class User {
 					'roles'               => [
 						'toType'        => 'UserRole',
 						'fromFieldName' => 'roles',
-						'resolve'       => function ( UserModel $user, $args, $context, $info ) {
+						'resolve'       => static function ( UserModel $user, $args, $context, $info ) {
 							$resolver = new UserRoleConnectionResolver( $user, $args, $context, $info );
 							// Only get roles matching the slugs of the roles belonging to the user
 
@@ -80,7 +80,7 @@ class User {
 					'databaseId'             => [
 						'type'        => [ 'non_null' => 'Int' ],
 						'description' => __( 'Identifies the primary key from the database.', 'wp-graphql' ),
-						'resolve'     => function ( \WPGraphQL\Model\User $user ) {
+						'resolve'     => static function ( \WPGraphQL\Model\User $user ) {
 							return absint( $user->userId );
 						},
 					],
@@ -178,7 +178,7 @@ class User {
 							],
 
 						],
-						'resolve' => function ( $user, $args, $context, $info ) {
+						'resolve' => static function ( $user, $args, $context, $info ) {
 
 							$avatar_args = [];
 							if ( is_numeric( $args['size'] ) ) {

--- a/src/Type/Union/MenuItemObjectUnion.php
+++ b/src/Type/Union/MenuItemObjectUnion.php
@@ -30,7 +30,7 @@ class MenuItemObjectUnion {
 			[
 				'typeNames'   => self::get_possible_types(),
 				'description' => __( 'Deprecated in favor of MenuItemLinkeable Interface', 'wp-graphql' ),
-				'resolveType' => function ( $object ) use ( $type_registry ) {
+				'resolveType' => static function ( $object ) use ( $type_registry ) {
 					_doing_it_wrong( 'MenuItemObjectUnion', esc_attr__( 'The MenuItemObjectUnion GraphQL type is deprecated in favor of MenuItemLinkeable Interface', 'wp-graphql' ), '0.10.3' );
 					// Post object
 					if ( $object instanceof Post && isset( $object->post_type ) && ! empty( $object->post_type ) ) {

--- a/src/Type/Union/PostObjectUnion.php
+++ b/src/Type/Union/PostObjectUnion.php
@@ -28,7 +28,7 @@ class PostObjectUnion {
 				'name'        => 'PostObjectUnion',
 				'typeNames'   => self::get_possible_types(),
 				'description' => __( 'Union between the post, page and media item types', 'wp-graphql' ),
-				'resolveType' => function ( $value ) use ( $type_registry ) {
+				'resolveType' => static function ( $value ) use ( $type_registry ) {
 					_doing_it_wrong( 'PostObjectUnion', esc_attr__( 'The PostObjectUnion GraphQL type is deprecated. Use the ContentNode interface instead.', 'wp-graphql' ), '1.14.1' );
 
 					$type = null;

--- a/src/Type/Union/TermObjectUnion.php
+++ b/src/Type/Union/TermObjectUnion.php
@@ -27,7 +27,7 @@ class TermObjectUnion {
 				'kind'        => 'union',
 				'typeNames'   => self::get_possible_types(),
 				'description' => __( 'Union between the Category, Tag and PostFormatPost types', 'wp-graphql' ),
-				'resolveType' => function ( $value ) use ( $type_registry ) {
+				'resolveType' => static function ( $value ) use ( $type_registry ) {
 					_doing_it_wrong( 'TermObjectUnion', esc_attr__( 'The TermObjectUnion GraphQL type is deprecated. Use the TermNode interface instead.', 'wp-graphql' ), '1.14.1' );
 
 					$type = null;

--- a/src/Type/WPConnectionType.php
+++ b/src/Type/WPConnectionType.php
@@ -169,7 +169,7 @@ class WPConnectionType {
 		$this->connection_args            = array_key_exists( 'connectionArgs', $config ) && is_array( $config['connectionArgs'] ) ? $config['connectionArgs'] : [];
 		$this->edge_fields                = array_key_exists( 'edgeFields', $config ) && is_array( $config['edgeFields'] ) ? $config['edgeFields'] : [];
 		$this->resolve_cursor             = array_key_exists( 'resolveCursor', $config ) && is_callable( $config['resolve'] ) ? $config['resolveCursor'] : null;
-		$this->resolve_connection         = array_key_exists( 'resolve', $config ) && is_callable( $config['resolve'] ) ? $config['resolve'] : function () {
+		$this->resolve_connection         = array_key_exists( 'resolve', $config ) && is_callable( $config['resolve'] ) ? $config['resolve'] : static function () {
 			return null;
 		};
 		$this->where_args                 = [];
@@ -284,8 +284,11 @@ class WPConnectionType {
 		$this->type_registry->register_input_type(
 			$input_name,
 			[
-				// Translators: Placeholder is the name of the connection
-				'description' => sprintf( __( 'Arguments for filtering the %s connection', 'wp-graphql' ), $this->connection_name ),
+				'description' => sprintf(
+					// translators: %s is the name of the connection
+					__( 'Arguments for filtering the %s connection', 'wp-graphql' ),
+					$this->connection_name
+				),
 				'fields'      => $this->connection_args,
 				'queryClass'  => $this->query_class,
 			]
@@ -324,8 +327,12 @@ class WPConnectionType {
 			$this->connection_name . 'Edge',
 			[
 				'interfaces'  => $interfaces,
-				// Translators: Placeholders are for the name of the Type the connection is coming from and the name of the Type the connection is going to
-				'description' => sprintf( __( 'Connection between the %1$s type and the %2$s type', 'wp-graphql' ), $this->from_type, $this->to_type ),
+				'description' => sprintf(
+					// translators: Placeholders are for the name of the Type the connection is coming from and the name of the Type the connection is going to
+					__( 'Connection between the %1$s type and the %2$s type', 'wp-graphql' ),
+					$this->from_type,
+					$this->to_type
+				),
 				'fields'      => array_merge(
 					[
 						'node' => [
@@ -355,7 +362,11 @@ class WPConnectionType {
 
 		$this->type_registry->register_object_type( $this->connection_name . 'PageInfo', [
 			'interfaces'  => [ $this->to_type . 'ConnectionPageInfo' ],
-			'description' => sprintf( __( 'Page Info on the "%s"', 'wp-graphql' ), $this->connection_name ),
+			'description' => sprintf(
+				// translators: %s is the name of the connection.
+				__( 'Page Info on the "%s"', 'wp-graphql' ),
+				$this->connection_name
+			),
 			'fields'      => PageInfo::get_fields(),
 		] );
 
@@ -429,8 +440,12 @@ class WPConnectionType {
 		$this->type_registry->register_object_type(
 			$this->connection_name,
 			[
-				// Translators: the placeholders are the name of the Types the connection is between.
-				'description'       => sprintf( __( 'Connection between the %1$s type and the %2$s type', 'wp-graphql' ), $this->from_type, $this->to_type ),
+				'description'       => sprintf(
+					// translators: the placeholders are the name of the Types the connection is between.
+					__( 'Connection between the %1$s type and the %2$s type', 'wp-graphql' ),
+					$this->from_type,
+					$this->to_type
+				),
 				'interfaces'        => $interfaces,
 				'connection_config' => $this->config,
 				'fields'            => $this->get_connection_fields(),
@@ -454,7 +469,7 @@ class WPConnectionType {
 				],
 				'edges'    => [
 					'type'        => [ 'non_null' => [ 'list_of' => [ 'non_null' => $this->connection_name . 'Edge' ] ] ],
-					// Translators: Placeholder is the name of the connection
+					// translators: %s is the name of the connection.
 					'description' => sprintf( __( 'Edges for the %s connection', 'wp-graphql' ), $this->connection_name ),
 				],
 				'nodes'    => [
@@ -519,7 +534,14 @@ class WPConnectionType {
 			'args'                  => array_merge( $this->get_pagination_args(), $this->where_args ),
 			'auth'                  => $this->auth,
 			'deprecationReason'     => ! empty( $this->config['deprecationReason'] ) ? $this->config['deprecationReason'] : null,
-			'description'           => ! empty( $this->config['description'] ) ? $this->config['description'] : sprintf( __( 'Connection between the %1$s type and the %2$s type', 'wp-graphql' ), $this->from_type, $this->to_type ),
+			'description'           => ! empty( $this->config['description'] ) 
+				? $this->config['description']
+				: sprintf(
+					// translators: the placeholders are the name of the Types the connection is between.
+					__( 'Connection between the %1$s type and the %2$s type', 'wp-graphql' ),
+					$this->from_type,
+					$this->to_type
+				),
 			'resolve'               => function ( $root, $args, $context, $info ) {
 				$context->connection_query_class = $this->query_class;
 				$resolve_connection              = $this->resolve_connection;
@@ -551,6 +573,7 @@ class WPConnectionType {
 		if ( ! $this->type_registry->has_type( $this->to_type . 'ConnectionPageInfo' ) ) {
 			$this->type_registry->register_interface_type( $this->to_type . 'ConnectionPageInfo', [
 				'interfaces'  => [ 'WPPageInfo' ],
+				// translators: %s is the name of the connection edge.
 				'description' => sprintf( __( 'Page Info on the connected %s', 'wp-graphql' ), $connection_edge_type ),
 				'fields'      => PageInfo::get_fields(),
 			] );
@@ -561,10 +584,12 @@ class WPConnectionType {
 
 			$this->type_registry->register_interface_type( $connection_edge_type, [
 				'interfaces'  => [ 'Edge' ],
+				// translators: %s is the name of the type the connection edge is to.
 				'description' => sprintf( __( 'Edge between a Node and a connected %s', 'wp-graphql' ), $this->to_type ),
 				'fields'      => [
 					'node' => [
 						'type'        => [ 'non_null' => $this->to_type ],
+						// translators: %s is the name of the type the connection edge is to.
 						'description' => sprintf( __( 'The connected %s Node', 'wp-graphql' ), $this->to_type ),
 					],
 				],
@@ -575,17 +600,24 @@ class WPConnectionType {
 		if ( ! $this->one_to_one && ! $this->type_registry->has_type( $this->to_type . 'Connection' ) ) {
 			$this->type_registry->register_interface_type( $this->to_type . 'Connection', [
 				'interfaces'  => [ 'Connection' ],
+				// translators: %s is the name of the type the connection is to.
 				'description' => sprintf( __( 'Connection to %s Nodes', 'wp-graphql' ), $this->to_type ),
 				'fields'      => [
 					'edges'    => [
 						'type'        => [ 'non_null' => [ 'list_of' => [ 'non_null' => $connection_edge_type ] ] ],
-						'description' => sprintf( __( 'A list of edges (relational context) between %1$s and connected %2$s Nodes', 'wp-graphql' ), $this->from_type, $this->to_type ),
+						'description' => sprintf(
+							// translators: %1$s is the name of the type the connection is from, %2$s is the name of the type the connection is to.
+							__( 'A list of edges (relational context) between %1$s and connected %2$s Nodes', 'wp-graphql' ),
+							$this->from_type,
+							$this->to_type
+						),
 					],
 					'pageInfo' => [
 						'type' => [ 'non_null' => $this->to_type . 'ConnectionPageInfo' ],
 					],
 					'nodes'    => [
 						'type'        => [ 'non_null' => [ 'list_of' => [ 'non_null' => $this->to_type ] ] ],
+						// translators: %s is the name of the type the connection is to.
 						'description' => sprintf( __( 'A list of connected %s Nodes', 'wp-graphql' ), $this->to_type ),
 					],
 				],

--- a/src/Type/WPInterfaceTrait.php
+++ b/src/Type/WPInterfaceTrait.php
@@ -51,19 +51,39 @@ trait WPInterfaceTrait {
 
 			// surface when interfaces are trying to be registered with invalid configuration
 			if ( ! is_string( $interface ) ) {
-				graphql_debug( sprintf( __( 'Invalid Interface registered to the "%s" Type. Interfaces can only be registered with an interface name or a valid instance of an InterfaceType', 'wp-graphql' ), $this->name ), [ 'invalid_interface' => $interface ] );
+				graphql_debug(
+					sprintf(
+						// translators: %s is the name of the GraphQL type.
+						__( 'Invalid Interface registered to the "%s" Type. Interfaces can only be registered with an interface name or a valid instance of an InterfaceType', 'wp-graphql' ),
+						$this->name
+					),
+					[ 'invalid_interface' => $interface ]
+				);
 				continue;
 			}
 
 			// Prevent an interface from implementing itself
 			if ( strtolower( $this->config['name'] ) === strtolower( $interface ) ) {
-				graphql_debug( sprintf( __( 'The "%s" Interface attempted to implement itself, which is not allowed', 'wp-graphql' ), $interface ) );
+				graphql_debug(
+					sprintf(
+						// translators: %s is the name of the interface.
+						__( 'The "%s" Interface attempted to implement itself, which is not allowed', 'wp-graphql' ),
+						$interface
+					)
+				);
 				continue;
 			}
 
 			$interface_type = $this->type_registry->get_type( $interface );
 			if ( ! $interface_type instanceof InterfaceType ) {
-				graphql_debug( sprintf( __( '"%1$s" is not a valid Interface Type and cannot be implemented as an Interface on the "%2$s" Type', 'wp-graphql' ), $interface, $this->name ) );
+				graphql_debug(
+					sprintf(
+						// translators: %1$s is the name of the interface, %2$s is the name of the type.
+						__( '"%1$s" is not a valid Interface Type and cannot be implemented as an Interface on the "%2$s" Type', 'wp-graphql' ),
+						$interface,
+						$this->name
+					)
+				);
 				continue;
 			}
 

--- a/src/Type/WPMutationType.php
+++ b/src/Type/WPMutationType.php
@@ -266,6 +266,7 @@ class WPMutationType {
 		$this->type_registry->register_input_type(
 			$input_name,
 			[
+				// translators: %s is the name of the mutation.
 				'description'       => sprintf( __( 'Input for the %1$s mutation.', 'wp-graphql' ), $this->mutation_name ),
 				'fields'            => $this->input_fields,
 				'deprecationReason' => ! empty( $this->config['deprecationReason'] ) ? $this->config['deprecationReason'] : null,
@@ -283,6 +284,7 @@ class WPMutationType {
 		$this->type_registry->register_object_type(
 			$object_name,
 			[
+				// translators: %s is the name of the mutation.
 				'description'       => sprintf( __( 'The payload for the %s mutation.', 'wp-graphql' ), $this->mutation_name ),
 				'fields'            => $this->output_fields,
 				'deprecationReason' => ! empty( $this->config['deprecationReason'] ) ? $this->config['deprecationReason'] : null,
@@ -302,11 +304,13 @@ class WPMutationType {
 				'args'        => [
 					'input' => [
 						'type'              => [ 'non_null' => $this->mutation_name . 'Input' ],
+						// translators: %s is the name of the mutation.
 						'description'       => sprintf( __( 'Input for the %s mutation', 'wp-graphql' ), $this->mutation_name ),
 						'deprecationReason' => ! empty( $this->config['deprecationReason'] ) ? $this->config['deprecationReason'] : null,
 					],
 				],
 				'auth'        => $this->auth,
+				// translators: %s is the name of the mutation.
 				'description' => ! empty( $this->config['description'] ) ? $this->config['description'] : sprintf( __( 'The %s mutation', 'wp-graphql' ), $this->mutation_name ),
 				'isPrivate'   => $this->is_private,
 				'type'        => $this->mutation_name . 'Payload',

--- a/src/Utils/QueryAnalyzer.php
+++ b/src/Utils/QueryAnalyzer.php
@@ -4,11 +4,15 @@ namespace WPGraphQL\Utils;
 
 use Exception;
 use GraphQL\Error\SyntaxError;
+use GraphQL\Language\AST\Node;
+use GraphQL\Language\AST\TypeDefinitionNode;
 use GraphQL\Language\Parser;
 use GraphQL\Language\Visitor;
 use GraphQL\Server\OperationParams;
 use GraphQL\Type\Definition\FieldDefinition;
 use GraphQL\Type\Definition\InterfaceType;
+use GraphQL\Type\Definition\ListOfType;
+use GraphQL\Type\Definition\NonNull;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Schema;
@@ -17,6 +21,7 @@ use GraphQLRelay\Relay;
 use Hoa\Math\Util;
 use WPGraphQL\Model\Model;
 use WPGraphQL\Request;
+use WPGraphQL\Type\WPConnectionType;
 use WPGraphQL\WPSchema;
 
 /**
@@ -296,6 +301,62 @@ class QueryAnalyzer {
 		return $this->query_id;
 	}
 
+
+	/**
+	 * @param \GraphQL\Type\Definition\Type $type The Type of field
+	 * @param \GraphQL\Type\Definition\FieldDefinition $field_def The field definition the type is for
+	 * @param mixed $parent_type The Parent Type
+	 * @param bool $is_list_type Whether the field is a list type field
+	 *
+	 * @return  \GraphQL\Type\Definition\Type|String|null
+	 */
+	public static function get_wrapped_field_type( Type $type, FieldDefinition $field_def, $parent_type, bool $is_list_type = false ) {
+
+		if ( ! isset( $parent_type->name ) || 'RootQuery' !== $parent_type->name ) {
+			return null;
+		}
+
+		if ( $type instanceof NonNull || $type instanceof ListOfType ) {
+
+			if ( $type instanceof ListOfType && isset( $parent_type->name ) && 'RootQuery' === $parent_type->name ) {
+				$is_list_type = true;
+			}
+
+			return self::get_wrapped_field_type( $type->getWrappedType(), $field_def, $parent_type, $is_list_type );
+		}
+
+		// Determine if we're dealing with a connection
+		if ( $type instanceof ObjectType || $type instanceof InterfaceType ) {
+
+			$interfaces      = method_exists( $type, 'getInterfaces' ) ? $type->getInterfaces() : [];
+			$interface_names = ! empty( $interfaces ) ? array_map( static function ( InterfaceType $interface ) {
+				return $interface->name;
+			}, $interfaces ) : [];
+
+			if ( array_key_exists( 'Connection', $interface_names ) ) {
+
+				if ( isset( $field_def->config['fromType'] ) && ( 'rootquery' !== strtolower( $field_def->config['fromType'] ) ) ) {
+					return null;
+				}
+
+				$to_type = $field_def->config['toType'] ?? null;
+				if ( empty( $to_type ) ) {
+					return null;
+				}
+
+				return $to_type;
+			}
+
+			if ( ! $is_list_type ) {
+				return null;
+			}
+
+			return $type;
+		}
+
+		return null;
+	}
+
 	/**
 	 * Given the Schema and a query string, return a list of GraphQL Types that are being asked for
 	 * by the query.
@@ -334,7 +395,12 @@ class QueryAnalyzer {
 		$type_info = new TypeInfo( $schema );
 
 		$visitor = [
-			'enter' => function ( $node, $key, $parent, $path, $ancestors ) use ( $type_info, &$type_map, $schema ) {
+			'enter' => static function ( $node, $key, $parent, $path, $ancestors ) use ( $type_info, &$type_map, $schema ) {
+				$parent_type = $type_info->getParentType();
+
+				if ( 'Field' !== $node->kind ) {
+					Visitor::skipNode();
+				}
 
 				$type_info->enter( $node );
 				$field_def = $type_info->getFieldDef();
@@ -343,67 +409,44 @@ class QueryAnalyzer {
 					return;
 				}
 
+				// Determine the wrapped type, which also determines if it's a listOf
 				$field_type = $field_def->getType();
+				$field_type = self::get_wrapped_field_type( $field_type, $field_def, $parent_type );
 
-				if ( empty( $field_type->config['interfaces'] ) ) {
+				if ( null === $field_type ) {
 					return;
 				}
 
-				if ( ! in_array( 'Connection', $field_type->config['interfaces'], true ) ) {
+				if ( ! empty( $field_type ) && is_string( $field_type ) ) {
+					$field_type = $schema->getType( Utils::format_type_name( $field_type ) );
+				}
+
+				if ( ! $field_type ) {
 					return;
 				}
 
-				if ( empty( $field_def->config['fromType'] ) || 'rootquery' !== strtolower( $field_def->config['fromType'] ) ) {
-					return;
-				}
+				$field_type = $schema->getType( $field_type );
 
-				if ( empty( $field_def->config['toType'] ) ) {
-					return;
-				}
-
-				$to_type = $schema->getType( ucfirst( $field_def->config['toType'] ) );
-
-				if ( ! $to_type instanceof Type ) {
-					return;
-				}
-
-				if ( ! isset( $node->kind ) || 'Field' !== $node->kind ) {
-					return;
-				}
-
-				if ( ! $to_type instanceof ObjectType && ! $to_type instanceof InterfaceType ) {
-					return;
-				}
-
-				$interfaces = $to_type->getInterfaces();
-
-				if ( empty( $interfaces ) ) {
-					return;
-				}
-
-				// Get the interface names
-				$interface_names = array_keys( $interfaces );
-
-				// If the Node interface isn't applied, it's not a node type
-				if ( ! in_array( 'Node', $interface_names, true ) ) {
+				if ( ! $field_type instanceof ObjectType && ! $field_type instanceof InterfaceType ) {
 					return;
 				}
 
 				// If the type being queried is an interface (i.e. ContentNode) the publishing a new
 				// item of any of the possible types (post, page, etc) should invalidate
 				// this query, so we need to tag this query with `list:$possible_type` for each possible type
-				if ( $to_type instanceof InterfaceType ) {
-					$possible_types = $schema->getPossibleTypes( $to_type );
+				if ( $field_type instanceof InterfaceType ) {
+					$possible_types = $schema->getPossibleTypes( $field_type );
 					if ( ! empty( $possible_types ) ) {
 						foreach ( $possible_types as $possible_type ) {
 							$type_map[] = 'list:' . strtolower( $possible_type );
 						}
 					}
 				} else {
-					$type_map[] = 'list:' . strtolower( $to_type );
+					$type_map[] = 'list:' . strtolower( $field_type );
 				}
+
 			},
-			'leave' => function ( $node, $key, $parent, $path, $ancestors ) use ( $type_info ) {
+			'leave' => static function ( $node, $key, $parent, $path, $ancestors ) use ( $type_info ) {
 				$type_info->leave( $node );
 			},
 		];
@@ -483,7 +526,7 @@ class QueryAnalyzer {
 					$type_map[] = strtolower( $named_type );
 				}
 			},
-			'leave' => function ( $node, $key, $parent, $path, $ancestors ) use ( $type_info ) {
+			'leave' => static function ( $node, $key, $parent, $path, $ancestors ) use ( $type_info ) {
 				$type_info->leave( $node );
 			},
 		];
@@ -530,7 +573,7 @@ class QueryAnalyzer {
 		$type_map  = [];
 		$type_info = new TypeInfo( $schema );
 		$visitor   = [
-			'enter' => function ( $node, $key, $parent, $path, $ancestors ) use ( $type_info, &$type_map, $schema ) {
+			'enter' => static function ( $node, $key, $parent, $path, $ancestors ) use ( $type_info, &$type_map, $schema ) {
 				$type_info->enter( $node );
 				$type = $type_info->getType();
 				if ( ! $type ) {
@@ -554,7 +597,7 @@ class QueryAnalyzer {
 					$type_map[] = $named_type->config['model'];
 				}
 			},
-			'leave' => function ( $node, $key, $parent, $path, $ancestors ) use ( $type_info ) {
+			'leave' => static function ( $node, $key, $parent, $path, $ancestors ) use ( $type_info ) {
 				$type_info->leave( $node );
 			},
 		];

--- a/src/Utils/QueryLog.php
+++ b/src/Utils/QueryLog.php
@@ -139,13 +139,17 @@ class QueryLog {
 		global $wpdb;
 
 		$save_queries_value = defined( 'SAVEQUERIES' ) && true === SAVEQUERIES ? 'true' : 'false';
-		$default_message    = sprintf( __( 'Query Logging has been disabled. The \'SAVEQUERIES\' Constant is set to \'%s\' on your server.', 'wp-graphql' ), $save_queries_value );
+		$default_message    = sprintf(
+			// translators: %s is the value of the SAVEQUERIES constant
+			__( 'Query Logging has been disabled. The \'SAVEQUERIES\' Constant is set to \'%s\' on your server.', 'wp-graphql' ),
+			$save_queries_value
+		);
 
 		// Default message
 		$trace = [ $default_message ];
 
 		if ( ! empty( $wpdb->queries ) && is_array( $wpdb->queries ) ) {
-			$queries = array_map( function ( $query ) {
+			$queries = array_map( static function ( $query ) {
 				return [
 					'sql'   => $query[0],
 					'time'  => $query[1],

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -54,7 +54,7 @@ class Utils {
 
 			if ( is_array( $value ) && ! empty( $value ) ) {
 				$value = array_map(
-					function ( $value ) {
+					static function ( $value ) {
 						if ( is_string( $value ) ) {
 							$value = sanitize_text_field( $value );
 						}

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -183,7 +183,7 @@ final class WPGraphQL {
 
 				add_action(
 					'admin_notices',
-					function () {
+					static function () {
 
 						if ( ! current_user_can( 'manage_options' ) ) {
 							return;
@@ -238,7 +238,7 @@ final class WPGraphQL {
 		 */
 		add_action(
 			'after_setup_theme',
-			function () {
+			static function () {
 
 				new \WPGraphQL\Data\Config();
 				$router = new Router();
@@ -288,7 +288,7 @@ final class WPGraphQL {
 		// Initialize Admin functionality
 		add_action( 'after_setup_theme', [ $this, 'init_admin' ] );
 
-		add_action('init_graphql_request', function () {
+		add_action('init_graphql_request', static function () {
 			$tracing = new \WPGraphQL\Utils\Tracing();
 			$tracing->init();
 
@@ -309,7 +309,14 @@ final class WPGraphQL {
 	 */
 	public function min_php_version_check() {
 		if ( defined( 'GRAPHQL_MIN_PHP_VERSION' ) && version_compare( PHP_VERSION, GRAPHQL_MIN_PHP_VERSION, '<' ) ) {
-			throw new \Exception( sprintf( __( 'The server\'s current PHP version %1$s is lower than the WPGraphQL minimum required version: %2$s', 'wp-graphql' ), PHP_VERSION, GRAPHQL_MIN_PHP_VERSION ) );
+			throw new \Exception(
+				sprintf(
+					// translators: %1$s is the current PHP version, %2$s is the minimum required PHP version.
+					__( 'The server\'s current PHP version %1$s is lower than the WPGraphQL minimum required version: %2$s', 'wp-graphql' ),
+					PHP_VERSION,
+					GRAPHQL_MIN_PHP_VERSION
+				)
+			);
 		}
 
 	}
@@ -385,7 +392,7 @@ final class WPGraphQL {
 		 *
 		 * @deprecated
 		 */
-		add_filter('graphql_type_interfaces', function ( $interfaces, $config, $type ) {
+		add_filter('graphql_type_interfaces', static function ( $interfaces, $config, $type ) {
 
 			if ( $type instanceof WPObjectType ) {
 				/**

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -127,7 +127,7 @@ final class WPGraphQL {
 
 		// Plugin version.
 		if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-			define( 'WPGRAPHQL_VERSION', '1.14.7' );
+			define( 'WPGRAPHQL_VERSION', '1.14.8' );
 		}
 
 		// Plugin Folder Path.

--- a/tests/wpunit/QueryAnalyzerTest.php
+++ b/tests/wpunit/QueryAnalyzerTest.php
@@ -316,8 +316,70 @@ class QueryAnalyzerTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$this->assertSame( [ 'list:page' ], $types );
 
+	}
 
+	public function testNonNullListOfNonNullPostMapsToListOfPosts() {
+
+		register_graphql_field( 'RootQuery', 'listOfThing', [
+			'type' => [
+				'non_null' => [
+					'list_of' => [
+						'non_null' => 'Post'
+					],
+				],
+			],
+		]);
+
+		$query = '
+		{
+		  listOfThing {
+		    __typename
+		  }
+		}
+		';
+
+		$request = graphql([
+			'query' => $query,
+		], true );
+
+		$request->execute();
+
+		$types = $request->get_query_analyzer()->get_list_types();
+
+		$this->assertContains( 'list:post', $types );
 
 	}
+
+	public function testListOfNonNullPostMapsToListOfPosts() {
+
+		register_graphql_field( 'RootQuery', 'listOfThing', [
+			'type' => [
+				'list_of' => [
+					'non_null' => 'Post'
+				],
+			],
+		]);
+
+		$query = '
+		{
+		  listOfThing {
+		    __typename
+		  }
+		}
+		';
+
+		$request = graphql([
+			'query' => $query,
+		], true );
+
+		$request->execute();
+
+		$types = $request->get_query_analyzer()->get_list_types();
+
+		$this->assertContains( 'list:post', $types );
+
+	}
+
+
 
 }

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.14.7
+ * Version: 1.14.8
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.14.3
+ * @version  1.14.8
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
# Release Notes

### Chores / Bugfixes

- [#2855](https://github.com/wp-graphql/wp-graphql/pull/2855): perf: enforce static closures when possible (PHPCS). Thanks @justlevine!
- [#2857](https://github.com/wp-graphql/wp-graphql/pull/2857): fix: Prevent truncation of query name inside the GraphiQL Query composer explorer tab. Thanks @LarsEjaas!
- [#2856](https://github.com/wp-graphql/wp-graphql/pull/2856): chore: add missing translator comments. Thanks @justlevine!
- [#2862](https://github.com/wp-graphql/wp-graphql/pull/2862): chore(deps-dev): bump word-wrap from 1.2.3 to 1.2.4
- [#2861](https://github.com/wp-graphql/wp-graphql/pull/2861): fix: output `list:$type` keys for Root fields that return a list of nodes
