### PR TITLE
fix: rename fields registered by connections when using `rename_graphql_field()`

### DIFF
--- a/access-functions.php
+++ b/access-functions.php
@@ -402,13 +402,32 @@ function register_graphql_connection_where_args( string $from_type, string $to_t
  * @since 1.3.4
  */
 function rename_graphql_field( string $type_name, string $field_name, string $new_field_name ) {
+	// Rename fields on the type.
 	add_filter(
 		"graphql_{$type_name}_fields",
 		static function ( $fields ) use ( $field_name, $new_field_name ) {
+			// Bail if the field doesn't exist.
+			if ( ! isset( $fields[ $field_name ] ) ) {
+				return $fields;
+			}
+
 			$fields[ $new_field_name ] = $fields[ $field_name ];
 			unset( $fields[ $field_name ] );
 
 			return $fields;
+		}
+	);
+
+	// Rename fields registered to the type by connections.
+	add_filter(
+		"graphql_wp_connection_{$type_name}_from_field_name",
+		static function ( $old_field_name ) use ( $field_name, $new_field_name ) {
+			// Bail if the field name doesn't match.
+			if ( $old_field_name !== $field_name ) {
+				return $old_field_name;
+			}
+
+			return $new_field_name;
 		}
 	);
 }

--- a/src/Type/WPConnectionType.php
+++ b/src/Type/WPConnectionType.php
@@ -150,10 +150,17 @@ class WPConnectionType {
 
 		$this->validate_config( $config );
 
-		$this->config          = $config;
-		$this->from_type       = $config['fromType'];
-		$this->to_type         = $config['toType'];
-		$this->from_field_name = $config['fromFieldName'];
+		$this->config    = $config;
+		$this->from_type = $config['fromType'];
+		$this->to_type   = $config['toType'];
+
+		/**
+		 * Filter the connection field name.
+		 *
+		 * @internal This filter is internal and used by rename_graphql_field(). It is not intended for use by external code.
+		 */
+		$this->from_field_name = apply_filters( "graphql_wp_connection_{$this->from_type}_from_field_name", $config['fromFieldName'] );
+
 		$this->connection_name = ! empty( $config['connectionTypeName'] ) ? $config['connectionTypeName'] : $this->get_connection_name( $this->from_type, $this->to_type, $this->from_field_name );
 
 		/**

--- a/src/Type/WPConnectionType.php
+++ b/src/Type/WPConnectionType.php
@@ -158,6 +158,8 @@ class WPConnectionType {
 		 * Filter the connection field name.
 		 *
 		 * @internal This filter is internal and used by rename_graphql_field(). It is not intended for use by external code.
+		 *
+		 * @param string $from_field_name The name of the field the connection will be exposed as.
 		 */
 		$this->from_field_name = apply_filters( "graphql_wp_connection_{$this->from_type}_from_field_name", $config['fromFieldName'] );
 

--- a/tests/wpunit/AccessFunctionsTest.php
+++ b/tests/wpunit/AccessFunctionsTest.php
@@ -636,6 +636,23 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		);
 	}
 
+	public function testRenameGraphQLConnectionFieldName() {
+		rename_graphql_field( 'RootQuery', 'users', 'wpUsers' );
+
+		$query    = '{ __type(name: "RootQuery") { fields { name } } }';
+		$response = $this->graphql( compact( 'query' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $response );
+
+		$this->assertQuerySuccessful(
+			$response,
+			[
+				$this->not()->expectedNode( '__type.fields', [ 'name' => 'users' ] ),
+				$this->expectedNode( '__type.fields', [ 'name' => 'wpUsers' ] ),
+			]
+		);
+	}
+
 	public function testRenameGraphQLType() {
 
 		register_graphql_union_type( 'PostObjectUnion', [


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR fixes `rename_graphql_field()` so fields registered by connections are also renamed (e.g. `RootQuery.users` => `RootQuery.wpUsers` ).

This is done by adding a `graphql_wp_connection_{$this->from_type}_from_field_name` filter to the `WPConnectionType::$from_field_name`. 

**Note: This filter is intended for internal use only, and marked as such**.

Additionally, fixes a PHP warning when the supplied field name doesnt exist.

Does this close any currently open issues?
------------------------------------------
<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Closes #1843 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
<!-- (If it’s long, please paste to https://ghostbin.com/ and insert the link here.) -->


Any other comments?
-------------------
See #1843 before closing.

Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + PHP 8.1.15)

**WordPress Version:** 6.3.1
