### PR TITLE
fix: type loader returns null when graphql_single_name value has underscores [regression]

### DIFF
--- a/src/Utils/QueryAnalyzer.php
+++ b/src/Utils/QueryAnalyzer.php
@@ -418,7 +418,7 @@ class QueryAnalyzer {
 				}
 
 				if ( ! empty( $field_type ) && is_string( $field_type ) ) {
-					$field_type = $schema->getType( Utils::format_type_name( $field_type ) );
+					$field_type = $schema->getType( ucfirst( $field_type ) );
 				}
 
 				if ( ! $field_type ) {

--- a/tests/wpunit/CustomPostTypeTest.php
+++ b/tests/wpunit/CustomPostTypeTest.php
@@ -1580,18 +1580,13 @@ class CustomPostTypeTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		}
 		';
 
-//		$custom_post = $this->factory()->post->create([
-//			'post_type' => 'test_events',
-//			'post_status' => 'publish',
-//			'post_title' => 'test event'
-//		]);
-
 		$actual = $this->graphql([
 			'query' => $query
 		]);
 
+		// ensure the query succeeds without error
 		self::assertQuerySuccessful( $actual, [
-			$this->expectedField( 'testEvents.nodes', self::IS_NULL )
+			$this->expectedField( 'testEvents.nodes', [] )
 		]);
 
 		unregister_post_type( 'test_events' );

--- a/tests/wpunit/CustomPostTypeTest.php
+++ b/tests/wpunit/CustomPostTypeTest.php
@@ -1561,4 +1561,41 @@ class CustomPostTypeTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->clearSchema();
 	}
 
+	public function testRegisterPostTypeWithUnderscoresAsGraphqlSingleName() {
+
+		register_post_type( 'test_events', [
+			'show_in_graphql' => true,
+			'graphql_single_name' => 'test_event',
+			'graphql_plural_name' => 'test_events'
+		]);
+
+		$query = '
+		{
+		  testEvents {
+		    nodes {
+		      __typename
+		      id
+		    }
+		  }
+		}
+		';
+
+//		$custom_post = $this->factory()->post->create([
+//			'post_type' => 'test_events',
+//			'post_status' => 'publish',
+//			'post_title' => 'test event'
+//		]);
+
+		$actual = $this->graphql([
+			'query' => $query
+		]);
+
+		self::assertQuerySuccessful( $actual, [
+			$this->expectedField( 'testEvents.nodes', self::IS_NULL )
+		]);
+
+		unregister_post_type( 'test_events' );
+
+	}
+
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This fixes a regression from v1.14.7 release where the QueryAnalyzer attempts to load types that might not exist when `graphql_single_name` for post types / taxonomies include underscores.

- failing test: https://github.com/wp-graphql/wp-graphql/actions/runs/5672998214
- passing test: https://github.com/wp-graphql/wp-graphql/actions/runs/5673008689

Does this close any currently open issues?
------------------------------------------
closes #2868 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
Given the following code to register a post type: 

```php
<?php
add_action( 'init', function() {

	register_post_type( 'test_events', [
		'show_in_graphql' => true,
		'graphql_single_name' => 'event_type', # Note the use of underscores here, technically valid but we recommend PascalCase
		'graphql_plural_name' => 'event_types'
	]);

} );
```

### Before

Querying for the Type would lead to an error

![CleanShot 2023-07-26 at 13 33 08](https://github.com/wp-graphql/wp-graphql/assets/1260765/fdaec29d-3fba-41f5-
8e46-69c72d63629b)


### After

No more errors

![CleanShot 2023-07-26 at 13 33 52](https://github.com/wp-graphql/wp-graphql/assets/1260765/9b9fbcf5-ae72-4830-b237-b449c97d620b)


Any other comments?
-------------------

This fixes a regression to the v1.14.7 release. 

**NOTE**, if you are using underscores in your `graphql_single_name` for post types / taxonomies, you might be seeing Debug messages like the following:

![CleanShot 2023-07-26 at 13 34 38](https://github.com/wp-graphql/wp-graphql/assets/1260765/6fb300b1-f6ee-470d-bc70-dc57b2bccecc)

This type of debug message existed _before_ this regression and will continue to exist after this fix. The best practice is to use `PascalCase` for your `graphql_single_name` and `graphql_plural_name` values, which would get rid of the debug message, but _might_ have other implications to your Schema, so move carefully.