### PR TITLE
fix: use all roles for `UserRoleEnum` instead of the filtered `editible_roles`

### DIFF
--- a/src/Type/Enum/UserRoleEnum.php
+++ b/src/Type/Enum/UserRoleEnum.php
@@ -12,30 +12,29 @@ class UserRoleEnum {
 	 * @return void
 	 */
 	public static function register_type() {
-		global $wp_roles;
-		$all_roles      = $wp_roles->roles;
-		$editable_roles = apply_filters( 'editable_roles', $all_roles );
-		$roles          = [];
+		$all_roles = wp_roles()->roles;
+		$roles     = [];
 
-		if ( ! empty( $editable_roles ) && is_array( $editable_roles ) ) {
-			foreach ( $editable_roles as $key => $role ) {
-				$formatted_role = WPEnumType::get_safe_name( isset( $role['name'] ) ? $role['name'] : $key );
+		foreach ( $all_roles as $key => $role ) {
+			$formatted_role = WPEnumType::get_safe_name( isset( $role['name'] ) ? $role['name'] : $key );
 
-				$roles[ $formatted_role ] = [
-					'description' => __( 'User role with specific capabilities', 'wp-graphql' ),
-					'value'       => $key,
-				];
-			}
+			$roles[ $formatted_role ] = [
+				'description' => __( 'User role with specific capabilities', 'wp-graphql' ),
+				'value'       => $key,
+			];
 		}
 
-		if ( ! empty( $roles ) && is_array( $roles ) ) {
-			register_graphql_enum_type(
-				'UserRoleEnum',
-				[
-					'description' => __( 'Names of available user roles', 'wp-graphql' ),
-					'values'      => $roles,
-				]
-			);
+		// Bail if there are no roles to register.
+		if ( empty( $roles ) ) {
+			return;
 		}
+
+		register_graphql_enum_type(
+			'UserRoleEnum',
+			[
+				'description' => __( 'Names of available user roles', 'wp-graphql' ),
+				'values'      => $roles,
+			]
+		);
 	}
 }


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR changes `UserRoleEnum` to use _all_ role values instead of just those filtered by [`editable_roles`](https://developer.wordpress.org/reference/hooks/editable_roles/).

The purpose of the `editable_roles` is to limit the roles that _the current user may assign to another user_. As such, it neither represents the roles a privileged user can query for, nor stays the same in the schema across all users.

Additionally, we're using `wp_roles()` instead of directly accessing the global, and early-returning to reduce code complexity.


Does this close any currently open issues?
------------------------------------------
<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
fixes #2537 

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
<!-- (If it’s long, please paste to https://ghostbin.com/ and insert the link here.) -->


Any other comments?
-------------------
- _Usage_ of `UserRoleEnum` is already validated in the codebase where it is used:
  - [Mutations](https://github.com/justlevine/wp-graphql/blob/32826dc3eb0afb500757a0cbb1ce6bf52d356b1f/src/Data/UserMutation.php#L253)
  - [Connections](https://github.com/justlevine/wp-graphql/blob/32826dc3eb0afb500757a0cbb1ce6bf52d356b1f/src/Data/Connection/UserConnectionResolver.php#L218-L230)
- Doesnt seem to be a need to write a testto cover #2537, since we're already testing the actual UserRoleEnum and no longer using `editable_roles` .

Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php 8.1.15)

**WordPress Version:** 6.3.1
