### PR TITLE
release: v1.14.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Chores / Bugfixes
 
 - [#2874](https://github.com/wp-graphql/wp-graphql/pull/2874): fix: improve PostObjectCursor support for meta queries. Thanks @kidunot89!
+- [#2880](https://github.com/wp-graphql/wp-graphql/pull/2880): fix: increase clarity of the description of "asPreview" argument
 
 ## 1.14.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.14.10
+
+- [#2874](https://github.com/wp-graphql/wp-graphql/pull/2874): fix: improve PostObjectCursor support for meta queries. Thanks @kidunot89!
+
 ## 1.14.9
 
 ## Chores / Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.14.10
 
+### Chores / Bugfixes
+
 - [#2874](https://github.com/wp-graphql/wp-graphql/pull/2874): fix: improve PostObjectCursor support for meta queries. Thanks @kidunot89!
 
 ## 1.14.9
@@ -14,7 +16,7 @@
 
 ## 1.14.8
 
-## Chores / Bugfixes
+### Chores / Bugfixes
 
 - [#2855](https://github.com/wp-graphql/wp-graphql/pull/2855): perf: enforce static closures when possible (PHPCS). Thanks @justlevine!
 - [#2857](https://github.com/wp-graphql/wp-graphql/pull/2857): fix: Prevent truncation of query name inside the GraphiQL Query composer explorer tab. Thanks @LarsEjaas!
@@ -24,7 +26,7 @@
 
 ## 1.14.7
 
-## Chores / Bugfixes
+### Chores / Bugfixes
 
 - [#2853](https://github.com/wp-graphql/wp-graphql/pull/2853): fix: internal server error when query max depth setting is left empty
 - [#2851](https://github.com/wp-graphql/wp-graphql/pull/2851): fix: querying posts by slug or uri with non-ascii characters
@@ -33,7 +35,7 @@
 
 ## 1.14.6
 
-## Chores / Bugfixes
+### Chores / Bugfixes
 
 - [#2841](https://github.com/wp-graphql/wp-graphql/pull/2841): ci: support STEP_DEBUG in Code Quality workflow. Thanks @justlevine!
 - [#2840](https://github.com/wp-graphql/wp-graphql/pull/2840): fix: update createMediaItem mutation to have better validation of input.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, JSON, API, Gatsby, Faust, Headless, Decoupled, Svelte, React, Nex
 Requires at least: 5.0
 Tested up to: 6.2
 Requires PHP: 7.1
-Stable tag: 1.14.9
+Stable tag: 1.14.10
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -239,6 +239,12 @@ The `uri` field was non-null on some Types in the Schema but has been changed to
 Composer dependencies are no longer versioned in Github. Recommended install source is WordPress.org or using Composer to get the code from Packagist.org or WPackagist.org.
 
 == Changelog ==
+
+= 1.14.10 =
+
+**Chores / Bugfixes**
+
+- [#2874](https://github.com/wp-graphql/wp-graphql/pull/2874): fix: improve PostObjectCursor support for meta queries. Thanks @kidunot89!
 
 = 1.14.9 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -245,6 +245,7 @@ Composer dependencies are no longer versioned in Github. Recommended install sou
 **Chores / Bugfixes**
 
 - [#2874](https://github.com/wp-graphql/wp-graphql/pull/2874): fix: improve PostObjectCursor support for meta queries. Thanks @kidunot89!
+- [#2880](https://github.com/wp-graphql/wp-graphql/pull/2880): fix: increase clarity of the description of "asPreview" argument
 
 = 1.14.9 =
 

--- a/src/Type/ObjectType/RootQuery.php
+++ b/src/Type/ObjectType/RootQuery.php
@@ -209,7 +209,7 @@ class RootQuery {
 							],
 							'asPreview'   => [
 								'type'        => 'Boolean',
-								'description' => __( 'Whether to return the node as a preview instance', 'wp-graphql' ),
+								'description' => __( 'Whether to return the Preview Node instead of the Published Node. When the ID of a Node is provided along with asPreview being set to true, the preview node with un-published changes will be returned instead of the published node. If no preview node exists or the requestor doesn\'t have proper capabilities to preview, no node will be returned.', 'wp-graphql' ),
 							],
 						],
 						'resolve'     => static function ( $root, $args, AppContext $context, ResolveInfo $info ) {
@@ -701,7 +701,7 @@ class RootQuery {
 						],
 						'asPreview' => [
 							'type'        => 'Boolean',
-							'description' => __( 'Whether to return the node as a preview instance', 'wp-graphql' ),
+							'description' => __( 'Whether to return the Preview Node instead of the Published Node. When the ID of a Node is provided along with asPreview being set to true, the preview node with un-published changes will be returned instead of the published node. If no preview node exists or the requestor doesn\'t have proper capabilities to preview, no node will be returned.', 'wp-graphql' ),
 						],
 					],
 					'resolve'     => static function ( $source, array $args, AppContext $context ) use ( $post_type_object ) {

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -127,7 +127,7 @@ final class WPGraphQL {
 
 		// Plugin version.
 		if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-			define( 'WPGRAPHQL_VERSION', '1.14.9' );
+			define( 'WPGRAPHQL_VERSION', '1.14.10' );
 		}
 
 		// Plugin Folder Path.

--- a/tests/wpunit/PostObjectCursorTest.php
+++ b/tests/wpunit/PostObjectCursorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class PostObjectCursorTest extends \Codeception\TestCase\WPTestCase {
+class PostObjectCursorTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 	public $current_time;
 	public $current_date;
 	public $current_date_gmt;
@@ -16,6 +16,8 @@ class PostObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 		$this->admin            = $this->factory()->user->create( [
 			'role' => 'administrator',
 		] );
+		$this->start_count      = 100;
+		$this->start_time       = time();
 		$this->created_post_ids = $this->create_posts();
 	}
 
@@ -59,6 +61,11 @@ class PostObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 		 */
 		update_post_meta( $post_id, '_edit_lock', $this->current_time . ':' . $this->admin );
 		update_post_meta( $post_id, '_edit_last', $this->admin );
+
+		update_post_meta( $post_id, 'test_meta_date', $this->start_time - $this->start_count );
+		update_post_meta( $post_id, 'test_meta_number', $this->start_count );
+
+		$this->start_count -= 1;
 
 		/**
 		 * Return the $id of the post_object that was created
@@ -460,5 +467,347 @@ class PostObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 			'order'    => 'ASC',
 			'meta_key' => 'test_meta',
 		] );
+	}
+
+	public function testPostOrderingByMultipleMeta() {
+		register_graphql_fields(
+			'Post',
+			[
+				'testMetaDate' => [
+					'type'    => 'String',
+					'resolve' => function( $source ) {
+						return get_post_meta( $source->ID, 'test_meta_date', true );
+					}
+				],
+				'testMetaNumber' => [
+					'type'    => 'Number',
+					'resolve' => function( $source ) {
+						return get_post_meta( $source->ID, 'test_meta_number', true );
+					}
+				],
+			]
+		);
+
+		add_filter(
+			'graphql_PostObjectsConnectionOrderbyEnum_values',
+			function( $values ) {
+				$values['TEST_META_DATE'] = 'test_meta_date';
+				$values['TEST_META_NUMBER'] = 'test_meta_number';
+				return $values;
+			}
+		);
+
+		add_filter(
+			'graphql_post_object_connection_query_args',
+			function ( $query_args ) {
+				if ( isset( $query_args['orderby'] ) && is_array( $query_args['orderby'] ) ) {
+					foreach( $query_args['orderby'] as $field => $order ) {
+						if ( in_array( $field, [ 'test_meta_date', 'test_meta_number' ], true ) ) {
+							if ( empty( $query_args['meta_query'] ) ) {
+								$query_args['meta_query'] = [];
+							}
+							$query_args['meta_query'][] = [
+								'key' => $field,
+								'type' => 'numeric',
+								'compare' => 'EXISTS',
+							];
+						}
+					}
+				} elseif ( isset( $query_args['orderby'] ) && is_string( $query_args['orderby'] ) ) {
+					if ( in_array( $query_args['orderby'], [ 'test_meta_date', 'test_meta_number' ], true ) ) {
+						if ( empty( $query_args['meta_query'] ) ) {
+							$query_args['meta_query'] = [];
+						}
+						$query_args['meta_query'][] = [
+							'key' => $query_args['orderby'],
+							'compare' => 'EXISTS',
+						];
+					}
+				} 
+
+				return $query_args;
+			},
+		);
+		// Clear cached schema so new fields are seen.
+		$this->clearSchema();
+
+		$query    = '
+			query ($first: Int, $last: Int, $before: String, $after: String, $where: RootQueryToPostConnectionWhereArgs!) {
+				posts(first: $first, last: $last, before: $before, after: $after, where: $where) {
+					nodes {
+						id
+						databaseId
+						testMetaDate
+						testMetaNumber
+					}
+				}
+			}
+		';
+
+		$variables = [
+			'first' => 5,
+			'where' => [
+				'orderby' => [
+					[
+						'field' => 'TEST_META_NUMBER',
+						'order' => 'ASC',
+					],
+					[
+						'field' => 'TEST_META_DATE',
+						'order' => 'DESC',
+					],
+				]
+			]
+		];
+		$response  = $this->graphql( compact( 'query', 'variables' ) );
+		$expected  = [
+			$this->expectedNode(
+				'posts.nodes',
+				[
+					$this->expectedField( 'id', $this->toRelayId( 'post', $this->created_post_ids[20] ) ),
+					$this->expectedField( 'testMetaDate', strval( $this->start_time - (100 - 19) ) ),
+					$this->expectedField( 'testMetaNumber', floatval(100 - 19) ),
+				],
+				0
+			),
+			$this->expectedNode(
+				'posts.nodes',
+				[
+					$this->expectedField( 'id', $this->toRelayId( 'post', $this->created_post_ids[19] ) ),
+					$this->expectedField( 'testMetaDate', strval( $this->start_time - (100 - 18) ) ),
+					$this->expectedField( 'testMetaNumber', floatval(100 - 18) ),
+				],
+				1
+			),
+			$this->expectedNode(
+				'posts.nodes',
+				[
+					$this->expectedField( 'id', $this->toRelayId( 'post', $this->created_post_ids[18] ) ),
+					$this->expectedField( 'testMetaDate', strval( $this->start_time - (100 - 17) ) ),
+					$this->expectedField( 'testMetaNumber', floatval(100 - 17) ),
+				],
+				2
+			),
+			$this->expectedNode(
+				'posts.nodes',
+				[
+					$this->expectedField( 'id', $this->toRelayId( 'post', $this->created_post_ids[17] ) ),
+					$this->expectedField( 'testMetaDate', strval( $this->start_time - (100 - 16) ) ),
+					$this->expectedField( 'testMetaNumber', floatval(100 - 16) ),
+				],
+				3
+			),
+			$this->expectedNode(
+				'posts.nodes',
+				[
+					$this->expectedField( 'id', $this->toRelayId( 'post', $this->created_post_ids[16] ) ),
+					$this->expectedField( 'testMetaDate', strval( $this->start_time - (100 - 15) ) ),
+					$this->expectedField( 'testMetaNumber', floatval(100 - 15) ),
+				],
+				4
+			),
+		];
+
+		$this->assertQuerySuccessful( $response, $expected );
+
+		$variables = [
+			'first' => 5,
+			'where' => [
+				'orderby' => [
+					[
+						'field' => 'TEST_META_NUMBER',
+						'order' => 'ASC',
+					],
+					[
+						'field' => 'TEST_META_DATE',
+						'order' => 'DESC',
+					],
+				],
+			],
+			'after' => base64_encode( 'arrayconnection:' . $this->created_post_ids[16] ),
+		];
+		$response  = $this->graphql( compact( 'query', 'variables' ) );
+		$expected  = [
+			$this->expectedNode(
+				'posts.nodes',
+				[
+					$this->expectedField( 'id', $this->toRelayId( 'post', $this->created_post_ids[15] ) ),
+					$this->expectedField( 'testMetaDate', strval( $this->start_time - (100 - 14) ) ),
+					$this->expectedField( 'testMetaNumber', floatval(100 - 14) ),
+				],
+				0
+			),
+			$this->expectedNode(
+				'posts.nodes',
+				[
+					$this->expectedField( 'id', $this->toRelayId( 'post', $this->created_post_ids[14] ) ),
+					$this->expectedField( 'testMetaDate', strval( $this->start_time - (100 - 13) ) ),
+					$this->expectedField( 'testMetaNumber', floatval(100 - 13) ),
+				],
+				1
+			),
+			$this->expectedNode(
+				'posts.nodes',
+				[
+					$this->expectedField( 'id', $this->toRelayId( 'post', $this->created_post_ids[13] ) ),
+					$this->expectedField( 'testMetaDate', strval( $this->start_time - (100 - 12) ) ),
+					$this->expectedField( 'testMetaNumber', floatval(100 - 12) ),
+				],
+				2
+			),
+			$this->expectedNode(
+				'posts.nodes',
+				[
+					$this->expectedField( 'id', $this->toRelayId( 'post', $this->created_post_ids[12] ) ),
+					$this->expectedField( 'testMetaDate', strval( $this->start_time - (100 - 11) ) ),
+					$this->expectedField( 'testMetaNumber', floatval(100 - 11) ),
+				],
+				3
+			),
+			$this->expectedNode(
+				'posts.nodes',
+				[
+					$this->expectedField( 'id', $this->toRelayId( 'post', $this->created_post_ids[11] ) ),
+					$this->expectedField( 'testMetaDate', strval( $this->start_time - (100 - 10) ) ),
+					$this->expectedField( 'testMetaNumber', floatval(100 - 10) ),
+				],
+				4
+			),
+		];
+
+		$this->assertQuerySuccessful( $response, $expected );
+
+		$variables = [
+			'last' => 5,
+			'where' => [
+				'orderby' => [
+					[
+						'field' => 'TEST_META_DATE',
+						'order' => 'DESC',
+					],
+					[
+						'field' => 'TEST_META_NUMBER',
+						'order' => 'ASC',
+					],
+				],
+			],
+		];
+		$response  = $this->graphql( compact( 'query', 'variables' ) );
+		$expected  = [			
+			$this->expectedNode(
+				'posts.nodes',
+				[
+					$this->expectedField( 'id', $this->toRelayId( 'post', $this->created_post_ids[5] ) ),
+					$this->expectedField( 'testMetaDate', strval( $this->start_time - 96 ) ),
+					$this->expectedField( 'testMetaNumber', floatval(96) ),
+				],
+				0
+			),
+			$this->expectedNode(
+				'posts.nodes',
+				[
+					$this->expectedField( 'id', $this->toRelayId( 'post', $this->created_post_ids[4] ) ),
+					$this->expectedField( 'testMetaDate', strval( $this->start_time - 97 ) ),
+					$this->expectedField( 'testMetaNumber', floatval(97) ),
+				],
+				1
+			),
+			$this->expectedNode(
+				'posts.nodes',
+				[
+					$this->expectedField( 'id', $this->toRelayId( 'post', $this->created_post_ids[3] ) ),
+					$this->expectedField( 'testMetaDate', strval( $this->start_time - 98 ) ),
+					$this->expectedField( 'testMetaNumber', floatval(98) ),
+				],
+				2
+			),
+			$this->expectedNode(
+				'posts.nodes',
+				[
+					$this->expectedField( 'id', $this->toRelayId( 'post', $this->created_post_ids[2] ) ),
+					$this->expectedField( 'testMetaDate', strval( $this->start_time - 99 ) ),
+					$this->expectedField( 'testMetaNumber', floatval(99) ),
+				],
+				3
+			),
+			$this->expectedNode(
+				'posts.nodes',
+				[
+					$this->expectedField( 'id', $this->toRelayId( 'post', $this->created_post_ids[1] ) ),
+					$this->expectedField( 'testMetaDate', strval( $this->start_time - 100 ) ),
+					$this->expectedField( 'testMetaNumber', floatval(100) ),
+				],
+				4
+			),
+		];
+
+		$this->assertQuerySuccessful( $response, $expected );
+
+		$variables = [
+			'last' => 5,
+			'where' => [
+				'orderby' => [
+					[
+						'field' => 'TEST_META_DATE',
+						'order' => 'DESC',
+					],
+					[
+						'field' => 'TEST_META_NUMBER',
+						'order' => 'ASC',
+					],
+				],
+			],
+			'before' => base64_encode( 'arrayconnection:' . $this->created_post_ids[5] ),
+		];
+		$response  = $this->graphql( compact( 'query', 'variables' ) );
+		$expected  = [
+			$this->expectedNode(
+				'posts.nodes',
+				[
+					$this->expectedField( 'id', $this->toRelayId( 'post', $this->created_post_ids[10] ) ),
+					$this->expectedField( 'testMetaDate', strval( $this->start_time - 91 ) ),
+					$this->expectedField( 'testMetaNumber', floatval(91) ),
+				],
+				0
+			),
+			$this->expectedNode(
+				'posts.nodes',
+				[
+					$this->expectedField( 'id', $this->toRelayId( 'post', $this->created_post_ids[9] ) ),
+					$this->expectedField( 'testMetaDate', strval( $this->start_time - 92 ) ),
+					$this->expectedField( 'testMetaNumber', floatval(92) ),
+				],
+				1
+			),
+			$this->expectedNode(
+				'posts.nodes',
+				[
+					$this->expectedField( 'id', $this->toRelayId( 'post', $this->created_post_ids[8] ) ),
+					$this->expectedField( 'testMetaDate', strval( $this->start_time - 93 ) ),
+					$this->expectedField( 'testMetaNumber', floatval(93) ),
+				],
+				2
+			),
+			$this->expectedNode(
+				'posts.nodes',
+				[
+					$this->expectedField( 'id', $this->toRelayId( 'post', $this->created_post_ids[7] ) ),
+					$this->expectedField( 'testMetaDate', strval( $this->start_time - 94 ) ),
+					$this->expectedField( 'testMetaNumber', floatval(94) ),
+				],
+				3
+			),
+			$this->expectedNode(
+				'posts.nodes',
+				[
+					$this->expectedField( 'id', $this->toRelayId( 'post', $this->created_post_ids[6] ) ),
+					$this->expectedField( 'testMetaDate', strval( $this->start_time - 95 ) ),
+					$this->expectedField( 'testMetaNumber', floatval(95) ),
+				],
+				4
+			),
+		];
+
+		$this->assertQuerySuccessful( $response, $expected );
 	}
 }

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.14.9
+ * Version: 1.14.10
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.14.9
+ * @version  1.14.10
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
# Release Notes

### Chores / Bugfixes

- [#2874](https://github.com/wp-graphql/wp-graphql/pull/2874): fix: improve PostObjectCursor support for meta queries. Thanks @kidunot89!
- [#2880](https://github.com/wp-graphql/wp-graphql/pull/2880): fix: increase clarity of the description of "asPreview" argument

