### PR TITLE
fix: user roles should return empty 

### DIFF
--- a/src/Type/ObjectType/User.php
+++ b/src/Type/ObjectType/User.php
@@ -67,6 +67,9 @@ class User {
 
 							if ( isset( $user->roles ) && ! empty( $user->roles ) ) {
 								$resolver->set_query_arg( 'slugIn', $user->roles );
+							} else {
+								// If the user has no roles, we don't want to return any roles
+								$resolver->set_query_arg('slugIn', []);
 							}
 
 							return $resolver->get_connection();

--- a/src/Type/ObjectType/User.php
+++ b/src/Type/ObjectType/User.php
@@ -63,15 +63,15 @@ class User {
 						'fromFieldName' => 'roles',
 						'resolve'       => static function ( UserModel $user, $args, $context, $info ) {
 							$resolver = new UserRoleConnectionResolver( $user, $args, $context, $info );
-							// Only get roles matching the slugs of the roles belonging to the user
+							
+							// abort if no roles are set
+							if( empty( $user->roles ) )  return null;
 
+							// Only get roles matching the slugs of the roles belonging to the user
 							if ( isset( $user->roles ) && ! empty( $user->roles ) ) {
 								$resolver->set_query_arg( 'slugIn', $user->roles );
-							} else {
-								// If the user has no roles, we don't want to return any roles
-								$resolver->set_query_arg('slugIn', []);
-							}
-
+							} 
+							
 							return $resolver->get_connection();
 						},
 					],

--- a/tests/wpunit/UserRoleConnectionQueriesTest.php
+++ b/tests/wpunit/UserRoleConnectionQueriesTest.php
@@ -115,6 +115,47 @@ class UserRoleConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 
 	}
 
+	/**
+	 * Test that a user with no role returns no roles in the query.
+	 */
+	public function testUserWithNoRole()
+	{
+		wp_set_current_user($this->admin);
+
+		// Create a user with no role
+		$user_with_no_role = $this->factory()->user->create(['role' => false]);
+
+		// Set the test query
+		$query = '
+			query MyQuery {
+				user(id: ' . $user_with_no_role . ', idType: DATABASE_ID) {
+					roles {
+						edges {
+							node {
+								displayName
+							}
+						}
+					}
+				}
+			}
+        ';
+
+		// Execute the GraphQL Query
+		$actual = $this->graphql(['query' => $query]);
+
+		var_dump($actual);
+
+		// Assert that the user with no role returns no roles in the query
+		$expected = [
+			'user' => [
+				'roles' => null
+			]
+		];
+
+		$this->assertArrayNotHasKey('errors', $actual);
+		$this->assertEquals($expected, $actual['data']);
+	}
+
 	public function testForwardPagination() {
 		wp_set_current_user( $this->admin );
 		$query = $this->getQuery();


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
When my user does not have any roles assigned.  wp-graphql is returning all existing roles instead of null or empty roles.
…


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
![CleanShot 2023-07-24 at 15 43 49](https://github.com/wp-graphql/wp-graphql/assets/16583879/368d03c4-599b-44eb-a7ae-abfcaadd938f)



Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** aws lightsail bitnami wordpress


**WordPress Version:** 6.2
