### PR TITLE
chore: remove unused parameters from resolver callbacks

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -10606,16 +10606,16 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "3.0.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "bb792cb331472b82c5d7f28fb9b8ec2d20f68826"
+                "reference": "b4caf9689f1a0e4a4c632679a44e638c1c67aff1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/bb792cb331472b82c5d7f28fb9b8ec2d20f68826",
-                "reference": "bb792cb331472b82c5d7f28fb9b8ec2d20f68826",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/b4caf9689f1a0e4a4c632679a44e638c1c67aff1",
+                "reference": "b4caf9689f1a0e4a4c632679a44e638c1c67aff1",
                 "shasum": ""
             },
             "require": {
@@ -10662,7 +10662,13 @@
                 "source": "https://github.com/WordPress/WordPress-Coding-Standards",
                 "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
-            "time": "2023-08-21T14:28:38+00:00"
+            "funding": [
+                {
+                    "url": "https://opencollective.com/thewpcc/contribute/wp-php-63406",
+                    "type": "custom"
+                }
+            ],
+            "time": "2023-09-14T07:06:09+00:00"
         },
         {
             "name": "wp-graphql/wp-graphql-testcase",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -88,8 +88,6 @@
 
 		<!-- This would be a breaking change to fix-->
 		<exclude name="WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid" />
-
-		<!-- Maybe should be added back -->
 		<exclude name="Generic.CodeAnalysis.UnusedFunctionParameter" />
 	</rule>
 

--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -49,7 +49,7 @@ class Admin {
 				'admin_menu',
 				static function () {
 					remove_menu_page( 'wp-graphiql/wp-graphiql.php' );
-				} 
+				}
 			);
 		}
 

--- a/src/Admin/GraphiQL/GraphiQL.php
+++ b/src/Admin/GraphiQL/GraphiQL.php
@@ -69,7 +69,7 @@ class GraphiQL {
     background-image:url(\'%s\'); float:left; width:22px !important; height:22px !important;
     margin-left: 5px !important; margin-top: 5px !important; margin-right: 5px !important;
     "></span>',
-			$icon_url 
+			$icon_url
 		);
 
 		$admin_bar->add_menu(
@@ -77,7 +77,7 @@ class GraphiQL {
 				'id'    => 'graphiql-ide',
 				'title' => $icon . __( 'GraphiQL IDE', 'wp-graphql' ),
 				'href'  => trailingslashit( admin_url() ) . 'admin.php?page=graphiql-ide',
-			] 
+			]
 		);
 	}
 

--- a/src/Admin/Settings/Settings.php
+++ b/src/Admin/Settings/Settings.php
@@ -88,7 +88,7 @@ class Settings {
 			'graphql_general_settings',
 			[
 				'title' => __( 'WPGraphQL General Settings', 'wp-graphql' ),
-			] 
+			]
 		);
 
 		$custom_endpoint = apply_filters( 'graphql_endpoint', null );
@@ -237,7 +237,7 @@ class Settings {
 					'value'    => true === \WPGraphQL::debug() ? 'on' : get_graphql_setting( 'public_introspection_enabled', 'off' ),
 					'disabled' => true === \WPGraphQL::debug(),
 				],
-			] 
+			]
 		);
 
 		// Action to hook into to register settings

