### PR TITLE
fix: use graphqlendpoint without scheme in url header

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -314,6 +314,10 @@ class Router {
 			]
 		);
 
+		// For cache url header, use the domain without protocol. Path for when it's multisite.
+		// Remove the starting http://, https://, :// from the full hostname/path.
+		$host_and_path = preg_replace( '#^.*?://#', '', graphql_get_endpoint_url() );
+
 		$headers = [
 			'Access-Control-Allow-Origin'  => '*',
 			'Access-Control-Allow-Headers' => implode( ', ', $access_control_allow_headers ),
@@ -322,7 +326,7 @@ class Router {
 			'Content-Type'                 => 'application/json ; charset=' . get_option( 'blog_charset' ),
 			'X-Robots-Tag'                 => 'noindex',
 			'X-Content-Type-Options'       => 'nosniff',
-			'X-GraphQL-URL'                => graphql_get_endpoint_url(),
+			'X-GraphQL-URL'                => $host_and_path,
 		];
 
 


### PR DESCRIPTION

What does this implement/fix? Explain your changes.
---------------------------------------------------
…Reopen the reverted [PR](https://github.com/wp-graphql/wp-graphql/pull/2904)

Strip the https://, https:// or :// from the graphql url endpoint used in thr graphql-url header.  This impacts network cache invalidation.

Blocks smart-cache matching [change](https://github.com/wp-graphql/wp-graphql/pull/2904)


Does this close any currently open issues?
------------------------------------------
smart cache [issue](https://github.com/wp-graphql/wp-graphql-smart-cache/pull/247)


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
<!-- (If it’s long, please paste to https://ghostbin.com/ and insert the link here.) -->


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
