### PR TITLE
revert: "fix: Use graphql endpoint without scheme in url header"

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -314,10 +314,6 @@ class Router {
 			]
 		);
 
-		// For cache url header, use the domain without protocol. Path for when it's multisite.
-		// Remove the starting http://, https://, :// from the full hostname/path.
-		$host_and_path = preg_replace( '#^.*?://#', '', graphql_get_endpoint_url() );
-
 		$headers = [
 			'Access-Control-Allow-Origin'  => '*',
 			'Access-Control-Allow-Headers' => implode( ', ', $access_control_allow_headers ),
@@ -326,7 +322,7 @@ class Router {
 			'Content-Type'                 => 'application/json ; charset=' . get_option( 'blog_charset' ),
 			'X-Robots-Tag'                 => 'noindex',
 			'X-Content-Type-Options'       => 'nosniff',
-			'X-GraphQL-URL'                => $host_and_path,
+			'X-GraphQL-URL'                => graphql_get_endpoint_url(),
 		];
 
 


### PR DESCRIPTION
reverting as this will cause a regression for WP Engine users until a deployment is made to WP Engine MU plugins. 

Will re-open this PR and release after the WP Engine MU plugins are updated for their users.