### PR TITLE
fix: Use graphql endpoint without scheme in url header

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -314,6 +314,10 @@ class Router {
 			]
 		);
 
+		// For cache url header, use the domain without protocol. Path for when it's multisite.
+		// Remove the starting http://, https://, :// from the full hostname/path.
+		$host_and_path = preg_replace( '#^.*?://#', '', graphql_get_endpoint_url() );
+
 		$headers = [
 			'Access-Control-Allow-Origin'  => '*',
 			'Access-Control-Allow-Headers' => implode( ', ', $access_control_allow_headers ),
@@ -322,7 +326,7 @@ class Router {
 			'Content-Type'                 => 'application/json ; charset=' . get_option( 'blog_charset' ),
 			'X-Robots-Tag'                 => 'noindex',
 			'X-Content-Type-Options'       => 'nosniff',
-			'X-GraphQL-URL'                => graphql_get_endpoint_url(),
+			'X-GraphQL-URL'                => $host_and_path,
 		];
 
 


### PR DESCRIPTION

What does this implement/fix? Explain your changes.
---------------------------------------------------
Related to the [work](https://github.com/wp-graphql/wp-graphql-smart-cache/issues/246) to remove wpengine specific code from this plugin, since that is being handled in the wpengine specific codebase to purge their network/varnish cache.  

This change removes the scheme (http://,https://,://) from the graphql url provided as cache header url.  The domain and path remains in the url.

A similar change is being made in the smart cache plugin to send the same hostname as part of the purge cache event.


Does this close any currently open issues?
------------------------------------------
<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
<!-- (If it’s long, please paste to https://ghostbin.com/ and insert the link here.) -->


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
