### PR TITLE
chore: restore commenting sniffs to PHPCS ruleset

### DIFF
--- a/access-functions.php
+++ b/access-functions.php
@@ -215,8 +215,8 @@ function register_graphql_type( string $type_name, array $config ) {
 /**
  * Given a Type Name and a $config array, this adds an Interface Type to the TypeRegistry
  *
- * @param string                                     $type_name The name of the Type to register
- * @param mixed|array|\GraphQL\Type\Definition\Type  $config    The Type config
+ * @param string                                    $type_name The name of the Type to register
+ * @param mixed|array|\GraphQL\Type\Definition\Type $config    The Type config
  *
  * @throws \Exception
  * @return void
@@ -340,7 +340,7 @@ function register_graphql_fields( string $type_name, array $fields ) {
  * @param string $from_type  The name of the Type the connection is coming from.
  * @param string $to_type    The name of the Type or Alias (the connection config's `FromFieldName`) the connection is going to.
  * @param string $field_name The name of the field to add to the connection edge.
- * @param array $config      The field config.
+ * @param array  $config      The field config.
  *
  * @since 1.13.0
  */
@@ -383,7 +383,7 @@ function register_graphql_edge_fields( string $from_type, string $to_type, array
  * @param string $from_type  The name of the Type the connection is coming from.
  * @param string $to_type    The name of the Type or Alias (the connection config's `FromFieldName`) the connection is going to.
  * @param string $field_name The name of the field to add to the connection edge.
- * @param array $config      The field config.
+ * @param array  $config      The field config.
  *
  * @since 1.13.0
  */

--- a/access-functions.php
+++ b/access-functions.php
@@ -2,6 +2,7 @@
 /**
  * This file contains access functions for various class methods
  *
+ * @package WPGraphQL
  * @since 0.0.2
  */
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -112,7 +112,6 @@
 		<exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop" />
 		<exclude name="Squiz.Commenting.FunctionComment.EmptyThrows" />
 		<exclude name="Squiz.Commenting.FunctionComment.MissingParamComment" />
-		<exclude name="Squiz.Commenting.FunctionComment.ThrowsNotCapital" />
 		<exclude name="Squiz.Commenting.FunctionComment.Missing" />
 		<properties>
 			<property name="skipIfInheritdoc" value="true" />

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -99,7 +99,6 @@
 		<!-- Should probably be added back -->
 		<exclude name="Squiz.Commenting.ClassComment" />
 		<exclude name="Squiz.Commenting.FileComment" />
-		<exclude name="Squiz.Commenting.VariableComment" />
 		<exclude name="Squiz.Commenting.FunctionCommentThrowTag" />
 		<exclude name="Squiz.Commenting.InlineComment" />
 	</rule>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -106,11 +106,12 @@
 	<rule ref="Squiz.Commenting.FunctionComment">
 		<!-- Conflicts with b/c in AbstractConnectionResolver -->
 		<exclude name="Squiz.Commenting.FunctionComment.InvalidNoReturn" />
+		<!-- Conflicts with FQCN -->
+		<exclude name="Squiz.Commenting.FunctionComment.IncorrectTypeHint" />
 		<!-- Should probably be added back -->
 		<exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop" />
 		<exclude name="Squiz.Commenting.FunctionComment.EmptyThrows" />
 		<exclude name="Squiz.Commenting.FunctionComment.MissingParamComment" />
-		<exclude name="Squiz.Commenting.FunctionComment.IncorrectTypeHint" />
 		<exclude name="Squiz.Commenting.FunctionComment.ParamNameNoMatch" />
 		<exclude name="Squiz.Commenting.FunctionComment.ThrowsNotCapital" />
 		<exclude name="Squiz.Commenting.FunctionComment.Missing" />

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -81,8 +81,6 @@
 	<!-- Load WordPress VIP Go standards - for use with projects on the (newer) VIP Go platform. -->
 	<rule ref="WordPress-VIP-Go" />
 
-	<rule ref="Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction"/>
-
 	<!-- Load WordPress Coding standards -->
 	<rule ref="WordPress">
 		<!-- Definitely should not be added back -->
@@ -100,17 +98,17 @@
 	<!-- Tests for inline documentation of code -->
 	<rule ref="WordPress-Docs">
 		<exclude name="Generic.Commenting.DocComment.MissingShort"/>
-		<!-- Conflicts with b/c in AbstractConnectionResolver -->
-		<exclude name="Squiz.Commenting.FunctionComment.InvalidNoReturn" />
 		<!-- Conflicts with FQCN -->
 		<exclude name="Squiz.Commenting.FunctionComment.IncorrectTypeHint" />
+		<!-- Conflicts with b/c in AbstractConnectionResolver -->
+		<exclude name="Squiz.Commenting.FunctionComment.InvalidNoReturn" />
 
 		<!-- Should probably be added back -->
 		<exclude name="Squiz.Commenting.ClassComment.Missing" />
 		<exclude name="Squiz.Commenting.FileComment.Missing" />
-		<exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop" />
 		<exclude name="Squiz.Commenting.FunctionComment.EmptyThrows" />
 		<exclude name="Squiz.Commenting.FunctionComment.MissingParamComment" />
+		<exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop" />
 		<exclude name="Squiz.Commenting.FunctionCommentThrowTag.Missing" />
 		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar" />
 	</rule>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -112,7 +112,6 @@
 		<exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop" />
 		<exclude name="Squiz.Commenting.FunctionComment.EmptyThrows" />
 		<exclude name="Squiz.Commenting.FunctionComment.MissingParamComment" />
-		<exclude name="Squiz.Commenting.FunctionComment.Missing" />
 		<properties>
 			<property name="skipIfInheritdoc" value="true" />
 		</properties>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -97,7 +97,6 @@
 		<exclude name="Generic.Commenting.DocComment.MissingShort"/>
 
 		<!-- Should probably be added back -->
-		<exclude name="Squiz.Commenting.BlockComment"/>
 		<exclude name="Squiz.Commenting.ClassComment" />
 		<exclude name="Squiz.Commenting.DocCommentAlignment" />
 		<exclude name="Squiz.Commenting.FileComment" />

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -109,7 +109,6 @@
 		<!-- Should probably be added back -->
 		<exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop" />
 		<exclude name="Squiz.Commenting.FunctionComment.EmptyThrows" />
-		<exclude name="Squiz.Commenting.FunctionComment.MissingParamTag" />
 		<exclude name="Squiz.Commenting.FunctionComment.MissingParamComment" />
 		<exclude name="Squiz.Commenting.FunctionComment.IncorrectTypeHint" />
 		<exclude name="Squiz.Commenting.FunctionComment.ParamNameNoMatch" />

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -97,13 +97,13 @@
 
 	<!-- Tests for inline documentation of code -->
 	<rule ref="WordPress-Docs">
-		<exclude name="Generic.Commenting.DocComment.MissingShort"/>
 		<!-- Conflicts with FQCN -->
 		<exclude name="Squiz.Commenting.FunctionComment.IncorrectTypeHint" />
 		<!-- Conflicts with b/c in AbstractConnectionResolver -->
 		<exclude name="Squiz.Commenting.FunctionComment.InvalidNoReturn" />
 
 		<!-- Should probably be added back -->
+		<exclude name="Generic.Commenting.DocComment.MissingShort"/>
 		<exclude name="Squiz.Commenting.ClassComment.Missing" />
 		<exclude name="Squiz.Commenting.FileComment.Missing" />
 		<exclude name="Squiz.Commenting.FunctionComment.EmptyThrows" />

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -98,7 +98,6 @@
 
 		<!-- Should probably be added back -->
 		<exclude name="Squiz.Commenting.ClassComment" />
-		<exclude name="Squiz.Commenting.DocCommentAlignment" />
 		<exclude name="Squiz.Commenting.FileComment" />
 		<exclude name="Squiz.Commenting.VariableComment" />
 		<exclude name="Squiz.Commenting.FunctionCommentThrowTag" />

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -96,20 +96,31 @@
 	<rule ref="WordPress-Docs">
 		<exclude name="Generic.Commenting.DocComment.MissingShort"/>
 
-		<!-- Should be re-enabled -->
-		<exclude name="Squiz.Commenting"/>
+		<!-- Should probably be added back -->
+		<exclude name="Squiz.Commenting.BlockComment"/>
+		<exclude name="Squiz.Commenting.ClassComment" />
+		<exclude name="Squiz.Commenting.DocCommentAlignment" />
+		<exclude name="Squiz.Commenting.FileComment" />
+		<exclude name="Squiz.Commenting.VariableComment" />
+		<exclude name="Squiz.Commenting.FunctionCommentThrowTag" />
+		<exclude name="Squiz.Commenting.InlineComment" />
 	</rule>
 
-		<!-- Additional commenting sniffs are in WPGraphQL-Docs -->
 	<rule ref="Squiz.Commenting.FunctionComment">
 		<!-- Conflicts with b/c in AbstractConnectionResolver -->
 		<exclude name="Squiz.Commenting.FunctionComment.InvalidNoReturn" />
-
 		<!-- Should probably be added back -->
 		<exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop" />
 		<exclude name="Squiz.Commenting.FunctionComment.EmptyThrows" />
+		<exclude name="Squiz.Commenting.FunctionComment.SpacingAfterParamType" />
+		<exclude name="Squiz.Commenting.FunctionComment.MissingParamTag" />
+		<exclude name="Squiz.Commenting.FunctionComment.MissingParamComment" />
+		<exclude name="Squiz.Commenting.FunctionComment.IncorrectTypeHint" />
+		<exclude name="Squiz.Commenting.FunctionComment.ParamNameNoMatch" />
+		<exclude name="Squiz.Commenting.FunctionComment.ThrowsNotCapital" />
+		<exclude name="Squiz.Commenting.FunctionComment.Missing" />
 		<properties>
-				<property name="skipIfInheritdoc" value="true" />
+			<property name="skipIfInheritdoc" value="true" />
 		</properties>
 	</rule>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -109,7 +109,6 @@
 		<exclude name="Squiz.Commenting.FunctionComment.EmptyThrows" />
 		<exclude name="Squiz.Commenting.FunctionComment.MissingParamComment" />
 		<exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop" />
-		<exclude name="Squiz.Commenting.FunctionCommentThrowTag.Missing" />
 		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar" />
 	</rule>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -67,6 +67,11 @@
 			<property name="blank_line_check" value="true"/>
 		</properties>
 	</rule>
+	<rule ref="Squiz.Commenting.FunctionComment">
+		<properties>
+			<property name="skipIfInheritdoc" value="true" />
+		</properties>
+	</rule>
 
 	<!-- Rules -->
 
@@ -95,26 +100,19 @@
 	<!-- Tests for inline documentation of code -->
 	<rule ref="WordPress-Docs">
 		<exclude name="Generic.Commenting.DocComment.MissingShort"/>
-
-		<!-- Should probably be added back -->
-		<exclude name="Squiz.Commenting.ClassComment" />
-		<exclude name="Squiz.Commenting.FileComment" />
-		<exclude name="Squiz.Commenting.FunctionCommentThrowTag" />
-		<exclude name="Squiz.Commenting.InlineComment" />
-	</rule>
-
-	<rule ref="Squiz.Commenting.FunctionComment">
 		<!-- Conflicts with b/c in AbstractConnectionResolver -->
 		<exclude name="Squiz.Commenting.FunctionComment.InvalidNoReturn" />
 		<!-- Conflicts with FQCN -->
 		<exclude name="Squiz.Commenting.FunctionComment.IncorrectTypeHint" />
+
 		<!-- Should probably be added back -->
+		<exclude name="Squiz.Commenting.ClassComment.Missing" />
+		<exclude name="Squiz.Commenting.FileComment.Missing" />
 		<exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop" />
 		<exclude name="Squiz.Commenting.FunctionComment.EmptyThrows" />
 		<exclude name="Squiz.Commenting.FunctionComment.MissingParamComment" />
-		<properties>
-			<property name="skipIfInheritdoc" value="true" />
-		</properties>
+		<exclude name="Squiz.Commenting.FunctionCommentThrowTag.Missing" />
+		<exclude name="Squiz.Commenting.InlineComment" />
 	</rule>
 
 	<!-- Enforce short array syntax -->

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -112,7 +112,6 @@
 		<exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop" />
 		<exclude name="Squiz.Commenting.FunctionComment.EmptyThrows" />
 		<exclude name="Squiz.Commenting.FunctionComment.MissingParamComment" />
-		<exclude name="Squiz.Commenting.FunctionComment.ParamNameNoMatch" />
 		<exclude name="Squiz.Commenting.FunctionComment.ThrowsNotCapital" />
 		<exclude name="Squiz.Commenting.FunctionComment.Missing" />
 		<properties>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -110,7 +110,6 @@
 		<!-- Should probably be added back -->
 		<exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop" />
 		<exclude name="Squiz.Commenting.FunctionComment.EmptyThrows" />
-		<exclude name="Squiz.Commenting.FunctionComment.SpacingAfterParamType" />
 		<exclude name="Squiz.Commenting.FunctionComment.MissingParamTag" />
 		<exclude name="Squiz.Commenting.FunctionComment.MissingParamComment" />
 		<exclude name="Squiz.Commenting.FunctionComment.IncorrectTypeHint" />

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -112,7 +112,7 @@
 		<exclude name="Squiz.Commenting.FunctionComment.EmptyThrows" />
 		<exclude name="Squiz.Commenting.FunctionComment.MissingParamComment" />
 		<exclude name="Squiz.Commenting.FunctionCommentThrowTag.Missing" />
-		<exclude name="Squiz.Commenting.InlineComment" />
+		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar" />
 	</rule>
 
 	<!-- Enforce short array syntax -->

--- a/src/Admin/Settings/SettingsRegistry.php
+++ b/src/Admin/Settings/SettingsRegistry.php
@@ -179,7 +179,7 @@ class SettingsRegistry {
 			add_settings_section( $id, $section['title'], $callback, $id );
 		}
 
-		//register settings fields
+		// register settings fields
 		foreach ( $this->settings_fields as $section => $field ) {
 			foreach ( $field as $option ) {
 				$name     = $option['name'];

--- a/src/AppContext.php
+++ b/src/AppContext.php
@@ -163,6 +163,7 @@ class AppContext {
 	 * @param string $key The name of the loader to get
 	 *
 	 * @return mixed
+	 * @throws \GraphQL\Error\UserError If the loader is not found.
 	 */
 	public function get_loader( $key ) {
 		if ( ! array_key_exists( $key, $this->loaders ) ) {

--- a/src/Data/CommentMutation.php
+++ b/src/Data/CommentMutation.php
@@ -115,10 +115,10 @@ class CommentMutation {
 	/**
 	 * This updates commentmeta.
 	 *
-	 * @param int         $comment_id    The ID of the postObject the comment is connected to
-	 * @param array       $input         The input for the mutation
-	 * @param string      $mutation_name The name of the mutation ( ex: create, update, delete )
-	 * @param \WPGraphQL\AppContext $context The AppContext passed down to all resolvers
+	 * @param int                                  $comment_id    The ID of the postObject the comment is connected to
+	 * @param array                                $input         The input for the mutation
+	 * @param string                               $mutation_name The name of the mutation ( ex: create, update, delete )
+	 * @param \WPGraphQL\AppContext                $context The AppContext passed down to all resolvers
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down to all resolvers
 	 *
 	 * @return void

--- a/src/Data/CommentMutation.php
+++ b/src/Data/CommentMutation.php
@@ -22,8 +22,8 @@ class CommentMutation {
 	 * @param string $mutation_name The name of the mutation being performed
 	 * @param bool   $update        Whether it's an update action
 	 *
-	 * @return array $output_args
-	 * @throws \Exception
+	 * @return array
+	 * @throws \GraphQL\Error\UserError If the comment author is not provided.
 	 */
 	public static function prepare_comment_object( array $input, array &$output_args, string $mutation_name, $update = false ) {
 		/**

--- a/src/Data/Config.php
+++ b/src/Data/Config.php
@@ -263,7 +263,8 @@ class Config {
 	 * the meta values have same values multiple times. This filter adds a
 	 * secondary ordering by the post ID which forces stable order in such cases.
 	 *
-	 * @param string $orderby The ORDER BY clause of the query.
+	 * @param string         $orderby The ORDER BY clause of the query.
+	 * @param \WP_User_Query $query The WP_User_Query instance (passed by reference).
 	 *
 	 * @return string
 	 */

--- a/src/Data/Config.php
+++ b/src/Data/Config.php
@@ -212,7 +212,7 @@ class Config {
 	 * This filters the WPQuery 'where' $args, enforcing the query to return results before or
 	 * after the referenced cursor
 	 *
-	 * @param string   $where The WHERE clause of the query.
+	 * @param string    $where The WHERE clause of the query.
 	 * @param \WP_Query $query The WP_Query instance (passed by reference).
 	 *
 	 * @return string
@@ -439,7 +439,7 @@ class Config {
 	 * This returns a modified version of the $pieces of the comment query clauses if the request
 	 * is a GraphQL Request and before or after cursors are passed to the query
 	 *
-	 * @param array            $pieces A compacted array of comment query clauses.
+	 * @param array             $pieces A compacted array of comment query clauses.
 	 * @param \WP_Comment_Query $query Current instance of WP_Comment_Query, passed by reference.
 	 *
 	 * @return array $pieces

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -123,7 +123,7 @@ abstract class AbstractConnectionResolver {
 	 * @param array       $args    array of arguments input in the field as part of the GraphQL
 	 *                             query
 	 * @param \WPGraphQL\AppContext $context Object containing app context that gets passed down the resolve
- * tree
+	 * tree
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info Info about fields passed down the resolve tree
 	 *
 	 * @throws \Exception

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -453,7 +453,7 @@ abstract class AbstractConnectionResolver {
 	 * This checks the $args to determine the amount requested, and if
 	 *
 	 * @return int|null
-	 * @throws \Exception
+	 * @throws \GraphQL\Error\UserError If there is an issue with the pagination $args.
 	 */
 	public function get_amount_requested() {
 

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -630,6 +630,8 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * Connections that use a string-based offset should override this method.
 	 *
+	 * @param ?string $cursor The cursor to convert to an offset.
+	 *
 	 * @return int|mixed
 	 */
 	public function get_offset_for_cursor( string $cursor = null ) {

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -119,11 +119,9 @@ abstract class AbstractConnectionResolver {
 	/**
 	 * ConnectionResolver constructor.
 	 *
-	 * @param mixed       $source  source passed down from the resolve tree
-	 * @param array       $args    array of arguments input in the field as part of the GraphQL
-	 *                             query
-	 * @param \WPGraphQL\AppContext $context Object containing app context that gets passed down the resolve
-	 * tree
+	 * @param mixed                                $source  source passed down from the resolve tree
+	 * @param array                                $args    array of arguments input in the field as part of the GraphQL query
+	 * @param \WPGraphQL\AppContext                $context Object containing app context that gets passed down the resolve tree
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info Info about fields passed down the resolve tree
 	 *
 	 * @throws \Exception
@@ -535,7 +533,7 @@ abstract class AbstractConnectionResolver {
 	 * Gets the array index for the given offset.
 	 *
 	 * @param int|string|false $offset The cursor pagination offset.
-	 * @param array      $ids    The array of ids from the query.
+	 * @param array            $ids    The array of ids from the query.
 	 *
 	 * @return int|false $index The array index of the offset.
 	 */

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -390,7 +390,7 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * @since 1.9.0
 	 *
-	 * @throws \Exception if child class forgot to implement this.
+	 * @throws \Exception If child class forgot to implement this.
 	 *
 	 * @return array the array of IDs.
 	 */

--- a/src/Data/Connection/CommentConnectionResolver.php
+++ b/src/Data/Connection/CommentConnectionResolver.php
@@ -22,6 +22,8 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 
 	/**
 	 * {@inheritDoc}
+	 *
+	 * @throws \GraphQL\Error\UserError If there is a problem with the $args.
 	 */
 	public function get_query_args() {
 

--- a/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
@@ -14,9 +14,9 @@ class EnqueuedScriptsConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * EnqueuedScriptsConnectionResolver constructor.
 	 *
-	 * @param mixed       $source     source passed down from the resolve tree
-	 * @param array       $args       array of arguments input in the field as part of the GraphQL query
-	 * @param \WPGraphQL\AppContext $context Object containing app context that gets passed down the resolve tree
+	 * @param mixed                                $source     source passed down from the resolve tree
+	 * @param array                                $args       array of arguments input in the field as part of the GraphQL query
+	 * @param \WPGraphQL\AppContext                $context Object containing app context that gets passed down the resolve tree
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info Info about fields passed down the resolve tree
 	 *
 	 * @throws \Exception

--- a/src/Data/Connection/EnqueuedStylesheetConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedStylesheetConnectionResolver.php
@@ -20,9 +20,9 @@ class EnqueuedStylesheetConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * EnqueuedStylesheetConnectionResolver constructor.
 	 *
-	 * @param mixed       $source     source passed down from the resolve tree
-	 * @param array       $args       array of arguments input in the field as part of the GraphQL query
-	 * @param \WPGraphQL\AppContext $context Object containing app context that gets passed down the resolve tree
+	 * @param mixed                                $source     source passed down from the resolve tree
+	 * @param array                                $args       array of arguments input in the field as part of the GraphQL query
+	 * @param \WPGraphQL\AppContext                $context Object containing app context that gets passed down the resolve tree
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info Info about fields passed down the resolve tree
 	 *
 	 * @throws \Exception

--- a/src/Data/Connection/MenuItemConnectionResolver.php
+++ b/src/Data/Connection/MenuItemConnectionResolver.php
@@ -15,9 +15,9 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 	/**
 	 * MenuItemConnectionResolver constructor.
 	 *
-	 * @param mixed       $source     source passed down from the resolve tree
-	 * @param array       $args       array of arguments input in the field as part of the GraphQL query
-	 * @param \WPGraphQL\AppContext $context Object containing app context that gets passed down the resolve tree
+	 * @param mixed                                $source     source passed down from the resolve tree
+	 * @param array                                $args       array of arguments input in the field as part of the GraphQL query
+	 * @param \WPGraphQL\AppContext                $context Object containing app context that gets passed down the resolve tree
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info Info about fields passed down the resolve tree
 	 *
 	 * @throws \Exception

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -85,7 +85,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	 *
 	 * @return \WP_Query|object
 	 *
-	 * @throws \Exception
+	 * @throws \GraphQL\Error\InvariantViolation If the query has been modified to suppress_filters.
 	 */
 	public function get_query() {
 		// Get query class.

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -31,13 +31,11 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * PostObjectConnectionResolver constructor.
 	 *
-	 * @param mixed              $source    source passed down from the resolve tree
-	 * @param array              $args      array of arguments input in the field as part of the
-	 *                                      GraphQL query
-	 * @param \WPGraphQL\AppContext $context Object containing app context that gets passed down the
-	 * resolve tree
+	 * @param mixed                                $source    source passed down from the resolve tree
+	 * @param array                                $args      array of arguments input in the field as part of the query
+	 * @param \WPGraphQL\AppContext                $context Object containing app context that gets passed down the resolve tree
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info Info about fields passed down the resolve tree
-	 * @param mixed|string|array $post_type The post type to resolve for
+	 * @param mixed|string|array                   $post_type The post type to resolve for
 	 *
 	 * @throws \Exception
 	 */

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -35,7 +35,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	 * @param array              $args      array of arguments input in the field as part of the
 	 *                                      GraphQL query
 	 * @param \WPGraphQL\AppContext $context Object containing app context that gets passed down the
- * resolve tree
+	 * resolve tree
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info Info about fields passed down the resolve tree
 	 * @param mixed|string|array $post_type The post type to resolve for
 	 *

--- a/src/Data/Connection/TermObjectConnectionResolver.php
+++ b/src/Data/Connection/TermObjectConnectionResolver.php
@@ -167,7 +167,7 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 	 * {@inheritDoc}
 	 */
 	public function get_ids_from_query() {
-		/** @var string[] $ids **/
+		/** @var string[] $ids */
 		$ids = ! empty( $this->query->get_terms() ) ? $this->query->get_terms() : [];
 
 		// If we're going backwards, we need to reverse the array.

--- a/src/Data/Connection/TermObjectConnectionResolver.php
+++ b/src/Data/Connection/TermObjectConnectionResolver.php
@@ -30,11 +30,11 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * TermObjectConnectionResolver constructor.
 	 *
-	 * @param mixed       $source     source passed down from the resolve tree
-	 * @param array       $args       array of arguments input in the field as part of the GraphQL query
-	 * @param \WPGraphQL\AppContext $context Object containing app context that gets passed down the resolve tree
+	 * @param mixed                                $source     source passed down from the resolve tree
+	 * @param array                                $args       array of arguments input in the field as part of the GraphQL query
+	 * @param \WPGraphQL\AppContext                $context Object containing app context that gets passed down the resolve tree
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info Info about fields passed down the resolve tree
-	 * @param mixed|string|null $taxonomy The name of the Taxonomy the resolver is intended to be used for
+	 * @param mixed|string|null                    $taxonomy The name of the Taxonomy the resolver is intended to be used for
 	 *
 	 * @throws \Exception
 	 */

--- a/src/Data/Connection/UserConnectionResolver.php
+++ b/src/Data/Connection/UserConnectionResolver.php
@@ -32,6 +32,9 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 		return true;
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	public function get_loader_name() {
 		return 'user';
 	}

--- a/src/Data/Connection/UserConnectionResolver.php
+++ b/src/Data/Connection/UserConnectionResolver.php
@@ -232,6 +232,7 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 	 * @param array $args The query "where" args
 	 *
 	 * @return array
+	 * @throws \GraphQL\Error\UserError If the user does not have the "list_users" capability.
 	 * @since  0.0.5
 	 */
 	protected function sanitize_input_fields( array $args ) {

--- a/src/Data/Cursor/CommentObjectCursor.php
+++ b/src/Data/Cursor/CommentObjectCursor.php
@@ -139,7 +139,7 @@ class CommentObjectCursor extends AbstractCursor {
 	}
 
 	/**
-	 *{@inheritDoc}
+	 * {@inheritDoc}
 	 */
 	public function to_sql() {
 		$sql = $this->builder->to_sql();

--- a/src/Data/Cursor/CommentObjectCursor.php
+++ b/src/Data/Cursor/CommentObjectCursor.php
@@ -20,7 +20,7 @@ class CommentObjectCursor extends AbstractCursor {
 
 	/**
 	 * @param array|\WP_Comment_Query $query_vars The query vars to use when building the SQL statement.
-	 * @param string|null            $cursor Whether to generate the before or after cursor. Default "after"
+	 * @param string|null             $cursor Whether to generate the before or after cursor. Default "after"
 	 *
 	 * @return void
 	 */

--- a/src/Data/Cursor/TermObjectCursor.php
+++ b/src/Data/Cursor/TermObjectCursor.php
@@ -19,6 +19,8 @@ class TermObjectCursor extends AbstractCursor {
 
 	/**
 	 * {@inheritDoc}
+	 *
+	 * @var string
 	 */
 	protected $id_key = 't.term_id';
 

--- a/src/Data/Cursor/UserCursor.php
+++ b/src/Data/Cursor/UserCursor.php
@@ -29,7 +29,7 @@ class UserCursor extends AbstractCursor {
 	 * UserCursor constructor.
 	 *
 	 * @param array|\WP_User_Query $query_vars The query vars to use when building the SQL statement.
-	 * @param string|null         $cursor     Whether to generate the before or after cursor
+	 * @param string|null          $cursor     Whether to generate the before or after cursor
 	 *
 	 * @return void
 	 */

--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -247,7 +247,6 @@ class DataSource {
 	 *
 	 * @return \WPGraphQL\Model\Theme object
 	 * @throws \GraphQL\Error\UserError
-	 * @throws \Exception
 	 * @since  0.0.5
 	 */
 	public static function resolve_theme( $stylesheet ) {

--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -399,7 +399,8 @@ class DataSource {
 	 * Get all of the allowed settings by group and return the
 	 * settings group that matches the group param
 	 *
-	 * @param string $group
+	 * @param string                           $group
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The WPGraphQL TypeRegistry
 	 *
 	 * @return array $settings_groups[ $group ]
 	 */

--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -53,7 +53,7 @@ class DataSource {
 	/**
 	 * Retrieves a WP_Comment object for the id that gets passed
 	 *
-	 * @param int        $id      ID of the comment we want to get the object for.
+	 * @param int                   $id      ID of the comment we want to get the object for.
 	 * @param \WPGraphQL\AppContext $context The context of the request.
 	 *
 	 * @return \GraphQL\Deferred object
@@ -87,9 +87,9 @@ class DataSource {
 	/**
 	 * Wrapper for the CommentsConnectionResolver class
 	 *
-	 * @param mixed       $source  The object the connection is coming from
-	 * @param array       $args    Query args to pass to the connection resolver
-	 * @param \WPGraphQL\AppContext $context The context of the query to pass along
+	 * @param mixed                                $source  The object the connection is coming from
+	 * @param array                                $args    Query args to pass to the connection resolver
+	 * @param \WPGraphQL\AppContext                $context The context of the query to pass along
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object
 	 *
 	 * @return mixed
@@ -105,9 +105,9 @@ class DataSource {
 	/**
 	 * Wrapper for PluginsConnectionResolver::resolve
 	 *
-	 * @param mixed       $source  The object the connection is coming from
-	 * @param array       $args    Array of arguments to pass to resolve method
-	 * @param \WPGraphQL\AppContext $context AppContext object passed down
+	 * @param mixed                                $source  The object the connection is coming from
+	 * @param array                                $args    Array of arguments to pass to resolve method
+	 * @param \WPGraphQL\AppContext                $context AppContext object passed down
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object
 	 *
 	 * @return array
@@ -122,7 +122,7 @@ class DataSource {
 	/**
 	 * Returns the post object for the ID and post type passed
 	 *
-	 * @param int        $id      ID of the post you are trying to retrieve
+	 * @param int                   $id      ID of the post you are trying to retrieve
 	 * @param \WPGraphQL\AppContext $context The context of the GraphQL Request
 	 *
 	 * @return \GraphQL\Deferred
@@ -139,7 +139,7 @@ class DataSource {
 	}
 
 	/**
-	 * @param int        $id      The ID of the menu item to load
+	 * @param int                   $id      The ID of the menu item to load
 	 * @param \WPGraphQL\AppContext $context The context of the GraphQL request
 	 *
 	 * @return \GraphQL\Deferred|null
@@ -155,11 +155,11 @@ class DataSource {
 	/**
 	 * Wrapper for PostObjectsConnectionResolver
 	 *
-	 * @param mixed              $source    The object the connection is coming from
-	 * @param array              $args      Arguments to pass to the resolve method
-	 * @param \WPGraphQL\AppContext $context AppContext object to pass down
+	 * @param mixed                                $source    The object the connection is coming from
+	 * @param array                                $args      Arguments to pass to the resolve method
+	 * @param \WPGraphQL\AppContext                $context AppContext object to pass down
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object
-	 * @param mixed|string|array $post_type Post type of the post we are trying to resolve
+	 * @param mixed|string|array                   $post_type Post type of the post we are trying to resolve
 	 *
 	 * @return mixed
 	 * @throws \Exception
@@ -207,7 +207,7 @@ class DataSource {
 	/**
 	 * Get the term object for a term
 	 *
-	 * @param int        $id      ID of the term you are trying to retrieve the object for
+	 * @param int                   $id      ID of the term you are trying to retrieve the object for
 	 * @param \WPGraphQL\AppContext $context The context of the GraphQL Request
 	 *
 	 * @return mixed
@@ -224,11 +224,11 @@ class DataSource {
 	/**
 	 * Wrapper for TermObjectConnectionResolver::resolve
 	 *
-	 * @param mixed       $source   The object the connection is coming from
-	 * @param array       $args     Array of args to be passed to the resolve method
-	 * @param \WPGraphQL\AppContext $context The AppContext object to be passed down
+	 * @param mixed                                $source   The object the connection is coming from
+	 * @param array                                $args     Array of args to be passed to the resolve method
+	 * @param \WPGraphQL\AppContext                $context The AppContext object to be passed down
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object
-	 * @param string      $taxonomy The name of the taxonomy the term belongs to
+	 * @param string                               $taxonomy The name of the taxonomy the term belongs to
 	 *
 	 * @return array
 	 * @throws \Exception
@@ -263,9 +263,9 @@ class DataSource {
 	/**
 	 * Wrapper for the ThemesConnectionResolver::resolve method
 	 *
-	 * @param mixed       $source  The object the connection is coming from
-	 * @param array       $args    Passes an array of arguments to the resolve method
-	 * @param \WPGraphQL\AppContext $context The AppContext object to be passed down
+	 * @param mixed                                $source  The object the connection is coming from
+	 * @param array                                $args    Passes an array of arguments to the resolve method
+	 * @param \WPGraphQL\AppContext                $context The AppContext object to be passed down
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object
 	 *
 	 * @return array
@@ -280,7 +280,7 @@ class DataSource {
 	/**
 	 * Gets the user object for the user ID specified
 	 *
-	 * @param int        $id      ID of the user you want the object for
+	 * @param int                   $id      ID of the user you want the object for
 	 * @param \WPGraphQL\AppContext $context The AppContext
 	 *
 	 * @return \GraphQL\Deferred
@@ -297,9 +297,9 @@ class DataSource {
 	/**
 	 * Wrapper for the UsersConnectionResolver::resolve method
 	 *
-	 * @param mixed       $source  The object the connection is coming from
-	 * @param array       $args    Array of args to be passed down to the resolve method
-	 * @param \WPGraphQL\AppContext $context The AppContext object to be passed down
+	 * @param mixed                                $source  The object the connection is coming from
+	 * @param array                                $args    Array of args to be passed down to the resolve method
+	 * @param \WPGraphQL\AppContext                $context The AppContext object to be passed down
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object
 	 *
 	 * @return array
@@ -360,9 +360,9 @@ class DataSource {
 	/**
 	 * Resolve the connection data for user roles
 	 *
-	 * @param array       $source  The Query results
-	 * @param array       $args    The query arguments
-	 * @param \WPGraphQL\AppContext $context The AppContext passed down to the query
+	 * @param array                                $source  The Query results
+	 * @param array                                $args    The query arguments
+	 * @param \WPGraphQL\AppContext                $context The AppContext passed down to the query
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object
 	 *
 	 * @return array
@@ -651,8 +651,8 @@ class DataSource {
 	/**
 	 * Given the ID of a node, this resolves the data
 	 *
-	 * @param string      $global_id The Global ID of the node
-	 * @param \WPGraphQL\AppContext $context The Context of the GraphQL Request
+	 * @param string                               $global_id The Global ID of the node
+	 * @param \WPGraphQL\AppContext                $context The Context of the GraphQL Request
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo for the GraphQL Request
 	 *
 	 * @return null|string
@@ -712,8 +712,8 @@ class DataSource {
 	 *
 	 * Based largely on the core parse_request function in wp-includes/class-wp.php
 	 *
-	 * @param string      $uri     The URI to fetch a resource from
-	 * @param \WPGraphQL\AppContext $context The AppContext passed through the GraphQL Resolve Tree
+	 * @param string                               $uri     The URI to fetch a resource from
+	 * @param \WPGraphQL\AppContext                $context The AppContext passed through the GraphQL Resolve Tree
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed through the GraphQL Resolve tree
 	 *
 	 * @return mixed

--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -177,7 +177,7 @@ class DataSource {
 	 * @param string $taxonomy Name of the taxonomy you want to retrieve the taxonomy object for
 	 *
 	 * @return \WPGraphQL\Model\Taxonomy object
-	 * @throws \GraphQL\Error\UserError|\Exception
+	 * @throws \GraphQL\Error\UserError If no taxonomy is found with the name passed.
 	 * @since  0.0.5
 	 */
 	public static function resolve_taxonomy( $taxonomy ) {
@@ -317,7 +317,7 @@ class DataSource {
 	 * @param string $name Name of the user role you want info for
 	 *
 	 * @return \WPGraphQL\Model\UserRole
-	 * @throws \Exception
+	 * @throws \GraphQL\Error\UserError If no user role is found with the name passed.
 	 * @since  0.0.30
 	 */
 	public static function resolve_user_role( $name ) {
@@ -561,6 +561,7 @@ class DataSource {
 	 * @param mixed $node The node to resolve the type of
 	 *
 	 * @return string
+	 * @throws \GraphQL\Error\UserError If no type is found for the node.
 	 */
 	public static function resolve_node_type( $node ) {
 		$type = null;
@@ -656,7 +657,7 @@ class DataSource {
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo for the GraphQL Request
 	 *
 	 * @return null|string
-	 * @throws \Exception
+	 * @throws \GraphQL\Error\UserError If no ID is passed.
 	 */
 	public static function resolve_node( $global_id, AppContext $context, ResolveInfo $info ) {
 		if ( empty( $global_id ) ) {

--- a/src/Data/MediaItemMutation.php
+++ b/src/Data/MediaItemMutation.php
@@ -17,11 +17,10 @@ class MediaItemMutation {
 	/**
 	 * This prepares the media item for insertion
 	 *
-	 * @param array        $input            The input for the mutation from the GraphQL request
+	 * @param array         $input            The input for the mutation from the GraphQL request
 	 * @param \WP_Post_Type $post_type_object The post_type_object for the mediaItem (attachment)
-	 * @param string       $mutation_name    The name of the mutation being performed (create,
-	 *                                       update, etc.)
-	 * @param mixed        $file             The mediaItem (attachment) file
+	 * @param string        $mutation_name    The name of the mutation being performed (create, update, etc.)
+	 * @param mixed         $file             The mediaItem (attachment) file
 	 *
 	 * @return array $media_item_args
 	 */
@@ -109,11 +108,11 @@ class MediaItemMutation {
 	/**
 	 * This updates additional data related to a mediaItem, such as postmeta.
 	 *
-	 * @param int          $media_item_id    The ID of the media item being mutated
-	 * @param array        $input            The input on the mutation
-	 * @param \WP_Post_Type $post_type_object The Post Type Object for the item being mutated
-	 * @param string       $mutation_name    The name of the mutation
-	 * @param \WPGraphQL\AppContext $context The AppContext that is passed down the resolve tree
+	 * @param int                                  $media_item_id    The ID of the media item being mutated
+	 * @param array                                $input            The input on the mutation
+	 * @param \WP_Post_Type                        $post_type_object The Post Type Object for the item being mutated
+	 * @param string                               $mutation_name    The name of the mutation
+	 * @param \WPGraphQL\AppContext                $context The AppContext that is passed down the resolve tree
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo that is passed down the resolve tree
 	 *
 	 * @return void

--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -108,7 +108,7 @@ class NodeResolver {
 	 * @param array|string $extra_query_vars Any extra query vars to consider
 	 *
 	 * @return mixed
-	 * @throws \Exception
+	 * @throws \GraphQL\Error\UserError If the query class does not exist.
 	 */
 	public function resolve_uri( string $uri, $extra_query_vars = '' ) {
 

--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -610,6 +610,8 @@ class NodeResolver {
 
 	/**
 	 * Checks if the node type is set in the query vars and, if so, whether it matches the node type.
+	 *
+	 * @param string $node_type The node type to check.
 	 */
 	protected function is_valid_node_type( string $node_type ): bool {
 		return ! isset( $this->wp->query_vars['nodeType'] ) || $this->wp->query_vars['nodeType'] === $node_type;

--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -308,7 +308,7 @@ class NodeResolver {
 	 *
 	 * Mimics WP::parse_request()
 	 *
-	 * @param string $uri
+	 * @param string       $uri
 	 * @param array|string $extra_query_vars
 	 *
 	 * @return string|null The parsed uri.

--- a/src/Data/PostObjectMutation.php
+++ b/src/Data/PostObjectMutation.php
@@ -131,10 +131,10 @@ class PostObjectMutation {
 	 *                                                                    delete)
 	 * @param \WPGraphQL\AppContext                $context The AppContext passed down to all resolvers
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down to all resolvers
-	 * @param string                               $intended_post_status  The intended post_status the post should have
-	 *                                                                    according to the mutation input
 	 * @param string                               $default_post_status   The default status posts should use if an
 	 *                                                                    intended status wasn't set
+	 * @param string                               $intended_post_status  The intended post_status the post should have
+	 *                                                                    according to the mutation input
 	 *
 	 * @return void
 	 */

--- a/src/Data/PostObjectMutation.php
+++ b/src/Data/PostObjectMutation.php
@@ -122,7 +122,7 @@ class PostObjectMutation {
 	 * This updates additional data related to a post object, such as postmeta, term relationships,
 	 * etc.
 	 *
-	 * @param int                                  $post_id               $post_id      The ID of the postObject being
+	 * @param int                                  $post_id               The ID of the postObject being
 	 *                                                                    mutated
 	 * @param array                                $input                 The input for the mutation
 	 * @param \WP_Post_Type                        $post_type_object The Post Type Object for the type of post being

--- a/src/Data/PostObjectMutation.php
+++ b/src/Data/PostObjectMutation.php
@@ -18,10 +18,10 @@ class PostObjectMutation {
 	/**
 	 * This handles inserting the post object
 	 *
-	 * @param array        $input             The input for the mutation
+	 * @param array         $input            The input for the mutation
 	 * @param \WP_Post_Type $post_type_object The post_type_object for the type of post being
 	 * mutated
-	 * @param string       $mutation_name     The name of the mutation being performed
+	 * @param string        $mutation_name    The name of the mutation being performed
 	 *
 	 * @return array $insert_post_args
 	 * @throws \Exception
@@ -122,19 +122,19 @@ class PostObjectMutation {
 	 * This updates additional data related to a post object, such as postmeta, term relationships,
 	 * etc.
 	 *
-	 * @param int          $post_id               $post_id      The ID of the postObject being
-	 *                                            mutated
-	 * @param array        $input                 The input for the mutation
-	 * @param \WP_Post_Type $post_type_object The Post Type Object for the type of post being
-	 * mutated
-	 * @param string       $mutation_name         The name of the mutation (ex: create, update,
-	 *                                            delete)
-	 * @param \WPGraphQL\AppContext $context The AppContext passed down to all resolvers
+	 * @param int                                  $post_id               $post_id      The ID of the postObject being
+	 *                                                                    mutated
+	 * @param array                                $input                 The input for the mutation
+	 * @param \WP_Post_Type                        $post_type_object The Post Type Object for the type of post being
+	 *                        mutated
+	 * @param string                               $mutation_name         The name of the mutation (ex: create, update,
+	 *                                                                    delete)
+	 * @param \WPGraphQL\AppContext                $context The AppContext passed down to all resolvers
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down to all resolvers
-	 * @param string       $intended_post_status  The intended post_status the post should have
-	 *                                            according to the mutation input
-	 * @param string       $default_post_status   The default status posts should use if an
-	 *                                            intended status wasn't set
+	 * @param string                               $intended_post_status  The intended post_status the post should have
+	 *                                                                    according to the mutation input
+	 * @param string                               $default_post_status   The default status posts should use if an
+	 *                                                                    intended status wasn't set
 	 *
 	 * @return void
 	 */
@@ -227,11 +227,11 @@ class PostObjectMutation {
 	 * Given a $post_id and $input from the mutation, check to see if any term associations are
 	 * being made, and properly set the relationships
 	 *
-	 * @param int          $post_id           The ID of the postObject being mutated
-	 * @param array        $input             The input for the mutation
+	 * @param int           $post_id           The ID of the postObject being mutated
+	 * @param array         $input             The input for the mutation
 	 * @param \WP_Post_Type $post_type_object The Post Type Object for the type of post being
 	 * mutated
-	 * @param string       $mutation_name     The name of the mutation (ex: create, update, delete)
+	 * @param string        $mutation_name     The name of the mutation (ex: create, update, delete)
 	 *
 	 * @return void
 	 */
@@ -470,8 +470,8 @@ class PostObjectMutation {
 	/**
 	 * Check the edit lock for a post
 	 *
-	 * @param false|int     $post_id ID of the post to delete the lock for
-	 * @param array      $input             The input for the mutation
+	 * @param false|int $post_id ID of the post to delete the lock for
+	 * @param array     $input             The input for the mutation
 	 *
 	 * @return false|int Return false if no lock or the user_id of the owner of the lock
 	 */

--- a/src/Data/PostObjectMutation.php
+++ b/src/Data/PostObjectMutation.php
@@ -20,7 +20,7 @@ class PostObjectMutation {
 	 *
 	 * @param array        $input             The input for the mutation
 	 * @param \WP_Post_Type $post_type_object The post_type_object for the type of post being
- * mutated
+	 * mutated
 	 * @param string       $mutation_name     The name of the mutation being performed
 	 *
 	 * @return array $insert_post_args
@@ -126,7 +126,7 @@ class PostObjectMutation {
 	 *                                            mutated
 	 * @param array        $input                 The input for the mutation
 	 * @param \WP_Post_Type $post_type_object The Post Type Object for the type of post being
- * mutated
+	 * mutated
 	 * @param string       $mutation_name         The name of the mutation (ex: create, update,
 	 *                                            delete)
 	 * @param \WPGraphQL\AppContext $context The AppContext passed down to all resolvers
@@ -230,7 +230,7 @@ class PostObjectMutation {
 	 * @param int          $post_id           The ID of the postObject being mutated
 	 * @param array        $input             The input for the mutation
 	 * @param \WP_Post_Type $post_type_object The Post Type Object for the type of post being
- * mutated
+	 * mutated
 	 * @param string       $mutation_name     The name of the mutation (ex: create, update, delete)
 	 *
 	 * @return void

--- a/src/Data/PostObjectMutation.php
+++ b/src/Data/PostObjectMutation.php
@@ -122,19 +122,14 @@ class PostObjectMutation {
 	 * This updates additional data related to a post object, such as postmeta, term relationships,
 	 * etc.
 	 *
-	 * @param int                                  $post_id               The ID of the postObject being
-	 *                                                                    mutated
-	 * @param array                                $input                 The input for the mutation
-	 * @param \WP_Post_Type                        $post_type_object The Post Type Object for the type of post being
-	 *                        mutated
-	 * @param string                               $mutation_name         The name of the mutation (ex: create, update,
-	 *                                                                    delete)
-	 * @param \WPGraphQL\AppContext                $context The AppContext passed down to all resolvers
-	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down to all resolvers
-	 * @param string                               $default_post_status   The default status posts should use if an
-	 *                                                                    intended status wasn't set
-	 * @param string                               $intended_post_status  The intended post_status the post should have
-	 *                                                                    according to the mutation input
+	 * @param int                                  $post_id              The ID of the postObject being mutated
+	 * @param array                                $input                The input for the mutation
+	 * @param \WP_Post_Type                        $post_type_object     The Post Type Object for the type of post being mutated
+	 * @param string                               $mutation_name        The name of the mutation (ex: create, update, delete)
+	 * @param \WPGraphQL\AppContext                $context              The AppContext passed down to all resolvers
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info                 The ResolveInfo passed down to all resolvers
+	 * @param string                               $default_post_status  The default status posts should use if an intended status wasn't set
+	 * @param string                               $intended_post_status The intended post_status the post should have according to the mutation input
 	 *
 	 * @return void
 	 */

--- a/src/Data/UserMutation.php
+++ b/src/Data/UserMutation.php
@@ -113,6 +113,7 @@ class UserMutation {
 	 * @param string $mutation_name Name of the mutation being performed
 	 *
 	 * @return array
+	 * @throws \GraphQL\Error\UserError If the passed email address is invalid.
 	 */
 	public static function prepare_user_object( $input, $mutation_name ) {
 		$insert_user_args = [];

--- a/src/Data/UserMutation.php
+++ b/src/Data/UserMutation.php
@@ -205,10 +205,10 @@ class UserMutation {
 	 * This updates additional data related to the user object after the initial mutation has
 	 * happened
 	 *
-	 * @param int         $user_id       The ID of the user being mutated
-	 * @param array       $input         The input data from the GraphQL query
-	 * @param string      $mutation_name Name of the mutation currently being run
-	 * @param \WPGraphQL\AppContext $context The AppContext passed down the resolve tree
+	 * @param int                                  $user_id       The ID of the user being mutated
+	 * @param array                                $input         The input data from the GraphQL query
+	 * @param string                               $mutation_name Name of the mutation currently being run
+	 * @param \WPGraphQL\AppContext                $context The AppContext passed down the resolve tree
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the Resolve Tree
 	 *
 	 * @return void

--- a/src/Mutation/PostObjectCreate.php
+++ b/src/Mutation/PostObjectCreate.php
@@ -191,7 +191,7 @@ class PostObjectCreate {
 	 * Defines the mutation data modification closure.
 	 *
 	 * @param \WP_Post_Type $post_type_object The post type of the mutation.
-	 * @param string       $mutation_name    The mutation name.
+	 * @param string        $mutation_name    The mutation name.
 	 *
 	 * @return callable
 	 */

--- a/src/Mutation/PostObjectDelete.php
+++ b/src/Mutation/PostObjectDelete.php
@@ -95,7 +95,7 @@ class PostObjectDelete {
 	 * Defines the mutation data modification closure.
 	 *
 	 * @param \WP_Post_Type $post_type_object The post type of the mutation.
-	 * @param string       $mutation_name    The mutation name.
+	 * @param string        $mutation_name    The mutation name.
 	 *
 	 * @return callable
 	 */

--- a/src/Mutation/TermObjectCreate.php
+++ b/src/Mutation/TermObjectCreate.php
@@ -105,7 +105,7 @@ class TermObjectCreate {
 	 * Defines the mutation data modification closure.
 	 *
 	 * @param \WP_Taxonomy $taxonomy The taxonomy type of the mutation.
-	 * @param string      $mutation_name The name of the mutation.
+	 * @param string       $mutation_name The name of the mutation.
 	 *
 	 * @return callable
 	 */

--- a/src/Mutation/TermObjectDelete.php
+++ b/src/Mutation/TermObjectDelete.php
@@ -85,7 +85,7 @@ class TermObjectDelete {
 	 * Defines the mutation data modification closure.
 	 *
 	 * @param \WP_Taxonomy $taxonomy The taxonomy type of the mutation.
-	 * @param string      $mutation_name The name of the mutation.
+	 * @param string       $mutation_name The name of the mutation.
 	 *
 	 * @return callable
 	 */

--- a/src/Mutation/UpdateSettings.php
+++ b/src/Mutation/UpdateSettings.php
@@ -148,7 +148,7 @@ class UpdateSettings {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @param array $input The mutation input
+	 * @param array                            $input The mutation input
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The WPGraphQL TypeRegistry
 	 *
 	 * @return array

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -653,7 +653,7 @@ class TypeRegistry {
 	/**
 	 * Add a Type to the Registry
 	 *
-	 * @param string $type_name The name of the type to register
+	 * @param string                                    $type_name The name of the type to register
 	 * @param mixed|array|\GraphQL\Type\Definition\Type $config The config for the type
 	 *
 	 * @throws \Exception
@@ -724,7 +724,7 @@ class TypeRegistry {
 	 * Add an Object Type to the Registry
 	 *
 	 * @param string $type_name The name of the type to register
-	 * @param array $config The configuration of the type
+	 * @param array  $config The configuration of the type
 	 *
 	 * @throws \Exception
 	 * @return void
@@ -752,7 +752,7 @@ class TypeRegistry {
 	 * Add an Enum Type to the registry
 	 *
 	 * @param string $type_name The name of the type to register
-	 * @param array $config he configuration of the type
+	 * @param array  $config he configuration of the type
 	 *
 	 * @return void
 	 * @throws \Exception
@@ -766,7 +766,7 @@ class TypeRegistry {
 	 * Add an Input Type to the Registry
 	 *
 	 * @param string $type_name The name of the type to register
-	 * @param array $config he configuration of the type
+	 * @param array  $config he configuration of the type
 	 *
 	 * @return void
 	 * @throws \Exception
@@ -780,7 +780,7 @@ class TypeRegistry {
 	 * Add a Union Type to the Registry
 	 *
 	 * @param string $type_name The name of the type to register
-	 * @param array $config he configuration of the type
+	 * @param array  $config he configuration of the type
 	 *
 	 * @return void
 	 *
@@ -792,7 +792,7 @@ class TypeRegistry {
 	}
 
 	/**
-	 * @param string $type_name The name of the type to register
+	 * @param string                                    $type_name The name of the type to register
 	 * @param mixed|array|\GraphQL\Type\Definition\Type $config he configuration of the type
 	 *
 	 * @return mixed|array|\GraphQL\Type\Definition\Type|null

--- a/src/Registry/Utils/PostObject.php
+++ b/src/Registry/Utils/PostObject.php
@@ -418,6 +418,8 @@ class PostObject {
 	/**
 	 * Register fields to the Type used for attachments (MediaItem).
 	 *
+	 * @param \WP_Post_Type $post_type_object Post type.
+	 *
 	 * @return void
 	 */
 	private static function register_attachment_fields( WP_Post_Type $post_type_object ) {

--- a/src/Router.php
+++ b/src/Router.php
@@ -532,12 +532,10 @@ class Router {
 	 *
 	 * @param mixed|array|\GraphQL\Executor\ExecutionResult $response The response of the GraphQL Request.
 	 * @param mixed|array|\GraphQL\Executor\ExecutionResult $graphql_results The results of the GraphQL execution.
-	 * @param string                      $query           The GraphQL query.
-	 * @param string                      $operation_name  The operation name of the GraphQL
-	 *                                                     Request.
-	 * @param mixed|array|null            $variables       The variables applied to the GraphQL
-	 *                                                     Request.
-	 * @param mixed|\WP_User|null $user The current user object.
+	 * @param string                                        $query           The GraphQL query.
+	 * @param string                                        $operation_name  The operation name of the GraphQL Request.
+	 * @param mixed|array|null                              $variables       The variables applied to the GraphQL Request.
+	 * @param mixed|\WP_User|null                           $user The current user object.
 	 *
 	 * @return void
 	 */

--- a/src/Server/ValidationRules/QueryDepth.php
+++ b/src/Server/ValidationRules/QueryDepth.php
@@ -66,8 +66,8 @@ class QueryDepth extends QuerySecurityRule {
 	 * Determine field depth
 	 *
 	 * @param mixed $node The node being analyzed
-	 * @param int $depth The depth of the field
-	 * @param int $maxDepth The max depth allowed
+	 * @param int   $depth The depth of the field
+	 * @param int   $maxDepth The max depth allowed
 	 *
 	 * @return int|mixed
 	 */
@@ -85,8 +85,8 @@ class QueryDepth extends QuerySecurityRule {
 	 * Determine node depth
 	 *
 	 * @param \GraphQL\Language\AST\Node $node The node being analyzed in the operation
-	 * @param int  $depth The depth of the operation
-	 * @param int  $maxDepth The Max Depth of the operation
+	 * @param int                        $depth The depth of the operation
+	 * @param int                        $maxDepth The Max Depth of the operation
 	 *
 	 * @return int|mixed
 	 */

--- a/src/Server/ValidationRules/RequireAuthentication.php
+++ b/src/Server/ValidationRules/RequireAuthentication.php
@@ -94,7 +94,7 @@ class RequireAuthentication extends QuerySecurityRule {
 									__( 'The field "%s" cannot be accessed without authentication.', 'wp-graphql' ),
 									$context->getParentType() . '.' . $node->name->value
 								),
-								//@phpstan-ignore-next-line
+								// @phpstan-ignore-next-line
 								[ $node ]
 							)
 						);

--- a/src/Type/Connection/PostObjects.php
+++ b/src/Type/Connection/PostObjects.php
@@ -228,7 +228,7 @@ class PostObjects {
 	 * registering a connection.
 	 *
 	 * @param mixed|\WP_Post_Type|\WP_Taxonomy $graphql_object The post type object for the post_type having a
- * connection registered to it
+	 * connection registered to it
 	 * @param array                          $args           The custom args to modify the connection registration
 	 *
 	 * @return array

--- a/src/Type/Connection/PostObjects.php
+++ b/src/Type/Connection/PostObjects.php
@@ -229,7 +229,7 @@ class PostObjects {
 	 *
 	 * @param mixed|\WP_Post_Type|\WP_Taxonomy $graphql_object The post type object for the post_type having a
 	 * connection registered to it
-	 * @param array                          $args           The custom args to modify the connection registration
+	 * @param array                            $args           The custom args to modify the connection registration
 	 *
 	 * @return array
 	 */
@@ -259,7 +259,7 @@ class PostObjects {
 	/**
 	 * Given an optional array of args, this returns the args to be used in the connection
 	 *
-	 * @param array         $args             The args to modify the defaults
+	 * @param array                            $args             The args to modify the defaults
 	 * @param mixed|\WP_Post_Type|\WP_Taxonomy $post_type_object The post type the connection is going to
 	 *
 	 * @return array

--- a/src/Type/ObjectType/PostObject.php
+++ b/src/Type/ObjectType/PostObject.php
@@ -16,7 +16,7 @@ class PostObject {
 	/**
 	 * Registers a post_type WPObject type to the schema.
 	 *
-	 * @param \WP_Post_Type $post_type_object Post type.
+	 * @param \WP_Post_Type                    $post_type_object Post type.
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The Type Registry
 	 *
 	 * @return void
@@ -33,7 +33,7 @@ class PostObject {
 	/**
 	 * Registers common post type fields on schema type corresponding to provided post type object.
 	 *
-	 * @param \WP_Post_Type $post_type_object Post type.
+	 * @param \WP_Post_Type                    $post_type_object Post type.
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The Type Registry
 	 *
 	 * @deprecated 1.12.0

--- a/src/Type/ObjectType/SettingGroup.php
+++ b/src/Type/ObjectType/SettingGroup.php
@@ -11,8 +11,8 @@ class SettingGroup {
 	/**
 	 * Register each settings group to the GraphQL Schema
 	 *
-	 * @param string       $group_name    The name of the setting group
-	 * @param string       $group         The settings group config
+	 * @param string                           $group_name    The name of the setting group
+	 * @param string                           $group         The settings group config
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The WPGraphQL TypeRegistry
 	 *
 	 * @return string|null
@@ -43,8 +43,8 @@ class SettingGroup {
 	/**
 	 * Given the name of a registered settings group, retrieve GraphQL fields for the group
 	 *
-	 * @param string $group_name Name of the settings group to retrieve fields for
-	 * @param string $group      The settings group config
+	 * @param string                           $group_name Name of the settings group to retrieve fields for
+	 * @param string                           $group      The settings group config
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The WPGraphQL TypeRegistry
 	 *
 	 * @return array

--- a/src/Type/WPConnectionType.php
+++ b/src/Type/WPConnectionType.php
@@ -205,6 +205,7 @@ class WPConnectionType {
 	 * @param array $config
 	 *
 	 * @return void
+	 * @throws \GraphQL\Exception\InvalidArgument If the config is invalid.
 	 */
 	protected function validate_config( array $config ): void {
 		if ( ! array_key_exists( 'fromType', $config ) ) {

--- a/src/Type/WPInputObjectType.php
+++ b/src/Type/WPInputObjectType.php
@@ -18,7 +18,7 @@ class WPInputObjectType extends InputObjectType {
 	/**
 	 * WPInputObjectType constructor.
 	 *
-	 * @param array        $config
+	 * @param array $config
 	 */
 	public function __construct( array $config, TypeRegistry $type_registry ) {
 		$name           = $config['name'];
@@ -47,9 +47,9 @@ class WPInputObjectType extends InputObjectType {
 	 * This function sorts the fields and applies a filter to allow for easily
 	 * extending/modifying the shape of the Schema for the type.
 	 *
-	 * @param array        $fields
-	 * @param string       $type_name
-	 * @param array        $config
+	 * @param array                            $fields
+	 * @param string                           $type_name
+	 * @param array                            $config
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 * @return mixed
 	 * @since 0.0.5

--- a/src/Type/WPInputObjectType.php
+++ b/src/Type/WPInputObjectType.php
@@ -18,7 +18,8 @@ class WPInputObjectType extends InputObjectType {
 	/**
 	 * WPInputObjectType constructor.
 	 *
-	 * @param array $config
+	 * @param array<string,mixed>              $config
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 */
 	public function __construct( array $config, TypeRegistry $type_registry ) {
 		$name           = $config['name'];

--- a/src/Type/WPInterfaceType.php
+++ b/src/Type/WPInterfaceType.php
@@ -24,7 +24,7 @@ class WPInterfaceType extends InterfaceType {
 	/**
 	 * WPInterfaceType constructor.
 	 *
-	 * @param array        $config
+	 * @param array                            $config
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
 	 * @throws \Exception

--- a/src/Type/WPMutationType.php
+++ b/src/Type/WPMutationType.php
@@ -70,7 +70,7 @@ class WPMutationType {
 	/**
 	 * WPMutationType constructor.
 	 *
-	 * @param array        $config        The config array for the mutation
+	 * @param array                            $config        The config array for the mutation
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry Instance of the WPGraphQL Type Registry
 	 *
 	 * @throws \Exception

--- a/src/Type/WPMutationType.php
+++ b/src/Type/WPMutationType.php
@@ -54,7 +54,7 @@ class WPMutationType {
 	protected $output_fields;
 
 	/**
-	 * The resolver function to resole the connection
+	 * The resolver function to resolve the mutation
 	 *
 	 * @var callable|\Closure
 	 */
@@ -188,6 +188,9 @@ class WPMutationType {
 		return $output_fields;
 	}
 
+	/**
+	 * Gets the resolver callable for the mutation.
+	 */
 	protected function get_resolver(): callable {
 		return function ( $root, array $args, AppContext $context, ResolveInfo $info ) {
 			$unfiltered_input = $args['input'];
@@ -277,6 +280,9 @@ class WPMutationType {
 		);
 	}
 
+	/**
+	 * Registers the payload type to the Schema.
+	 */
 	protected function register_mutation_payload(): void {
 		$object_name = $this->mutation_name . 'Payload';
 

--- a/src/Type/WPObjectType.php
+++ b/src/Type/WPObjectType.php
@@ -45,7 +45,7 @@ class WPObjectType extends ObjectType {
 	/**
 	 * WPObjectType constructor.
 	 *
-	 * @param array        $config
+	 * @param array                            $config
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
 	 * @throws \Exception

--- a/src/Type/WPScalar.php
+++ b/src/Type/WPScalar.php
@@ -14,7 +14,7 @@ class WPScalar extends CustomScalarType {
 	/**
 	 * WPScalar constructor.
 	 *
-	 * @param array        $config
+	 * @param array                            $config
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 */
 	public function __construct( array $config, TypeRegistry $type_registry ) {

--- a/src/Type/WPUnionType.php
+++ b/src/Type/WPUnionType.php
@@ -24,7 +24,7 @@ class WPUnionType extends UnionType {
 	/**
 	 * WPUnionType constructor.
 	 *
-	 * @param array        $config The Config to setup a Union Type
+	 * @param array                            $config The Config to setup a Union Type
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
 	 * @since 0.0.30

--- a/src/Utils/DebugLog.php
+++ b/src/Utils/DebugLog.php
@@ -44,7 +44,7 @@ class DebugLog {
 	 * Given a message and a config, a log entry is added to the log
 	 *
 	 * @param mixed|string|array $message The debug log message
-	 * @param array  $config Config for the debug log. Set type and any additional information to log
+	 * @param array              $config Config for the debug log. Set type and any additional information to log
 	 *
 	 * @return array
 	 */

--- a/src/Utils/InstrumentSchema.php
+++ b/src/Utils/InstrumentSchema.php
@@ -18,7 +18,7 @@ class InstrumentSchema {
 
 	/**
 	 * @param \GraphQL\Type\Definition\Type $type Instance of the Schema.
-	 * @param string $type_name Name of the Type
+	 * @param string                        $type_name Name of the Type
 	 *
 	 * @return \GraphQL\Type\Definition\Type
 	 */
@@ -193,13 +193,13 @@ class InstrumentSchema {
 	 *
 	 * This takes into account auth params defined in the Schema
 	 *
-	 * @param mixed                 $source         The source passed down the Resolve Tree
-	 * @param array                 $args           The args for the field
-	 * @param \WPGraphQL\AppContext $context The AppContext passed down the ResolveTree
-	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the ResolveTree
-	 * @param mixed|callable|string $field_resolver The Resolve function for the field
-	 * @param string                $type_name      The name of the type the fields belong to
-	 * @param string                $field_key      The name of the field
+	 * @param mixed                                    $source         The source passed down the Resolve Tree
+	 * @param array                                    $args           The args for the field
+	 * @param \WPGraphQL\AppContext                    $context The AppContext passed down the ResolveTree
+	 * @param \GraphQL\Type\Definition\ResolveInfo     $info The ResolveInfo passed down the ResolveTree
+	 * @param mixed|callable|string                    $field_resolver The Resolve function for the field
+	 * @param string                                   $type_name      The name of the type the fields belong to
+	 * @param string                                   $field_key      The name of the field
 	 * @param \GraphQL\Type\Definition\FieldDefinition $field The Field Definition for the resolving field
 	 *
 	 * @return void

--- a/src/Utils/QueryAnalyzer.php
+++ b/src/Utils/QueryAnalyzer.php
@@ -183,9 +183,9 @@ class QueryAnalyzer {
 	/**
 	 * Determine the keys associated with the GraphQL document being executed
 	 *
-	 * @param ?string         $query     The GraphQL query
-	 * @param ?string         $operation The name of the operation
-	 * @param ?array          $variables Variables to be passed to your GraphQL request
+	 * @param ?string                         $query     The GraphQL query
+	 * @param ?string                         $operation The name of the operation
+	 * @param ?array                          $variables Variables to be passed to your GraphQL request
 	 * @param \GraphQL\Server\OperationParams $params The Operation Params. This includes any extra params,
 	 * such as extensions or any other modifications to the request body
 	 *
@@ -296,10 +296,10 @@ class QueryAnalyzer {
 
 
 	/**
-	 * @param \GraphQL\Type\Definition\Type $type The Type of field
+	 * @param \GraphQL\Type\Definition\Type            $type The Type of field
 	 * @param \GraphQL\Type\Definition\FieldDefinition $field_def The field definition the type is for
-	 * @param mixed $parent_type The Parent Type
-	 * @param bool $is_list_type Whether the field is a list type field
+	 * @param mixed                                    $parent_type The Parent Type
+	 * @param bool                                     $is_list_type Whether the field is a list type field
 	 *
 	 * @return  \GraphQL\Type\Definition\Type|String|null
 	 */
@@ -354,7 +354,7 @@ class QueryAnalyzer {
 	 * by the query.
 	 *
 	 * @param ?\GraphQL\Type\Schema $schema The WPGraphQL Schema
-	 * @param ?string $query  The query string
+	 * @param ?string               $query  The query string
 	 *
 	 * @return array
 	 * @throws \GraphQL\Error\SyntaxError|\Exception
@@ -453,7 +453,7 @@ class QueryAnalyzer {
 	 * by the query.
 	 *
 	 * @param ?\GraphQL\Type\Schema $schema The WPGraphQL Schema
-	 * @param ?string $query  The query string
+	 * @param ?string               $query  The query string
 	 *
 	 * @return array
 	 * @throws \Exception
@@ -531,7 +531,7 @@ class QueryAnalyzer {
 	 * asked for by the query.
 	 *
 	 * @param ?\GraphQL\Type\Schema $schema The WPGraphQL Schema
-	 * @param ?string $query  The query string
+	 * @param ?string               $query  The query string
 	 *
 	 * @return array
 	 * @throws \GraphQL\Error\SyntaxError|\Exception
@@ -757,11 +757,11 @@ class QueryAnalyzer {
 	/**
 	 * Outputs Query Analyzer data in the extensions response
 	 *
-	 * @param mixed       $response
+	 * @param mixed               $response
 	 * @param \WPGraphQL\WPSchema $schema The WPGraphQL Schema
-	 * @param string|null $operation_name The operation name being executed
-	 * @param string|null $request        The GraphQL Request being made
-	 * @param array|null  $variables      The variables sent with the request
+	 * @param string|null         $operation_name The operation name being executed
+	 * @param string|null         $request        The GraphQL Request being made
+	 * @param array|null          $variables      The variables sent with the request
 	 *
 	 * @return array|object|null
 	 */

--- a/src/Utils/QueryLog.php
+++ b/src/Utils/QueryLog.php
@@ -93,11 +93,11 @@ class QueryLog {
 	/**
 	 * Filter the results of the GraphQL Response to include the Query Log
 	 *
-	 * @param mixed    $response
+	 * @param mixed               $response
 	 * @param \WPGraphQL\WPSchema $schema The WPGraphQL Schema
-	 * @param string   $operation_name The operation name being executed
-	 * @param string   $request        The GraphQL Request being made
-	 * @param array    $variables      The variables sent with the request
+	 * @param string              $operation_name The operation name being executed
+	 * @param string              $request        The GraphQL Request being made
+	 * @param array               $variables      The variables sent with the request
 	 *
 	 * @return array
 	 */

--- a/src/Utils/Tracing.php
+++ b/src/Utils/Tracing.php
@@ -135,9 +135,9 @@ class Tracing {
 	/**
 	 * Initialize tracing for an individual field
 	 *
-	 * @param mixed               $source         The source passed down the Resolve Tree
-	 * @param array               $args           The args for the field
-	 * @param \WPGraphQL\AppContext $context The AppContext passed down the ResolveTree
+	 * @param mixed                                $source         The source passed down the Resolve Tree
+	 * @param array                                $args           The args for the field
+	 * @param \WPGraphQL\AppContext                $context The AppContext passed down the ResolveTree
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the ResolveTree
 	 *
 	 * @return void

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -82,7 +82,7 @@ class Utils {
 	 * Checks the post_date_gmt or modified_gmt and prepare any post or
 	 * modified date for single post output.
 	 *
-	 * @param string $date_gmt GMT publication time.
+	 * @param string            $date_gmt GMT publication time.
 	 * @param mixed|string|null $date Optional. Local publication time. Default null.
 	 *
 	 * @return string|null ISO8601/RFC3339 formatted datetime.

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -1,6 +1,9 @@
 <?php
-
-// Global. - namespace WPGraphQL;
+/**
+ * The global WPGraphQL class.
+ *
+ * @package WPGraphQL
+ */
 
 use WPGraphQL\Utils\Preview;
 use WPGraphQL\Utils\InstrumentSchema;
@@ -15,8 +18,6 @@ use WPGraphQL\Type\WPObjectType;
  * Class WPGraphQL
  *
  * This is the one true WPGraphQL class
- *
- * @package WPGraphQL
  */
 final class WPGraphQL {
 

--- a/src/WPSchema.php
+++ b/src/WPSchema.php
@@ -32,7 +32,7 @@ class WPSchema extends Schema {
 	/**
 	 * WPSchema constructor.
 	 *
-	 * @param \GraphQL\Type\SchemaConfig $config The config for the Schema.
+	 * @param \GraphQL\Type\SchemaConfig       $config The config for the Schema.
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
 	 * @since 0.0.9


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR restores the `Squiz.Commenting` PHPCS ruleset, and addresses the resulting smells. 
More specifically: 

- `Squiz.Commenting.BlockComment`, `Squiz.Commenting.DocCommenting.Alignment`, `Squiz.FunctionComment.SpacingAfterParam`, and `Squiz.Commenting.InlineComment.NoSpaceBefore` were autofixed.
- added missing and fixed existing`@var` tags, `@params` and their types, `@throws` tags.
- fixed bad file comment formatting
- (smaller changes are listed as individual commits).

See additional comments for the remaining `Squiz.Commenting` smells that are now explicitly excluded.

**No production code has been changed in this PR**

Does this close any currently open issues?
------------------------------------------
<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
<!-- (If it’s long, please paste to https://ghostbin.com/ and insert the link here.) -->


Any other comments?
-------------------
- `Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction` has been removed from the ruleset as it is already included by `WordPress`.
- `Generic.Commenting.DocComment.MissingShort` has been reclassified as "Should probably be added back".
- `Squiz.Commenting.FunctionComment.IncorrectTypeHint` throws false positives when used in conjunction with FCQN. which is significantly more important in terms of IDE hinting.
- `Squiz.Commenting.ClassComment.Missing`, `Squiz.Commenting.FileComment.Missing`. These don't affect IDE hinting, and a lot of effort to add.
- `Squiz.Commenting.FunctionComment.EmptyThrows`, `Squiz.Commenting.FunctionComment.MissingParamComment`. While adding param explanations would be nice, this would be a lot of work to remediate. Saving for a future PR.
- `Squiz.Commenting.InlineComment.InvalidEndChar`, would be a lot of work to remediate for only formatting.


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php8.1.15)

**WordPress Version:** 6.3.2
