### PR TITLE
fix: Decode slug so it works with other languages

### DIFF
--- a/src/Model/Menu.php
+++ b/src/Model/Menu.php
@@ -90,7 +90,7 @@ class Menu extends Model {
 					return ! empty( $this->data->name ) ? $this->data->name : null;
 				},
 				'slug'       => function () {
-					return ! empty( $this->data->slug ) ? $this->data->slug : null;
+					return ! empty( $this->data->slug ) ? urldecode( $this->data->slug ) : null;
 				},
 				'locations'  => function () {
 					$menu_locations = get_theme_mod( 'nav_menu_locations' );

--- a/src/Model/Term.php
+++ b/src/Model/Term.php
@@ -145,7 +145,7 @@ class Term extends Model {
 					return ! empty( $this->data->name ) ? $this->html_entity_decode( $this->data->name, 'name', true ) : null;
 				},
 				'slug'                     => function () {
-					return ! empty( $this->data->slug ) ? $this->data->slug : null;
+					return ! empty( $this->data->slug ) ? urldecode( $this->data->slug ) : null;
 				},
 				'termGroupId'              => function () {
 					return ! empty( $this->data->term_group ) ? absint( $this->data->term_group ) : null;

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -663,11 +663,6 @@ class TypeRegistry {
 	public function register_type( string $type_name, $config ): void {
 
 		/**
-		* Decodes the type name, so it works with different languages (e.g. Chinese, Hebrew, etc.)
-		*/
-		$type_name = urldecode( $type_name );
-
-		/**
 		 * If the type should be excluded from the schema, skip it.
 		 */
 		if ( in_array( strtolower( $type_name ), $this->get_excluded_types(), true ) ) {

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -661,7 +661,6 @@ class TypeRegistry {
 	 * @return void
 	 */
 	public function register_type( string $type_name, $config ): void {
-
 		/**
 		 * If the type should be excluded from the schema, skip it.
 		 */

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -661,6 +661,12 @@ class TypeRegistry {
 	 * @return void
 	 */
 	public function register_type( string $type_name, $config ): void {
+
+		/**
+		* Decodes the type name, so it works with different languages (e.g. Chinese, Hebrew, etc.)
+		*/
+		$type_name = urldecode( $type_name );
+
 		/**
 		 * If the type should be excluded from the schema, skip it.
 		 */


### PR DESCRIPTION
# fix: Decode strings so it works with other languages

What does this implement/fix? Explain your changes.
---------------------------------------------------
- Decodes the slug so it works with other languages. Like Hebrew, Arabic, etc.
- ~~Decodes the type name, so it works with different languages (e.g. Chinese, Hebrew, etc.)~~

##Example:
 - Before: "**%d7%90%d7%91%d7%99%d7%96%d7%a8%d7%99%d7%9d**"
 - After:  "**הטבה לרוכשים**"


Where has this been tested?
---------------------------

**WordPress Version:** 6.3.1