--- a/src/AppContext.php
+++ b/src/AppContext.php
@@ -153,7 +153,7 @@ class AppContext {
 	 * @deprecated Use get_loader instead.
 	 */
 	public function getLoader( $key ) {
-		_deprecated_function( __METHOD__, '0.8.4', self::class . '::get_loader()' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		_deprecated_function( __METHOD__, '0.8.4', self::class . '::get_loader()' );
 		return $this->get_loader( $key );
 	}
 
@@ -180,7 +180,7 @@ class AppContext {
 	 * @return array|mixed
 	 */
 	public function getConnectionArgs() {
-		_deprecated_function( __METHOD__, '0.8.4', self::class . '::get_connection_args()' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		_deprecated_function( __METHOD__, '0.8.4', self::class . '::get_connection_args()' );
 		return $this->get_connection_args();
 	}
 

--- a/src/Data/Config.php
+++ b/src/Data/Config.php
@@ -104,7 +104,7 @@ class Config {
 						[
 							$query->query_where,
 							&$query,
-						] 
+						]
 					);
 
 					/**
@@ -118,7 +118,7 @@ class Config {
 						[
 							$query->query_orderby,
 							&$query,
-						] 
+						]
 					);
 				}
 
@@ -174,11 +174,11 @@ class Config {
 
 		/**
 		 * If pre-filter hooked, return $pre_orderby.
-		 * 
+		 *
 		 * @param null|string $pre_orderby The pre-filtered ORDER BY clause of the query.
 		 * @param string      $orderby     The ORDER BY clause of the query.
 		 * @param \WP_Query   $query       The WP_Query instance (passed by reference).
-		 * 
+		 *
 		 * @return null|string
 		 */
 		$pre_orderby = apply_filters( 'graphql_pre_wp_query_cursor_pagination_stability', null, $orderby, $query );
@@ -225,11 +225,11 @@ class Config {
 
 		/**
 		 * If pre-filter hooked, return $pre_where.
-		 * 
+		 *
 		 * @param null|string $pre_where The pre-filtered WHERE clause of the query.
 		 * @param string     $where     The WHERE clause of the query.
 		 * @param \WP_Query  $query     The WP_Query instance (passed by reference).
-		 * 
+		 *
 		 * @return null|string
 		 */
 		$pre_where = apply_filters( 'graphql_pre_wp_query_cursor_pagination_support', null, $where, $query );
@@ -276,11 +276,11 @@ class Config {
 
 		/**
 		 * If pre-filter hooked, return $pre_orderby.
-		 * 
+		 *
 		 * @param null|string     $pre_orderby The pre-filtered ORDER BY clause of the query.
 		 * @param string          $orderby     The ORDER BY clause of the query.
 		 * @param \WP_User_Query  $query       The WP_User_Query instance (passed by reference).
-		 * 
+		 *
 		 * @return null|string
 		 */
 		$pre_orderby = apply_filters( 'graphql_pre_wp_user_query_cursor_pagination_stability', null, $orderby, $query );
@@ -327,11 +327,11 @@ class Config {
 
 		/**
 		 * If pre-filter hooked, return $pre_where.
-		 * 
+		 *
 		 * @param null|string    $pre_where The pre-filtered WHERE clause of the query.
 		 * @param string         $where     The WHERE clause of the query.
 		 * @param \WP_User_Query $query     The WP_Query instance (passed by reference).
-		 * 
+		 *
 		 * @return null|string
 		 */
 		$pre_where = apply_filters( 'graphql_pre_wp_user_query_cursor_pagination_support', null, $where, $query );
@@ -380,12 +380,12 @@ class Config {
 
 		/**
 		 * If pre-filter hooked, return $pre_pieces.
-		 * 
+		 *
 		 * @param null|array $pre_pieces The pre-filtered term query SQL clauses.
 		 * @param array      $pieces     Terms query SQL clauses.
 		 * @param array      $taxonomies An array of taxonomies.
 		 * @param array      $args       An array of terms query arguments.
-		 * 
+		 *
 		 * @return null|array
 		 */
 		$pre_pieces = apply_filters( 'graphql_pre_wp_term_query_cursor_pagination_support', null, $pieces, $taxonomies, $args );
@@ -442,11 +442,11 @@ class Config {
 
 		/**
 		 * If pre-filter hooked, return $pre_pieces.
-		 * 
+		 *
 		 * @param null|array        $pre_pieces The pre-filtered comment query clauses.
 		 * @param array             $pieces     A compacted array of comment query clauses.
 		 * @param \WP_Comment_Query $query      Current instance of WP_Comment_Query, passed by reference.
-		 * 
+		 *
 		 * @return null|array
 		 */
 		$pre_pieces = apply_filters( 'graphql_pre_wp_comments_query_cursor_pagination_support', null, $pieces, $query );

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -230,7 +230,7 @@ abstract class AbstractConnectionResolver {
 	 * @codeCoverageIgnore
 	 */
 	public function getArgs(): array {
-		_deprecated_function( __METHOD__, '1.11.0', static::class . '::get_args()' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		_deprecated_function( __METHOD__, '1.11.0', static::class . '::get_args()' );
 		return $this->get_args();
 	}
 
@@ -283,7 +283,7 @@ abstract class AbstractConnectionResolver {
 	 * @codeCoverageIgnore
 	 */
 	public function setQueryArg( $key, $value ) {
-		_deprecated_function( __METHOD__, '0.3.0', static::class . '::set_query_arg()' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		_deprecated_function( __METHOD__, '0.3.0', static::class . '::set_query_arg()' );
 
 		return $this->set_query_arg( $key, $value );
 	}
@@ -618,7 +618,7 @@ abstract class AbstractConnectionResolver {
 	 * @return int|mixed
 	 */
 	public function get_offset() {
-		_deprecated_function( __METHOD__, '1.9.0', static::class . '::get_offset_for_cursor()' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		_deprecated_function( __METHOD__, '1.9.0', static::class . '::get_offset_for_cursor()' );
 
 		// Using shorthand since this is for deprecated code.
 		$cursor = $this->args['after'] ?? null;
@@ -639,7 +639,7 @@ abstract class AbstractConnectionResolver {
 
 		// We avoid using ArrayConnection::cursorToOffset() because it assumes an `int` offset.
 		if ( ! empty( $cursor ) ) {
-			$offset = substr( base64_decode( $cursor ), strlen( 'arrayconnection:' ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+			$offset = substr( base64_decode( $cursor ), strlen( 'arrayconnection:' ) );
 		}
 
 		/**
@@ -795,7 +795,7 @@ abstract class AbstractConnectionResolver {
 	 * @return string
 	 */
 	protected function get_cursor_for_node( $id ) {
-		return base64_encode( 'arrayconnection:' . $id ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+		return base64_encode( 'arrayconnection:' . $id );
 	}
 
 	/**

--- a/src/Data/Connection/CommentConnectionResolver.php
+++ b/src/Data/Connection/CommentConnectionResolver.php
@@ -229,7 +229,7 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 								static function ( $id ) {
 									return Utils::get_database_id_from_id( $id );
 								},
-								$input_value 
+								$input_value
 							);
 							break;
 						}
@@ -247,7 +247,7 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 
 								return Utils::get_database_id_from_id( $id );
 							},
-							$input_value 
+							$input_value
 						);
 						break;
 				}

--- a/src/Data/Connection/CommentConnectionResolver.php
+++ b/src/Data/Connection/CommentConnectionResolver.php
@@ -294,7 +294,7 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 			'contentAuthorNotIn' => 'post_author__not_in',
 			'contentId'          => 'post_id',
 			'contentIdIn'        => 'post__in',
-			'contentIdNotIn'     => 'post__not_in', // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn
+			'contentIdNotIn'     => 'post__not_in',
 			'contentName'        => 'post_name',
 			'contentParent'      => 'post_parent',
 			'contentStatus'      => 'post_status',

--- a/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
@@ -35,7 +35,7 @@ class EnqueuedScriptsConnectionResolver extends AbstractConnectionResolver {
 				return $max;
 			},
 			10,
-			5 
+			5
 		);
 
 		parent::__construct( $source, $args, $context, $info );

--- a/src/Data/Connection/EnqueuedStylesheetConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedStylesheetConnectionResolver.php
@@ -41,7 +41,7 @@ class EnqueuedStylesheetConnectionResolver extends AbstractConnectionResolver {
 				return $max;
 			},
 			10,
-			5 
+			5
 		);
 
 		parent::__construct( $source, $args, $context, $info );

--- a/src/Data/Connection/MenuItemConnectionResolver.php
+++ b/src/Data/Connection/MenuItemConnectionResolver.php
@@ -44,12 +44,12 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 		$query_args['order']   = isset( $last ) ? 'DESC' : 'ASC';
 
 		if ( isset( $this->args['where']['parentDatabaseId'] ) ) {
-			$query_args['meta_key']   = '_menu_item_menu_item_parent'; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+			$query_args['meta_key']   = '_menu_item_menu_item_parent';
 			$query_args['meta_value'] = (int) $this->args['where']['parentDatabaseId']; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 		}
 
 		if ( ! empty( $this->args['where']['parentId'] ) || ( isset( $this->args['where']['parentId'] ) && 0 === (int) $this->args['where']['parentId'] ) ) {
-			$query_args['meta_key']   = '_menu_item_menu_item_parent'; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+			$query_args['meta_key']   = '_menu_item_menu_item_parent';
 			$query_args['meta_value'] = $this->args['where']['parentId']; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 		}
 

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -408,7 +408,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 			'in'            => 'post__in',
 			'mimeType'      => 'post_mime_type',
 			'nameIn'        => 'post_name__in',
-			'notIn'         => 'post__not_in', // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn
+			'notIn'         => 'post__not_in',
 			'parent'        => 'post_parent',
 			'parentIn'      => 'post_parent__in',
 			'parentNotIn'   => 'post_parent__not_in',

--- a/src/Data/Connection/TermObjectConnectionResolver.php
+++ b/src/Data/Connection/TermObjectConnectionResolver.php
@@ -285,7 +285,7 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 								static function ( $id ) {
 									return Utils::get_database_id_from_id( $id );
 								},
-								$input_value 
+								$input_value
 							);
 							break;
 						}

--- a/src/Data/Cursor/AbstractCursor.php
+++ b/src/Data/Cursor/AbstractCursor.php
@@ -86,7 +86,7 @@ abstract class AbstractCursor {
 			$offset = $this->get_query_var( 'graphql_cursor_offset' );
 
 			if ( ! empty( $offset ) ) {
-				_doing_it_wrong( self::class . "::get_query_var('graphql_cursor_offset')", "Use 'graphql_before_cursor' or 'graphql_after_cursor' instead.", '1.9.0' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				_doing_it_wrong( self::class . "::get_query_var('graphql_cursor_offset')", "Use 'graphql_before_cursor' or 'graphql_after_cursor' instead.", '1.9.0' );
 			}
 		}
 

--- a/src/Data/Cursor/PostObjectCursor.php
+++ b/src/Data/Cursor/PostObjectCursor.php
@@ -79,7 +79,7 @@ class PostObjectCursor extends AbstractCursor {
 	 * @return ?\WP_Post
 	 */
 	public function get_cursor_post() {
-		_deprecated_function( __METHOD__, '1.9.0', self::class . '::get_cursor_node()' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		_deprecated_function( __METHOD__, '1.9.0', self::class . '::get_cursor_node()' );
 
 		return $this->cursor_node;
 	}

--- a/src/Data/Cursor/TermObjectCursor.php
+++ b/src/Data/Cursor/TermObjectCursor.php
@@ -30,7 +30,7 @@ class TermObjectCursor extends AbstractCursor {
 	 * @return mixed|null
 	 */
 	public function get_query_arg( string $name ) {
-		_deprecated_function( __METHOD__, '1.9.0', self::class . '::get_query_var()' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		_deprecated_function( __METHOD__, '1.9.0', self::class . '::get_query_var()' );
 
 		return $this->get_query_var( $name );
 	}
@@ -71,7 +71,7 @@ class TermObjectCursor extends AbstractCursor {
 	 * @deprecated 1.9.0
 	 */
 	public function get_cursor_term() {
-		_deprecated_function( __METHOD__, '1.9.0', self::class . '::get_cursor_node()' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		_deprecated_function( __METHOD__, '1.9.0', self::class . '::get_cursor_node()' );
 
 		return $this->cursor_node;
 	}

--- a/src/Data/Cursor/UserCursor.php
+++ b/src/Data/Cursor/UserCursor.php
@@ -95,7 +95,7 @@ class UserCursor extends AbstractCursor {
 	 * @deprecated 1.9.0
 	 */
 	public function get_cursor_user() {
-		_deprecated_function( __METHOD__, '1.9.0', self::class . '::get_cursor_node()' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		_deprecated_function( __METHOD__, '1.9.0', self::class . '::get_cursor_node()' );
 
 		return $this->cursor_node;
 	}

--- a/src/Data/Loader/AbstractDataLoader.php
+++ b/src/Data/Loader/AbstractDataLoader.php
@@ -205,7 +205,7 @@ abstract class AbstractDataLoader {
 	 * @deprecated in favor of clear_all
 	 */
 	public function clearAll() {
-		_deprecated_function( __METHOD__, '0.8.4', static::class . '::clear_all()' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		_deprecated_function( __METHOD__, '0.8.4', static::class . '::clear_all()' );
 		return $this->clear_all();
 	}
 
@@ -235,7 +235,7 @@ abstract class AbstractDataLoader {
 	 * @deprecated Use load_many instead
 	 */
 	public function loadMany( array $keys, $asArray = false ) {
-		_deprecated_function( __METHOD__, '0.8.4', static::class . '::load_many()' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		_deprecated_function( __METHOD__, '0.8.4', static::class . '::load_many()' );
 		return $this->load_many( $keys, $asArray );
 	}
 
@@ -303,7 +303,7 @@ abstract class AbstractDataLoader {
 					'Method ' . static::class . '::loadKeys is expected to return array, but it threw: ' .
 					esc_html( $e->getMessage() ),
 					0,
-					$e // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					$e // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
 				);
 			}
 
@@ -364,7 +364,7 @@ abstract class AbstractDataLoader {
 	 * @deprecated Use key_to_scalar instead
 	 */
 	protected function keyToScalar( $key ) {
-		_deprecated_function( __METHOD__, '0.8.4', static::class . '::key_to_scalar()' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		_deprecated_function( __METHOD__, '0.8.4', static::class . '::key_to_scalar()' );
 		return $this->key_to_scalar( $key );
 	}
 

--- a/src/Data/Loader/PostObjectLoader.php
+++ b/src/Data/Loader/PostObjectLoader.php
@@ -87,7 +87,7 @@ class PostObjectLoader extends AbstractDataLoader {
 		$args       = [
 			'post_type'           => $post_types,
 			'post_status'         => 'any',
-			'posts_per_page'      => count( $keys ), // phpcs:ignore WordPress.WP.PostsPerPage.posts_per_page_posts_per_page
+			'posts_per_page'      => count( $keys ),
 			'post__in'            => $keys,
 			'orderby'             => 'post__in',
 			'no_found_rows'       => true,

--- a/src/Data/Loader/UserLoader.php
+++ b/src/Data/Loader/UserLoader.php
@@ -77,10 +77,8 @@ class UserLoader extends AbstractDataLoader {
 		global $wpdb;
 
 		$results = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.DirectQuery
-			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-			// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
 			$wpdb->prepare(
-				"SELECT DISTINCT `post_author` FROM $wpdb->posts $where AND `post_author` IN ( $ids ) LIMIT $count",
+				"SELECT DISTINCT `post_author` FROM $wpdb->posts $where AND `post_author` IN ( $ids ) LIMIT $count", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
 				$keys
 			)
 		);

--- a/src/Data/TermObjectMutation.php
+++ b/src/Data/TermObjectMutation.php
@@ -13,7 +13,7 @@ class TermObjectMutation {
 	 * and mapped from input args to WordPress $args
 	 *
 	 * @throws \GraphQL\Error\UserError User error for invalid term.
-	 * 
+	 *
 	 * @param array        $input         The input from the GraphQL Request
 	 * @param \WP_Taxonomy $taxonomy The Taxonomy object for the type of term being mutated
 	 * @param string       $mutation_name The name of the mutation (create, update, etc)

--- a/src/Mutation/CommentDelete.php
+++ b/src/Mutation/CommentDelete.php
@@ -3,9 +3,7 @@
 namespace WPGraphQL\Mutation;
 
 use GraphQL\Error\UserError;
-use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
-use WPGraphQL\AppContext;
 use WPGraphQL\Model\Comment;
 use WPGraphQL\Utils\Utils;
 
@@ -66,7 +64,7 @@ class CommentDelete {
 			'comment'   => [
 				'type'        => 'Comment',
 				'description' => __( 'The deleted comment object', 'wp-graphql' ),
-				'resolve'     => static function ( $payload, $args, AppContext $context, ResolveInfo $info ) {
+				'resolve'     => static function ( $payload ) {
 					return $payload['commentObject'] ? $payload['commentObject'] : null;
 				},
 			],

--- a/src/Mutation/MediaItemCreate.php
+++ b/src/Mutation/MediaItemCreate.php
@@ -198,7 +198,7 @@ class MediaItemCreate {
 			 */
 			require_once ABSPATH . 'wp-admin/includes/file.php';
 
-			$file_contents = file_get_contents( $input['filePath'] ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			$file_contents = file_get_contents( $input['filePath'] );
 
 			/**
 			 * If the mediaItem file is from a local server, use wp_upload_bits before saving it to the uploads folder

--- a/src/Mutation/PostObjectCreate.php
+++ b/src/Mutation/PostObjectCreate.php
@@ -128,7 +128,7 @@ class PostObjectCreate {
 				'attachment',
 				'revision',
 			],
-			true 
+			true
 		) ) {
 			$fields['parentId'] = [
 				'type'        => 'ID',
@@ -273,7 +273,7 @@ class PostObjectCreate {
 					'draft',
 					'pending',
 				],
-				true 
+				true
 			) ) {
 				$intended_post_status = 'pending';
 			}

--- a/src/Mutation/PostObjectCreate.php
+++ b/src/Mutation/PostObjectCreate.php
@@ -176,7 +176,7 @@ class PostObjectCreate {
 			$post_type_object->graphql_single_name => [
 				'type'        => $post_type_object->graphql_single_name,
 				'description' => __( 'The Post object mutation type.', 'wp-graphql' ),
-				'resolve'     => static function ( $payload, $args, AppContext $context, ResolveInfo $info ) {
+				'resolve'     => static function ( $payload, $_args, AppContext $context ) {
 					if ( empty( $payload['postObjectId'] ) || ! absint( $payload['postObjectId'] ) ) {
 						return null;
 					}

--- a/src/Mutation/ResetUserPassword.php
+++ b/src/Mutation/ResetUserPassword.php
@@ -2,7 +2,6 @@
 namespace WPGraphQL\Mutation;
 
 use GraphQL\Error\UserError;
-use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
 
 class ResetUserPassword {
@@ -60,7 +59,7 @@ class ResetUserPassword {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload() {
-		return static function ( $input, AppContext $context, ResolveInfo $info ) {
+		return static function ( $input, AppContext $context ) {
 			if ( empty( $input['key'] ) ) {
 				throw new UserError( esc_html__( 'A password reset key is required.', 'wp-graphql' ) );
 			}

--- a/src/Mutation/TermObjectCreate.php
+++ b/src/Mutation/TermObjectCreate.php
@@ -92,7 +92,7 @@ class TermObjectCreate {
 				'type'        => $taxonomy->graphql_single_name,
 				// translators: Placeholder is the name of the taxonomy
 				'description' => sprintf( __( 'The created %s', 'wp-graphql' ), $taxonomy->name ),
-				'resolve'     => static function ( $payload, $args, AppContext $context, ResolveInfo $info ) {
+				'resolve'     => static function ( $payload, $_args, AppContext $context ) {
 					$id = isset( $payload['termId'] ) ? absint( $payload['termId'] ) : null;
 
 					return $context->get_loader( 'term' )->load_deferred( $id );

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -225,7 +225,7 @@ class TypeRegistry {
 				function ( $type_name ) {
 					return $this->get_type( $type_name );
 				},
-				$this->eager_type_map 
+				$this->eager_type_map
 			);
 		}
 
@@ -560,7 +560,7 @@ class TypeRegistry {
 					'resolve'     => static function () {
 						return get_site_url();
 					},
-				] 
+				]
 			);
 		}
 

--- a/src/Registry/Utils/PostObject.php
+++ b/src/Registry/Utils/PostObject.php
@@ -356,7 +356,7 @@ class PostObject {
 				],
 				'deprecationReason' => __( 'Deprecated in favor of the databaseId field', 'wp-graphql' ),
 				'description'       => __( 'The id field matches the WP_Post->ID field.', 'wp-graphql' ),
-				'resolve'           => static function ( Post $post, $args, $context, $info ) {
+				'resolve'           => static function ( Post $post ) {
 					return absint( $post->ID );
 				},
 			],
@@ -540,7 +540,7 @@ class PostObject {
 							'description' => __( 'Size of the MediaItem to return', 'wp-graphql' ),
 						],
 					],
-					'resolve'     => static function ( $image, $args, $context, $info ) {
+					'resolve'     => static function ( $image, $args ) {
 						// @codingStandardsIgnoreLine.
 						$size = null;
 						if ( isset( $args['size'] ) ) {
@@ -559,7 +559,7 @@ class PostObject {
 							'description' => __( 'Size of the MediaItem to return', 'wp-graphql' ),
 						],
 					],
-					'resolve'     => static function ( $image, $args, $context, $info ) {
+					'resolve'     => static function ( $image, $args ) {
 
 						// @codingStandardsIgnoreLine.
 						$size = null;

--- a/src/Registry/Utils/PostObject.php
+++ b/src/Registry/Utils/PostObject.php
@@ -495,7 +495,7 @@ class PostObject {
 								],
 								$src,
 								null,
-								$source->ID 
+								$source->ID
 							);
 
 							return ! empty( $sizes ) ? $sizes : null;

--- a/src/Registry/Utils/TermObject.php
+++ b/src/Registry/Utils/TermObject.php
@@ -315,12 +315,12 @@ class TermObject {
 				'type'              => 'Int',
 				'deprecationReason' => __( 'Deprecated in favor of databaseId', 'wp-graphql' ),
 				'description'       => __( 'The id field matches the WP_Post->ID field.', 'wp-graphql' ),
-				'resolve'           => static function ( Term $term, $args, $context, $info ) {
+				'resolve'           => static function ( Term $term ) {
 					return absint( $term->term_id );
 				},
 			],
 			'uri'               => [
-				'resolve' => static function ( $term, $args, $context, $info ) {
+				'resolve' => static function ( $term ) {
 					$url = $term->link;
 					if ( ! empty( $url ) ) {
 						$parsed = wp_parse_url( $url );

--- a/src/Registry/Utils/TermObject.php
+++ b/src/Registry/Utils/TermObject.php
@@ -214,12 +214,12 @@ class TermObject {
 										'field'            => 'term_id',
 										'include_children' => false,
 									],
-								] 
+								]
 							);
 
 							return $resolver->get_connection();
 						},
-					] 
+					]
 				);
 
 				// We won't need to register this connection again.
@@ -243,7 +243,7 @@ class TermObject {
 									'field'            => 'term_id',
 									'include_children' => false,
 								],
-							] 
+							]
 						);
 
 						return $resolver->get_connection();

--- a/src/Request.php
+++ b/src/Request.php
@@ -170,7 +170,7 @@ class Request {
 		$app_context                = new AppContext();
 		$app_context->viewer        = wp_get_current_user();
 		$app_context->root_url      = get_bloginfo( 'url' );
-		$app_context->request = !empty($_REQUEST) ? $_REQUEST : null; // phpcs:ignore
+		$app_context->request       = ! empty( $_REQUEST ) ? $_REQUEST : null; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$app_context->type_registry = $this->type_registry;
 		$this->app_context          = $app_context;
 

--- a/src/Router.php
+++ b/src/Router.php
@@ -212,7 +212,7 @@ class Router {
 	 * @deprecated 0.4.1 Use Router::is_graphql_http_request instead. This now resolves to it
 	 */
 	public static function is_graphql_request() {
-		_deprecated_function( __METHOD__, '0.4.1', self::class . 'is_graphql_http_request()' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		_deprecated_function( __METHOD__, '0.4.1', self::class . 'is_graphql_http_request()' );
 		return self::is_graphql_http_request();
 	}
 

--- a/src/Type/Connection/Comments.php
+++ b/src/Type/Connection/Comments.php
@@ -44,8 +44,8 @@ class Comments {
 						return $resolver->set_query_arg( 'user_id', absint( $user->userId ) )->get_connection();
 					},
 
-				] 
-			) 
+				]
+			)
 		);
 
 		register_graphql_connection(
@@ -61,8 +61,8 @@ class Comments {
 
 						return ! empty( $comment->comment_parent_id ) ? $resolver->one_to_one()->set_query_arg( 'comment__in', [ $comment->comment_parent_id ] )->get_connection() : null;
 					},
-				] 
-			) 
+				]
+			)
 		);
 
 		/**

--- a/src/Type/Connection/MenuItems.php
+++ b/src/Type/Connection/MenuItems.php
@@ -74,7 +74,7 @@ class MenuItems {
 									'include_children' => true,
 									'operator'         => 'IN',
 								],
-							] 
+							]
 						);
 
 						return $resolver->get_connection();

--- a/src/Type/Connection/PostObjects.php
+++ b/src/Type/Connection/PostObjects.php
@@ -43,7 +43,7 @@ class PostObjects {
 
 					return $resolver->get_connection();
 				},
-			] 
+			]
 		);
 
 		register_graphql_connection(
@@ -62,7 +62,7 @@ class PostObjects {
 
 					return $resolver->one_to_one()->set_query_arg( 'p', $id )->set_query_arg( 'post_parent', null )->get_connection();
 				},
-			] 
+			]
 		);
 
 		register_graphql_connection(
@@ -82,7 +82,7 @@ class PostObjects {
 
 					return $resolver->one_to_one()->get_connection();
 				},
-			] 
+			]
 		);
 
 		register_graphql_connection(
@@ -118,7 +118,7 @@ class PostObjects {
 
 					return $resolver->one_to_one()->get_connection();
 				},
-			] 
+			]
 		);
 
 		register_graphql_connection(
@@ -141,7 +141,7 @@ class PostObjects {
 
 					return $resolver->get_connection();
 				},
-			] 
+			]
 		);
 
 		register_graphql_connection(
@@ -164,7 +164,7 @@ class PostObjects {
 
 					return $resolver->get_connection();
 				},
-			] 
+			]
 		);
 
 		/**

--- a/src/Type/Connection/Users.php
+++ b/src/Type/Connection/Users.php
@@ -48,7 +48,7 @@ class Users {
 					'lockTimestamp' => [
 						'type'        => 'String',
 						'description' => __( 'The timestamp for when the node was last edited', 'wp-graphql' ),
-						'resolve'     => static function ( $edge, $args, $context, $info ) {
+						'resolve'     => static function ( $edge ) {
 							if ( isset( $edge['source'] ) && ( $edge['source'] instanceof Post ) ) {
 								$edit_lock = $edge['source']->editLock;
 								$time      = ( is_array( $edit_lock ) && ! empty( $edit_lock[0] ) ) ? $edit_lock[0] : null;

--- a/src/Type/InterfaceType/Commenter.php
+++ b/src/Type/InterfaceType/Commenter.php
@@ -68,7 +68,7 @@ class Commenter {
 						'description' => __( 'Whether the author information is considered restricted. (not fully public)', 'wp-graphql' ),
 					],
 				],
-			] 
+			]
 		);
 	}
 }

--- a/src/Type/InterfaceType/Edge.php
+++ b/src/Type/InterfaceType/Edge.php
@@ -28,7 +28,7 @@ class Edge {
 						'description' => __( 'The connected node', 'wp-graphql' ),
 					],
 				],
-			] 
+			]
 		);
 	}
 }

--- a/src/Type/InterfaceType/MenuItemLinkable.php
+++ b/src/Type/InterfaceType/MenuItemLinkable.php
@@ -41,7 +41,7 @@ class MenuItemLinkable {
 
 					return $type;
 				},
-			] 
+			]
 		);
 	}
 }

--- a/src/Type/InterfaceType/OneToOneConnection.php
+++ b/src/Type/InterfaceType/OneToOneConnection.php
@@ -25,7 +25,7 @@ class OneToOneConnection {
 						'description' => __( 'The connected node', 'wp-graphql' ),
 					],
 				],
-			] 
+			]
 		);
 	}
 }

--- a/src/Type/InterfaceType/PageInfo.php
+++ b/src/Type/InterfaceType/PageInfo.php
@@ -20,7 +20,7 @@ class PageInfo {
 				'description' => __( 'Information about pagination in a connection.', 'wp-graphql' ),
 				'interfaces'  => [ 'PageInfo' ],
 				'fields'      => self::get_fields(),
-			] 
+			]
 		);
 
 		register_graphql_interface_type(
@@ -28,7 +28,7 @@ class PageInfo {
 			[
 				'description' => __( 'Information about pagination in a connection.', 'wp-graphql' ),
 				'fields'      => self::get_fields(),
-			] 
+			]
 		);
 	}
 

--- a/src/Type/InterfaceType/TermNode.php
+++ b/src/Type/InterfaceType/TermNode.php
@@ -65,7 +65,7 @@ class TermNode {
 					'databaseId'     => [
 						'type'        => [ 'non_null' => 'Int' ],
 						'description' => __( 'Identifies the primary key from the database.', 'wp-graphql' ),
-						'resolve'     => static function ( Term $term, $args, $context, $info ) {
+						'resolve'     => static function ( Term $term ) {
 							return absint( $term->term_id );
 						},
 					],

--- a/src/Type/ObjectType/Comment.php
+++ b/src/Type/ObjectType/Comment.php
@@ -2,7 +2,6 @@
 
 namespace WPGraphQL\Type\ObjectType;
 
-use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
 use WPGraphQL\Model\Comment as CommentModel;
 
@@ -30,7 +29,7 @@ class Comment {
 						'toType'      => 'Commenter',
 						'description' => __( 'The author of the comment', 'wp-graphql' ),
 						'oneToOne'    => true,
-						'resolve'     => static function ( $comment, $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => static function ( $comment, $_args, AppContext $context ) {
 							$node = null;
 
 							// try and load the user node
@@ -60,7 +59,7 @@ class Comment {
 						'type'              => 'Boolean',
 						'description'       => __( 'The approval status of the comment. This field is equivalent to WP_Comment->comment_approved and the value matching the "comment_approved" column in SQL.', 'wp-graphql' ),
 						'deprecationReason' => __( 'Deprecated in favor of the `status` field', 'wp-graphql' ),
-						'resolve'           => static function ( $comment, $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'           => static function ( $comment ) {
 							return 'approve' === $comment->status;
 						},
 					],

--- a/src/Type/ObjectType/CommentAuthor.php
+++ b/src/Type/ObjectType/CommentAuthor.php
@@ -56,7 +56,7 @@ class CommentAuthor {
 							],
 
 						],
-						'resolve' => static function ( $comment_author, $args, $context, $info ) {
+						'resolve' => static function ( $comment_author, $args ) {
 							/**
 							 * If the $comment_author is a user, the User model only returns the email address if the requesting user is authenticated.
 							 * But, to resolve the Avatar we need a valid email, even for unauthenticated requests.

--- a/src/Type/ObjectType/EnqueuedScript.php
+++ b/src/Type/ObjectType/EnqueuedScript.php
@@ -44,7 +44,7 @@ class EnqueuedScript {
 						},
 					],
 				],
-			] 
+			]
 		);
 	}
 }

--- a/src/Type/ObjectType/EnqueuedStylesheet.php
+++ b/src/Type/ObjectType/EnqueuedStylesheet.php
@@ -44,7 +44,7 @@ class EnqueuedStylesheet {
 						},
 					],
 				],
-			] 
+			]
 		);
 	}
 }

--- a/src/Type/ObjectType/MediaItemMeta.php
+++ b/src/Type/ObjectType/MediaItemMeta.php
@@ -39,7 +39,7 @@ class MediaItemMeta {
 					'createdTimestamp' => [
 						'type'        => 'Int',
 						'description' => __( 'The date/time when the media was created.', 'wp-graphql' ),
-						'resolve'     => static function ( $meta, $args, $context, $info ) {
+						'resolve'     => static function ( $meta ) {
 							return ! empty( $meta['created_timestamp'] ) ? $meta['created_timestamp'] : null;
 						},
 					],
@@ -50,7 +50,7 @@ class MediaItemMeta {
 					'focalLength'      => [
 						'type'        => 'Float',
 						'description' => __( 'The focal length value of the media item.', 'wp-graphql' ),
-						'resolve'     => static function ( $meta, $args, $context, $info ) {
+						'resolve'     => static function ( $meta ) {
 							return ! empty( $meta['focal_length'] ) ? $meta['focal_length'] : null;
 						},
 					],
@@ -61,7 +61,7 @@ class MediaItemMeta {
 					'shutterSpeed'     => [
 						'type'        => 'Float',
 						'description' => __( 'The shutter speed information of the media item.', 'wp-graphql' ),
-						'resolve'     => static function ( $meta, $args, $context, $info ) {
+						'resolve'     => static function ( $meta ) {
 							return ! empty( $meta['shutter_speed'] ) ? $meta['shutter_speed'] : null;
 						},
 					],

--- a/src/Type/ObjectType/MediaSize.php
+++ b/src/Type/ObjectType/MediaSize.php
@@ -34,14 +34,14 @@ class MediaSize {
 					'mimeType'  => [
 						'type'        => 'String',
 						'description' => __( 'The mime type of the referenced size', 'wp-graphql' ),
-						'resolve'     => static function ( $image, $args, $context, $info ) {
+						'resolve'     => static function ( $image ) {
 							return ! empty( $image['mime-type'] ) ? $image['mime-type'] : null;
 						},
 					],
 					'fileSize'  => [
 						'type'        => 'Int',
 						'description' => __( 'The filesize of the resource', 'wp-graphql' ),
-						'resolve'     => static function ( $image, $args, $context, $info ) {
+						'resolve'     => static function ( $image ) {
 							if ( ! empty( $image['ID'] ) && ! empty( $image['file'] ) ) {
 								$original_file = get_attached_file( absint( $image['ID'] ) );
 								$filesize_path = ! empty( $original_file ) ? path_join( dirname( $original_file ), $image['file'] ) : null;
@@ -55,7 +55,7 @@ class MediaSize {
 					'sourceUrl' => [
 						'type'        => 'String',
 						'description' => __( 'The url of the referenced size', 'wp-graphql' ),
-						'resolve'     => static function ( $image, $args, $context, $info ) {
+						'resolve'     => static function ( $image ) {
 							$src_url = null;
 
 							if ( ! empty( $image['ID'] ) ) {

--- a/src/Type/ObjectType/RootQuery.php
+++ b/src/Type/ObjectType/RootQuery.php
@@ -169,7 +169,7 @@ class RootQuery {
 								'description' => __( 'Type of unique identifier to fetch a comment by. Default is Global ID', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => static function ( $source, array $args, AppContext $context, $info ) {
+						'resolve'     => static function ( $_source, array $args, AppContext $context ) {
 							$id_type = isset( $args['idType'] ) ? $args['idType'] : 'id';
 
 							switch ( $id_type ) {
@@ -212,7 +212,7 @@ class RootQuery {
 								'description' => __( 'Whether to return the Preview Node instead of the Published Node. When the ID of a Node is provided along with asPreview being set to true, the preview node with un-published changes will be returned instead of the published node. If no preview node exists or the requestor doesn\'t have proper capabilities to preview, no node will be returned.', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => static function ( $root, $args, AppContext $context, ResolveInfo $info ) {
+						'resolve'     => static function ( $_root, $args, AppContext $context ) {
 							$idType = $args['idType'] ?? 'global_id';
 							switch ( $idType ) {
 								case 'uri':
@@ -280,7 +280,7 @@ class RootQuery {
 								'description' => __( 'Type of unique identifier to fetch a content type by. Default is Global ID', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => static function ( $root, $args, $context, $info ) {
+						'resolve'     => static function ( $_root, $args, $context ) {
 							$id_type = isset( $args['idType'] ) ? $args['idType'] : 'id';
 
 							$id = null;
@@ -312,7 +312,7 @@ class RootQuery {
 								'description' => __( 'Type of unique identifier to fetch a taxonomy by. Default is Global ID', 'wp-graphql' ),
 							],
 						],
-						'resolve'     => static function ( $root, $args, $context, $info ) {
+						'resolve'     => static function ( $_root, $args, $context ) {
 							$id_type = isset( $args['idType'] ) ? $args['idType'] : 'id';
 
 							$id = null;
@@ -922,7 +922,7 @@ class RootQuery {
 							'description' => __( 'Type of unique identifier to fetch by. Default is Global ID', 'wp-graphql' ),
 						],
 					],
-					'resolve'     => static function ( $source, array $args, $context, $info ) use ( $tax_object ) {
+					'resolve'     => static function ( $_source, array $args, $context ) use ( $tax_object ) {
 						$idType  = isset( $args['idType'] ) ? $args['idType'] : 'global_id';
 						$term_id = null;
 

--- a/src/Type/ObjectType/SettingGroup.php
+++ b/src/Type/ObjectType/SettingGroup.php
@@ -85,7 +85,7 @@ class SettingGroup {
 						'type'        => $type_registry->get_type( $setting_field['type'] ),
 						// translators: %s is the name of the setting group.
 						'description' => isset( $setting_field['description'] ) && ! empty( $setting_field['description'] ) ? $setting_field['description'] : sprintf( __( 'The %s Settings Group', 'wp-graphql' ), $setting_field['type'] ),
-						'resolve'     => static function ( $root, array $args, $context, $info ) use ( $setting_field ) {
+						'resolve'     => static function () use ( $setting_field ) {
 
 							/**
 							 * Check to see if the user querying the email field has the 'manage_options' capability

--- a/src/Type/ObjectType/Settings.php
+++ b/src/Type/ObjectType/Settings.php
@@ -90,7 +90,7 @@ class Settings {
 						'type'        => $setting_field['type'],
 						// translators: %s is the name of the setting group.
 						'description' => sprintf( __( 'Settings of the the %s Settings Group', 'wp-graphql' ), $setting_field['type'] ),
-						'resolve'     => static function ( $root, $args, $context, $info ) use ( $setting_field, $key ) {
+						'resolve'     => static function () use ( $setting_field, $key ) {
 							/**
 							 * Check to see if the user querying the email field has the 'manage_options' capability
 							 * All other options should be public by default

--- a/src/Type/ObjectType/User.php
+++ b/src/Type/ObjectType/User.php
@@ -180,7 +180,7 @@ class User {
 							],
 
 						],
-						'resolve' => static function ( $user, $args, $context, $info ) {
+						'resolve' => static function ( $user, $args ) {
 							$avatar_args = [];
 							if ( is_numeric( $args['size'] ) ) {
 								$avatar_args['size'] = absint( $args['size'] );

--- a/src/Type/WPConnectionType.php
+++ b/src/Type/WPConnectionType.php
@@ -362,7 +362,7 @@ class WPConnectionType {
 					$this->connection_name
 				),
 				'fields'      => PageInfo::get_fields(),
-			] 
+			]
 		);
 	}
 
@@ -519,7 +519,7 @@ class WPConnectionType {
 				'args'                  => array_merge( $this->get_pagination_args(), $this->where_args ),
 				'auth'                  => $this->auth,
 				'deprecationReason'     => ! empty( $this->config['deprecationReason'] ) ? $this->config['deprecationReason'] : null,
-				'description'           => ! empty( $this->config['description'] ) 
+				'description'           => ! empty( $this->config['description'] )
 					? $this->config['description']
 					: sprintf(
 						// translators: the placeholders are the name of the Types the connection is between.
@@ -537,7 +537,7 @@ class WPConnectionType {
 					return $resolve_connection( $root, $args, $context, $info );
 				},
 				'allowFieldUnderscores' => isset( $this->config['allowFieldUnderscores'] ) && true === $this->config['allowFieldUnderscores'],
-			] 
+			]
 		);
 
 		$this->type_registry->register_field(
@@ -562,7 +562,7 @@ class WPConnectionType {
 					// translators: %s is the name of the connection edge.
 					'description' => sprintf( __( 'Page Info on the connected %s', 'wp-graphql' ), $connection_edge_type ),
 					'fields'      => PageInfo::get_fields(),
-				] 
+				]
 			);
 		}
 
@@ -581,7 +581,7 @@ class WPConnectionType {
 							'description' => sprintf( __( 'The connected %s Node', 'wp-graphql' ), $this->to_type ),
 						],
 					],
-				] 
+				]
 			);
 		}
 
@@ -611,7 +611,7 @@ class WPConnectionType {
 							'description' => sprintf( __( 'A list of connected %s Nodes', 'wp-graphql' ), $this->to_type ),
 						],
 					],
-				] 
+				]
 			);
 		}
 	}

--- a/src/Type/WPMutationType.php
+++ b/src/Type/WPMutationType.php
@@ -134,7 +134,7 @@ class WPMutationType {
 				__( 'Mutation config needs to have a valid name.', 'wp-graphql' ),
 				[
 					'config' => $config,
-				] 
+				]
 			);
 			$is_valid = false;
 		}
@@ -144,7 +144,7 @@ class WPMutationType {
 				__( 'Mutation config needs to have "mutateAndGetPayload" defined as a callable.', 'wp-graphql' ),
 				[
 					'config' => $config,
-				] 
+				]
 			);
 			$is_valid = false;
 		}

--- a/src/Utils/DebugLog.php
+++ b/src/Utils/DebugLog.php
@@ -79,7 +79,7 @@ class DebugLog {
 					'type'    => $type,
 					'message' => $message,
 				],
-				$config 
+				$config
 			);
 
 			$this->logs[ wp_json_encode( $message ) ] = $log_entry;

--- a/src/Utils/InstrumentSchema.php
+++ b/src/Utils/InstrumentSchema.php
@@ -203,7 +203,7 @@ class InstrumentSchema {
 	 * @param \GraphQL\Type\Definition\FieldDefinition $field The Field Definition for the resolving field
 	 *
 	 * @return void
-	 *             
+	 *
 	 * @throws \GraphQL\Error\UserError
 	 */
 	public static function check_field_permissions( $source, array $args, AppContext $context, ResolveInfo $info, $field_resolver, string $type_name, string $field_key, FieldDefinition $field ) {

--- a/src/Utils/QueryAnalyzer.php
+++ b/src/Utils/QueryAnalyzer.php
@@ -446,7 +446,6 @@ class QueryAnalyzer {
 		Visitor::visit( $ast, Visitor::visitWithTypeInfo( $type_info, $visitor ) );
 		$map = array_values( array_unique( array_filter( $type_map ) ) );
 
-		// @phpcs:ignore
 		return apply_filters( 'graphql_cache_collection_get_list_types', $map, $schema, $query, $type_info );
 	}
 
@@ -525,7 +524,6 @@ class QueryAnalyzer {
 		Visitor::visit( $ast, Visitor::visitWithTypeInfo( $type_info, $visitor ) );
 		$map = array_values( array_unique( array_filter( $type_map ) ) );
 
-		// @phpcs:ignore
 		return apply_filters( 'graphql_cache_collection_get_query_types', $map, $schema, $query, $type_info );
 	}
 
@@ -596,7 +594,6 @@ class QueryAnalyzer {
 		Visitor::visit( $ast, Visitor::visitWithTypeInfo( $type_info, $visitor ) );
 		$map = array_values( array_unique( array_filter( $type_map ) ) );
 
-		// @phpcs:ignore
 		return apply_filters( 'graphql_cache_collection_get_query_models', $map, $schema, $query, $type_info );
 	}
 

--- a/src/Utils/QueryAnalyzer.php
+++ b/src/Utils/QueryAnalyzer.php
@@ -176,7 +176,7 @@ class QueryAnalyzer {
 				'show_query_analyzer_in_extensions',
 			],
 			10,
-			5 
+			5
 		);
 	}
 
@@ -324,7 +324,7 @@ class QueryAnalyzer {
 				static function ( InterfaceType $interface_obj ) {
 					return $interface_obj->name;
 				},
-				$interfaces 
+				$interfaces
 			) : [];
 
 			if ( array_key_exists( 'Connection', $interface_names ) ) {
@@ -730,7 +730,7 @@ class QueryAnalyzer {
 			$return_keys,
 			$this->skipped_keys,
 			$return_keys_array,
-			$skipped_keys_array 
+			$skipped_keys_array
 		);
 
 		return $this->graphql_keys;

--- a/src/Utils/QueryLog.php
+++ b/src/Utils/QueryLog.php
@@ -148,7 +148,7 @@ class QueryLog {
 						'stack' => $query[2],
 					];
 				},
-				$wpdb->queries 
+				$wpdb->queries
 			);
 
 			$times      = wp_list_pluck( $queries, 'time' );

--- a/src/Utils/Tracing.php
+++ b/src/Utils/Tracing.php
@@ -104,7 +104,7 @@ class Tracing {
 				'add_tracing_to_response_extensions',
 			],
 			10,
-			1 
+			1
 		);
 		add_action( 'graphql_before_resolve_field', [ $this, 'init_field_resolver_trace' ], 10, 4 );
 		add_action( 'graphql_after_resolve_field', [ $this, 'end_field_resolver_trace' ], 10 );
@@ -201,7 +201,7 @@ class Tracing {
 				$this,
 				'sanitize_trace_resolver_path',
 			],
-			$trace['path'] 
+			$trace['path']
 		) : [];
 		$sanitized_trace['parentType']  = ! empty( $trace['parentType'] ) ? esc_html( $trace['parentType'] ) : '';
 		$sanitized_trace['fieldName']   = ! empty( $trace['fieldName'] ) ? esc_html( $trace['fieldName'] ) : '';

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -862,8 +862,8 @@ final class WPGraphQL {
 	 */
 	public static function get_static_schema() {
 		$schema = null;
-		if (file_exists(WPGRAPHQL_PLUGIN_DIR . 'schema.graphql') && !empty(file_get_contents(WPGRAPHQL_PLUGIN_DIR . 'schema.graphql'))) { // phpcs:ignore
-			$schema = file_get_contents(WPGRAPHQL_PLUGIN_DIR . 'schema.graphql'); // phpcs:ignore
+		if ( file_exists( WPGRAPHQL_PLUGIN_DIR . 'schema.graphql' ) && ! empty( file_get_contents( WPGRAPHQL_PLUGIN_DIR . 'schema.graphql' ) ) ) {
+			$schema = file_get_contents( WPGRAPHQL_PLUGIN_DIR . 'schema.graphql' );
 		}
 
 		return $schema;
@@ -883,7 +883,7 @@ final class WPGraphQL {
 		$app_context           = new AppContext();
 		$app_context->viewer   = wp_get_current_user();
 		$app_context->root_url = get_bloginfo( 'url' );
-		$app_context->request = !empty($_REQUEST) ? $_REQUEST : null; // phpcs:ignore
+		$app_context->request  = ! empty( $_REQUEST ) ? $_REQUEST : null; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		return $app_context;
 	}

--- a/tests/wpunit/AccessFunctionsTest.php
+++ b/tests/wpunit/AccessFunctionsTest.php
@@ -175,11 +175,11 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		 * Introspection query to query the names of fields on the Type
 		 */
 		$query = '{
-			__type( name: "RootQueryToTestCptConnectionWhereArgs" ) { 
+			__type( name: "RootQueryToTestCptConnectionWhereArgs" ) {
 				inputFields {
 					name
 				}
-			} 
+			}
 		}';
 
 		$response = $this->graphql( compact( 'query' ) );
@@ -332,7 +332,7 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		 * Introspection query to query the names of fields on the Type
 		 */
 		$query = '{
-			__type( name: "RootQueryToRegisterFieldsCptConnectionWhereArgs" ) { 
+			__type( name: "RootQueryToRegisterFieldsCptConnectionWhereArgs" ) {
 				inputFields {
 					name
 				}
@@ -1728,7 +1728,7 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$query = '
 		query GetType( $name: String! ){
 		  __type(name:$name) {
-		    fields(includeDeprecated:true) { 
+		    fields(includeDeprecated:true) {
 		      name
 		    }
 		  }

--- a/tests/wpunit/CommentMutationsTest.php
+++ b/tests/wpunit/CommentMutationsTest.php
@@ -102,7 +102,7 @@ class CommentMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$query = '
 		mutation createCommentTest( $commentOn:Int!, $author:String, $email: String, $content:String! ){
-			createComment( 
+			createComment(
 				input: {
 					commentOn: $commentOn
 					content: $content
@@ -261,7 +261,7 @@ class CommentMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$query = '
 		mutation updateCommentTest( $id: ID!, $content: String! ) {
-			updateComment( 
+			updateComment(
 				input: {
 					id: $id
 					content: $content
@@ -317,7 +317,7 @@ class CommentMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$query = '
 		mutation updateCommentStatus( $id: ID!, $status: CommentStatusEnum ) {
-			updateComment( 
+			updateComment(
 				input: {
 					id: $id
 					status: $status
@@ -387,7 +387,7 @@ class CommentMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$query = '
 		mutation deleteCommentTest( $id: ID! ) {
-			deleteComment( 
+			deleteComment(
 				input: {
 					id: $id
 				}
@@ -461,7 +461,7 @@ class CommentMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$query = '
 		mutation restoreCommentTest( $id: ID! ) {
-			restoreComment( 
+			restoreComment(
 				input: {
 					id: $id
 				}

--- a/tests/wpunit/CustomPostTypeTest.php
+++ b/tests/wpunit/CustomPostTypeTest.php
@@ -1208,7 +1208,7 @@ class CustomPostTypeTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$query = '
 		query {
 		  __type(name:"RootMutation") {
-		    fields { 
+		    fields {
 		      name
 		    }
 		  }
@@ -1247,7 +1247,7 @@ class CustomPostTypeTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$query = '
 		query {
 		  __type(name:"RootMutation") {
-		    fields { 
+		    fields {
 		      name
 		    }
 		  }
@@ -1286,7 +1286,7 @@ class CustomPostTypeTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$query = '
 		query {
 		  __type(name:"RootMutation") {
-		    fields { 
+		    fields {
 		      name
 		    }
 		  }
@@ -1399,7 +1399,7 @@ class CustomPostTypeTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$query = '
 		query {
 		  __type(name:"GraphqlExcludeField") {
-		    fields { 
+		    fields {
 		      name
 		    }
 		  }
@@ -1445,7 +1445,7 @@ class CustomPostTypeTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$query = '
 		query GetType( $name: String! ){
 		  __type(name:$name) {
-		    fields(includeDeprecated:true) { 
+		    fields(includeDeprecated:true) {
 		      name
 		    }
 		  }

--- a/tests/wpunit/CustomTaxonomyTest.php
+++ b/tests/wpunit/CustomTaxonomyTest.php
@@ -820,7 +820,7 @@ class CustomTaxonomyTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$query = '
 		query {
 		  __type(name:"RootMutation") {
-		    fields { 
+		    fields {
 		      name
 		    }
 		  }
@@ -859,7 +859,7 @@ class CustomTaxonomyTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$query = '
 		query {
 		  __type(name:"RootMutation") {
-		    fields { 
+		    fields {
 		      name
 		    }
 		  }
@@ -898,7 +898,7 @@ class CustomTaxonomyTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$query = '
 		query {
 		  __type(name:"RootMutation") {
-		    fields { 
+		    fields {
 		      name
 		    }
 		  }
@@ -1017,7 +1017,7 @@ class CustomTaxonomyTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$query = '
 		query {
 		  __type(name:"GraphqlExcludeField") {
-		    fields { 
+		    fields {
 		      name
 		    }
 		  }

--- a/tests/wpunit/MediaItemQueriesTest.php
+++ b/tests/wpunit/MediaItemQueriesTest.php
@@ -507,7 +507,7 @@ class MediaItemQueriesTest  extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase 
 		$query_by_source_url = '
 			query GetMediaItem($id:ID!) {
 				mediaItem(
-				id: $id, 
+				id: $id,
 				idType: SOURCE_URL
 			) {
 				__typename

--- a/tests/wpunit/MediaItemQueriesTest.php
+++ b/tests/wpunit/MediaItemQueriesTest.php
@@ -633,7 +633,7 @@ class MediaItemQueriesTest  extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase 
 		// Get all sizes except the thumbnail.
 		$variables = [
 			'id'      => $attachment_global_id,
-			'exclude' => 'THUMBNAIL', // phpcs:ignore
+			'exclude' => 'THUMBNAIL',
 		];
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
@@ -647,7 +647,7 @@ class MediaItemQueriesTest  extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase 
 		$variables = [
 			'id'      => $attachment_global_id,
 			'include' => [ 'THUMBNAIL', 'MEDIUM' ],
-			'exclude' => 'MEDIUM', // phpcs:ignore
+			'exclude' => 'MEDIUM',
 		];
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );

--- a/tests/wpunit/NodesTest.php
+++ b/tests/wpunit/NodesTest.php
@@ -52,13 +52,13 @@ class NodesTest extends \Codeception\TestCase\WPTestCase {
 		 * Create the query string to pass to the $query
 		 */
 		$query = '
-		query getPageByNode( $id:ID! ) { 
-			node( id:$id ) { 
-				__typename 
+		query getPageByNode( $id:ID! ) {
+			node( id:$id ) {
+				__typename
 				...on Page {
 					pageId
 				}
-			} 
+			}
 		}';
 
 		$variables = [
@@ -118,13 +118,13 @@ class NodesTest extends \Codeception\TestCase\WPTestCase {
 		 * Create the query string to pass to the $query
 		 */
 		$query = "
-		query { 
-			node(id: \"{$global_id}\") { 
-				__typename 
+		query {
+			node(id: \"{$global_id}\") {
+				__typename
 				...on Page {
 					pageId
 				}
-			} 
+			}
 		}";
 
 		/**
@@ -165,13 +165,13 @@ class NodesTest extends \Codeception\TestCase\WPTestCase {
 		$global_id = \GraphQLRelay\Relay::toGlobalId( 'post', $post_id );
 
 		$query  = "
-		query { 
-			node(id: \"{$global_id}\") { 
+		query {
+			node(id: \"{$global_id}\") {
 				__typename
 				... on Post {
 					postId
 				}
-			} 
+			}
 		}";
 		$actual = do_graphql_request( $query );
 
@@ -203,13 +203,13 @@ class NodesTest extends \Codeception\TestCase\WPTestCase {
 		$attachment_id = $this->factory->post->create( $args );
 		$global_id     = \GraphQLRelay\Relay::toGlobalId( 'post', $attachment_id );
 		$query         = "
-		query { 
-			node(id: \"{$global_id}\") { 
+		query {
+			node(id: \"{$global_id}\") {
 				__typename
 				...on MediaItem {
 					mediaItemId
 				}
-			} 
+			}
 		}";
 		$actual        = do_graphql_request( $query );
 
@@ -233,13 +233,13 @@ class NodesTest extends \Codeception\TestCase\WPTestCase {
 		$plugin_path = 'wp-graphql/wp-graphql.php';
 		$global_id   = \GraphQLRelay\Relay::toGlobalId( 'plugin', $plugin_path );
 		$query       = "
-		query { 
-			node(id: \"{$global_id}\") { 
+		query {
+			node(id: \"{$global_id}\") {
 				__typename
 				... on Plugin {
 					path
 				}
-			} 
+			}
 		}";
 
 		wp_set_current_user( $this->admin );
@@ -271,13 +271,13 @@ class NodesTest extends \Codeception\TestCase\WPTestCase {
 
 		$global_id = \GraphQLRelay\Relay::toGlobalId( 'theme', $active_theme );
 		$query     = "
-		query { 
-			node(id: \"{$global_id}\") { 
-				__typename 
-				...on Theme{ 
-					slug 
-				} 
-			} 
+		query {
+			node(id: \"{$global_id}\") {
+				__typename
+				...on Theme{
+					slug
+				}
+			}
 		}";
 		wp_set_current_user( $this->admin );
 		$actual = do_graphql_request( $query );
@@ -340,13 +340,13 @@ class NodesTest extends \Codeception\TestCase\WPTestCase {
 
 		$global_id = \GraphQLRelay\Relay::toGlobalId( 'user', $user_id );
 		$query     = "
-		query { 
-			node(id: \"{$global_id}\") { 
-				__typename 
-				...on User{ 
-					userId 
-				} 
-			} 
+		query {
+			node(id: \"{$global_id}\") {
+				__typename
+				...on User{
+					userId
+				}
+			}
 		}
 		";
 		$actual    = do_graphql_request( $query );
@@ -423,13 +423,13 @@ class NodesTest extends \Codeception\TestCase\WPTestCase {
 
 		$global_id = \GraphQLRelay\Relay::toGlobalId( 'comment', $comment_id );
 		$query     = "
-		query { 
+		query {
 			node(id: \"{$global_id}\") {
-				__typename 
-				...on Comment{ 
-					commentId 
-				} 
-			} 
+				__typename
+				...on Comment{
+					commentId
+				}
+			}
 		}
 		";
 		$actual    = do_graphql_request( $query );

--- a/tests/wpunit/PreviewTest.php
+++ b/tests/wpunit/PreviewTest.php
@@ -340,7 +340,7 @@ class PreviewTest extends \Codeception\TestCase\WPTestCase {
 		   databaseId
 		   metaKey
 		   title
-		   content 
+		   content
 		   author {
 		     node {
 		       id
@@ -351,7 +351,7 @@ class PreviewTest extends \Codeception\TestCase\WPTestCase {
 		       databaseId
 		       metaKey
 		       title
-		       content 
+		       content
 		      author {
 		         node {
 		           id
@@ -452,7 +452,7 @@ class PreviewTest extends \Codeception\TestCase\WPTestCase {
 		   revisedMetaKey
 		   publishedMetaKey
 		   title
-		   content 
+		   content
 		   author {
 		     node {
 		       id
@@ -464,7 +464,7 @@ class PreviewTest extends \Codeception\TestCase\WPTestCase {
 		       publishedMetaKey
 		       revisedMetaKey
 		       title
-		       content 
+		       content
 		      author {
 		         node {
 		           id
@@ -533,14 +533,14 @@ class PreviewTest extends \Codeception\TestCase\WPTestCase {
 				   enclosure
 				   publishedMetaKey
 				   title
-				   content 
+				   content
 				   preview {
 				     node {
 				       databaseId
 				       enclosure
 				       publishedMetaKey
 				       title
-				       content 
+				       content
 				     }
 				   }
 				 }

--- a/tests/wpunit/SettingsMutationsTest.php
+++ b/tests/wpunit/SettingsMutationsTest.php
@@ -477,7 +477,7 @@ class SettingsMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase 
 
 		$query = '
 		mutation updateSettings( $input: UpdateSettingsInput! ) {
-			updateSettings( input: $input ) { 
+			updateSettings( input: $input ) {
 				allSettings {
 					mySettingGroupSettingsMySettingField
 				}

--- a/tests/wpunit/TermObjectCursorTest.php
+++ b/tests/wpunit/TermObjectCursorTest.php
@@ -214,7 +214,7 @@ class TermObjectCursorTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
         ];
 
         $this->assertQuerySuccessful( $response, $expected );
-    
+
         /**
 		 * Assert that the reverse query is successful.
 		 */

--- a/tests/wpunit/TracingTest.php
+++ b/tests/wpunit/TracingTest.php
@@ -23,10 +23,10 @@ class TracingTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$query = '
 		{
-		  posts { 
-		    nodes { 
-		      id 
-		    } 
+		  posts {
+		    nodes {
+		      id
+		    }
 		  }
 		}
 		';
@@ -52,10 +52,10 @@ class TracingTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$query = '
 		{
-		  posts { 
-		    nodes { 
-		      id 
-		    } 
+		  posts {
+		    nodes {
+		      id
+		    }
 		  }
 		}
 		';

--- a/tests/wpunit/UtilsTest.php
+++ b/tests/wpunit/UtilsTest.php
@@ -9,13 +9,13 @@ class UtilsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$query_without_spaces = '{posts{nodes{id,title}}}';
 		$query_with_spaces = '{ posts { nodes { id, title } } }';
 		$query_with_line_breaks = '
-		{ 
-			posts { 
-				nodes { 
+		{
+			posts {
+				nodes {
 					id
-					title 
-				} 
-			} 
+					title
+				}
+			}
 		}';
 
 		$id1 = \WPGraphQL\Utils\Utils::get_query_id( $query_without_spaces );


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR removes unused parameters from any `'resolve'` callbacks, addressing the nonbreaking parts of the currently ignored `Generic.CodeAnalysis.UnusedFunctionParameter` sniff. 
That sniff has now been relabeled as `This would be a breaking change to fix` in our PHPCS ruleset.

**Note**: This is based on #2932 (for diff conflict reasons) and requires that to be merged first. See https://github.com/wp-graphql/wp-graphql/pull/2933/commits/e609f3dcd318f2fce980e4bb901b910c0d6f705d for the diff relevant to this PR.

Does this close any currently open issues?
------------------------------------------
<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
No, but addresses part of #2925 

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
<!-- (If it’s long, please paste to https://ghostbin.com/ and insert the link here.) -->


Any other comments?
-------------------
The remaining smells all come from actual functions, and as such would be a breaking change to remove the parameter. Conversation will occur in #2925 on how to proceed.


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php 8.1.14 )

**WordPress Version:** 6.3.1
