### PR TITLE
fix: correctly get `default` user role for settings selectbox

### DIFF
--- a/src/Admin/Settings/SettingsRegistry.php
+++ b/src/Admin/Settings/SettingsRegistry.php
@@ -531,7 +531,7 @@ class SettingsRegistry {
 		$selected = esc_attr( $this->get_option( $args['id'], $args['section'], $args['std'] ) );
 
 		if ( empty( $selected ) ) {
-			$selected = isset( $args['defualt'] ) ? $args['defualt'] : null;
+			$selected = isset( $args['default'] ) ? $args['default'] : null;
 		}
 
 		$name = $args['section'] . '[' . $args['id'] . ']';

--- a/tests/functional/GraphqlSettingsPageCept.php
+++ b/tests/functional/GraphqlSettingsPageCept.php
@@ -1,0 +1,15 @@
+<?php
+
+$I = new FunctionalTester( $scenario );
+
+$I->wantTo( 'Test GraphQL Settings Page Renders and Saves as Expected' );
+
+$I->loginAsAdmin();
+
+$I->amOnAdminPage( '/admin.php?page=graphql-settings' );
+
+$I->see( 'WPGraphQL General Settings' );
+
+// Verify that the default value is populated
+$I->seeOptionIsSelected( 'graphql_general_settings[tracing_user_role]', 'Administrator' );
+$I->seeOptionIsSelected( 'graphql_general_settings[query_log_user_role]', 'Administrator' );


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR fixes `SettingsRegistry::callback_user_role_select()` to correctly check `$args['default']` for the default role to use.

Cherrypicked from @szepeviktor 's work in https://github.com/wp-graphql/wp-graphql/pull/2947


Does this close any currently open issues?
------------------------------------------
<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Supercedes #2497 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
<!-- (If it’s long, please paste to https://ghostbin.com/ and insert the link here.) -->


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + PHP 8.1.15 )

**WordPress Version:** 6.3.1
