### PR TITLE
release: v1.15.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,7 +6,9 @@ body:
       value: >-
         Thank you for taking the time to report a possible bug!
 
-        Please remember, a bug report is not the place to ask questions. You can
+        Before submitting a bug report, please take a minute to review the [WPGraphQL Debugging Guide](https://www.wpgraphql.com/docs/debugging) so you can share the necessary information to help us debug your issue.
+
+        Please remember, a bug report is _not the place to ask questions_. You can
         use [Slack](https://join.slack.com/t/wp-graphql/shared_invite/zt-3vloo60z-PpJV2PFIwEathWDOxCTTLA) for that, or start a topic in [GitHub
         Discussions](https://github.com/wp-graphql/wp-graphql/discussions).
   - type: textarea

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,9 +3,9 @@
 ### Your checklist for this pull request
 Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
 
-🚨 Please review the [guidelines for contributing](/.github/CONTRIBUTING.md) to this repository.
+🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md
 
-- [ ] Make sure your PR title follows Conventional Commit standards. See: [https://www.conventionalcommits.org/en/v1.0.0/#specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
+- [ ] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
 - [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
 - [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!
 
@@ -26,7 +26,7 @@ Does this close any currently open issues?
 
 Any relevant logs, error output, GraphiQL screenshots, etc?
 -------------------------------------
-(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)
+<!-- (If it’s long, please paste to https://ghostbin.com/ and insert the link here.) -->
 
 
 Any other comments?

--- a/.github/workflows/deploy-docker-image.yml
+++ b/.github/workflows/deploy-docker-image.yml
@@ -15,15 +15,24 @@ jobs:
       matrix:
         php: [ '8.1', '8.0', '7.4', '7.3' ]
         wordpress: [ '6.2', '6.1', '6.0', '5.9', '5.8', '5.7.2', '5.6', '5.5.3' ]
+        include:
+          - php: '8.2'
+            wordpress: '6.1'
+          - php: '8.2'
+            wordpress: '6.2'
+          - php: '8.2'
+            wordpress: '6.3'
+          - php: '8.1'
+            wordpress: '6.3'
         exclude:
-          - php: '8.0'
-            wordpress: '5.5.3'
           - php: '8.1'
             wordpress: '5.5.3'
           - php: '8.1'
             wordpress: '5.6'
           - php: '8.1'
             wordpress: '5.7.2'
+          - php: '8.0'
+            wordpress: '5.5.3'
           - php: '7.3'
             wordpress: '6.0'
           - php: '7.3'

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -18,18 +18,18 @@ jobs:
         with:
           # see: https://github.com/commitizen/conventional-commit-types
           types: |
+            build
+            chore
+            ci
+            docs
             feat
             fix
-            docs
-            style
-            refactor
             perf
-            test
-            build
-            ci
-            chore
-            revert
+            refactor
             release
+            revert
+            style
+            test
           requireScope: false
           ignoreLabels: |
             bot

--- a/.github/workflows/testing-integration.yml
+++ b/.github/workflows/testing-integration.yml
@@ -21,8 +21,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.0', '7.4' ]
-        wordpress: [ '6.2', '6.1', '6.0', '5.9', '5.8', '5.7', '5.6' ]
+        php: [ '8.2', '8.1', '8.0' ]
+        wordpress: [ '6.3', '6.2', '6.1' ]
         include:
           - php: '8.1'
             wordpress: '6.2'
@@ -31,11 +31,11 @@ jobs:
             wordpress: '6.2'
             coverage: 1
           - php: '8.1'
-            wordpress: '6.1'
-          - php: '8.1'
             wordpress: '6.0'
           - php: '8.1'
             wordpress: '5.9'
+          - php: '7.4'
+            wordpress: '6.1.1'
           - php: '7.3'
             wordpress: '5.9'
           - php: '7.3'
@@ -44,10 +44,6 @@ jobs:
             wordpress: '5.7'
           - php: '7.3'
             wordpress: '5.6'
-        # This is a temporary exclusion until a php74 image is released. See #2780
-        exclude:
-          - php: '7.4'
-            wordpress: '6.2'
 
     steps:
       - name: Cancel previous runs of this workflow (pull requests only)
@@ -65,7 +61,7 @@ jobs:
           php-version: ${{ matrix.php }}
           tools: composer:v2
           extensions: json, mbstring
-      
+
       - name: Install dependencies
         uses: ramsey/composer-install@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 1.15.0
+
+### New Features
+
+- [#2908](https://github.com/wp-graphql/wp-graphql/pull/2908): feat: Skip param added to Utils::map_input(). Thanks @kidunot89!
+
+### Chores / Bugfixes
+
+- [#2907](https://github.com/wp-graphql/wp-graphql/pull/2907): ci: Use WP 6.3 image, not the beta one
+- [#2902](https://github.com/wp-graphql/wp-graphql/pull/2902): chore: handle unused variables (phpcs). Thanks @justlevine!
+- [#2901](https://github.com/wp-graphql/wp-graphql/pull/2901): chore: remove useless ternaries (phpcs). Thanks @justlevine!
+- [#2898](https://github.com/wp-graphql/wp-graphql/pull/2898): chore: restore excluded PHPCS sniffs. Thanks @justlevine!
+- [#2899](https://github.com/wp-graphql/wp-graphql/pull/2899): chore: Configure PHPCS blank line check and autofix. Thanks @justlevine!
+- [#2900](https://github.com/wp-graphql/wp-graphql/pull/2900): chore: implement PHPCS sniffs from Slevomat Coding Standards. Thanks @justlevine!
+- [#2897](https://github.com/wp-graphql/wp-graphql/pull/2897): fix: default excerptRendered to empty string. Thanks @izzygld!
+- [#2890](https://github.com/wp-graphql/wp-graphql/pull/2890): fix: Use hostname for graphql cache header url for varnish
+- [#2892](https://github.com/wp-graphql/wp-graphql/pull/2889): chore: GitHub template tweaks. Thanks @justlevine!
+- [#2889](https://github.com/wp-graphql/wp-graphql/pull/2889): ci: update tests to test against WordPress 6.3, simplify the matrix
+- [#2891](https://github.com/wp-graphql/wp-graphql/pull/2891): chore: bump graphql-php to 14.11.10 and update Composer dev-deps. Thanks @justlevine!
+
 ## 1.14.10
 
 ### Chores / Bugfixes

--- a/access-functions.php
+++ b/access-functions.php
@@ -73,7 +73,6 @@ function graphql( array $request_data = [], bool $return_request = false ) {
 	}
 
 	return $request->execute();
-
 }
 
 /**
@@ -135,7 +134,6 @@ function get_graphql_register_action() {
  * @return void
  */
 function register_graphql_interfaces_to_types( $interface_names, $type_names ) {
-
 	if ( is_string( $type_names ) ) {
 		$type_names = [ $type_names ];
 	}
@@ -151,7 +149,6 @@ function register_graphql_interfaces_to_types( $interface_names, $type_names ) {
 			add_filter(
 				'graphql_type_interfaces',
 				static function ( $interfaces, $config ) use ( $type_name, $interface_names ) {
-
 					$interfaces = is_array( $interfaces ) ? $interfaces : [];
 
 					if ( strtolower( $type_name ) === strtolower( $config['name'] ) ) {
@@ -163,7 +160,6 @@ function register_graphql_interfaces_to_types( $interface_names, $type_names ) {
 				10,
 				2
 			);
-
 		}
 	}
 }
@@ -243,7 +239,6 @@ function register_graphql_input_type( string $type_name, array $config ) {
  * @return void
  */
 function register_graphql_union_type( string $type_name, array $config ) {
-
 	add_action(
 		get_graphql_register_action(),
 		static function ( TypeRegistry $type_registry ) use ( $type_name, $config ) {
@@ -280,7 +275,6 @@ function register_graphql_enum_type( string $type_name, array $config ) {
  * @since 0.1.0
  */
 function register_graphql_field( string $type_name, string $field_name, array $config ) {
-
 	add_action(
 		get_graphql_register_action(),
 		static function ( TypeRegistry $type_registry ) use ( $type_name, $field_name, $config ) {
@@ -776,7 +770,6 @@ function register_graphql_settings_fields( string $group, array $fields ) {
  * @since 0.13.0
  */
 function get_graphql_setting( string $option_name, $default = '', $section_name = 'graphql_general_settings' ) {
-
 	$section_fields = get_option( $section_name );
 
 	/**

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 	],
 	"require": {
 		"php": "^7.1 || ^8.0",
-		"webonyx/graphql-php": "14.11.9",
+		"webonyx/graphql-php": "14.11.10",
 		"ivome/graphql-relay-php": "0.6.0",
 		"appsero/client": "1.2.1"
 	},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f2a22af29ee16cade4ae557e8999dcb7",
+    "content-hash": "a30b29c716cd82e830c4675d7746bd7f",
     "packages": [
         {
             "name": "appsero/client",
@@ -99,16 +99,16 @@
         },
         {
             "name": "webonyx/graphql-php",
-            "version": "v14.11.9",
+            "version": "v14.11.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webonyx/graphql-php.git",
-                "reference": "ff91c9f3cf241db702e30b2c42bcc0920e70ac70"
+                "reference": "d9c2fdebc6aa01d831bc2969da00e8588cffef19"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/ff91c9f3cf241db702e30b2c42bcc0920e70ac70",
-                "reference": "ff91c9f3cf241db702e30b2c42bcc0920e70ac70",
+                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/d9c2fdebc6aa01d831bc2969da00e8588cffef19",
+                "reference": "d9c2fdebc6aa01d831bc2969da00e8588cffef19",
                 "shasum": ""
             },
             "require": {
@@ -128,8 +128,7 @@
                 "phpunit/phpunit": "^7.2 || ^8.5",
                 "psr/http-message": "^1.0",
                 "react/promise": "2.*",
-                "simpod/php-coveralls-mirror": "^3.0",
-                "squizlabs/php_codesniffer": "3.5.4"
+                "simpod/php-coveralls-mirror": "^3.0"
             },
             "suggest": {
                 "psr/http-message": "To use standard GraphQL server",
@@ -153,7 +152,7 @@
             ],
             "support": {
                 "issues": "https://github.com/webonyx/graphql-php/issues",
-                "source": "https://github.com/webonyx/graphql-php/tree/v14.11.9"
+                "source": "https://github.com/webonyx/graphql-php/tree/v14.11.10"
             },
             "funding": [
                 {
@@ -161,7 +160,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2023-01-06T12:12:50+00:00"
+            "time": "2023-07-05T14:23:37+00:00"
         }
     ],
     "packages-dev": [
@@ -2284,24 +2283,28 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "2.68.1",
+            "version": "2.69.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/briannesbitt/Carbon.git",
-                "reference": "4f991ed2a403c85efbc4f23eb4030063fdbe01da"
+                "reference": "4308217830e4ca445583a37d1bf4aff4153fa81c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/4f991ed2a403c85efbc4f23eb4030063fdbe01da",
-                "reference": "4f991ed2a403c85efbc4f23eb4030063fdbe01da",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/4308217830e4ca445583a37d1bf4aff4153fa81c",
+                "reference": "4308217830e4ca445583a37d1bf4aff4153fa81c",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "php": "^7.1.8 || ^8.0",
+                "psr/clock": "^1.0",
                 "symfony/polyfill-mbstring": "^1.0",
                 "symfony/polyfill-php80": "^1.16",
                 "symfony/translation": "^3.4 || ^4.0 || ^5.0 || ^6.0"
+            },
+            "provide": {
+                "psr/clock-implementation": "1.0"
             },
             "require-dev": {
                 "doctrine/dbal": "^2.0 || ^3.1.4",
@@ -2382,20 +2385,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-06-20T18:29:04+00:00"
+            "time": "2023-08-03T09:00:52+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.16.0",
+            "version": "v4.17.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "19526a33fb561ef417e822e85f08a00db4059c17"
+                "reference": "a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/19526a33fb561ef417e822e85f08a00db4059c17",
-                "reference": "19526a33fb561ef417e822e85f08a00db4059c17",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d",
+                "reference": "a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d",
                 "shasum": ""
             },
             "require": {
@@ -2436,9 +2439,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.16.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.17.1"
             },
-            "time": "2023-06-25T14:52:30+00:00"
+            "time": "2023-08-13T19:53:39+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -2553,21 +2556,21 @@
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v6.2.1",
+            "version": "v6.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "0009429e639b748eef1c955200ea0d4e5ad5627d"
+                "reference": "adda7609e71d5f4dc7b87c74f8ec9e3437d2e92c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/0009429e639b748eef1c955200ea0d4e5ad5627d",
-                "reference": "0009429e639b748eef1c955200ea0d4e5ad5627d",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/adda7609e71d5f4dc7b87c74f8ec9e3437d2e92c",
+                "reference": "adda7609e71d5f4dc7b87c74f8ec9e3437d2e92c",
                 "shasum": ""
             },
             "require-dev": {
-                "nikic/php-parser": "< 4.12.0",
-                "php": "~7.3 || ~8.0",
+                "nikic/php-parser": "^4.13",
+                "php": "^7.4 || ~8.0.0",
                 "php-stubs/generator": "^0.8.3",
                 "phpdocumentor/reflection-docblock": "^5.3",
                 "phpstan/phpstan": "^1.10.12",
@@ -2575,7 +2578,6 @@
             },
             "suggest": {
                 "paragonie/sodium_compat": "Pure PHP implementation of libsodium",
-                "symfony/polyfill-php73": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
                 "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
             },
             "type": "library",
@@ -2592,9 +2594,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.2.1"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.3.0"
             },
-            "time": "2023-05-18T04:35:23+00:00"
+            "time": "2023-08-10T16:34:11+00:00"
         },
         {
             "name": "php-webdriver/webdriver",
@@ -2882,16 +2884,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.23.0",
+            "version": "1.23.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "a2b24135c35852b348894320d47b3902a94bc494"
+                "reference": "846ae76eef31c6d7790fac9bc399ecee45160b26"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a2b24135c35852b348894320d47b3902a94bc494",
-                "reference": "a2b24135c35852b348894320d47b3902a94bc494",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/846ae76eef31c6d7790fac9bc399ecee45160b26",
+                "reference": "846ae76eef31c6d7790fac9bc399ecee45160b26",
                 "shasum": ""
             },
             "require": {
@@ -2923,22 +2925,22 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.23.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.23.1"
             },
-            "time": "2023-07-23T22:17:56+00:00"
+            "time": "2023-08-03T16:32:59+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.26",
+            "version": "1.10.29",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "5d660cbb7e1b89253a47147ae44044f49832351f"
+                "reference": "ee5d8f2d3977fb09e55603eee6fb53bdd76ee9c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/5d660cbb7e1b89253a47147ae44044f49832351f",
-                "reference": "5d660cbb7e1b89253a47147ae44044f49832351f",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/ee5d8f2d3977fb09e55603eee6fb53bdd76ee9c1",
+                "reference": "ee5d8f2d3977fb09e55603eee6fb53bdd76ee9c1",
                 "shasum": ""
             },
             "require": {
@@ -2987,7 +2989,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-19T12:44:37+00:00"
+            "time": "2023-08-14T13:24:11+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3410,6 +3412,54 @@
                 }
             ],
             "time": "2023-07-10T04:04:23+00:00"
+        },
+        {
+            "name": "psr/clock",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/clock.git",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/clock/zipball/e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Clock\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for reading the clock.",
+            "homepage": "https://github.com/php-fig/clock",
+            "keywords": [
+                "clock",
+                "now",
+                "psr",
+                "psr-20",
+                "time"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/clock/issues",
+                "source": "https://github.com/php-fig/clock/tree/1.0.0"
+            },
+            "time": "2022-11-25T14:36:26+00:00"
         },
         {
             "name": "psr/container",
@@ -4213,16 +4263,16 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.5",
+            "version": "5.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2"
+                "reference": "bde739e7565280bda77be70044ac1047bc007e34"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/0ca8db5a5fc9c8646244e629625ac486fa286bf2",
-                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bde739e7565280bda77be70044ac1047bc007e34",
+                "reference": "bde739e7565280bda77be70044ac1047bc007e34",
                 "shasum": ""
             },
             "require": {
@@ -4265,7 +4315,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.5"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.6"
             },
             "funding": [
                 {
@@ -4273,7 +4323,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-02-14T08:28:10+00:00"
+            "time": "2023-08-02T09:26:13+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -4760,16 +4810,16 @@
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",
-            "version": "v2.11.16",
+            "version": "v2.11.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
-                "reference": "dc5582dc5a93a235557af73e523c389aac9a8e88"
+                "reference": "3b71162a6bf0cde2bff1752e40a1788d8273d049"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/dc5582dc5a93a235557af73e523c389aac9a8e88",
-                "reference": "dc5582dc5a93a235557af73e523c389aac9a8e88",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/3b71162a6bf0cde2bff1752e40a1788d8273d049",
+                "reference": "3b71162a6bf0cde2bff1752e40a1788d8273d049",
                 "shasum": ""
             },
             "require": {
@@ -4814,7 +4864,7 @@
                 "source": "https://github.com/sirbrillig/phpcs-variable-analysis",
                 "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
             },
-            "time": "2023-03-31T16:46:32+00:00"
+            "time": "2023-08-05T23:46:11+00:00"
         },
         {
             "name": "slevomat/coding-standard",
@@ -5081,16 +5131,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v5.4.21",
+            "version": "v5.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "2a6b1111d038adfa15d52c0871e540f3b352d1e4"
+                "reference": "8109892f27beed9252bd1f1c1880aeb4ad842650"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/2a6b1111d038adfa15d52c0871e540f3b352d1e4",
-                "reference": "2a6b1111d038adfa15d52c0871e540f3b352d1e4",
+                "url": "https://api.github.com/repos/symfony/config/zipball/8109892f27beed9252bd1f1c1880aeb4ad842650",
+                "reference": "8109892f27beed9252bd1f1c1880aeb4ad842650",
                 "shasum": ""
             },
             "require": {
@@ -5140,7 +5190,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v5.4.21"
+                "source": "https://github.com/symfony/config/tree/v5.4.26"
             },
             "funding": [
                 {
@@ -5156,20 +5206,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-14T08:03:56+00:00"
+            "time": "2023-07-19T20:21:11+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v5.4.24",
+            "version": "v5.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "560fc3ed7a43e6d30ea94a07d77f9a60b8ed0fb8"
+                "reference": "b504a3d266ad2bb632f196c0936ef2af5ff6e273"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/560fc3ed7a43e6d30ea94a07d77f9a60b8ed0fb8",
-                "reference": "560fc3ed7a43e6d30ea94a07d77f9a60b8ed0fb8",
+                "url": "https://api.github.com/repos/symfony/console/zipball/b504a3d266ad2bb632f196c0936ef2af5ff6e273",
+                "reference": "b504a3d266ad2bb632f196c0936ef2af5ff6e273",
                 "shasum": ""
             },
             "require": {
@@ -5239,7 +5289,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.24"
+                "source": "https://github.com/symfony/console/tree/v5.4.26"
             },
             "funding": [
                 {
@@ -5255,20 +5305,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-26T05:13:16+00:00"
+            "time": "2023-07-19T20:11:33+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v5.4.21",
+            "version": "v5.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "95f3c7468db1da8cc360b24fa2a26e7cefcb355d"
+                "reference": "0ad3f7e9a1ab492c5b4214cf22a9dc55dcf8600a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/95f3c7468db1da8cc360b24fa2a26e7cefcb355d",
-                "reference": "95f3c7468db1da8cc360b24fa2a26e7cefcb355d",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/0ad3f7e9a1ab492c5b4214cf22a9dc55dcf8600a",
+                "reference": "0ad3f7e9a1ab492c5b4214cf22a9dc55dcf8600a",
                 "shasum": ""
             },
             "require": {
@@ -5305,7 +5355,7 @@
             "description": "Converts CSS selectors to XPath expressions",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/css-selector/tree/v5.4.21"
+                "source": "https://github.com/symfony/css-selector/tree/v5.4.26"
             },
             "funding": [
                 {
@@ -5321,7 +5371,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-14T08:03:56+00:00"
+            "time": "2023-07-07T06:10:25+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -5467,16 +5517,16 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v5.4.22",
+            "version": "v5.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "1df20e45d56da29a4b1d8259dd6e950acbf1b13f"
+                "reference": "5dcc00e03413f05c1e7900090927bb7247cb0aac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/1df20e45d56da29a4b1d8259dd6e950acbf1b13f",
-                "reference": "1df20e45d56da29a4b1d8259dd6e950acbf1b13f",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/5dcc00e03413f05c1e7900090927bb7247cb0aac",
+                "reference": "5dcc00e03413f05c1e7900090927bb7247cb0aac",
                 "shasum": ""
             },
             "require": {
@@ -5532,7 +5582,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v5.4.22"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v5.4.26"
             },
             "funding": [
                 {
@@ -5548,7 +5598,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-17T11:31:58+00:00"
+            "time": "2023-07-06T06:34:20+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -5695,16 +5745,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v5.4.21",
+            "version": "v5.4.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "078e9a5e1871fcfe6a5ce421b539344c21afef19"
+                "reference": "ff4bce3c33451e7ec778070e45bd23f74214cd5d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/078e9a5e1871fcfe6a5ce421b539344c21afef19",
-                "reference": "078e9a5e1871fcfe6a5ce421b539344c21afef19",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/ff4bce3c33451e7ec778070e45bd23f74214cd5d",
+                "reference": "ff4bce3c33451e7ec778070e45bd23f74214cd5d",
                 "shasum": ""
             },
             "require": {
@@ -5738,7 +5788,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v5.4.21"
+                "source": "https://github.com/symfony/finder/tree/v5.4.27"
             },
             "funding": [
                 {
@@ -5754,7 +5804,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-16T09:33:00+00:00"
+            "time": "2023-07-31T08:02:31+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -6492,16 +6542,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v5.4.24",
+            "version": "v5.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "e3c46cc5689c8782944274bb30702106ecbe3b64"
+                "reference": "1a44dc377ec86a50fab40d066cd061e28a6b482f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/e3c46cc5689c8782944274bb30702106ecbe3b64",
-                "reference": "e3c46cc5689c8782944274bb30702106ecbe3b64",
+                "url": "https://api.github.com/repos/symfony/process/zipball/1a44dc377ec86a50fab40d066cd061e28a6b482f",
+                "reference": "1a44dc377ec86a50fab40d066cd061e28a6b482f",
                 "shasum": ""
             },
             "require": {
@@ -6534,7 +6584,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v5.4.24"
+                "source": "https://github.com/symfony/process/tree/v5.4.26"
             },
             "funding": [
                 {
@@ -6550,7 +6600,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-17T11:26:05+00:00"
+            "time": "2023-07-12T15:44:31+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -6699,16 +6749,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v5.4.22",
+            "version": "v5.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "8036a4c76c0dd29e60b6a7cafcacc50cf088ea62"
+                "reference": "1181fe9270e373537475e826873b5867b863883c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/8036a4c76c0dd29e60b6a7cafcacc50cf088ea62",
-                "reference": "8036a4c76c0dd29e60b6a7cafcacc50cf088ea62",
+                "url": "https://api.github.com/repos/symfony/string/zipball/1181fe9270e373537475e826873b5867b863883c",
+                "reference": "1181fe9270e373537475e826873b5867b863883c",
                 "shasum": ""
             },
             "require": {
@@ -6765,7 +6815,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.4.22"
+                "source": "https://github.com/symfony/string/tree/v5.4.26"
             },
             "funding": [
                 {
@@ -6781,7 +6831,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-14T06:11:53+00:00"
+            "time": "2023-06-28T12:46:07+00:00"
         },
         {
             "name": "symfony/translation",

--- a/deactivation.php
+++ b/deactivation.php
@@ -13,7 +13,6 @@ function graphql_deactivation_callback() {
 
 	// Delete data during activation
 	delete_graphql_data();
-
 }
 
 /**
@@ -50,5 +49,4 @@ function delete_graphql_data() {
 	}
 
 	do_action( 'graphql_delete_data' );
-
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,50 +2,68 @@
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WPGraphQL" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
 	<description>Coding standards for the WPGraphQL plugin</description>
 
-	<!-- Configure the PHP version -->
-	<config name="testVersion" value="7.1-" />
-
-	<!-- Check against minimum WP version. -->
-	<config name="minimum_supported_wp_version" value="5.0" />
-
-	<!--
-	Pass some flags to PHPCS:
-	p flag: Show progress of the run.
-	s flag: Show sniff codes in all reports.
-	-->
-	<arg value="ps" />
-
-	<!-- Enable colors in report -->
-	<arg name="colors" />
-
-	<!-- Whenever possible, cache the scan results and re-use those for unchanged files on the next scan. -->
-	<arg name="cache" value="tests/_output/cache.json" />
-
-	<!-- Check 20 files in parallel. -->
-	<arg name="parallel" value="20" />
-
-	<!-- Set severity to 1 to see everything that isn't effectively turned off. -->
-	<arg name="severity" value="1" />
-
-	<!-- Includes -->
+	<!-- What to scan: include any root-level PHP files, and the /src folder -->
 	<file>./access-functions.php</file>
 	<file>./activation.php</file>
 	<file>./deactivation.php</file>
 	<file>./wp-graphql.php</file>
 	<file>./src</file>
-
-	<!-- Only lint php files by default -->
-	<arg name="extensions" value="php" />
-
 	<exclude-pattern>*/**/tests/</exclude-pattern>
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 
+	<!--
+	Prevent errors caused by WordPress Coding Standards not supporting PHP 8.0+.
+	See: https://github.com/WordPress/WordPress-Coding-Standards/issues/2035
+	See: https://github.com/WordPress/WordPress-Coding-Standards/issues/2035#issuecomment-1325532520
+	-->
+	<ini name="error_reporting" value="E_ALL &#38; ~E_DEPRECATED" />
+
+	<!--How to scan: include CLI args so you don't need to pass them manually -->
+	<!--Usage instructions: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
+	<!--
+		p flag: Show progress of the run.
+		s flag: Show sniff codes in all reports.
+	-->
+	<arg value="sp"/>
+	<!-- Strip the file paths down to the relevant bit -->
+	<arg name="basepath" value="./"/>
+	<!-- Enable colors in report -->
+	<arg name="colors" />
+	<!-- Only lint php files by default -->
+	<arg name="extensions" value="php" />
+	<!-- Whenever possible, cache the scan results and re-use those for unchanged files on the next scan. -->
+	<arg name="cache" value="tests/_output/cache.json" />
+	<!-- Check 20 files in parallel. -->
+	<arg name="parallel" value="20" />
+	<!-- Set severity to 1 to see everything that isn't effectively turned off. -->
+	<arg name="severity" value="1" />
+
+	<!-- Ruleset Config: set these to match your project constraints-->
+
+	<!--
+		Tests for PHP version compatibility.
+		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards#Recomended-additional-rulesets
+	-->
+	<config name="testVersion" value="7.1-"/>
+
+	<!--
+		Tests for WordPress version compatibility.
+		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties
+	-->
+	<config name="minimum_supported_wp_version" value="5.0"/>
+
+	<!-- Individual rule configuration -->
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<property name="text_domain" type="array">
 				<element value="wp-graphql" />
 			</property>
+		</properties>
+	</rule>
+	<rule ref="WordPress.WhiteSpace.ControlStructureSpacing">
+		<properties>
+			<property name="blank_line_check" value="true"/>
 		</properties>
 	</rule>
 
@@ -59,31 +77,20 @@
 
 	<rule ref="Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction"/>
 
-	<rule ref="WordPress-Core">
+	<!-- Load WordPress Coding standards -->
+	<rule ref="WordPress">
+		<!-- Definitely should not be added back -->
 		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
+		<exclude name="WordPress.CodeAnalysis.AssignmentInCondition.Found"/>
+		<exclude name="WordPress.Files.FileName"/>
+		<exclude name="WordPress.NamingConventions.ValidVariableName"/>
+		<exclude name="WordPress.PHP.DisallowShortTernary.Found"/>
+
+		<!-- This would be a breaking change to fix-->
+		<exclude name="WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid" />
 
 		<!-- Should probably not be added back -->
 		<exclude name="PHPCompatibility.Keywords.ForbiddenNamesAsDeclared.objectFound"/>
-		<exclude name="Squiz.PHP.DisallowMultipleAssignments.FoundInControlStructure"/>
-
-		<!-- Should maybe Add Back Later -->
-		<exclude name="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket"/>
-		<exclude name="PEAR.Functions.FunctionCallSignature.CloseBracketLine"/>
-		<exclude name="PEAR.Functions.FunctionCallSignature.MultipleArguments"/>
-	</rule>
-
-	<!-- Load WordPress Coding standards -->
-	<rule ref="WordPress">
-		<exclude name="WordPress.NamingConventions.ValidVariableName"/>
-		<exclude name="WordPress.Files.FileName"/>
-
-		<!-- Definitely should not be added back -->
-		<exclude name="WordPress.PHP.DisallowShortTernary.Found"/>
-		<exclude name="WordPress.CodeAnalysis.AssignmentInCondition.Found"/>
-
-		<!-- Should probably not be added back -->
-		<exclude name="WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid"/>
-		<exclude name="WordPress.DateTime.RestrictedFunctions.date_date"/>
 	</rule>
 
 	<!-- Tests for inline documentation of code -->
@@ -94,12 +101,66 @@
 		<exclude name="Squiz.Commenting"/>
 	</rule>
 
+		<!-- Additional commenting sniffs are in WPGraphQL-Docs -->
+	<rule ref="Squiz.Commenting.FunctionComment">
+		<!-- Conflicts with b/c in AbstractConnectionResolver -->
+		<exclude name="Squiz.Commenting.FunctionComment.InvalidNoReturn" />
+
+		<!-- Should probably be added back -->
+		<exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop" />
+		<exclude name="Squiz.Commenting.FunctionComment.EmptyThrows" />
+		<properties>
+				<property name="skipIfInheritdoc" value="true" />
+		</properties>
+	</rule>
+
 	<!-- Enforce short array syntax -->
 	<rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
 
-	<!-- Use FQCN for PHPDoc types -->
-	<rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameInAnnotation"/>
-	<!-- Enforce static closures -->
-	<rule ref="SlevomatCodingStandard.Functions.StaticClosure" />
+	<!-- Slevomat Coding Standards-->
+	<rule ref="SlevomatCodingStandard.Arrays">
+		<!-- Conflicts with WPCS -->
+		<exclude name="SlevomatCodingStandard.Arrays.SingleLineArrayWhitespace"/>
+		<!-- Semantic sorting is a valid pattern -->
+		<exclude name="SlevomatCodingStandard.Arrays.AlphabeticallySortedByKeys"/>
+	</rule>
 
+	<rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference">
+		<properties>
+			<!-- Doesn't use PHPCompatibility-->
+			<property name="enableOnObjects" value="false"/>
+		</properties>
+	</rule>
+	<rule ref="SlevomatCodingStandard.Classes.RequireSelfReference" />
+	<rule ref="SlevomatCodingStandard.Classes.DisallowConstructorPropertyPromotion" />
+	<rule ref="SlevomatCodingStandard.Classes.DisallowLateStaticBindingForConstants" />
+	<rule ref="SlevomatCodingStandard.Classes.DisallowMultiConstantDefinition" />
+	<rule ref="SlevomatCodingStandard.Classes.DisallowMultiPropertyDefinition" />
+	<rule ref="SlevomatCodingStandard.Classes.DisallowStringExpressionPropertyFetch" />
+	<rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility" />
+	<rule ref="SlevomatCodingStandard.Classes.UselessLateStaticBinding" />
+
+	<rule ref="SlevomatCodingStandard.ControlStructures.UselessTernaryOperator" />
+
+	<rule ref="SlevomatCodingStandard.Exceptions.DeadCatch" />
+	<rule ref="SlevomatCodingStandard.Exceptions.DisallowNonCapturingCatch" />
+	<rule ref="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly" />
+
+	<rule ref="SlevomatCodingStandard.Functions.StaticClosure" />
+	<rule ref="SlevomatCodingStandard.Functions.UnusedInheritedVariablePassedToClosure" />
+	<rule ref="SlevomatCodingStandard.Functions.UselessParameterDefaultValue" />
+
+	<rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameInAnnotation"/>
+	<rule ref="SlevomatCodingStandard.Namespaces.UnusedUses" />
+	<rule ref="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash" />
+
+	<rule ref="SlevomatCodingStandard.PHP.OptimizedFunctionsWithoutUnpacking" />
+	<rule ref="SlevomatCodingStandard.PHP.TypeCast" />
+
+	<rule ref="SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable" />
+	<rule ref="SlevomatCodingStandard.Variables.UnusedVariable" >
+		<properties>
+			<property name="ignoreUnusedValuesWhenOnlyKeysAreUsedInForeach" value="true" />
+		</properties>
+	</rule>
 </ruleset>

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, JSON, API, Gatsby, Faust, Headless, Decoupled, Svelte, React, Nex
 Requires at least: 5.0
 Tested up to: 6.2
 Requires PHP: 7.1
-Stable tag: 1.14.10
+Stable tag: 1.15.0
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -239,6 +239,27 @@ The `uri` field was non-null on some Types in the Schema but has been changed to
 Composer dependencies are no longer versioned in Github. Recommended install source is WordPress.org or using Composer to get the code from Packagist.org or WPackagist.org.
 
 == Changelog ==
+
+= 1.15.0 =
+
+**New Features**
+
+- [#2908](https://github.com/wp-graphql/wp-graphql/pull/2908): feat: Skip param added to Utils::map_input(). Thanks @kidunot89!
+
+**Chores / Bugfixes**
+
+- [#2907](https://github.com/wp-graphql/wp-graphql/pull/2907): ci: Use WP 6.3 image, not the beta one
+- [#2902](https://github.com/wp-graphql/wp-graphql/pull/2902): chore: handle unused variables (phpcs). Thanks @justlevine!
+- [#2901](https://github.com/wp-graphql/wp-graphql/pull/2901): chore: remove useless ternaries (phpcs). Thanks @justlevine!
+- [#2898](https://github.com/wp-graphql/wp-graphql/pull/2898): chore: restore excluded PHPCS sniffs. Thanks @justlevine!
+- [#2899](https://github.com/wp-graphql/wp-graphql/pull/2899): chore: Configure PHPCS blank line check and autofix. Thanks @justlevine!
+- [#2900](https://github.com/wp-graphql/wp-graphql/pull/2900): chore: implement PHPCS sniffs from Slevomat Coding Standards. Thanks @justlevine!
+- [#2897](https://github.com/wp-graphql/wp-graphql/pull/2897): fix: default excerptRendered to empty string. Thanks @izzygld!
+- [#2890](https://github.com/wp-graphql/wp-graphql/pull/2890): fix: Use hostname for graphql cache header url for varnish
+- [#2892](https://github.com/wp-graphql/wp-graphql/pull/2889): chore: GitHub template tweaks. Thanks @justlevine!
+- [#2889](https://github.com/wp-graphql/wp-graphql/pull/2889): ci: update tests to test against WordPress 6.3, simplify the matrix
+- [#2891](https://github.com/wp-graphql/wp-graphql/pull/2891): chore: bump graphql-php to 14.11.10 and update Composer dev-deps. Thanks @justlevine!
+
 
 = 1.14.10 =
 

--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -45,9 +45,12 @@ class Admin {
 
 		// This removes the menu page for WPGraphiQL as it's now built into WPGraphQL
 		if ( $this->graphiql_enabled ) {
-			add_action( 'admin_menu', static function () {
-				remove_menu_page( 'wp-graphiql/wp-graphiql.php' );
-			} );
+			add_action(
+				'admin_menu',
+				static function () {
+					remove_menu_page( 'wp-graphiql/wp-graphiql.php' );
+				} 
+			);
 		}
 
 		// If the admin is disabled, prevent admin from being scaffolded.
@@ -63,7 +66,6 @@ class Admin {
 			$graphiql = new GraphiQL();
 			$graphiql->init();
 		}
-
 	}
 
 }

--- a/src/Admin/GraphiQL/GraphiQL.php
+++ b/src/Admin/GraphiQL/GraphiQL.php
@@ -24,8 +24,7 @@ class GraphiQL {
 	 * @return void
 	 */
 	public function init() {
-
-		$this->is_enabled = get_graphql_setting( 'graphiql_enabled' ) === 'off' ? false : true;
+		$this->is_enabled = get_graphql_setting( 'graphiql_enabled' ) !== 'off';
 
 		/**
 		 * If GraphiQL is disabled, don't set it up in the Admin
@@ -49,7 +48,6 @@ class GraphiQL {
 		add_action( 'enqueue_graphiql_extension', [ $this, 'graphiql_enqueue_query_composer' ] );
 		add_action( 'enqueue_graphiql_extension', [ $this, 'graphiql_enqueue_auth_switch' ] );
 		add_action( 'enqueue_graphiql_extension', [ $this, 'graphiql_enqueue_fullscreen_toggle' ] );
-
 	}
 
 	/**
@@ -60,24 +58,27 @@ class GraphiQL {
 	 * @return void
 	 */
 	public function register_admin_bar_menu( WP_Admin_Bar $admin_bar ) {
-
 		if ( ! current_user_can( 'manage_options' ) || 'off' === get_graphql_setting( 'show_graphiql_link_in_admin_bar' ) ) {
 			return;
 		}
 
 		$icon_url = 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0MDAgNDAwIj48cGF0aCBmaWxsPSIjRTEwMDk4IiBkPSJNNTcuNDY4IDMwMi42NmwtMTQuMzc2LTguMyAxNjAuMTUtMjc3LjM4IDE0LjM3NiA4LjN6Ii8+PHBhdGggZmlsbD0iI0UxMDA5OCIgZD0iTTM5LjggMjcyLjJoMzIwLjN2MTYuNkgzOS44eiIvPjxwYXRoIGZpbGw9IiNFMTAwOTgiIGQ9Ik0yMDYuMzQ4IDM3NC4wMjZsLTE2MC4yMS05Mi41IDguMy0xNC4zNzYgMTYwLjIxIDkyLjV6TTM0NS41MjIgMTMyLjk0N2wtMTYwLjIxLTkyLjUgOC4zLTE0LjM3NiAxNjAuMjEgOTIuNXoiLz48cGF0aCBmaWxsPSIjRTEwMDk4IiBkPSJNNTQuNDgyIDEzMi44ODNsLTguMy0xNC4zNzUgMTYwLjIxLTkyLjUgOC4zIDE0LjM3NnoiLz48cGF0aCBmaWxsPSIjRTEwMDk4IiBkPSJNMzQyLjU2OCAzMDIuNjYzbC0xNjAuMTUtMjc3LjM4IDE0LjM3Ni04LjMgMTYwLjE1IDI3Ny4zOHpNNTIuNSAxMDcuNWgxNi42djE4NUg1Mi41ek0zMzAuOSAxMDcuNWgxNi42djE4NWgtMTYuNnoiLz48cGF0aCBmaWxsPSIjRTEwMDk4IiBkPSJNMjAzLjUyMiAzNjdsLTcuMjUtMTIuNTU4IDEzOS4zNC04MC40NSA3LjI1IDEyLjU1N3oiLz48cGF0aCBmaWxsPSIjRTEwMDk4IiBkPSJNMzY5LjUgMjk3LjljLTkuNiAxNi43LTMxIDIyLjQtNDcuNyAxMi44LTE2LjctOS42LTIyLjQtMzEtMTIuOC00Ny43IDkuNi0xNi43IDMxLTIyLjQgNDcuNy0xMi44IDE2LjggOS43IDIyLjUgMzEgMTIuOCA0Ny43TTkwLjkgMTM3Yy05LjYgMTYuNy0zMSAyMi40LTQ3LjcgMTIuOC0xNi43LTkuNi0yMi40LTMxLTEyLjgtNDcuNyA5LjYtMTYuNyAzMS0yMi40IDQ3LjctMTIuOCAxNi43IDkuNyAyMi40IDMxIDEyLjggNDcuN00zMC41IDI5Ny45Yy05LjYtMTYuNy0zLjktMzggMTIuOC00Ny43IDE2LjctOS42IDM4LTMuOSA0Ny43IDEyLjggOS42IDE2LjcgMy45IDM4LTEyLjggNDcuNy0xNi44IDkuNi0zOC4xIDMuOS00Ny43LTEyLjhNMzA5LjEgMTM3Yy05LjYtMTYuNy0zLjktMzggMTIuOC00Ny43IDE2LjctOS42IDM4LTMuOSA0Ny43IDEyLjggOS42IDE2LjcgMy45IDM4LTEyLjggNDcuNy0xNi43IDkuNi0zOC4xIDMuOS00Ny43LTEyLjhNMjAwIDM5NS44Yy0xOS4zIDAtMzQuOS0xNS42LTM0LjktMzQuOSAwLTE5LjMgMTUuNi0zNC45IDM0LjktMzQuOSAxOS4zIDAgMzQuOSAxNS42IDM0LjkgMzQuOSAwIDE5LjItMTUuNiAzNC45LTM0LjkgMzQuOU0yMDAgNzRjLTE5LjMgMC0zNC45LTE1LjYtMzQuOS0zNC45IDAtMTkuMyAxNS42LTM0LjkgMzQuOS0zNC45IDE5LjMgMCAzNC45IDE1LjYgMzQuOSAzNC45IDAgMTkuMy0xNS42IDM0LjktMzQuOSAzNC45Ii8+PC9zdmc+';
 
-		$icon = sprintf( '<span class="custom-icon" style="
+		$icon = sprintf(
+			'<span class="custom-icon" style="
     background-image:url(\'%s\'); float:left; width:22px !important; height:22px !important;
     margin-left: 5px !important; margin-top: 5px !important; margin-right: 5px !important;
-    "></span>', $icon_url );
+    "></span>',
+			$icon_url 
+		);
 
-		$admin_bar->add_menu( [
-			'id'    => 'graphiql-ide',
-			'title' => $icon . __( 'GraphiQL IDE', 'wp-graphql' ),
-			'href'  => trailingslashit( admin_url() ) . 'admin.php?page=graphiql-ide',
-		] );
-
+		$admin_bar->add_menu(
+			[
+				'id'    => 'graphiql-ide',
+				'title' => $icon . __( 'GraphiQL IDE', 'wp-graphql' ),
+				'href'  => trailingslashit( admin_url() ) . 'admin.php?page=graphiql-ide',
+			] 
+		);
 	}
 
 	/**
@@ -125,7 +126,6 @@ class GraphiQL {
 	 * @return void
 	 */
 	public function enqueue_graphiql() {
-
 		if ( null === get_current_screen() || ! strpos( get_current_screen()->id, 'graphiql' ) ) {
 			return;
 		}
@@ -173,7 +173,6 @@ class GraphiQL {
 		// Extensions looking to extend GraphiQL can hook in here,
 		// after the window object is established, but before the App renders
 		do_action( 'enqueue_graphiql_extension' );
-
 	}
 
 	/**
@@ -183,7 +182,6 @@ class GraphiQL {
 	 * @return void
 	 */
 	public function graphiql_enqueue_auth_switch() {
-
 		$auth_switch_asset_file = include WPGRAPHQL_PLUGIN_DIR . 'build/graphiqlAuthSwitch.asset.php';
 
 		wp_enqueue_script(
@@ -222,7 +220,6 @@ class GraphiQL {
 			[ 'wp-components' ],
 			$composer_asset_file['version']
 		);
-
 	}
 
 	/**
@@ -232,7 +229,6 @@ class GraphiQL {
 	 * @return void
 	 */
 	public function graphiql_enqueue_fullscreen_toggle() {
-
 		$fullscreen_toggle_asset_file = include WPGRAPHQL_PLUGIN_DIR . 'build/graphiqlFullscreenToggle.asset.php';
 
 		wp_enqueue_script(
@@ -249,7 +245,6 @@ class GraphiQL {
 			[ 'wp-components' ],
 			$fullscreen_toggle_asset_file['version']
 		);
-
 	}
 
 }

--- a/src/Admin/Settings/Settings.php
+++ b/src/Admin/Settings/Settings.php
@@ -55,7 +55,6 @@ class Settings {
 	 * @return void
 	 */
 	public function add_options_page() {
-
 		$graphiql_enabled = get_graphql_setting( 'graphiql_enabled' );
 
 		if ( 'off' === $graphiql_enabled ) {
@@ -67,7 +66,6 @@ class Settings {
 				[ $this, 'render_settings_page' ],
 				'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0MDAgNDAwIj48cGF0aCBmaWxsPSIjRTEwMDk4IiBkPSJNNTcuNDY4IDMwMi42NmwtMTQuMzc2LTguMyAxNjAuMTUtMjc3LjM4IDE0LjM3NiA4LjN6Ii8+PHBhdGggZmlsbD0iI0UxMDA5OCIgZD0iTTM5LjggMjcyLjJoMzIwLjN2MTYuNkgzOS44eiIvPjxwYXRoIGZpbGw9IiNFMTAwOTgiIGQ9Ik0yMDYuMzQ4IDM3NC4wMjZsLTE2MC4yMS05Mi41IDguMy0xNC4zNzYgMTYwLjIxIDkyLjV6TTM0NS41MjIgMTMyLjk0N2wtMTYwLjIxLTkyLjUgOC4zLTE0LjM3NiAxNjAuMjEgOTIuNXoiLz48cGF0aCBmaWxsPSIjRTEwMDk4IiBkPSJNNTQuNDgyIDEzMi44ODNsLTguMy0xNC4zNzUgMTYwLjIxLTkyLjUgOC4zIDE0LjM3NnoiLz48cGF0aCBmaWxsPSIjRTEwMDk4IiBkPSJNMzQyLjU2OCAzMDIuNjYzbC0xNjAuMTUtMjc3LjM4IDE0LjM3Ni04LjMgMTYwLjE1IDI3Ny4zOHpNNTIuNSAxMDcuNWgxNi42djE4NUg1Mi41ek0zMzAuOSAxMDcuNWgxNi42djE4NWgtMTYuNnoiLz48cGF0aCBmaWxsPSIjRTEwMDk4IiBkPSJNMjAzLjUyMiAzNjdsLTcuMjUtMTIuNTU4IDEzOS4zNC04MC40NSA3LjI1IDEyLjU1N3oiLz48cGF0aCBmaWxsPSIjRTEwMDk4IiBkPSJNMzY5LjUgMjk3LjljLTkuNiAxNi43LTMxIDIyLjQtNDcuNyAxMi44LTE2LjctOS42LTIyLjQtMzEtMTIuOC00Ny43IDkuNi0xNi43IDMxLTIyLjQgNDcuNy0xMi44IDE2LjggOS43IDIyLjUgMzEgMTIuOCA0Ny43TTkwLjkgMTM3Yy05LjYgMTYuNy0zMSAyMi40LTQ3LjcgMTIuOC0xNi43LTkuNi0yMi40LTMxLTEyLjgtNDcuNyA5LjYtMTYuNyAzMS0yMi40IDQ3LjctMTIuOCAxNi43IDkuNyAyMi40IDMxIDEyLjggNDcuN00zMC41IDI5Ny45Yy05LjYtMTYuNy0zLjktMzggMTIuOC00Ny43IDE2LjctOS42IDM4LTMuOSA0Ny43IDEyLjggOS42IDE2LjcgMy45IDM4LTEyLjggNDcuNy0xNi44IDkuNi0zOC4xIDMuOS00Ny43LTEyLjhNMzA5LjEgMTM3Yy05LjYtMTYuNy0zLjktMzggMTIuOC00Ny43IDE2LjctOS42IDM4LTMuOSA0Ny43IDEyLjggOS42IDE2LjcgMy45IDM4LTEyLjggNDcuNy0xNi43IDkuNi0zOC4xIDMuOS00Ny43LTEyLjhNMjAwIDM5NS44Yy0xOS4zIDAtMzQuOS0xNS42LTM0LjktMzQuOSAwLTE5LjMgMTUuNi0zNC45IDM0LjktMzQuOSAxOS4zIDAgMzQuOSAxNS42IDM0LjkgMzQuOSAwIDE5LjItMTUuNiAzNC45LTM0LjkgMzQuOU0yMDAgNzRjLTE5LjMgMC0zNC45LTE1LjYtMzQuOS0zNC45IDAtMTkuMyAxNS42LTM0LjkgMzQuOS0zNC45IDE5LjMgMCAzNC45IDE1LjYgMzQuOSAzNC45IDAgMTkuMy0xNS42IDM0LjktMzQuOSAzNC45Ii8+PC9zdmc+'
 			);
-
 		} else {
 			add_submenu_page(
 				'graphiql-ide',
@@ -78,7 +76,6 @@ class Settings {
 				[ $this, 'render_settings_page' ]
 			);
 		}
-
 	}
 
 	/**
@@ -87,13 +84,16 @@ class Settings {
 	 * @return void
 	 */
 	public function register_settings() {
-
-		$this->settings_api->register_section( 'graphql_general_settings', [
-			'title' => __( 'WPGraphQL General Settings', 'wp-graphql' ),
-		] );
+		$this->settings_api->register_section(
+			'graphql_general_settings',
+			[
+				'title' => __( 'WPGraphQL General Settings', 'wp-graphql' ),
+			] 
+		);
 
 		$custom_endpoint = apply_filters( 'graphql_endpoint', null );
-		$this->settings_api->register_field( 'graphql_general_settings',
+		$this->settings_api->register_field(
+			'graphql_general_settings',
 			[
 				'name'              => 'graphql_endpoint',
 				'label'             => __( 'GraphQL Endpoint', 'wp-graphql' ),
@@ -106,7 +106,7 @@ class Settings {
 				'type'              => 'text',
 				'value'             => ! empty( $custom_endpoint ) ? $custom_endpoint : null,
 				'default'           => ! empty( $custom_endpoint ) ? $custom_endpoint : 'graphql',
-				'disabled'          => ! empty( $custom_endpoint ) ? true : false,
+				'disabled'          => ! empty( $custom_endpoint ),
 				'sanitize_callback' => static function ( $value ) {
 					if ( empty( $value ) ) {
 						add_settings_error( 'graphql_endpoint', 'required', __( 'The "GraphQL Endpoint" field is required and cannot be blank. The default endpoint is "graphql"', 'wp-graphql' ), 'error' );
@@ -119,127 +119,129 @@ class Settings {
 			]
 		);
 
-		$this->settings_api->register_fields( 'graphql_general_settings', [
+		$this->settings_api->register_fields(
+			'graphql_general_settings',
 			[
-				'name'    => 'restrict_endpoint_to_logged_in_users',
-				'label'   => __( 'Restrict Endpoint to Authenticated Users', 'wp-graphql' ),
-				'desc'    => __( 'Limit the execution of GraphQL operations to authenticated requests. Non-authenticated requests to the GraphQL endpoint will not execute and will return an error.', 'wp-graphql' ),
-				'type'    => 'checkbox',
-				'default' => 'off',
-			],
-			[
-				'name'    => 'batch_queries_enabled',
-				'label'   => __( 'Enable Batch Queries', 'wp-graphql' ),
-				'desc'    => __( 'WPGraphQL supports batch queries, or the ability to send multiple GraphQL operations in a single HTTP request. Batch requests are enabled by default.', 'wp-graphql' ),
-				'type'    => 'checkbox',
-				'default' => 'on',
-			],
-			[
-				'name'    => 'batch_limit',
-				'label'   => __( 'Batch Query Limit', 'wp-graphql' ),
-				'desc'    => __( 'If Batch Queries are enabled, this value sets the max number of batch operations to allow per request. Requests containing more batch operations than allowed will be rejected before execution.', 'wp-graphql' ),
-				'type'    => 'number',
-				'default' => 10,
-			],
-			[
-				'name'    => 'query_depth_enabled',
-				'label'   => __( 'Enable Query Depth Limiting', 'wp-graphql' ),
-				'desc'    => __( 'Enabling this will limit the depth of queries WPGraphQL will execute using the value of the Max Depth setting.', 'wp-graphql' ),
-				'type'    => 'checkbox',
-				'default' => 'off',
-			],
-			[
-				'name'              => 'query_depth_max',
-				'label'             => __( 'Max Depth to allow for GraphQL Queries', 'wp-graphql' ),
-				'desc'              => __( 'If Query Depth limiting is enabled, this is the number of levels WPGraphQL will allow. Queries with deeper nesting will be rejected. Must be a positive integer value. Default 10.', 'wp-graphql' ),
-				'type'              => 'number',
-				'default'           => 10,
-				'sanitize_callback' => static function ( $value ) {
-					// if the entered value is not a positive integer, default to 10
-					if ( ! absint( $value ) ) {
-						$value = 10;
-					}
-					return absint( $value );
-				},
-			],
-			[
-				'name'    => 'graphiql_enabled',
-				'label'   => __( 'Enable GraphiQL IDE', 'wp-graphql' ),
-				'desc'    => __( 'GraphiQL IDE is a tool for exploring the GraphQL Schema and test GraphQL operations. Uncheck this to disable GraphiQL in the Dashboard.', 'wp-graphql' ),
-				'type'    => 'checkbox',
-				'default' => 'on',
-			],
-			[
-				'name'    => 'show_graphiql_link_in_admin_bar',
-				'label'   => __( 'GraphiQL IDE Admin Bar Link', 'wp-graphql' ),
-				'desc'    => __( 'Show GraphiQL IDE Link in the WordPress Admin Bar', 'wp-graphql' ),
-				'type'    => 'checkbox',
-				'default' => 'on',
-			],
-			[
-				'name'    => 'delete_data_on_deactivate',
-				'label'   => __( 'Delete Data on Deactivation', 'wp-graphql' ),
-				'desc'    => __( 'Delete settings and any other data stored by WPGraphQL upon de-activation of the plugin. Un-checking this will keep data after the plugin is de-activated.', 'wp-graphql' ),
-				'type'    => 'checkbox',
-				'default' => 'on',
-			],
-			[
-				'name'     => 'debug_mode_enabled',
-				'label'    => __( 'Enable GraphQL Debug Mode', 'wp-graphql' ),
-				'desc'     => defined( 'GRAPHQL_DEBUG' )
-					// translators: %s is the value of the GRAPHQL_DEBUG constant
-					? sprintf( __( 'This setting is disabled. "GRAPHQL_DEBUG" has been set to "%s" with code', 'wp-graphql' ), GRAPHQL_DEBUG ? 'true' : 'false' )
-					: __( 'Whether GraphQL requests should execute in "debug" mode. This setting is disabled if <strong>GRAPHQL_DEBUG</strong> is defined in wp-config.php. <br/>This will provide more information in GraphQL errors but can leak server implementation details so this setting is <strong>NOT RECOMMENDED FOR PRODUCTION ENVIRONMENTS</strong>.', 'wp-graphql' ),
-				'type'     => 'checkbox',
-				'value'    => true === \WPGraphQL::debug() ? 'on' : get_graphql_setting( 'debug_mode_enabled', 'off' ),
-				'disabled' => defined( 'GRAPHQL_DEBUG' ) ? true : false,
-			],
-			[
-				'name'    => 'tracing_enabled',
-				'label'   => __( 'Enable GraphQL Tracing', 'wp-graphql' ),
-				'desc'    => __( 'Adds trace data to the extensions portion of GraphQL responses. This can help identify bottlenecks for specific fields.', 'wp-graphql' ),
-				'type'    => 'checkbox',
-				'default' => 'off',
-			],
-			[
-				'name'    => 'tracing_user_role',
-				'label'   => __( 'Tracing Role', 'wp-graphql' ),
-				'desc'    => __( 'If Tracing is enabled, this limits it to requests from users with the specified User Role.', 'wp-graphql' ),
-				'type'    => 'user_role_select',
-				'default' => 'administrator',
-			],
-			[
-				'name'    => 'query_logs_enabled',
-				'label'   => __( 'Enable GraphQL Query Logs', 'wp-graphql' ),
-				'desc'    => __( 'Adds SQL Query logs to the extensions portion of GraphQL responses. <br/><strong>Note:</strong> This is a debug tool that can have an impact on performance and is not recommended to have active in production.', 'wp-graphql' ),
-				'type'    => 'checkbox',
-				'default' => 'off',
-			],
-			[
-				'name'    => 'query_log_user_role',
-				'label'   => __( 'Query Log Role', 'wp-graphql' ),
-				'desc'    => __( 'If Query Logs are enabled, this limits them to requests from users with the specified User Role.', 'wp-graphql' ),
-				'type'    => 'user_role_select',
-				'default' => 'administrator',
-			],
-			[
-				'name'     => 'public_introspection_enabled',
-				'label'    => __( 'Enable Public Introspection', 'wp-graphql' ),
-				'desc'     => sprintf(
-					// translators: %s is either empty or a string with a note about debug mode.
-					__( 'GraphQL Introspection is a feature that allows the GraphQL Schema to be queried. For Production and Staging environments, WPGraphQL will by default limit introspection queries to authenticated requests. Checking this enables Introspection for public requests, regardless of environment. %s ', 'wp-graphql' ),
-					true === \WPGraphQL::debug() ? '<strong>' . __( 'NOTE: This setting is force enabled because GraphQL Debug Mode is enabled. ', 'wp-graphql' ) . '</strong>' : ''
-				),
-				'type'     => 'checkbox',
-				'default'  => ( 'local' === $this->get_wp_environment() || 'development' === $this->get_wp_environment() ) ? 'on' : 'off',
-				'value'    => true === \WPGraphQL::debug() ? 'on' : get_graphql_setting( 'public_introspection_enabled', 'off' ),
-				'disabled' => true === \WPGraphQL::debug(),
-			],
-		] );
+				[
+					'name'    => 'restrict_endpoint_to_logged_in_users',
+					'label'   => __( 'Restrict Endpoint to Authenticated Users', 'wp-graphql' ),
+					'desc'    => __( 'Limit the execution of GraphQL operations to authenticated requests. Non-authenticated requests to the GraphQL endpoint will not execute and will return an error.', 'wp-graphql' ),
+					'type'    => 'checkbox',
+					'default' => 'off',
+				],
+				[
+					'name'    => 'batch_queries_enabled',
+					'label'   => __( 'Enable Batch Queries', 'wp-graphql' ),
+					'desc'    => __( 'WPGraphQL supports batch queries, or the ability to send multiple GraphQL operations in a single HTTP request. Batch requests are enabled by default.', 'wp-graphql' ),
+					'type'    => 'checkbox',
+					'default' => 'on',
+				],
+				[
+					'name'    => 'batch_limit',
+					'label'   => __( 'Batch Query Limit', 'wp-graphql' ),
+					'desc'    => __( 'If Batch Queries are enabled, this value sets the max number of batch operations to allow per request. Requests containing more batch operations than allowed will be rejected before execution.', 'wp-graphql' ),
+					'type'    => 'number',
+					'default' => 10,
+				],
+				[
+					'name'    => 'query_depth_enabled',
+					'label'   => __( 'Enable Query Depth Limiting', 'wp-graphql' ),
+					'desc'    => __( 'Enabling this will limit the depth of queries WPGraphQL will execute using the value of the Max Depth setting.', 'wp-graphql' ),
+					'type'    => 'checkbox',
+					'default' => 'off',
+				],
+				[
+					'name'              => 'query_depth_max',
+					'label'             => __( 'Max Depth to allow for GraphQL Queries', 'wp-graphql' ),
+					'desc'              => __( 'If Query Depth limiting is enabled, this is the number of levels WPGraphQL will allow. Queries with deeper nesting will be rejected. Must be a positive integer value. Default 10.', 'wp-graphql' ),
+					'type'              => 'number',
+					'default'           => 10,
+					'sanitize_callback' => static function ( $value ) {
+						// if the entered value is not a positive integer, default to 10
+						if ( ! absint( $value ) ) {
+							$value = 10;
+						}
+						return absint( $value );
+					},
+				],
+				[
+					'name'    => 'graphiql_enabled',
+					'label'   => __( 'Enable GraphiQL IDE', 'wp-graphql' ),
+					'desc'    => __( 'GraphiQL IDE is a tool for exploring the GraphQL Schema and test GraphQL operations. Uncheck this to disable GraphiQL in the Dashboard.', 'wp-graphql' ),
+					'type'    => 'checkbox',
+					'default' => 'on',
+				],
+				[
+					'name'    => 'show_graphiql_link_in_admin_bar',
+					'label'   => __( 'GraphiQL IDE Admin Bar Link', 'wp-graphql' ),
+					'desc'    => __( 'Show GraphiQL IDE Link in the WordPress Admin Bar', 'wp-graphql' ),
+					'type'    => 'checkbox',
+					'default' => 'on',
+				],
+				[
+					'name'    => 'delete_data_on_deactivate',
+					'label'   => __( 'Delete Data on Deactivation', 'wp-graphql' ),
+					'desc'    => __( 'Delete settings and any other data stored by WPGraphQL upon de-activation of the plugin. Un-checking this will keep data after the plugin is de-activated.', 'wp-graphql' ),
+					'type'    => 'checkbox',
+					'default' => 'on',
+				],
+				[
+					'name'     => 'debug_mode_enabled',
+					'label'    => __( 'Enable GraphQL Debug Mode', 'wp-graphql' ),
+					'desc'     => defined( 'GRAPHQL_DEBUG' )
+						// translators: %s is the value of the GRAPHQL_DEBUG constant
+						? sprintf( __( 'This setting is disabled. "GRAPHQL_DEBUG" has been set to "%s" with code', 'wp-graphql' ), GRAPHQL_DEBUG ? 'true' : 'false' )
+						: __( 'Whether GraphQL requests should execute in "debug" mode. This setting is disabled if <strong>GRAPHQL_DEBUG</strong> is defined in wp-config.php. <br/>This will provide more information in GraphQL errors but can leak server implementation details so this setting is <strong>NOT RECOMMENDED FOR PRODUCTION ENVIRONMENTS</strong>.', 'wp-graphql' ),
+					'type'     => 'checkbox',
+					'value'    => true === \WPGraphQL::debug() ? 'on' : get_graphql_setting( 'debug_mode_enabled', 'off' ),
+					'disabled' => defined( 'GRAPHQL_DEBUG' ),
+				],
+				[
+					'name'    => 'tracing_enabled',
+					'label'   => __( 'Enable GraphQL Tracing', 'wp-graphql' ),
+					'desc'    => __( 'Adds trace data to the extensions portion of GraphQL responses. This can help identify bottlenecks for specific fields.', 'wp-graphql' ),
+					'type'    => 'checkbox',
+					'default' => 'off',
+				],
+				[
+					'name'    => 'tracing_user_role',
+					'label'   => __( 'Tracing Role', 'wp-graphql' ),
+					'desc'    => __( 'If Tracing is enabled, this limits it to requests from users with the specified User Role.', 'wp-graphql' ),
+					'type'    => 'user_role_select',
+					'default' => 'administrator',
+				],
+				[
+					'name'    => 'query_logs_enabled',
+					'label'   => __( 'Enable GraphQL Query Logs', 'wp-graphql' ),
+					'desc'    => __( 'Adds SQL Query logs to the extensions portion of GraphQL responses. <br/><strong>Note:</strong> This is a debug tool that can have an impact on performance and is not recommended to have active in production.', 'wp-graphql' ),
+					'type'    => 'checkbox',
+					'default' => 'off',
+				],
+				[
+					'name'    => 'query_log_user_role',
+					'label'   => __( 'Query Log Role', 'wp-graphql' ),
+					'desc'    => __( 'If Query Logs are enabled, this limits them to requests from users with the specified User Role.', 'wp-graphql' ),
+					'type'    => 'user_role_select',
+					'default' => 'administrator',
+				],
+				[
+					'name'     => 'public_introspection_enabled',
+					'label'    => __( 'Enable Public Introspection', 'wp-graphql' ),
+					'desc'     => sprintf(
+						// translators: %s is either empty or a string with a note about debug mode.
+						__( 'GraphQL Introspection is a feature that allows the GraphQL Schema to be queried. For Production and Staging environments, WPGraphQL will by default limit introspection queries to authenticated requests. Checking this enables Introspection for public requests, regardless of environment. %s ', 'wp-graphql' ),
+						true === \WPGraphQL::debug() ? '<strong>' . __( 'NOTE: This setting is force enabled because GraphQL Debug Mode is enabled. ', 'wp-graphql' ) . '</strong>' : ''
+					),
+					'type'     => 'checkbox',
+					'default'  => ( 'local' === $this->get_wp_environment() || 'development' === $this->get_wp_environment() ) ? 'on' : 'off',
+					'value'    => true === \WPGraphQL::debug() ? 'on' : get_graphql_setting( 'public_introspection_enabled', 'off' ),
+					'disabled' => true === \WPGraphQL::debug(),
+				],
+			] 
+		);
 
 		// Action to hook into to register settings
 		do_action( 'graphql_register_settings', $this );
-
 	}
 
 	/**

--- a/src/Admin/Settings/SettingsRegistry.php
+++ b/src/Admin/Settings/SettingsRegistry.php
@@ -182,7 +182,6 @@ class SettingsRegistry {
 		//register settings fields
 		foreach ( $this->settings_fields as $section => $field ) {
 			foreach ( $field as $option ) {
-
 				$name     = $option['name'];
 				$type     = isset( $option['type'] ) ? $option['type'] : 'text';
 				$label    = isset( $option['label'] ) ? $option['label'] : '';
@@ -298,7 +297,6 @@ class SettingsRegistry {
 	 * @return void
 	 */
 	public function callback_checkbox( array $args ) {
-
 		$value    = isset( $args['value'] ) && ! empty( $args['value'] ) ? esc_attr( $args['value'] ) : esc_attr( $this->get_option( $args['id'], $args['section'], $args['std'] ) );
 		$disabled = isset( $args['disabled'] ) && true === $args['disabled'] ? 'disabled' : null;
 
@@ -320,7 +318,6 @@ class SettingsRegistry {
 	 * @return void
 	 */
 	public function callback_multicheck( array $args ) {
-
 		$value = $this->get_option( $args['id'], $args['section'], $args['std'] );
 		$html  = '<fieldset>';
 		$html .= sprintf( '<input type="hidden" name="%1$s[%2$s]" value="">', $args['section'], $args['id'] );
@@ -345,7 +342,6 @@ class SettingsRegistry {
 	 * @return void
 	 */
 	public function callback_radio( array $args ) {
-
 		$value = $this->get_option( $args['id'], $args['section'], $args['std'] );
 		$html  = '<fieldset>';
 
@@ -369,7 +365,6 @@ class SettingsRegistry {
 	 * @return void
 	 */
 	public function callback_select( array $args ) {
-
 		$value = esc_attr( $this->get_option( $args['id'], $args['section'], $args['std'] ) );
 		$size  = isset( $args['size'] ) && ! is_null( $args['size'] ) ? $args['size'] : 'regular';
 		$html  = sprintf( '<select class="%1$s" name="%2$s[%3$s]" id="%2$s[%3$s]">', $size, $args['section'], $args['id'] );
@@ -392,7 +387,6 @@ class SettingsRegistry {
 	 * @return void
 	 */
 	public function callback_textarea( array $args ) {
-
 		$value       = esc_textarea( $this->get_option( $args['id'], $args['section'], $args['std'] ) );
 		$size        = isset( $args['size'] ) && ! is_null( $args['size'] ) ? $args['size'] : 'regular';
 		$placeholder = empty( $args['placeholder'] ) ? '' : ' placeholder="' . $args['placeholder'] . '"';
@@ -422,7 +416,6 @@ class SettingsRegistry {
 	 * @return void
 	 */
 	public function callback_wysiwyg( array $args ) {
-
 		$value = $this->get_option( $args['id'], $args['section'], $args['std'] );
 		$size  = isset( $args['size'] ) && ! is_null( $args['size'] ) ? $args['size'] : '500px';
 
@@ -453,10 +446,8 @@ class SettingsRegistry {
 	 * @return void
 	 */
 	public function callback_file( array $args ) {
-
 		$value = esc_attr( $this->get_option( $args['id'], $args['section'], $args['std'] ) );
 		$size  = isset( $args['size'] ) && ! is_null( $args['size'] ) ? $args['size'] : 'regular';
-		$id    = $args['section'] . '[' . $args['id'] . ']';
 		$label = isset( $args['options']['button_label'] ) ? $args['options']['button_label'] : __( 'Choose File', 'wp-graphql' );
 
 		$html  = sprintf( '<input type="text" class="%1$s-text wpsa-url" id="%2$s[%3$s]" name="%2$s[%3$s]" value="%4$s">', $size, $args['section'], $args['id'], $value );
@@ -474,7 +465,6 @@ class SettingsRegistry {
 	 * @return void
 	 */
 	public function callback_password( array $args ) {
-
 		$value = esc_attr( $this->get_option( $args['id'], $args['section'], $args['std'] ) );
 		$size  = isset( $args['size'] ) && ! is_null( $args['size'] ) ? $args['size'] : 'regular';
 
@@ -492,7 +482,6 @@ class SettingsRegistry {
 	 * @return void
 	 */
 	public function callback_color( $args ) {
-
 		$value = esc_attr( $this->get_option( $args['id'], $args['section'], $args['std'] ) );
 		$size  = isset( $args['size'] ) && ! is_null( $args['size'] ) ? $args['size'] : 'regular';
 
@@ -511,13 +500,15 @@ class SettingsRegistry {
 	 * @return void
 	 */
 	public function callback_pages( array $args ) {
-
-		$dropdown_args = array_merge( [
-			'selected' => esc_attr( $this->get_option( $args['id'], $args['section'], $args['std'] ) ),
-			'name'     => $args['section'] . '[' . $args['id'] . ']',
-			'id'       => $args['section'] . '[' . $args['id'] . ']',
-			'echo'     => 0,
-		], $args );
+		$dropdown_args = array_merge(
+			[
+				'selected' => esc_attr( $this->get_option( $args['id'], $args['section'], $args['std'] ) ),
+				'name'     => $args['section'] . '[' . $args['id'] . ']',
+				'id'       => $args['section'] . '[' . $args['id'] . ']',
+				'echo'     => 0,
+			],
+			$args 
+		);
 
 		$clean_args = [];
 		foreach ( $dropdown_args as $key => $arg ) {
@@ -561,7 +552,6 @@ class SettingsRegistry {
 	 * @return mixed
 	 */
 	public function sanitize_options( array $options ) {
-
 		if ( ! $options ) {
 			return $options;
 		}
@@ -592,7 +582,7 @@ class SettingsRegistry {
 		}
 
 		// Iterate over registered fields and see if we can find proper callback
-		foreach ( $this->settings_fields as $section => $options ) {
+		foreach ( $this->settings_fields as $options ) {
 			foreach ( $options as $option ) {
 				if ( $slug !== $option['name'] ) {
 					continue;
@@ -616,7 +606,6 @@ class SettingsRegistry {
 	 * @return string
 	 */
 	public function get_option( $option, $section, $default = '' ) {
-
 		$options = get_option( $section );
 
 		if ( isset( $options[ $option ] ) ) {

--- a/src/AppContext.php
+++ b/src/AppContext.php
@@ -3,7 +3,6 @@
 namespace WPGraphQL;
 
 use GraphQL\Error\UserError;
-use WP_User;
 use WPGraphQL\Data\Loader\CommentAuthorLoader;
 use WPGraphQL\Data\Loader\CommentLoader;
 use WPGraphQL\Data\Loader\EnqueuedScriptLoader;
@@ -17,7 +16,6 @@ use WPGraphQL\Data\Loader\ThemeLoader;
 use WPGraphQL\Data\Loader\UserLoader;
 use WPGraphQL\Data\Loader\UserRoleLoader;
 use WPGraphQL\Data\NodeResolver;
-use WPGraphQL\Registry\TypeRegistry;
 
 /**
  * Class AppContext
@@ -155,7 +153,7 @@ class AppContext {
 	 * @deprecated Use get_loader instead.
 	 */
 	public function getLoader( $key ) {
-		_deprecated_function( __METHOD__, '0.8.4', __CLASS__ . '::get_loader()' );
+		_deprecated_function( __METHOD__, '0.8.4', self::class . '::get_loader()' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		return $this->get_loader( $key );
 	}
 
@@ -182,7 +180,7 @@ class AppContext {
 	 * @return array|mixed
 	 */
 	public function getConnectionArgs() {
-		_deprecated_function( __METHOD__, '0.8.4', __CLASS__ . '::get_connection_args()' );
+		_deprecated_function( __METHOD__, '0.8.4', self::class . '::get_connection_args()' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		return $this->get_connection_args();
 	}
 

--- a/src/Data/CommentMutation.php
+++ b/src/Data/CommentMutation.php
@@ -2,7 +2,6 @@
 
 namespace WPGraphQL\Data;
 
-use Exception;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
@@ -46,7 +45,6 @@ class CommentMutation {
 		$user = self::get_comment_author( $input['authorEmail'] ?? null );
 
 		if ( false !== $user ) {
-
 			$output_args['user_id'] = $user->ID;
 
 			$input['author']      = ! empty( $input['author'] ) ? $input['author'] : $user->display_name;

--- a/src/Data/Config.php
+++ b/src/Data/Config.php
@@ -84,7 +84,6 @@ class Config {
 		add_filter(
 			'pre_user_query',
 			static function ( $query ) {
-
 				if ( ! $query->get( 'suppress_filters' ) ) {
 					$query->set( 'suppress_filters', 0 );
 				}
@@ -100,10 +99,13 @@ class Config {
 					 * @param string        $where The WHERE clause of the query.
 					 * @param \WPGraphQL\Data\WP_User_Query $query The WP_User_Query instance (passed by reference).
 					 */
-					$query->query_where = apply_filters_ref_array( 'graphql_users_where', [
-						$query->query_where,
-						&$query,
-					] );
+					$query->query_where = apply_filters_ref_array(
+						'graphql_users_where',
+						[
+							$query->query_where,
+							&$query,
+						] 
+					);
 
 					/**
 					 * Filters the ORDER BY clause of the query.
@@ -111,15 +113,16 @@ class Config {
 					 * @param string        $orderby The ORDER BY clause of the query.
 					 * @param \WPGraphQL\Data\WP_User_Query $query The WP_User_Query instance (passed by reference).
 					 */
-					$query->query_orderby = apply_filters_ref_array( 'graphql_users_orderby', [
-						$query->query_orderby,
-						&$query,
-					] );
-
+					$query->query_orderby = apply_filters_ref_array(
+						'graphql_users_orderby',
+						[
+							$query->query_orderby,
+							&$query,
+						] 
+					);
 				}
 
 				return $query;
-
 			}
 		);
 
@@ -149,7 +152,6 @@ class Config {
 			10,
 			1
 		);
-
 	}
 
 	/**
@@ -165,7 +167,6 @@ class Config {
 	 * @return string
 	 */
 	public function graphql_wp_query_cursor_pagination_stability( string $orderby, WP_Query $wp_query ) {
-
 		if ( true !== is_graphql_request() ) {
 			return $orderby;
 		}
@@ -183,7 +184,6 @@ class Config {
 
 		// If there is a cursor compare in the arguments, use it as the stablizer for cursors.
 		return "{$orderby}, {$wpdb->posts}.ID {$order} ";
-
 	}
 
 	/**
@@ -227,7 +227,6 @@ class Config {
 	 * @return string
 	 */
 	public function graphql_wp_user_query_cursor_pagination_stability( $orderby ) {
-
 		if ( true === is_graphql_request() ) {
 			global $wpdb;
 
@@ -305,7 +304,6 @@ class Config {
 		}
 
 		return $pieces;
-
 	}
 
 	/**
@@ -337,7 +335,6 @@ class Config {
 		}
 
 		return $pieces;
-
 	}
 
 }

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -7,8 +7,6 @@ use GraphQL\Deferred;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
-use WPGraphQL\Data\Loader\AbstractDataLoader;
-use WPGraphQL\Model\Model;
 use WPGraphQL\Model\Post;
 
 /**
@@ -198,7 +196,6 @@ abstract class AbstractConnectionResolver {
 		 * @param array                      $unfiltered_args Array of arguments input in the field as part of the GraphQL query.
 		 */
 		$this->query_args = apply_filters( 'graphql_connection_query_args', $this->get_query_args(), $this, $args );
-
 	}
 
 	/**
@@ -404,7 +401,7 @@ abstract class AbstractConnectionResolver {
 			sprintf(
 				// translators: %s is the name of the connection resolver class.
 				__( 'Class %s does not implement a valid method `get_ids_from_query()`.', 'wp-graphql' ),
-				get_class( $this )
+				static::class
 			)
 		);
 	}
@@ -450,7 +447,6 @@ abstract class AbstractConnectionResolver {
 		$max_query_amount = apply_filters( 'graphql_connection_max_query_amount', 100, $this->source, $this->args, $this->context, $this->info );
 
 		return min( $max_query_amount, absint( $this->get_amount_requested() ) );
-
 	}
 
 	/**
@@ -507,7 +503,6 @@ abstract class AbstractConnectionResolver {
 		 * @param \WPGraphQL\Data\Connection\AbstractConnectionResolver $resolver Instance of the connection resolver class
 		 */
 		return max( 0, apply_filters( 'graphql_connection_amount_requested', $amount_requested, $this ) );
-
 	}
 
 	/**
@@ -573,7 +568,6 @@ abstract class AbstractConnectionResolver {
 
 		// First we slice the array from the front.
 		if ( ! empty( $this->args['after'] ) ) {
-
 			$offset = $this->get_offset_for_cursor( $this->args['after'] );
 			$index  = $this->get_array_index_for_offset( $offset, $ids );
 
@@ -821,7 +815,6 @@ abstract class AbstractConnectionResolver {
 
 		// The nodes are already ordered, sliced, and populated. What's left is to populate the edge data for each one.
 		foreach ( $this->nodes as $id => $node ) {
-
 			$edge = [
 				'cursor'     => $this->get_cursor_for_node( $id ),
 				'node'       => $node,
@@ -860,7 +853,6 @@ abstract class AbstractConnectionResolver {
 	 * @return array
 	 */
 	public function get_page_info() {
-
 		$page_info = [
 			'startCursor'     => $this->get_start_cursor(),
 			'endCursor'       => $this->get_end_cursor(),
@@ -896,7 +888,6 @@ abstract class AbstractConnectionResolver {
 		 * });
 		 */
 		return apply_filters( 'graphql_connection_page_info', $page_info, $this );
-
 	}
 
 	/**
@@ -969,7 +960,6 @@ abstract class AbstractConnectionResolver {
 		$this->loader->buffer( $this->ids );
 
 		return $this->ids;
-
 	}
 
 	/**
@@ -982,7 +972,6 @@ abstract class AbstractConnectionResolver {
 	 * @throws \Exception
 	 */
 	public function get_connection() {
-
 		$this->execute_and_get_ids();
 
 		/**
@@ -991,7 +980,6 @@ abstract class AbstractConnectionResolver {
 		 */
 		return new Deferred(
 			function () {
-
 				if ( ! empty( $this->ids ) ) {
 					$this->loader->load_many( $this->ids );
 				}
@@ -1036,10 +1024,8 @@ abstract class AbstractConnectionResolver {
 				 * @param \WPGraphQL\Data\Connection\AbstractConnectionResolver $connection_resolver The instance of the connection resolver
 				 */
 				return apply_filters( 'graphql_connection', $connection, $this );
-
 			}
 		);
-
 	}
 
 }

--- a/src/Data/Connection/CommentConnectionResolver.php
+++ b/src/Data/Connection/CommentConnectionResolver.php
@@ -2,11 +2,8 @@
 
 namespace WPGraphQL\Data\Connection;
 
-use Exception;
 use GraphQL\Error\UserError;
-use GraphQL\Type\Definition\ResolveInfo;
 use WP_Comment_Query;
-use WPGraphQL\AppContext;
 use WPGraphQL\Utils\Utils;
 
 /**
@@ -228,9 +225,12 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 					case 'contentAuthor':
 					case 'userId':
 						if ( is_array( $input_value ) ) {
-							$args['where'][ $input_key ] = array_map( static function ( $id ) {
-								return Utils::get_database_id_from_id( $id );
-							}, $input_value );
+							$args['where'][ $input_key ] = array_map(
+								static function ( $id ) {
+									return Utils::get_database_id_from_id( $id );
+								},
+								$input_value 
+							);
 							break;
 						}
 						$args['where'][ $input_key ] = Utils::get_database_id_from_id( $input_value );
@@ -239,13 +239,16 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 						if ( is_string( $input_value ) ) {
 							$input_value = [ $input_value ];
 						}
-						$args['where'][ $input_key ] = array_map( static function ( $id ) {
-							if ( is_email( $id ) ) {
-								return $id;
-							}
+						$args['where'][ $input_key ] = array_map(
+							static function ( $id ) {
+								if ( is_email( $id ) ) {
+									return $id;
+								}
 
-							return Utils::get_database_id_from_id( $id );
-						}, $input_value );
+								return Utils::get_database_id_from_id( $id );
+							},
+							$input_value 
+						);
 						break;
 				}
 			}
@@ -276,7 +279,6 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 	 * @return array
 	 */
 	public function sanitize_input_fields( array $args ) {
-
 		$arg_mapping = [
 			'authorEmail'        => 'author_email',
 			'authorIn'           => 'author__in',
@@ -319,7 +321,6 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 		$query_args = apply_filters( 'graphql_map_input_fields_to_wp_comment_query', $query_args, $args, $this->source, $this->args, $this->context, $this->info );
 
 		return ! empty( $query_args ) && is_array( $query_args ) ? $query_args : [];
-
 	}
 
 	/**

--- a/src/Data/Connection/ContentTypeConnectionResolver.php
+++ b/src/Data/Connection/ContentTypeConnectionResolver.php
@@ -18,7 +18,6 @@ class ContentTypeConnectionResolver extends AbstractConnectionResolver {
 	 * {@inheritDoc}
 	 */
 	public function get_ids_from_query() {
-
 		$ids     = [];
 		$queried = $this->query;
 
@@ -48,7 +47,6 @@ class ContentTypeConnectionResolver extends AbstractConnectionResolver {
 	 * @return array
 	 */
 	public function get_query() {
-
 		if ( isset( $this->query_args['contentTypeNames'] ) && is_array( $this->query_args['contentTypeNames'] ) ) {
 			return $this->query_args['contentTypeNames'];
 		}

--- a/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
@@ -1,7 +1,6 @@
 <?php
 namespace WPGraphQL\Data\Connection;
 
-use Exception;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
 
@@ -27,12 +26,17 @@ class EnqueuedScriptsConnectionResolver extends AbstractConnectionResolver {
 		/**
 		 * Filter the query amount to be 1000 for
 		 */
-		add_filter( 'graphql_connection_max_query_amount', static function ( $max, $source, $args, $context, ResolveInfo $info ) {
-			if ( 'enqueuedScripts' === $info->fieldName || 'registeredScripts' === $info->fieldName ) {
-				return 1000;
-			}
-			return $max;
-		}, 10, 5 );
+		add_filter(
+			'graphql_connection_max_query_amount',
+			static function ( $max, $source, $args, $context, ResolveInfo $info ) {
+				if ( 'enqueuedScripts' === $info->fieldName || 'registeredScripts' === $info->fieldName ) {
+					return 1000;
+				}
+				return $max;
+			},
+			10,
+			5 
+		);
 
 		parent::__construct( $source, $args, $context, $info );
 	}
@@ -53,7 +57,6 @@ class EnqueuedScriptsConnectionResolver extends AbstractConnectionResolver {
 		}
 
 		return $ids;
-
 	}
 
 	/**
@@ -91,7 +94,7 @@ class EnqueuedScriptsConnectionResolver extends AbstractConnectionResolver {
 	 * @return bool
 	 */
 	protected function is_valid_model( $model ) {
-		return isset( $model->handle ) ? true : false;
+		return isset( $model->handle );
 	}
 
 	/**

--- a/src/Data/Connection/EnqueuedStylesheetConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedStylesheetConnectionResolver.php
@@ -1,7 +1,6 @@
 <?php
 namespace WPGraphQL\Data\Connection;
 
-use Exception;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
 
@@ -33,12 +32,17 @@ class EnqueuedStylesheetConnectionResolver extends AbstractConnectionResolver {
 		/**
 		 * Filter the query amount to be 1000 for
 		 */
-		add_filter( 'graphql_connection_max_query_amount', static function ( $max, $source, $args, $context, ResolveInfo $info ) {
-			if ( 'enqueuedStylesheets' === $info->fieldName || 'registeredStylesheets' === $info->fieldName ) {
-				return 1000;
-			}
-			return $max;
-		}, 10, 5 );
+		add_filter(
+			'graphql_connection_max_query_amount',
+			static function ( $max, $source, $args, $context, ResolveInfo $info ) {
+				if ( 'enqueuedStylesheets' === $info->fieldName || 'registeredStylesheets' === $info->fieldName ) {
+					return 1000;
+				}
+				return $max;
+			},
+			10,
+			5 
+		);
 
 		parent::__construct( $source, $args, $context, $info );
 	}
@@ -61,7 +65,6 @@ class EnqueuedStylesheetConnectionResolver extends AbstractConnectionResolver {
 		}
 
 		return $ids;
-
 	}
 
 	/**
@@ -99,7 +102,7 @@ class EnqueuedStylesheetConnectionResolver extends AbstractConnectionResolver {
 	 * @return bool
 	 */
 	protected function is_valid_model( $model ) {
-		return isset( $model->handle ) ? true : false;
+		return isset( $model->handle );
 	}
 
 	/**

--- a/src/Data/Connection/MenuConnectionResolver.php
+++ b/src/Data/Connection/MenuConnectionResolver.php
@@ -2,8 +2,6 @@
 
 namespace WPGraphQL\Data\Connection;
 
-use Exception;
-
 /**
  * Class MenuConnectionResolver
  *

--- a/src/Data/Connection/MenuItemConnectionResolver.php
+++ b/src/Data/Connection/MenuItemConnectionResolver.php
@@ -1,8 +1,6 @@
 <?php
 namespace WPGraphQL\Data\Connection;
 
-use Exception;
-use GraphQLRelay\Relay;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
 use WPGraphQL\Utils\Utils;
@@ -63,7 +61,6 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 
 		// If the location argument is set, set the argument to the input argument
 		if ( isset( $this->args['where']['location'], $menu_locations[ $this->args['where']['location'] ] ) ) {
-
 			$locations = [ $menu_locations[ $this->args['where']['location'] ] ];
 
 			// if the $locations are NOT set and the user has proper capabilities, let the user query

--- a/src/Data/Connection/PluginConnectionResolver.php
+++ b/src/Data/Connection/PluginConnectionResolver.php
@@ -86,7 +86,6 @@ class PluginConnectionResolver extends AbstractConnectionResolver {
 
 		// Loop through the plugins, add additional data, and store them in $plugins_by_status.
 		foreach ( (array) $all_plugins as $plugin_file => $plugin_data ) {
-
 			if ( ! file_exists( WP_PLUGIN_DIR . '/' . $plugin_file ) ) {
 				unset( $all_plugins[ $plugin_file ] );
 				continue;

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -2,7 +2,6 @@
 
 namespace WPGraphQL\Data\Connection;
 
-use Exception;
 use GraphQL\Error\InvariantViolation;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
@@ -72,7 +71,6 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		 * Call the parent construct to setup class data
 		 */
 		parent::__construct( $source, $args, $context, $info );
-
 	}
 
 	/**
@@ -130,7 +128,6 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	 * @return bool
 	 */
 	public function should_execute() {
-
 		if ( false === $this->should_execute ) {
 			return false;
 		}
@@ -143,7 +140,6 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		 * even execute the connection
 		 */
 		if ( isset( $this->post_type ) && 'revision' === $this->post_type ) {
-
 			if ( $this->source instanceof Post ) {
 				$parent_post_type_obj = get_post_type_object( $this->source->post_type );
 				if ( ! isset( $parent_post_type_obj->cap->edit_post ) || ! current_user_can( $parent_post_type_obj->cap->edit_post, $this->source->ID ) ) {
@@ -273,12 +269,14 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		}
 
 		if ( empty( $this->args['where']['orderby'] ) && ! empty( $query_args['post__in'] ) ) {
-
 			$post_in = $query_args['post__in'];
 			// Make sure the IDs are integers
-			$post_in = array_map( static function ( $id ) {
-				return absint( $id );
-			}, $post_in );
+			$post_in = array_map(
+				static function ( $id ) {
+					return absint( $id );
+				},
+				$post_in 
+			);
 
 			// If we're coming backwards, let's reverse the IDs
 			if ( ! empty( $this->args['last'] ) || ! empty( $this->args['before'] ) ) {
@@ -383,7 +381,6 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the GraphQL tree
 		 */
 		return apply_filters( 'graphql_post_object_connection_query_args', $query_args, $this->source, $this->args, $this->context, $this->info );
-
 	}
 
 	/**
@@ -398,7 +395,6 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	 * @since  0.0.5
 	 */
 	public function sanitize_input_fields( array $where_args ) {
-
 		$arg_mapping = [
 			'authorIn'      => 'author__in',
 			'authorName'    => 'author_name',
@@ -462,7 +458,6 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		 * Return the Query Args
 		 */
 		return ! empty( $query_args ) && is_array( $query_args ) ? $query_args : [];
-
 	}
 
 	/**
@@ -586,9 +581,12 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 					case 'tagIn':
 					case 'tagNotIn':
 						if ( is_array( $input_value ) ) {
-							$args['where'][ $input_key ] = array_map( static function ( $id ) {
-								return Utils::get_database_id_from_id( $id );
-							}, $input_value );
+							$args['where'][ $input_key ] = array_map(
+								static function ( $id ) {
+									return Utils::get_database_id_from_id( $id );
+								},
+								$input_value 
+							);
 							break;
 						}
 

--- a/src/Data/Connection/TaxonomyConnectionResolver.php
+++ b/src/Data/Connection/TaxonomyConnectionResolver.php
@@ -18,7 +18,6 @@ class TaxonomyConnectionResolver extends AbstractConnectionResolver {
 	 * {@inheritDoc}
 	 */
 	public function get_ids_from_query() {
-
 		$ids     = [];
 		$queried = $this->query;
 

--- a/src/Data/Connection/TermObjectConnectionResolver.php
+++ b/src/Data/Connection/TermObjectConnectionResolver.php
@@ -2,7 +2,6 @@
 
 namespace WPGraphQL\Data\Connection;
 
-use Exception;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
 use WPGraphQL\Utils\Utils;
@@ -48,8 +47,6 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 	 * {@inheritDoc}
 	 */
 	public function get_query_args() {
-
-
 		$all_taxonomies = \WPGraphQL::get_allowed_taxonomies();
 		$taxonomy       = ! empty( $this->taxonomy ) && in_array( $this->taxonomy, $all_taxonomies, true ) ? [ $this->taxonomy ] : $all_taxonomies;
 
@@ -133,7 +130,6 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 		 * If there's no orderby params in the inputArgs, set order based on the first/last argument
 		 */
 		if ( ! empty( $query_args['order'] ) ) {
-
 			if ( ! empty( $last ) ) {
 				if ( 'ASC' === $query_args['order'] ) {
 					$query_args['order'] = 'DESC';
@@ -212,7 +208,6 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 	 * @return array
 	 */
 	public function sanitize_input_fields() {
-
 		$arg_mapping = [
 			'objectIds'           => 'object_ids',
 			'hideEmpty'           => 'hide_empty',
@@ -289,9 +284,12 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 					case 'termTaxonomId':
 					case 'termTaxonomyId':
 						if ( is_array( $input_value ) ) {
-							$args['where'][ $input_key ] = array_map( static function ( $id ) {
-								return Utils::get_database_id_from_id( $id );
-							}, $input_value );
+							$args['where'][ $input_key ] = array_map(
+								static function ( $id ) {
+									return Utils::get_database_id_from_id( $id );
+								},
+								$input_value 
+							);
 							break;
 						}
 

--- a/src/Data/Connection/ThemeConnectionResolver.php
+++ b/src/Data/Connection/ThemeConnectionResolver.php
@@ -31,7 +31,6 @@ class ThemeConnectionResolver extends AbstractConnectionResolver {
 		}
 
 		return $ids;
-
 	}
 
 	/**

--- a/src/Data/Connection/UserConnectionResolver.php
+++ b/src/Data/Connection/UserConnectionResolver.php
@@ -3,8 +3,6 @@
 namespace WPGraphQL\Data\Connection;
 
 use GraphQL\Error\UserError;
-use GraphQL\Type\Definition\ResolveInfo;
-use WPGraphQL\AppContext;
 use WPGraphQL\Utils\Utils;
 
 /**
@@ -121,7 +119,6 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 		 * Map the orderby inputArgs to the WP_User_Query
 		 */
 		if ( ! empty( $this->args['where']['orderby'] ) && is_array( $this->args['where']['orderby'] ) ) {
-
 			foreach ( $this->args['where']['orderby'] as $orderby_input ) {
 				/**
 				 * These orderby options should not include the order parameter.
@@ -136,7 +133,6 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 				) ) {
 					$query_args['orderby'] = esc_sql( $orderby_input['field'] );
 				} elseif ( ! empty( $orderby_input['field'] ) ) {
-
 					$order = $orderby_input['order'];
 					if ( ! empty( $this->args['last'] ) ) {
 						if ( 'ASC' === $order ) {
@@ -268,7 +264,6 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 		$query_args = apply_filters( 'graphql_map_input_fields_to_wp_user_query', $query_args, $args, $this->source, $this->args, $this->context, $this->info );
 
 		return ! empty( $query_args ) && is_array( $query_args ) ? $query_args : [];
-
 	}
 
 	/**

--- a/src/Data/Connection/UserRoleConnectionResolver.php
+++ b/src/Data/Connection/UserRoleConnectionResolver.php
@@ -82,7 +82,6 @@ class UserRoleConnectionResolver extends AbstractConnectionResolver {
 	 * @return bool
 	 */
 	public function should_execute() {
-
 		if (
 			current_user_can( 'list_users' ) ||
 			(

--- a/src/Data/Cursor/AbstractCursor.php
+++ b/src/Data/Cursor/AbstractCursor.php
@@ -2,8 +2,6 @@
 
 namespace WPGraphQL\Data\Cursor;
 
-use wpdb;
-
 /**
  * Abstract Cursor
  *

--- a/src/Data/Cursor/CommentObjectCursor.php
+++ b/src/Data/Cursor/CommentObjectCursor.php
@@ -33,7 +33,6 @@ class CommentObjectCursor extends AbstractCursor {
 
 		// Initialize the class properties.
 		parent::__construct( $query_vars, $cursor );
-
 	}
 
 	/**
@@ -76,7 +75,6 @@ class CommentObjectCursor extends AbstractCursor {
 		$this->builder->add_field( "{$this->wpdb->comments}.comment_ID", $this->cursor_offset, 'ID', null, $this );
 
 		return $this->to_sql();
-
 	}
 
 	/**
@@ -88,7 +86,6 @@ class CommentObjectCursor extends AbstractCursor {
 	 * @return void
 	 */
 	public function compare_with( $by, $order ) {
-
 		$type = null;
 
 		if ( 'comment_date' === $by ) {
@@ -100,7 +97,6 @@ class CommentObjectCursor extends AbstractCursor {
 			$this->builder->add_field( "{$this->wpdb->comments}.{$by}", $value, $type );
 			return;
 		}
-
 	}
 
 	/**

--- a/src/Data/Cursor/CursorBuilder.php
+++ b/src/Data/Cursor/CursorBuilder.php
@@ -85,7 +85,6 @@ class CursorBuilder {
 		}
 
 		$this->fields[] = $escaped_field;
-
 	}
 
 	/**
@@ -105,7 +104,6 @@ class CursorBuilder {
 	 * @return string
 	 */
 	public function to_sql( $fields = null ) {
-
 		if ( null === $fields ) {
 			$fields = $this->fields;
 		}

--- a/src/Data/Cursor/PostObjectCursor.php
+++ b/src/Data/Cursor/PostObjectCursor.php
@@ -69,7 +69,6 @@ class PostObjectCursor extends AbstractCursor {
 	 * {@inheritDoc}
 	 */
 	public function to_sql() {
-
 		$orderby = isset( $this->query_vars['orderby'] ) ? $this->query_vars['orderby'] : null;
 
 		$orderby_should_not_convert_to_sql = isset( $orderby ) && in_array(
@@ -109,7 +108,6 @@ class PostObjectCursor extends AbstractCursor {
 
 		if ( 'menu_order' === $orderby ) {
 			if ( '>' === $this->compare ) {
-
 				$order         = 'DESC';
 				$this->compare = '<';
 			} elseif ( '<' === $this->compare ) {
@@ -132,7 +130,6 @@ class PostObjectCursor extends AbstractCursor {
 			 * If $orderby is just a string just compare with it directly as DESC
 			 */
 			$this->compare_with( $orderby, $order );
-
 		}
 
 		/**
@@ -156,7 +153,6 @@ class PostObjectCursor extends AbstractCursor {
 	 * @return void
 	 */
 	private function compare_with( $by, $order ) {
-
 		switch ( $by ) {
 			case 'author':
 			case 'title':
@@ -188,7 +184,6 @@ class PostObjectCursor extends AbstractCursor {
 		if ( $meta_key ) {
 			$this->compare_with_meta_field( $meta_key, $order );
 		}
-
 	}
 
 	/**
@@ -242,7 +237,6 @@ class PostObjectCursor extends AbstractCursor {
 	 * @return string|null
 	 */
 	private function get_meta_key( $by ) {
-
 		if ( 'meta_value' === $by || 'meta_value_num' === $by ) {
 			return $this->get_query_var( 'meta_key' );
 		}

--- a/src/Data/Cursor/TermObjectCursor.php
+++ b/src/Data/Cursor/TermObjectCursor.php
@@ -88,7 +88,6 @@ class TermObjectCursor extends AbstractCursor {
 			 * If $orderby is just a string just compare with it directly as DESC
 			 */
 			$this->compare_with( $orderby, $order );
-
 		}
 
 		$this->builder->add_field( 't.term_id', $this->cursor_offset, 'ID' );
@@ -105,14 +104,12 @@ class TermObjectCursor extends AbstractCursor {
 	 * @return void
 	 */
 	private function compare_with( string $by, string $order ) {
-
 		$value = $this->cursor_node->{$by};
 
 		/**
 		 * Compare by the term field if the key matches an value
 		 */
 		if ( ! empty( $value ) ) {
-
 			if ( '>' === $this->compare ) {
 				$order = 'DESC';
 			} else {
@@ -133,7 +130,6 @@ class TermObjectCursor extends AbstractCursor {
 
 			return;
 		}
-
 	}
 
 	/**
@@ -155,7 +151,6 @@ class TermObjectCursor extends AbstractCursor {
 		 */
 		if ( 0 !== $this->meta_join_alias ) {
 			$key = "mt{$this->meta_join_alias}.meta_value";
-
 		}
 
 		$this->meta_join_alias ++;
@@ -171,7 +166,6 @@ class TermObjectCursor extends AbstractCursor {
 	 * @return string|null
 	 */
 	private function get_meta_key( string $by ) {
-
 		if ( 'meta_value' === $by || 'meta_value_num' === $by ) {
 			return $this->get_query_var( 'meta_key' );
 		}

--- a/src/Data/Cursor/UserCursor.php
+++ b/src/Data/Cursor/UserCursor.php
@@ -2,7 +2,6 @@
 
 namespace WPGraphQL\Data\Cursor;
 
-use WP_User;
 use WP_User_Query;
 
 /**
@@ -115,7 +114,6 @@ class UserCursor extends AbstractCursor {
 			 * If $orderby is just a string just compare with it directly as DESC
 			 */
 			$this->compare_with( $orderby, $order );
-
 		}
 
 		/**
@@ -139,7 +137,6 @@ class UserCursor extends AbstractCursor {
 	 * @return void
 	 */
 	private function compare_with( $by, $order ) {
-
 		switch ( $by ) {
 			case 'email':
 			case 'login':
@@ -170,7 +167,6 @@ class UserCursor extends AbstractCursor {
 
 			return;
 		}
-
 	}
 
 	/**
@@ -201,7 +197,6 @@ class UserCursor extends AbstractCursor {
 		 */
 		if ( 0 !== $this->meta_join_alias ) {
 			$key = "mt{$this->meta_join_alias}.meta_value";
-
 		}
 
 		$this->meta_join_alias ++;
@@ -217,7 +212,6 @@ class UserCursor extends AbstractCursor {
 	 * @return string|null
 	 */
 	private function get_meta_key( $by ) {
-
 		if ( 'meta_value' === $by ) {
 			return $this->get_query_var( 'meta_key' );
 		}

--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -2,8 +2,6 @@
 
 namespace WPGraphQL\Data;
 
-use Exception;
-use GraphQL\Deferred;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
@@ -81,7 +79,6 @@ class DataSource {
 	 * @throws \Exception Throws Exception.
 	 */
 	public static function resolve_comment_author( int $comment_id ) {
-
 		$comment_author = get_comment( $comment_id );
 
 		return ! empty( $comment_author ) ? new CommentAuthor( $comment_author ) : null;
@@ -205,7 +202,6 @@ class DataSource {
 		}
 
 		return new Taxonomy( $tax_object );
-
 	}
 
 	/**
@@ -314,7 +310,6 @@ class DataSource {
 		$resolver = new UserConnectionResolver( $source, $args, $context, $info );
 
 		return $resolver->get_connection();
-
 	}
 
 	/**
@@ -327,7 +322,6 @@ class DataSource {
 	 * @since  0.0.30
 	 */
 	public static function resolve_user_role( $name ) {
-
 		$role = isset( wp_roles()->roles[ $name ] ) ? wp_roles()->roles[ $name ] : null;
 
 		if ( null === $role ) {
@@ -341,7 +335,6 @@ class DataSource {
 
 			return new UserRole( $role );
 		}
-
 	}
 
 	/**
@@ -354,7 +347,6 @@ class DataSource {
 	 * @throws \Exception
 	 */
 	public static function resolve_avatar( int $user_id, array $args ) {
-
 		$avatar = get_avatar_data( absint( $user_id ), $args );
 
 		// if there's no url returned, return null
@@ -363,7 +355,6 @@ class DataSource {
 		}
 
 		return new Avatar( $avatar );
-
 	}
 
 	/**
@@ -378,7 +369,6 @@ class DataSource {
 	 * @throws \Exception
 	 */
 	public static function resolve_user_role_connection( $source, array $args, AppContext $context, ResolveInfo $info ) {
-
 		$resolver = new UserRoleConnectionResolver( $source, $args, $context, $info );
 
 		return $resolver->get_connection();
@@ -421,7 +411,6 @@ class DataSource {
 		$settings_groups = self::get_allowed_settings_by_group( $type_registry );
 
 		return ! empty( $settings_groups[ $group ] ) ? $settings_groups[ $group ] : [];
-
 	}
 
 	/**
@@ -473,7 +462,6 @@ class DataSource {
 		 * @param array $allowed_settings_by_group
 		 */
 		return apply_filters( 'graphql_allowed_settings_by_group', $allowed_settings_by_group );
-
 	}
 
 	/**
@@ -502,7 +490,6 @@ class DataSource {
 			 * add it to the $allowed_settings array
 			 */
 			foreach ( $registered_settings as $key => $setting ) {
-
 				if ( ! isset( $setting['type'] ) || ! $type_registry->get_type( $setting['type'] ) ) {
 					continue;
 				}
@@ -545,9 +532,7 @@ class DataSource {
 	 * @throws \GraphQL\Error\UserError
 	 */
 	public static function get_node_definition() {
-
 		if ( null === self::$node_definition ) {
-
 			$node_definition = Relay::nodeDefinitions(
 			// The ID fetcher definition
 				static function ( $global_id, AppContext $context, ResolveInfo $info ) {
@@ -560,7 +545,6 @@ class DataSource {
 			);
 
 			self::$node_definition = $node_definition;
-
 		}
 
 		return self::$node_definition;
@@ -577,7 +561,6 @@ class DataSource {
 		$type = null;
 
 		if ( true === is_object( $node ) ) {
-
 			switch ( true ) {
 				case $node instanceof Post:
 					if ( $node->isRevision ) {
@@ -671,7 +654,6 @@ class DataSource {
 	 * @throws \Exception
 	 */
 	public static function resolve_node( $global_id, AppContext $context, ResolveInfo $info ) {
-
 		if ( empty( $global_id ) ) {
 			throw new UserError( __( 'An ID needs to be provided to resolve a node.', 'wp-graphql' ) );
 		}
@@ -703,7 +685,6 @@ class DataSource {
 			}
 
 			return null;
-
 		} else {
 			// translators: %s is the global ID.
 			throw new UserError( sprintf( __( 'The global ID isn\'t recognized ID: %s', 'wp-graphql' ), $global_id ) );
@@ -737,7 +718,6 @@ class DataSource {
 		$node_resolver = new NodeResolver( $context );
 
 		return $node_resolver->resolve_uri( $uri );
-
 	}
 
 }

--- a/src/Data/Loader/AbstractDataLoader.php
+++ b/src/Data/Loader/AbstractDataLoader.php
@@ -3,7 +3,6 @@
 namespace WPGraphQL\Data\Loader;
 
 use Exception;
-use Generator;
 use GraphQL\Deferred;
 use GraphQL\Utils\Utils;
 use WPGraphQL\AppContext;
@@ -66,7 +65,6 @@ abstract class AbstractDataLoader {
 	 * @throws \Exception
 	 */
 	public function load_deferred( $database_id ) {
-
 		if ( empty( $database_id ) ) {
 			return null;
 		}
@@ -80,7 +78,6 @@ abstract class AbstractDataLoader {
 				return $this->load( $database_id );
 			}
 		);
-
 	}
 
 	/**
@@ -96,7 +93,7 @@ abstract class AbstractDataLoader {
 			$key = $this->key_to_scalar( $key );
 			if ( ! is_scalar( $key ) ) {
 				throw new Exception(
-					get_class( $this ) . '::buffer expects all keys to be scalars, but key ' .
+					static::class . '::buffer expects all keys to be scalars, but key ' .
 					'at position ' . $index . ' is ' . Utils::printSafe( $keys ) . '. ' .
 					$this->get_scalar_key_hint( $key )
 				);
@@ -117,11 +114,10 @@ abstract class AbstractDataLoader {
 	 * @throws \Exception
 	 */
 	public function load( $key ) {
-
 		$key = $this->key_to_scalar( $key );
 		if ( ! is_scalar( $key ) ) {
 			throw new Exception(
-				get_class( $this ) . '::load expects key to be scalar, but got ' . Utils::printSafe( $key ) .
+				static::class . '::load expects key to be scalar, but got ' . Utils::printSafe( $key ) .
 				$this->get_scalar_key_hint( $key )
 			);
 		}
@@ -149,13 +145,13 @@ abstract class AbstractDataLoader {
 		$key = $this->key_to_scalar( $key );
 		if ( ! is_scalar( $key ) ) {
 			throw new Exception(
-				get_class( $this ) . '::prime is expecting scalar $key, but got ' . Utils::printSafe( $key )
+				static::class . '::prime is expecting scalar $key, but got ' . Utils::printSafe( $key )
 				. $this->get_scalar_key_hint( $key )
 			);
 		}
 		if ( null === $value ) {
 			throw new Exception(
-				get_class( $this ) . '::prime is expecting non-null $value, but got null. Double-check for null or ' .
+				static::class . '::prime is expecting non-null $value, but got null. Double-check for null or ' .
 				' use `clear` if you want to clear the cache'
 			);
 		}
@@ -296,9 +292,9 @@ abstract class AbstractDataLoader {
 		if ( ! empty( $keysToLoad ) ) {
 			try {
 				$loaded = $this->loadKeys( $keysToLoad );
-			} catch ( Exception $e ) {
+			} catch ( \Throwable $e ) {
 				throw new Exception(
-					'Method ' . get_class( $this ) . '::loadKeys is expected to return array, but it threw: ' .
+					'Method ' . static::class . '::loadKeys is expected to return array, but it threw: ' .
 					$e->getMessage(),
 					0,
 					$e
@@ -307,7 +303,7 @@ abstract class AbstractDataLoader {
 
 			if ( ! is_array( $loaded ) ) {
 				throw new Exception(
-					'Method ' . get_class( $this ) . '::loadKeys is expected to return an array with keys ' .
+					'Method ' . static::class . '::loadKeys is expected to return an array with keys ' .
 					'but got: ' . Utils::printSafe( $loaded )
 				);
 			}
@@ -337,7 +333,7 @@ abstract class AbstractDataLoader {
 		if ( null === $key ) {
 			return ' Make sure to add additional checks for null values.';
 		} else {
-			return ' Try overriding ' . __CLASS__ . '::key_to_scalar if your keys are composite.';
+			return ' Try overriding ' . self::class . '::key_to_scalar if your keys are composite.';
 		}
 	}
 
@@ -439,7 +435,7 @@ abstract class AbstractDataLoader {
 			'graphql_dataloader_get_cached',
 			$value,
 			$key,
-			get_class( $this ),
+			static::class,
 			$this
 		);
 
@@ -471,7 +467,7 @@ abstract class AbstractDataLoader {
 			'graphql_dataloader_set_cached',
 			$value,
 			$key,
-			get_class( $this ),
+			static::class,
 			$this
 		);
 	}

--- a/src/Data/Loader/CommentAuthorLoader.php
+++ b/src/Data/Loader/CommentAuthorLoader.php
@@ -1,7 +1,6 @@
 <?php
 namespace WPGraphQL\Data\Loader;
 
-use Exception;
 use WPGraphQL\Model\CommentAuthor;
 
 /**
@@ -19,7 +18,6 @@ class CommentAuthorLoader extends AbstractDataLoader {
 	 * @throws \Exception
 	 */
 	protected function get_model( $entry, $key ) {
-
 		if ( ! $entry instanceof \WP_Comment ) {
 			return null;
 		}

--- a/src/Data/Loader/CommentLoader.php
+++ b/src/Data/Loader/CommentLoader.php
@@ -2,7 +2,6 @@
 
 namespace WPGraphQL\Data\Loader;
 
-use Exception;
 use WPGraphQL\Model\Comment;
 
 /**
@@ -20,7 +19,6 @@ class CommentLoader extends AbstractDataLoader {
 	 * @throws \Exception
 	 */
 	protected function get_model( $entry, $key ) {
-
 		if ( ! $entry instanceof \WP_Comment ) {
 			return null;
 		}

--- a/src/Data/Loader/PluginLoader.php
+++ b/src/Data/Loader/PluginLoader.php
@@ -2,8 +2,6 @@
 
 namespace WPGraphQL\Data\Loader;
 
-use Exception;
-use WPGraphQL\Model\Model;
 use WPGraphQL\Model\Plugin;
 
 /**

--- a/src/Data/Loader/PostObjectLoader.php
+++ b/src/Data/Loader/PostObjectLoader.php
@@ -2,9 +2,6 @@
 
 namespace WPGraphQL\Data\Loader;
 
-use Exception;
-use GraphQL\Deferred;
-use WPGraphQL\Model\Menu;
 use WPGraphQL\Model\MenuItem;
 use WPGraphQL\Model\Post;
 
@@ -23,7 +20,6 @@ class PostObjectLoader extends AbstractDataLoader {
 	 * @throws \Exception
 	 */
 	protected function get_model( $entry, $key ) {
-
 		if ( ! $entry instanceof \WP_Post ) {
 			return null;
 		}
@@ -74,7 +70,6 @@ class PostObjectLoader extends AbstractDataLoader {
 	 * @throws \Exception
 	 */
 	public function loadKeys( array $keys ) {
-
 		if ( empty( $keys ) ) {
 			return $keys;
 		}
@@ -134,7 +129,6 @@ class PostObjectLoader extends AbstractDataLoader {
 				 * Once dependencies are loaded, return the Post Object
 				 */
 				$loaded_posts[ $key ] = $post_object;
-
 			}
 		}
 		return $loaded_posts;

--- a/src/Data/Loader/PostTypeLoader.php
+++ b/src/Data/Loader/PostTypeLoader.php
@@ -1,7 +1,6 @@
 <?php
 namespace WPGraphQL\Data\Loader;
 
-use Exception;
 use WPGraphQL\Model\PostType;
 
 /**
@@ -43,6 +42,5 @@ class PostTypeLoader extends AbstractDataLoader {
 		}
 
 		return $loaded;
-
 	}
 }

--- a/src/Data/Loader/TaxonomyLoader.php
+++ b/src/Data/Loader/TaxonomyLoader.php
@@ -1,7 +1,6 @@
 <?php
 namespace WPGraphQL\Data\Loader;
 
-use Exception;
 use WPGraphQL\Model\Taxonomy;
 
 /**

--- a/src/Data/Loader/TermObjectLoader.php
+++ b/src/Data/Loader/TermObjectLoader.php
@@ -2,8 +2,6 @@
 
 namespace WPGraphQL\Data\Loader;
 
-use Exception;
-use GraphQL\Deferred;
 use WPGraphQL\Model\Menu;
 use WPGraphQL\Model\Term;
 
@@ -22,14 +20,12 @@ class TermObjectLoader extends AbstractDataLoader {
 	 * @throws \Exception
 	 */
 	protected function get_model( $entry, $key ) {
-
 		if ( is_a( $entry, 'WP_Term' ) ) {
 
 			/**
 			 * For nav_menu terms, we want to pass through a different model
 			 */
 			if ( 'nav_menu' === $entry->taxonomy ) {
-
 				$menu = new Menu( $entry );
 				if ( empty( $menu->fields ) ) {
 					return null;
@@ -37,7 +33,6 @@ class TermObjectLoader extends AbstractDataLoader {
 					return $menu;
 				}
 			} else {
-
 				$term = new Term( $entry );
 				if ( empty( $term->fields ) ) {
 					return null;
@@ -65,7 +60,6 @@ class TermObjectLoader extends AbstractDataLoader {
 	 * @throws \Exception
 	 */
 	public function loadKeys( array $keys ) {
-
 		if ( empty( $keys ) ) {
 			return $keys;
 		}
@@ -105,11 +99,9 @@ class TermObjectLoader extends AbstractDataLoader {
 			 * object isn't in the cache, meaning it didn't come back when queried.
 			 */
 			$loaded[ $key ] = get_term( (int) $key );
-
 		}
 
 		return $loaded;
-
 	}
 
 }

--- a/src/Data/Loader/ThemeLoader.php
+++ b/src/Data/Loader/ThemeLoader.php
@@ -1,8 +1,6 @@
 <?php
 namespace WPGraphQL\Data\Loader;
 
-use Exception;
-use WPGraphQL\Model\Model;
 use WPGraphQL\Model\Theme;
 
 /**
@@ -35,7 +33,6 @@ class ThemeLoader extends AbstractDataLoader {
 
 		if ( is_array( $themes ) && ! empty( $themes ) ) {
 			foreach ( $keys as $key ) {
-
 				$loaded[ $key ] = null;
 
 				if ( isset( $themes[ $key ] ) ) {

--- a/src/Data/Loader/UserLoader.php
+++ b/src/Data/Loader/UserLoader.php
@@ -1,7 +1,6 @@
 <?php
 namespace WPGraphQL\Data\Loader;
 
-use Exception;
 use WPGraphQL\Model\User;
 
 /**
@@ -50,9 +49,12 @@ class UserLoader extends AbstractDataLoader {
 		// Get public post types that are set to show in GraphQL
 		// as public users are determined by whether they've published
 		// content in one of these post types
-		$post_types = \WPGraphQL::get_allowed_post_types( 'names', [
-			'public' => true,
-		] );
+		$post_types = \WPGraphQL::get_allowed_post_types(
+			'names',
+			[
+				'public' => true,
+			] 
+		);
 
 		/**
 		 * Exclude revisions and attachments, since neither ever receive the
@@ -119,7 +121,6 @@ class UserLoader extends AbstractDataLoader {
 	 * @throws \Exception
 	 */
 	public function loadKeys( array $keys ) {
-
 		if ( empty( $keys ) ) {
 			return $keys;
 		}

--- a/src/Data/Loader/UserRoleLoader.php
+++ b/src/Data/Loader/UserRoleLoader.php
@@ -2,7 +2,6 @@
 
 namespace WPGraphQL\Data\Loader;
 
-use Exception;
 use WPGraphQL\Model\UserRole;
 
 /**

--- a/src/Data/MediaItemMutation.php
+++ b/src/Data/MediaItemMutation.php
@@ -3,7 +3,6 @@
 namespace WPGraphQL\Data;
 
 use GraphQL\Type\Definition\ResolveInfo;
-use GraphQLRelay\Relay;
 use WP_Post_Type;
 use WPGraphQL\AppContext;
 use WPGraphQL\Utils\Utils;
@@ -27,7 +26,6 @@ class MediaItemMutation {
 	 * @return array $media_item_args
 	 */
 	public static function prepare_media_item( array $input, WP_Post_Type $post_type_object, string $mutation_name, $file ) {
-
 		$insert_post_args = [];
 		
 		/**
@@ -142,7 +140,6 @@ class MediaItemMutation {
 		 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo that is passed down the resolve tree
 		 */
 		do_action( 'graphql_media_item_mutation_update_additional_data', $media_item_id, $input, $post_type_object, $mutation_name, $context, $info );
-
 	}
 
 }

--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -2,9 +2,7 @@
 
 namespace WPGraphQL\Data;
 
-use Exception;
 use GraphQL\Deferred;
-use WP;
 use WP_Post;
 use WPGraphQL\AppContext;
 use GraphQL\Error\UserError;
@@ -44,8 +42,6 @@ class NodeResolver {
 	 * @return \WP_Post|null
 	 */
 	public function validate_post( WP_Post $post ) {
-
-
 		if ( isset( $this->wp->query_vars['post_type'] ) && ( $post->post_type !== $this->wp->query_vars['post_type'] ) ) {
 			return null;
 		}
@@ -231,7 +227,6 @@ class NodeResolver {
 
 			// Validate the post before returning it.
 			if ( ! $this->validate_post( $queried_object ) ) {
-
 				return null;
 			}
 
@@ -302,9 +297,12 @@ class NodeResolver {
 		$parsed_url = wp_parse_url( $uri );
 
 		if ( false === $parsed_url ) {
-			graphql_debug( __( 'Cannot parse provided URI', 'wp-graphql' ), [
-				'uri' => $uri,
-			] );
+			graphql_debug(
+				__( 'Cannot parse provided URI', 'wp-graphql' ),
+				[
+					'uri' => $uri,
+				] 
+			);
 			return null;
 		}
 
@@ -325,9 +323,12 @@ class NodeResolver {
 				],
 				true
 			) ) {
-				graphql_debug( __( 'Cannot return a resource for an external URI', 'wp-graphql' ), [
-					'uri' => $uri,
-				] );
+				graphql_debug(
+					__( 'Cannot return a resource for an external URI', 'wp-graphql' ),
+					[
+						'uri' => $uri,
+					] 
+				);
 				return null;
 			}
 		}
@@ -431,7 +432,6 @@ class NodeResolver {
 						preg_match( "#^$match#", $request_match, $matches ) ||
 						preg_match( "#^$match#", urldecode( $request_match ), $matches )
 					) {
-
 						if ( $wp_rewrite->use_verbose_page_rules && preg_match( '/pagename=\$matches\[([0-9]+)\]/', $query, $varmatch ) ) {
 							// This is a verbose page match, let's check to be sure about it.
 							$page = get_page_by_path( $matches[ $varmatch[1] ] ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.get_page_by_path_get_page_by_path
@@ -498,7 +498,6 @@ class NodeResolver {
 		}
 
 		foreach ( $this->wp->public_query_vars as $wpvar ) {
-
 			$parsed_query = [];
 			if ( isset( $parsed_url['query'] ) ) {
 				parse_str( $parsed_url['query'], $parsed_query );
@@ -533,7 +532,7 @@ class NodeResolver {
 		}
 
 		// Convert urldecoded spaces back into '+'.
-		foreach ( get_taxonomies( [ 'show_in_graphql' => true ], 'objects' ) as $taxonomy => $t ) {
+		foreach ( get_taxonomies( [ 'show_in_graphql' => true ], 'objects' ) as $t ) {
 			if ( $t->query_var && isset( $this->wp->query_vars[ $t->query_var ] ) ) {
 				$this->wp->query_vars[ $t->query_var ] = str_replace( ' ', '+', $this->wp->query_vars[ $t->query_var ] );
 			}
@@ -601,7 +600,6 @@ class NodeResolver {
 
 		// If the homepage is a static page, return the page.
 		if ( 'page' === $show_on_front && ! empty( $page_id ) ) {
-
 			$page = get_post( $page_id );
 
 			if ( empty( $page ) ) {

--- a/src/Data/PostObjectMutation.php
+++ b/src/Data/PostObjectMutation.php
@@ -27,7 +27,6 @@ class PostObjectMutation {
 	 * @throws \Exception
 	 */
 	public static function prepare_post_object( $input, $post_type_object, $mutation_name ) {
-
 		$insert_post_args = [];
 
 		/**
@@ -117,7 +116,6 @@ class PostObjectMutation {
 		 * Return the $args
 		 */
 		return $insert_post_args;
-
 	}
 
 	/**
@@ -223,7 +221,6 @@ class PostObjectMutation {
 			 */
 			self::remove_edit_lock( $post_id );
 		}
-
 	}
 
 	/**
@@ -270,13 +267,12 @@ class PostObjectMutation {
 				 * If there is input for the taxonomy, process it
 				 */
 				if ( isset( $input[ lcfirst( $tax_object->graphql_plural_name ) ] ) ) {
-
 					$term_input = $input[ lcfirst( $tax_object->graphql_plural_name ) ];
 
 					/**
 					 * Default append to true, but allow input to set it to false.
 					 */
-					$append = isset( $term_input['append'] ) && false === $term_input['append'] ? false : true;
+					$append = ! isset( $term_input['append'] ) || false !== $term_input['append'];
 
 					/**
 					 * Start an array of terms to connect
@@ -300,18 +296,14 @@ class PostObjectMutation {
 					 * If there are nodes in the term_input
 					 */
 					if ( ! empty( $term_input['nodes'] ) && is_array( $term_input['nodes'] ) ) {
-
 						foreach ( $term_input['nodes'] as $node ) {
-
 							$term_exists = false;
 
 							/**
 							 * Handle the input for ID first.
 							 */
 							if ( ! empty( $node['id'] ) ) {
-
 								if ( ! absint( $node['id'] ) ) {
-
 									$id_parts = Relay::fromGlobalId( $node['id'] );
 
 									if ( ! empty( $id_parts['id'] ) ) {
@@ -373,7 +365,6 @@ class PostObjectMutation {
 					}
 
 					wp_set_object_terms( $post_id, $terms_to_connect, $tax_object->name, $append );
-
 				}
 			}
 		}
@@ -389,7 +380,6 @@ class PostObjectMutation {
 	 * @return int $term_id The ID of the created term. 0 if no term was created.
 	 */
 	protected static function create_term_to_connect( $node, $taxonomy ) {
-
 		$created_term   = [];
 		$term_to_create = [];
 		$term_args      = [];
@@ -417,20 +407,17 @@ class PostObjectMutation {
 		}
 
 		if ( is_wp_error( $created_term ) ) {
-
 			if ( isset( $created_term->error_data['term_exists'] ) ) {
 				return $created_term->error_data['term_exists'];
 			}
 
 			return 0;
-
 		}
 
 		/**
 		 * Return the created term, or 0
 		 */
 		return isset( $created_term['term_id'] ) ? absint( $created_term['term_id'] ) : 0;
-
 	}
 
 	/**
@@ -445,7 +432,6 @@ class PostObjectMutation {
 	 *                     there is no current user.
 	 */
 	public static function set_edit_lock( $post_id ) {
-
 		$post    = get_post( $post_id );
 		$user_id = get_current_user_id();
 
@@ -462,7 +448,6 @@ class PostObjectMutation {
 		update_post_meta( $post->ID, '_edit_lock', $lock );
 
 		return [ $now, $user_id ];
-
 	}
 
 	/**
@@ -473,7 +458,6 @@ class PostObjectMutation {
 	 * @return bool
 	 */
 	public static function remove_edit_lock( int $post_id ) {
-
 		$post = get_post( $post_id );
 
 		if ( empty( $post ) ) {
@@ -481,7 +465,6 @@ class PostObjectMutation {
 		}
 
 		return delete_post_meta( $post->ID, '_edit_lock' );
-
 	}
 
 	/**

--- a/src/Data/TermObjectMutation.php
+++ b/src/Data/TermObjectMutation.php
@@ -21,7 +21,6 @@ class TermObjectMutation {
 	 * @return mixed
 	 */
 	public static function prepare_object( array $input, WP_Taxonomy $taxonomy, string $mutation_name ) {
-
 		$insert_args = [];
 
 		/**

--- a/src/Data/UserMutation.php
+++ b/src/Data/UserMutation.php
@@ -27,9 +27,7 @@ class UserMutation {
 	 * @return array|null
 	 */
 	public static function input_fields() {
-
 		if ( empty( self::$input_fields ) ) {
-
 			$input_fields = [
 				'password'    => [
 					'type'        => 'String',
@@ -103,11 +101,9 @@ class UserMutation {
 			 * @var array $input_fields
 			 */
 			self::$input_fields = apply_filters( 'graphql_user_mutation_input_fields', $input_fields );
-
 		}
 
 		return ( ! empty( self::$input_fields ) ) ? self::$input_fields : null;
-
 	}
 
 	/**
@@ -119,7 +115,6 @@ class UserMutation {
 	 * @return array
 	 */
 	public static function prepare_user_object( $input, $mutation_name ) {
-
 		$insert_user_args = [];
 
 		/**
@@ -204,7 +199,6 @@ class UserMutation {
 		$insert_user_args = apply_filters( 'graphql_user_insert_post_args', $insert_user_args, $input, $mutation_name );
 
 		return $insert_user_args;
-
 	}
 
 	/**
@@ -221,7 +215,6 @@ class UserMutation {
 	 * @throws \Exception
 	 */
 	public static function update_additional_user_object_data( $user_id, $input, $mutation_name, AppContext $context, ResolveInfo $info ) {
-
 		$roles = ! empty( $input['roles'] ) ? $input['roles'] : [];
 		self::add_user_roles( $user_id, $roles );
 
@@ -237,7 +230,6 @@ class UserMutation {
 		 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the Resolve Tree
 		 */
 		do_action( 'graphql_user_object_mutation_update_additional_data', $user_id, $input, $mutation_name, $context, $info );
-
 	}
 
 	/**
@@ -250,7 +242,6 @@ class UserMutation {
 	 * @throws \Exception
 	 */
 	private static function add_user_roles( $user_id, $roles ) {
-
 		if ( empty( $roles ) || ! is_array( $roles ) || ! current_user_can( 'edit_user', $user_id ) ) {
 			return;
 		}
@@ -258,9 +249,7 @@ class UserMutation {
 		$user = get_user_by( 'ID', $user_id );
 
 		if ( false !== $user ) {
-
 			foreach ( $roles as $role ) {
-
 				$verified = self::verify_user_role( $role, $user_id );
 
 				if ( true === $verified ) {
@@ -274,7 +263,6 @@ class UserMutation {
 				}
 			}
 		}
-
 	}
 
 	/**
@@ -287,7 +275,6 @@ class UserMutation {
 	 * @return mixed|bool|\WP_Error
 	 */
 	private static function verify_user_role( $role, $user_id ) {
-
 		global $wp_roles;
 
 		$potential_role = isset( $wp_roles->role_objects[ $role ] ) ? $wp_roles->role_objects[ $role ] : '';
@@ -324,7 +311,6 @@ class UserMutation {
 		} else {
 			return true;
 		}
-
 	}
 
 }

--- a/src/Model/Avatar.php
+++ b/src/Model/Avatar.php
@@ -2,8 +2,6 @@
 
 namespace WPGraphQL\Model;
 
-use Exception;
-
 /**
  * Class Avatar - Models data for avatars
  *
@@ -47,9 +45,7 @@ class Avatar extends Model {
 	 * @return void
 	 */
 	protected function init() {
-
 		if ( empty( $this->fields ) ) {
-
 			$this->fields = [
 				'size'         => function () {
 					return ! empty( $this->data['size'] ) ? absint( $this->data['size'] ) : null;
@@ -82,7 +78,6 @@ class Avatar extends Model {
 					return ! empty( $this->data['url'] ) ? $this->data['url'] : null;
 				},
 			];
-
 		}
 	}
 }

--- a/src/Model/Comment.php
+++ b/src/Model/Comment.php
@@ -2,7 +2,6 @@
 
 namespace WPGraphQL\Model;
 
-use Exception;
 use GraphQLRelay\Relay;
 use WP_Comment;
 
@@ -48,7 +47,6 @@ class Comment extends Model {
 	 * @throws \Exception
 	 */
 	public function __construct( WP_Comment $comment ) {
-
 		$allowed_restricted_fields = [
 			'id',
 			'ID',
@@ -73,7 +71,6 @@ class Comment extends Model {
 		$this->data = $comment;
 		$owner      = ! empty( $comment->user_id ) ? absint( $comment->user_id ) : null;
 		parent::__construct( 'moderate_comments', $allowed_restricted_fields, $owner );
-
 	}
 
 	/**
@@ -83,7 +80,6 @@ class Comment extends Model {
 	 * @throws \Exception
 	 */
 	protected function is_private() {
-
 		if ( empty( $this->data->comment_post_ID ) ) {
 			return true;
 		}
@@ -109,7 +105,6 @@ class Comment extends Model {
 		}
 
 		return false;
-
 	}
 
 	/**
@@ -118,9 +113,7 @@ class Comment extends Model {
 	 * @return void
 	 */
 	protected function init() {
-
 		if ( empty( $this->fields ) ) {
-
 			$this->fields = [
 				'id'                 => function () {
 					return ! empty( $this->data->comment_ID ) ? Relay::toGlobalId( 'comment', $this->data->comment_ID ) : null;
@@ -196,8 +189,6 @@ class Comment extends Model {
 					return ! empty( $this->data->user_id ) ? absint( $this->data->user_id ) : null;
 				},
 			];
-
 		}
-
 	}
 }

--- a/src/Model/CommentAuthor.php
+++ b/src/Model/CommentAuthor.php
@@ -2,7 +2,6 @@
 
 namespace WPGraphQL\Model;
 
-use Exception;
 use GraphQLRelay\Relay;
 use WP_Comment;
 
@@ -44,9 +43,7 @@ class CommentAuthor extends Model {
 	 * @return void
 	 */
 	protected function init() {
-
 		if ( empty( $this->fields ) ) {
-
 			$this->fields = [
 				'id'         => function () {
 					return ! empty( $this->data->comment_ID ) ? Relay::toGlobalId( 'comment_author', $this->data->comment_ID ) : null;
@@ -64,7 +61,6 @@ class CommentAuthor extends Model {
 					return ! empty( $this->data->comment_author_url ) ? $this->data->comment_author_url : '';
 				},
 			];
-
 		}
 	}
 }

--- a/src/Model/Menu.php
+++ b/src/Model/Menu.php
@@ -72,9 +72,7 @@ class Menu extends Model {
 	 * @return void
 	 */
 	protected function init() {
-
 		if ( empty( $this->fields ) ) {
-
 			$this->fields = [
 				'id'         => function () {
 					return ! empty( $this->data->term_id ) ? Relay::toGlobalId( 'term', (string) $this->data->term_id ) : null;
@@ -109,12 +107,9 @@ class Menu extends Model {
 					}
 
 					return $locations;
-
 				},
 			];
-
 		}
-
 	}
 
 }

--- a/src/Model/MenuItem.php
+++ b/src/Model/MenuItem.php
@@ -101,9 +101,7 @@ class MenuItem extends Model {
 	 * @return void
 	 */
 	protected function init() {
-
 		if ( empty( $this->fields ) ) {
-
 			$this->fields = [
 				'id'               => function () {
 					return ! empty( $this->data->ID ) ? Relay::toGlobalId( 'post', $this->data->ID ) : null;
@@ -156,7 +154,6 @@ class MenuItem extends Model {
 					return ! empty( $this->data->url ) ? $this->data->url : null;
 				},
 				'path'             => function () {
-
 					$url = $this->url;
 
 					if ( ! empty( $url ) ) {
@@ -168,7 +165,6 @@ class MenuItem extends Model {
 					}
 
 					return $url;
-
 				},
 				'order'            => function () {
 					return $this->data->menu_order;
@@ -177,7 +173,6 @@ class MenuItem extends Model {
 					return ! empty( $this->menuDatabaseId ) ? Relay::toGlobalId( 'term', (string) $this->menuDatabaseId ) : null;
 				},
 				'menuDatabaseId'   => function () {
-
 					$menus = wp_get_object_terms( $this->data->ID, 'nav_menu' );
 					if ( is_wp_error( $menus ) ) {
 						throw new UserError( $menus->get_error_message() );
@@ -186,7 +181,6 @@ class MenuItem extends Model {
 					return ! empty( $menus[0]->term_id ) ? $menus[0]->term_id : null;
 				},
 				'locations'        => function () {
-
 					if ( empty( $this->menuDatabaseId ) ) {
 						return null;
 					}
@@ -205,12 +199,9 @@ class MenuItem extends Model {
 					}
 
 					return $locations;
-
 				},
 			];
-
 		}
-
 	}
 
 }

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -3,7 +3,6 @@
 namespace WPGraphQL\Model;
 
 use Exception;
-use WP_User;
 
 /**
  * Class Model - Abstract class for modeling data for all core types
@@ -83,7 +82,6 @@ abstract class Model {
 	 * @throws \Exception Throws Exception.
 	 */
 	protected function __construct( $restricted_cap = '', $allowed_restricted_fields = [], $owner = null ) {
-
 		if ( empty( $this->data ) ) {
 			// translators: %s is the name of the model.
 			throw new Exception( sprintf( __( 'An empty data set was used to initialize the modeling of this %s object', 'wp-graphql' ), $this->get_model_name() ) );
@@ -100,7 +98,6 @@ abstract class Model {
 
 		$this->init();
 		$this->prepare_fields();
-
 	}
 
 	/**
@@ -183,7 +180,6 @@ abstract class Model {
 	 * @return string
 	 */
 	protected function get_model_name() {
-
 		$name = static::class;
 
 		if ( empty( $this->model_name ) ) {
@@ -197,7 +193,6 @@ abstract class Model {
 		}
 
 		return ! empty( $this->model_name ) ? $this->model_name : $name;
-
 	}
 
 	/**
@@ -206,7 +201,6 @@ abstract class Model {
 	 * @return string|null
 	 */
 	public function get_visibility() {
-
 		if ( null === $this->visibility ) {
 
 			/**
@@ -283,7 +277,6 @@ abstract class Model {
 		 * @return string
 		 */
 		return apply_filters( 'graphql_object_visibility', $this->visibility, $this->get_model_name(), $this->data, $this->owner, $this->current_user );
-
 	}
 
 	/**
@@ -341,7 +334,6 @@ abstract class Model {
 	 * @return void
 	 */
 	protected function wrap_fields() {
-
 		if ( ! is_array( $this->fields ) || empty( $this->fields ) ) {
 			return;
 		}
@@ -349,7 +341,6 @@ abstract class Model {
 		$clean_array = [];
 		$self        = $this;
 		foreach ( $this->fields as $key => $data ) {
-
 			$clean_array[ $key ] = function () use ( $key, $data, $self ) {
 				if ( is_array( $data ) ) {
 					$callback = ( ! empty( $data['callback'] ) ) ? $data['callback'] : null;
@@ -439,7 +430,6 @@ abstract class Model {
 		}
 
 		$this->fields = $clean_array;
-
 	}
 
 	/**
@@ -461,7 +451,6 @@ abstract class Model {
 		$this->fields['isPrivate']    = function () {
 			return 'private' === $this->get_visibility();
 		};
-
 	}
 
 	/**
@@ -470,7 +459,6 @@ abstract class Model {
 	 * @return void
 	 */
 	protected function prepare_fields() {
-
 		if ( 'restricted' === $this->get_visibility() ) {
 			$this->restrict_fields();
 		}
@@ -534,7 +522,6 @@ abstract class Model {
 		}
 
 		return html_entity_decode( $string );
-
 	}
 
 	/**
@@ -549,7 +536,6 @@ abstract class Model {
 	 * @return void
 	 */
 	public function filter( $fields ) {
-
 		if ( is_string( $fields ) ) {
 			$fields = [ $fields ];
 		}
@@ -557,7 +543,6 @@ abstract class Model {
 		if ( is_array( $fields ) ) {
 			$this->fields = array_intersect_key( $this->fields, array_flip( $fields ) );
 		}
-
 	}
 
 	/**

--- a/src/Model/Plugin.php
+++ b/src/Model/Plugin.php
@@ -45,7 +45,6 @@ class Plugin extends Model {
 	 * @return bool
 	 */
 	protected function is_private() {
-
 		if ( is_multisite() ) {
 				// update_, install_, and delete_ are handled above with is_super_admin().
 				$menu_perms = get_site_option( 'menu_items', [] );
@@ -57,7 +56,6 @@ class Plugin extends Model {
 		}
 
 		return false;
-
 	}
 
 	/**
@@ -66,9 +64,7 @@ class Plugin extends Model {
 	 * @return void
 	 */
 	protected function init() {
-
 		if ( empty( $this->fields ) ) {
-
 			$this->fields = [
 				'id'          => function () {
 					return ! empty( $this->data['Path'] ) ? Relay::toGlobalId( 'plugin', $this->data['Path'] ) : null;
@@ -95,7 +91,6 @@ class Plugin extends Model {
 					return ! empty( $this->data['Path'] ) ? $this->data['Path'] : null;
 				},
 			];
-
 		}
 	}
 }

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -7,11 +7,8 @@
 
 namespace WPGraphQL\Model;
 
-use Exception;
 use GraphQLRelay\Relay;
 use WP_Post;
-use WP_Post_Type;
-use WP_Query;
 use WPGraphQL\Utils\Utils;
 
 /**
@@ -165,7 +162,6 @@ class Post extends Model {
 		$restricted_cap = $this->get_restricted_cap();
 
 		parent::__construct( $restricted_cap, $allowed_restricted_fields, (int) $post->post_author );
-
 	}
 
 	/**
@@ -174,7 +170,6 @@ class Post extends Model {
 	 * @return void
 	 */
 	public function setup() {
-
 		global $wp_query, $post;
 
 		/**
@@ -188,7 +183,6 @@ class Post extends Model {
 		 * post data being set up.
 		 */
 		if ( $this->data instanceof WP_Post ) {
-
 			$id        = $this->data->ID;
 			$post_type = $this->data->post_type;
 			$post_name = $this->data->post_name;
@@ -249,7 +243,6 @@ class Post extends Model {
 			$GLOBALS['post']             = $data; // phpcs:ignore WordPress.WP.GlobalVariablesOverride
 			$wp_query->queried_object    = get_post( $this->data->ID );
 			$wp_query->queried_object_id = $this->data->ID;
-
 		}
 	}
 
@@ -278,7 +271,6 @@ class Post extends Model {
 		}
 
 		return $cap;
-
 	}
 
 	/**
@@ -305,7 +297,6 @@ class Post extends Model {
 
 			// Determine if the revision is private using capabilities relative to the parent
 			return $this->is_post_private( $parent_post );
-
 		}
 
 		/**
@@ -343,7 +334,6 @@ class Post extends Model {
 	 * @return bool
 	 */
 	protected function is_post_private( $post_object = null ) {
-
 		$post_type_object = $this->post_type_object;
 
 		if ( ! $post_type_object ) {
@@ -403,7 +393,6 @@ class Post extends Model {
 		}
 
 		return false;
-
 	}
 
 	/**
@@ -412,9 +401,7 @@ class Post extends Model {
 	 * @return void
 	 */
 	protected function init() {
-
 		if ( empty( $this->fields ) ) {
-
 			$this->fields = [
 				'ID'                        => function () {
 					return $this->data->ID;
@@ -441,14 +428,12 @@ class Post extends Model {
 					return ! empty( $this->data->post_type ) ? $this->data->post_type : null;
 				},
 				'authorId'                  => function () {
-
 					if ( true === $this->isPreview ) {
 						$parent_post = get_post( $this->data->post_parent );
 						if ( empty( $parent_post ) ) {
 							return null;
 						}
 						$id = (int) $parent_post->post_author;
-
 					} else {
 						$id = ! empty( $this->data->post_author ) ? (int) $this->data->post_author : null;
 					}
@@ -466,7 +451,6 @@ class Post extends Model {
 					}
 
 					return ! empty( $this->data->post_author ) ? (int) $this->data->post_author : null;
-
 				},
 				'date'                      => function () {
 					return ! empty( $this->data->post_date ) && '0000-00-00 00:00:00' !== $this->data->post_date ? Utils::prepare_date_response( $this->data->post_date_gmt, $this->data->post_date ) : null;
@@ -503,7 +487,7 @@ class Post extends Model {
 					'capability' => isset( $this->post_type_object->cap->edit_posts ) ? $this->post_type_object->cap->edit_posts : 'edit_posts',
 				],
 				'excerptRendered'           => function () {
-					$excerpt = ! empty( $this->data->post_excerpt ) ? $this->data->post_excerpt : null;
+					$excerpt = ! empty( $this->data->post_excerpt ) ? $this->data->post_excerpt : '';
 					$excerpt = apply_filters( 'get_the_excerpt', $excerpt, $this->data );
 
 					return $this->html_entity_decode( apply_filters( 'the_excerpt', $excerpt ), 'excerptRendered' );
@@ -530,7 +514,6 @@ class Post extends Model {
 					return ! empty( $this->data->post_name ) ? urldecode( $this->data->post_name ) : null;
 				},
 				'template'                  => function () {
-
 					$registered_templates = wp_get_theme()->get_page_templates( null, $this->data->post_type );
 
 					$template = [
@@ -539,7 +522,6 @@ class Post extends Model {
 					];
 
 					if ( true === $this->isPreview ) {
-
 						$parent_post = get_post( $this->parentDatabaseId );
 
 						if ( empty( $parent_post ) ) {
@@ -563,12 +545,11 @@ class Post extends Model {
 						}
 
 						$template_name = ! empty( $template_name ) ? $template_name : 'Default';
-
 					} else {
 						if ( empty( $registered_templates ) ) {
 							return $template;
 						}
-						$post_type     = $this->data->post_type;
+
 						$set_template  = get_post_meta( $this->data->ID, '_wp_page_template', true );
 						$template_name = get_page_template_slug( $this->data->ID );
 
@@ -652,7 +633,6 @@ class Post extends Model {
 					return ! empty( $edit_last ) ? absint( $edit_last ) : null;
 				},
 				'editLock'                  => function () {
-
 					require_once ABSPATH . 'wp-admin/includes/post.php';
 					if ( ! wp_check_post_lock( $this->data->ID ) ) {
 						return null;
@@ -710,7 +690,6 @@ class Post extends Model {
 					return ! empty( $this->featuredImageDatabaseId ) ? Relay::toGlobalId( 'post', (string) $this->featuredImageDatabaseId ) : null;
 				},
 				'featuredImageDatabaseId'   => function () {
-
 					if ( $this->isRevision ) {
 						$id = $this->parentDatabaseId;
 					} else {
@@ -871,9 +850,7 @@ class Post extends Model {
 					return absint( $this->data->ID );
 				};
 			};
-
 		}
-
 	}
 
 }

--- a/src/Model/PostType.php
+++ b/src/Model/PostType.php
@@ -53,7 +53,6 @@ class PostType extends Model {
 	 * @throws \Exception
 	 */
 	public function __construct( \WP_Post_Type $post_type ) {
-
 		$this->data = $post_type;
 
 		$allowed_restricted_fields = [
@@ -78,7 +77,6 @@ class PostType extends Model {
 		$capability = isset( $post_type->cap->edit_posts ) ? $post_type->cap->edit_posts : 'edit_posts';
 
 		parent::__construct( $capability, $allowed_restricted_fields );
-
 	}
 
 	/**
@@ -87,13 +85,11 @@ class PostType extends Model {
 	 * @return bool
 	 */
 	protected function is_private() {
-
 		if ( false === $this->data->public && ( ! isset( $this->data->cap->edit_posts ) || ! current_user_can( $this->data->cap->edit_posts ) ) ) {
 			return true;
 		}
 
 		return false;
-
 	}
 
 	/**
@@ -102,9 +98,7 @@ class PostType extends Model {
 	 * @return void
 	 */
 	protected function init() {
-
 		if ( empty( $this->fields ) ) {
-
 			$this->fields = [
 				'id'                  => function () {
 					return ! empty( $this->data->name ) ? Relay::toGlobalId( 'post_type', $this->data->name ) : null;
@@ -125,25 +119,25 @@ class PostType extends Model {
 					return ! empty( $this->data->public ) ? (bool) $this->data->public : null;
 				},
 				'hierarchical'        => function () {
-					return ( true === $this->data->hierarchical || ! empty( $this->data->hierarchical ) ) ? true : false;
+					return true === $this->data->hierarchical || ! empty( $this->data->hierarchical );
 				},
 				'excludeFromSearch'   => function () {
-					return ( true === $this->data->exclude_from_search ) ? true : false;
+					return true === $this->data->exclude_from_search;
 				},
 				'publiclyQueryable'   => function () {
-					return ( true === $this->data->publicly_queryable ) ? true : false;
+					return true === $this->data->publicly_queryable;
 				},
 				'showUi'              => function () {
-					return ( true === $this->data->show_ui ) ? true : false;
+					return true === $this->data->show_ui;
 				},
 				'showInMenu'          => function () {
-					return ( true === $this->data->show_in_menu ) ? true : false;
+					return true === $this->data->show_in_menu;
 				},
 				'showInNavMenus'      => function () {
-					return ( true === $this->data->show_in_nav_menus ) ? true : false;
+					return true === $this->data->show_in_nav_menus;
 				},
 				'showInAdminBar'      => function () {
-					return ( true === $this->data->show_in_admin_bar ) ? true : false;
+					return true === $this->data->show_in_admin_bar;
 				},
 				'menuPosition'        => function () {
 					return ! empty( $this->data->menu_position ) ? $this->data->menu_position : null;
@@ -152,20 +146,20 @@ class PostType extends Model {
 					return ! empty( $this->data->menu_icon ) ? $this->data->menu_icon : null;
 				},
 				'hasArchive'          => function () {
-					return ! empty( $this->uri ) ? true : false;
+					return ! empty( $this->uri );
 				},
 				'canExport'           => function () {
-					return ( true === $this->data->can_export ) ? true : false;
+					return true === $this->data->can_export;
 				},
 				'deleteWithUser'      => function () {
-					return ( true === $this->data->delete_with_user ) ? true : false;
+					return true === $this->data->delete_with_user;
 				},
 				'taxonomies'          => function () {
 					$object_taxonomies = get_object_taxonomies( $this->data->name );
 					return ( ! empty( $object_taxonomies ) ) ? $object_taxonomies : null;
 				},
 				'showInRest'          => function () {
-					return ( true === $this->data->show_in_rest ) ? true : false;
+					return true === $this->data->show_in_rest;
 				},
 				'restBase'            => function () {
 					return ! empty( $this->data->rest_base ) ? $this->data->rest_base : null;
@@ -174,7 +168,7 @@ class PostType extends Model {
 					return ! empty( $this->data->rest_controller_class ) ? $this->data->rest_controller_class : null;
 				},
 				'showInGraphql'       => function () {
-					return ( true === $this->data->show_in_graphql ) ? true : false;
+					return true === $this->data->show_in_graphql;
 				},
 				'graphqlSingleName'   => function () {
 					return ! empty( $this->data->graphql_single_name ) ? $this->data->graphql_single_name : null;
@@ -194,7 +188,6 @@ class PostType extends Model {
 				},
 				// If the homepage settings are ot set to
 				'isPostsPage'         => function () {
-
 					if (
 						'post' === $this->name &&
 						(
@@ -207,7 +200,6 @@ class PostType extends Model {
 					return false;
 				},
 				'isFrontPage'         => function () {
-
 					if (
 						'post' === $this->name &&
 						(
@@ -221,7 +213,6 @@ class PostType extends Model {
 					return false;
 				},
 			];
-
 		}
 	}
 }

--- a/src/Model/Taxonomy.php
+++ b/src/Model/Taxonomy.php
@@ -48,7 +48,6 @@ class Taxonomy extends Model {
 	 * @throws \Exception
 	 */
 	public function __construct( \WP_Taxonomy $taxonomy ) {
-
 		$this->data = $taxonomy;
 
 		$allowed_restricted_fields = [
@@ -69,7 +68,6 @@ class Taxonomy extends Model {
 		$capability = isset( $this->data->cap->edit_terms ) ? $this->data->cap->edit_terms : 'edit_terms';
 
 		parent::__construct( $capability, $allowed_restricted_fields );
-
 	}
 
 	/**
@@ -78,13 +76,11 @@ class Taxonomy extends Model {
 	 * @return bool
 	 */
 	protected function is_private() {
-
 		if ( false === $this->data->public && ( ! isset( $this->data->cap->edit_terms ) || ! current_user_can( $this->data->cap->edit_terms ) ) ) {
 			return true;
 		}
 
 		return false;
-
 	}
 
 	/**
@@ -93,9 +89,7 @@ class Taxonomy extends Model {
 	 * @return void
 	 */
 	protected function init() {
-
 		if ( empty( $this->fields ) ) {
-
 			$this->fields = [
 				'id'                  => function () {
 					return ! empty( $this->data->name ) ? Relay::toGlobalId( 'taxonomy', $this->data->name ) : null;
@@ -116,28 +110,28 @@ class Taxonomy extends Model {
 					return ! empty( $this->data->public ) ? (bool) $this->data->public : true;
 				},
 				'hierarchical'        => function () {
-					return ( true === $this->data->hierarchical ) ? true : false;
+					return true === $this->data->hierarchical;
 				},
 				'showUi'              => function () {
-					return ( true === $this->data->show_ui ) ? true : false;
+					return true === $this->data->show_ui;
 				},
 				'showInMenu'          => function () {
-					return ( true === $this->data->show_in_menu ) ? true : false;
+					return true === $this->data->show_in_menu;
 				},
 				'showInNavMenus'      => function () {
-					return ( true === $this->data->show_in_nav_menus ) ? true : false;
+					return true === $this->data->show_in_nav_menus;
 				},
 				'showCloud'           => function () {
-					return ( true === $this->data->show_tagcloud ) ? true : false;
+					return true === $this->data->show_tagcloud;
 				},
 				'showInQuickEdit'     => function () {
-					return ( true === $this->data->show_in_quick_edit ) ? true : false;
+					return true === $this->data->show_in_quick_edit;
 				},
 				'showInAdminColumn'   => function () {
-					return ( true === $this->data->show_admin_column ) ? true : false;
+					return true === $this->data->show_admin_column;
 				},
 				'showInRest'          => function () {
-					return ( true === $this->data->show_in_rest ) ? true : false;
+					return true === $this->data->show_in_rest;
 				},
 				'restBase'            => function () {
 					return ! empty( $this->data->rest_base ) ? $this->data->rest_base : null;
@@ -146,7 +140,7 @@ class Taxonomy extends Model {
 					return ! empty( $this->data->rest_controller_class ) ? $this->data->rest_controller_class : null;
 				},
 				'showInGraphql'       => function () {
-					return ( true === $this->data->show_in_graphql ) ? true : false;
+					return true === $this->data->show_in_graphql;
 				},
 				'graphqlSingleName'   => function () {
 					return ! empty( $this->data->graphql_single_name ) ? $this->data->graphql_single_name : null;
@@ -161,7 +155,6 @@ class Taxonomy extends Model {
 					return ! empty( $this->data->graphql_plural_name ) ? $this->data->graphql_plural_name : null;
 				},
 			];
-
 		}
 	}
 }

--- a/src/Model/Term.php
+++ b/src/Model/Term.php
@@ -2,9 +2,7 @@
 
 namespace WPGraphQL\Model;
 
-use Exception;
 use GraphQLRelay\Relay;
-use WP_Post;
 use WP_Taxonomy;
 use WP_Term;
 
@@ -72,7 +70,6 @@ class Term extends Model {
 	 * @return void
 	 */
 	public function setup() {
-
 		global $wp_query, $post;
 
 		/**
@@ -127,9 +124,7 @@ class Term extends Model {
 	 * @return void
 	 */
 	protected function init() {
-
 		if ( empty( $this->fields ) ) {
-
 			$this->fields = [
 				'id'                       => function () {
 					return ( ! empty( $this->data->taxonomy ) && ! empty( $this->data->term_id ) ) ? Relay::toGlobalId( 'term', (string) $this->data->term_id ) : null;
@@ -209,7 +204,6 @@ class Term extends Model {
 				$this->fields[ $type_id ] = absint( $this->data->term_id );
 			}
 		}
-
 	}
 
 }

--- a/src/Model/Theme.php
+++ b/src/Model/Theme.php
@@ -58,7 +58,6 @@ class Theme extends Model {
 		}
 
 		return false;
-
 	}
 
 	/**
@@ -67,9 +66,7 @@ class Theme extends Model {
 	 * @return void
 	 */
 	protected function init() {
-
 		if ( empty( $this->fields ) ) {
-
 			$this->fields = [
 				'id'          => function () {
 					$stylesheet = $this->data->get_stylesheet();
@@ -108,7 +105,6 @@ class Theme extends Model {
 					return ! empty( $this->data->version ) ? $this->data->version : null;
 				},
 			];
-
 		}
 	}
 }

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -2,9 +2,7 @@
 
 namespace WPGraphQL\Model;
 
-use Exception;
 use GraphQLRelay\Relay;
-use WP_Post;
 use WP_User;
 
 /**
@@ -88,7 +86,6 @@ class User extends Model {
 		];
 
 		parent::__construct( 'list_users', $allowed_restricted_fields, $user->ID );
-
 	}
 
 	/**
@@ -97,7 +94,6 @@ class User extends Model {
 	 * @return void
 	 */
 	public function setup() {
-
 		global $wp_query, $post, $authordata;
 
 		// Store variables for resetting at tear down
@@ -122,7 +118,6 @@ class User extends Model {
 			$wp_query->queried_object    = get_user_by( 'id', $this->data->ID );
 			$wp_query->queried_object_id = $this->data->ID;
 		}
-
 	}
 
 	/**
@@ -166,7 +161,6 @@ class User extends Model {
 	 * @return void
 	 */
 	protected function init() {
-
 		if ( empty( $this->fields ) ) {
 			$this->fields = [
 				'id'                       => function () {
@@ -190,11 +184,9 @@ class User extends Model {
 								}
 							)
 						);
-
 					}
 
 					return ! empty( $capabilities ) ? $capabilities : null;
-
 				},
 				'capKey'                   => function () {
 					return ! empty( $this->data->cap_key ) ? $this->data->cap_key : null;
@@ -247,7 +239,7 @@ class User extends Model {
 				'shouldShowAdminToolbar'   => function () {
 					$toolbar_preference_meta = get_user_meta( $this->data->ID, 'show_admin_bar_front', true );
 
-					return 'true' === $toolbar_preference_meta ? true : false;
+					return 'true' === $toolbar_preference_meta;
 				},
 				'userId'                   => ! empty( $this->data->ID ) ? absint( $this->data->ID ) : null,
 				'uri'                      => function () {
@@ -274,9 +266,7 @@ class User extends Model {
 					return $queue;
 				},
 			];
-
 		}
-
 	}
 
 }

--- a/src/Model/UserRole.php
+++ b/src/Model/UserRole.php
@@ -42,7 +42,6 @@ class UserRole extends Model {
 	 * @return bool
 	 */
 	protected function is_private() {
-
 		if ( current_user_can( 'list_users' ) ) {
 			return false;
 		}
@@ -62,7 +61,6 @@ class UserRole extends Model {
 	 * @return void
 	 */
 	protected function init() {
-
 		if ( empty( $this->fields ) ) {
 			$this->fields = [
 				'id'           => function () {
@@ -83,7 +81,6 @@ class UserRole extends Model {
 					}
 				},
 			];
-
 		}
 	}
 

--- a/src/Mutation/CommentCreate.php
+++ b/src/Mutation/CommentCreate.php
@@ -2,7 +2,6 @@
 
 namespace WPGraphQL\Mutation;
 
-use Exception;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
@@ -169,7 +168,6 @@ class CommentCreate {
 			 * Throw an exception if the comment failed to be created
 			 */
 			if ( is_wp_error( $comment_id ) ) {
-
 				$error_message = $comment_id->get_error_message();
 				if ( ! empty( $error_message ) ) {
 					throw new UserError( esc_html( $error_message ) );

--- a/src/Mutation/CommentDelete.php
+++ b/src/Mutation/CommentDelete.php
@@ -2,7 +2,6 @@
 
 namespace WPGraphQL\Mutation;
 
-use Exception;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;

--- a/src/Mutation/CommentUpdate.php
+++ b/src/Mutation/CommentUpdate.php
@@ -2,10 +2,8 @@
 
 namespace WPGraphQL\Mutation;
 
-use Exception;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
-use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
 use WPGraphQL\Data\CommentMutation;
 use WPGraphQL\Utils\Utils;

--- a/src/Mutation/MediaItemCreate.php
+++ b/src/Mutation/MediaItemCreate.php
@@ -2,7 +2,6 @@
 
 namespace WPGraphQL\Mutation;
 
-use Exception;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
@@ -156,7 +155,7 @@ class MediaItemCreate {
 			$sanitized_file_path = sanitize_file_name( $input['filePath'] );
 
 			// Check that the filetype is allowed
-			$check_file = wp_check_filetype( $uploaded_file_url );
+			$check_file = wp_check_filetype( $sanitized_file_path );
 
 			// if the file doesn't pass the check, throw an error
 			if ( ! $check_file['ext'] || ! $check_file['type'] || ! wp_http_validate_url( $uploaded_file_url ) ) {

--- a/src/Mutation/MediaItemDelete.php
+++ b/src/Mutation/MediaItemDelete.php
@@ -1,7 +1,6 @@
 <?php
 namespace WPGraphQL\Mutation;
 
-use Exception;
 use GraphQL\Error\UserError;
 use GraphQLRelay\Relay;
 use WPGraphQL\Model\Post;

--- a/src/Mutation/MediaItemUpdate.php
+++ b/src/Mutation/MediaItemUpdate.php
@@ -2,11 +2,8 @@
 
 namespace WPGraphQL\Mutation;
 
-use Exception;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
-use GraphQLRelay\Relay;
-use WP_Post_Type;
 use WPGraphQL\AppContext;
 use WPGraphQL\Data\MediaItemMutation;
 use WPGraphQL\Utils\Utils;

--- a/src/Mutation/PostObjectCreate.php
+++ b/src/Mutation/PostObjectCreate.php
@@ -102,7 +102,6 @@ class PostObjectCreate {
 		}
 
 		if ( post_type_supports( $post_type_object->name, 'trackbacks' ) ) {
-
 			$fields['pinged'] = [
 				'type'        => [
 					'list_of' => 'String',
@@ -123,10 +122,14 @@ class PostObjectCreate {
 			];
 		}
 
-		if ( $post_type_object->hierarchical || in_array( $post_type_object->name, [
-			'attachment',
-			'revision',
-		], true ) ) {
+		if ( $post_type_object->hierarchical || in_array(
+			$post_type_object->name,
+			[
+				'attachment',
+				'revision',
+			],
+			true 
+		) ) {
 			$fields['parentId'] = [
 				'type'        => 'ID',
 				'description' => __( 'The ID of the parent object', 'wp-graphql' ),
@@ -174,7 +177,6 @@ class PostObjectCreate {
 				'type'        => $post_type_object->graphql_single_name,
 				'description' => __( 'The Post object mutation type.', 'wp-graphql' ),
 				'resolve'     => static function ( $payload, $args, AppContext $context, ResolveInfo $info ) {
-
 					if ( empty( $payload['postObjectId'] ) || ! absint( $payload['postObjectId'] ) ) {
 						return null;
 					}
@@ -265,10 +267,14 @@ class PostObjectCreate {
 			 * If the current user cannot publish posts but their intent was to publish,
 			 * default the status to pending.
 			 */
-			if ( ( ! isset( $post_type_object->cap->publish_posts ) || ! current_user_can( $post_type_object->cap->publish_posts ) ) && ! in_array( $intended_post_status, [
-				'draft',
-				'pending',
-			], true ) ) {
+			if ( ( ! isset( $post_type_object->cap->publish_posts ) || ! current_user_can( $post_type_object->cap->publish_posts ) ) && ! in_array(
+				$intended_post_status,
+				[
+					'draft',
+					'pending',
+				],
+				true 
+			) ) {
 				$intended_post_status = 'pending';
 			}
 
@@ -340,7 +346,8 @@ class PostObjectCreate {
 				 * If the post was deleted by a side effect action before getting here,
 				 * don't proceed.
 				 */
-				if ( ! $new_post = get_post( $post_id ) ) {
+				$new_post = get_post( $post_id );
+				if ( empty( $new_post ) ) {
 					throw new UserError( __( 'The status of the post could not be set', 'wp-graphql' ) );
 				}
 

--- a/src/Mutation/PostObjectDelete.php
+++ b/src/Mutation/PostObjectDelete.php
@@ -2,7 +2,6 @@
 
 namespace WPGraphQL\Mutation;
 
-use Exception;
 use GraphQL\Error\UserError;
 use GraphQLRelay\Relay;
 use WP_Post_Type;

--- a/src/Mutation/PostObjectUpdate.php
+++ b/src/Mutation/PostObjectUpdate.php
@@ -1,10 +1,8 @@
 <?php
 namespace WPGraphQL\Mutation;
 
-use Exception;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
-use GraphQLRelay\Relay;
 use WP_Post_Type;
 use WPGraphQL\AppContext;
 use WPGraphQL\Data\PostObjectMutation;

--- a/src/Mutation/ResetUserPassword.php
+++ b/src/Mutation/ResetUserPassword.php
@@ -61,7 +61,6 @@ class ResetUserPassword {
 	 */
 	public static function mutate_and_get_payload() {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) {
-
 			if ( empty( $input['key'] ) ) {
 				throw new UserError( __( 'A password reset key is required.', 'wp-graphql' ) );
 			}

--- a/src/Mutation/SendPasswordResetEmail.php
+++ b/src/Mutation/SendPasswordResetEmail.php
@@ -2,10 +2,7 @@
 
 namespace WPGraphQL\Mutation;
 
-use Exception;
 use GraphQL\Error\UserError;
-use GraphQL\Type\Definition\ResolveInfo;
-use WP_User;
 use WPGraphQL\AppContext;
 
 class SendPasswordResetEmail {
@@ -148,7 +145,6 @@ class SendPasswordResetEmail {
 	 */
 	private static function get_user_data( $username ) {
 		if ( self::is_email_address( $username ) ) {
-
 			$username = wp_unslash( $username );
 
 			if ( ! is_string( $username ) ) {

--- a/src/Mutation/TermObjectCreate.php
+++ b/src/Mutation/TermObjectCreate.php
@@ -96,7 +96,6 @@ class TermObjectCreate {
 					$id = isset( $payload['termId'] ) ? absint( $payload['termId'] ) : null;
 
 					return $context->get_loader( 'term' )->load_deferred( $id );
-
 				},
 			],
 		];

--- a/src/Mutation/TermObjectUpdate.php
+++ b/src/Mutation/TermObjectUpdate.php
@@ -3,7 +3,6 @@ namespace WPGraphQL\Mutation;
 
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
-use GraphQLRelay\Relay;
 use WP_Taxonomy;
 use WPGraphQL\AppContext;
 use WPGraphQL\Data\TermObjectMutation;

--- a/src/Mutation/UpdateSettings.php
+++ b/src/Mutation/UpdateSettings.php
@@ -2,7 +2,6 @@
 
 namespace WPGraphQL\Mutation;
 
-use Exception;
 use GraphQL\Error\UserError;
 use WPGraphQL\Data\DataSource;
 use WPGraphQL\Registry\TypeRegistry;
@@ -61,7 +60,6 @@ class UpdateSettings {
 			 * for the individual settings
 			 */
 			foreach ( $allowed_settings as $key => $setting ) {
-
 				if ( ! isset( $setting['type'] ) || ! $type_registry->get_type( $setting['type'] ) ) {
 					continue;
 				}
@@ -131,7 +129,6 @@ class UpdateSettings {
 
 		if ( ! empty( $allowed_setting_groups ) && is_array( $allowed_setting_groups ) ) {
 			foreach ( $allowed_setting_groups as $group => $setting_type ) {
-
 				$setting_type      = DataSource::format_group_name( $group );
 				$setting_type_name = Utils::format_type_name( $setting_type . 'Settings' );
 
@@ -143,7 +140,6 @@ class UpdateSettings {
 						return $setting_type_name;
 					},
 				];
-
 			}
 		}
 		return $output_fields;
@@ -199,7 +195,6 @@ class UpdateSettings {
 				'option' => $key,
 				'group'  => $setting['group'],
 			];
-
 		}
 
 		foreach ( $input as $key => $value ) {

--- a/src/Mutation/UserCreate.php
+++ b/src/Mutation/UserCreate.php
@@ -6,7 +6,6 @@ use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
 use WPGraphQL\Data\UserMutation;
-use WPGraphQL\Model\User;
 
 /**
  * Class UserCreate

--- a/src/Mutation/UserDelete.php
+++ b/src/Mutation/UserDelete.php
@@ -152,7 +152,6 @@ class UserDelete {
 
 				// delete the user
 				$deleted_user = wpmu_delete_user( $user_id );
-
 			} else {
 				$deleted_user = wp_delete_user( $user_id, $reassign_id );
 			}

--- a/src/Mutation/UserRegister.php
+++ b/src/Mutation/UserRegister.php
@@ -53,7 +53,6 @@ class UserRegister {
 		unset( $input_fields['role'], $input_fields['roles'] );
 
 		return $input_fields;
-
 	}
 
 	/**
@@ -72,7 +71,6 @@ class UserRegister {
 	 */
 	public static function mutate_and_get_payload() {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) {
-
 			if ( ! get_option( 'users_can_register' ) ) {
 				throw new UserError( __( 'User registration is currently not allowed.', 'wp-graphql' ) );
 			}
@@ -137,7 +135,7 @@ class UserRegister {
 			/**
 			 * Prevent "Password Changed" emails from being sent.
 			 */
-			add_filter( 'send_password_change_email', [ __CLASS__, 'return_false' ] );
+			add_filter( 'send_password_change_email', [ self::class, 'return_false' ] );
 
 			/**
 			 * Update the registered user with the additional input (firstName, lastName, etc) from the mutation
@@ -147,7 +145,7 @@ class UserRegister {
 			/**
 			 * Remove filter preventing "Password Changed" emails.
 			 */
-			remove_filter( 'send_password_change_email', [ __CLASS__, 'return_false' ] );
+			remove_filter( 'send_password_change_email', [ self::class, 'return_false' ] );
 
 			/**
 			 * Update additional user data
@@ -161,7 +159,6 @@ class UserRegister {
 				'id'   => $user_id,
 				'user' => $context->get_loader( 'user' )->load_deferred( $user_id ),
 			];
-
 		};
 	}
 

--- a/src/Mutation/UserUpdate.php
+++ b/src/Mutation/UserUpdate.php
@@ -1,7 +1,6 @@
 <?php
 namespace WPGraphQL\Mutation;
 
-use Exception;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;

--- a/src/Registry/SchemaRegistry.php
+++ b/src/Registry/SchemaRegistry.php
@@ -2,7 +2,6 @@
 
 namespace WPGraphQL\Registry;
 
-use Exception;
 use GraphQL\Type\SchemaConfig;
 use WPGraphQL\WPSchema;
 
@@ -34,7 +33,6 @@ class SchemaRegistry {
 	 * @throws \Exception
 	 */
 	public function get_schema() {
-
 		$this->type_registry->init();
 
 		$schema_config             = new SchemaConfig();
@@ -57,7 +55,6 @@ class SchemaRegistry {
 		 * @param \WPGraphQL\Registry\SchemaRegistry $registry The Schema Registry Instance
 		 */
 		return apply_filters( 'graphql_schema', $schema, $this );
-
 	}
 
 

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -2,9 +2,7 @@
 
 namespace WPGraphQL\Registry;
 
-use Exception;
 use GraphQL\Type\Definition\Type;
-use InvalidArgumentException;
 use WPGraphQL\Data\DataSource;
 use WPGraphQL\Mutation\CommentCreate;
 use WPGraphQL\Mutation\CommentDelete;
@@ -71,7 +69,6 @@ use WPGraphQL\Type\InterfaceType\Commenter;
 use WPGraphQL\Type\InterfaceType\Connection;
 use WPGraphQL\Type\InterfaceType\ContentNode;
 use WPGraphQL\Type\InterfaceType\ContentTemplate;
-use WPGraphQL\Type\InterfaceType\ContentTypeConnection;
 use WPGraphQL\Type\InterfaceType\DatabaseIdentifier;
 use WPGraphQL\Type\InterfaceType\Edge;
 use WPGraphQL\Type\InterfaceType\EnqueuedAsset;
@@ -223,12 +220,13 @@ class TypeRegistry {
 	 * @return array
 	 */
 	protected function get_eager_type_map() {
-
 		if ( ! empty( $this->eager_type_map ) ) {
-			return array_map( function ( $type_name ) {
-				return $this->get_type( $type_name );
-			}, $this->eager_type_map );
-
+			return array_map(
+				function ( $type_name ) {
+					return $this->get_type( $type_name );
+				},
+				$this->eager_type_map 
+			);
 		}
 
 		return [];
@@ -242,7 +240,6 @@ class TypeRegistry {
 	 * @return void
 	 */
 	public function init() {
-
 		$this->register_type( 'Bool', Type::boolean() );
 		$this->register_type( 'Boolean', Type::boolean() );
 		$this->register_type( 'Float', Type::float() );
@@ -263,7 +260,6 @@ class TypeRegistry {
 		 * @param \WPGraphQL\Registry\TypeRegistry $registry Instance of the TypeRegistry
 		 */
 		do_action( 'init_graphql_type_registry', $this );
-
 	}
 
 	/**
@@ -274,7 +270,7 @@ class TypeRegistry {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function init_type_registry( TypeRegistry $type_registry ) {
+	public function init_type_registry( self $type_registry ) {
 
 		/**
 		 * Fire an action as the type registry is initialized. This executes
@@ -429,7 +425,6 @@ class TypeRegistry {
 				 * they aren't created manually.
 				 */
 				if ( 'revision' !== $post_type_object->name ) {
-
 					if ( empty( $post_type_object->graphql_exclude_mutations ) || ! in_array( 'create', $post_type_object->graphql_exclude_mutations, true ) ) {
 						PostObjectCreate::register_mutation( $post_type_object );
 					}
@@ -508,7 +503,8 @@ class TypeRegistry {
 									'type'        => 'Boolean',
 									'description' => sprintf(
 										// translators: %1$s is the GraphQL name of the taxonomy, %2$s is the plural GraphQL name of the taxonomy.
-										__( 'If true, this will append the %1$s to existing related %2$s. If false, this will replace existing relationships. Default true.', 'wp-graphql' ), $tax_object->graphql_single_name,
+										__( 'If true, this will append the %1$s to existing related %2$s. If false, this will replace existing relationships. Default true.', 'wp-graphql' ),
+										$tax_object->graphql_single_name,
 										$tax_object->graphql_plural_name
 									),
 								],
@@ -555,19 +551,21 @@ class TypeRegistry {
 		 * to expose the URL to the Schema for multisite sites
 		 */
 		if ( is_multisite() ) {
-			$this->register_field( 'GeneralSettings', 'url', [
-				'type'        => 'String',
-				'description' => __( 'Site URL.', 'wp-graphql' ),
-				'resolve'     => static function () {
-					return get_site_url();
-				},
-			] );
+			$this->register_field(
+				'GeneralSettings',
+				'url',
+				[
+					'type'        => 'String',
+					'description' => __( 'Site URL.', 'wp-graphql' ),
+					'resolve'     => static function () {
+						return get_site_url();
+					},
+				] 
+			);
 		}
 
 		if ( ! empty( $allowed_setting_types ) && is_array( $allowed_setting_types ) ) {
-
 			foreach ( $allowed_setting_types as $group_name => $setting_type ) {
-
 				$group_name = DataSource::format_group_name( $group_name );
 				$type_name  = SettingGroup::register_settings_group( $group_name, $group_name, $this );
 
@@ -608,7 +606,6 @@ class TypeRegistry {
 		 * @param \WPGraphQL\Registry\TypeRegistry $registry Instance of the TypeRegistry
 		 */
 		do_action( 'graphql_register_types_late', $type_registry );
-
 	}
 
 	/**
@@ -636,7 +633,6 @@ class TypeRegistry {
 	 * @throws \Exception
 	 */
 	protected function register_connections_from_config( array $config ) {
-
 		$connections = $config['connections'] ?? null;
 
 		if ( ! is_array( $connections ) ) {
@@ -644,7 +640,6 @@ class TypeRegistry {
 		}
 
 		foreach ( $connections as $field_name => $connection_config ) {
-
 			if ( ! is_array( $connection_config ) ) {
 				continue;
 			}
@@ -652,9 +647,7 @@ class TypeRegistry {
 			$connection_config['fromType']      = $config['name'];
 			$connection_config['fromFieldName'] = $field_name;
 			register_graphql_connection( $connection_config );
-
 		}
-
 	}
 
 	/**
@@ -819,7 +812,6 @@ class TypeRegistry {
 		$prepared_type = null;
 
 		if ( ! empty( $config ) ) {
-
 			$kind           = isset( $config['kind'] ) ? $config['kind'] : null;
 			$config['name'] = ucfirst( $type_name );
 
@@ -846,7 +838,6 @@ class TypeRegistry {
 		}
 
 		return $prepared_type;
-
 	}
 
 	/**
@@ -858,7 +849,6 @@ class TypeRegistry {
 	 * |null
 	 */
 	public function get_type( string $type_name ) {
-
 		$key = $this->format_key( $type_name );
 
 		if ( isset( $this->type_loaders[ $key ] ) ) {
@@ -932,7 +922,6 @@ class TypeRegistry {
 	 * @throws \Exception
 	 */
 	protected function prepare_field( string $field_name, array $field_config, string $type_name ): ?array {
-
 		if ( ! isset( $field_config['name'] ) ) {
 			$field_config['name'] = lcfirst( $field_name );
 		}
@@ -1041,7 +1030,6 @@ class TypeRegistry {
 		}
 
 		return $type;
-
 	}
 
 	/**
@@ -1075,8 +1063,6 @@ class TypeRegistry {
 	 * @throws \Exception
 	 */
 	public function register_field( string $type_name, string $field_name, array $config ): void {
-
-
 		add_filter(
 			'graphql_' . $type_name . '_fields',
 			function ( $fields ) use ( $type_name, $field_name, $config ) {
@@ -1130,12 +1116,10 @@ class TypeRegistry {
 				}
 
 				return $fields;
-
 			},
 			10,
 			1
 		);
-
 	}
 
 	/**
@@ -1147,20 +1131,16 @@ class TypeRegistry {
 	 * @return void
 	 */
 	public function deregister_field( string $type_name, string $field_name ) {
-
 		add_filter(
 			'graphql_' . $type_name . '_fields',
 			static function ( $fields ) use ( $field_name ) {
-
 				if ( isset( $fields[ $field_name ] ) ) {
 					unset( $fields[ $field_name ] );
 				}
 
 				return $fields;
-
 			}
 		);
-
 	}
 
 	/**
@@ -1237,7 +1217,6 @@ class TypeRegistry {
 		add_filter(
 			'graphql_excluded_connections',
 			static function ( $excluded_connections ) use ( $connection_name ) {
-
 				$connection_name = strtolower( $connection_name );
 
 				if ( ! in_array( $connection_name, $excluded_connections, true ) ) {

--- a/src/Registry/Utils/PostObject.php
+++ b/src/Registry/Utils/PostObject.php
@@ -2,7 +2,6 @@
 
 namespace WPGraphQL\Registry\Utils;
 
-use Exception;
 use GraphQL\Type\Definition\ResolveInfo;
 use WP_Post_Type;
 use WPGraphQL;
@@ -117,7 +116,6 @@ class PostObject {
 				'toType'         => 'Comment',
 				'connectionArgs' => Comments::get_connection_args(),
 				'resolve'        => static function ( Post $post, $args, $context, $info ) {
-
 					if ( $post->isRevision ) {
 						$id = $post->parentDatabaseId;
 					} else {
@@ -140,7 +138,8 @@ class PostObject {
 				'deprecationReason'  => ( true === $post_type_object->publicly_queryable || true === $post_type_object->public ) ? null
 					: sprintf(
 						// translators: %s is the post type's GraphQL name.
-						__( 'The "%s" Type is not publicly queryable and does not support previews. This field will be removed in the future.', 'wp-graphql' ), WPGraphQL\Utils\Utils::format_type_name( $post_type_object->graphql_single_name )
+						__( 'The "%s" Type is not publicly queryable and does not support previews. This field will be removed in the future.', 'wp-graphql' ),
+						WPGraphQL\Utils\Utils::format_type_name( $post_type_object->graphql_single_name )
 					),
 				'resolve'            => static function ( Post $post, $args, AppContext $context, ResolveInfo $info ) {
 					if ( $post->isRevision ) {
@@ -180,7 +179,6 @@ class PostObject {
 		$allowed_taxonomies = WPGraphQL::get_allowed_taxonomies( 'objects' );
 
 		foreach ( $allowed_taxonomies as $tax_object ) {
-
 			if ( ! in_array( $post_type_object->name, $tax_object->object_type, true ) ) {
 				continue;
 			}
@@ -222,7 +220,6 @@ class PostObject {
 				'queryClass'     => 'WP_Term_Query',
 				'connectionArgs' => TermObjects::get_connection_args(),
 				'resolve'        => static function ( Post $post, $args, AppContext $context, $info ) use ( $tax_object ) {
-
 					$object_id = true === $post->isPreview && ! empty( $post->parentDatabaseId ) ? $post->parentDatabaseId : $post->ID;
 
 					if ( empty( $object_id ) || ! absint( $object_id ) ) {
@@ -235,7 +232,6 @@ class PostObject {
 					return $resolver->get_connection();
 				},
 			];
-
 		}
 
 		// Merge with connections set in register_post_type.
@@ -492,10 +488,15 @@ class PostObject {
 						$image = wp_get_attachment_image_src( $source->ID, $size );
 						if ( $image ) {
 							list( $src, $width, $height ) = $image;
-							$sizes                        = wp_calculate_image_sizes( [
-								absint( $width ),
-								absint( $height ),
-							], $src, null, $source->ID );
+							$sizes                        = wp_calculate_image_sizes(
+								[
+									absint( $width ),
+									absint( $height ),
+								],
+								$src,
+								null,
+								$source->ID 
+							);
 
 							return ! empty( $sizes ) ? $sizes : null;
 						}
@@ -572,7 +573,6 @@ class PostObject {
 						$filesize_path = ! empty( $original_file ) ? path_join( dirname( $original_file ), $path_parts['basename'] ) : null;
 
 						return ! empty( $filesize_path ) ? filesize( $filesize_path ) : null;
-
 					},
 				],
 				'mimeType'     => [

--- a/src/Registry/Utils/TermObject.php
+++ b/src/Registry/Utils/TermObject.php
@@ -2,7 +2,6 @@
 
 namespace WPGraphQL\Registry\Utils;
 
-use Exception;
 use GraphQL\Type\Definition\ResolveInfo;
 use WP_Taxonomy;
 use WPGraphQL;
@@ -139,7 +138,6 @@ class TermObject {
 					$resolver->set_query_arg( 'parent', $term->term_id );
 
 					return $resolver->get_connection();
-
 				},
 			];
 
@@ -195,53 +193,63 @@ class TermObject {
 		$allowed_post_types = WPGraphQL::get_allowed_post_types( 'objects' );
 
 		foreach ( $allowed_post_types as $post_type_object ) {
-
 			if ( ! in_array( $tax_object->name, get_object_taxonomies( $post_type_object->name ), true ) ) {
 				continue;
 			}
 
 			// ContentNodes.
 			if ( ! $already_registered ) {
+				$connections['contentNodes'] = PostObjects::get_connection_config(
+					$tax_object,
+					[
+						'toType'  => 'ContentNode',
+						'resolve' => static function ( Term $term, $args, $context, $info ) {
+							$resolver = new PostObjectConnectionResolver( $term, $args, $context, $info, 'any' );
+							$resolver->set_query_arg(
+								'tax_query',
+								[
+									[
+										'taxonomy'         => $term->taxonomyName,
+										'terms'            => [ $term->term_id ],
+										'field'            => 'term_id',
+										'include_children' => false,
+									],
+								] 
+							);
 
-				$connections['contentNodes'] = PostObjects::get_connection_config( $tax_object, [
-					'toType'  => 'ContentNode',
-					'resolve' => static function ( Term $term, $args, $context, $info ) {
-						$resolver = new PostObjectConnectionResolver( $term, $args, $context, $info, 'any' );
-						$resolver->set_query_arg( 'tax_query', [
-							[
-								'taxonomy'         => $term->taxonomyName,
-								'terms'            => [ $term->term_id ],
-								'field'            => 'term_id',
-								'include_children' => false,
-							],
-						] );
-
-						return $resolver->get_connection();
-					},
-				] );
+							return $resolver->get_connection();
+						},
+					] 
+				);
 
 				// We won't need to register this connection again.
 				$already_registered = true;
 			}
 
 			// PostObjects.
-			$connections[ $post_type_object->graphql_plural_name ] = PostObjects::get_connection_config( $post_type_object, [
-				'toType'     => $post_type_object->graphql_single_name,
-				'queryClass' => 'WP_Query',
-				'resolve'    => static function ( Term $term, $args, AppContext $context, ResolveInfo $info ) use ( $post_type_object ) {
-					$resolver = new PostObjectConnectionResolver( $term, $args, $context, $info, $post_type_object->name );
-					$resolver->set_query_arg( 'tax_query', [
-						[
-							'taxonomy'         => $term->taxonomyName,
-							'terms'            => [ $term->term_id ],
-							'field'            => 'term_id',
-							'include_children' => false,
-						],
-					] );
+			$connections[ $post_type_object->graphql_plural_name ] = PostObjects::get_connection_config(
+				$post_type_object,
+				[
+					'toType'     => $post_type_object->graphql_single_name,
+					'queryClass' => 'WP_Query',
+					'resolve'    => static function ( Term $term, $args, AppContext $context, ResolveInfo $info ) use ( $post_type_object ) {
+						$resolver = new PostObjectConnectionResolver( $term, $args, $context, $info, $post_type_object->name );
+						$resolver->set_query_arg(
+							'tax_query',
+							[
+								[
+									'taxonomy'         => $term->taxonomyName,
+									'terms'            => [ $term->term_id ],
+									'field'            => 'term_id',
+									'include_children' => false,
+								],
+							] 
+						);
 
-					return $resolver->get_connection();
-				},
-			]);
+						return $resolver->get_connection();
+					},
+				]
+			);
 		}
 
 		// Merge with connections set in register_taxonomy.

--- a/src/Request.php
+++ b/src/Request.php
@@ -10,8 +10,6 @@ use GraphQL\Server\OperationParams;
 use GraphQL\Server\ServerConfig;
 use GraphQL\Server\StandardServer;
 use WPGraphQL\Server\ValidationRules\DisableIntrospection;
-use WP_Post;
-use WP_Query;
 use WPGraphQL\Server\ValidationRules\QueryDepth;
 use WPGraphQL\Server\ValidationRules\RequireAuthentication;
 use WPGraphQL\Server\WPHelper;
@@ -182,7 +180,6 @@ class Request {
 		// to return in headers and debug messages to help developers understand
 		// what was resolved, how to cache it, etc.
 		$this->query_analyzer->init();
-
 	}
 
 	/**
@@ -205,7 +202,6 @@ class Request {
 	 * @return array
 	 */
 	protected function get_validation_rules(): array {
-
 		$validation_rules = GraphQL::getStandardValidationRules();
 
 		$validation_rules['require_authentication'] = new RequireAuthentication();
@@ -219,7 +215,6 @@ class Request {
 		 * @param \WPGraphQL\Request $request The Request instance
 		 */
 		return apply_filters( 'graphql_validation_rules', $validation_rules, $this );
-
 	}
 
 	/**
@@ -295,7 +290,6 @@ class Request {
 
 			// Process the batched requests
 			array_walk( $this->params, [ $this, 'do_action' ] );
-
 		} else {
 			$this->do_action( $this->params );
 		}
@@ -306,7 +300,6 @@ class Request {
 		 * @param \WPGraphQL\Request $request The instance of the Request being executed
 		 */
 		do_action( 'graphql_before_execute', $this );
-
 	}
 
 	/**
@@ -359,7 +352,6 @@ class Request {
 			 * If the user is not logged in, determine if there's a nonce
 			 */
 		} else {
-
 			$nonce = null;
 
 			if ( isset( $_REQUEST['_wpnonce'] ) ) {
@@ -477,7 +469,6 @@ class Request {
 		 * Return the filtered response
 		 */
 		return $filtered_response;
-
 	}
 
 	/**
@@ -620,10 +611,13 @@ class Request {
 		}
 
 		if ( is_array( $this->params ) ) {
-			return array_map(function ( $data ) {
-				$this->data = $data;
-				return $this->execute();
-			}, $this->params);
+			return array_map(
+				function ( $data ) {
+					$this->data = $data;
+					return $this->execute();
+				},
+				$this->params
+			);
 		}
 
 		// If $this->params isnt an array or an OperationParams instance, then something probably went wrong.
@@ -760,7 +754,6 @@ class Request {
 		 * @param \GraphQL\Server\OperationParams $params Request operation params
 		 */
 		return apply_filters( 'graphql_is_batch_queries_enabled', $batch_queries_enabled, $this->params );
-
 	}
 
 	/**
@@ -800,6 +793,5 @@ class Request {
 		do_action( 'graphql_server_config', $config, $this->params );
 
 		return new StandardServer( $config );
-
 	}
 }

--- a/src/Router.php
+++ b/src/Router.php
@@ -2,9 +2,7 @@
 
 namespace WPGraphQL;
 
-use Exception;
 use GraphQL\Error\FormattedError;
-use GraphQL\Executor\ExecutionResult;
 use WP_User;
 use WPGraphQL\Utils\QueryAnalyzer;
 
@@ -50,7 +48,6 @@ class Router {
 	 * @throws \Exception
 	 */
 	public function init() {
-
 		self::$route = graphql_get_endpoint();
 
 		/**
@@ -78,8 +75,6 @@ class Router {
 		 * Adds support for application passwords
 		 */
 		add_filter( 'application_password_is_api_request', [ $this, 'is_api_request' ] );
-
-
 	}
 
 	/**
@@ -99,13 +94,11 @@ class Router {
 	 * @uses   add_rewrite_rule()
 	 */
 	public static function add_rewrite_rule() {
-
 		add_rewrite_rule(
 			self::$route . '/?$',
 			'index.php?' . self::$route . '=true',
 			'top'
 		);
-
 	}
 
 	/**
@@ -130,11 +123,9 @@ class Router {
 	 * @since  0.0.1
 	 */
 	public static function add_query_var( $query_vars ) {
-
 		$query_vars[] = self::$route;
 
 		return $query_vars;
-
 	}
 
 	/**
@@ -173,12 +164,10 @@ class Router {
 		if ( isset( $_GET[ self::$route ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 
 			$is_graphql_http_request = true;
-
 		} else {
 
 			// Check the server to determine if the GraphQL endpoint is being requested
 			if ( isset( $_SERVER['HTTP_HOST'] ) && isset( $_SERVER['REQUEST_URI'] ) ) {
-
 				$host = wp_unslash( $_SERVER['HTTP_HOST'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 				$uri  = wp_unslash( $_SERVER['REQUEST_URI'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
@@ -213,7 +202,6 @@ class Router {
 		 * @param boolean $is_graphql_http_request Whether the request is a GraphQL HTTP Request. Default false.
 		 */
 		return apply_filters( 'graphql_is_graphql_http_request', $is_graphql_http_request );
-
 	}
 
 	/**
@@ -227,7 +215,7 @@ class Router {
 	 * @deprecated 0.4.1 Use Router::is_graphql_http_request instead. This now resolves to it
 	 */
 	public static function is_graphql_request() {
-		_deprecated_function( __METHOD__, '0.4.1', __CLASS__ . 'is_graphql_http_request()' );
+		_deprecated_function( __METHOD__, '0.4.1', self::class . 'is_graphql_http_request()' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		return self::is_graphql_http_request();
 	}
 
@@ -375,7 +363,6 @@ class Router {
 	 * @since  0.0.1
 	 */
 	public static function set_headers() {
-
 		if ( false === headers_sent() ) {
 
 			/**
@@ -392,7 +379,6 @@ class Router {
 			 * If there are headers, set them for the response
 			 */
 			if ( ! empty( $headers ) && is_array( $headers ) ) {
-
 				foreach ( $headers as $key => $value ) {
 					self::send_header( $key, $value );
 				}
@@ -404,7 +390,6 @@ class Router {
 			 * @param array $headers The headers sent in the response
 			 */
 			do_action( 'graphql_response_set_headers', $headers );
-
 		}
 	}
 
@@ -479,7 +464,6 @@ class Router {
 		self::$request  = new Request();
 
 		try {
-
 			$response = self::$request->execute_http();
 
 			// Get the operation params from the request.
@@ -487,8 +471,7 @@ class Router {
 			$query          = isset( $params->query ) ? $params->query : '';
 			$operation_name = isset( $params->operation ) ? $params->operation : '';
 			$variables      = isset( $params->variables ) ? $params->variables : null;
-
-		} catch ( Exception $error ) {
+		} catch ( \Throwable $error ) {
 
 			/**
 			 * If there are errors, set the status to 500
@@ -501,9 +484,9 @@ class Router {
 			/**
 			 * Filter thrown GraphQL errors
 			 *
-			 * @param array               $errors   Formatted errors object.
-			 * @param \Exception $error Thrown error.
-			 * @param \WPGraphQL\Request  $request  WPGraphQL Request object.
+			 * @param array               $errors  Formatted errors object.
+			 * @param \Throwable          $error   Thrown error.
+			 * @param \WPGraphQL\Request  $request WPGraphQL Request object.
 			 */
 			$response['errors'] = apply_filters(
 				'graphql_http_request_response_errors',
@@ -541,7 +524,6 @@ class Router {
 		 * Send the response
 		 */
 		wp_send_json( $response );
-
 	}
 
 	/**
@@ -577,6 +559,5 @@ class Router {
 		 * Set the response headers
 		 */
 		self::set_headers();
-
 	}
 }

--- a/src/Server/ValidationRules/DisableIntrospection.php
+++ b/src/Server/ValidationRules/DisableIntrospection.php
@@ -13,7 +13,6 @@ class DisableIntrospection extends \GraphQL\Validator\Rules\DisableIntrospection
 	 * @return bool
 	 */
 	public function isEnabled() {
-
 		$enabled = false;
 
 		if ( ! get_current_user_id() && ! \WPGraphQL::debug() && 'off' === get_graphql_setting( 'public_introspection_enabled', 'off' ) ) {

--- a/src/Server/ValidationRules/QueryDepth.php
+++ b/src/Server/ValidationRules/QueryDepth.php
@@ -160,7 +160,6 @@ class QueryDepth extends QuerySecurityRule {
 	 * @return bool
 	 */
 	protected function isEnabled() {
-
 		$is_enabled = false;
 
 		$enabled = get_graphql_setting( 'query_depth_enabled', 'off' );
@@ -170,6 +169,5 @@ class QueryDepth extends QuerySecurityRule {
 		}
 
 		return $is_enabled;
-
 	}
 }

--- a/src/Server/ValidationRules/RequireAuthentication.php
+++ b/src/Server/ValidationRules/RequireAuthentication.php
@@ -8,7 +8,6 @@ use GraphQL\Language\AST\NodeKind;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Validator\Rules\QuerySecurityRule;
 use GraphQL\Validator\ValidationContext;
-use WPGraphQL\AppContext;
 
 /**
  * Class RequireAuthentication
@@ -21,7 +20,6 @@ class RequireAuthentication extends QuerySecurityRule {
 	 * @return bool
 	 */
 	protected function isEnabled() {
-
 		$restrict_endpoint = null;
 
 		/**
@@ -64,7 +62,6 @@ class RequireAuthentication extends QuerySecurityRule {
 	 * @return callable[]|mixed[]
 	 */
 	public function getVisitor( ValidationContext $context ) {
-
 		$allowed_root_fields = [];
 
 		/**
@@ -79,7 +76,6 @@ class RequireAuthentication extends QuerySecurityRule {
 			$context,
 			[
 				NodeKind::FIELD => static function ( FieldNode $node ) use ( $context, $allowed_root_fields ) {
-
 					$parent_type = $context->getParentType();
 
 					if ( ! $parent_type instanceof Type || empty( $parent_type->name ) ) {

--- a/src/Server/WPHelper.php
+++ b/src/Server/WPHelper.php
@@ -3,8 +3,6 @@
 namespace WPGraphQL\Server;
 
 use GraphQL\Server\Helper;
-use GraphQL\Server\OperationParams;
-use GraphQL\Server\RequestError;
 
 /**
  * Extends GraphQL\Server\Helper to apply filters and parse query extensions.

--- a/src/Type/Connection/Comments.php
+++ b/src/Type/Connection/Comments.php
@@ -2,7 +2,6 @@
 
 namespace WPGraphQL\Type\Connection;
 
-use Exception;
 use WPGraphQL\Data\Connection\CommentConnectionResolver;
 use WPGraphQL\Data\DataSource;
 use WPGraphQL\Model\Comment;
@@ -35,28 +34,36 @@ class Comments {
 		/**
 		 * Register connection from User to Comments
 		 */
-		register_graphql_connection( self::get_connection_config( [
-			'fromType' => 'User',
-			'resolve'  => static function ( User $user, $args, $context, $info ) {
-				$resolver = new CommentConnectionResolver( $user, $args, $context, $info );
+		register_graphql_connection(
+			self::get_connection_config(
+				[
+					'fromType' => 'User',
+					'resolve'  => static function ( User $user, $args, $context, $info ) {
+						$resolver = new CommentConnectionResolver( $user, $args, $context, $info );
 
-				return $resolver->set_query_arg( 'user_id', absint( $user->userId ) )->get_connection();
-			},
+						return $resolver->set_query_arg( 'user_id', absint( $user->userId ) )->get_connection();
+					},
 
-		] ) );
+				] 
+			) 
+		);
 
-		register_graphql_connection( self::get_connection_config( [
-			'fromType'           => 'Comment',
-			'toType'             => 'Comment',
-			'fromFieldName'      => 'parent',
-			'connectionTypeName' => 'CommentToParentCommentConnection',
-			'oneToOne'           => true,
-			'resolve'            => static function ( Comment $comment, $args, $context, $info ) {
-				$resolver = new CommentConnectionResolver( $comment, $args, $context, $info );
+		register_graphql_connection(
+			self::get_connection_config(
+				[
+					'fromType'           => 'Comment',
+					'toType'             => 'Comment',
+					'fromFieldName'      => 'parent',
+					'connectionTypeName' => 'CommentToParentCommentConnection',
+					'oneToOne'           => true,
+					'resolve'            => static function ( Comment $comment, $args, $context, $info ) {
+						$resolver = new CommentConnectionResolver( $comment, $args, $context, $info );
 
-				return ! empty( $comment->comment_parent_id ) ? $resolver->one_to_one()->set_query_arg( 'comment__in', [ $comment->comment_parent_id ] )->get_connection() : null;
-			},
-		] ) );
+						return ! empty( $comment->comment_parent_id ) ? $resolver->one_to_one()->set_query_arg( 'comment__in', [ $comment->comment_parent_id ] )->get_connection() : null;
+					},
+				] 
+			) 
+		);
 
 		/**
 		 * Register connection from Comment to children comments

--- a/src/Type/Connection/MenuItems.php
+++ b/src/Type/Connection/MenuItems.php
@@ -2,7 +2,6 @@
 
 namespace WPGraphQL\Type\Connection;
 
-use Exception;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
 use WPGraphQL\Data\Connection\MenuItemConnectionResolver;
@@ -41,7 +40,6 @@ class MenuItems {
 					'fromType'      => 'MenuItem',
 					'fromFieldName' => 'childItems',
 					'resolve'       => static function ( MenuItem $menu_item, $args, AppContext $context, ResolveInfo $info ) {
-
 						if ( empty( $menu_item->menuId ) || empty( $menu_item->databaseId ) ) {
 							return null;
 						}
@@ -51,7 +49,6 @@ class MenuItems {
 						$resolver->set_query_arg( 'meta_key', '_menu_item_menu_item_parent' );
 						$resolver->set_query_arg( 'meta_value', (int) $menu_item->databaseId );
 						return $resolver->get_connection();
-
 					},
 				]
 			)
@@ -66,24 +63,25 @@ class MenuItems {
 					'fromType' => 'Menu',
 					'toType'   => 'MenuItem',
 					'resolve'  => static function ( Menu $menu, $args, AppContext $context, ResolveInfo $info ) {
-
 						$resolver = new MenuItemConnectionResolver( $menu, $args, $context, $info );
-						$resolver->set_query_arg( 'tax_query', [
+						$resolver->set_query_arg(
+							'tax_query',
 							[
-								'taxonomy'         => 'nav_menu',
-								'field'            => 'term_id',
-								'terms'            => (int) $menu->menuId,
-								'include_children' => true,
-								'operator'         => 'IN',
-							],
-						] );
+								[
+									'taxonomy'         => 'nav_menu',
+									'field'            => 'term_id',
+									'terms'            => (int) $menu->menuId,
+									'include_children' => true,
+									'operator'         => 'IN',
+								],
+							] 
+						);
 
 						return $resolver->get_connection();
 					},
 				]
 			)
 		);
-
 	}
 
 	/**

--- a/src/Type/Connection/Taxonomies.php
+++ b/src/Type/Connection/Taxonomies.php
@@ -13,7 +13,6 @@ class Taxonomies {
 	 * @return void
 	 */
 	public static function register_connections() {
-
 		register_graphql_connection(
 			[
 				'fromType'      => 'RootQuery',

--- a/src/Type/Connection/TermObjects.php
+++ b/src/Type/Connection/TermObjects.php
@@ -21,7 +21,6 @@ class TermObjects {
 	 * @return void
 	 */
 	public static function register_connections() {
-
 		register_graphql_connection(
 			[
 				'fromType'       => 'RootQuery',
@@ -89,7 +88,6 @@ class TermObjects {
 	 * @return array
 	 */
 	public static function get_connection_config( $tax_object, $args = [] ) {
-
 		$defaults = [
 			'fromType'       => 'RootQuery',
 			'queryClass'     => 'WP_Term_Query',

--- a/src/Type/Connection/Users.php
+++ b/src/Type/Connection/Users.php
@@ -39,78 +39,78 @@ class Users {
 			]
 		);
 
-		register_graphql_connection([
-			'fromType'           => 'ContentNode',
-			'toType'             => 'User',
-			'connectionTypeName' => 'ContentNodeToEditLockConnection',
-			'edgeFields'         => [
-				'lockTimestamp' => [
-					'type'        => 'String',
-					'description' => __( 'The timestamp for when the node was last edited', 'wp-graphql' ),
-					'resolve'     => static function ( $edge, $args, $context, $info ) {
-						if ( isset( $edge['source'] ) && ( $edge['source'] instanceof Post ) ) {
-							$edit_lock = $edge['source']->editLock;
-							$time      = ( is_array( $edit_lock ) && ! empty( $edit_lock[0] ) ) ? $edit_lock[0] : null;
-							return ! empty( $time ) ? Utils::prepare_date_response( $time, gmdate( 'Y-m-d H:i:s', $time ) ) : null;
-						}
-						return null;
-					},
+		register_graphql_connection(
+			[
+				'fromType'           => 'ContentNode',
+				'toType'             => 'User',
+				'connectionTypeName' => 'ContentNodeToEditLockConnection',
+				'edgeFields'         => [
+					'lockTimestamp' => [
+						'type'        => 'String',
+						'description' => __( 'The timestamp for when the node was last edited', 'wp-graphql' ),
+						'resolve'     => static function ( $edge, $args, $context, $info ) {
+							if ( isset( $edge['source'] ) && ( $edge['source'] instanceof Post ) ) {
+								$edit_lock = $edge['source']->editLock;
+								$time      = ( is_array( $edit_lock ) && ! empty( $edit_lock[0] ) ) ? $edit_lock[0] : null;
+								return ! empty( $time ) ? Utils::prepare_date_response( $time, gmdate( 'Y-m-d H:i:s', $time ) ) : null;
+							}
+							return null;
+						},
+					],
 				],
-			],
-			'fromFieldName'      => 'editingLockedBy',
-			'description'        => __( 'If a user has edited the node within the past 15 seconds, this will return the user that last edited. Null if the edit lock doesn\'t exist or is greater than 15 seconds', 'wp-graphql' ),
-			'oneToOne'           => true,
-			'resolve'            => static function ( Post $source, $args, $context, $info ) {
+				'fromFieldName'      => 'editingLockedBy',
+				'description'        => __( 'If a user has edited the node within the past 15 seconds, this will return the user that last edited. Null if the edit lock doesn\'t exist or is greater than 15 seconds', 'wp-graphql' ),
+				'oneToOne'           => true,
+				'resolve'            => static function ( Post $source, $args, $context, $info ) {
+					if ( ! isset( $source->editLock[1] ) || ! absint( $source->editLock[1] ) ) {
+						return null;
+					}
 
-				if ( ! isset( $source->editLock[1] ) || ! absint( $source->editLock[1] ) ) {
-					return null;
-				}
+					$resolver = new UserConnectionResolver( $source, $args, $context, $info );
+					$resolver->one_to_one()->set_query_arg( 'include', [ absint( $source->editLock[1] ) ] );
 
-				$resolver = new UserConnectionResolver( $source, $args, $context, $info );
-				$resolver->one_to_one()->set_query_arg( 'include', [ absint( $source->editLock[1] ) ] );
+					return $resolver->get_connection();
+				},
+			]
+		);
 
-				return $resolver->get_connection();
+		register_graphql_connection(
+			[
+				'fromType'           => 'ContentNode',
+				'toType'             => 'User',
+				'fromFieldName'      => 'lastEditedBy',
+				'connectionTypeName' => 'ContentNodeToEditLastConnection',
+				'description'        => __( 'The user that most recently edited the node', 'wp-graphql' ),
+				'oneToOne'           => true,
+				'resolve'            => static function ( Post $source, $args, $context, $info ) {
+					if ( empty( $source->editLastId ) ) {
+						return null;
+					}
 
-			},
-		]);
+					$resolver = new UserConnectionResolver( $source, $args, $context, $info );
+					$resolver->set_query_arg( 'include', [ absint( $source->editLastId ) ] );
+					return $resolver->one_to_one()->get_connection();
+				},
+			]
+		);
 
-		register_graphql_connection([
-			'fromType'           => 'ContentNode',
-			'toType'             => 'User',
-			'fromFieldName'      => 'lastEditedBy',
-			'connectionTypeName' => 'ContentNodeToEditLastConnection',
-			'description'        => __( 'The user that most recently edited the node', 'wp-graphql' ),
-			'oneToOne'           => true,
-			'resolve'            => static function ( Post $source, $args, $context, $info ) {
+		register_graphql_connection(
+			[
+				'fromType'      => 'NodeWithAuthor',
+				'toType'        => 'User',
+				'fromFieldName' => 'author',
+				'oneToOne'      => true,
+				'resolve'       => static function ( Post $post, $args, AppContext $context, ResolveInfo $info ) {
+					if ( empty( $post->authorDatabaseId ) ) {
+						return null;
+					}
 
-				if ( empty( $source->editLastId ) ) {
-					return null;
-				}
-
-				$resolver = new UserConnectionResolver( $source, $args, $context, $info );
-				$resolver->set_query_arg( 'include', [ absint( $source->editLastId ) ] );
-				return $resolver->one_to_one()->get_connection();
-
-			},
-		]);
-
-		register_graphql_connection( [
-			'fromType'      => 'NodeWithAuthor',
-			'toType'        => 'User',
-			'fromFieldName' => 'author',
-			'oneToOne'      => true,
-			'resolve'       => static function ( Post $post, $args, AppContext $context, ResolveInfo $info ) {
-
-				if ( empty( $post->authorDatabaseId ) ) {
-					return null;
-				}
-
-				$resolver = new UserConnectionResolver( $post, $args, $context, $info );
-				$resolver->set_query_arg( 'include', [ absint( $post->authorDatabaseId ) ] );
-				return $resolver->one_to_one()->get_connection();
-			},
-		] );
-
+					$resolver = new UserConnectionResolver( $post, $args, $context, $info );
+					$resolver->set_query_arg( 'include', [ absint( $post->authorDatabaseId ) ] );
+					return $resolver->one_to_one()->get_connection();
+				},
+			] 
+		);
 	}
 
 	/**

--- a/src/Type/Enum/CommentNodeIdTypeEnum.php
+++ b/src/Type/Enum/CommentNodeIdTypeEnum.php
@@ -14,20 +14,23 @@ class CommentNodeIdTypeEnum {
 	 * @return void
 	 */
 	public static function register_type() {
-		register_graphql_enum_type( 'CommentNodeIdTypeEnum', [
-			'description' => __( 'The Type of Identifier used to fetch a single comment node. Default is "ID". To be used along with the "id" field.', 'wp-graphql' ),
-			'values'      => [
-				'ID'          => [
-					'name'        => 'ID',
-					'value'       => 'global_id',
-					'description' => __( 'Identify a resource by the (hashed) Global ID.', 'wp-graphql' ),
+		register_graphql_enum_type(
+			'CommentNodeIdTypeEnum',
+			[
+				'description' => __( 'The Type of Identifier used to fetch a single comment node. Default is "ID". To be used along with the "id" field.', 'wp-graphql' ),
+				'values'      => [
+					'ID'          => [
+						'name'        => 'ID',
+						'value'       => 'global_id',
+						'description' => __( 'Identify a resource by the (hashed) Global ID.', 'wp-graphql' ),
+					],
+					'DATABASE_ID' => [
+						'name'        => 'DATABASE_ID',
+						'value'       => 'database_id',
+						'description' => __( 'Identify a resource by the Database ID.', 'wp-graphql' ),
+					],
 				],
-				'DATABASE_ID' => [
-					'name'        => 'DATABASE_ID',
-					'value'       => 'database_id',
-					'description' => __( 'Identify a resource by the Database ID.', 'wp-graphql' ),
-				],
-			],
-		]);
+			]
+		);
 	}
 }

--- a/src/Type/Enum/CommentStatusEnum.php
+++ b/src/Type/Enum/CommentStatusEnum.php
@@ -20,7 +20,6 @@ class CommentStatusEnum {
 		 * Loop through the post_stati
 		 */
 		foreach ( $stati as $status => $name ) {
-
 			$values[ WPEnumType::get_safe_name( $status ) ] = [
 				// translators: %s is the name of the comment status
 				'description' => sprintf( __( 'Comments with the %1$s status', 'wp-graphql' ), $name ),
@@ -35,6 +34,5 @@ class CommentStatusEnum {
 				'values'      => $values,
 			]
 		);
-
 	}
 }

--- a/src/Type/Enum/ContentNodeIdTypeEnum.php
+++ b/src/Type/Enum/ContentNodeIdTypeEnum.php
@@ -10,7 +10,6 @@ class ContentNodeIdTypeEnum {
 	 * @return void
 	 */
 	public static function register_type() {
-
 		register_graphql_enum_type(
 			'ContentNodeIdTypeEnum',
 			[

--- a/src/Type/Enum/ContentTypeEnum.php
+++ b/src/Type/Enum/ContentTypeEnum.php
@@ -67,7 +67,6 @@ class ContentTypeEnum {
 			}
 
 			if ( ! empty( $taxonomy_values ) ) {
-
 				register_graphql_enum_type(
 					'ContentTypesOf' . Utils::format_type_name( $tax_object->graphql_single_name ) . 'Enum',
 					[
@@ -81,6 +80,5 @@ class ContentTypeEnum {
 				);
 			}
 		}
-
 	}
 }

--- a/src/Type/Enum/ContentTypeIdTypeEnum.php
+++ b/src/Type/Enum/ContentTypeIdTypeEnum.php
@@ -10,7 +10,6 @@ class ContentTypeIdTypeEnum {
 	 * @return void
 	 */
 	public static function register_type() {
-
 		register_graphql_enum_type(
 			'ContentTypeIdTypeEnum',
 			[
@@ -29,6 +28,5 @@ class ContentTypeIdTypeEnum {
 				],
 			]
 		);
-
 	}
 }

--- a/src/Type/Enum/MediaItemStatusEnum.php
+++ b/src/Type/Enum/MediaItemStatusEnum.php
@@ -25,7 +25,6 @@ class MediaItemStatusEnum {
 		 * Loop through the post_stati
 		 */
 		foreach ( $post_stati as $status ) {
-
 			$values[ WPEnumType::get_safe_name( $status ) ] = [
 				'description' => sprintf(
 					// translators: %1$s is the post status.
@@ -43,6 +42,5 @@ class MediaItemStatusEnum {
 				'values'      => $values,
 			]
 		);
-
 	}
 }

--- a/src/Type/Enum/MenuItemNodeIdTypeEnum.php
+++ b/src/Type/Enum/MenuItemNodeIdTypeEnum.php
@@ -14,20 +14,23 @@ class MenuItemNodeIdTypeEnum {
 	 * @return void
 	 */
 	public static function register_type() {
-		register_graphql_enum_type( 'MenuItemNodeIdTypeEnum', [
-			'description' => __( 'The Type of Identifier used to fetch a single node. Default is "ID". To be used along with the "id" field.', 'wp-graphql' ),
-			'values'      => [
-				'ID'          => [
-					'name'        => 'ID',
-					'value'       => 'global_id',
-					'description' => __( 'Identify a resource by the (hashed) Global ID.', 'wp-graphql' ),
+		register_graphql_enum_type(
+			'MenuItemNodeIdTypeEnum',
+			[
+				'description' => __( 'The Type of Identifier used to fetch a single node. Default is "ID". To be used along with the "id" field.', 'wp-graphql' ),
+				'values'      => [
+					'ID'          => [
+						'name'        => 'ID',
+						'value'       => 'global_id',
+						'description' => __( 'Identify a resource by the (hashed) Global ID.', 'wp-graphql' ),
+					],
+					'DATABASE_ID' => [
+						'name'        => 'DATABASE_ID',
+						'value'       => 'database_id',
+						'description' => __( 'Identify a resource by the Database ID.', 'wp-graphql' ),
+					],
 				],
-				'DATABASE_ID' => [
-					'name'        => 'DATABASE_ID',
-					'value'       => 'database_id',
-					'description' => __( 'Identify a resource by the Database ID.', 'wp-graphql' ),
-				],
-			],
-		]);
+			]
+		);
 	}
 }

--- a/src/Type/Enum/MenuNodeIdTypeEnum.php
+++ b/src/Type/Enum/MenuNodeIdTypeEnum.php
@@ -14,35 +14,38 @@ class MenuNodeIdTypeEnum {
 	 * @return void
 	 */
 	public static function register_type() {
-		register_graphql_enum_type( 'MenuNodeIdTypeEnum', [
-			'description' => __( 'The Type of Identifier used to fetch a single node. Default is "ID". To be used along with the "id" field.', 'wp-graphql' ),
-			'values'      => [
-				'ID'          => [
-					'name'        => 'ID',
-					'value'       => 'global_id',
-					'description' => __( 'Identify a menu node by the (hashed) Global ID.', 'wp-graphql' ),
+		register_graphql_enum_type(
+			'MenuNodeIdTypeEnum',
+			[
+				'description' => __( 'The Type of Identifier used to fetch a single node. Default is "ID". To be used along with the "id" field.', 'wp-graphql' ),
+				'values'      => [
+					'ID'          => [
+						'name'        => 'ID',
+						'value'       => 'global_id',
+						'description' => __( 'Identify a menu node by the (hashed) Global ID.', 'wp-graphql' ),
+					],
+					'DATABASE_ID' => [
+						'name'        => 'DATABASE_ID',
+						'value'       => 'database_id',
+						'description' => __( 'Identify a menu node by the Database ID.', 'wp-graphql' ),
+					],
+					'LOCATION'    => [
+						'name'        => 'LOCATION',
+						'value'       => 'location',
+						'description' => __( 'Identify a menu node by the slug of menu location to which it is assigned', 'wp-graphql' ),
+					],
+					'NAME'        => [
+						'name'        => 'NAME',
+						'value'       => 'name',
+						'description' => __( 'Identify a menu node by its name', 'wp-graphql' ),
+					],
+					'SLUG'        => [
+						'name'        => 'SLUG',
+						'value'       => 'slug',
+						'description' => __( 'Identify a menu node by its slug', 'wp-graphql' ),
+					],
 				],
-				'DATABASE_ID' => [
-					'name'        => 'DATABASE_ID',
-					'value'       => 'database_id',
-					'description' => __( 'Identify a menu node by the Database ID.', 'wp-graphql' ),
-				],
-				'LOCATION'    => [
-					'name'        => 'LOCATION',
-					'value'       => 'location',
-					'description' => __( 'Identify a menu node by the slug of menu location to which it is assigned', 'wp-graphql' ),
-				],
-				'NAME'        => [
-					'name'        => 'NAME',
-					'value'       => 'name',
-					'description' => __( 'Identify a menu node by its name', 'wp-graphql' ),
-				],
-				'SLUG'        => [
-					'name'        => 'SLUG',
-					'value'       => 'slug',
-					'description' => __( 'Identify a menu node by its slug', 'wp-graphql' ),
-				],
-			],
-		]);
+			]
+		);
 	}
 }

--- a/src/Type/Enum/MimeTypeEnum.php
+++ b/src/Type/Enum/MimeTypeEnum.php
@@ -42,6 +42,5 @@ class MimeTypeEnum {
 				'values'      => $values,
 			]
 		);
-
 	}
 }

--- a/src/Type/Enum/PostObjectsConnectionOrderbyEnum.php
+++ b/src/Type/Enum/PostObjectsConnectionOrderbyEnum.php
@@ -58,6 +58,5 @@ class PostObjectsConnectionOrderbyEnum {
 				],
 			]
 		);
-
 	}
 }

--- a/src/Type/Enum/PostStatusEnum.php
+++ b/src/Type/Enum/PostStatusEnum.php
@@ -28,7 +28,6 @@ class PostStatusEnum {
 			 * Loop through the post_stati
 			 */
 			foreach ( $post_stati as $status ) {
-
 				if ( ! is_string( $status ) ) {
 					continue;
 				}
@@ -51,6 +50,5 @@ class PostStatusEnum {
 				'values'      => $post_status_enum_values,
 			]
 		);
-
 	}
 }

--- a/src/Type/Enum/TaxonomyEnum.php
+++ b/src/Type/Enum/TaxonomyEnum.php
@@ -42,6 +42,5 @@ class TaxonomyEnum {
 				'values'      => $values,
 			]
 		);
-
 	}
 }

--- a/src/Type/Enum/TaxonomyIdTypeEnum.php
+++ b/src/Type/Enum/TaxonomyIdTypeEnum.php
@@ -10,7 +10,6 @@ class TaxonomyIdTypeEnum {
 	 * @return void
 	 */
 	public static function register_type() {
-
 		register_graphql_enum_type(
 			'TaxonomyIdTypeEnum',
 			[
@@ -29,6 +28,5 @@ class TaxonomyIdTypeEnum {
 				],
 			]
 		);
-
 	}
 }

--- a/src/Type/Enum/TermNodeIdTypeEnum.php
+++ b/src/Type/Enum/TermNodeIdTypeEnum.php
@@ -10,7 +10,6 @@ class TermNodeIdTypeEnum {
 	 * @return void
 	 */
 	public static function register_type() {
-
 		register_graphql_enum_type(
 			'TermNodeIdTypeEnum',
 			[

--- a/src/Type/Enum/TimezoneEnum.php
+++ b/src/Type/Enum/TimezoneEnum.php
@@ -43,7 +43,7 @@ class TimezoneEnum {
 			load_textdomain( 'continents-cities', $mofile );
 			$mo_loaded = true;
 		}
-	
+
 		$zonen = [];
 		foreach ( timezone_identifiers_list() as $zone ) {
 			$zone = explode( '/', $zone );
@@ -72,18 +72,13 @@ class TimezoneEnum {
 		}
 		usort( $zonen, '_wp_timezone_choice_usort_callback' );
 
-		foreach ( $zonen as $key => $zone ) {
+		foreach ( $zonen as $zone ) {
 			// Build value in an array to join later
 			$value = [ $zone['continent'] ];
 			if ( empty( $zone['city'] ) ) {
 				// It's at the continent level (generally won't happen)
 				$display = $zone['t_continent'];
 			} else {
-				// It's inside a continent group
-				// Continent optgroup
-				if ( ! isset( $zonen[ $key - 1 ] ) || $zonen[ $key - 1 ]['continent'] !== $zone['continent'] ) {
-					$label = $zone['t_continent'];
-				}
 				// Add the city to the value
 				$value[] = $zone['city'];
 				$display = $zone['t_city'];
@@ -100,7 +95,6 @@ class TimezoneEnum {
 				'value'       => $value,
 				'description' => $display,
 			];
-
 		}
 		$offset_range = [
 			- 12,
@@ -160,7 +154,6 @@ class TimezoneEnum {
 			14,
 		];
 		foreach ( $offset_range as $offset ) {
-
 			if ( 0 <= $offset ) {
 				$offset_name = '+' . $offset;
 			} else {
@@ -188,7 +181,6 @@ class TimezoneEnum {
 					$offset_name
 				),
 			];
-
 		}
 
 		register_graphql_enum_type(

--- a/src/Type/Enum/UserRoleEnum.php
+++ b/src/Type/Enum/UserRoleEnum.php
@@ -19,7 +19,6 @@ class UserRoleEnum {
 
 		if ( ! empty( $editable_roles ) && is_array( $editable_roles ) ) {
 			foreach ( $editable_roles as $key => $role ) {
-
 				$formatted_role = WPEnumType::get_safe_name( isset( $role['name'] ) ? $role['name'] : $key );
 
 				$roles[ $formatted_role ] = [

--- a/src/Type/Enum/UsersConnectionOrderbyEnum.php
+++ b/src/Type/Enum/UsersConnectionOrderbyEnum.php
@@ -10,7 +10,6 @@ class UsersConnectionOrderbyEnum {
 	 * @return void
 	 */
 	public static function register_type() {
-
 		register_graphql_enum_type(
 			'UsersConnectionOrderbyEnum',
 			[
@@ -51,6 +50,5 @@ class UsersConnectionOrderbyEnum {
 				],
 			]
 		);
-
 	}
 }

--- a/src/Type/Input/DateQueryInput.php
+++ b/src/Type/Input/DateQueryInput.php
@@ -70,6 +70,5 @@ class DateQueryInput {
 				],
 			]
 		);
-
 	}
 }

--- a/src/Type/Input/PostObjectsConnectionOrderbyInput.php
+++ b/src/Type/Input/PostObjectsConnectionOrderbyInput.php
@@ -30,6 +30,5 @@ class PostObjectsConnectionOrderbyInput {
 				],
 			]
 		);
-
 	}
 }

--- a/src/Type/Input/UsersConnectionOrderbyInput.php
+++ b/src/Type/Input/UsersConnectionOrderbyInput.php
@@ -10,7 +10,6 @@ class UsersConnectionOrderbyInput {
 	 * @return void
 	 */
 	public static function register_type() {
-
 		register_graphql_input_type(
 			'UsersConnectionOrderbyInput',
 			[
@@ -29,6 +28,5 @@ class UsersConnectionOrderbyInput {
 				],
 			]
 		);
-
 	}
 }

--- a/src/Type/InterfaceType/Commenter.php
+++ b/src/Type/InterfaceType/Commenter.php
@@ -20,55 +20,56 @@ class Commenter {
 	 * @return void
 	 */
 	public static function register_type( TypeRegistry $type_registry ) {
+		register_graphql_interface_type(
+			'Commenter',
+			[
+				'description' => __( 'The author of a comment', 'wp-graphql' ),
+				'interfaces'  => [ 'Node', 'DatabaseIdentifier' ],
+				'resolveType' => static function ( $comment_author ) use ( $type_registry ) {
+					if ( $comment_author instanceof User ) {
+						$type = $type_registry->get_type( 'User' );
+					} else {
+						$type = $type_registry->get_type( 'CommentAuthor' );
+					}
 
-		register_graphql_interface_type( 'Commenter', [
-			'description' => __( 'The author of a comment', 'wp-graphql' ),
-			'interfaces'  => [ 'Node', 'DatabaseIdentifier' ],
-			'resolveType' => static function ( $comment_author ) use ( $type_registry ) {
-				if ( $comment_author instanceof User ) {
-					$type = $type_registry->get_type( 'User' );
-				} else {
-					$type = $type_registry->get_type( 'CommentAuthor' );
-				}
-
-				return $type;
-			},
-			'fields'      => [
-				'id'           => [
-					'type'        => [
-						'non_null' => 'ID',
+					return $type;
+				},
+				'fields'      => [
+					'id'           => [
+						'type'        => [
+							'non_null' => 'ID',
+						],
+						'description' => __( 'The globally unique identifier for the comment author.', 'wp-graphql' ),
 					],
-					'description' => __( 'The globally unique identifier for the comment author.', 'wp-graphql' ),
-				],
-				'avatar'       => [
-					'type'        => 'Avatar',
-					'description' => __( 'Avatar object for user. The avatar object can be retrieved in different sizes by specifying the size argument.', 'wp-graphql' ),
-				],
-				'databaseId'   => [
-					'type'        => [
-						'non_null' => 'Int',
+					'avatar'       => [
+						'type'        => 'Avatar',
+						'description' => __( 'Avatar object for user. The avatar object can be retrieved in different sizes by specifying the size argument.', 'wp-graphql' ),
 					],
-					'description' => __( 'Identifies the primary key from the database.', 'wp-graphql' ),
+					'databaseId'   => [
+						'type'        => [
+							'non_null' => 'Int',
+						],
+						'description' => __( 'Identifies the primary key from the database.', 'wp-graphql' ),
+					],
+					'name'         => [
+						'type'        => 'String',
+						'description' => __( 'The name of the author of a comment.', 'wp-graphql' ),
+					],
+					'email'        => [
+						'type'        => 'String',
+						'description' => __( 'The email address of the author of a comment.', 'wp-graphql' ),
+					],
+					'url'          => [
+						'type'        => 'String',
+						'description' => __( 'The url of the author of a comment.', 'wp-graphql' ),
+					],
+					'isRestricted' => [
+						'type'        => 'Boolean',
+						'description' => __( 'Whether the author information is considered restricted. (not fully public)', 'wp-graphql' ),
+					],
 				],
-				'name'         => [
-					'type'        => 'String',
-					'description' => __( 'The name of the author of a comment.', 'wp-graphql' ),
-				],
-				'email'        => [
-					'type'        => 'String',
-					'description' => __( 'The email address of the author of a comment.', 'wp-graphql' ),
-				],
-				'url'          => [
-					'type'        => 'String',
-					'description' => __( 'The url of the author of a comment.', 'wp-graphql' ),
-				],
-				'isRestricted' => [
-					'type'        => 'Boolean',
-					'description' => __( 'Whether the author information is considered restricted. (not fully public)', 'wp-graphql' ),
-				],
-			],
-		] );
-
+			] 
+		);
 	}
 
 }

--- a/src/Type/InterfaceType/Connection.php
+++ b/src/Type/InterfaceType/Connection.php
@@ -2,7 +2,6 @@
 
 namespace WPGraphQL\Type\InterfaceType;
 
-use Exception;
 use WPGraphQL\Registry\TypeRegistry;
 
 class Connection {
@@ -15,7 +14,6 @@ class Connection {
 	 * @throws \Exception
 	 */
 	public static function register_type( TypeRegistry $type_registry ): void {
-
 		register_graphql_interface_type(
 			'Connection',
 			[
@@ -36,6 +34,5 @@ class Connection {
 				],
 			]
 		);
-
 	}
 }

--- a/src/Type/InterfaceType/ContentNode.php
+++ b/src/Type/InterfaceType/ContentNode.php
@@ -1,7 +1,6 @@
 <?php
 namespace WPGraphQL\Type\InterfaceType;
 
-use Exception;
 use WPGraphQL\Data\Connection\ContentTypeConnectionResolver;
 use WPGraphQL\Data\Connection\EnqueuedScriptsConnectionResolver;
 use WPGraphQL\Data\Connection\EnqueuedStylesheetConnectionResolver;
@@ -33,7 +32,6 @@ class ContentNode {
 					'contentType'         => [
 						'toType'   => 'ContentType',
 						'resolve'  => static function ( Post $source, $args, $context, $info ) {
-
 							if ( $source->isRevision ) {
 								$parent    = get_post( $source->parentDatabaseId );
 								$post_type = $parent->post_type ?? null;
@@ -94,7 +92,6 @@ class ContentNode {
 					}
 
 					return ! empty( $type ) ? $type : null;
-
 				},
 				'fields'      => [
 					'contentTypeName'           => [
@@ -173,7 +170,6 @@ class ContentNode {
 				],
 			]
 		);
-
 	}
 
 }

--- a/src/Type/InterfaceType/ContentTemplate.php
+++ b/src/Type/InterfaceType/ContentTemplate.php
@@ -47,7 +47,7 @@ class ContentTemplate {
 		}
 
 		// Register each template to the schema
-		foreach ( $page_templates as $file => $name ) {
+		foreach ( $page_templates as $name ) {
 			$name          = ucwords( $name );
 			$replaced_name = preg_replace( '/[^\w]/', '', $name );
 

--- a/src/Type/InterfaceType/DatabaseIdentifier.php
+++ b/src/Type/InterfaceType/DatabaseIdentifier.php
@@ -15,15 +15,17 @@ class DatabaseIdentifier {
 	 * @return void
 	 */
 	public static function register_type() {
-
-		register_graphql_interface_type( 'DatabaseIdentifier', [
-			'description' => __( 'Object that can be identified with a Database ID', 'wp-graphql' ),
-			'fields'      => [
-				'databaseId' => [
-					'type'        => [ 'non_null' => 'Int' ],
-					'description' => __( 'The unique identifier stored in the database', 'wp-graphql' ),
+		register_graphql_interface_type(
+			'DatabaseIdentifier',
+			[
+				'description' => __( 'Object that can be identified with a Database ID', 'wp-graphql' ),
+				'fields'      => [
+					'databaseId' => [
+						'type'        => [ 'non_null' => 'Int' ],
+						'description' => __( 'The unique identifier stored in the database', 'wp-graphql' ),
+					],
 				],
-			],
-		]);
+			]
+		);
 	}
 }

--- a/src/Type/InterfaceType/Edge.php
+++ b/src/Type/InterfaceType/Edge.php
@@ -2,7 +2,6 @@
 
 namespace WPGraphQL\Type\InterfaceType;
 
-use Exception;
 use WPGraphQL\Registry\TypeRegistry;
 
 class Edge {
@@ -15,20 +14,21 @@ class Edge {
 	 * @throws \Exception
 	 */
 	public static function register_type( TypeRegistry $type_registry ): void {
-
-		register_graphql_interface_type( 'Edge', [
-			'description' => __( 'Relational context between connected nodes', 'wp-graphql' ),
-			'fields'      => [
-				'cursor' => [
-					'type'        => 'String',
-					'description' => __( 'Opaque reference to the nodes position in the connection. Value can be used with pagination args.', 'wp-graphql' ),
+		register_graphql_interface_type(
+			'Edge',
+			[
+				'description' => __( 'Relational context between connected nodes', 'wp-graphql' ),
+				'fields'      => [
+					'cursor' => [
+						'type'        => 'String',
+						'description' => __( 'Opaque reference to the nodes position in the connection. Value can be used with pagination args.', 'wp-graphql' ),
+					],
+					'node'   => [
+						'type'        => [ 'non_null' => 'Node' ],
+						'description' => __( 'The connected node', 'wp-graphql' ),
+					],
 				],
-				'node'   => [
-					'type'        => [ 'non_null' => 'Node' ],
-					'description' => __( 'The connected node', 'wp-graphql' ),
-				],
-			],
-		] );
-
+			] 
+		);
 	}
 }

--- a/src/Type/InterfaceType/EnqueuedAsset.php
+++ b/src/Type/InterfaceType/EnqueuedAsset.php
@@ -18,67 +18,67 @@ class EnqueuedAsset {
 	 * @return void
 	 */
 	public static function register_type( TypeRegistry $type_registry ) {
+		register_graphql_interface_type(
+			'EnqueuedAsset',
+			[
+				'description' => __( 'Asset enqueued by the CMS', 'wp-graphql' ),
+				'resolveType' => static function ( $asset ) use ( $type_registry ) {
 
-		register_graphql_interface_type( 'EnqueuedAsset', [
-			'description' => __( 'Asset enqueued by the CMS', 'wp-graphql' ),
-			'resolveType' => static function ( $asset ) use ( $type_registry ) {
+					/**
+					 * The resolveType callback is used at runtime to determine what Type an object
+					 * implementing the EnqueuedAsset Interface should be resolved as.
+					 *
+					 * You can filter this centrally using the "graphql_wp_interface_type_config" filter
+					 * to override if you need something other than a Post object to be resolved via the
+					 * $post->post_type attribute.
+					 */
+					$type = null;
 
-				/**
-				 * The resolveType callback is used at runtime to determine what Type an object
-				 * implementing the EnqueuedAsset Interface should be resolved as.
-				 *
-				 * You can filter this centrally using the "graphql_wp_interface_type_config" filter
-				 * to override if you need something other than a Post object to be resolved via the
-				 * $post->post_type attribute.
-				 */
-				$type = null;
+					if ( isset( $asset['type'] ) ) {
+						$type = $type_registry->get_type( $asset['type'] );
+					}
 
-				if ( isset( $asset['type'] ) ) {
-					$type = $type_registry->get_type( $asset['type'] );
-				}
-
-				return ! empty( $type ) ? $type : null;
-
-			},
-			'fields'      => [
-				'id'           => [
-					'type'        => [
-						'non_null' => 'ID',
+					return ! empty( $type ) ? $type : null;
+				},
+				'fields'      => [
+					'id'           => [
+						'type'        => [
+							'non_null' => 'ID',
+						],
+						'description' => __( 'The ID of the enqueued asset', 'wp-graphql' ),
 					],
-					'description' => __( 'The ID of the enqueued asset', 'wp-graphql' ),
-				],
-				'handle'       => [
-					'type'        => 'String',
-					'description' => __( 'The handle of the enqueued asset', 'wp-graphql' ),
-				],
-				'version'      => [
-					'type'        => 'String',
-					'description' => __( 'The version of the enqueued asset', 'wp-graphql' ),
-				],
-				'src'          => [
-					'type'        => 'String',
-					'description' => __( 'The source of the asset', 'wp-graphql' ),
-				],
-				'dependencies' => [
-					'type'        => [
-						'list_of' => 'EnqueuedScript',
+					'handle'       => [
+						'type'        => 'String',
+						'description' => __( 'The handle of the enqueued asset', 'wp-graphql' ),
 					],
-					'description' => __( 'Dependencies needed to use this asset', 'wp-graphql' ),
+					'version'      => [
+						'type'        => 'String',
+						'description' => __( 'The version of the enqueued asset', 'wp-graphql' ),
+					],
+					'src'          => [
+						'type'        => 'String',
+						'description' => __( 'The source of the asset', 'wp-graphql' ),
+					],
+					'dependencies' => [
+						'type'        => [
+							'list_of' => 'EnqueuedScript',
+						],
+						'description' => __( 'Dependencies needed to use this asset', 'wp-graphql' ),
+					],
+					'args'         => [
+						'type'        => 'Boolean',
+						'description' => __( '@todo', 'wp-graphql' ),
+					],
+					'extra'        => [
+						'type'        => 'String',
+						'description' => __( 'Extra information needed for the script', 'wp-graphql' ),
+						'resolve'     => static function ( $asset ) {
+							return isset( $asset->extra['data'] ) ? $asset->extra['data'] : null;
+						},
+					],
 				],
-				'args'         => [
-					'type'        => 'Boolean',
-					'description' => __( '@todo', 'wp-graphql' ),
-				],
-				'extra'        => [
-					'type'        => 'String',
-					'description' => __( 'Extra information needed for the script', 'wp-graphql' ),
-					'resolve'     => static function ( $asset ) {
-						return isset( $asset->extra['data'] ) ? $asset->extra['data'] : null;
-					},
-				],
-			],
-		]);
-
+			]
+		);
 	}
 
 }

--- a/src/Type/InterfaceType/HierarchicalContentNode.php
+++ b/src/Type/InterfaceType/HierarchicalContentNode.php
@@ -1,7 +1,6 @@
 <?php
 namespace WPGraphQL\Type\InterfaceType;
 
-use Exception;
 use WPGraphQL\Registry\TypeRegistry;
 
 /**

--- a/src/Type/InterfaceType/HierarchicalNode.php
+++ b/src/Type/InterfaceType/HierarchicalNode.php
@@ -2,7 +2,6 @@
 
 namespace WPGraphQL\Type\InterfaceType;
 
-use Exception;
 use WPGraphQL\Registry\TypeRegistry;
 
 /**
@@ -21,7 +20,6 @@ class HierarchicalNode {
 	 * @throws \Exception
 	 */
 	public static function register_type( TypeRegistry $type_registry ):void {
-
 		register_graphql_interface_type(
 			'HierarchicalNode',
 			[
@@ -42,7 +40,6 @@ class HierarchicalNode {
 				],
 			]
 		);
-
 	}
 
 }

--- a/src/Type/InterfaceType/HierarchicalTermNode.php
+++ b/src/Type/InterfaceType/HierarchicalTermNode.php
@@ -1,7 +1,6 @@
 <?php
 namespace WPGraphQL\Type\InterfaceType;
 
-use Exception;
 use WPGraphQL\Registry\TypeRegistry;
 
 /**
@@ -20,27 +19,28 @@ class HierarchicalTermNode {
 	 * @throws \Exception
 	 */
 	public static function register_type( TypeRegistry $type_registry ): void {
-
-		register_graphql_interface_type( 'HierarchicalTermNode', [
-			'description' => __( 'Term node with hierarchical (parent/child) relationships', 'wp-graphql' ),
-			'interfaces'  => [
-				'Node',
-				'TermNode',
-				'DatabaseIdentifier',
-				'HierarchicalNode',
-			],
-			'fields'      => [
-				'parentId'         => [
-					'type'        => 'ID',
-					'description' => __( 'The globally unique identifier of the parent node.', 'wp-graphql' ),
+		register_graphql_interface_type(
+			'HierarchicalTermNode',
+			[
+				'description' => __( 'Term node with hierarchical (parent/child) relationships', 'wp-graphql' ),
+				'interfaces'  => [
+					'Node',
+					'TermNode',
+					'DatabaseIdentifier',
+					'HierarchicalNode',
 				],
-				'parentDatabaseId' => [
-					'type'        => 'Int',
-					'description' => __( 'Database id of the parent node', 'wp-graphql' ),
+				'fields'      => [
+					'parentId'         => [
+						'type'        => 'ID',
+						'description' => __( 'The globally unique identifier of the parent node.', 'wp-graphql' ),
+					],
+					'parentDatabaseId' => [
+						'type'        => 'Int',
+						'description' => __( 'Database id of the parent node', 'wp-graphql' ),
+					],
 				],
-			],
-		]);
-
+			]
+		);
 	}
 
 }

--- a/src/Type/InterfaceType/MenuItemLinkable.php
+++ b/src/Type/InterfaceType/MenuItemLinkable.php
@@ -2,11 +2,9 @@
 
 namespace WPGraphQL\Type\InterfaceType;
 
-use Exception;
 use WPGraphQL\Model\Post;
 use WPGraphQL\Model\Term;
 use WPGraphQL\Registry\TypeRegistry;
-use WPGraphQL\Type\ObjectType\User;
 
 class MenuItemLinkable {
 
@@ -19,32 +17,31 @@ class MenuItemLinkable {
 	 * @throws \Exception
 	 */
 	public static function register_type( TypeRegistry $type_registry ): void {
+		register_graphql_interface_type(
+			'MenuItemLinkable',
+			[
+				'description' => __( 'Nodes that can be linked to as Menu Items', 'wp-graphql' ),
+				'interfaces'  => [ 'Node', 'UniformResourceIdentifiable', 'DatabaseIdentifier' ],
+				'fields'      => [],
+				'resolveType' => static function ( $node ) use ( $type_registry ) {
+					switch ( true ) {
+						case $node instanceof Post:
+							/** @var \WP_Post_Type $post_type_object */
+							$post_type_object = get_post_type_object( $node->post_type );
+							$type             = $type_registry->get_type( $post_type_object->graphql_single_name );
+							break;
+						case $node instanceof Term:
+							/** @var \WP_Taxonomy $tax_object */
+							$tax_object = get_taxonomy( $node->taxonomyName );
+							$type       = $type_registry->get_type( $tax_object->graphql_single_name );
+							break;
+						default:
+							$type = null;
+					}
 
-		register_graphql_interface_type( 'MenuItemLinkable', [
-			'description' => __( 'Nodes that can be linked to as Menu Items', 'wp-graphql' ),
-			'interfaces'  => [ 'Node', 'UniformResourceIdentifiable', 'DatabaseIdentifier' ],
-			'fields'      => [],
-			'resolveType' => static function ( $node ) use ( $type_registry ) {
-
-				switch ( true ) {
-					case $node instanceof Post:
-						/** @var \WP_Post_Type $post_type_object */
-						$post_type_object = get_post_type_object( $node->post_type );
-						$type             = $type_registry->get_type( $post_type_object->graphql_single_name );
-						break;
-					case $node instanceof Term:
-						/** @var \WP_Taxonomy $tax_object */
-						$tax_object = get_taxonomy( $node->taxonomyName );
-						$type       = $type_registry->get_type( $tax_object->graphql_single_name );
-						break;
-					default:
-						$type = null;
-				}
-
-				return $type;
-
-			},
-		] );
-
+					return $type;
+				},
+			] 
+		);
 	}
 }

--- a/src/Type/InterfaceType/NodeWithAuthor.php
+++ b/src/Type/InterfaceType/NodeWithAuthor.php
@@ -1,10 +1,6 @@
 <?php
 namespace WPGraphQL\Type\InterfaceType;
 
-use GraphQL\Type\Definition\ResolveInfo;
-use WPGraphQL\AppContext;
-use WPGraphQL\Data\DataSource;
-use WPGraphQL\Model\Post;
 use WPGraphQL\Registry\TypeRegistry;
 
 class NodeWithAuthor {

--- a/src/Type/InterfaceType/NodeWithFeaturedImage.php
+++ b/src/Type/InterfaceType/NodeWithFeaturedImage.php
@@ -1,7 +1,6 @@
 <?php
 namespace WPGraphQL\Type\InterfaceType;
 
-use Exception;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
 use WPGraphQL\Data\Connection\PostObjectConnectionResolver;
@@ -19,7 +18,6 @@ class NodeWithFeaturedImage {
 	 * @throws \Exception
 	 */
 	public static function register_type( TypeRegistry $type_registry ) {
-
 		register_graphql_interface_type(
 			'NodeWithFeaturedImage',
 			[
@@ -30,7 +28,6 @@ class NodeWithFeaturedImage {
 						'toType'   => 'MediaItem',
 						'oneToOne' => true,
 						'resolve'  => static function ( Post $post, $args, AppContext $context, ResolveInfo $info ) {
-
 							if ( empty( $post->featuredImageDatabaseId ) ) {
 								return null;
 							}
@@ -39,7 +36,6 @@ class NodeWithFeaturedImage {
 							$resolver->set_query_arg( 'p', absint( $post->featuredImageDatabaseId ) );
 
 							return $resolver->one_to_one()->get_connection();
-
 						},
 					],
 				],

--- a/src/Type/InterfaceType/NodeWithTemplate.php
+++ b/src/Type/InterfaceType/NodeWithTemplate.php
@@ -13,15 +13,18 @@ class NodeWithTemplate {
 	 * @return void
 	 */
 	public static function register_type( TypeRegistry $type_registry ) {
-		register_graphql_interface_type( 'NodeWithTemplate', [
-			'description' => __( 'A node that can have a template associated with it', 'wp-graphql' ),
-			'interfaces'  => [ 'Node' ],
-			'fields'      => [
-				'template' => [
-					'description' => __( 'The template assigned to the node', 'wp-graphql' ),
-					'type'        => 'ContentTemplate',
+		register_graphql_interface_type(
+			'NodeWithTemplate',
+			[
+				'description' => __( 'A node that can have a template associated with it', 'wp-graphql' ),
+				'interfaces'  => [ 'Node' ],
+				'fields'      => [
+					'template' => [
+						'description' => __( 'The template assigned to the node', 'wp-graphql' ),
+						'type'        => 'ContentTemplate',
+					],
 				],
-			],
-		]);
+			]
+		);
 	}
 }

--- a/src/Type/InterfaceType/NodeWithTitle.php
+++ b/src/Type/InterfaceType/NodeWithTitle.php
@@ -1,10 +1,6 @@
 <?php
 namespace WPGraphQL\Type\InterfaceType;
 
-use GraphQL\Type\Definition\ResolveInfo;
-use WPGraphQL\AppContext;
-use WPGraphQL\Data\DataSource;
-use WPGraphQL\Model\Post;
 use WPGraphQL\Registry\TypeRegistry;
 
 class NodeWithTitle {
@@ -17,7 +13,6 @@ class NodeWithTitle {
 	 * @return void
 	 */
 	public static function register_type( TypeRegistry $type_registry ) {
-
 		register_graphql_interface_type(
 			'NodeWithTitle',
 			[
@@ -46,6 +41,5 @@ class NodeWithTitle {
 				],
 			]
 		);
-
 	}
 }

--- a/src/Type/InterfaceType/OneToOneConnection.php
+++ b/src/Type/InterfaceType/OneToOneConnection.php
@@ -2,7 +2,6 @@
 
 namespace WPGraphQL\Type\InterfaceType;
 
-use Exception;
 use WPGraphQL\Registry\TypeRegistry;
 
 class OneToOneConnection {
@@ -15,17 +14,18 @@ class OneToOneConnection {
 	 * @throws \Exception
 	 */
 	public static function register_type( TypeRegistry $type_registry ): void {
-
-		register_graphql_interface_type( 'OneToOneConnection', [
-			'description' => __( 'A singular connection from one Node to another, with support for relational data on the "edge" of the connection.', 'wp-graphql' ),
-			'interfaces'  => [ 'Edge' ],
-			'fields'      => [
-				'node' => [
-					'type'        => [ 'non_null' => 'Node' ],
-					'description' => __( 'The connected node', 'wp-graphql' ),
+		register_graphql_interface_type(
+			'OneToOneConnection',
+			[
+				'description' => __( 'A singular connection from one Node to another, with support for relational data on the "edge" of the connection.', 'wp-graphql' ),
+				'interfaces'  => [ 'Edge' ],
+				'fields'      => [
+					'node' => [
+						'type'        => [ 'non_null' => 'Node' ],
+						'description' => __( 'The connected node', 'wp-graphql' ),
+					],
 				],
-			],
-		] );
-
+			] 
+		);
 	}
 }

--- a/src/Type/InterfaceType/PageInfo.php
+++ b/src/Type/InterfaceType/PageInfo.php
@@ -2,7 +2,6 @@
 
 namespace WPGraphQL\Type\InterfaceType;
 
-use Exception;
 use WPGraphQL\Registry\TypeRegistry;
 
 class PageInfo {
@@ -15,18 +14,22 @@ class PageInfo {
 	 * @throws \Exception
 	 */
 	public static function register_type( TypeRegistry $type_registry ): void {
+		register_graphql_interface_type(
+			'WPPageInfo',
+			[
+				'description' => __( 'Information about pagination in a connection.', 'wp-graphql' ),
+				'interfaces'  => [ 'PageInfo' ],
+				'fields'      => self::get_fields(),
+			] 
+		);
 
-		register_graphql_interface_type( 'WPPageInfo', [
-			'description' => __( 'Information about pagination in a connection.', 'wp-graphql' ),
-			'interfaces'  => [ 'PageInfo' ],
-			'fields'      => self::get_fields(),
-		] );
-
-		register_graphql_interface_type( 'PageInfo', [
-			'description' => __( 'Information about pagination in a connection.', 'wp-graphql' ),
-			'fields'      => self::get_fields(),
-		] );
-
+		register_graphql_interface_type(
+			'PageInfo',
+			[
+				'description' => __( 'Information about pagination in a connection.', 'wp-graphql' ),
+				'fields'      => self::get_fields(),
+			] 
+		);
 	}
 
 	/**

--- a/src/Type/InterfaceType/Previewable.php
+++ b/src/Type/InterfaceType/Previewable.php
@@ -2,7 +2,6 @@
 
 namespace WPGraphQL\Type\InterfaceType;
 
-use Exception;
 use WPGraphQL\Model\Post;
 use WPGraphQL\Registry\TypeRegistry;
 
@@ -36,7 +35,6 @@ class Previewable {
 					],
 				],
 				'resolveType' => static function ( Post $post ) use ( $type_registry ) {
-
 					$type = 'Post';
 
 					$post_type_object = isset( $post->post_type ) ? get_post_type_object( $post->post_type ) : null;

--- a/src/Type/InterfaceType/TermNode.php
+++ b/src/Type/InterfaceType/TermNode.php
@@ -2,10 +2,8 @@
 
 namespace WPGraphQL\Type\InterfaceType;
 
-use Exception;
 use WPGraphQL\Data\Connection\EnqueuedScriptsConnectionResolver;
 use WPGraphQL\Data\Connection\EnqueuedStylesheetConnectionResolver;
-use WPGraphQL\Data\DataSource;
 use WPGraphQL\Model\Term;
 use WPGraphQL\Registry\TypeRegistry;
 
@@ -20,7 +18,6 @@ class TermNode {
 	 * @throws \Exception
 	 */
 	public static function register_type( TypeRegistry $type_registry ) {
-
 		register_graphql_interface_type(
 			'TermNode',
 			[
@@ -63,7 +60,6 @@ class TermNode {
 					}
 
 					return ! empty( $type ) ? $type : null;
-
 				},
 				'fields'      => [
 					'databaseId'     => [
@@ -112,6 +108,5 @@ class TermNode {
 				],
 			]
 		);
-
 	}
 }

--- a/src/Type/InterfaceType/UniformResourceIdentifiable.php
+++ b/src/Type/InterfaceType/UniformResourceIdentifiable.php
@@ -2,8 +2,6 @@
 
 namespace WPGraphQL\Type\InterfaceType;
 
-use WP_Post_Type;
-use WP_Taxonomy;
 use WPGraphQL\Model\Post;
 use WPGraphQL\Model\PostType;
 use WPGraphQL\Model\Term;
@@ -49,7 +47,6 @@ class UniformResourceIdentifiable {
 					],
 				],
 				'resolveType' => static function ( $node ) use ( $type_registry ) {
-
 					switch ( true ) {
 						case $node instanceof Post:
 							/** @var \WP_Post_Type $post_type_object */

--- a/src/Type/ObjectType/Avatar.php
+++ b/src/Type/ObjectType/Avatar.php
@@ -65,6 +65,5 @@ class Avatar {
 				],
 			]
 		);
-
 	}
 }

--- a/src/Type/ObjectType/Comment.php
+++ b/src/Type/ObjectType/Comment.php
@@ -31,7 +31,6 @@ class Comment {
 						'description' => __( 'The author of the comment', 'wp-graphql' ),
 						'oneToOne'    => true,
 						'resolve'     => static function ( $comment, $args, AppContext $context, ResolveInfo $info ) {
-
 							$node = null;
 
 							// try and load the user node
@@ -49,7 +48,6 @@ class Comment {
 								'node'   => $node,
 								'source' => $comment,
 							];
-
 						},
 					],
 				],
@@ -130,6 +128,5 @@ class Comment {
 				],
 			]
 		);
-
 	}
 }

--- a/src/Type/ObjectType/CommentAuthor.php
+++ b/src/Type/ObjectType/CommentAuthor.php
@@ -2,7 +2,7 @@
 
 namespace WPGraphQL\Type\ObjectType;
 
-use \WPGraphQL\Model\CommentAuthor as CommentAuthorModel;
+use WPGraphQL\Model\CommentAuthor as CommentAuthorModel;
 
 class CommentAuthor {
 

--- a/src/Type/ObjectType/ContentType.php
+++ b/src/Type/ObjectType/ContentType.php
@@ -12,7 +12,6 @@ class ContentType {
 	 * @return void
 	 */
 	public static function register_type() {
-
 		$interfaces = [ 'Node', 'UniformResourceIdentifiable' ];
 
 		register_graphql_object_type(
@@ -133,6 +132,5 @@ class ContentType {
 
 			]
 		);
-
 	}
 }

--- a/src/Type/ObjectType/EnqueuedScript.php
+++ b/src/Type/ObjectType/EnqueuedScript.php
@@ -17,31 +17,34 @@ class EnqueuedScript {
 	 * @return void
 	 */
 	public static function register_type() {
-		register_graphql_object_type( 'EnqueuedScript', [
-			'description' => __( 'Script enqueued by the CMS', 'wp-graphql' ),
-			'interfaces'  => [ 'Node', 'EnqueuedAsset' ],
-			'fields'      => [
-				'id'      => [
-					'type'    => [
-						'non_null' => 'ID',
+		register_graphql_object_type(
+			'EnqueuedScript',
+			[
+				'description' => __( 'Script enqueued by the CMS', 'wp-graphql' ),
+				'interfaces'  => [ 'Node', 'EnqueuedAsset' ],
+				'fields'      => [
+					'id'      => [
+						'type'    => [
+							'non_null' => 'ID',
+						],
+						'resolve' => static function ( $asset ) {
+							return isset( $asset->handle ) ? Relay::toGlobalId( 'enqueued_script', $asset->handle ) : null;
+						},
 					],
-					'resolve' => static function ( $asset ) {
-						return isset( $asset->handle ) ? Relay::toGlobalId( 'enqueued_script', $asset->handle ) : null;
-					},
-				],
-				'src'     => [
-					'resolve' => static function ( \_WP_Dependency $script ) {
-						return ! empty( $script->src ) && is_string( $script->src ) ? $script->src : null;
-					},
-				],
-				'version' => [
-					'resolve' => static function ( \_WP_Dependency $script ) {
-						global $wp_scripts;
+					'src'     => [
+						'resolve' => static function ( \_WP_Dependency $script ) {
+							return ! empty( $script->src ) && is_string( $script->src ) ? $script->src : null;
+						},
+					],
+					'version' => [
+						'resolve' => static function ( \_WP_Dependency $script ) {
+							global $wp_scripts;
 
-						return ! empty( $script->ver ) && is_string( $script->ver ) ? (string) $script->ver : $wp_scripts->default_version;
-					},
+							return ! empty( $script->ver ) && is_string( $script->ver ) ? (string) $script->ver : $wp_scripts->default_version;
+						},
+					],
 				],
-			],
-		] );
+			] 
+		);
 	}
 }

--- a/src/Type/ObjectType/EnqueuedStylesheet.php
+++ b/src/Type/ObjectType/EnqueuedStylesheet.php
@@ -17,31 +17,34 @@ class EnqueuedStylesheet {
 	 * @return void
 	 */
 	public static function register_type() {
-		register_graphql_object_type( 'EnqueuedStylesheet', [
-			'description' => __( 'Stylesheet enqueued by the CMS', 'wp-graphql' ),
-			'interfaces'  => [ 'Node', 'EnqueuedAsset' ],
-			'fields'      => [
-				'id'      => [
-					'type'    => [
-						'non_null' => 'ID',
+		register_graphql_object_type(
+			'EnqueuedStylesheet',
+			[
+				'description' => __( 'Stylesheet enqueued by the CMS', 'wp-graphql' ),
+				'interfaces'  => [ 'Node', 'EnqueuedAsset' ],
+				'fields'      => [
+					'id'      => [
+						'type'    => [
+							'non_null' => 'ID',
+						],
+						'resolve' => static function ( $asset ) {
+							return isset( $asset->handle ) ? Relay::toGlobalId( 'enqueued_stylesheet', $asset->handle ) : null;
+						},
 					],
-					'resolve' => static function ( $asset ) {
-						return isset( $asset->handle ) ? Relay::toGlobalId( 'enqueued_stylesheet', $asset->handle ) : null;
-					},
-				],
-				'src'     => [
-					'resolve' => static function ( \_WP_Dependency $stylesheet ) {
-						return ! empty( $stylesheet->src ) && is_string( $stylesheet->src ) ? $stylesheet->src : null;
-					},
-				],
-				'version' => [
-					'resolve' => static function ( \_WP_Dependency $stylesheet ) {
-						global $wp_styles;
+					'src'     => [
+						'resolve' => static function ( \_WP_Dependency $stylesheet ) {
+							return ! empty( $stylesheet->src ) && is_string( $stylesheet->src ) ? $stylesheet->src : null;
+						},
+					],
+					'version' => [
+						'resolve' => static function ( \_WP_Dependency $stylesheet ) {
+							global $wp_styles;
 
-						return ! empty( $stylesheet->ver ) && is_string( $stylesheet->ver ) ? $stylesheet->ver : $wp_styles->default_version;
-					},
+							return ! empty( $stylesheet->ver ) && is_string( $stylesheet->ver ) ? $stylesheet->ver : $wp_styles->default_version;
+						},
+					],
 				],
-			],
-		] );
+			] 
+		);
 	}
 }

--- a/src/Type/ObjectType/MediaSize.php
+++ b/src/Type/ObjectType/MediaSize.php
@@ -42,24 +42,20 @@ class MediaSize {
 						'type'        => 'Int',
 						'description' => __( 'The filesize of the resource', 'wp-graphql' ),
 						'resolve'     => static function ( $image, $args, $context, $info ) {
-
-							$src_url = null;
-
 							if ( ! empty( $image['ID'] ) && ! empty( $image['file'] ) ) {
 								$original_file = get_attached_file( absint( $image['ID'] ) );
 								$filesize_path = ! empty( $original_file ) ? path_join( dirname( $original_file ), $image['file'] ) : null;
+
 								return ! empty( $filesize_path ) ? filesize( $filesize_path ) : null;
 							}
 
 							return null;
-
 						},
 					],
 					'sourceUrl' => [
 						'type'        => 'String',
 						'description' => __( 'The url of the referenced size', 'wp-graphql' ),
 						'resolve'     => static function ( $image, $args, $context, $info ) {
-
 							$src_url = null;
 
 							if ( ! empty( $image['ID'] ) ) {
@@ -77,6 +73,5 @@ class MediaSize {
 				],
 			]
 		);
-
 	}
 }

--- a/src/Type/ObjectType/Menu.php
+++ b/src/Type/ObjectType/Menu.php
@@ -2,7 +2,7 @@
 
 namespace WPGraphQL\Type\ObjectType;
 
-use \WPGraphQL\Model\Menu as MenuModel;
+use WPGraphQL\Model\Menu as MenuModel;
 
 class Menu {
 

--- a/src/Type/ObjectType/MenuItem.php
+++ b/src/Type/ObjectType/MenuItem.php
@@ -29,7 +29,6 @@ class MenuItem {
 						'description' => __( 'Connection from MenuItem to it\'s connected node', 'wp-graphql' ),
 						'oneToOne'    => true,
 						'resolve'     => static function ( MenuItemModel $menu_item, $args, AppContext $context, ResolveInfo $info ) {
-
 							if ( ! isset( $menu_item->databaseId ) ) {
 								return null;
 							}
@@ -58,7 +57,6 @@ class MenuItem {
 							}
 
 							return null !== $resolver ? $resolver->one_to_one()->get_connection() : null;
-
 						},
 					],
 					'menu'          => [
@@ -149,7 +147,6 @@ class MenuItem {
 						'deprecationReason' => __( 'Deprecated in favor of the connectedNode field', 'wp-graphql' ),
 						'description'       => __( 'The object connected to this menu item.', 'wp-graphql' ),
 						'resolve'           => static function ( $menu_item, array $args, AppContext $context, $info ) {
-
 							$object_id   = intval( get_post_meta( $menu_item->menuItemId, '_menu_item_object_id', true ) );
 							$object_type = get_post_meta( $menu_item->menuItemId, '_menu_item_type', true );
 
@@ -197,6 +194,5 @@ class MenuItem {
 				],
 			]
 		);
-
 	}
 }

--- a/src/Type/ObjectType/Plugin.php
+++ b/src/Type/ObjectType/Plugin.php
@@ -2,7 +2,7 @@
 
 namespace WPGraphQL\Type\ObjectType;
 
-use \WPGraphQL\Model\Plugin as PluginModel;
+use WPGraphQL\Model\Plugin as PluginModel;
 
 /**
  * Class Plugin

--- a/src/Type/ObjectType/PostObject.php
+++ b/src/Type/ObjectType/PostObject.php
@@ -2,7 +2,6 @@
 
 namespace WPGraphQL\Type\ObjectType;
 
-use Exception;
 use WP_Post_Type;
 use WPGraphQL\Registry\TypeRegistry;
 
@@ -25,7 +24,6 @@ class PostObject {
 	 * @deprecated 1.12.0
 	 */
 	public static function register_post_object_types( WP_Post_Type $post_type_object, TypeRegistry $type_registry ) {
-
 		_deprecated_function( __FUNCTION__, '1.12.0', esc_attr( \WPGraphQL\Registry\Utils\PostObject::class ) . '::register_types()' );
 
 		\WPGraphQL\Registry\Utils\PostObject::register_types( $post_type_object );

--- a/src/Type/ObjectType/PostTypeLabelDetails.php
+++ b/src/Type/ObjectType/PostTypeLabelDetails.php
@@ -189,6 +189,5 @@ class PostTypeLabelDetails {
 				],
 			]
 		);
-
 	}
 }

--- a/src/Type/ObjectType/RootMutation.php
+++ b/src/Type/ObjectType/RootMutation.php
@@ -10,7 +10,6 @@ class RootMutation {
 	 * @return void
 	 */
 	public static function register_type() {
-
 		register_graphql_object_type(
 			'RootMutation',
 			[
@@ -32,6 +31,5 @@ class RootMutation {
 				],
 			]
 		);
-
 	}
 }

--- a/src/Type/ObjectType/RootQuery.php
+++ b/src/Type/ObjectType/RootQuery.php
@@ -213,7 +213,6 @@ class RootQuery {
 							],
 						],
 						'resolve'     => static function ( $root, $args, AppContext $context, ResolveInfo $info ) {
-
 							$idType = $args['idType'] ?? 'global_id';
 							switch ( $idType ) {
 								case 'uri':
@@ -266,7 +265,6 @@ class RootQuery {
 									return $post;
 								}
 							) : null;
-
 						},
 					],
 					'contentType' => [
@@ -283,7 +281,6 @@ class RootQuery {
 							],
 						],
 						'resolve'     => static function ( $root, $args, $context, $info ) {
-
 							$id_type = isset( $args['idType'] ) ? $args['idType'] : 'id';
 
 							$id = null;
@@ -300,7 +297,6 @@ class RootQuery {
 							}
 
 							return ! empty( $id ) ? $context->get_loader( 'post_type' )->load_deferred( $id ) : null;
-
 						},
 					],
 					'taxonomy'    => [
@@ -317,7 +313,6 @@ class RootQuery {
 							],
 						],
 						'resolve'     => static function ( $root, $args, $context, $info ) {
-
 							$id_type = isset( $args['idType'] ) ? $args['idType'] : 'id';
 
 							$id = null;
@@ -334,7 +329,6 @@ class RootQuery {
 							}
 
 							return ! empty( $id ) ? $context->get_loader( 'taxonomy' )->load_deferred( $id ) : null;
-
 						},
 					],
 					'node'        => [
@@ -379,7 +373,6 @@ class RootQuery {
 							],
 						],
 						'resolve'     => static function ( $source, array $args, AppContext $context ) {
-
 							$id_type = isset( $args['idType'] ) ? $args['idType'] : 'id';
 
 							switch ( $id_type ) {
@@ -504,7 +497,6 @@ class RootQuery {
 							],
 						],
 						'resolve'     => static function ( $root, $args, AppContext $context ) {
-
 							$idType  = isset( $args['idType'] ) ? $args['idType'] : 'global_id';
 							$term_id = null;
 
@@ -546,7 +538,6 @@ class RootQuery {
 									}
 									$term_id = absint( $id_components['id'] );
 									break;
-
 							}
 
 							return ! empty( $term_id ) ? $context->get_loader( 'term' )->load_deferred( $term_id ) : null;
@@ -585,7 +576,6 @@ class RootQuery {
 							],
 						],
 						'resolve'     => static function ( $source, array $args, $context ) {
-
 							$idType = isset( $args['idType'] ) ? $args['idType'] : 'id';
 
 							switch ( $idType ) {
@@ -647,11 +637,9 @@ class RootQuery {
 							],
 						],
 						'resolve'     => static function ( $source, array $args ) {
-
 							$id_components = Relay::fromGlobalId( $args['id'] );
 
 							return DataSource::resolve_user_role( $id_components['id'] );
-
 						},
 					],
 					'viewer'      => [
@@ -676,7 +664,6 @@ class RootQuery {
 		$allowed_post_types = \WPGraphQL::get_allowed_post_types( 'objects', [ 'graphql_register_root_field' => true ] );
 
 		foreach ( $allowed_post_types as $post_type_object ) {
-
 			register_graphql_field(
 				'RootQuery',
 				$post_type_object->graphql_single_name,
@@ -705,7 +692,6 @@ class RootQuery {
 						],
 					],
 					'resolve'     => static function ( $source, array $args, AppContext $context ) use ( $post_type_object ) {
-
 						$idType  = isset( $args['idType'] ) ? $args['idType'] : 'global_id';
 						$post_id = null;
 						switch ( $idType ) {
@@ -768,10 +754,14 @@ class RootQuery {
 									return null;
 								}
 
-								if ( ! isset( $post->post_type ) || ! in_array( $post->post_type, [
-									'revision',
-									$post_type_object->name,
-								], true ) ) {
+								if ( ! isset( $post->post_type ) || ! in_array(
+									$post->post_type,
+									[
+										'revision',
+										$post_type_object->name,
+									],
+									true 
+								) ) {
 									return null;
 								}
 
@@ -834,8 +824,8 @@ class RootQuery {
 					),
 					'args'              => $post_by_args,
 					'resolve'           => static function ( $source, array $args, $context ) use ( $post_type_object ) {
-						$post_object = null;
-						$post_id     = 0;
+						$post_id = 0;
+
 						if ( ! empty( $args['id'] ) ) {
 							$id_components = Relay::fromGlobalId( $args['id'] );
 							if ( empty( $id_components['id'] ) || empty( $id_components['type'] ) ) {
@@ -846,7 +836,6 @@ class RootQuery {
 							$id      = $args[ lcfirst( $post_type_object->graphql_single_name . 'Id' ) ];
 							$post_id = absint( $id );
 						} elseif ( ! empty( $args['uri'] ) ) {
-
 							return $context->node_resolver->resolve_uri(
 								$args['uri'],
 								[
@@ -866,7 +855,6 @@ class RootQuery {
 									'nodeType'  => 'ContentNode',
 								]
 							);
-
 						}
 
 						return $context->get_loader( 'post' )->load_deferred( $post_id )->then(
@@ -882,17 +870,20 @@ class RootQuery {
 									return null;
 								}
 
-								if ( ! isset( $post->post_type ) || ! in_array( $post->post_type, [
-									'revision',
-									$post_type_object->name,
-								], true ) ) {
+								if ( ! isset( $post->post_type ) || ! in_array(
+									$post->post_type,
+									[
+										'revision',
+										$post_type_object->name,
+									],
+									true 
+								) ) {
 									return null;
 								}
 
 								return $post;
 							}
 						);
-
 					},
 				]
 			);
@@ -909,7 +900,6 @@ class RootQuery {
 		$allowed_taxonomies = \WPGraphQL::get_allowed_taxonomies( 'objects', [ 'graphql_register_root_field' => true ] );
 
 		foreach ( $allowed_taxonomies as $tax_object ) {
-
 			register_graphql_field(
 				'RootQuery',
 				$tax_object->graphql_single_name,
@@ -933,7 +923,6 @@ class RootQuery {
 						],
 					],
 					'resolve'     => static function ( $source, array $args, $context, $info ) use ( $tax_object ) {
-
 						$idType  = isset( $args['idType'] ) ? $args['idType'] : 'global_id';
 						$term_id = null;
 
@@ -963,7 +952,6 @@ class RootQuery {
 								}
 								$term_id = absint( $id_components['id'] );
 								break;
-
 						}
 
 						return ! empty( $term_id ) ? $context->get_loader( 'term' )->load_deferred( (int) $term_id ) : null;

--- a/src/Type/ObjectType/SettingGroup.php
+++ b/src/Type/ObjectType/SettingGroup.php
@@ -2,7 +2,6 @@
 
 namespace WPGraphQL\Type\ObjectType;
 
-use Exception;
 use GraphQL\Error\UserError;
 use WPGraphQL\Data\DataSource;
 use WPGraphQL\Registry\TypeRegistry;
@@ -20,7 +19,6 @@ class SettingGroup {
 	 * @throws \Exception
 	 */
 	public static function register_settings_group( string $group_name, string $group, TypeRegistry $type_registry ) {
-
 		$fields = self::get_settings_group_fields( $group_name, $group, $type_registry );
 
 		// if the settings group doesn't have any fields that
@@ -40,7 +38,6 @@ class SettingGroup {
 		);
 
 		return ucfirst( $group_name ) . 'Settings';
-
 	}
 
 	/**
@@ -53,14 +50,11 @@ class SettingGroup {
 	 * @return array
 	 */
 	public static function get_settings_group_fields( string $group_name, string $group, TypeRegistry $type_registry ) {
-
 		$setting_fields = DataSource::get_setting_group_fields( $group, $type_registry );
 		$fields         = [];
 
 		if ( ! empty( $setting_fields ) && is_array( $setting_fields ) ) {
-
 			foreach ( $setting_fields as $key => $setting_field ) {
-
 				if ( ! isset( $setting_field['type'] ) || ! $type_registry->get_type( $setting_field['type'] ) ) {
 					continue;
 				}
@@ -122,13 +116,11 @@ class SettingGroup {
 							return ! empty( $option ) ? $option : null;
 						},
 					];
-
 				}
 			}
 		}
 
 		return $fields;
-
 	}
 
 }

--- a/src/Type/ObjectType/Settings.php
+++ b/src/Type/ObjectType/Settings.php
@@ -22,7 +22,6 @@ class Settings {
 	 * @return void
 	 */
 	public static function register_type( TypeRegistry $type_registry ) {
-
 		$fields = self::get_fields( $type_registry );
 
 		if ( empty( $fields ) ) {
@@ -36,7 +35,6 @@ class Settings {
 				'fields'      => $fields,
 			]
 		);
-
 	}
 
 	/**
@@ -58,7 +56,6 @@ class Settings {
 			 * proper fields
 			 */
 			foreach ( $registered_settings as $key => $setting_field ) {
-
 				if ( ! isset( $setting_field['type'] ) || ! $type_registry->get_type( $setting_field['type'] ) ) {
 					continue;
 				}
@@ -122,7 +119,6 @@ class Settings {
 							return isset( $option ) ? $option : null;
 						},
 					];
-
 				}
 			}
 		}

--- a/src/Type/ObjectType/Taxonomy.php
+++ b/src/Type/ObjectType/Taxonomy.php
@@ -15,7 +15,6 @@ class Taxonomy {
 	 * @return void
 	 */
 	public static function register_type() {
-
 		register_graphql_object_type(
 			'Taxonomy',
 			[
@@ -27,12 +26,10 @@ class Taxonomy {
 						'toType'      => 'ContentType',
 						'description' => __( 'List of Content Types associated with the Taxonomy', 'wp-graphql' ),
 						'resolve'     => static function ( TaxonomyModel $taxonomy, $args, AppContext $context, ResolveInfo $info ) {
-
 							$connected_post_types = ! empty( $taxonomy->object_type ) ? $taxonomy->object_type : [];
 							$resolver             = new ContentTypeConnectionResolver( $taxonomy, $args, $context, $info );
 							$resolver->set_query_arg( 'contentTypeNames', $connected_post_types );
 							return $resolver->get_connection();
-
 						},
 					],
 				],

--- a/src/Type/ObjectType/TermObject.php
+++ b/src/Type/ObjectType/TermObject.php
@@ -2,7 +2,6 @@
 
 namespace WPGraphQL\Type\ObjectType;
 
-use Exception;
 use WP_Taxonomy;
 
 /**

--- a/src/Type/ObjectType/User.php
+++ b/src/Type/ObjectType/User.php
@@ -7,7 +7,7 @@ use WPGraphQL\Data\Connection\EnqueuedStylesheetConnectionResolver;
 use WPGraphQL\Data\Connection\PostObjectConnectionResolver;
 use WPGraphQL\Data\Connection\UserRoleConnectionResolver;
 use WPGraphQL\Data\DataSource;
-use \WPGraphQL\Model\User as UserModel;
+use WPGraphQL\Model\User as UserModel;
 use WPGraphQL\Type\Connection\PostObjects;
 
 /**
@@ -181,7 +181,6 @@ class User {
 
 						],
 						'resolve' => static function ( $user, $args, $context, $info ) {
-
 							$avatar_args = [];
 							if ( is_numeric( $args['size'] ) ) {
 								$avatar_args['size'] = absint( $args['size'] );

--- a/src/Type/Union/MenuItemObjectUnion.php
+++ b/src/Type/Union/MenuItemObjectUnion.php
@@ -2,7 +2,6 @@
 
 namespace WPGraphQL\Type\Union;
 
-use Exception;
 use WPGraphQL\Model\Post;
 use WPGraphQL\Model\Term;
 use WPGraphQL\Registry\TypeRegistry;
@@ -24,7 +23,6 @@ class MenuItemObjectUnion {
 	 * @throws \Exception
 	 */
 	public static function register_type( TypeRegistry $type_registry ) {
-
 		register_graphql_union_type(
 			'MenuItemObjectUnion',
 			[

--- a/src/Type/Union/PostObjectUnion.php
+++ b/src/Type/Union/PostObjectUnion.php
@@ -2,7 +2,6 @@
 
 namespace WPGraphQL\Type\Union;
 
-use Exception;
 use WPGraphQL\Registry\TypeRegistry;
 
 /**

--- a/src/Type/Union/TermObjectUnion.php
+++ b/src/Type/Union/TermObjectUnion.php
@@ -1,7 +1,6 @@
 <?php
 namespace WPGraphQL\Type\Union;
 
-use Exception;
 use WPGraphQL\Registry\TypeRegistry;
 
 /**
@@ -39,7 +38,6 @@ class TermObjectUnion {
 					}
 
 					return ! empty( $type ) ? $type : null;
-
 				},
 			]
 		);

--- a/src/Type/WPConnectionType.php
+++ b/src/Type/WPConnectionType.php
@@ -138,7 +138,6 @@ class WPConnectionType {
 	 * @throws \Exception
 	 */
 	public function __construct( array $config, TypeRegistry $type_registry ) {
-
 		$this->type_registry = $type_registry;
 
 		/**
@@ -199,7 +198,6 @@ class WPConnectionType {
 	 * @return void
 	 */
 	protected function validate_config( array $config ): void {
-
 		if ( ! array_key_exists( 'fromType', $config ) ) {
 			throw new InvalidArgument( __( 'Connection config needs to have at least a fromType defined', 'wp-graphql' ) );
 		}
@@ -211,7 +209,6 @@ class WPConnectionType {
 		if ( ! array_key_exists( 'fromFieldName', $config ) || ! is_string( $config['fromFieldName'] ) ) {
 			throw new InvalidArgument( __( 'Connection config needs to have "fromFieldName" defined as a string value', 'wp-graphql' ) );
 		}
-
 	}
 
 	/**
@@ -258,7 +255,6 @@ class WPConnectionType {
 		}
 
 		return $connection_name;
-
 	}
 
 	/**
@@ -270,7 +266,6 @@ class WPConnectionType {
 	 * @throws \Exception
 	 */
 	protected function register_connection_input() {
-
 		if ( empty( $this->connection_args ) ) {
 			return;
 		}
@@ -300,7 +295,6 @@ class WPConnectionType {
 				'type'        => $this->connection_name . 'WhereArgs',
 			],
 		];
-
 	}
 
 	/**
@@ -311,7 +305,6 @@ class WPConnectionType {
 	 * @throws \Exception
 	 */
 	protected function register_one_to_one_connection_edge_type(): void {
-
 		if ( $this->type_registry->has_type( $this->connection_name . 'Edge' ) ) {
 			return;
 		}
@@ -355,21 +348,22 @@ class WPConnectionType {
 	 * @throws \Exception
 	 */
 	public function register_connection_page_info_type(): void {
-
 		if ( $this->type_registry->has_type( $this->connection_name . 'PageInfo' ) ) {
 			return;
 		}
 
-		$this->type_registry->register_object_type( $this->connection_name . 'PageInfo', [
-			'interfaces'  => [ $this->to_type . 'ConnectionPageInfo' ],
-			'description' => sprintf(
-				// translators: %s is the name of the connection.
-				__( 'Page Info on the "%s"', 'wp-graphql' ),
-				$this->connection_name
-			),
-			'fields'      => PageInfo::get_fields(),
-		] );
-
+		$this->type_registry->register_object_type(
+			$this->connection_name . 'PageInfo',
+			[
+				'interfaces'  => [ $this->to_type . 'ConnectionPageInfo' ],
+				'description' => sprintf(
+					// translators: %s is the name of the connection.
+					__( 'Page Info on the "%s"', 'wp-graphql' ),
+					$this->connection_name
+				),
+				'fields'      => PageInfo::get_fields(),
+			] 
+		);
 	}
 
 	/**
@@ -380,7 +374,6 @@ class WPConnectionType {
 	 * @throws \Exception
 	 */
 	protected function register_connection_edge_type(): void {
-
 		if ( $this->type_registry->has_type( $this->connection_name . 'Edge' ) ) {
 			return;
 		}
@@ -413,7 +406,6 @@ class WPConnectionType {
 				),
 			]
 		);
-
 	}
 
 	/**
@@ -424,7 +416,6 @@ class WPConnectionType {
 	 * @throws \Exception
 	 */
 	protected function register_connection_type(): void {
-
 		if ( $this->type_registry->has_type( $this->connection_name ) ) {
 			return;
 		}
@@ -451,7 +442,6 @@ class WPConnectionType {
 				'fields'            => $this->get_connection_fields(),
 			]
 		);
-
 	}
 
 	/**
@@ -460,7 +450,6 @@ class WPConnectionType {
 	 * @return array
 	 */
 	protected function get_connection_fields(): array {
-
 		return array_merge(
 			[
 				'pageInfo' => [
@@ -479,7 +468,6 @@ class WPConnectionType {
 			],
 			$this->connection_fields
 		);
-
 	}
 
 	/**
@@ -488,13 +476,9 @@ class WPConnectionType {
 	 * @return array|array[]
 	 */
 	protected function get_pagination_args(): array {
-
 		if ( true === $this->one_to_one ) {
-
 			$pagination_args = [];
-
 		} else {
-
 			$pagination_args = [
 				'first'  => [
 					'type'        => 'Int',
@@ -513,7 +497,6 @@ class WPConnectionType {
 					'description' => __( 'Cursor used along with the "last" argument to reference where in the dataset to get data', 'wp-graphql' ),
 				],
 			];
-
 		}
 
 		return $pagination_args;
@@ -529,37 +512,39 @@ class WPConnectionType {
 
 		// merge the config so the raw data passed to the connection
 		// is passed to the field and can be accessed via $info in resolvers
-		$field_config = array_merge( $this->config, [
-			'type'                  => true === $this->one_to_one ? $this->connection_name . 'Edge' : $this->connection_name,
-			'args'                  => array_merge( $this->get_pagination_args(), $this->where_args ),
-			'auth'                  => $this->auth,
-			'deprecationReason'     => ! empty( $this->config['deprecationReason'] ) ? $this->config['deprecationReason'] : null,
-			'description'           => ! empty( $this->config['description'] ) 
-				? $this->config['description']
-				: sprintf(
-					// translators: the placeholders are the name of the Types the connection is between.
-					__( 'Connection between the %1$s type and the %2$s type', 'wp-graphql' ),
-					$this->from_type,
-					$this->to_type
-				),
-			'resolve'               => function ( $root, $args, $context, $info ) {
-				$context->connection_query_class = $this->query_class;
-				$resolve_connection              = $this->resolve_connection;
+		$field_config = array_merge(
+			$this->config,
+			[
+				'type'                  => true === $this->one_to_one ? $this->connection_name . 'Edge' : $this->connection_name,
+				'args'                  => array_merge( $this->get_pagination_args(), $this->where_args ),
+				'auth'                  => $this->auth,
+				'deprecationReason'     => ! empty( $this->config['deprecationReason'] ) ? $this->config['deprecationReason'] : null,
+				'description'           => ! empty( $this->config['description'] ) 
+					? $this->config['description']
+					: sprintf(
+						// translators: the placeholders are the name of the Types the connection is between.
+						__( 'Connection between the %1$s type and the %2$s type', 'wp-graphql' ),
+						$this->from_type,
+						$this->to_type
+					),
+				'resolve'               => function ( $root, $args, $context, $info ) {
+					$context->connection_query_class = $this->query_class;
+					$resolve_connection              = $this->resolve_connection;
 
-				/**
-				 * Return the results of the connection resolver
-				 */
-				return $resolve_connection( $root, $args, $context, $info );
-			},
-			'allowFieldUnderscores' => isset( $this->config['allowFieldUnderscores'] ) && true === $this->config['allowFieldUnderscores'],
-		] );
+					/**
+					 * Return the results of the connection resolver
+					 */
+					return $resolve_connection( $root, $args, $context, $info );
+				},
+				'allowFieldUnderscores' => isset( $this->config['allowFieldUnderscores'] ) && true === $this->config['allowFieldUnderscores'],
+			] 
+		);
 
 		$this->type_registry->register_field(
 			$this->from_type,
 			$this->from_field_name,
 			$field_config
 		);
-
 	}
 
 	/**
@@ -567,63 +552,68 @@ class WPConnectionType {
 	 * @throws \Exception
 	 */
 	public function register_connection_interfaces(): void {
-
 		$connection_edge_type = Utils::format_type_name( $this->to_type . 'ConnectionEdge' );
 
 		if ( ! $this->type_registry->has_type( $this->to_type . 'ConnectionPageInfo' ) ) {
-			$this->type_registry->register_interface_type( $this->to_type . 'ConnectionPageInfo', [
-				'interfaces'  => [ 'WPPageInfo' ],
-				// translators: %s is the name of the connection edge.
-				'description' => sprintf( __( 'Page Info on the connected %s', 'wp-graphql' ), $connection_edge_type ),
-				'fields'      => PageInfo::get_fields(),
-			] );
+			$this->type_registry->register_interface_type(
+				$this->to_type . 'ConnectionPageInfo',
+				[
+					'interfaces'  => [ 'WPPageInfo' ],
+					// translators: %s is the name of the connection edge.
+					'description' => sprintf( __( 'Page Info on the connected %s', 'wp-graphql' ), $connection_edge_type ),
+					'fields'      => PageInfo::get_fields(),
+				] 
+			);
 		}
 
 
 		if ( ! $this->type_registry->has_type( $connection_edge_type ) ) {
-
-			$this->type_registry->register_interface_type( $connection_edge_type, [
-				'interfaces'  => [ 'Edge' ],
-				// translators: %s is the name of the type the connection edge is to.
-				'description' => sprintf( __( 'Edge between a Node and a connected %s', 'wp-graphql' ), $this->to_type ),
-				'fields'      => [
-					'node' => [
-						'type'        => [ 'non_null' => $this->to_type ],
-						// translators: %s is the name of the type the connection edge is to.
-						'description' => sprintf( __( 'The connected %s Node', 'wp-graphql' ), $this->to_type ),
+			$this->type_registry->register_interface_type(
+				$connection_edge_type,
+				[
+					'interfaces'  => [ 'Edge' ],
+					// translators: %s is the name of the type the connection edge is to.
+					'description' => sprintf( __( 'Edge between a Node and a connected %s', 'wp-graphql' ), $this->to_type ),
+					'fields'      => [
+						'node' => [
+							'type'        => [ 'non_null' => $this->to_type ],
+							// translators: %s is the name of the type the connection edge is to.
+							'description' => sprintf( __( 'The connected %s Node', 'wp-graphql' ), $this->to_type ),
+						],
 					],
-				],
-			] );
-
+				] 
+			);
 		}
 
 		if ( ! $this->one_to_one && ! $this->type_registry->has_type( $this->to_type . 'Connection' ) ) {
-			$this->type_registry->register_interface_type( $this->to_type . 'Connection', [
-				'interfaces'  => [ 'Connection' ],
-				// translators: %s is the name of the type the connection is to.
-				'description' => sprintf( __( 'Connection to %s Nodes', 'wp-graphql' ), $this->to_type ),
-				'fields'      => [
-					'edges'    => [
-						'type'        => [ 'non_null' => [ 'list_of' => [ 'non_null' => $connection_edge_type ] ] ],
-						'description' => sprintf(
-							// translators: %1$s is the name of the type the connection is from, %2$s is the name of the type the connection is to.
-							__( 'A list of edges (relational context) between %1$s and connected %2$s Nodes', 'wp-graphql' ),
-							$this->from_type,
-							$this->to_type
-						),
+			$this->type_registry->register_interface_type(
+				$this->to_type . 'Connection',
+				[
+					'interfaces'  => [ 'Connection' ],
+					// translators: %s is the name of the type the connection is to.
+					'description' => sprintf( __( 'Connection to %s Nodes', 'wp-graphql' ), $this->to_type ),
+					'fields'      => [
+						'edges'    => [
+							'type'        => [ 'non_null' => [ 'list_of' => [ 'non_null' => $connection_edge_type ] ] ],
+							'description' => sprintf(
+								// translators: %1$s is the name of the type the connection is from, %2$s is the name of the type the connection is to.
+								__( 'A list of edges (relational context) between %1$s and connected %2$s Nodes', 'wp-graphql' ),
+								$this->from_type,
+								$this->to_type
+							),
+						],
+						'pageInfo' => [
+							'type' => [ 'non_null' => $this->to_type . 'ConnectionPageInfo' ],
+						],
+						'nodes'    => [
+							'type'        => [ 'non_null' => [ 'list_of' => [ 'non_null' => $this->to_type ] ] ],
+							// translators: %s is the name of the type the connection is to.
+							'description' => sprintf( __( 'A list of connected %s Nodes', 'wp-graphql' ), $this->to_type ),
+						],
 					],
-					'pageInfo' => [
-						'type' => [ 'non_null' => $this->to_type . 'ConnectionPageInfo' ],
-					],
-					'nodes'    => [
-						'type'        => [ 'non_null' => [ 'list_of' => [ 'non_null' => $this->to_type ] ] ],
-						// translators: %s is the name of the type the connection is to.
-						'description' => sprintf( __( 'A list of connected %s Nodes', 'wp-graphql' ), $this->to_type ),
-					],
-				],
-			] );
+				] 
+			);
 		}
-
 	}
 
 	/**
@@ -636,7 +626,6 @@ class WPConnectionType {
 	 * @throws \Exception
 	 */
 	public function register_connection(): void {
-
 		$this->register_connection_input();
 
 		if ( false !== $this->include_default_interfaces ) {
@@ -652,7 +641,6 @@ class WPConnectionType {
 		}
 
 		$this->register_connection_field();
-
 	}
 
 	/**

--- a/src/Type/WPEnumType.php
+++ b/src/Type/WPEnumType.php
@@ -31,7 +31,6 @@ class WPEnumType extends EnumType {
 	 * @return string
 	 */
 	public static function get_safe_name( string $value ) {
-
 		$replaced = preg_replace( '#[^A-z0-9]#', '_', $value );
 
 		if ( ! empty( $replaced ) ) {
@@ -96,7 +95,6 @@ class WPEnumType extends EnumType {
 		 * @since 0.0.5
 		 */
 		return $values;
-
 	}
 
 }

--- a/src/Type/WPInterfaceTrait.php
+++ b/src/Type/WPInterfaceTrait.php
@@ -20,7 +20,6 @@ trait WPInterfaceTrait {
 	 * @return array
 	 */
 	protected function get_implemented_interfaces(): array {
-
 		if ( ! isset( $this->config['interfaces'] ) || ! is_array( $this->config['interfaces'] ) || empty( $this->config['interfaces'] ) ) {
 			$interfaces = parent::getInterfaces();
 		} else {
@@ -43,7 +42,6 @@ trait WPInterfaceTrait {
 		$new_interfaces = [];
 
 		foreach ( $interfaces as $interface ) {
-
 			if ( $interface instanceof InterfaceType && $interface->name !== $this->name ) {
 				$new_interfaces[ $interface->name ] = $interface;
 				continue;
@@ -104,7 +102,6 @@ trait WPInterfaceTrait {
 		}
 
 		return array_unique( $new_interfaces );
-
 	}
 
 }

--- a/src/Type/WPInterfaceType.php
+++ b/src/Type/WPInterfaceType.php
@@ -2,7 +2,6 @@
 
 namespace WPGraphQL\Type;
 
-use Exception;
 use GraphQL\Type\Definition\InterfaceType;
 use WPGraphQL\Registry\TypeRegistry;
 
@@ -31,7 +30,6 @@ class WPInterfaceType extends InterfaceType {
 	 * @throws \Exception
 	 */
 	public function __construct( array $config, TypeRegistry $type_registry ) {
-
 		$this->type_registry = $type_registry;
 
 		$this->config = $config;
@@ -39,7 +37,6 @@ class WPInterfaceType extends InterfaceType {
 		$name             = ucfirst( $config['name'] );
 		$config['name']   = apply_filters( 'graphql_type_name', $name, $config, $this );
 		$config['fields'] = function () use ( $config ) {
-
 			$fields = $config['fields'];
 
 			/**
@@ -48,11 +45,9 @@ class WPInterfaceType extends InterfaceType {
 			 * Types are still responsible for ensuring the fields resolve properly.
 			 */
 			if ( ! empty( $this->getInterfaces() ) && is_array( $this->getInterfaces() ) ) {
-
 				$interface_fields = [];
 
 				foreach ( $this->getInterfaces() as $interface_type ) {
-
 					if ( ! $interface_type instanceof InterfaceType ) {
 						$interface_type = $this->type_registry->get_type( $interface_type );
 					}

--- a/src/Type/WPMutationType.php
+++ b/src/Type/WPMutationType.php
@@ -1,7 +1,6 @@
 <?php
 namespace WPGraphQL\Type;
 
-use Closure;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
 use WPGraphQL\Registry\TypeRegistry;
@@ -128,25 +127,29 @@ class WPMutationType {
 	 * @return bool
 	 */
 	protected function is_config_valid( array $config ): bool {
-
 		$is_valid = true;
 
 		if ( ! array_key_exists( 'name', $config ) || ! is_string( $config['name'] ) ) {
-			graphql_debug( __( 'Mutation config needs to have a valid name.', 'wp-graphql' ), [
-				'config' => $config,
-			] );
+			graphql_debug(
+				__( 'Mutation config needs to have a valid name.', 'wp-graphql' ),
+				[
+					'config' => $config,
+				] 
+			);
 			$is_valid = false;
 		}
 
 		if ( ! array_key_exists( 'mutateAndGetPayload', $config ) || ! is_callable( $config['mutateAndGetPayload'] ) ) {
-			graphql_debug( __( 'Mutation config needs to have "mutateAndGetPayload" defined as a callable.', 'wp-graphql' ), [
-				'config' => $config,
-			] );
+			graphql_debug(
+				__( 'Mutation config needs to have "mutateAndGetPayload" defined as a callable.', 'wp-graphql' ),
+				[
+					'config' => $config,
+				] 
+			);
 			$is_valid = false;
 		}
 
 		return (bool) $is_valid;
-
 	}
 
 	/**
@@ -298,8 +301,8 @@ class WPMutationType {
 	 * @throws \Exception
 	 */
 	protected function register_mutation_field() : void {
-
-		$field_config = array_merge( $this->config,
+		$field_config = array_merge(
+			$this->config,
 			[
 				'args'        => [
 					'input' => [

--- a/src/Type/WPObjectType.php
+++ b/src/Type/WPObjectType.php
@@ -6,7 +6,6 @@ use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\ObjectType;
 use WPGraphQL\Data\DataSource;
 use WPGraphQL\Registry\TypeRegistry;
-use WPGraphQL\Type\InterfaceType\Node;
 
 /**
  * Class WPObjectType
@@ -81,7 +80,6 @@ class WPObjectType extends ObjectType {
 		 * @return array|mixed
 		 */
 		$config['fields'] = function () use ( $config ) {
-
 			$fields = $config['fields'];
 
 			/**
@@ -90,11 +88,9 @@ class WPObjectType extends ObjectType {
 			 * Types are still responsible for ensuring the fields resolve properly.
 			 */
 			if ( ! empty( $this->getInterfaces() ) && is_array( $this->getInterfaces() ) ) {
-
 				$interface_fields = [];
 
 				foreach ( $this->getInterfaces() as $interface_type ) {
-
 					if ( ! $interface_type instanceof InterfaceType ) {
 						$interface_type = $this->type_registry->get_type( $interface_type );
 					}
@@ -155,14 +151,12 @@ class WPObjectType extends ObjectType {
 	 * @since 0.0.5
 	 */
 	public static function node_interface() {
-
 		if ( null === self::$node_interface ) {
 			$node_interface       = DataSource::get_node_definition();
 			self::$node_interface = $node_interface['nodeInterface'];
 		}
 
 		return self::$node_interface;
-
 	}
 
 	/**

--- a/src/Type/WPScalar.php
+++ b/src/Type/WPScalar.php
@@ -18,7 +18,6 @@ class WPScalar extends CustomScalarType {
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 */
 	public function __construct( array $config, TypeRegistry $type_registry ) {
-
 		$name           = $config['name'];
 		$config['name'] = apply_filters( 'graphql_type_name', $name, $config, $this );
 		$config         = apply_filters( 'graphql_custom_scalar_config', $config, $type_registry );

--- a/src/Type/WPUnionType.php
+++ b/src/Type/WPUnionType.php
@@ -30,7 +30,6 @@ class WPUnionType extends UnionType {
 	 * @since 0.0.30
 	 */
 	public function __construct( array $config, TypeRegistry $type_registry ) {
-
 		$this->type_registry = $type_registry;
 
 		/**

--- a/src/Utils/DebugLog.php
+++ b/src/Utils/DebugLog.php
@@ -49,7 +49,6 @@ class DebugLog {
 	 * @return array
 	 */
 	public function add_log_entry( $message, $config = [] ) {
-
 		if ( empty( $message ) ) {
 			return [];
 		}
@@ -75,10 +74,13 @@ class DebugLog {
 		}
 
 		if ( ! isset( $this->logs[ wp_json_encode( $message ) ] ) ) {
-			$log_entry = array_merge( [
-				'type'    => $type,
-				'message' => $message,
-			], $config );
+			$log_entry = array_merge(
+				[
+					'type'    => $type,
+					'message' => $message,
+				],
+				$config 
+			);
 
 			$this->logs[ wp_json_encode( $message ) ] = $log_entry;
 
@@ -92,7 +94,6 @@ class DebugLog {
 		}
 
 		return [];
-
 	}
 
 	/**

--- a/src/Utils/InstrumentSchema.php
+++ b/src/Utils/InstrumentSchema.php
@@ -2,7 +2,6 @@
 
 namespace WPGraphQL\Utils;
 
-use Exception;
 use GraphQL\Error\UserError;
 use GraphQL\Executor\Executor;
 use GraphQL\Type\Definition\FieldDefinition;
@@ -24,7 +23,6 @@ class InstrumentSchema {
 	 * @return \GraphQL\Type\Definition\Type
 	 */
 	public static function instrument_resolvers( Type $type, string $type_name ): Type {
-
 		if ( ! method_exists( $type, 'getFields' ) ) {
 			return $type;
 		}
@@ -37,7 +35,6 @@ class InstrumentSchema {
 		$type->config['fields'] = $fields;
 
 		return $type;
-
 	}
 
 	/**
@@ -52,7 +49,6 @@ class InstrumentSchema {
 	 * @return mixed
 	 */
 	protected static function wrap_fields( array $fields, string $type_name ) {
-
 		if ( empty( $fields ) || ! is_array( $fields ) ) {
 			return $fields;
 		}
@@ -149,7 +145,6 @@ class InstrumentSchema {
 						$result = Executor::defaultFieldResolver( $source, $args, $context, $info );
 					} else {
 						$result = $field_resolver( $source, $args, $context, $info );
-
 					}
 				}
 
@@ -184,7 +179,6 @@ class InstrumentSchema {
 				do_action( 'graphql_after_resolve_field', $source, $args, $context, $info, $field_resolver, $type_name, $field_key, $field, $result );
 
 				return $result;
-
 			};
 		}
 
@@ -192,7 +186,6 @@ class InstrumentSchema {
 		 * Return the fields
 		 */
 		return $fields;
-
 	}
 
 	/**
@@ -214,7 +207,6 @@ class InstrumentSchema {
 	 * @throws \GraphQL\Error\UserError
 	 */
 	public static function check_field_permissions( $source, array $args, AppContext $context, ResolveInfo $info, $field_resolver, string $type_name, string $field_key, FieldDefinition $field ) {
-
 		if ( ( ! isset( $field->config['auth'] ) || ! is_array( $field->config['auth'] ) ) && ! isset( $field->config['isPrivate'] ) ) {
 			return;
 		}
@@ -237,7 +229,6 @@ class InstrumentSchema {
 		 * execute the callback before continuing resolution
 		 */
 		if ( isset( $field->config['auth']['callback'] ) && is_callable( $field->config['auth']['callback'] ) ) {
-
 			$authorized = call_user_func( $field->config['auth']['callback'], $field, $field_key, $source, $args, $context, $info, $field_resolver );
 
 			// If callback returns explicit false throw.
@@ -278,7 +269,6 @@ class InstrumentSchema {
 				throw new UserError( $auth_error );
 			}
 		}
-
 	}
 
 }

--- a/src/Utils/Preview.php
+++ b/src/Utils/Preview.php
@@ -21,7 +21,6 @@ class Preview {
 	 * @return mixed
 	 */
 	public static function filter_post_meta_for_previews( $default_value, int $object_id, ?string $meta_key = null, ?bool $single = false ) {
-
 		if ( ! is_graphql_request() ) {
 			return $default_value;
 		}
@@ -52,11 +51,9 @@ class Preview {
 			$meta_key = ! empty( $meta_key ) ? $meta_key : '';
 
 			return isset( $parent->ID ) && absint( $parent->ID ) ? get_post_meta( $parent->ID, $meta_key, (bool) $single ) : $default_value;
-
 		}
 
 		return $default_value;
-
 	}
 
 }

--- a/src/Utils/QueryAnalyzer.php
+++ b/src/Utils/QueryAnalyzer.php
@@ -2,10 +2,7 @@
 
 namespace WPGraphQL\Utils;
 
-use Exception;
 use GraphQL\Error\SyntaxError;
-use GraphQL\Language\AST\Node;
-use GraphQL\Language\AST\TypeDefinitionNode;
 use GraphQL\Language\Parser;
 use GraphQL\Language\Visitor;
 use GraphQL\Server\OperationParams;
@@ -17,11 +14,7 @@ use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Schema;
 use GraphQL\Utils\TypeInfo;
-use GraphQLRelay\Relay;
-use Hoa\Math\Util;
-use WPGraphQL\Model\Model;
 use WPGraphQL\Request;
-use WPGraphQL\Type\WPConnectionType;
 use WPGraphQL\WPSchema;
 
 /**
@@ -176,11 +169,15 @@ class QueryAnalyzer {
 		add_filter( 'graphql_dataloader_get_model', [ $this, 'track_nodes' ], 10, 1 );
 
 		// Expose query analyzer data in extensions
-		add_filter( 'graphql_request_results', [
-			$this,
-			'show_query_analyzer_in_extensions',
-		], 10, 5 );
-
+		add_filter(
+			'graphql_request_results',
+			[
+				$this,
+				'show_query_analyzer_in_extensions',
+			],
+			10,
+			5 
+		);
 	}
 
 	/**
@@ -223,7 +220,6 @@ class QueryAnalyzer {
 		 * @param string        $query          The query string being executed
 		 */
 		do_action( 'graphql_determine_graphql_keys', $this, $query );
-
 	}
 
 	/**
@@ -257,7 +253,6 @@ class QueryAnalyzer {
 		$runtime_nodes = apply_filters( 'graphql_query_analyzer_get_runtime_nodes', $this->runtime_nodes );
 
 		return array_unique( $runtime_nodes );
-
 	}
 
 	/**
@@ -273,7 +268,6 @@ class QueryAnalyzer {
 	 * @return string|null
 	 */
 	public function get_operation_name(): ?string {
-
 		$operation_name = ! empty( $this->request->params->operation ) ? $this->request->params->operation : null;
 
 		if ( empty( $operation_name ) ) {
@@ -311,13 +305,11 @@ class QueryAnalyzer {
 	 * @return  \GraphQL\Type\Definition\Type|String|null
 	 */
 	public static function get_wrapped_field_type( Type $type, FieldDefinition $field_def, $parent_type, bool $is_list_type = false ) {
-
 		if ( ! isset( $parent_type->name ) || 'RootQuery' !== $parent_type->name ) {
 			return null;
 		}
 
 		if ( $type instanceof NonNull || $type instanceof ListOfType ) {
-
 			if ( $type instanceof ListOfType && isset( $parent_type->name ) && 'RootQuery' === $parent_type->name ) {
 				$is_list_type = true;
 			}
@@ -327,14 +319,15 @@ class QueryAnalyzer {
 
 		// Determine if we're dealing with a connection
 		if ( $type instanceof ObjectType || $type instanceof InterfaceType ) {
-
 			$interfaces      = method_exists( $type, 'getInterfaces' ) ? $type->getInterfaces() : [];
-			$interface_names = ! empty( $interfaces ) ? array_map( static function ( InterfaceType $interface ) {
-				return $interface->name;
-			}, $interfaces ) : [];
+			$interface_names = ! empty( $interfaces ) ? array_map(
+				static function ( InterfaceType $interface ) {
+					return $interface->name;
+				},
+				$interfaces 
+			) : [];
 
 			if ( array_key_exists( 'Connection', $interface_names ) ) {
-
 				if ( isset( $field_def->config['fromType'] ) && ( 'rootquery' !== strtolower( $field_def->config['fromType'] ) ) ) {
 					return null;
 				}
@@ -444,7 +437,6 @@ class QueryAnalyzer {
 				} else {
 					$type_map[] = 'list:' . strtolower( $field_type );
 				}
-
 			},
 			'leave' => static function ( $node, $key, $parent, $path, $ancestors ) use ( $type_info ) {
 				$type_info->leave( $node );
@@ -501,7 +493,6 @@ class QueryAnalyzer {
 				}
 
 				if ( empty( $this->root_operation ) ) {
-
 					if ( $type === $schema->getQueryType() ) {
 						$this->root_operation = 'Query';
 					}
@@ -618,7 +609,6 @@ class QueryAnalyzer {
 	 * @return mixed
 	 */
 	public function track_nodes( $model ) {
-
 		if ( isset( $model->id ) && in_array( get_class( $model ), $this->get_query_models(), true ) ) {
 			// Is this model type part of the requested/returned data in the asked for query?
 
@@ -649,7 +639,6 @@ class QueryAnalyzer {
 	 * @return array
 	 */
 	public function get_graphql_keys() {
-
 		if ( ! empty( $this->graphql_keys ) ) {
 			return $this->graphql_keys;
 		}
@@ -678,7 +667,6 @@ class QueryAnalyzer {
 		}
 
 		if ( ! empty( $keys ) ) {
-
 			$all_keys = implode( ' ', array_unique( array_values( $keys ) ) );
 
 			// Use the header_length_limit to wrap the words with a separator
@@ -731,18 +719,24 @@ class QueryAnalyzer {
 		 * @param array  $return_keys_array  The keys returned to the X-GraphQL-Keys header, in array instead of string
 		 * @param array  $skipped_keys_array The keys skipped, in array instead of string
 		 */
-		$this->graphql_keys = apply_filters( 'graphql_query_analyzer_graphql_keys', [
-			'keys'             => $return_keys,
-			'keysLength'       => strlen( $return_keys ),
-			'keysCount'        => ! empty( $return_keys_array ) ? count( $return_keys_array ) : 0,
-			'skippedKeys'      => $this->skipped_keys,
-			'skippedKeysSize'  => strlen( $this->skipped_keys ),
-			'skippedKeysCount' => ! empty( $skipped_keys_array ) ? count( $skipped_keys_array ) : 0,
-			'skippedTypes'     => $skipped_types,
-		], $return_keys, $this->skipped_keys, $return_keys_array, $skipped_keys_array );
+		$this->graphql_keys = apply_filters(
+			'graphql_query_analyzer_graphql_keys',
+			[
+				'keys'             => $return_keys,
+				'keysLength'       => strlen( $return_keys ),
+				'keysCount'        => ! empty( $return_keys_array ) ? count( $return_keys_array ) : 0,
+				'skippedKeys'      => $this->skipped_keys,
+				'skippedKeysSize'  => strlen( $this->skipped_keys ),
+				'skippedKeysCount' => ! empty( $skipped_keys_array ) ? count( $skipped_keys_array ) : 0,
+				'skippedTypes'     => $skipped_types,
+			],
+			$return_keys,
+			$this->skipped_keys,
+			$return_keys_array,
+			$skipped_keys_array 
+		);
 
 		return $this->graphql_keys;
-
 	}
 
 
@@ -754,11 +748,9 @@ class QueryAnalyzer {
 	 * @return array
 	 */
 	public function get_headers( array $headers = [] ): array {
-
 		$keys = $this->get_graphql_keys();
 
 		if ( ! empty( $keys ) ) {
-
 			$headers['X-GraphQL-Query-ID'] = $this->query_id ?: null;
 			$headers['X-GraphQL-Keys']     = $keys['keys'] ?: null;
 		}
@@ -778,7 +770,6 @@ class QueryAnalyzer {
 	 * @return array|object|null
 	 */
 	public function show_query_analyzer_in_extensions( $response, WPSchema $schema, ?string $operation_name, ?string $request, ?array $variables ) {
-
 		$should = \WPGraphQL::debug();
 
 		/**
@@ -809,7 +800,6 @@ class QueryAnalyzer {
 		}
 
 		return $response;
-
 	}
 
 }

--- a/src/Utils/QueryLog.php
+++ b/src/Utils/QueryLog.php
@@ -2,8 +2,6 @@
 
 namespace WPGraphQL\Utils;
 
-use WPGraphQL\WPSchema;
-
 /**
  * Class QueryLog
  *
@@ -34,7 +32,7 @@ class QueryLog {
 
 		// Check whether Query Logs have been enabled from the settings page
 		$enabled                  = get_graphql_setting( 'query_logs_enabled', 'off' );
-		$this->query_logs_enabled = 'on' === $enabled ? true : false;
+		$this->query_logs_enabled = 'on' === $enabled;
 
 		$this->query_log_user_role = get_graphql_setting( 'query_log_user_role', 'manage_options' );
 
@@ -65,7 +63,6 @@ class QueryLog {
 	 * @return boolean
 	 */
 	public function user_can_see_logs() {
-
 		$can_see = false;
 
 		// If logs are disabled, user cannot see logs
@@ -94,7 +91,6 @@ class QueryLog {
 		 * @param boolean $can_see Whether the requestor can see the logs or not
 		 */
 		return apply_filters( 'graphql_user_can_see_query_logs', $can_see );
-
 	}
 
 	/**
@@ -109,7 +105,6 @@ class QueryLog {
 	 * @return array
 	 */
 	public function show_results( $response, $schema, $operation_name, $request, $variables ) {
-
 		$query_log = $this->get_query_log();
 
 		// If the user cannot see the logs, return the response as-is without the logs
@@ -127,7 +122,6 @@ class QueryLog {
 		}
 
 		return $response;
-
 	}
 
 	/**
@@ -149,13 +143,16 @@ class QueryLog {
 		$trace = [ $default_message ];
 
 		if ( ! empty( $wpdb->queries ) && is_array( $wpdb->queries ) ) {
-			$queries = array_map( static function ( $query ) {
-				return [
-					'sql'   => $query[0],
-					'time'  => $query[1],
-					'stack' => $query[2],
-				];
-			}, $wpdb->queries );
+			$queries = array_map(
+				static function ( $query ) {
+					return [
+						'sql'   => $query[0],
+						'time'  => $query[1],
+						'stack' => $query[2],
+					];
+				},
+				$wpdb->queries 
+			);
 
 			$times      = wp_list_pluck( $queries, 'time' );
 			$total_time = array_sum( $times );
@@ -173,7 +170,6 @@ class QueryLog {
 		 * @param \WPGraphQL\Utils\QueryLog $instance The QueryLog class instance
 		 */
 		return apply_filters( 'graphql_tracing_response', $trace, $this );
-
 	}
 
 }

--- a/src/Utils/Tracing.php
+++ b/src/Utils/Tracing.php
@@ -97,10 +97,15 @@ class Tracing {
 		add_filter( 'do_graphql_request', [ $this, 'init_trace' ] );
 		add_action( 'graphql_execute', [ $this, 'end_trace' ], 99, 0 );
 		add_filter( 'graphql_access_control_allow_headers', [ $this, 'return_tracing_headers' ] );
-		add_filter( 'graphql_request_results', [
-			$this,
-			'add_tracing_to_response_extensions',
-		], 10, 1 );
+		add_filter(
+			'graphql_request_results',
+			[
+				$this,
+				'add_tracing_to_response_extensions',
+			],
+			10,
+			1 
+		);
 		add_action( 'graphql_before_resolve_field', [ $this, 'init_field_resolver_trace' ], 10, 4 );
 		add_action( 'graphql_after_resolve_field', [ $this, 'end_field_resolver_trace' ], 10 );
 	}
@@ -146,7 +151,6 @@ class Tracing {
 			'startOffset'    => $this->get_start_offset(),
 			'startMicrotime' => microtime( true ),
 		];
-
 	}
 
 	/**
@@ -155,7 +159,6 @@ class Tracing {
 	 * @return void
 	 */
 	public function end_field_resolver_trace() {
-
 		if ( ! empty( $this->field_trace ) ) {
 			$this->field_trace['duration'] = $this->get_field_resolver_duration();
 			$sanitized_trace               = $this->sanitize_resolver_trace( $this->field_trace );
@@ -192,12 +195,14 @@ class Tracing {
 	 * @return mixed
 	 */
 	public function sanitize_resolver_trace( array $trace ) {
-
 		$sanitized_trace                = [];
-		$sanitized_trace['path']        = ! empty( $trace['path'] ) && is_array( $trace['path'] ) ? array_map( [
-			$this,
-			'sanitize_trace_resolver_path',
-		], $trace['path'] ) : [];
+		$sanitized_trace['path']        = ! empty( $trace['path'] ) && is_array( $trace['path'] ) ? array_map(
+			[
+				$this,
+				'sanitize_trace_resolver_path',
+			],
+			$trace['path'] 
+		) : [];
 		$sanitized_trace['parentType']  = ! empty( $trace['parentType'] ) ? esc_html( $trace['parentType'] ) : '';
 		$sanitized_trace['fieldName']   = ! empty( $trace['fieldName'] ) ? esc_html( $trace['fieldName'] ) : '';
 		$sanitized_trace['returnType']  = ! empty( $trace['returnType'] ) ? esc_html( $trace['returnType'] ) : '';
@@ -300,7 +305,6 @@ class Tracing {
 	 * @return boolean
 	 */
 	public function user_can_see_trace_data(): bool {
-
 		$can_see = false;
 
 		// If logs are disabled, user cannot see logs
@@ -328,7 +332,6 @@ class Tracing {
 		 * @param boolean $can_see Whether the requestor can see the logs or not
 		 */
 		return apply_filters( 'graphql_user_can_see_trace_data', $can_see );
-
 	}
 
 	/**

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -3,7 +3,6 @@
 namespace WPGraphQL\Utils;
 
 use GraphQLRelay\Relay;
-use WPGraphQL\Model\Model;
 
 class Utils {
 
@@ -27,23 +26,22 @@ class Utils {
 			$query_ast = \GraphQL\Language\Parser::parse( $query );
 			$query     = \GraphQL\Language\Printer::doPrint( $query_ast );
 			return hash( $hash_algorithm, $query );
-		} catch ( \Exception $exception ) {
+		} catch ( \Throwable $exception ) {
 			return null;
 		}
-
 	}
 
 	/**
-	 * Maps new input query args and sa nitizes the input
+	 * Maps new input query args and sanitizes the input
 	 *
 	 * @param mixed|array|string $args The raw query args from the GraphQL query
 	 * @param mixed|array|string $map  The mapping of where each of the args should go
+	 * @param string[]           $skip Fields to skipped and not be added to the output array.
 	 *
 	 * @return array
 	 * @since  0.5.0
 	 */
-	public static function map_input( $args, $map ) {
-
+	public static function map_input( $args, $map, $skip = [] ) {
 		if ( ! is_array( $args ) || ! is_array( $map ) ) {
 			return [];
 		}
@@ -51,6 +49,9 @@ class Utils {
 		$query_args = [];
 
 		foreach ( $args as $arg => $value ) {
+			if ( [] !== $skip && in_array( $arg, $skip, true ) ) {
+				continue;
+			}
 
 			if ( is_array( $value ) && ! empty( $value ) ) {
 				$value = array_map(
@@ -75,7 +76,6 @@ class Utils {
 		}
 
 		return $query_args;
-
 	}
 
 	/**
@@ -111,7 +111,6 @@ class Utils {
 	 * @return string
 	 */
 	public static function format_field_name( string $field_name, bool $allow_underscores = false ): string {
-
 		$replaced = preg_replace( '[^a-zA-Z0-9 -]', '_', $field_name );
 
 		// If any values were replaced, use the replaced string as the new field name

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -127,7 +127,7 @@ final class WPGraphQL {
 
 		// Plugin version.
 		if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-			define( 'WPGRAPHQL_VERSION', '1.14.10' );
+			define( 'WPGRAPHQL_VERSION', '1.15.0' );
 		}
 
 		// Plugin Folder Path.

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -4,15 +4,12 @@
 
 use WPGraphQL\Utils\Preview;
 use WPGraphQL\Utils\InstrumentSchema;
-use GraphQL\Error\UserError;
 use WPGraphQL\Admin\Admin;
 use WPGraphQL\AppContext;
 use WPGraphQL\Registry\SchemaRegistry;
 use WPGraphQL\Registry\TypeRegistry;
 use WPGraphQL\Router;
-use WPGraphQL\Type\WPInterfaceType;
 use WPGraphQL\Type\WPObjectType;
-use WPGraphQL\WPSchema;
 
 /**
  * Class WPGraphQL
@@ -100,7 +97,6 @@ final class WPGraphQL {
 	public function __clone() {
 		// Cloning instances of the class is forbidden.
 		_doing_it_wrong( __FUNCTION__, esc_html__( 'The WPGraphQL class should not be cloned.', 'wp-graphql' ), '0.0.1' );
-
 	}
 
 	/**
@@ -112,7 +108,6 @@ final class WPGraphQL {
 	public function __wakeup() {
 		// De-serializing instances of the class is forbidden.
 		_doing_it_wrong( __FUNCTION__, esc_html__( 'De-serializing instances of the WPGraphQL class is not allowed', 'wp-graphql' ), '0.0.1' );
-
 	}
 
 	/**
@@ -149,7 +144,6 @@ final class WPGraphQL {
 		if ( ! defined( 'GRAPHQL_MIN_PHP_VERSION' ) ) {
 			define( 'GRAPHQL_MIN_PHP_VERSION', '7.1' );
 		}
-
 	}
 
 	/**
@@ -170,7 +164,6 @@ final class WPGraphQL {
 		 * so this is set to false for tests.
 		 */
 		if ( defined( 'WPGRAPHQL_AUTOLOAD' ) && true === WPGRAPHQL_AUTOLOAD ) {
-
 			if ( file_exists( WPGRAPHQL_PLUGIN_DIR . 'vendor/autoload.php' ) ) {
 				// Autoload Required Classes.
 				require_once WPGRAPHQL_PLUGIN_DIR . 'vendor/autoload.php';
@@ -180,11 +173,9 @@ final class WPGraphQL {
 			// detected. This likely means the user cloned the repo from Github
 			// but did not run `composer install`
 			if ( ! class_exists( 'GraphQL\GraphQL' ) ) {
-
 				add_action(
 					'admin_notices',
 					static function () {
-
 						if ( ! current_user_can( 'manage_options' ) ) {
 							return;
 						}
@@ -203,7 +194,6 @@ final class WPGraphQL {
 		}
 
 		return true;
-
 	}
 
 	/**
@@ -239,7 +229,6 @@ final class WPGraphQL {
 		add_action(
 			'after_setup_theme',
 			static function () {
-
 				new \WPGraphQL\Data\Config();
 				$router = new Router();
 				$router->init();
@@ -288,14 +277,16 @@ final class WPGraphQL {
 		// Initialize Admin functionality
 		add_action( 'after_setup_theme', [ $this, 'init_admin' ] );
 
-		add_action('init_graphql_request', static function () {
-			$tracing = new \WPGraphQL\Utils\Tracing();
-			$tracing->init();
+		add_action(
+			'init_graphql_request',
+			static function () {
+				$tracing = new \WPGraphQL\Utils\Tracing();
+				$tracing->init();
 
-			$query_log = new \WPGraphQL\Utils\QueryLog();
-			$query_log->init();
-		});
-
+				$query_log = new \WPGraphQL\Utils\QueryLog();
+				$query_log->init();
+			}
+		);
 	}
 
 	/**
@@ -318,7 +309,6 @@ final class WPGraphQL {
 				)
 			);
 		}
-
 	}
 
 	/**
@@ -331,7 +321,6 @@ final class WPGraphQL {
 		if ( ! defined( 'WPGRAPHQL_PLUGIN_URL' ) ) {
 			define( 'WPGRAPHQL_PLUGIN_URL', plugin_dir_url( dirname( __DIR__ ) . '/wp-graphql.php' ) );
 		}
-
 	}
 
 	/**
@@ -381,10 +370,15 @@ final class WPGraphQL {
 		);
 
 		// Filter how metadata is retrieved during GraphQL requests
-		add_filter('get_post_metadata', [
-			Preview::class,
-			'filter_post_meta_for_previews',
-		], 10, 4);
+		add_filter(
+			'get_post_metadata',
+			[
+				Preview::class,
+				'filter_post_meta_for_previews',
+			],
+			10,
+			4
+		);
 
 		/**
 		 * Adds back compat support for the `graphql_object_type_interfaces` filter which was renamed
@@ -392,23 +386,25 @@ final class WPGraphQL {
 		 *
 		 * @deprecated
 		 */
-		add_filter('graphql_type_interfaces', static function ( $interfaces, $config, $type ) {
+		add_filter(
+			'graphql_type_interfaces',
+			static function ( $interfaces, $config, $type ) {
+				if ( $type instanceof WPObjectType ) {
+					/**
+					 * Filters the interfaces applied to an object type
+					 *
+					 * @param array                              $interfaces List of interfaces applied to the Object Type
+					 * @param array                              $config     The config for the Object Type
+					 * @param mixed|\WPGraphQL\Type\WPInterfaceType|\WPGraphQL\Type\WPObjectType $type The Type instance
+					 */
+					return apply_filters_deprecated( 'graphql_object_type_interfaces', [ $interfaces, $config, $type ], '1.4.1', 'graphql_type_interfaces' );
+				}
 
-			if ( $type instanceof WPObjectType ) {
-				/**
-				 * Filters the interfaces applied to an object type
-				 *
-				 * @param array                              $interfaces List of interfaces applied to the Object Type
-				 * @param array                              $config     The config for the Object Type
-				 * @param mixed|\WPGraphQL\Type\WPInterfaceType|\WPGraphQL\Type\WPObjectType $type The Type instance
-				 */
-				return apply_filters_deprecated( 'graphql_object_type_interfaces', [ $interfaces, $config, $type ], '1.4.1', 'graphql_type_interfaces' );
-			}
-
-			return $interfaces;
-
-		}, 10, 3);
-
+				return $interfaces;
+			},
+			10,
+			3
+		);
 	}
 
 	/**
@@ -428,12 +424,12 @@ final class WPGraphQL {
 	 * @since  0.0.2
 	 */
 	public static function show_in_graphql() {
-		add_filter( 'register_post_type_args', [ __CLASS__, 'setup_default_post_types' ], 10, 2 );
-		add_filter( 'register_taxonomy_args', [ __CLASS__, 'setup_default_taxonomies' ], 10, 2 );
+		add_filter( 'register_post_type_args', [ self::class, 'setup_default_post_types' ], 10, 2 );
+		add_filter( 'register_taxonomy_args', [ self::class, 'setup_default_taxonomies' ], 10, 2 );
 
 		// Run late so the user can filter the args themselves.
-		add_filter( 'register_post_type_args', [ __CLASS__, 'register_graphql_post_type_args' ], 99, 2 );
-		add_filter( 'register_taxonomy_args', [ __CLASS__, 'register_graphql_taxonomy_args' ], 99, 2 );
+		add_filter( 'register_post_type_args', [ self::class, 'register_graphql_post_type_args' ], 99, 2 );
+		add_filter( 'register_taxonomy_args', [ self::class, 'register_graphql_taxonomy_args' ], 99, 2 );
 	}
 
 	/**
@@ -518,7 +514,6 @@ final class WPGraphQL {
 		$graphql_args = apply_filters( 'register_graphql_post_type_args', $graphql_args, $post_type_name );
 
 		return wp_parse_args( $args, $graphql_args );
-
 	}
 
 	/**
@@ -548,7 +543,6 @@ final class WPGraphQL {
 		$graphql_args = apply_filters( 'register_graphql_taxonomy_args', $graphql_args, $taxonomy_name );
 
 		return wp_parse_args( $args, $graphql_args );
-
 	}
 
 	/**
@@ -557,7 +551,6 @@ final class WPGraphQL {
 	 * @since 1.12.0
 	 */
 	public static function get_default_graphql_type_args(): array {
-
 		return [
 			// The "kind" of GraphQL type to register. Can be `interface`, `object`, or `union`.
 			'graphql_kind'                     => 'object',
@@ -629,31 +622,33 @@ final class WPGraphQL {
 			$allowed_post_type_names = apply_filters( 'graphql_post_entities_allowed_post_types', $post_type_names, $post_type_objects );
 
 			// Filter the post type objects if the list of allowed types have changed.
-			$post_type_objects = array_filter( $post_type_objects, static function ( $obj ) use ( $allowed_post_type_names ) {
+			$post_type_objects = array_filter(
+				$post_type_objects,
+				static function ( $obj ) use ( $allowed_post_type_names ) {
+					if ( empty( $obj->graphql_plural_name ) && ! empty( $obj->graphql_single_name ) ) {
+						$obj->graphql_plural_name = $obj->graphql_single_name;
+					}
 
-				if ( empty( $obj->graphql_plural_name ) && ! empty( $obj->graphql_single_name ) ) {
-					$obj->graphql_plural_name = $obj->graphql_single_name;
+					/**
+					 * Validate that the post_types have a graphql_single_name and graphql_plural_name
+					 */
+					if ( empty( $obj->graphql_single_name ) || empty( $obj->graphql_plural_name ) ) {
+						graphql_debug(
+							sprintf(
+							/* translators: %s will replaced with the registered type */
+								__( 'The "%s" post_type isn\'t configured properly to show in GraphQL. It needs a "graphql_single_name" and a "graphql_plural_name"', 'wp-graphql' ),
+								$obj->name
+							),
+							[
+								'invalid_post_type' => $obj,
+							]
+						);
+						return false;
+					}
+
+					return in_array( $obj->name, $allowed_post_type_names, true );
 				}
-
-				/**
-				 * Validate that the post_types have a graphql_single_name and graphql_plural_name
-				 */
-				if ( empty( $obj->graphql_single_name ) || empty( $obj->graphql_plural_name ) ) {
-					graphql_debug(
-						sprintf(
-						/* translators: %s will replaced with the registered type */
-							__( 'The "%s" post_type isn\'t configured properly to show in GraphQL. It needs a "graphql_single_name" and a "graphql_plural_name"', 'wp-graphql' ),
-							$obj->name
-						),
-						[
-							'invalid_post_type' => $obj,
-						]
-					);
-					return false;
-				}
-
-				return in_array( $obj->name, $allowed_post_type_names, true );
-			});
+			);
 
 			self::$allowed_post_types = $post_type_objects;
 		}
@@ -712,31 +707,33 @@ final class WPGraphQL {
 			 */
 			$allowed_tax_names = apply_filters( 'graphql_term_entities_allowed_taxonomies', $tax_names, $tax_objects );
 
-			$tax_objects = array_filter( $tax_objects, static function ( $obj ) use ( $allowed_tax_names ) {
+			$tax_objects = array_filter(
+				$tax_objects,
+				static function ( $obj ) use ( $allowed_tax_names ) {
+					if ( empty( $obj->graphql_plural_name ) && ! empty( $obj->graphql_single_name ) ) {
+						$obj->graphql_plural_name = $obj->graphql_single_name;
+					}
 
-				if ( empty( $obj->graphql_plural_name ) && ! empty( $obj->graphql_single_name ) ) {
-					$obj->graphql_plural_name = $obj->graphql_single_name;
+					/**
+					 * Validate that the post_types have a graphql_single_name and graphql_plural_name
+					 */
+					if ( empty( $obj->graphql_single_name ) || empty( $obj->graphql_plural_name ) ) {
+						graphql_debug(
+							sprintf(
+							/* translators: %s will replaced with the registered taxonomty */
+								__( 'The "%s" taxonomy isn\'t configured properly to show in GraphQL. It needs a "graphql_single_name" and a "graphql_plural_name"', 'wp-graphql' ),
+								$obj->name
+							),
+							[
+								'invalid_taxonomy' => $obj,
+							]
+						);
+						return false;
+					}
+
+					return in_array( $obj->name, $allowed_tax_names, true );
 				}
-
-				/**
-				 * Validate that the post_types have a graphql_single_name and graphql_plural_name
-				 */
-				if ( empty( $obj->graphql_single_name ) || empty( $obj->graphql_plural_name ) ) {
-					graphql_debug(
-						sprintf(
-						/* translators: %s will replaced with the registered taxonomty */
-							__( 'The "%s" taxonomy isn\'t configured properly to show in GraphQL. It needs a "graphql_single_name" and a "graphql_plural_name"', 'wp-graphql' ),
-							$obj->name
-						),
-						[
-							'invalid_taxonomy' => $obj,
-						]
-					);
-					return false;
-				}
-
-				return in_array( $obj->name, $allowed_tax_names, true );
-			});
+			);
 
 			self::$allowed_taxonomies = $tax_objects;
 		}
@@ -776,7 +773,6 @@ final class WPGraphQL {
 	 */
 	public static function get_schema() {
 		if ( null === self::$schema ) {
-
 			$schema_registry = new SchemaRegistry();
 			$schema          = $schema_registry->get_schema();
 
@@ -832,7 +828,6 @@ final class WPGraphQL {
 	 */
 	public static function get_type_registry() {
 		if ( null === self::$type_registry ) {
-
 			$type_registry = new TypeRegistry();
 
 			/**
@@ -856,7 +851,6 @@ final class WPGraphQL {
 		 * Return the Schema after applying filters
 		 */
 		return ! empty( self::$type_registry ) ? self::$type_registry : null;
-
 	}
 
 	/**

--- a/src/WPSchema.php
+++ b/src/WPSchema.php
@@ -38,7 +38,6 @@ class WPSchema extends Schema {
 	 * @since 0.0.9
 	 */
 	public function __construct( SchemaConfig $config, TypeRegistry $type_registry ) {
-
 		$this->config = $config;
 
 		/**

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.14.10
+ * Version: 1.15.0
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.14.10
+ * @version  1.15.0
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
# Release Notes

### New Features

- [#2908](https://github.com/wp-graphql/wp-graphql/pull/2908): feat: Skip param added to Utils::map_input(). Thanks @kidunot89!

### Chores / Bugfixes

- [#2907](https://github.com/wp-graphql/wp-graphql/pull/2907): ci: Use WP 6.3 image, not the beta one
- [#2902](https://github.com/wp-graphql/wp-graphql/pull/2902): chore: handle unused variables (phpcs). Thanks @justlevine!
- [#2901](https://github.com/wp-graphql/wp-graphql/pull/2901): chore: remove useless ternaries (phpcs). Thanks @justlevine!
- [#2898](https://github.com/wp-graphql/wp-graphql/pull/2898): chore: restore excluded PHPCS sniffs. Thanks @justlevine!
- [#2899](https://github.com/wp-graphql/wp-graphql/pull/2899): chore: Configure PHPCS blank line check and autofix. Thanks @justlevine!
- [#2900](https://github.com/wp-graphql/wp-graphql/pull/2900): chore: implement PHPCS sniffs from Slevomat Coding Standards. Thanks @justlevine!
- [#2897](https://github.com/wp-graphql/wp-graphql/pull/2897): fix: default excerptRendered to empty string. Thanks @izzygld!
- [#2890](https://github.com/wp-graphql/wp-graphql/pull/2890): fix: Use hostname for graphql cache header url for varnish
- [#2892](https://github.com/wp-graphql/wp-graphql/pull/2889): chore: GitHub template tweaks. Thanks @justlevine!
- [#2889](https://github.com/wp-graphql/wp-graphql/pull/2889): ci: update tests to test against WordPress 6.3, simplify the matrix
- [#2891](https://github.com/wp-graphql/wp-graphql/pull/2891): chore: bump graphql-php to 14.11.10 and update Composer dev-deps. Thanks @justlevine!
