### PR TITLE
feat: add `graphql_format_name()` access method

### DIFF
--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -382,7 +382,7 @@ class DataSource {
 	 * @return string $group
 	 */
 	public static function format_group_name( string $group ) {
-		$replaced_group = preg_replace( '[^a-zA-Z0-9 -]', ' ', $group );
+		$replaced_group = graphql_format_name( $group, ' ', '/[^a-zA-Z0-9 -]/' );
 
 		if ( ! empty( $replaced_group ) ) {
 			$group = $replaced_group;

--- a/src/Mutation/UpdateSettings.php
+++ b/src/Mutation/UpdateSettings.php
@@ -75,7 +75,7 @@ class UpdateSettings {
 					$individual_setting_key = lcfirst( $setting['group'] . 'Settings' . str_replace( '_', '', ucwords( $key, '_' ) ) );
 				}
 
-				$replaced_setting_key = preg_replace( '[^a-zA-Z0-9 -]', ' ', $individual_setting_key );
+				$replaced_setting_key = graphql_format_name( $individual_setting_key, ' ', '/[^a-zA-Z0-9 -]/' );
 
 				if ( ! empty( $replaced_setting_key ) ) {
 					$individual_setting_key = $replaced_setting_key;

--- a/src/Type/ObjectType/SettingGroup.php
+++ b/src/Type/ObjectType/SettingGroup.php
@@ -70,7 +70,7 @@ class SettingGroup {
 					$field_key = $key;
 				}
 
-				$field_key = lcfirst( preg_replace( '[^a-zA-Z0-9 -]', ' ', $field_key ) );
+				$field_key = graphql_format_name( $field_key, ' ', '/[^a-zA-Z0-9 -]/' );
 				$field_key = lcfirst( str_replace( '_', ' ', ucwords( $field_key, '_' ) ) );
 				$field_key = lcfirst( str_replace( '-', ' ', ucwords( $field_key, '_' ) ) );
 				$field_key = lcfirst( str_replace( ' ', '', ucwords( $field_key, ' ' ) ) );

--- a/src/Type/ObjectType/Settings.php
+++ b/src/Type/ObjectType/Settings.php
@@ -73,7 +73,7 @@ class Settings {
 
 				$group = DataSource::format_group_name( $setting_field['group'] );
 
-				$field_key = lcfirst( preg_replace( '[^a-zA-Z0-9 -]', ' ', $field_key ) );
+				$field_key = lcfirst( graphql_format_name( $field_key, ' ', '/[^a-zA-Z0-9 -]/' ) );
 				$field_key = lcfirst( str_replace( '_', ' ', ucwords( $field_key, '_' ) ) );
 				$field_key = lcfirst( str_replace( '-', ' ', ucwords( $field_key, '_' ) ) );
 				$field_key = lcfirst( str_replace( ' ', '', ucwords( $field_key, ' ' ) ) );

--- a/src/Type/WPEnumType.php
+++ b/src/Type/WPEnumType.php
@@ -25,22 +25,23 @@ class WPEnumType extends EnumType {
 	}
 
 	/**
-	 * Generate a safe / sanitized name from a menu location slug.
+	 * Generate a safe / sanitized Enum value from a string.
 	 *
 	 * @param  string $value Enum value.
 	 * @return string
 	 */
 	public static function get_safe_name( string $value ) {
-		$replaced = preg_replace( '#[^A-z0-9]#', '_', $value );
+		$sanitized_enum_name = graphql_format_name( $value, '_' );
 
-		if ( ! empty( $replaced ) ) {
-			$value = $replaced;
+		// If the sanitized name is empty, we want to return the original value so it displays in the error.
+		if ( ! empty( $sanitized_enum_name ) ) {
+			$value = $sanitized_enum_name;
 		}
 
 		$safe_name = strtoupper( $value );
 
 		// Enum names must start with a letter or underscore.
-		if ( ! preg_match( '#^[_a-zA-Z]#', $value ) ) {
+		if ( ! preg_match( '#^[_a-zA-Z]#', $safe_name ) ) {
 			return '_' . $safe_name;
 		}
 

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -146,7 +146,8 @@ class Utils {
 				graphql_debug(
 					esc_html__( 'The `graphql_pre_format_name` filter must return a string or null.', 'wp-graphql' ),
 					[
-						'originalName' => esc_html( $name ),
+						'type'          => 'INVALID_GRAPHQL_NAME',
+						'original_name' => esc_html( $name ),
 					]
 				);
 			}
@@ -227,13 +228,13 @@ class Utils {
 	public static function format_type_name_for_wp_template( string $name, string $file ): string {
 		$name = ucwords( $name );
 		// Strip out not ASCII characters.
-		$name = format_graphql_name( $name, '', '/[^\w]/' );
+		$name = graphql_format_name( $name, '', '/[^\w]/' );
 
 		// If replaced_name is empty, use the file name.
 		if ( empty( $name ) ) {
 			$file_parts    = explode( '.', $file );
 			$file_name     = ! empty( $file_parts[0] ) ? self::format_type_name( $file_parts[0] ) : '';
-			$replaced_name = ! empty( $file_name ) ? format_graphql_name( $file_name, '', '/[^\w]/' ) : '';
+			$replaced_name = ! empty( $file_name ) ? graphql_format_name( $file_name, '', '/[^\w]/' ) : '';
 
 			$name = ! empty( $replaced_name ) ? $replaced_name : $name;
 		}

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -142,7 +142,7 @@ class Utils {
 			$name = trim( sanitize_text_field( $pre_format_name ) );
 		} else {
 			// Throw a warning if someone is using the filter incorrectly.
-			if ( ! is_string( $pre_format_name ) ) {
+			if ( null !== $pre_format_name ) {
 				graphql_debug(
 					esc_html__( 'The `graphql_pre_format_name` filter must return a string or null.', 'wp-graphql' ),
 					[

--- a/tests/wpunit/AccessFunctionsTest.php
+++ b/tests/wpunit/AccessFunctionsTest.php
@@ -176,7 +176,7 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertEquals( 'The `graphql_pre_format_name` filter must return a string or null.', $actual['extensions']['debug']['0']['message'] );
-		$this->assertEquals( $original_name, $actual['extensions']['debug']['0']['originalName'] );
+		$this->assertEquals( $original_name, $actual['extensions']['debug']['0']['original_name'] );
 
 		// Cleanup filter
 		remove_all_filters( 'graphql_pre_format_name' );

--- a/tests/wpunit/AccessFunctionsTest.php
+++ b/tests/wpunit/AccessFunctionsTest.php
@@ -99,6 +99,89 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 	}
 
+	public function testFormatName(): void {
+		// Test empty.
+		$actual   = graphql_format_name( '' );
+		$expected = '';
+		$this->assertEquals( $expected, $actual );
+
+		// Test default regex.
+		$actual   = graphql_format_name( '^&This Is-some name123%$!' );
+		$expected = '_This_Is_some_name123___';
+		$this->assertEquals( $expected, $actual );
+
+		// Test custom replacement chars.
+		$actual   = graphql_format_name( '^&This Is-some name123%$!', '' );
+		$expected = 'ThisIssomename123';
+		$this->assertEquals( $expected, $actual );
+
+		// Test custom regex. only letters.
+		$actual   = graphql_format_name( '^&This Is-some name123%$!', '', '/[^a-zA-Z]/' );
+		$expected = 'ThisIssomename';
+		$this->assertEquals( $expected, $actual );
+
+		// Test with filter.
+		add_filter( 'graphql_pre_format_name', function ( $name, string $original_name, string $replacement_chars, string $regex ) {
+			// Transliteration example.
+			$mapped_chars = [
+				'ä' => 'ae',
+				'ö' => 'oe',
+				'ü' => 'ue',
+				'ß' => 'ss',
+			];
+
+			$transliterated_name = str_replace( array_keys( $mapped_chars ), array_values( $mapped_chars ), $original_name );
+
+			return preg_replace( $regex, $replacement_chars, $transliterated_name );
+		}, 10, 4 );
+
+		// Use a name with those special chars.
+		$actual         = graphql_format_name( '_#ä_ö ü-ß', '' );
+		$expected       = '_ae_oeuess';
+		$this->assertEquals( $expected, $actual );
+
+		// Cleanup
+		remove_all_filters( 'graphql_pre_format_name' );
+	}
+
+	public function testFormatNameWithBadFilter() {
+		add_filter( 'graphql_pre_format_name', function ( $name, string $original_name, string $replacement_chars, string $regex ) {
+			return 123;
+		}, 10, 4 );
+
+		$original_name = '^*This Is-some name123%$!';
+
+		// Test filter falls back to default.
+		$actual   = graphql_format_name( $original_name, '' );
+		$expected = 'ThisIssomename123';
+
+		$this->assertEquals( $expected, $actual );
+
+		// Test a schema query to make sure a warning was logged.
+		$query    = '{
+			__schema {
+				queryType {
+					fields {
+						name
+						type {
+							name
+							kind
+						}
+					}
+				}
+			}
+		}';
+
+		$actual = $this->graphql( compact( 'query' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEquals( 'The `graphql_pre_format_name` filter must return a string or null.', $actual['extensions']['debug']['0']['message'] );
+		$this->assertEquals( $original_name, $actual['extensions']['debug']['0']['originalName'] );
+
+		// Cleanup filter
+		remove_all_filters( 'graphql_pre_format_name' );
+	}
+
 	// tests
 	public function testFormatFieldName() {
 		$actual   = graphql_format_field_name( 'This is some field name' );


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR adds the `graphql_format_name()` access function to the codebase, and refactors methods to use that function instead of their own `preg_replace()` calls.

The `graphql_format_name()` method allows us to centralize the logic for ensuring that all GraphQL names meet the [spec](http://spec.graphql.org/draft/#sec-Names), ensuring uniformity and reducing user error. The method can be called with one parameter ( `graphql_format_name( $string_to_format )` ) to return a fully compliant name, or with additional parameters to provide a custom replacement character or regex ( e.g. `graphql_format_name( $string_to_format, ' ', '/[^a-zA-Z0-9 -]/' )`, used often before a `camelCase` or similar transformation.

Additionally, the method allows the formatting to be overridable with the `graphql_pre_format_name` filter. This can be used to provide i18n support without weighing down WPGraphQL core, either by requiring and using the `iconv` library, or even a simple string replace like so:

```php
add_filter( 'graphql_pre_format_name',
  function ( $formatted_name, string $original_name, string $replacement, string $regex ): string {
    // E.g. transliterate Hebrew
    $char_map = [
      'א' => 'A',
      'ב' => 'B',
      'ג' => 'C',
      ...
    ];
   
     // First transliterate the values.
    $transliterated = str_replace( array_keys( $char_map ), array_values( $char_map ), $name ); 
    
    // Then run the standard regex.
    return preg_replace( $regex, $replacement, $transliterated );
  },
  10,
  4
);
```

Does this close any currently open issues?
------------------------------------------
<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Provides workarounds for:
- #2807
- #2492
- #1658 
- #2175
- https://github.com/AxeWP/wp-graphql-gravity-forms/issues/372

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
<!-- (If it’s long, please paste to https://ghostbin.com/ and insert the link here.) -->


Any other comments?
-------------------
- The logic in the methods now using `graphql_format_name()` was refactored _sparingly_ to avoid potential breaking changes, (e.g. old regexes were left untouched ), so there is likely room for improvement in a future PR. 
- Notably I avoided some changes so #2808 could be merged without conflicts.

Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php 8.1.15 )

**WordPress Version:** 6.3.1
