### PR TITLE
fix: Deprecated: trim(): Passing null to parameter #1 () of type stri…

### DIFF
--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -502,11 +502,16 @@ class Post extends Model {
 					},
 					'capability' => isset( $this->post_type_object->cap->edit_posts ) ? $this->post_type_object->cap->edit_posts : 'edit_posts',
 				],
-				'excerptRendered'           => function () {
+				'excerptRendered' => function () {
 					$excerpt = ! empty( $this->data->post_excerpt ) ? $this->data->post_excerpt : null;
 					$excerpt = apply_filters( 'get_the_excerpt', $excerpt, $this->data );
-
-					return $this->html_entity_decode( apply_filters( 'the_excerpt', $excerpt ), 'excerptRendered' );
+			
+					if ($excerpt !== null) {
+							$excerpt = trim(apply_filters( 'the_excerpt', $excerpt ));
+							return $this->html_entity_decode( $excerpt, 'excerptRendered' );
+					}
+			
+					return ''; // Return an empty string if $excerpt is null
 				},
 				'excerptRaw'                => [
 					'callback'   => function () {


### PR DESCRIPTION
**Error:** Deprecated:` trim():` Passing null to parameter #1 `($string)` of type string is deprecated
**Goal:** To return empty string if no excerpt, (instead of just null)

<img width="1105" alt="Screenshot 2023-08-14 at 11 49 09" src="https://github.com/wp-graphql/wp-graphql/assets/12534341/f18caf4d-6019-43ae-a624-7e1d21906446">


Where has this been tested?
---------------------------
**Plugin Version:** 1.14.10

**WordPress Version:** 6.3
