### PR TITLE
chore: remove @phpstan-ignore annotations

### DIFF
--- a/phpstan/constants.php
+++ b/phpstan/constants.php
@@ -8,4 +8,5 @@ define( 'SAVEQUERIES', true );
 define( 'WPGRAPHQL_PLUGIN_URL', true );
 define( 'WP_CONTENT_DIR', true );
 define( 'WP_PLUGIN_DIR', true );
+define( 'WPGRAPHQL_AUTOLOAD', false );
 define( 'PHPSTAN', true );

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -93,7 +93,6 @@ function graphql_can_load_plugin(): bool {
 	 * The codeception tests are an example of an environment where adding the autoloader again causes issues
 	 * so this is set to false for tests.
 	 */
-	// @phpstan-ignore-next-line: this is ignored as the constant could be defined in wp-config, prior to being defined above
 	if ( defined( 'WPGRAPHQL_AUTOLOAD' ) && false === WPGRAPHQL_AUTOLOAD ) {
 
 		// IF WPGRAPHQL_AUTOLOAD is defined as false,
@@ -102,8 +101,7 @@ function graphql_can_load_plugin(): bool {
 		return true;
 	}
 
-	// @phpstan-ignore-next-line: this is ignored as the constant could be defined in wp-config, prior to being defined above
-	if ( ( ! defined( 'WPGRAPHQL_AUTOLOAD' ) || true === WPGRAPHQL_AUTOLOAD ) && file_exists( plugin_dir_path( __FILE__ ) . 'vendor/autoload.php' ) ) {
+	if ( file_exists( plugin_dir_path( __FILE__ ) . 'vendor/autoload.php' ) ) {
 		// Autoload Required Classes.
 		require_once plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
 	}


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Follow up to #2954. Removes the use of `@phpstan-ignore-next-line` by defining the constant for PHPStan, and drops some unnecessary conditional logic.


Does this close any currently open issues?
------------------------------------------
<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
<!-- (If it’s long, please paste to https://ghostbin.com/ and insert the link here.) -->


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + PHP 8.1.15)

**WordPress Version:** 6.3.1
