### PR TITLE
fix: increase clarity of the description of `asPreview` argument

### DIFF
--- a/src/Type/ObjectType/RootQuery.php
+++ b/src/Type/ObjectType/RootQuery.php
@@ -209,7 +209,7 @@ class RootQuery {
 							],
 							'asPreview'   => [
 								'type'        => 'Boolean',
-								'description' => __( 'Whether to return the node as a preview instance', 'wp-graphql' ),
+								'description' => __( 'Whether to return the Preview Node instead of the Published Node. When the ID of a Node is provided along with asPreview being set to true, the preview node with un-published changes will be returned instead of the published node. If no preview node exists or the requestor doesn\'t have proper capabilities to preview, no node will be returned.', 'wp-graphql' ),
 							],
 						],
 						'resolve'     => static function ( $root, $args, AppContext $context, ResolveInfo $info ) {
@@ -701,7 +701,7 @@ class RootQuery {
 						],
 						'asPreview' => [
 							'type'        => 'Boolean',
-							'description' => __( 'Whether to return the node as a preview instance', 'wp-graphql' ),
+							'description' => __( 'Whether to return the Preview Node instead of the Published Node. When the ID of a Node is provided along with asPreview being set to true, the preview node with un-published changes will be returned instead of the published node. If no preview node exists or the requestor doesn\'t have proper capabilities to preview, no node will be returned.', 'wp-graphql' ),
 						],
 					],
 					'resolve'     => static function ( $source, array $args, AppContext $context ) use ( $post_type_object ) {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Improve description of the `asPreview` argument as discussed in #2876 

Does this close any currently open issues?
------------------------------------------
closes #2879 

Any other comments?
-------------------

### Before

The description is a bit vague.

![CleanShot 2023-08-03 at 14 41 32](https://github.com/wp-graphql/wp-graphql/assets/1260765/34ee9e97-02aa-4b3a-a5f1-8f0db0276899)

### After

The description provides more clarity about how the argument will impact the field's response.

![CleanShot 2023-08-03 at 14 40 25](https://github.com/wp-graphql/wp-graphql/assets/1260765/50a87b29-04fc-4a17-9b34-2b261d095b41)

