### PR TITLE
fix: zip artifact in GH not in subfolder

### DIFF
--- a/.github/workflows/deploy-to-wordpress.yml
+++ b/.github/workflows/deploy-to-wordpress.yml
@@ -28,8 +28,7 @@ jobs:
           SLUG: wp-graphql
       - name: Create Artifact
         run: |
-          mkdir plugin-build
-          composer archive -vvv --format=zip --file="plugin-build/wp-graphql"
+          composer run-script zip
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 1.16.0
+
+### Upgrade Notice
+
+**WPGraphQL Smart Cache**
+For WPGraphQL Smart Cache users, you should update WPGraphQL Smart Cache to v1.2.0 when updating 
+WPGraphQL to v1.16.0 to ensure caches continue to purge as expected.
+
+**Cursor Pagination Updates**
+This version fixes some behaviors of Cursor Pagination which _may_ lead to behavior changes in your application.
+
+As with any release, we recommend you test in staging environments. For this release, specifically any 
+queries you have using pagination arguments (`first`, `last`, `after`, `before`). 
+
+### New Features
+
+- [#2918](https://github.com/wp-graphql/wp-graphql/pull/2918): feat: Use graphql endpoint without scheme in url header. 
+- [#2882](https://github.com/wp-graphql/wp-graphql/pull/2882): feat: Config and Cursor Classes refactor
+
 ## 1.15.0
 
 ### New Features

--- a/composer.json
+++ b/composer.json
@@ -103,5 +103,6 @@
 			"rsync -rc --exclude-from=.distignore --exclude=plugin-build . plugin-build/wp-graphql/ --delete --delete-excluded -v",
 			"cd plugin-build ; zip -r wp-graphql.zip wp-graphql",
 			"rm -rf plugin-build/wp-graphql/"
+		]
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -94,19 +94,12 @@
 		],
 		"phpstan": [
 			"phpstan analyze --ansi --memory-limit=2G"
-		]
-	},
-	"archive": {
-		"exclude": [
-			"*.yml",
-			"!vendor/",
-			"plugin-build/",
-			"node_modules/",
-			"!.wordpress-org/",
-			"docs/",
-			"wp-graphql.zip",
-			"!build",
-			"packages"
+		],
+		"zip": [
+			"mkdir -p plugin-build/wp-graphql",
+			"rsync -rc --exclude-from=.distignore --exclude=plugin-build . plugin-build/wp-graphql/ --delete --delete-excluded -v",
+			"cd plugin-build ; zip -r wp-graphql.zip wp-graphql",
+			"rm -rf plugin-build/wp-graphql/"
 		]
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -95,11 +95,13 @@
 		"phpstan": [
 			"phpstan analyze --ansi --memory-limit=2G"
 		],
+		"build-plugin": [
+			"composer install --no-dev && composer run-script zip && composer install"
+		],
 		"zip": [
 			"mkdir -p plugin-build/wp-graphql",
 			"rsync -rc --exclude-from=.distignore --exclude=plugin-build . plugin-build/wp-graphql/ --delete --delete-excluded -v",
 			"cd plugin-build ; zip -r wp-graphql.zip wp-graphql",
 			"rm -rf plugin-build/wp-graphql/"
-		]
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, JSON, API, Gatsby, Faust, Headless, Decoupled, Svelte, React, Nex
 Requires at least: 5.0
 Tested up to: 6.2
 Requires PHP: 7.1
-Stable tag: 1.15.0
+Stable tag: 1.16.0
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -86,6 +86,18 @@ Integrating Appsero SDK **DOES NOT IMMEDIATELY** start gathering data, **without
 Learn more about how [Appsero collects and uses this data](https://appsero.com/privacy-policy/).
 
 == Upgrade Notice ==
+
+= 1.16.0 =
+
+**WPGraphQL Smart Cache**
+For WPGraphQL Smart Cache users, you should update WPGraphQL Smart Cache to v1.2.0 when updating
+WPGraphQL to v1.16.0 to ensure caches continue to purge as expected.
+
+**Cursor Pagination Updates**
+This version fixes some behaviors of Cursor Pagination which _may_ lead to behavior changes in your application.
+
+As with any release, we recommend you test in staging environments. For this release, specifically any
+queries you have using pagination arguments (`first`, `last`, `after`, `before`).
 
 = 1.14.6 =
 
@@ -239,6 +251,14 @@ The `uri` field was non-null on some Types in the Schema but has been changed to
 Composer dependencies are no longer versioned in Github. Recommended install source is WordPress.org or using Composer to get the code from Packagist.org or WPackagist.org.
 
 == Changelog ==
+
+= 1.16.0 =
+
+### New Features
+
+- [#2918](https://github.com/wp-graphql/wp-graphql/pull/2918): feat: Use graphql endpoint without scheme in url header.
+- [#2882](https://github.com/wp-graphql/wp-graphql/pull/2882): feat: Config and Cursor Classes refactor
+
 
 = 1.15.0 =
 

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -122,7 +122,7 @@ final class WPGraphQL {
 
 		// Plugin version.
 		if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-			define( 'WPGRAPHQL_VERSION', '1.15.0' );
+			define( 'WPGRAPHQL_VERSION', '1.16.0' );
 		}
 
 		// Plugin Folder Path.

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.15.0
+ * Version: 1.16.0
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.15.0
+ * @version  1.16.0
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [ ] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
…The downloadable zip files in the 'assets' for a release [page](https://github.com/wp-graphql/wp-graphql/tags) in GitHub, do not use a subfolder folder as the [plugin](https://wordpress.org/plugins/wpgraphql-smart-cache/) downloaded from wordpress.org does. 

The rsync in this PR is similar to how the 10up WordPress deploy works. 10up/action-wordpress-plugin-deploy

Add this as a composer command to be useable locally.

Similar to wp-graphql-smart-cache [fix](https://github.com/wp-graphql/wp-graphql-smart-cache/issues/256).

Does this close any currently open issues?
------------------------------------------
<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
<!-- (If it’s long, please paste to https://ghostbin.com/ and insert the link here.) -->


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
