### PR TITLE
revert: "fix: Use hostname for graphql cache header url for varnish"

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -326,10 +326,6 @@ class Router {
 			]
 		);
 
-		// For cache url header, use the domain without protocol or path.
-		$graphql_endpoint  = graphql_get_endpoint_url();
-		$endpoint_hostname = wp_parse_url( $graphql_endpoint, PHP_URL_HOST ) ?: $graphql_endpoint;
-
 		$headers = [
 			'Access-Control-Allow-Origin'  => '*',
 			'Access-Control-Allow-Headers' => implode( ', ', $access_control_allow_headers ),
@@ -338,7 +334,7 @@ class Router {
 			'Content-Type'                 => 'application/json ; charset=' . get_option( 'blog_charset' ),
 			'X-Robots-Tag'                 => 'noindex',
 			'X-Content-Type-Options'       => 'nosniff',
-			'X-GraphQL-URL'                => $endpoint_hostname,
+			'X-GraphQL-URL'                => graphql_get_endpoint_url(),
 		];
 
 


### PR DESCRIPTION
Reverts wp-graphql/wp-graphql#2890

see: https://github.com/wp-graphql/wp-graphql/pull/2890#issuecomment-1673721688