### PR TITLE
ci: update tests to test against WordPress 6.3, simplify the matrix

### DIFF
--- a/.github/workflows/deploy-docker-image.yml
+++ b/.github/workflows/deploy-docker-image.yml
@@ -15,6 +15,11 @@ jobs:
       matrix:
         php: [ '8.1', '8.0', '7.4', '7.3' ]
         wordpress: [ '6.2', '6.1', '6.0', '5.9', '5.8', '5.7.2', '5.6', '5.5.3' ]
+        include:
+          - php: '8.1'
+            wordpress: 'beta-6.3'
+          - php: '8.2'
+            wordpress: 'beta-6.3'
         exclude:
           - php: '8.0'
             wordpress: '5.5.3'

--- a/.github/workflows/testing-integration.yml
+++ b/.github/workflows/testing-integration.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.2', 8.1' ]
+        php: [ '8.2', '8.1' ]
         wordpress: [ '6.2', '6.1' ]
         include:
           - php: '8.1'

--- a/.github/workflows/testing-integration.yml
+++ b/.github/workflows/testing-integration.yml
@@ -21,9 +21,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.0', '7.4' ]
-        wordpress: [ '6.2', '6.1', '6.0', '5.9', '5.8', '5.7', '5.6' ]
+        php: [ '8.2', 8.1' ]
+        wordpress: [ '6.2', '6.1' ]
         include:
+          - php: '8.1'
+            wordpress: 'beta-6.3'
           - php: '8.1'
             wordpress: '6.2'
             multisite: true
@@ -48,6 +50,8 @@ jobs:
         exclude:
           - php: '7.4'
             wordpress: '6.2'
+          - php: '7.4'
+            wordpress: '6.2'
 
     steps:
       - name: Cancel previous runs of this workflow (pull requests only)
@@ -65,7 +69,7 @@ jobs:
           php-version: ${{ matrix.php }}
           tools: composer:v2
           extensions: json, mbstring
-      
+
       - name: Install dependencies
         uses: ramsey/composer-install@v2
         with:

--- a/.github/workflows/testing-integration.yml
+++ b/.github/workflows/testing-integration.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.2', '8.1' ]
+        php: [ '8.2', '8.1', '8.0' ]
         wordpress: [ '6.2', '6.1' ]
         include:
           - php: '8.1'
@@ -46,12 +46,8 @@ jobs:
             wordpress: '5.7'
           - php: '7.3'
             wordpress: '5.6'
-        # This is a temporary exclusion until a php74 image is released. See #2780
-        exclude:
           - php: '7.4'
-            wordpress: '6.2'
-          - php: '7.4'
-            wordpress: '6.2'
+            wordpress: '6.1.1'
 
     steps:
       - name: Cancel previous runs of this workflow (pull requests only)


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Updates the test matrix to test against WordPress 6.3 (currently available as a beta)

Does this close any currently open issues?
------------------------------------------
closes #2886 


Any other comments?
-------------------
This simplifies the matrix and drops testing for some older versions of WordPress
