### PR TITLE
chore: implement stricter type hinting with `SlevomatCodingStandard.TypeHints` [phpcs]

### DIFF
--- a/access-functions.php
+++ b/access-functions.php
@@ -86,10 +86,10 @@ function graphql_format_type_name( $type_name ) {
 /**
  * Provides a simple way to run a GraphQL query without posting a request to the endpoint.
  *
- * @param array $request_data   The GraphQL request data (query, variables, operation_name).
- * @param bool  $return_request If true, return the Request object, else return the results of the request execution
+ * @param array<string,mixed> $request_data   The GraphQL request data (query, variables, operation_name).
+ * @param bool                $return_request If true, return the Request object, else return the results of the request execution
  *
- * @return array|\WPGraphQL\Request
+ * @return array<string,mixed>|\WPGraphQL\Request
  * @throws \Exception
  * @since  0.2.0
  */
@@ -109,12 +109,12 @@ function graphql( array $request_data = [], bool $return_request = false ) {
  * Previous access function for running GraphQL queries directly. This function will
  * eventually be deprecated in favor of `graphql`.
  *
- * @param string $query          The GraphQL query to run
- * @param string $operation_name The name of the operation
- * @param array  $variables      Variables to be passed to your GraphQL request
- * @param bool   $return_request If true, return the Request object, else return the results of the request execution
+ * @param string              $query          The GraphQL query to run
+ * @param string              $operation_name The name of the operation
+ * @param array<string,mixed> $variables      Variables to be passed to your GraphQL request
+ * @param bool                $return_request If true, return the Request object, else return the results of the request execution
  *
- * @return array|\WPGraphQL\Request
+ * @return array<string,mixed>|\WPGraphQL\Request
  * @throws \Exception
  * @since  0.0.2
  */
@@ -197,8 +197,8 @@ function register_graphql_interfaces_to_types( $interface_names, $type_names ) {
 /**
  * Given a Type Name and a $config array, this adds a Type to the TypeRegistry
  *
- * @param string $type_name The name of the Type to register
- * @param array  $config    The Type config
+ * @param string              $type_name The name of the Type to register
+ * @param array<string,mixed> $config    The Type config
  *
  * @throws \Exception
  * @return void
@@ -216,8 +216,8 @@ function register_graphql_type( string $type_name, array $config ) {
 /**
  * Given a Type Name and a $config array, this adds an Interface Type to the TypeRegistry
  *
- * @param string                                    $type_name The name of the Type to register
- * @param mixed|array|\GraphQL\Type\Definition\Type $config    The Type config
+ * @param string                                                  $type_name The name of the Type to register
+ * @param mixed|array<string,mixed>|\GraphQL\Type\Definition\Type $config    The Type config
  *
  * @throws \Exception
  * @return void
@@ -235,8 +235,8 @@ function register_graphql_interface_type( string $type_name, $config ) {
 /**
  * Given a Type Name and a $config array, this adds an ObjectType to the TypeRegistry
  *
- * @param string $type_name The name of the Type to register
- * @param array  $config    The Type config
+ * @param string              $type_name The name of the Type to register
+ * @param array<string,mixed> $config    The Type config
  *
  * @return void
  */
@@ -248,8 +248,8 @@ function register_graphql_object_type( string $type_name, array $config ) {
 /**
  * Given a Type Name and a $config array, this adds an InputType to the TypeRegistry
  *
- * @param string $type_name The name of the Type to register
- * @param array  $config    The Type config
+ * @param string              $type_name The name of the Type to register
+ * @param array<string,mixed> $config    The Type config
  *
  * @return void
  */
@@ -261,8 +261,8 @@ function register_graphql_input_type( string $type_name, array $config ) {
 /**
  * Given a Type Name and a $config array, this adds an UnionType to the TypeRegistry
  *
- * @param string $type_name The name of the Type to register
- * @param array  $config    The Type config
+ * @param string              $type_name The name of the Type to register
+ * @param array<string,mixed> $config    The Type config
  *
  * @throws \Exception
  *
@@ -282,8 +282,8 @@ function register_graphql_union_type( string $type_name, array $config ) {
 /**
  * Given a Type Name and a $config array, this adds an EnumType to the TypeRegistry
  *
- * @param string $type_name The name of the Type to register
- * @param array  $config    The Type config
+ * @param string              $type_name The name of the Type to register
+ * @param array<string,mixed> $config    The Type config
  *
  * @return void
  */
@@ -296,9 +296,9 @@ function register_graphql_enum_type( string $type_name, array $config ) {
  * Given a Type Name, Field Name, and a $config array, this adds a Field to a registered Type in
  * the TypeRegistry
  *
- * @param string $type_name                       The name of the Type to add the field to
- * @param string $field_name                      The name of the Field to add to the Type
- * @param array  $config                          The Type config
+ * @param string              $type_name  The name of the Type to add the field to
+ * @param string              $field_name The name of the Field to add to the Type
+ * @param array<string,mixed> $config     The Type config
  *
  * @return void
  * @throws \Exception
@@ -318,8 +318,8 @@ function register_graphql_field( string $type_name, string $field_name, array $c
  * Given a Type Name and an array of field configs, this adds the fields to the registered type in
  * the TypeRegistry
  *
- * @param string $type_name The name of the Type to add the fields to
- * @param array  $fields    An array of field configs
+ * @param string                            $type_name The name of the Type to add the fields to
+ * @param array<string,array<string,mixed>> $fields    An array of field configs
  *
  * @return void
  * @throws \Exception
@@ -338,10 +338,10 @@ function register_graphql_fields( string $type_name, array $fields ) {
 /**
  * Adds a field to the Connection Edge between the provided 'From' Type Name and 'To' Type Name.
  *
- * @param string $from_type  The name of the Type the connection is coming from.
- * @param string $to_type    The name of the Type or Alias (the connection config's `FromFieldName`) the connection is going to.
- * @param string $field_name The name of the field to add to the connection edge.
- * @param array  $config      The field config.
+ * @param string              $from_type  The name of the Type the connection is coming from.
+ * @param string              $to_type    The name of the Type or Alias (the connection config's `FromFieldName`) the connection is going to.
+ * @param string              $field_name The name of the field to add to the connection edge.
+ * @param array<string,mixed> $config     The field config.
  *
  * @since 1.13.0
  */
@@ -360,9 +360,9 @@ function register_graphql_edge_field( string $from_type, string $to_type, string
 /**
  * Adds several fields to the Connection Edge between the provided 'From' Type Name and 'To' Type Name.
  *
- * @param string $from_type The name of the Type the connection is coming from.
- * @param string $to_type   The name of the Type or Alias (the connection config's `FromFieldName`) the connection is going to.
- * @param array  $fields    An array of field configs.
+ * @param string                            $from_type The name of the Type the connection is coming from.
+ * @param string                            $to_type   The name of the Type or Alias (the connection config's `FromFieldName`) the connection is going to.
+ * @param array<string,array<string,mixed>> $fields    An array of field configs.
  *
  * @since 1.13.0
  */
@@ -381,10 +381,10 @@ function register_graphql_edge_fields( string $from_type, string $to_type, array
 /**
  * Adds an input field to the Connection Where Args between the provided 'From' Type Name and 'To' Type Name.
  *
- * @param string $from_type  The name of the Type the connection is coming from.
- * @param string $to_type    The name of the Type or Alias (the connection config's `FromFieldName`) the connection is going to.
- * @param string $field_name The name of the field to add to the connection edge.
- * @param array  $config      The field config.
+ * @param string              $from_type  The name of the Type the connection is coming from.
+ * @param string              $to_type    The name of the Type or Alias (the connection config's `FromFieldName`) the connection is going to.
+ * @param string              $field_name The name of the field to add to the connection edge.
+ * @param array<string,mixed> $config      The field config.
  *
  * @since 1.13.0
  */
@@ -403,9 +403,9 @@ function register_graphql_connection_where_arg( string $from_type, string $to_ty
 /**
  * Adds several input fields to the Connection Where Args between the provided 'From' Type Name and 'To' Type Name.
  *
- * @param string $from_type The name of the Type the connection is coming from.
- * @param string $to_type   The name of the Type or Alias (the connection config's `FromFieldName`) the connection is going to.
- * @param array  $fields    An array of field configs.
+ * @param string                            $from_type The name of the Type the connection is coming from.
+ * @param string                            $to_type   The name of the Type or Alias (the connection config's `FromFieldName`) the connection is going to.
+ * @param array<string,array<string,mixed>> $fields    An array of field configs.
  *
  * @since 1.13.0
  */
@@ -503,7 +503,7 @@ function rename_graphql_type( string $type_name, string $new_type_name ) {
  * Given a config array for a connection, this registers a connection by creating all appropriate
  * fields and types for the connection
  *
- * @param array $config Array to configure the connection
+ * @param array<string,mixed> $config Array to configure the connection
  *
  * @throws \Exception
  * @return void
@@ -523,8 +523,8 @@ function register_graphql_connection( array $config ) {
 /**
  * Given a Mutation Name and Config array, this adds a Mutation to the Schema
  *
- * @param string $mutation_name The name of the Mutation to register
- * @param array  $config        The config for the mutation
+ * @param string              $mutation_name The name of the Mutation to register
+ * @param array<string,mixed> $config        The config for the mutation
  *
  * @throws \Exception
  *
@@ -544,8 +544,8 @@ function register_graphql_mutation( string $mutation_name, array $config ) {
 /**
  * Given a config array for a custom Scalar, this registers a Scalar for use in the Schema
  *
- * @param string $type_name The name of the Type to register
- * @param array  $config    The config for the scalar type to register
+ * @param string              $type_name The name of the Type to register
+ * @param array<string,mixed> $config    The config for the scalar type to register
  *
  * @throws \Exception
  * @return void
@@ -699,8 +699,8 @@ function is_graphql_http_request() {
 /**
  * Registers a GraphQL Settings Section
  *
- * @param string $slug   The slug of the group being registered
- * @param array  $config Array configuring the section. Should include: title
+ * @param string              $slug   The slug of the group being registered
+ * @param array<string,mixed> $config Array configuring the section. Should include: title
  *
  * @return void
  * @since 0.13.0
@@ -717,8 +717,8 @@ function register_graphql_settings_section( string $slug, array $config ) {
 /**
  * Registers a GraphQL Settings Field
  *
- * @param string $group  The name of the group to register a setting field to
- * @param array  $config The config for the settings field being registered
+ * @param string              $group  The name of the group to register a setting field to
+ * @param array<string,mixed> $config The config for the settings field being registered
  *
  * @return void
  * @since 0.13.0
@@ -735,12 +735,10 @@ function register_graphql_settings_field( string $group, array $config ) {
 /**
  * Given a message and an optional config array
  *
- * @param mixed|string|array $message The debug message
- * @param array              $config  The debug config. Should be an associative array of keys and
- *                                    values.
- *                                    $config['type'] will set the "type" of the log, default type
- *                                    is GRAPHQL_DEBUG. Other fields added to $config will be
- *                                    merged into the debug entry.
+ * @param mixed|string|mixed[] $message The debug message
+ * @param array<string,mixed>  $config  The debug config. Should be an associative array of keys and values.
+ *                                      $config['type'] will set the "type" of the log, default type is GRAPHQL_DEBUG. 
+ *                                      Other fields added to $config will be merged into the debug entry.
  *
  * @return void
  * @since 0.14.0
@@ -793,8 +791,8 @@ function is_valid_graphql_name( string $type_name ) {
 /**
  * Registers a series of GraphQL Settings Fields
  *
- * @param string $group  The name of the settings group to register fields to
- * @param array  $fields Array of field configs to register to the group
+ * @param string                $group  The name of the settings group to register fields to
+ * @param array<string,mixed>[] $fields Array of field configs to register to the group
  *
  * @return void
  * @since 0.13.0
@@ -887,7 +885,7 @@ function graphql_get_endpoint_url() {
 if ( ! function_exists( 'array_key_first' ) ) {
 
 	/**
-	 * @param array $arr
+	 * @param mixed[] $arr
 	 *
 	 * @return int|string|null
 	 */
@@ -909,7 +907,7 @@ if ( ! function_exists( 'array_key_first' ) ) {
 if ( ! function_exists( 'array_key_last' ) ) {
 
 	/**
-	 * @param array $arr
+	 * @param mixed[] $arr
 	 *
 	 * @return int|string|null
 	 */

--- a/access-functions.php
+++ b/access-functions.php
@@ -150,12 +150,10 @@ function get_graphql_register_action() {
  *
  * Should be used at the `graphql_register_types` hook.
  *
- * @param mixed|string|array<string> $interface_names Array of one or more names of the GraphQL
- *                                                    Interfaces to apply to the GraphQL Types
- * @param mixed|string|array<string> $type_names      Array of one or more names of the GraphQL
- *                                                    Types to apply the interfaces to
+ * @param mixed|string|array<string> $interface_names Array of one or more names of the GraphQL Interfaces to apply to the GraphQL Types
+ * @param mixed|string|array<string> $type_names      Array of one or more names of the GraphQL Types to apply the interfaces to.
  *
- * example:
+ * Example:
  * The following would register the "MyNewInterface" interface to the Post and Page type in the
  * Schema.
  *

--- a/access-functions.php
+++ b/access-functions.php
@@ -813,7 +813,7 @@ function register_graphql_settings_fields( string $group, array $fields ) {
  * @param mixed  $default_value The default value the setting should return if no value is set
  * @param string $section_name  The settings group section that the option belongs to
  *
- * @return mixed|string|int|boolean
+ * @return mixed|string|int|bool
  * @since 0.13.0
  */
 function get_graphql_setting( string $option_name, $default_value = '', $section_name = 'graphql_general_settings' ) {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -160,6 +160,22 @@
 	<rule ref="SlevomatCodingStandard.PHP.OptimizedFunctionsWithoutUnpacking" />
 	<rule ref="SlevomatCodingStandard.PHP.TypeCast" />
 
+	<rule ref="SlevomatCodingStandard.TypeHints">
+		<!-- Array syntax is preferred -->
+		<exclude name="SlevomatCodingStandard.TypeHints.DisallowArrayTypeHintSyntax.DisallowedArrayTypeHintSyntax" />
+		<!-- WP dependencies are too loosely typed to implement these safely. Breaking change. -->
+		<exclude name="SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint" />
+		<exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint" />
+		<exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint" />
+		<exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint" />
+		<!-- Depends on Squiz.Commenting.FunctionComment.MissingParamComment -->
+		<exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.UselessAnnotation" />
+
+		<!-- Should probably be added back. -->
+		<exclude name="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue.NullabilityTypeMissing" />
+		<exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing" />
+	</rule>
+
 	<rule ref="SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable" />
 	<rule ref="SlevomatCodingStandard.Variables.UnusedVariable" >
 		<properties>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,7 +1,7 @@
 parameters:
     level: 8
     inferPrivatePropertyTypeFromConstructor: true
-    checkMissingIterableValueType: false
+    checkMissingIterableValueType: true
     treatPhpDocTypesAsCertain: false
     stubFiles:
         # Simulate added properties

--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -15,14 +15,14 @@ class Admin {
 	/**
 	 * Whether Admin Pages are enabled or not
 	 *
-	 * @var boolean
+	 * @var bool
 	 */
 	protected $admin_enabled;
 
 	/**
 	 * Whether GraphiQL is enabled or not
 	 *
-	 * @var boolean
+	 * @var bool
 	 */
 	protected $graphiql_enabled;
 

--- a/src/Admin/Settings/SettingsRegistry.php
+++ b/src/Admin/Settings/SettingsRegistry.php
@@ -224,8 +224,6 @@ class SettingsRegistry {
 	 * Get field description for display
 	 *
 	 * @param array $args settings field args
-	 *
-	 * @return string
 	 */
 	public function get_field_description( array $args ): string {
 		if ( ! empty( $args['desc'] ) ) {

--- a/src/Admin/Settings/SettingsRegistry.php
+++ b/src/Admin/Settings/SettingsRegistry.php
@@ -20,26 +20,30 @@ class SettingsRegistry {
 	/**
 	 * Settings sections array
 	 *
-	 * @var array
+	 * @var array<string,array<string,mixed>>
 	 */
 	protected $settings_sections = [];
 
 	/**
 	 * Settings fields array
 	 *
-	 * @var array
+	 * @var array<string,array<string,mixed>[]>
 	 */
 	protected $settings_fields = [];
 
 	/**
-	 * @return array
+	 * Returns the settings sections.
+	 *
+	 * @return array<string,array<string,mixed>>
 	 */
 	public function get_settings_sections() {
 		return $this->settings_sections;
 	}
 
 	/**
-	 * @return array
+	 * Returns the settings fields.
+	 *
+	 * @return array<string,array<string,mixed>[]>
 	 */
 	public function get_settings_fields() {
 		return $this->settings_fields;
@@ -69,8 +73,8 @@ class SettingsRegistry {
 	/**
 	 * Set settings sections
 	 *
-	 * @param string $slug    Setting Section Slug
-	 * @param array  $section setting section config
+	 * @param string              $slug    Setting Section Slug
+	 * @param array<string,mixed> $section setting section config.
 	 *
 	 * @return \WPGraphQL\Admin\Settings\SettingsRegistry
 	 */
@@ -84,8 +88,8 @@ class SettingsRegistry {
 	/**
 	 * Register fields to a section
 	 *
-	 * @param string $section The slug of the section to register a field to
-	 * @param array  $fields  settings fields array
+	 * @param string                $section The slug of the section to register a field to
+	 * @param array<string,mixed>[] $fields  settings fields array
 	 *
 	 * @return \WPGraphQL\Admin\Settings\SettingsRegistry
 	 */
@@ -100,8 +104,8 @@ class SettingsRegistry {
 	/**
 	 * Register a field to a section
 	 *
-	 * @param string $section The slug of the section to register a field to
-	 * @param array  $field   The config for the field being registered
+	 * @param string              $section The slug of the section to register a field to
+	 * @param array<string,mixed> $field   The config for the field being registered
 	 *
 	 * @return \WPGraphQL\Admin\Settings\SettingsRegistry
 	 */
@@ -223,7 +227,7 @@ class SettingsRegistry {
 	/**
 	 * Get field description for display
 	 *
-	 * @param array $args settings field args
+	 * @param array<string,string> $args settings field args
 	 */
 	public function get_field_description( array $args ): string {
 		if ( ! empty( $args['desc'] ) ) {
@@ -238,7 +242,7 @@ class SettingsRegistry {
 	/**
 	 * Displays a text field for a settings field
 	 *
-	 * @param array $args settings field args
+	 * @param array<string,mixed> $args settings field args
 	 *
 	 * @return void
 	 */
@@ -257,7 +261,7 @@ class SettingsRegistry {
 	/**
 	 * Displays a url field for a settings field
 	 *
-	 * @param array $args settings field args
+	 * @param array<string,mixed> $args settings field args
 	 *
 	 * @return void
 	 */
@@ -268,7 +272,7 @@ class SettingsRegistry {
 	/**
 	 * Displays a number field for a settings field
 	 *
-	 * @param array $args settings field args
+	 * @param array<string,mixed> $args settings field args
 	 *
 	 * @return void
 	 */
@@ -290,7 +294,7 @@ class SettingsRegistry {
 	/**
 	 * Displays a checkbox for a settings field
 	 *
-	 * @param array $args settings field args
+	 * @param array<string,mixed> $args settings field args
 	 *
 	 * @return void
 	 */
@@ -311,7 +315,7 @@ class SettingsRegistry {
 	/**
 	 * Displays a multicheckbox for a settings field
 	 *
-	 * @param array $args settings field args
+	 * @param array<string,mixed> $args settings field args
 	 *
 	 * @return void
 	 */
@@ -335,7 +339,7 @@ class SettingsRegistry {
 	/**
 	 * Displays a radio button for a settings field
 	 *
-	 * @param array $args settings field args
+	 * @param array<string,mixed> $args settings field args
 	 *
 	 * @return void
 	 */
@@ -358,7 +362,7 @@ class SettingsRegistry {
 	/**
 	 * Displays a selectbox for a settings field
 	 *
-	 * @param array $args settings field args
+	 * @param array<string,mixed> $args settings field args
 	 *
 	 * @return void
 	 */
@@ -380,7 +384,7 @@ class SettingsRegistry {
 	/**
 	 * Displays a textarea for a settings field
 	 *
-	 * @param array $args settings field args
+	 * @param array<string,mixed> $args settings field args
 	 *
 	 * @return void
 	 */
@@ -398,7 +402,7 @@ class SettingsRegistry {
 	/**
 	 * Displays the html for a settings field
 	 *
-	 * @param array $args settings field args
+	 * @param array<string,mixed> $args settings field args
 	 *
 	 * @return void
 	 */
@@ -409,7 +413,7 @@ class SettingsRegistry {
 	/**
 	 * Displays a rich text textarea for a settings field
 	 *
-	 * @param array $args settings field args
+	 * @param array<string,mixed> $args settings field args
 	 *
 	 * @return void
 	 */
@@ -439,7 +443,7 @@ class SettingsRegistry {
 	/**
 	 * Displays a file upload field for a settings field
 	 *
-	 * @param array $args settings field args
+	 * @param array<string,mixed> $args settings field args
 	 *
 	 * @return void
 	 */
@@ -458,7 +462,7 @@ class SettingsRegistry {
 	/**
 	 * Displays a password field for a settings field
 	 *
-	 * @param array $args settings field args
+	 * @param array<string,mixed> $args settings field args
 	 *
 	 * @return void
 	 */
@@ -475,7 +479,7 @@ class SettingsRegistry {
 	/**
 	 * Displays a color picker field for a settings field
 	 *
-	 * @param array $args settings field args
+	 * @param array<string,mixed> $args settings field args
 	 *
 	 * @return void
 	 */
@@ -493,7 +497,7 @@ class SettingsRegistry {
 	/**
 	 * Displays a select box for creating the pages select box
 	 *
-	 * @param array $args settings field args
+	 * @param array<string,mixed> $args settings field args
 	 *
 	 * @return void
 	 */
@@ -521,7 +525,7 @@ class SettingsRegistry {
 	/**
 	 * Displays a select box for user roles
 	 *
-	 * @param array $args settings field args
+	 * @param array<string,mixed> $args settings field args
 	 *
 	 * @return void
 	 */
@@ -545,7 +549,7 @@ class SettingsRegistry {
 	/**
 	 * Sanitize callback for Settings API
 	 *
-	 * @param array $options
+	 * @param array<string,mixed> $options settings field args
 	 *
 	 * @return mixed
 	 */

--- a/src/AppContext.php
+++ b/src/AppContext.php
@@ -197,14 +197,14 @@ class AppContext {
 	/**
 	 * Returns the current connection
 	 *
-	 * @return mixed|null|string
+	 * @return mixed|string|null
 	 */
 	public function get_current_connection() {
 		return isset( $this->currentConnection ) ? $this->currentConnection : null;
 	}
 
 	/**
-	 * @return mixed|null|string
+	 * @return mixed|string|null
 	 * @deprecated use get_current_connection instead.
 	 */
 	public function getCurrentConnection() {

--- a/src/AppContext.php
+++ b/src/AppContext.php
@@ -73,14 +73,14 @@ class AppContext {
 	/**
 	 * Passes context about the current connection
 	 *
-	 * @var array
+	 * @var array<string,mixed>
 	 */
 	public $connectionArgs = [];
 
 	/**
 	 * Stores the loaders for the class
 	 *
-	 * @var array
+	 * @var array<string,\WPGraphQL\Data\Loader\AbstractDataLoader>
 	 */
 	public $loaders = [];
 
@@ -162,7 +162,7 @@ class AppContext {
 	 *
 	 * @param string $key The name of the loader to get
 	 *
-	 * @return mixed
+	 * @return \WPGraphQL\Data\Loader\AbstractDataLoader|mixed
 	 * @throws \GraphQL\Error\UserError If the loader is not found.
 	 */
 	public function get_loader( $key ) {
@@ -178,7 +178,7 @@ class AppContext {
 	 * Returns the $args for the connection the field is a part of
 	 *
 	 * @deprecated use get_connection_args() instead
-	 * @return array|mixed
+	 * @return mixed[]|mixed
 	 */
 	public function getConnectionArgs() {
 		_deprecated_function( __METHOD__, '0.8.4', self::class . '::get_connection_args()' );
@@ -188,7 +188,7 @@ class AppContext {
 	/**
 	 * Returns the $args for the connection the field is a part of
 	 *
-	 * @return array|mixed
+	 * @return mixed[]|mixed
 	 */
 	public function get_connection_args() {
 		return isset( $this->currentConnection ) && isset( $this->connectionArgs[ $this->currentConnection ] ) ? $this->connectionArgs[ $this->currentConnection ] : [];
@@ -197,14 +197,14 @@ class AppContext {
 	/**
 	 * Returns the current connection
 	 *
-	 * @return mixed|null|String
+	 * @return mixed|null|string
 	 */
 	public function get_current_connection() {
 		return isset( $this->currentConnection ) ? $this->currentConnection : null;
 	}
 
 	/**
-	 * @return mixed|null|String
+	 * @return mixed|null|string
 	 * @deprecated use get_current_connection instead.
 	 */
 	public function getCurrentConnection() {

--- a/src/Data/CommentMutation.php
+++ b/src/Data/CommentMutation.php
@@ -17,12 +17,12 @@ class CommentMutation {
 	/**
 	 * This handles inserting the comment and creating
 	 *
-	 * @param array  $input         The input for the mutation
-	 * @param array  $output_args   The output args
-	 * @param string $mutation_name The name of the mutation being performed
-	 * @param bool   $update        Whether it's an update action
+	 * @param array<string,mixed> $input         The input for the mutation
+	 * @param array<string,mixed> $output_args   The output args
+	 * @param string              $mutation_name The name of the mutation being performed
+	 * @param bool                $update        Whether it's an update action
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 * @throws \GraphQL\Error\UserError If the comment author is not provided.
 	 */
 	public static function prepare_comment_object( array $input, array &$output_args, string $mutation_name, $update = false ) {
@@ -116,7 +116,7 @@ class CommentMutation {
 	 * This updates commentmeta.
 	 *
 	 * @param int                                  $comment_id    The ID of the postObject the comment is connected to
-	 * @param array                                $input         The input for the mutation
+	 * @param array<string,mixed>                  $input         The input for the mutation
 	 * @param string                               $mutation_name The name of the mutation ( ex: create, update, delete )
 	 * @param \WPGraphQL\AppContext                $context The AppContext passed down to all resolvers
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down to all resolvers

--- a/src/Data/Config.php
+++ b/src/Data/Config.php
@@ -175,11 +175,11 @@ class Config {
 		/**
 		 * If pre-filter hooked, return $pre_orderby.
 		 *
-		 * @param null|string $pre_orderby The pre-filtered ORDER BY clause of the query.
+		 * @param string|null $pre_orderby The pre-filtered ORDER BY clause of the query.
 		 * @param string      $orderby     The ORDER BY clause of the query.
 		 * @param \WP_Query   $query       The WP_Query instance (passed by reference).
 		 *
-		 * @return null|string
+		 * @return string|null
 		 */
 		$pre_orderby = apply_filters( 'graphql_pre_wp_query_cursor_pagination_stability', null, $orderby, $query );
 		if ( null !== $pre_orderby ) {
@@ -226,11 +226,11 @@ class Config {
 		/**
 		 * If pre-filter hooked, return $pre_where.
 		 *
-		 * @param null|string $pre_where The pre-filtered WHERE clause of the query.
+		 * @param string|null $pre_where The pre-filtered WHERE clause of the query.
 		 * @param string     $where     The WHERE clause of the query.
 		 * @param \WP_Query  $query     The WP_Query instance (passed by reference).
 		 *
-		 * @return null|string
+		 * @return string|null
 		 */
 		$pre_where = apply_filters( 'graphql_pre_wp_query_cursor_pagination_support', null, $where, $query );
 		if ( null !== $pre_where ) {
@@ -278,11 +278,11 @@ class Config {
 		/**
 		 * If pre-filter hooked, return $pre_orderby.
 		 *
-		 * @param null|string     $pre_orderby The pre-filtered ORDER BY clause of the query.
+		 * @param string|null     $pre_orderby The pre-filtered ORDER BY clause of the query.
 		 * @param string          $orderby     The ORDER BY clause of the query.
 		 * @param \WP_User_Query  $query       The WP_User_Query instance (passed by reference).
 		 *
-		 * @return null|string
+		 * @return string|null
 		 */
 		$pre_orderby = apply_filters( 'graphql_pre_wp_user_query_cursor_pagination_stability', null, $orderby, $query );
 		if ( null !== $pre_orderby ) {
@@ -329,11 +329,11 @@ class Config {
 		/**
 		 * If pre-filter hooked, return $pre_where.
 		 *
-		 * @param null|string    $pre_where The pre-filtered WHERE clause of the query.
+		 * @param string|null    $pre_where The pre-filtered WHERE clause of the query.
 		 * @param string         $where     The WHERE clause of the query.
 		 * @param \WP_User_Query $query     The WP_Query instance (passed by reference).
 		 *
-		 * @return null|string
+		 * @return string|null
 		 */
 		$pre_where = apply_filters( 'graphql_pre_wp_user_query_cursor_pagination_support', null, $where, $query );
 		if ( null !== $pre_where ) {
@@ -382,12 +382,12 @@ class Config {
 		/**
 		 * If pre-filter hooked, return $pre_pieces.
 		 *
-		 * @param null|array<string,mixed> $pre_pieces The pre-filtered term query SQL clauses.
+		 * @param array<string, mixed>|null $pre_pieces The pre-filtered term query SQL clauses.
 		 * @param array<string,mixed>      $pieces     Terms query SQL clauses.
 		 * @param string[]                 $taxonomies An array of taxonomies.
 		 * @param array<string,mixed>      $args       An array of terms query arguments.
 		 *
-		 * @return null|array
+		 * @return array|null
 		 */
 		$pre_pieces = apply_filters( 'graphql_pre_wp_term_query_cursor_pagination_support', null, $pieces, $taxonomies, $args );
 		if ( null !== $pre_pieces ) {
@@ -455,11 +455,11 @@ class Config {
 		/**
 		 * If pre-filter hooked, return $pre_pieces.
 		 *
-		 * @param null|array        $pre_pieces The pre-filtered comment query clauses.
+		 * @param array|null        $pre_pieces The pre-filtered comment query clauses.
 		 * @param array             $pieces     A compacted array of comment query clauses.
 		 * @param \WP_Comment_Query $query      Current instance of WP_Comment_Query, passed by reference.
 		 *
-		 * @return null|array
+		 * @return array|null
 		 */
 		$pre_pieces = apply_filters( 'graphql_pre_wp_comments_query_cursor_pagination_support', null, $pieces, $query );
 		if ( null !== $pre_pieces ) {

--- a/src/Data/Config.php
+++ b/src/Data/Config.php
@@ -366,11 +366,11 @@ class Config {
 	 * we can move forward or backward from a particular record, instead of typical offset
 	 * pagination which can be much more expensive and less accurate.
 	 *
-	 * @param array $pieces     Terms query SQL clauses.
-	 * @param array $taxonomies An array of taxonomies.
-	 * @param array $args       An array of terms query arguments.
+	 * @param array<string,mixed> $pieces     Terms query SQL clauses.
+	 * @param string[]            $taxonomies An array of taxonomies.
+	 * @param array<string,mixed> $args       An array of terms query arguments.
 	 *
-	 * @return array $pieces
+	 * @return array<string,mixed> $pieces
 	 */
 	public function graphql_wp_term_query_cursor_pagination_support( array $pieces, array $taxonomies, array $args ) {
 
@@ -382,10 +382,10 @@ class Config {
 		/**
 		 * If pre-filter hooked, return $pre_pieces.
 		 *
-		 * @param null|array $pre_pieces The pre-filtered term query SQL clauses.
-		 * @param array      $pieces     Terms query SQL clauses.
-		 * @param array      $taxonomies An array of taxonomies.
-		 * @param array      $args       An array of terms query arguments.
+		 * @param null|array<string,mixed> $pre_pieces The pre-filtered term query SQL clauses.
+		 * @param array<string,mixed>      $pieces     Terms query SQL clauses.
+		 * @param string[]                 $taxonomies An array of taxonomies.
+		 * @param array<string,mixed>      $args       An array of terms query arguments.
 		 *
 		 * @return null|array
 		 */
@@ -440,10 +440,10 @@ class Config {
 	 * This returns a modified version of the $pieces of the comment query clauses if the request
 	 * is a GraphQL Request and before or after cursors are passed to the query
 	 *
-	 * @param array             $pieces A compacted array of comment query clauses.
-	 * @param \WP_Comment_Query $query Current instance of WP_Comment_Query, passed by reference.
+	 * @param array<string,mixed> $pieces A compacted array of comment query clauses.
+	 * @param \WP_Comment_Query   $query Current instance of WP_Comment_Query, passed by reference.
 	 *
-	 * @return array $pieces
+	 * @return array<string,mixed> $pieces
 	 */
 	public function graphql_wp_comments_query_cursor_pagination_support( array $pieces, WP_Comment_Query $query ) {
 

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -29,7 +29,7 @@ abstract class AbstractConnectionResolver {
 	/**
 	 * The args input on the field calling the connection
 	 *
-	 * @var array
+	 * @var array<string,mixed>
 	 */
 	protected $args;
 
@@ -50,7 +50,7 @@ abstract class AbstractConnectionResolver {
 	/**
 	 * The query args used to query for data to resolve the connection
 	 *
-	 * @var array
+	 * @var array<string,mixed>
 	 */
 	protected $query_args;
 
@@ -92,22 +92,22 @@ abstract class AbstractConnectionResolver {
 	protected $query;
 
 	/**
-	 * @var array
+	 * @var mixed[]
 	 */
 	protected $items;
 
 	/**
-	 * @var array
+	 * @var int[]|string[]
 	 */
 	protected $ids;
 
 	/**
-	 * @var array
+	 * @var array<string,mixed>
 	 */
 	protected $nodes;
 
 	/**
-	 * @var array
+	 * @var array<string,mixed>[]
 	 */
 	protected $edges;
 
@@ -120,7 +120,7 @@ abstract class AbstractConnectionResolver {
 	 * ConnectionResolver constructor.
 	 *
 	 * @param mixed                                $source  source passed down from the resolve tree
-	 * @param array                                $args    array of arguments input in the field as part of the GraphQL query
+	 * @param array<string,mixed>                  $args    array of arguments input in the field as part of the GraphQL query
 	 * @param \WPGraphQL\AppContext                $context Object containing app context that gets passed down the resolve tree
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info Info about fields passed down the resolve tree
 	 *
@@ -225,6 +225,8 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * @deprecated Deprecated since v1.11.0 in favor of $this->get_args();
 	 *
+	 * @return array<string,mixed>
+	 *
 	 * @codeCoverageIgnore
 	 */
 	public function getArgs(): array {
@@ -237,7 +239,7 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * Useful for modifying the $args before they are passed to $this->get_query_args().
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 */
 	public function get_args(): array {
 		return $this->args;
@@ -324,7 +326,7 @@ abstract class AbstractConnectionResolver {
 	 * For example, if the ConnectionResolver uses WP_Query to fetch the data, this
 	 * should return $args for use in `new WP_Query`
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 */
 	abstract public function get_query_args();
 
@@ -386,7 +388,7 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * @throws \Exception If child class forgot to implement this.
 	 *
-	 * @return array the array of IDs.
+	 * @return int[]|string[] the array of IDs.
 	 */
 	public function get_ids_from_query() {
 		throw new Exception(
@@ -527,7 +529,7 @@ abstract class AbstractConnectionResolver {
 	 * Gets the array index for the given offset.
 	 *
 	 * @param int|string|false $offset The cursor pagination offset.
-	 * @param array            $ids    The array of ids from the query.
+	 * @param int[]|string[]   $ids    The array of ids from the query.
 	 *
 	 * @return int|false $index The array index of the offset.
 	 */
@@ -547,11 +549,11 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * @see https://relay.dev/graphql/connections.htm#sec-Pagination-algorithm
 	 *
-	 * @param array $ids The array of IDs from the query to slice, ordered as expected by the GraphQL query.
+	 * @param int[]|string[] $ids The array of IDs from the query to slice, ordered as expected by the GraphQL query.
 	 *
 	 * @since 1.9.0
 	 *
-	 * @return array
+	 * @return int[]|string[]
 	 */
 	public function apply_cursors_to_ids( array $ids ) {
 		if ( empty( $ids ) ) {
@@ -589,7 +591,7 @@ abstract class AbstractConnectionResolver {
 	 * These IDs have been fetched from the query with all the query args applied,
 	 * then sliced (overfetching by 1) by pagination args.
 	 *
-	 * @return array
+	 * @return int[]|string[]
 	 */
 	public function get_ids() {
 		$ids = $this->get_ids_from_query();
@@ -697,7 +699,7 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * Determine the start cursor from the connection
 	 *
-	 * @return mixed string|null
+	 * @return mixed|string|null
 	 */
 	public function get_start_cursor() {
 		$first_edge = $this->edges && ! empty( $this->edges ) ? $this->edges[0] : null;
@@ -710,7 +712,7 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * Determine the end cursor from the connection
 	 *
-	 * @return mixed string|null
+	 * @return mixed|string|null
 	 */
 	public function get_end_cursor() {
 		$last_edge = ! empty( $this->edges ) ? $this->edges[ count( $this->edges ) - 1 ] : null;
@@ -725,7 +727,7 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * @used-by AbstractConnectionResolver::get_nodes()
 	 *
-	 * @return array
+	 * @return int[]|string[]
 	 */
 	public function get_ids_for_nodes() {
 		if ( empty( $this->ids ) ) {
@@ -748,7 +750,7 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * @uses AbstractConnectionResolver::get_ids_for_nodes()
 	 *
-	 * @return array
+	 * @return array<int|string,mixed|\WPGraphQL\Model\Model|null>
 	 * @throws \Exception
 	 */
 	public function get_nodes() {
@@ -784,12 +786,12 @@ abstract class AbstractConnectionResolver {
 	/**
 	 * Given an ID, a cursor is returned
 	 *
-	 * @param int $id
+	 * @param int|string $id
 	 *
 	 * @return string
 	 */
 	protected function get_cursor_for_node( $id ) {
-		return base64_encode( 'arrayconnection:' . $id );
+		return base64_encode( 'arrayconnection:' . (string) $id );
 	}
 
 	/**
@@ -797,7 +799,7 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * This iterates over the nodes and returns edges
 	 *
-	 * @return array
+	 * @return array<string,mixed>[]
 	 */
 	public function get_edges() {
 		// Bail early if there are no nodes.
@@ -844,7 +846,7 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * Returns pageInfo for the connection
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 */
 	public function get_page_info() {
 		$page_info = [
@@ -887,7 +889,7 @@ abstract class AbstractConnectionResolver {
 	/**
 	 * Execute the resolver query and get the data for the connection
 	 *
-	 * @return array
+	 * @return int[]|string[]
 	 *
 	 * @throws \Exception
 	 */
@@ -961,7 +963,7 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * Get the connection to return to the Connection Resolver
 	 *
-	 * @return mixed|array|\GraphQL\Deferred
+	 * @return \GraphQL\Deferred
 	 *
 	 * @throws \Exception
 	 */

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -654,7 +654,7 @@ abstract class AbstractConnectionResolver {
 	 * ore if there are more "items" after the "before" argument, has_next_page()
 	 * will be set to true
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function has_next_page() {
 		if ( ! empty( $this->args['first'] ) ) {
@@ -679,7 +679,7 @@ abstract class AbstractConnectionResolver {
 	 * or if there are more "items" before the "after" argument, has_previous_page()
 	 * will be set to true.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function has_previous_page() {
 		if ( ! empty( $this->args['last'] ) ) {

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -403,8 +403,7 @@ abstract class AbstractConnectionResolver {
 	/**
 	 * Given an ID, return the model for the entity or null
 	 *
-	 * @param mixed $id The ID to identify the object by. Could be a database ID or an in-memory ID
-	 *                  (like post_type name)
+	 * @param mixed $id The ID to identify the object by. Could be a database ID or an in-memory ID (like post_type name)
 	 *
 	 * @return mixed|\WPGraphQL\Model\Model|null
 	 * @throws \Exception

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -245,8 +245,6 @@ abstract class AbstractConnectionResolver {
 
 	/**
 	 * Returns the AppContext of the connection
-	 *
-	 * @return \WPGraphQL\AppContext
 	 */
 	public function getContext(): AppContext {
 		return $this->context;
@@ -254,8 +252,6 @@ abstract class AbstractConnectionResolver {
 
 	/**
 	 * Returns the ResolveInfo of the connection
-	 *
-	 * @return \GraphQL\Type\Definition\ResolveInfo
 	 */
 	public function getInfo(): ResolveInfo {
 		return $this->info;
@@ -263,8 +259,6 @@ abstract class AbstractConnectionResolver {
 
 	/**
 	 * Returns whether the connection should execute
-	 *
-	 * @return bool
 	 */
 	public function getShouldExecute(): bool {
 		return $this->should_execute;

--- a/src/Data/Connection/CommentConnectionResolver.php
+++ b/src/Data/Connection/CommentConnectionResolver.php
@@ -147,9 +147,7 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * Get_query
-	 *
-	 * Return the instance of the WP_Comment_Query
+	 * {@inheritDoc}
 	 *
 	 * @return \WP_Comment_Query
 	 * @throws \Exception
@@ -159,9 +157,7 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * Return the name of the loader
-	 *
-	 * @return string
+	 * {@inheritDoc}
 	 */
 	public function get_loader_name() {
 		return 'comment';
@@ -171,7 +167,7 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 	 * {@inheritDoc}
 	 */
 	public function get_ids_from_query() {
-		/** @var array $ids */
+		/** @var int[]|string[] $ids */
 		$ids = ! empty( $this->query->get_comments() ) ? $this->query->get_comments() : [];
 
 		// If we're going backwards, we need to reverse the array.
@@ -183,7 +179,7 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * This can be used to determine whether the connection query should even execute.
+	 * {@inheritDoc}
 	 *
 	 * For example, if the $source were a post_type that didn't support comments, we could prevent
 	 * the connection query from even executing. In our case, we prevent comments from even showing
@@ -200,7 +196,7 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * Filters the GraphQL args before they are used in get_query_args().
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 */
 	public function get_args(): array {
 		$args = $this->args;
@@ -275,10 +271,10 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 	 * There's probably a cleaner/more dynamic way to approach this, but this was quick. I'd be
 	 * down to explore more dynamic ways to map this, but for now this gets the job done.
 	 *
-	 * @param array $args The array of query arguments
+	 * @param array<string,mixed> $args The array of query arguments
 	 *
 	 * @since  0.0.5
-	 * @return array
+	 * @return array<string,mixed>
 	 */
 	public function sanitize_input_fields( array $args ) {
 		$arg_mapping = [
@@ -326,13 +322,9 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * Determine whether or not the the offset is valid, i.e the comment corresponding to the
-	 * offset exists. Offset is equivalent to comment_id. So this function is equivalent to
-	 * checking if the comment with the given ID exists.
+	 * {@inheritDoc}
 	 *
-	 * @param int $offset The ID of the node used for the cursor offset
-	 *
-	 * @return bool
+	 * @param int $offset The ID of the node used for the cursor offset.
 	 */
 	public function is_valid_offset( $offset ) {
 		return ! empty( get_comment( $offset ) );

--- a/src/Data/Connection/CommentConnectionResolver.php
+++ b/src/Data/Connection/CommentConnectionResolver.php
@@ -186,7 +186,7 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 	 * in the Schema for post types that don't have comment support, so we don't need to worry
 	 * about that, but there may be other situations where we'd need to prevent it.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function should_execute() {
 		return true;

--- a/src/Data/Connection/ContentTypeConnectionResolver.php
+++ b/src/Data/Connection/ContentTypeConnectionResolver.php
@@ -10,7 +10,7 @@ class ContentTypeConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @var array
+	 * @var string[]
 	 */
 	protected $query;
 
@@ -42,9 +42,9 @@ class ContentTypeConnectionResolver extends AbstractConnectionResolver {
 
 
 	/**
-	 * Get the items from the source
+	 * {@inheritDoc}
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	public function get_query() {
 		if ( isset( $this->query_args['contentTypeNames'] ) && is_array( $this->query_args['contentTypeNames'] ) ) {
@@ -60,29 +60,23 @@ class ContentTypeConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * The name of the loader to load the data
-	 *
-	 * @return string
+	 * {@inheritDoc}
 	 */
 	public function get_loader_name() {
 		return 'post_type';
 	}
 
 	/**
-	 * Determine if the offset used for pagination is valid
+	 * {@inheritDoc}
 	 *
-	 * @param mixed $offset
-	 *
-	 * @return bool
+	 * @param string $offset The offset (post type name) to check.
 	 */
 	public function is_valid_offset( $offset ) {
 		return (bool) get_post_type_object( $offset );
 	}
 
 	/**
-	 * Determine if the query should execute
-	 *
-	 * @return bool
+	 * {@inheritDoc}
 	 */
 	public function should_execute() {
 		return true;

--- a/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
@@ -12,14 +12,7 @@ use WPGraphQL\AppContext;
 class EnqueuedScriptsConnectionResolver extends AbstractConnectionResolver {
 
 	/**
-	 * EnqueuedScriptsConnectionResolver constructor.
-	 *
-	 * @param mixed                                $source     source passed down from the resolve tree
-	 * @param array                                $args       array of arguments input in the field as part of the GraphQL query
-	 * @param \WPGraphQL\AppContext                $context Object containing app context that gets passed down the resolve tree
-	 * @param \GraphQL\Type\Definition\ResolveInfo $info Info about fields passed down the resolve tree
-	 *
-	 * @throws \Exception
+	 * {@inheritDoc}
 	 */
 	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info ) {
 
@@ -69,18 +62,16 @@ class EnqueuedScriptsConnectionResolver extends AbstractConnectionResolver {
 
 
 	/**
-	 * Get the items from the source
+	 * {@inheritDoc}
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	public function get_query() {
 		return $this->source->enqueuedScriptsQueue ? $this->source->enqueuedScriptsQueue : [];
 	}
 
 	/**
-	 * The name of the loader to load the data
-	 *
-	 * @return string
+	 * {@inheritDoc}
 	 */
 	public function get_loader_name() {
 		return 'enqueued_script';
@@ -98,11 +89,7 @@ class EnqueuedScriptsConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * Determine if the offset used for pagination is valid
-	 *
-	 * @param mixed $offset
-	 *
-	 * @return bool
+	 * {@inheritDoc}
 	 */
 	public function is_valid_offset( $offset ) {
 		global $wp_scripts;
@@ -110,9 +97,7 @@ class EnqueuedScriptsConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * Determine if the query should execute
-	 *
-	 * @return bool
+	 * {@inheritDoc}
 	 */
 	public function should_execute() {
 		return true;

--- a/src/Data/Connection/EnqueuedStylesheetConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedStylesheetConnectionResolver.php
@@ -13,19 +13,12 @@ class EnqueuedStylesheetConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @var array
+	 * @var string[]
 	 */
 	protected $query;
 
 	/**
-	 * EnqueuedStylesheetConnectionResolver constructor.
-	 *
-	 * @param mixed                                $source     source passed down from the resolve tree
-	 * @param array                                $args       array of arguments input in the field as part of the GraphQL query
-	 * @param \WPGraphQL\AppContext                $context Object containing app context that gets passed down the resolve tree
-	 * @param \GraphQL\Type\Definition\ResolveInfo $info Info about fields passed down the resolve tree
-	 *
-	 * @throws \Exception
+	 * {@inheritDoc}
 	 */
 	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info ) {
 
@@ -50,7 +43,7 @@ class EnqueuedStylesheetConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * Get the IDs from the source
 	 *
-	 * @return array
+	 * @return mixed[]
 	 */
 	public function get_ids_from_query() {
 		$ids     = [];
@@ -79,7 +72,7 @@ class EnqueuedStylesheetConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * Get the items from the source
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	public function get_query() {
 		return $this->source->enqueuedStylesheetsQueue ? $this->source->enqueuedStylesheetsQueue : [];
@@ -106,11 +99,7 @@ class EnqueuedStylesheetConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * Determine if the offset used for pagination is valid
-	 *
-	 * @param mixed $offset
-	 *
-	 * @return bool
+	 * {@inheritDoc}
 	 */
 	public function is_valid_offset( $offset ) {
 		global $wp_styles;
@@ -118,9 +107,7 @@ class EnqueuedStylesheetConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * Determine if the query should execute
-	 *
-	 * @return bool
+	 * D{@inheritDoc}
 	 */
 	public function should_execute() {
 		return true;

--- a/src/Data/Connection/MenuConnectionResolver.php
+++ b/src/Data/Connection/MenuConnectionResolver.php
@@ -10,9 +10,8 @@ namespace WPGraphQL\Data\Connection;
 class MenuConnectionResolver extends TermObjectConnectionResolver {
 
 	/**
-	 * Get the connection args for use in WP_Term_Query to query the menus
+	 * {@inheritDoc}
 	 *
-	 * @return array
 	 * @throws \Exception
 	 */
 	public function get_query_args() {

--- a/src/Data/Connection/MenuItemConnectionResolver.php
+++ b/src/Data/Connection/MenuItemConnectionResolver.php
@@ -13,23 +13,14 @@ use WPGraphQL\Utils\Utils;
 class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 
 	/**
-	 * MenuItemConnectionResolver constructor.
-	 *
-	 * @param mixed                                $source     source passed down from the resolve tree
-	 * @param array                                $args       array of arguments input in the field as part of the GraphQL query
-	 * @param \WPGraphQL\AppContext                $context Object containing app context that gets passed down the resolve tree
-	 * @param \GraphQL\Type\Definition\ResolveInfo $info Info about fields passed down the resolve tree
-	 *
-	 * @throws \Exception
+	 * {@inheritDoc}
 	 */
 	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info ) {
 		parent::__construct( $source, $args, $context, $info, 'nav_menu_item' );
 	}
 
 	/**
-	 * Returns the query args for the connection to resolve with
-	 *
-	 * @return array
+	 * {@inheritDoc}
 	 */
 	public function get_query_args() {
 		/**
@@ -89,9 +80,7 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 	}
 
 	/**
-	 * Filters the GraphQL args before they are used in get_query_args().
-	 *
-	 * @return array
+	 * {@inheritDoc}
 	 */
 	public function get_args(): array {
 		$args = $this->args;

--- a/src/Data/Connection/PluginConnectionResolver.php
+++ b/src/Data/Connection/PluginConnectionResolver.php
@@ -11,7 +11,7 @@ class PluginConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @var array
+	 * @var array<string,array<string,mixed>>
 	 */
 	protected $query;
 
@@ -49,7 +49,7 @@ class PluginConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public function get_query() {
 		// File has not loaded.
@@ -243,7 +243,7 @@ class PluginConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * @return bool
+	 * {@inheritDoc}
 	 */
 	public function should_execute() {
 		if ( is_multisite() ) {

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -29,15 +29,9 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	 */
 	protected $query;
 	/**
-	 * PostObjectConnectionResolver constructor.
+	 * {@inheritDoc}
 	 *
-	 * @param mixed                                $source    source passed down from the resolve tree
-	 * @param array                                $args      array of arguments input in the field as part of the query
-	 * @param \WPGraphQL\AppContext                $context Object containing app context that gets passed down the resolve tree
-	 * @param \GraphQL\Type\Definition\ResolveInfo $info Info about fields passed down the resolve tree
-	 * @param mixed|string|array                   $post_type The post type to resolve for
-	 *
-	 * @throws \Exception
+	 * @param mixed|string|string[] $post_type The post type to resolve for
 	 */
 	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info, $post_type = 'any' ) {
 
@@ -72,16 +66,14 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * Return the name of the loader
-	 *
-	 * @return string
+	 * {@inheritDoc}
 	 */
 	public function get_loader_name() {
 		return 'post';
 	}
 
 	/**
-	 * Returns the query being executed
+	 * {@inheritDoc}
 	 *
 	 * @return \WP_Query|object
 	 *
@@ -117,13 +109,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * Determine whether the Query should execute. If it's determined that the query should
-	 * not be run based on context such as, but not limited to, who the user is, where in the
-	 * ResolveTree the Query is, the relation to the node the Query is connected to, etc
-	 *
-	 * Return false to prevent the query from executing.
-	 *
-	 * @return bool
+	 * {@inheritDoc}
 	 */
 	public function should_execute() {
 		if ( false === $this->should_execute ) {
@@ -156,11 +142,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * Here, we map the args from the input, then we make sure that we're only querying
-	 * for IDs. The IDs are then passed down the resolve tree, and deferred resolvers
-	 * handle batch resolution of the posts.
-	 *
-	 * @return array
+	 * {@inheritDoc}
 	 */
 	public function get_query_args() {
 		/**
@@ -305,7 +287,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 
 			foreach ( $this->args['where']['orderby'] as $orderby_input ) {
 				// Create a type hint for orderby_input. This is an array with a field and order key.
-				/** @var array<string, string> $orderby_input */
+				/** @var array<string,string> $orderby_input */
 				if ( empty( $orderby_input['field'] ) ) {
 					continue;
 				}
@@ -385,9 +367,9 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	 * this was quick. I'd be down to explore more dynamic ways to map this, but for
 	 * now this gets the job done.
 	 *
-	 * @param array $where_args The args passed to the connection
+	 * @param array<string,mixed> $where_args The args passed to the connection
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 * @since  0.0.5
 	 */
 	public function sanitize_input_fields( array $where_args ) {
@@ -466,7 +448,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	 *
 	 * @param mixed $stati The status(es) to sanitize
 	 *
-	 * @return array|null
+	 * @return string[]|null
 	 */
 	public function sanitize_post_stati( $stati ) {
 
@@ -549,9 +531,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * Filters the GraphQL args before they are used in get_query_args().
-	 *
-	 * @return array
+	 * {@inheritDoc}
 	 */
 	public function get_args(): array {
 		$args = $this->args;
@@ -606,13 +586,9 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * Determine whether or not the the offset is valid, i.e the post corresponding to the offset
-	 * exists. Offset is equivalent to post_id. So this function is equivalent to checking if the
-	 * post with the given ID exists.
+	 * {@inheritDoc}
 	 *
-	 * @param int $offset The ID of the node used in the cursor offset
-	 *
-	 * @return bool
+	 * @param int $offset The ID of the node used in the cursor offset.
 	 */
 	public function is_valid_offset( $offset ) {
 		return (bool) get_post( absint( $offset ) );

--- a/src/Data/Connection/TaxonomyConnectionResolver.php
+++ b/src/Data/Connection/TaxonomyConnectionResolver.php
@@ -10,7 +10,7 @@ class TaxonomyConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @var array
+	 * @var string[]
 	 */
 	protected $query;
 
@@ -44,7 +44,7 @@ class TaxonomyConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * Get the items from the source
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	public function get_query() {
 		if ( isset( $this->query_args['name'] ) ) {
@@ -60,29 +60,23 @@ class TaxonomyConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * The name of the loader to load the data
-	 *
-	 * @return string
+	 * {@inheritDoc}
 	 */
 	public function get_loader_name() {
 		return 'taxonomy';
 	}
 
 	/**
-	 * Determine if the offset used for pagination is valid
+	 * {@inheritDoc}
 	 *
-	 * @param mixed $offset
-	 *
-	 * @return bool
+	 * @param string $offset The offset (taxonomy name) to check.
 	 */
 	public function is_valid_offset( $offset ) {
 		return (bool) get_taxonomy( $offset );
 	}
 
 	/**
-	 * Determine if the query should execute
-	 *
-	 * @return bool
+	 * {@inheritDoc}
 	 */
 	public function should_execute() {
 		return true;

--- a/src/Data/Connection/TermObjectConnectionResolver.php
+++ b/src/Data/Connection/TermObjectConnectionResolver.php
@@ -28,15 +28,9 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 	protected $taxonomy;
 
 	/**
-	 * TermObjectConnectionResolver constructor.
+	 * {@inheritDoc}
 	 *
-	 * @param mixed                                $source     source passed down from the resolve tree
-	 * @param array                                $args       array of arguments input in the field as part of the GraphQL query
-	 * @param \WPGraphQL\AppContext                $context Object containing app context that gets passed down the resolve tree
-	 * @param \GraphQL\Type\Definition\ResolveInfo $info Info about fields passed down the resolve tree
-	 * @param mixed|string|null                    $taxonomy The name of the Taxonomy the resolver is intended to be used for
-	 *
-	 * @throws \Exception
+	 * @param mixed|string|null $taxonomy The name of the Taxonomy the resolver is intended to be used for.
 	 */
 	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info, $taxonomy = null ) {
 		$this->taxonomy = $taxonomy;
@@ -186,11 +180,9 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * Whether the connection query should execute. Certain contexts _may_ warrant
-	 * restricting the query to execute at all. Default is true, meaning any time
-	 * a TermObjectConnection resolver is asked for, it will execute.
+	 * {@inheritDoc}
 	 *
-	 * @return bool
+	 * Default is true, meaning any time a TermObjectConnection resolver is asked for, it will execute.
 	 */
 	public function should_execute() {
 		return true;
@@ -202,7 +194,7 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 	 * to explore more dynamic ways to map this, but for now this gets the job done.
 	 *
 	 * @since  0.0.5
-	 * @return array
+	 * @return array<string,mixed>
 	 */
 	public function sanitize_input_fields() {
 		$arg_mapping = [
@@ -259,9 +251,7 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * Filters the GraphQL args before they are used in get_query_args().
-	 *
-	 * @return array
+	 * {@inheritDoc}
 	 */
 	public function get_args(): array {
 		$args = $this->args;
@@ -310,13 +300,9 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * Determine whether or not the the offset is valid, i.e the term corresponding to the offset
-	 * exists. Offset is equivalent to term_id. So this function is equivalent to checking if the
-	 * term with the given ID exists.
+	 * {@inheritDoc}
 	 *
-	 * @param int $offset The ID of the node used in the cursor for offset
-	 *
-	 * @return bool
+	 * @param int $offset The ID of the node used in the cursor for offset.
 	 */
 	public function is_valid_offset( $offset ) {
 		return get_term( absint( $offset ) ) instanceof \WP_Term;

--- a/src/Data/Connection/ThemeConnectionResolver.php
+++ b/src/Data/Connection/ThemeConnectionResolver.php
@@ -11,7 +11,7 @@ class ThemeConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @var array
+	 * @var string[]
 	 */
 	protected $query;
 
@@ -46,7 +46,7 @@ class ThemeConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * Get the items from the source
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	public function get_query() {
 		$query_args = $this->query_args;
@@ -55,20 +55,14 @@ class ThemeConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * The name of the loader to load the data
-	 *
-	 * @return string
+	 * {@inheritDoc}
 	 */
 	public function get_loader_name() {
 		return 'theme';
 	}
 
 	/**
-	 * Determine if the offset used for pagination is valid
-	 *
-	 * @param mixed $offset
-	 *
-	 * @return bool
+	 * {@inheritDoc}
 	 */
 	public function is_valid_offset( $offset ) {
 		$theme = wp_get_theme( $offset );
@@ -76,9 +70,7 @@ class ThemeConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * Determine if the query should execute
-	 *
-	 * @return bool
+	 * {@inheritDoc}
 	 */
 	public function should_execute() {
 		return true;

--- a/src/Data/Connection/UserConnectionResolver.php
+++ b/src/Data/Connection/UserConnectionResolver.php
@@ -21,12 +21,7 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 	protected $query;
 
 	/**
-	 * Determines whether the query should execute at all. It's possible that in some
-	 * situations we may want to prevent the underlying query from executing at all.
-	 *
-	 * In those cases, this would be set to false.
-	 *
-	 * @return bool
+	 * {@inheritDoc}
 	 */
 	public function should_execute() {
 		return true;
@@ -40,10 +35,8 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * Converts the args that were input to the connection into args that can be executed
-	 * by WP_User_Query
+	 * {@inheritDoc}
 	 *
-	 * @return array
 	 * @throws \Exception
 	 */
 	public function get_query_args() {
@@ -207,9 +200,9 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * Returns an array of ids from the query being executed.
+	 * {@inheritDoc}
 	 *
-	 * @return array
+	 * @return int[]
 	 */
 	public function get_ids_from_query() {
 		$ids = method_exists( $this->query, 'get_results' ) ? $this->query->get_results() : [];
@@ -229,9 +222,9 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 	 * There's probably a cleaner/more dynamic way to approach this, but this was quick. I'd be
 	 * down to explore more dynamic ways to map this, but for now this gets the job done.
 	 *
-	 * @param array $args The query "where" args
+	 * @param array<string,mixed> $args The query "where" args
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 * @throws \GraphQL\Error\UserError If the user does not have the "list_users" capability.
 	 * @since  0.0.5
 	 */
@@ -289,9 +282,7 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * Determine whether or not the the offset is valid, i.e the user corresponding to the offset
-	 * exists. Offset is equivalent to user_id. So this function is equivalent to checking if the
-	 * user with the given ID exists.
+	 * {@inheritDoc}
 	 *
 	 * @param int $offset The ID of the node used as the offset in the cursor
 	 *

--- a/src/Data/Connection/UserRoleConnectionResolver.php
+++ b/src/Data/Connection/UserRoleConnectionResolver.php
@@ -14,7 +14,7 @@ class UserRoleConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @var array
+	 * @var string[]
 	 */
 	protected $query;
 
@@ -53,7 +53,7 @@ class UserRoleConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	public function get_query() {
 		$wp_roles = wp_roles();
@@ -69,16 +69,14 @@ class UserRoleConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * @param mixed $offset Whether the provided offset is valid for the connection
-	 *
-	 * @return bool
+	 * {@inheritDoc}
 	 */
 	public function is_valid_offset( $offset ) {
 		return (bool) get_role( $offset );
 	}
 
 	/**
-	 * @return bool
+	 * {@inheritDoc}
 	 */
 	public function should_execute() {
 		if (

--- a/src/Data/Cursor/AbstractCursor.php
+++ b/src/Data/Cursor/AbstractCursor.php
@@ -52,7 +52,7 @@ abstract class AbstractCursor {
 	/**
 	 * Copy of query vars so we can modify them safely
 	 *
-	 * @var array
+	 * @var array<string,mixed>
 	 */
 	public $query_vars = [];
 
@@ -66,8 +66,8 @@ abstract class AbstractCursor {
 	/**
 	 * The constructor
 	 *
-	 * @param array       $query_vars         Query variable for the query to be executed.
-	 * @param string|null $cursor             Cursor type. Either 'after' or 'before'.
+	 * @param array<string,mixed> $query_vars         Query variable for the query to be executed.
+	 * @param string|null         $cursor             Cursor type. Either 'after' or 'before'.
 	 */
 	public function __construct( $query_vars, $cursor = 'after' ) {
 		global $wpdb;
@@ -149,7 +149,7 @@ abstract class AbstractCursor {
 	 * Validates cursor compare field configuration. Validation failure results in a fatal
 	 * error because query execution is guaranteed to fail.
 	 *
-	 * @param array|mixed $field  Threshold configuration.
+	 * @param array<string,mixed>|mixed $field  Threshold configuration.
 	 *
 	 * @throws \GraphQL\Error\InvariantViolation Invalid configuration format.
 	 */
@@ -238,7 +238,7 @@ abstract class AbstractCursor {
 	/**
 	 * Applies cursor compare fields to the cursor cutoff.
 	 *
-	 * @param array $fallback  Fallback cursor compare fields.
+	 * @param array<string,mixed>[] $fallback Fallback cursor compare fields.
 	 *
 	 * @throws \GraphQL\Error\InvariantViolation Invalid configuration format.
 	 */
@@ -246,7 +246,7 @@ abstract class AbstractCursor {
 		/**
 		 * Get cursor compare fields from query vars.
 		 *
-		 * @var array|null $cursor_compare_fields
+		 * @var array<string,mixed>[]|null $cursor_compare_fields
 		 */
 		$cursor_compare_fields = $this->get_query_var( 'graphql_cursor_compare_fields' );
 		if ( null === $cursor_compare_fields ) {

--- a/src/Data/Cursor/AbstractCursor.php
+++ b/src/Data/Cursor/AbstractCursor.php
@@ -152,8 +152,6 @@ abstract class AbstractCursor {
 	 * @param array|mixed $field  Threshold configuration.
 	 *
 	 * @throws \GraphQL\Error\InvariantViolation Invalid configuration format.
-	 *
-	 * @return void
 	 */
 	protected function validate_cursor_compare_field( $field ): void {
 		// Throw if an array not provided.

--- a/src/Data/Cursor/CommentObjectCursor.php
+++ b/src/Data/Cursor/CommentObjectCursor.php
@@ -19,10 +19,9 @@ class CommentObjectCursor extends AbstractCursor {
 	public $cursor_node;
 
 	/**
-	 * @param array|\WP_Comment_Query $query_vars The query vars to use when building the SQL statement.
-	 * @param string|null             $cursor Whether to generate the before or after cursor. Default "after"
+	 * {@inheritDoc}
 	 *
-	 * @return void
+	 * @param array<string,mixed>|\WP_Comment_Query $query_vars The query vars to use when building the SQL statement.
 	 */
 	public function __construct( $query_vars, $cursor = 'after' ) {
 		// Handle deprecated use of $query.

--- a/src/Data/Cursor/CommentObjectCursor.php
+++ b/src/Data/Cursor/CommentObjectCursor.php
@@ -51,11 +51,11 @@ class CommentObjectCursor extends AbstractCursor {
 		/**
 		 * If pre-hooked, return filtered node.
 		 *
-		 * @param null|\WP_Comment                           $pre_comment The pre-filtered comment node.
+		 * @param \WP_Comment|null                           $pre_comment The pre-filtered comment node.
 		 * @param int                                        $offset      The cursor offset.
 		 * @param \WPGraphQL\Data\Cursor\CommentObjectCursor $node        The cursor instance.
 		 *
-		 * @return null|\WP_Comment
+		 * @return \WP_Comment|null
 		 */
 		$pre_comment = apply_filters( 'graphql_pre_comment_cursor_node', null, $this->cursor_offset, $this );
 		if ( null !== $pre_comment ) {

--- a/src/Data/Cursor/CursorBuilder.php
+++ b/src/Data/Cursor/CursorBuilder.php
@@ -10,7 +10,7 @@ class CursorBuilder {
 	/**
 	 * The field by which the cursor should order the results
 	 *
-	 * @var array
+	 * @var array<string,mixed>[]
 	 */
 	public $fields;
 
@@ -99,7 +99,7 @@ class CursorBuilder {
 	/**
 	 * Generate the final SQL string to be appended to WHERE clause
 	 *
-	 * @param mixed|array|null $fields
+	 * @param mixed|array<string,mixed>[]|null $fields
 	 *
 	 * @return string
 	 */

--- a/src/Data/Cursor/CursorBuilder.php
+++ b/src/Data/Cursor/CursorBuilder.php
@@ -90,7 +90,7 @@ class CursorBuilder {
 	/**
 	 * Returns true at least one ordering field has been added
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function has_fields() {
 		return count( $this->fields ) > 0;

--- a/src/Data/Cursor/PostObjectCursor.php
+++ b/src/Data/Cursor/PostObjectCursor.php
@@ -53,11 +53,11 @@ class PostObjectCursor extends AbstractCursor {
 		/**
 		 * If pre-hooked, return filtered node.
 		 *
-		 * @param null|\WP_Post                           $pre_post The pre-filtered post node.
+		 * @param \WP_Post|null                           $pre_post The pre-filtered post node.
 		 * @param int                                     $offset   The cursor offset.
 		 * @param \WPGraphQL\Data\Cursor\PostObjectCursor $node     The cursor instance.
 		 *
-		 * @return null|\WP_Post
+		 * @return \WP_Post|null
 		 */
 		$pre_post = apply_filters( 'graphql_pre_post_cursor_node', null, $this->cursor_offset, $this );
 		if ( null !== $pre_post ) {

--- a/src/Data/Cursor/PostObjectCursor.php
+++ b/src/Data/Cursor/PostObjectCursor.php
@@ -23,10 +23,7 @@ class PostObjectCursor extends AbstractCursor {
 	public $meta_join_alias = 0;
 
 	/**
-	 * PostCursor constructor.
-	 *
-	 * @param array|\WP_Query $query_vars The query vars to use when building the SQL statement.
-	 * @param string|null     $cursor Whether to generate the before or after cursor. Default "after"
+	 * {@inheritDoc}
 	 */
 	public function __construct( $query_vars, $cursor = 'after' ) {
 		// Handle deprecated use of $query.

--- a/src/Data/Cursor/PostObjectCursor.php
+++ b/src/Data/Cursor/PostObjectCursor.php
@@ -18,7 +18,7 @@ class PostObjectCursor extends AbstractCursor {
 	/**
 	 * Counter for meta value joins
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	public $meta_join_alias = 0;
 

--- a/src/Data/Cursor/TermObjectCursor.php
+++ b/src/Data/Cursor/TermObjectCursor.php
@@ -53,11 +53,11 @@ class TermObjectCursor extends AbstractCursor {
 		/**
 		 * If pre-hooked, return filtered node.
 		 *
-		 * @param null|\WP_Term                           $pre_term The pre-filtered term node.
+		 * @param \WP_Term|null                           $pre_term The pre-filtered term node.
 		 * @param int                                     $offset   The cursor offset.
 		 * @param \WPGraphQL\Data\Cursor\TermObjectCursor $node     The cursor instance.
 		 *
-		 * @return null|\WP_Term
+		 * @return \WP_Term|null
 		 */
 		$pre_term = apply_filters( 'graphql_pre_term_cursor_node', null, $this->cursor_offset, $this );
 		if ( null !== $pre_term ) {

--- a/src/Data/Cursor/TermObjectCursor.php
+++ b/src/Data/Cursor/TermObjectCursor.php
@@ -13,7 +13,7 @@ class TermObjectCursor extends AbstractCursor {
 	/**
 	 * Counter for meta value joins
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	public $meta_join_alias = 0;
 

--- a/src/Data/Cursor/TermObjectCursor.php
+++ b/src/Data/Cursor/TermObjectCursor.php
@@ -25,6 +25,8 @@ class TermObjectCursor extends AbstractCursor {
 	protected $id_key = 't.term_id';
 
 	/**
+	 * Deprecated in favor of get_query_var()
+	 *
 	 * @param string $name The name of the query var to get
 	 *
 	 * @deprecated 1.9.0
@@ -69,7 +71,9 @@ class TermObjectCursor extends AbstractCursor {
 	}
 
 	/**
-	 * @return ?\WP_Term ;
+	 * Deprecated in favor of get_cursor_node().
+	 *
+	 * @return ?\WP_Term
 	 * @deprecated 1.9.0
 	 */
 	public function get_cursor_term() {
@@ -79,11 +83,9 @@ class TermObjectCursor extends AbstractCursor {
 	}
 
 	/**
-	 * Build and return the SQL statement to add to the Query
+	 * {@inheritDoc}
 	 *
-	 * @param array|null $fields The fields from the CursorBuilder to convert to SQL
-	 *
-	 * @return string
+	 * @param array<array<string,mixed>>[]|null $fields The fields from the CursorBuilder to convert to SQL.
 	 */
 	public function to_sql( $fields = null ) {
 		$sql = $this->builder->to_sql( $fields );

--- a/src/Data/Cursor/UserCursor.php
+++ b/src/Data/Cursor/UserCursor.php
@@ -26,12 +26,9 @@ class UserCursor extends AbstractCursor {
 	public $meta_join_alias = 0;
 
 	/**
-	 * UserCursor constructor.
+	 * {@inheritDoc}
 	 *
-	 * @param array|\WP_User_Query $query_vars The query vars to use when building the SQL statement.
-	 * @param string|null          $cursor     Whether to generate the before or after cursor
-	 *
-	 * @return void
+	 * @param array<string,mixed>|\WP_User_Query $query_vars The query vars to use when building the SQL statement.
 	 */
 	public function __construct( $query_vars, $cursor = 'after' ) {
 		// Handle deprecated use of $query.
@@ -91,6 +88,8 @@ class UserCursor extends AbstractCursor {
 	}
 
 	/**
+	 * Deprecated in favor of get_cursor_node().
+	 *
 	 * @return ?\WP_User
 	 * @deprecated 1.9.0
 	 */

--- a/src/Data/Cursor/UserCursor.php
+++ b/src/Data/Cursor/UserCursor.php
@@ -70,11 +70,11 @@ class UserCursor extends AbstractCursor {
 		/**
 		 * If pre-hooked, return filtered node.
 		 *
-		 * @param null|\WP_User                        $pre_user The pre-filtered user node.
+		 * @param \WP_User|null                        $pre_user The pre-filtered user node.
 		 * @param int                                  $offset   The cursor offset.
 		 * @param \WPGraphQL\Data\Cursor\UserCursor    $node     The cursor instance.
 		 *
-		 * @return null|\WP_User
+		 * @return \WP_User|null
 		 */
 		$pre_user = apply_filters( 'graphql_pre_user_cursor_node', null, $this->cursor_offset, $this );
 		if ( null !== $pre_user ) {

--- a/src/Data/Cursor/UserCursor.php
+++ b/src/Data/Cursor/UserCursor.php
@@ -21,7 +21,7 @@ class UserCursor extends AbstractCursor {
 	/**
 	 * Counter for meta value joins
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	public $meta_join_alias = 0;
 

--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -653,7 +653,7 @@ class DataSource {
 	 * @param \WPGraphQL\AppContext                $context The Context of the GraphQL Request
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo for the GraphQL Request
 	 *
-	 * @return null|string
+	 * @return string|null
 	 * @throws \GraphQL\Error\UserError If no ID is passed.
 	 */
 	public static function resolve_node( $global_id, AppContext $context, ResolveInfo $info ) {

--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -44,7 +44,7 @@ class DataSource {
 	/**
 	 * Stores an array of node definitions
 	 *
-	 * @var array $node_definition
+	 * @var mixed[] $node_definition
 	 * @since  0.0.4
 	 */
 	protected static $node_definition;
@@ -87,7 +87,7 @@ class DataSource {
 	 * Wrapper for the CommentsConnectionResolver class
 	 *
 	 * @param mixed                                $source  The object the connection is coming from
-	 * @param array                                $args    Query args to pass to the connection resolver
+	 * @param array<string,mixed>                  $args    Query args to pass to the connection resolver
 	 * @param \WPGraphQL\AppContext                $context The context of the query to pass along
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object
 	 *
@@ -105,11 +105,11 @@ class DataSource {
 	 * Wrapper for PluginsConnectionResolver::resolve
 	 *
 	 * @param mixed                                $source  The object the connection is coming from
-	 * @param array                                $args    Array of arguments to pass to resolve method
+	 * @param array<string,mixed>                  $args    Array of arguments to pass to resolve method
 	 * @param \WPGraphQL\AppContext                $context AppContext object passed down
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object
 	 *
-	 * @return array
+	 * @return \GraphQL\Deferred
 	 * @throws \Exception
 	 * @since  0.0.5
 	 */
@@ -155,10 +155,10 @@ class DataSource {
 	 * Wrapper for PostObjectsConnectionResolver
 	 *
 	 * @param mixed                                $source    The object the connection is coming from
-	 * @param array                                $args      Arguments to pass to the resolve method
+	 * @param array<string,mixed>                  $args      Arguments to pass to the resolve method
 	 * @param \WPGraphQL\AppContext                $context AppContext object to pass down
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object
-	 * @param mixed|string|array                   $post_type Post type of the post we are trying to resolve
+	 * @param mixed|string|string[]                $post_type Post type of the post we are trying to resolve
 	 *
 	 * @return mixed
 	 * @throws \Exception
@@ -224,12 +224,12 @@ class DataSource {
 	 * Wrapper for TermObjectConnectionResolver::resolve
 	 *
 	 * @param mixed                                $source   The object the connection is coming from
-	 * @param array                                $args     Array of args to be passed to the resolve method
+	 * @param array<string,mixed>                  $args     Array of args to be passed to the resolve method
 	 * @param \WPGraphQL\AppContext                $context The AppContext object to be passed down
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object
 	 * @param string                               $taxonomy The name of the taxonomy the term belongs to
 	 *
-	 * @return array
+	 * @return \GraphQL\Deferred
 	 * @throws \Exception
 	 * @since  0.0.5
 	 */
@@ -262,11 +262,11 @@ class DataSource {
 	 * Wrapper for the ThemesConnectionResolver::resolve method
 	 *
 	 * @param mixed                                $source  The object the connection is coming from
-	 * @param array                                $args    Passes an array of arguments to the resolve method
+	 * @param array<string,mixed>                  $args    Passes an array of arguments to the resolve method
 	 * @param \WPGraphQL\AppContext                $context The AppContext object to be passed down
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object
 	 *
-	 * @return array
+	 * @return \GraphQL\Deferred
 	 * @throws \Exception
 	 * @since  0.0.5
 	 */
@@ -296,11 +296,11 @@ class DataSource {
 	 * Wrapper for the UsersConnectionResolver::resolve method
 	 *
 	 * @param mixed                                $source  The object the connection is coming from
-	 * @param array                                $args    Array of args to be passed down to the resolve method
+	 * @param array<string,mixed>                  $args    Array of args to be passed down to the resolve method
 	 * @param \WPGraphQL\AppContext                $context The AppContext object to be passed down
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object
 	 *
-	 * @return array
+	 * @return \GraphQL\Deferred
 	 * @throws \Exception
 	 * @since  0.0.5
 	 */
@@ -338,8 +338,8 @@ class DataSource {
 	/**
 	 * Resolve the avatar for a user
 	 *
-	 * @param int   $user_id ID of the user to get the avatar data for
-	 * @param array $args    The args to pass to the get_avatar_data function
+	 * @param int                 $user_id ID of the user to get the avatar data for
+	 * @param array<string,mixed> $args    The args to pass to the get_avatar_data function
 	 *
 	 * @return \WPGraphQL\Model\Avatar|null
 	 * @throws \Exception
@@ -358,12 +358,12 @@ class DataSource {
 	/**
 	 * Resolve the connection data for user roles
 	 *
-	 * @param array                                $source  The Query results
-	 * @param array                                $args    The query arguments
+	 * @param mixed[]                              $source  The Query results
+	 * @param array<string,mixed>                  $args    The query arguments
 	 * @param \WPGraphQL\AppContext                $context The AppContext passed down to the query
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object
 	 *
-	 * @return array
+	 * @return \GraphQL\Deferred
 	 * @throws \Exception
 	 */
 	public static function resolve_user_role_connection( $source, array $args, AppContext $context, ResolveInfo $info ) {
@@ -400,7 +400,7 @@ class DataSource {
 	 * @param string                           $group
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The WPGraphQL TypeRegistry
 	 *
-	 * @return array $settings_groups[ $group ]
+	 * @return array<string,mixed>
 	 */
 	public static function get_setting_group_fields( string $group, TypeRegistry $type_registry ) {
 
@@ -417,7 +417,7 @@ class DataSource {
 	 *
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The WPGraphQL TypeRegistry
 	 *
-	 * @return array $allowed_settings_by_group
+	 * @return array<string,array<string,mixed>> $allowed_settings_by_group
 	 */
 	public static function get_allowed_settings_by_group( TypeRegistry $type_registry ) {
 
@@ -473,7 +473,7 @@ class DataSource {
 	 *
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The WPGraphQL TypeRegistry
 	 *
-	 * @return array $allowed_settings
+	 * @return array<string,array<string,mixed>> $allowed_settings
 	 */
 	public static function get_allowed_settings( TypeRegistry $type_registry ) {
 
@@ -519,9 +519,7 @@ class DataSource {
 		 * Filter the $allowed_settings to allow some to be enabled or disabled from showing in
 		 * the GraphQL Schema.
 		 *
-		 * @param array $allowed_settings
-		 *
-		 * @return array
+		 * @param array<string,array<string,mixed>> $allowed_settings
 		 */
 		return apply_filters( 'graphql_allowed_setting_groups', $allowed_settings );
 	}
@@ -532,7 +530,7 @@ class DataSource {
 	 * The first method is the way we resolve an ID to its object. The second is the way we resolve
 	 * an object that implements node to its type.
 	 *
-	 * @return array
+	 * @return mixed[]
 	 * @throws \GraphQL\Error\UserError
 	 */
 	public static function get_node_definition() {
@@ -699,7 +697,7 @@ class DataSource {
 	/**
 	 * Returns array of nav menu location names
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	public static function get_registered_nav_menu_locations() {
 		global $_wp_registered_nav_menus;

--- a/src/Data/Loader/AbstractDataLoader.php
+++ b/src/Data/Loader/AbstractDataLoader.php
@@ -372,7 +372,7 @@ abstract class AbstractDataLoader {
 	 * @param mixed $entry The entry loaded from the dataloader to be used to generate a Model
 	 * @param mixed $key   The Key used to identify the loaded entry
 	 *
-	 * @return null|\WPGraphQL\Model\Model
+	 * @return \WPGraphQL\Model\Model|null
 	 */
 	protected function normalize_entry( $entry, $key ) {
 

--- a/src/Data/Loader/AbstractDataLoader.php
+++ b/src/Data/Loader/AbstractDataLoader.php
@@ -28,14 +28,14 @@ abstract class AbstractDataLoader {
 	/**
 	 * This stores an array of items that have already been loaded
 	 *
-	 * @var array
+	 * @var array<int|string,mixed>
 	 */
 	private $cached = [];
 
 	/**
 	 * This stores an array of IDs that need to be loaded
 	 *
-	 * @var array
+	 * @var array<int|string,int|string>
 	 */
 	private $buffer = [];
 
@@ -83,7 +83,7 @@ abstract class AbstractDataLoader {
 	/**
 	 * Add keys to buffer to be loaded in single batch later.
 	 *
-	 * @param array $keys The keys of the objects to buffer
+	 * @param int[]|string[] $keys The keys of the objects to buffer
 	 *
 	 * @return $this
 	 * @throws \Exception
@@ -181,7 +181,7 @@ abstract class AbstractDataLoader {
 	 * Clears the value at `key` from the cache, if it exists. Returns itself for
 	 * method chaining.
 	 *
-	 * @param array $keys
+	 * @param int[]|string[] $keys
 	 *
 	 * @return $this
 	 */
@@ -226,10 +226,10 @@ abstract class AbstractDataLoader {
 	 * Loads multiple keys. Returns generator where each entry directly corresponds to entry in
 	 * $keys. If second argument $asArray is set to true, returns array instead of generator
 	 *
-	 * @param array $keys
-	 * @param bool  $asArray
+	 * @param int[]|string[] $keys
+	 * @param bool           $asArray
 	 *
-	 * @return array|\Generator
+	 * @return \Generator|array<int|string,mixed>
 	 * @throws \Exception
 	 *
 	 * @deprecated Use load_many instead
@@ -243,10 +243,10 @@ abstract class AbstractDataLoader {
 	 * Loads multiple keys. Returns generator where each entry directly corresponds to entry in
 	 * $keys. If second argument $asArray is set to true, returns array instead of generator
 	 *
-	 * @param array $keys
-	 * @param bool  $asArray
+	 * @param int[]|string[] $keys
+	 * @param bool           $asArray
 	 *
-	 * @return array|\Generator
+	 * @return \Generator|array<int|string,mixed>
 	 * @throws \Exception
 	 */
 	public function load_many( array $keys, $asArray = false ) {
@@ -265,8 +265,8 @@ abstract class AbstractDataLoader {
 	/**
 	 * Given an array of keys, this yields the object from the cached results
 	 *
-	 * @param array $keys   The keys to generate results for
-	 * @param array $result The results for all keys
+	 * @param int[]|string[]          $keys   The keys to generate results for
+	 * @param array<int|string,mixed> $result The results for all keys
 	 *
 	 * @return \Generator
 	 */
@@ -282,7 +282,7 @@ abstract class AbstractDataLoader {
 	 * executes the loaders `loadKeys` method to load the items and adds them
 	 * to the cache if necessary
 	 *
-	 * @return array
+	 * @return array<int|string,mixed>
 	 * @throws \Exception
 	 */
 	private function load_buffered() {
@@ -349,18 +349,18 @@ abstract class AbstractDataLoader {
 	 * to the loader, we could have the loader centrally decode the keys into their
 	 * integer values in the PostObjectLoader by overriding this method.
 	 *
-	 * @param mixed $key
+	 * @param int|string|mixed $key
 	 *
-	 * @return mixed
+	 * @return int|string
 	 */
 	protected function key_to_scalar( $key ) {
 		return $key;
 	}
 
 	/**
-	 * @param mixed $key
+	 * @param int|string|mixed $key
 	 *
-	 * @return mixed
+	 * @return int|string
 	 * @deprecated Use key_to_scalar instead
 	 */
 	protected function keyToScalar( $key ) {
@@ -455,10 +455,10 @@ abstract class AbstractDataLoader {
 	/**
 	 * Caches a data object by key.
 	 *
-	 * @param mixed $key    Key.
-	 * @param mixed $value  Data object.
+	 * @param int|string $key    Key.
+	 * @param mixed      $value  Data object.
 	 *
-	 * @return mixed
+	 * @return void
 	 */
 	protected function set_cached( $key, $value ) {
 		/**
@@ -482,10 +482,10 @@ abstract class AbstractDataLoader {
 	 * If the loader needs to do any tweaks between getting raw data from the DB and caching,
 	 * this can be overridden by the specific loader and used for transformations, etc.
 	 *
-	 * @param mixed $entry The User Role object
-	 * @param mixed $key   The Key to identify the user role by
+	 * @param mixed $entry The entry data to be used to generate a Model.
+	 * @param mixed $key   The Key to identify the entry by.
 	 *
-	 * @return \WPGraphQL\Model\Model
+	 * @return ?\WPGraphQL\Model\Model
 	 */
 	protected function get_model( $entry, $key ) {
 		return $entry;
@@ -501,9 +501,9 @@ abstract class AbstractDataLoader {
 	 * For example:
 	 * loadKeys(['a', 'b', 'c']) -> ['a' => 'value1, 'b' => null, 'c' => 'value3']
 	 *
-	 * @param array $keys
+	 * @param int[]|string[] $keys
 	 *
-	 * @return array
+	 * @return array<int|string,mixed>
 	 */
 	abstract protected function loadKeys( array $keys );
 }

--- a/src/Data/Loader/AbstractDataLoader.php
+++ b/src/Data/Loader/AbstractDataLoader.php
@@ -58,8 +58,7 @@ abstract class AbstractDataLoader {
 	/**
 	 * Given a Database ID, the particular loader will buffer it and resolve it deferred.
 	 *
-	 * @param mixed|int|string $database_id The database ID for a particular loader to load an
-	 *                                      object
+	 * @param mixed|int|string $database_id The database ID for a particular loader to load an object
 	 *
 	 * @return \GraphQL\Deferred|null
 	 * @throws \Exception

--- a/src/Data/Loader/CommentAuthorLoader.php
+++ b/src/Data/Loader/CommentAuthorLoader.php
@@ -11,11 +11,9 @@ use WPGraphQL\Model\CommentAuthor;
 class CommentAuthorLoader extends AbstractDataLoader {
 
 	/**
-	 * @param mixed $entry The User Role object
-	 * @param mixed $key The Key to identify the user role by
+	 * {@inheritDoc}
 	 *
-	 * @return mixed|\WPGraphQL\Model\CommentAuthor
-	 * @throws \Exception
+	 * @return ?\WPGraphQL\Model\CommentAuthor
 	 */
 	protected function get_model( $entry, $key ) {
 		if ( ! $entry instanceof \WP_Comment ) {
@@ -26,9 +24,9 @@ class CommentAuthorLoader extends AbstractDataLoader {
 	}
 
 	/**
-	 * @param array $keys
+	 * {@inheritDoc}
 	 *
-	 * @return array
+	 * @param int[] $keys Array of IDs to load
 	 */
 	public function loadKeys( array $keys ) {
 		/**

--- a/src/Data/Loader/CommentLoader.php
+++ b/src/Data/Loader/CommentLoader.php
@@ -12,10 +12,9 @@ use WPGraphQL\Model\Comment;
 class CommentLoader extends AbstractDataLoader {
 
 	/**
-	 * @param mixed $entry The User Role object
-	 * @param mixed $key The Key to identify the user role by
+	 * {@inheritDoc}
 	 *
-	 * @return mixed|\WPGraphQL\Model\Comment|null
+	 * @return ?\WPGraphQL\Model\Comment
 	 * @throws \Exception
 	 */
 	protected function get_model( $entry, $key ) {
@@ -32,19 +31,9 @@ class CommentLoader extends AbstractDataLoader {
 	}
 
 	/**
-	 * Given array of keys, loads and returns a map consisting of keys from `keys` array and loaded
-	 * comments as the values
+	 * {@inheritDoc}
 	 *
-	 * Note that order of returned values must match exactly the order of keys.
-	 * If some entry is not available for given key - it must include null for the missing key.
-	 *
-	 * For example:
-	 * loadKeys(['a', 'b', 'c']) -> ['a' => 'value1, 'b' => null, 'c' => 'value3']
-	 *
-	 * @param array $keys
-	 *
-	 * @return array
-	 * @throws \Exception
+	 * @param int[] $keys Array of IDs to load
 	 */
 	public function loadKeys( array $keys = [] ) {
 

--- a/src/Data/Loader/EnqueuedScriptLoader.php
+++ b/src/Data/Loader/EnqueuedScriptLoader.php
@@ -9,12 +9,11 @@ namespace WPGraphQL\Data\Loader;
 class EnqueuedScriptLoader extends AbstractDataLoader {
 
 	/**
-	 * Given an array of enqueued script handles ($keys) load the associated
-	 * enqueued scripts from the $wp_scripts registry.
+	 * {@inheritDoc}
 	 *
-	 * @param array $keys
+	 * @param string[] $keys Array of script handles to load
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 */
 	public function loadKeys( array $keys ) {
 		/** @var \WP_Scripts $wp_scripts */

--- a/src/Data/Loader/EnqueuedStylesheetLoader.php
+++ b/src/Data/Loader/EnqueuedStylesheetLoader.php
@@ -9,12 +9,11 @@ namespace WPGraphQL\Data\Loader;
 class EnqueuedStylesheetLoader extends AbstractDataLoader {
 
 	/**
-	 * Given an array of enqueued stylesheet handles ($keys) load the associated
-	 * enqueued stylesheets from the $wp_styles registry.
+	 * {@inheritDoc}
 	 *
-	 * @param array $keys
+	 * @param string[] $keys Array of stylesheet handles to load
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 */
 	public function loadKeys( array $keys ) {
 		global $wp_styles;

--- a/src/Data/Loader/PluginLoader.php
+++ b/src/Data/Loader/PluginLoader.php
@@ -12,10 +12,11 @@ use WPGraphQL\Model\Plugin;
 class PluginLoader extends AbstractDataLoader {
 
 	/**
-	 * @param mixed $entry The User Role object
-	 * @param mixed $key The Key to identify the user role by
+	 * {@inheritDoc}
 	 *
-	 * @return \WPGraphQL\Model\Model|\WPGraphQL\Model\Plugin
+	 * @param array<string,mixed> $entry The plugin data
+	 *
+	 * @return \WPGraphQL\Model\Plugin
 	 * @throws \Exception
 	 */
 	protected function get_model( $entry, $key ) {
@@ -23,11 +24,11 @@ class PluginLoader extends AbstractDataLoader {
 	}
 
 	/**
-	 * Given an array of plugin names, load the associated plugins from the plugin registry.
+	 * {@inheritDoc}
 	 *
-	 * @param array $keys
+	 * @param string[] $keys Array of plugin names to load
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>|null>
 	 * @throws \Exception
 	 */
 	public function loadKeys( array $keys ) {

--- a/src/Data/Loader/PostObjectLoader.php
+++ b/src/Data/Loader/PostObjectLoader.php
@@ -13,11 +13,11 @@ use WPGraphQL\Model\Post;
 class PostObjectLoader extends AbstractDataLoader {
 
 	/**
-	 * @param mixed $entry The User Role object
-	 * @param mixed $key The Key to identify the user role by
+	 * {@inheritDoc}
 	 *
-	 * @return mixed|\WPGraphQL\Model\Post
-	 * @throws \Exception
+	 * @param mixed|\WP_Post $entry The Post Object
+	 *
+	 * @return \WPGraphQL\Model\Post|\WPGraphQL\Model\MenuItem|null
 	 */
 	protected function get_model( $entry, $key ) {
 		if ( ! $entry instanceof \WP_Post ) {
@@ -55,19 +55,9 @@ class PostObjectLoader extends AbstractDataLoader {
 	}
 
 	/**
-	 * Given array of keys, loads and returns a map consisting of keys from `keys` array and loaded
-	 * posts as the values
+	 * {@inheritDoc}
 	 *
-	 * Note that order of returned values must match exactly the order of keys.
-	 * If some entry is not available for given key - it must include null for the missing key.
-	 *
-	 * For example:
-	 * loadKeys(['a', 'b', 'c']) -> ['a' => 'value1, 'b' => null, 'c' => 'value3']
-	 *
-	 * @param array $keys
-	 *
-	 * @return array
-	 * @throws \Exception
+	 * @return array<string|int, \WP_Post|null>
 	 */
 	public function loadKeys( array $keys ) {
 		if ( empty( $keys ) ) {

--- a/src/Data/Loader/PostTypeLoader.php
+++ b/src/Data/Loader/PostTypeLoader.php
@@ -11,21 +11,21 @@ use WPGraphQL\Model\PostType;
 class PostTypeLoader extends AbstractDataLoader {
 
 	/**
-	 * @param mixed $entry The User Role object
-	 * @param mixed $key The Key to identify the user role by
+	 * {@inheritDoc}
 	 *
-	 * @return mixed|\WPGraphQL\Model\PostType
-	 * @throws \Exception
+	 * @param mixed|\WP_Post_Type $entry The Post Type Object
+	 *
+	 * @return \WPGraphQL\Model\PostType
 	 */
 	protected function get_model( $entry, $key ) {
 		return new PostType( $entry );
 	}
 
 	/**
-	 * @param array $keys
+	 * {@inheritDoc}
 	 *
-	 * @return array
-	 * @throws \Exception
+	 * @param string[] $keys
+	 * @return array<string,\WP_Post|null>
 	 */
 	public function loadKeys( array $keys ) {
 		$post_types = \WPGraphQL::get_allowed_post_types( 'objects' );

--- a/src/Data/Loader/TaxonomyLoader.php
+++ b/src/Data/Loader/TaxonomyLoader.php
@@ -11,21 +11,22 @@ use WPGraphQL\Model\Taxonomy;
 class TaxonomyLoader extends AbstractDataLoader {
 
 	/**
-	 * @param mixed $entry The User Role object
-	 * @param mixed $key The Key to identify the user role by
+	 * {@inheritDoc}
+	 * 
+	 * @param mixed|\WP_Taxonomy $entry The Taxonomy Object
 	 *
-	 * @return mixed|\WPGraphQL\Model\Taxonomy
-	 * @throws \Exception
+	 * @return \WPGraphQL\Model\Taxonomy
 	 */
 	protected function get_model( $entry, $key ) {
 		return new Taxonomy( $entry );
 	}
 
 	/**
-	 * @param array $keys
+	 * {@inheritDoc}
 	 *
-	 * @return array
-	 * @throws \Exception
+	 * @param string[] $keys
+	 *
+	 * @return array<string,\WP_Taxonomy|null>
 	 */
 	public function loadKeys( array $keys ) {
 		$taxonomies = \WPGraphQL::get_allowed_taxonomies( 'objects' );

--- a/src/Data/Loader/TermObjectLoader.php
+++ b/src/Data/Loader/TermObjectLoader.php
@@ -13,10 +13,11 @@ use WPGraphQL\Model\Term;
 class TermObjectLoader extends AbstractDataLoader {
 
 	/**
-	 * @param mixed $entry The User Role object
-	 * @param mixed $key The Key to identify the user role by
+	 * {@inheritDoc}
 	 *
-	 * @return mixed|\WPGraphQL\Model\Term
+	 * @param mixed|\WP_Term $entry The Term Object
+	 *
+	 * @return \WPGraphQL\Model\Term|\WPGraphQL\Model\Menu|null
 	 * @throws \Exception
 	 */
 	protected function get_model( $entry, $key ) {
@@ -45,19 +46,11 @@ class TermObjectLoader extends AbstractDataLoader {
 	}
 
 	/**
-	 * Given array of keys, loads and returns a map consisting of keys from `keys` array and loaded
-	 * posts as the values
-	 *
-	 * Note that order of returned values must match exactly the order of keys.
-	 * If some entry is not available for given key - it must include null for the missing key.
-	 *
-	 * For example:
-	 * loadKeys(['a', 'b', 'c']) -> ['a' => 'value1, 'b' => null, 'c' => 'value3']
+	 * {@inheritDoc}
 	 *
 	 * @param int[] $keys
 	 *
-	 * @return array
-	 * @throws \Exception
+	 * @return array<int, mixed>
 	 */
 	public function loadKeys( array $keys ) {
 		if ( empty( $keys ) ) {

--- a/src/Data/Loader/ThemeLoader.php
+++ b/src/Data/Loader/ThemeLoader.php
@@ -11,21 +11,20 @@ use WPGraphQL\Model\Theme;
 class ThemeLoader extends AbstractDataLoader {
 
 	/**
-	 * @param mixed $entry The User Role object
-	 * @param mixed $key The Key to identify the user role by
+	 * {@inheritDoc}
 	 *
-	 * @return \WPGraphQL\Model\Model|\WPGraphQL\Model\Theme
-	 * @throws \Exception
+	 * @param mixed|\WP_Theme $entry The User Role object
+	 *
+	 * @return \WPGraphQL\Model\Theme
 	 */
 	protected function get_model( $entry, $key ) {
 		return new Theme( $entry );
 	}
 
 	/**
-	 * @param array $keys
+	 * {@inheritDoc}
 	 *
-	 * @return array
-	 * @throws \Exception
+	 * @return array<int|string,?\WP_Theme>
 	 */
 	public function loadKeys( array $keys ) {
 		$themes = wp_get_themes();

--- a/src/Data/Loader/UserLoader.php
+++ b/src/Data/Loader/UserLoader.php
@@ -11,10 +11,11 @@ use WPGraphQL\Model\User;
 class UserLoader extends AbstractDataLoader {
 
 	/**
-	 * @param mixed $entry The User Role object
-	 * @param mixed $key The Key to identify the user role by
+	 * {@inheritDoc}
 	 *
-	 * @return mixed|\WPGraphQL\Model\User
+	 * @param mixed|\WP_User $entry The User object
+	 *
+	 * @return ?\WPGraphQL\Model\User
 	 * @throws \Exception
 	 */
 	protected function get_model( $entry, $key ) {
@@ -40,9 +41,9 @@ class UserLoader extends AbstractDataLoader {
 	 * In this example, user 1 is not public (has no published posts) and is
 	 * omitted from the returned array.
 	 *
-	 * @param array $keys Array of author IDs (int).
+	 * @param int[] $keys Array of author IDs (int).
 	 *
-	 * @return array
+	 * @return array<int, bool> Associative array of author IDs (int) to boolean.
 	 */
 	public function get_public_users( array $keys ) {
 
@@ -104,19 +105,11 @@ class UserLoader extends AbstractDataLoader {
 	}
 
 	/**
-	 * Given array of keys, loads and returns a map consisting of keys from `keys` array and loaded
-	 * values
+	 * {@inheritDoc}
 	 *
-	 * Note that order of returned values must match exactly the order of keys.
-	 * If some entry is not available for given key - it must include null for the missing key.
+	 * @param int[] $keys
 	 *
-	 * For example:
-	 * loadKeys(['a', 'b', 'c']) -> ['a' => 'value1, 'b' => null, 'c' => 'value3']
-	 *
-	 * @param array $keys
-	 *
-	 * @return array
-	 * @throws \Exception
+	 * @return array<int, \WP_User|null>
 	 */
 	public function loadKeys( array $keys ) {
 		if ( empty( $keys ) ) {

--- a/src/Data/Loader/UserRoleLoader.php
+++ b/src/Data/Loader/UserRoleLoader.php
@@ -12,21 +12,16 @@ use WPGraphQL\Model\UserRole;
 class UserRoleLoader extends AbstractDataLoader {
 
 	/**
-	 * @param mixed $entry The User Role object
-	 * @param mixed $key The Key to identify the user role by
+	 * {@inheritDoc}
 	 *
-	 * @return mixed|\WPGraphQL\Model\UserRole
-	 * @throws \Exception
+	 * @return \WPGraphQL\Model\UserRole
 	 */
 	protected function get_model( $entry, $key ) {
 		return new UserRole( $entry );
 	}
 
 	/**
-	 * @param array $keys
-	 *
-	 * @return array
-	 * @throws \Exception
+	 * {@inheritDoc}
 	 */
 	public function loadKeys( array $keys ) {
 		$wp_roles = wp_roles()->roles;

--- a/src/Data/MediaItemMutation.php
+++ b/src/Data/MediaItemMutation.php
@@ -17,12 +17,12 @@ class MediaItemMutation {
 	/**
 	 * This prepares the media item for insertion
 	 *
-	 * @param array         $input            The input for the mutation from the GraphQL request
-	 * @param \WP_Post_Type $post_type_object The post_type_object for the mediaItem (attachment)
-	 * @param string        $mutation_name    The name of the mutation being performed (create, update, etc.)
-	 * @param mixed         $file             The mediaItem (attachment) file
+	 * @param array<string,mixed> $input            The input for the mutation from the GraphQL request
+	 * @param \WP_Post_Type       $post_type_object The post_type_object for the mediaItem (attachment)
+	 * @param string              $mutation_name    The name of the mutation being performed (create, update, etc.)
+	 * @param mixed               $file             The mediaItem (attachment) file
 	 *
-	 * @return array $media_item_args
+	 * @return array<string,mixed>
 	 */
 	public static function prepare_media_item( array $input, WP_Post_Type $post_type_object, string $mutation_name, $file ) {
 		$insert_post_args = [];
@@ -109,7 +109,7 @@ class MediaItemMutation {
 	 * This updates additional data related to a mediaItem, such as postmeta.
 	 *
 	 * @param int                                  $media_item_id    The ID of the media item being mutated
-	 * @param array                                $input            The input on the mutation
+	 * @param array<string,mixed>                  $input            The input on the mutation
 	 * @param \WP_Post_Type                        $post_type_object The Post Type Object for the item being mutated
 	 * @param string                               $mutation_name    The name of the mutation
 	 * @param \WPGraphQL\AppContext                $context The AppContext that is passed down the resolve tree

--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -103,9 +103,8 @@ class NodeResolver {
 	 * Given the URI of a resource, this method attempts to resolve it and return the
 	 * appropriate related object
 	 *
-	 * @param string       $uri              The path to be used as an identifier for the
-	 *                                             resource.
-	 * @param array|string $extra_query_vars Any extra query vars to consider
+	 * @param string                     $uri              The path to be used as an identifier for the resource.
+	 * @param array<string,mixed>|string $extra_query_vars Any extra query vars to consider
 	 *
 	 * @return mixed
 	 * @throws \GraphQL\Error\UserError If the query class does not exist.
@@ -123,7 +122,7 @@ class NodeResolver {
 		 * @param string $uri The uri being searched.
 		 * @param \WPGraphQL\AppContext $content The app context.
 		 * @param \WP $wp WP object.
-		 * @param mixed|array|string $extra_query_vars Any extra query vars to consider.
+		 * @param mixed|array<string,mixed>|string $extra_query_vars Any extra query vars to consider.
 		 */
 		$node = apply_filters( 'graphql_pre_resolve_uri', null, $uri, $this->context, $this->wp, $extra_query_vars );
 
@@ -308,8 +307,8 @@ class NodeResolver {
 	 *
 	 * Mimics WP::parse_request()
 	 *
-	 * @param string       $uri
-	 * @param array|string $extra_query_vars
+	 * @param string                     $uri
+	 * @param array<string,mixed>|string $extra_query_vars
 	 *
 	 * @return string|null The parsed uri.
 	 */
@@ -333,8 +332,8 @@ class NodeResolver {
 			$home_url = wp_parse_url( home_url() );
 
 			/**
-			 * @var array $home_url
-			 * @var array $site_url
+			 * @var array<string,mixed> $home_url
+			 * @var array<string,mixed> $site_url
 			 */
 			if ( ! in_array(
 				$parsed_url['host'],

--- a/src/Data/PostObjectMutation.php
+++ b/src/Data/PostObjectMutation.php
@@ -18,12 +18,12 @@ class PostObjectMutation {
 	/**
 	 * This handles inserting the post object
 	 *
-	 * @param array         $input            The input for the mutation
-	 * @param \WP_Post_Type $post_type_object The post_type_object for the type of post being
-	 * mutated
-	 * @param string        $mutation_name    The name of the mutation being performed
+	 * @param array<string,mixed> $input            The input for the mutation
+	 * @param \WP_Post_Type       $post_type_object The post_type_object for the type of post being
+	 *       mutated
+	 * @param string              $mutation_name    The name of the mutation being performed
 	 *
-	 * @return array $insert_post_args
+	 * @return array<string,mixed>
 	 * @throws \Exception
 	 */
 	public static function prepare_post_object( $input, $post_type_object, $mutation_name ) {
@@ -123,7 +123,7 @@ class PostObjectMutation {
 	 * etc.
 	 *
 	 * @param int                                  $post_id              The ID of the postObject being mutated
-	 * @param array                                $input                The input for the mutation
+	 * @param array<string,mixed>                  $input                The input for the mutation
 	 * @param \WP_Post_Type                        $post_type_object     The Post Type Object for the type of post being mutated
 	 * @param string                               $mutation_name        The name of the mutation (ex: create, update, delete)
 	 * @param \WPGraphQL\AppContext                $context              The AppContext passed down to all resolvers
@@ -222,11 +222,11 @@ class PostObjectMutation {
 	 * Given a $post_id and $input from the mutation, check to see if any term associations are
 	 * being made, and properly set the relationships
 	 *
-	 * @param int           $post_id           The ID of the postObject being mutated
-	 * @param array         $input             The input for the mutation
-	 * @param \WP_Post_Type $post_type_object The Post Type Object for the type of post being
-	 * mutated
-	 * @param string        $mutation_name     The name of the mutation (ex: create, update, delete)
+	 * @param int                 $post_id           The ID of the postObject being mutated
+	 * @param array<string,mixed> $input             The input for the mutation
+	 * @param \WP_Post_Type       $post_type_object The Post Type Object for the type of post being
+	 *       mutated
+	 * @param string              $mutation_name     The name of the mutation (ex: create, update, delete)
 	 *
 	 * @return void
 	 */
@@ -369,8 +369,8 @@ class PostObjectMutation {
 	 * Given an array of Term properties (slug, name, description, etc), create the term and return
 	 * a term_id
 	 *
-	 * @param array  $node     The node input for the term
-	 * @param string $taxonomy The taxonomy the term input is for
+	 * @param array<string,mixed> $node     The node input for the term
+	 * @param string              $taxonomy The taxonomy the term input is for
 	 *
 	 * @return int $term_id The ID of the created term. 0 if no term was created.
 	 */
@@ -423,7 +423,7 @@ class PostObjectMutation {
 	 *
 	 * @param int $post_id ID of the post being edited.
 	 *
-	 * @return array|false Array of the lock time and user ID. False if the post does not exist, or
+	 * @return int[]|false Array of the lock time and user ID. False if the post does not exist, or
 	 *                     there is no current user.
 	 */
 	public static function set_edit_lock( $post_id ) {
@@ -465,8 +465,8 @@ class PostObjectMutation {
 	/**
 	 * Check the edit lock for a post
 	 *
-	 * @param false|int $post_id ID of the post to delete the lock for
-	 * @param array     $input             The input for the mutation
+	 * @param false|int           $post_id ID of the post to delete the lock for
+	 * @param array<string,mixed> $input             The input for the mutation
 	 *
 	 * @return false|int Return false if no lock or the user_id of the owner of the lock
 	 */

--- a/src/Data/PostObjectMutation.php
+++ b/src/Data/PostObjectMutation.php
@@ -19,8 +19,7 @@ class PostObjectMutation {
 	 * This handles inserting the post object
 	 *
 	 * @param array<string,mixed> $input            The input for the mutation
-	 * @param \WP_Post_Type       $post_type_object The post_type_object for the type of post being
-	 *       mutated
+	 * @param \WP_Post_Type       $post_type_object The post_type_object for the type of post being mutated
 	 * @param string              $mutation_name    The name of the mutation being performed
 	 *
 	 * @return array<string,mixed>
@@ -224,8 +223,7 @@ class PostObjectMutation {
 	 *
 	 * @param int                 $post_id           The ID of the postObject being mutated
 	 * @param array<string,mixed> $input             The input for the mutation
-	 * @param \WP_Post_Type       $post_type_object The Post Type Object for the type of post being
-	 *       mutated
+	 * @param \WP_Post_Type       $post_type_object The Post Type Object for the type of post being mutated
 	 * @param string              $mutation_name     The name of the mutation (ex: create, update, delete)
 	 *
 	 * @return void

--- a/src/Data/TermObjectMutation.php
+++ b/src/Data/TermObjectMutation.php
@@ -14,11 +14,11 @@ class TermObjectMutation {
 	 *
 	 * @throws \GraphQL\Error\UserError User error for invalid term.
 	 *
-	 * @param array        $input         The input from the GraphQL Request
-	 * @param \WP_Taxonomy $taxonomy The Taxonomy object for the type of term being mutated
-	 * @param string       $mutation_name The name of the mutation (create, update, etc)
+	 * @param array<string,mixed> $input         The input from the GraphQL Request
+	 * @param \WP_Taxonomy        $taxonomy The Taxonomy object for the type of term being mutated
+	 * @param string              $mutation_name The name of the mutation (create, update, etc)
 	 *
-	 * @return mixed
+	 * @return array<string,mixed>
 	 */
 	public static function prepare_object( array $input, WP_Taxonomy $taxonomy, string $mutation_name ) {
 		$insert_args = [];

--- a/src/Data/UserMutation.php
+++ b/src/Data/UserMutation.php
@@ -17,14 +17,14 @@ class UserMutation {
 	/**
 	 * Stores the input fields static definition
 	 *
-	 * @var array $input_fields
+	 * @var array<string,array<string,mixed>>
 	 */
 	private static $input_fields = [];
 
 	/**
 	 * Defines the accepted input arguments
 	 *
-	 * @return array|null
+	 * @return array<string,array<string,mixed>>|null
 	 */
 	public static function input_fields() {
 		if ( empty( self::$input_fields ) ) {
@@ -98,7 +98,7 @@ class UserMutation {
 			/**
 			 * Filters all of the fields available for input
 			 *
-			 * @var array $input_fields
+			 * @var array<string,array<string,mixed>> $input_fields
 			 */
 			self::$input_fields = apply_filters( 'graphql_user_mutation_input_fields', $input_fields );
 		}
@@ -109,10 +109,10 @@ class UserMutation {
 	/**
 	 * Maps the GraphQL input to a format that the WordPress functions can use
 	 *
-	 * @param array  $input         Data coming from the GraphQL mutation query input
-	 * @param string $mutation_name Name of the mutation being performed
+	 * @param array<string,mixed> $input         Data coming from the GraphQL mutation query input
+	 * @param string              $mutation_name Name of the mutation being performed
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 * @throws \GraphQL\Error\UserError If the passed email address is invalid.
 	 */
 	public static function prepare_user_object( $input, $mutation_name ) {
@@ -207,7 +207,7 @@ class UserMutation {
 	 * happened
 	 *
 	 * @param int                                  $user_id       The ID of the user being mutated
-	 * @param array                                $input         The input data from the GraphQL query
+	 * @param array<string,mixed>                  $input         The input data from the GraphQL query
 	 * @param string                               $mutation_name Name of the mutation currently being run
 	 * @param \WPGraphQL\AppContext                $context The AppContext passed down the resolve tree
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the Resolve Tree
@@ -236,8 +236,8 @@ class UserMutation {
 	/**
 	 * Method to add user roles to a user object
 	 *
-	 * @param int   $user_id The ID of the user
-	 * @param array $roles   List of roles that need to get added to the user
+	 * @param int      $user_id The ID of the user
+	 * @param string[] $roles   List of roles that need to get added to the user
 	 *
 	 * @return void
 	 * @throws \Exception

--- a/src/Model/Avatar.php
+++ b/src/Model/Avatar.php
@@ -23,16 +23,14 @@ class Avatar extends Model {
 	/**
 	 * Stores the incoming avatar to be modeled
 	 *
-	 * @var array $data
+	 * @var array<string,mixed>
 	 */
 	protected $data;
 
 	/**
 	 * Avatar constructor.
 	 *
-	 * @param array $avatar The incoming avatar to be modeled
-	 *
-	 * @throws \Exception Throws Exception.
+	 * @param array<string,mixed> $avatar The incoming avatar to be modeled.
 	 */
 	public function __construct( array $avatar ) {
 		$this->data = $avatar;
@@ -40,9 +38,7 @@ class Avatar extends Model {
 	}
 
 	/**
-	 * Initializes the object
-	 *
-	 * @return void
+	 * {@inheritDoc}
 	 */
 	protected function init() {
 		if ( empty( $this->fields ) ) {

--- a/src/Model/Comment.php
+++ b/src/Model/Comment.php
@@ -43,8 +43,6 @@ class Comment extends Model {
 	 * Comment constructor.
 	 *
 	 * @param \WP_Comment $comment The incoming WP_Comment to be modeled
-	 *
-	 * @throws \Exception
 	 */
 	public function __construct( WP_Comment $comment ) {
 		$allowed_restricted_fields = [
@@ -74,10 +72,7 @@ class Comment extends Model {
 	}
 
 	/**
-	 * Method for determining if the data should be considered private or not
-	 *
-	 * @return bool
-	 * @throws \Exception
+	 * {@inheritDoc}
 	 */
 	protected function is_private() {
 		if ( empty( $this->data->comment_post_ID ) ) {
@@ -108,9 +103,7 @@ class Comment extends Model {
 	}
 
 	/**
-	 * Initializes the object
-	 *
-	 * @return void
+	 * {@inheritDoc}
 	 */
 	protected function init() {
 		if ( empty( $this->fields ) ) {

--- a/src/Model/CommentAuthor.php
+++ b/src/Model/CommentAuthor.php
@@ -29,8 +29,6 @@ class CommentAuthor extends Model {
 	 * CommentAuthor constructor.
 	 *
 	 * @param \WP_Comment $comment_author The incoming comment author array to be modeled
-	 *
-	 * @throws \Exception
 	 */
 	public function __construct( WP_Comment $comment_author ) {
 		$this->data = $comment_author;
@@ -38,9 +36,7 @@ class CommentAuthor extends Model {
 	}
 
 	/**
-	 * Initializes the object
-	 *
-	 * @return void
+	 * {@inheritDoc}
 	 */
 	protected function init() {
 		if ( empty( $this->fields ) ) {

--- a/src/Model/Menu.php
+++ b/src/Model/Menu.php
@@ -31,7 +31,6 @@ class Menu extends Model {
 	 * @param \WP_Term $term The incoming WP_Term object that needs modeling
 	 *
 	 * @return void
-	 * @throws \Exception
 	 */
 	public function __construct( \WP_Term $term ) {
 		$this->data = $term;
@@ -39,13 +38,10 @@ class Menu extends Model {
 	}
 
 	/**
-	 * Determines whether a Menu should be considered private.
+	 * {@inheritDoc}
 	 *
 	 * If a Menu is not connected to a menu that's assigned to a location
-	 * it's not considered a public node
-	 *
-	 * @return bool
-	 * @throws \Exception
+	 * it's not considered a public node.
 	 */
 	public function is_private() {
 
@@ -67,9 +63,7 @@ class Menu extends Model {
 	}
 
 	/**
-	 * Initializes the Menu object
-	 *
-	 * @return void
+	 * {@inheritDoc}
 	 */
 	protected function init() {
 		if ( empty( $this->fields ) ) {

--- a/src/Model/MenuItem.php
+++ b/src/Model/MenuItem.php
@@ -42,7 +42,6 @@ class MenuItem extends Model {
 	 * @param \WP_Post $post The incoming WP_Post object that needs modeling
 	 *
 	 * @return void
-	 * @throws \Exception
 	 */
 	public function __construct( WP_Post $post ) {
 		$this->data = wp_setup_nav_menu_item( $post );
@@ -50,12 +49,11 @@ class MenuItem extends Model {
 	}
 
 	/**
-	 * Determines whether a MenuItem should be considered private.
+	 * {@inheritDoc}
 	 *
 	 * If a MenuItem is not connected to a menu that's assigned to a location
-	 * it's not considered a public node
+	 * it's not considered a public node.
 	 *
-	 * @return bool
 	 * @throws \Exception
 	 */
 	public function is_private() {
@@ -96,9 +94,7 @@ class MenuItem extends Model {
 	}
 
 	/**
-	 * Initialize the MenuItem object
-	 *
-	 * @return void
+	 * {@inheritDoc}
 	 */
 	protected function init() {
 		if ( empty( $this->fields ) ) {
@@ -157,7 +153,7 @@ class MenuItem extends Model {
 					$url = $this->url;
 
 					if ( ! empty( $url ) ) {
-						/** @var array $parsed */
+						/** @var array<string,mixed> $parsed */
 						$parsed = wp_parse_url( $url );
 						if ( isset( $parsed['host'] ) && strpos( home_url(), $parsed['host'] ) ) {
 							return $parsed['path'];

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -14,14 +14,14 @@ abstract class Model {
 	/**
 	 * Stores the name of the type the child class extending this one represents
 	 *
-	 * @var string $model_name
+	 * @var string
 	 */
 	protected $model_name;
 
 	/**
 	 * Stores the raw data passed to the child class when it's instantiated before it's transformed
 	 *
-	 * @var array|object|mixed $data
+	 * @var mixed[]|object|mixed
 	 */
 	protected $data;
 
@@ -29,21 +29,21 @@ abstract class Model {
 	 * Stores the capability name for what to check on the user if the data should be considered
 	 * "Restricted"
 	 *
-	 * @var string $restricted_cap
+	 * @var string
 	 */
 	protected $restricted_cap;
 
 	/**
 	 * Stores the array of allowed fields to show if the data is restricted
 	 *
-	 * @var array $allowed_restricted_fields
+	 * @var string[]
 	 */
 	protected $allowed_restricted_fields;
 
 	/**
 	 * Stores the DB ID of the user that owns this piece of data, or null if there is no owner
 	 *
-	 * @var int|null $owner
+	 * @var int|null
 	 */
 	protected $owner;
 
@@ -64,7 +64,7 @@ abstract class Model {
 	/**
 	 * The fields for the modeled object. This will be populated in the child class
 	 *
-	 * @var array $fields
+	 * @var array<string,mixed>
 	 */
 	public $fields;
 
@@ -73,8 +73,7 @@ abstract class Model {
 	 *
 	 * @param string   $restricted_cap            The capability to check against to determine if
 	 *                                            the data should be restricted or not
-	 * @param array    $allowed_restricted_fields The allowed fields if the data is in fact
-	 *                                            restricted
+	 * @param string[] $allowed_restricted_fields The allowed fields if the data is in fact restricted
 	 * @param null|int $owner                     Database ID of the user that owns this piece of
 	 *                                            data to compare with the current user ID
 	 *
@@ -158,7 +157,7 @@ abstract class Model {
 	}
 
 	/**
-	 * Generic model setup before the resolver function executes
+	 * Setup the global data for the model to have proper context when resolving.
 	 *
 	 * @return void
 	 */
@@ -314,7 +313,7 @@ abstract class Model {
 			/**
 			 * Filter for the allowed restricted fields
 			 *
-			 * @param array       $allowed_restricted_fields The fields to allow when the data is designated as restricted to the current user
+			 * @param string[]    $allowed_restricted_fields The fields to allow when the data is designated as restricted to the current user
 			 * @param string      $model_name                Name of the model the filter is currently being executed in
 			 * @param mixed       $data                      The un-modeled incoming data
 			 * @param string|null $visibility                The visibility that has currently been set for the data at this point
@@ -527,7 +526,7 @@ abstract class Model {
 	/**
 	 * Filter the fields returned for the object
 	 *
-	 * @param null|string|array $fields The field or fields to build in the modeled object. You can
+	 * @param null|string|mixed[] $fields The field or fields to build in the modeled object. You can
 	 *                                  pass null to build all of the fields, a string to only
 	 *                                  build an object with one field, or an array of field keys
 	 *                                  to build an object with those keys and their respective
@@ -546,7 +545,9 @@ abstract class Model {
 	}
 
 	/**
-	 * @return mixed
+	 * Initialized the object.
+	 *
+	 * @return void
 	 */
 	abstract protected function init();
 }

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -242,7 +242,7 @@ abstract class Model {
 			/**
 			 * Filter to determine if the data should be considered private or not
 			 *
-			 * @param boolean     $is_private   Whether the model is private
+			 * @param bool     $is_private   Whether the model is private
 			 * @param string      $model_name   Name of the model the filter is currently being executed in
 			 * @param mixed       $data         The un-modeled incoming data
 			 * @param string|null $visibility   The visibility that has currently been set for the data at this point

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -529,8 +529,7 @@ abstract class Model {
 	 * @param string|mixed[]|null $fields The field or fields to build in the modeled object. You can
 	 *                                  pass null to build all of the fields, a string to only
 	 *                                  build an object with one field, or an array of field keys
-	 *                                  to build an object with those keys and their respective
-	 *                                  values.
+	 *                                  to build an object with those keys and their respective values.
 	 *
 	 * @return void
 	 */

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -74,7 +74,7 @@ abstract class Model {
 	 * @param string   $restricted_cap            The capability to check against to determine if
 	 *                                            the data should be restricted or not
 	 * @param string[] $allowed_restricted_fields The allowed fields if the data is in fact restricted
-	 * @param null|int $owner                     Database ID of the user that owns this piece of
+	 * @param int|null $owner                     Database ID of the user that owns this piece of
 	 *                                            data to compare with the current user ID
 	 *
 	 * @return void
@@ -209,7 +209,7 @@ abstract class Model {
 			 * @param string      $model_name     Name of the model the filter is currently being executed in
 			 * @param mixed       $data           The un-modeled incoming data
 			 * @param string|null $visibility     The visibility that has currently been set for the data at this point
-			 * @param null|int    $owner          The user ID for the owner of this piece of data
+			 * @param int|null    $owner          The user ID for the owner of this piece of data
 			 * @param \WP_User $current_user The current user for the session
 			 *
 			 * @return string
@@ -224,7 +224,7 @@ abstract class Model {
 			 * @param string      $model_name   Name of the model the filter is currently being executed in
 			 * @param mixed       $data         The un-modeled incoming data
 			 * @param string|null $visibility   The visibility that has currently been set for the data at this point
-			 * @param null|int    $owner        The user ID for the owner of this piece of data
+			 * @param int|null    $owner        The user ID for the owner of this piece of data
 			 * @param \WP_User $current_user The current user for the session
 			 *
 			 * @return bool|null
@@ -246,7 +246,7 @@ abstract class Model {
 			 * @param string      $model_name   Name of the model the filter is currently being executed in
 			 * @param mixed       $data         The un-modeled incoming data
 			 * @param string|null $visibility   The visibility that has currently been set for the data at this point
-			 * @param null|int    $owner        The user ID for the owner of this piece of data
+			 * @param int|null    $owner        The user ID for the owner of this piece of data
 			 * @param \WP_User $current_user The current user for the session
 			 *
 			 * @return bool
@@ -270,7 +270,7 @@ abstract class Model {
 		 * @param string|null $visibility   The visibility that has currently been set for the data at this point
 		 * @param string      $model_name   Name of the model the filter is currently being executed in
 		 * @param mixed       $data         The un-modeled incoming data
-		 * @param null|int    $owner        The user ID for the owner of this piece of data
+		 * @param int|null    $owner        The user ID for the owner of this piece of data
 		 * @param \WP_User $current_user The current user for the session
 		 *
 		 * @return string
@@ -317,7 +317,7 @@ abstract class Model {
 			 * @param string      $model_name                Name of the model the filter is currently being executed in
 			 * @param mixed       $data                      The un-modeled incoming data
 			 * @param string|null $visibility                The visibility that has currently been set for the data at this point
-			 * @param null|int    $owner                     The user ID for the owner of this piece of data
+			 * @param int|null    $owner                     The user ID for the owner of this piece of data
 			 * @param \WP_User $current_user The current user for the session
 			 *
 			 * @return array
@@ -352,7 +352,7 @@ abstract class Model {
 					 * @param string   $model_name   Name of the model the filter is currently being executed in
 					 * @param mixed    $data         The un-modeled incoming data
 					 * @param string   $visibility   The visibility setting for this piece of data
-					 * @param null|int $owner        The user ID for the owner of this piece of data
+					 * @param int|null $owner        The user ID for the owner of this piece of data
 					 * @param \WP_User $current_user The current user for the session
 					 *
 					 * @return string
@@ -377,10 +377,10 @@ abstract class Model {
 				 * @param string   $model_name   Name of the model the filter is currently being executed in
 				 * @param mixed    $data         The un-modeled incoming data
 				 * @param string   $visibility   The visibility setting for this piece of data
-				 * @param null|int $owner        The user ID for the owner of this piece of data
+				 * @param int|null $owner        The user ID for the owner of this piece of data
 				 * @param \WP_User $current_user The current user for the session
 				 *
-				 * @return null|callable|int|string|array|mixed
+				 * @return callable|int|string|array|mixed|null
 				 */
 				$pre = apply_filters( 'graphql_pre_return_field_from_model', null, $key, $this->get_model_name(), $this->data, $this->visibility, $this->owner, $this->current_user );
 
@@ -403,7 +403,7 @@ abstract class Model {
 					 * @param string   $model_name   Name of the model the filter is currently being executed in
 					 * @param mixed    $data         The un-modeled incoming data
 					 * @param string   $visibility   The visibility setting for this piece of data
-					 * @param null|int $owner        The user ID for the owner of this piece of data
+					 * @param int|null $owner        The user ID for the owner of this piece of data
 					 * @param \WP_User $current_user The current user for the session
 					 *
 					 * @return mixed
@@ -419,7 +419,7 @@ abstract class Model {
 				 * @param string   $model_name   Name of the model the filter is currently being executed in
 				 * @param mixed    $data         The un-modeled incoming data
 				 * @param string   $visibility   The visibility setting for this piece of data
-				 * @param null|int $owner        The user ID for the owner of this piece of data
+				 * @param int|null $owner        The user ID for the owner of this piece of data
 				 * @param \WP_User $current_user The current user for the session
 				 */
 				do_action( 'graphql_after_return_field_from_model', $result, $key, $this->get_model_name(), $this->data, $this->visibility, $this->owner, $this->current_user );
@@ -468,7 +468,7 @@ abstract class Model {
 		 * @param array    $fields       The array of fields for the model
 		 * @param string   $model_name   Name of the model the filter is currently being executed in
 		 * @param string   $visibility   The visibility setting for this piece of data
-		 * @param null|int $owner        The user ID for the owner of this piece of data
+		 * @param int|null $owner        The user ID for the owner of this piece of data
 		 * @param \WP_User $current_user The current user for the session
 		 *
 		 * @return array
@@ -484,7 +484,7 @@ abstract class Model {
 		 * @param string   $model_name   Name of the model the filter is currently being executed in
 		 * @param mixed    $data         The un-modeled incoming data
 		 * @param string   $visibility   The visibility setting for this piece of data
-		 * @param null|int $owner        The user ID for the owner of this piece of data
+		 * @param int|null $owner        The user ID for the owner of this piece of data
 		 * @param \WP_User $current_user The current user for the session
 		 *
 		 * @return array
@@ -526,7 +526,7 @@ abstract class Model {
 	/**
 	 * Filter the fields returned for the object
 	 *
-	 * @param null|string|mixed[] $fields The field or fields to build in the modeled object. You can
+	 * @param string|mixed[]|null $fields The field or fields to build in the modeled object. You can
 	 *                                  pass null to build all of the fields, a string to only
 	 *                                  build an object with one field, or an array of field keys
 	 *                                  to build an object with those keys and their respective

--- a/src/Model/Plugin.php
+++ b/src/Model/Plugin.php
@@ -23,16 +23,14 @@ class Plugin extends Model {
 	/**
 	 * Stores the incoming plugin data to be modeled
 	 *
-	 * @var array $data
+	 * @var array<string,mixed> $data
 	 */
 	protected $data;
 
 	/**
 	 * Plugin constructor.
 	 *
-	 * @param array $plugin The incoming Plugin data to be modeled
-	 *
-	 * @throws \Exception
+	 * @param array<string,mixed> $plugin The incoming Plugin data to be modeled.
 	 */
 	public function __construct( $plugin ) {
 		$this->data = $plugin;
@@ -40,9 +38,7 @@ class Plugin extends Model {
 	}
 
 	/**
-	 * Method for determining if the data should be considered private or not
-	 *
-	 * @return bool
+	 * {@inheritDoc}
 	 */
 	protected function is_private() {
 		if ( is_multisite() ) {
@@ -59,9 +55,7 @@ class Plugin extends Model {
 	}
 
 	/**
-	 * Initializes the object
-	 *
-	 * @return void
+	 * {@inheritDoc}
 	 */
 	protected function init() {
 		if ( empty( $this->fields ) ) {

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -35,12 +35,12 @@ use WP_Post;
  * @property string  $pingStatus
  * @property string  $slug
  * @property array   $template
- * @property boolean $isFrontPage
- * @property boolean $isPrivacyPage
- * @property boolean $isPostsPage
- * @property boolean $isPreview
- * @property boolean $isRevision
- * @property boolean $isSticky
+ * @property bool $isFrontPage
+ * @property bool $isPrivacyPage
+ * @property bool $isPostsPage
+ * @property bool $isPreview
+ * @property bool $isRevision
+ * @property bool $isSticky
  * @property string  $toPing
  * @property string  $pinged
  * @property string  $modified

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -91,7 +91,7 @@ class Post extends Model {
 	/**
 	 * Stores the incoming post type object for the post being modeled
 	 *
-	 * @var null|\WP_Post_Type $post_type_object
+	 * @var \WP_Post_Type|null $post_type_object
 	 */
 	protected $post_type_object;
 

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -108,7 +108,6 @@ class Post extends Model {
 	 * @param \WP_Post $post The incoming WP_Post object that needs modeling.
 	 *
 	 * @return void
-	 * @throws \Exception
 	 */
 	public function __construct( WP_Post $post ) {
 
@@ -165,9 +164,7 @@ class Post extends Model {
 	}
 
 	/**
-	 * Setup the global data for the model to have proper context when resolving
-	 *
-	 * @return void
+	 * {@inheritDoc}
 	 */
 	public function setup() {
 		global $wp_query, $post;
@@ -274,9 +271,7 @@ class Post extends Model {
 	}
 
 	/**
-	 * Determine if the model is private
-	 *
-	 * @return bool
+	 * {@inheritDoc}
 	 */
 	public function is_private() {
 
@@ -396,9 +391,7 @@ class Post extends Model {
 	}
 
 	/**
-	 * Initialize the Post object
-	 *
-	 * @return void
+	 * {@inheritDoc}
 	 */
 	protected function init() {
 		if ( empty( $this->fields ) ) {

--- a/src/Model/PostType.php
+++ b/src/Model/PostType.php
@@ -48,9 +48,7 @@ class PostType extends Model {
 	/**
 	 * PostType constructor.
 	 *
-	 * @param \WP_Post_Type $post_type The incoming post type to model
-	 *
-	 * @throws \Exception
+	 * @param \WP_Post_Type $post_type The incoming post type to model.
 	 */
 	public function __construct( \WP_Post_Type $post_type ) {
 		$this->data = $post_type;
@@ -80,9 +78,7 @@ class PostType extends Model {
 	}
 
 	/**
-	 * Method for determining if the data should be considered private or not
-	 *
-	 * @return bool
+	 * {@inheritDoc}
 	 */
 	protected function is_private() {
 		if ( false === $this->data->public && ( ! isset( $this->data->cap->edit_posts ) || ! current_user_can( $this->data->cap->edit_posts ) ) ) {
@@ -93,9 +89,7 @@ class PostType extends Model {
 	}
 
 	/**
-	 * Initializes the object
-	 *
-	 * @return void
+	 * {@inheritDoc}
 	 */
 	protected function init() {
 		if ( empty( $this->fields ) ) {

--- a/src/Model/Taxonomy.php
+++ b/src/Model/Taxonomy.php
@@ -43,9 +43,7 @@ class Taxonomy extends Model {
 	/**
 	 * Taxonomy constructor.
 	 *
-	 * @param \WP_Taxonomy $taxonomy The incoming Taxonomy to model
-	 *
-	 * @throws \Exception
+	 * @param \WP_Taxonomy $taxonomy The incoming Taxonomy to model.
 	 */
 	public function __construct( \WP_Taxonomy $taxonomy ) {
 		$this->data = $taxonomy;
@@ -71,9 +69,7 @@ class Taxonomy extends Model {
 	}
 
 	/**
-	 * Method for determining if the data should be considered private or not
-	 *
-	 * @return bool
+	 * {@inheritDoc}
 	 */
 	protected function is_private() {
 		if ( false === $this->data->public && ( ! isset( $this->data->cap->edit_terms ) || ! current_user_can( $this->data->cap->edit_terms ) ) ) {
@@ -84,9 +80,7 @@ class Taxonomy extends Model {
 	}
 
 	/**
-	 * Initializes the object
-	 *
-	 * @return void
+	 * {@inheritDoc}
 	 */
 	protected function init() {
 		if ( empty( $this->fields ) ) {

--- a/src/Model/Term.php
+++ b/src/Model/Term.php
@@ -38,7 +38,7 @@ class Term extends Model {
 	/**
 	 * Stores the taxonomy object for the term being modeled
 	 *
-	 * @var null|\WP_Taxonomy $taxonomy_object
+	 * @var \WP_Taxonomy|null $taxonomy_object
 	 */
 	protected $taxonomy_object;
 

--- a/src/Model/Term.php
+++ b/src/Model/Term.php
@@ -55,7 +55,6 @@ class Term extends Model {
 	 * @param \WP_Term $term The incoming WP_Term object that needs modeling
 	 *
 	 * @return void
-	 * @throws \Exception
 	 */
 	public function __construct( WP_Term $term ) {
 		$this->data            = $term;
@@ -65,9 +64,7 @@ class Term extends Model {
 	}
 
 	/**
-	 * Setup the global state for the model to have proper context when resolving
-	 *
-	 * @return void
+	 * {@inheritDoc}
 	 */
 	public function setup() {
 		global $wp_query, $post;
@@ -108,10 +105,7 @@ class Term extends Model {
 	}
 
 	/**
-	 * Reset global state after the model fields
-	 * have been generated
-	 *
-	 * @return void
+	 * {@inheritDoc}
 	 */
 	public function tear_down() {
 		$GLOBALS['post'] = $this->global_post; // phpcs:ignore WordPress.WP.GlobalVariablesOverride
@@ -119,9 +113,7 @@ class Term extends Model {
 	}
 
 	/**
-	 * Initializes the Term object
-	 *
-	 * @return void
+	 * {@inheritDoc}
 	 */
 	protected function init() {
 		if ( empty( $this->fields ) ) {

--- a/src/Model/Theme.php
+++ b/src/Model/Theme.php
@@ -43,9 +43,7 @@ class Theme extends Model {
 	}
 
 	/**
-	 * Method for determining if the data should be considered private or not
-	 *
-	 * @return bool
+	 * {@inheritDoc}
 	 */
 	protected function is_private() {
 		// Don't assume a capabilities hierarchy, since it's likely headless sites might disable some capabilities site-wide.
@@ -61,9 +59,7 @@ class Theme extends Model {
 	}
 
 	/**
-	 * Initialize the object
-	 *
-	 * @return void
+	 * {@inheritDoc}
 	 */
 	protected function init() {
 		if ( empty( $this->fields ) ) {

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -62,7 +62,6 @@ class User extends Model {
 	 * @param \WP_User $user The incoming WP_User object that needs modeling
 	 *
 	 * @return void
-	 * @throws \Exception
 	 */
 	public function __construct( WP_User $user ) {
 
@@ -89,9 +88,7 @@ class User extends Model {
 	}
 
 	/**
-	 * Setup the global data for the model to have proper context when resolving
-	 *
-	 * @return void
+	 * {@inheritDoc}
 	 */
 	public function setup() {
 		global $wp_query, $post, $authordata;
@@ -121,10 +118,7 @@ class User extends Model {
 	}
 
 	/**
-	 * Reset global state after the model fields
-	 * have been generated
-	 *
-	 * @return void
+	 * {@inheritDoc}
 	 */
 	public function tear_down() {
 		$GLOBALS['authordata'] = $this->global_authordata; // phpcs:ignore WordPress.WP.GlobalVariablesOverride
@@ -133,9 +127,7 @@ class User extends Model {
 	}
 
 	/**
-	 * Method for determining if the data should be considered private or not
-	 *
-	 * @return bool
+	 * {@inheritDoc}
 	 */
 	protected function is_private() {
 		/**
@@ -156,9 +148,7 @@ class User extends Model {
 	}
 
 	/**
-	 * Initialize the User object
-	 *
-	 * @return void
+	 * {@inheritDoc}
 	 */
 	protected function init() {
 		if ( empty( $this->fields ) ) {

--- a/src/Model/UserRole.php
+++ b/src/Model/UserRole.php
@@ -19,14 +19,14 @@ class UserRole extends Model {
 	/**
 	 * Stores the incoming user role to be modeled
 	 *
-	 * @var array $data
+	 * @var array<string,mixed> $data
 	 */
 	protected $data;
 
 	/**
 	 * UserRole constructor.
 	 *
-	 * @param array $user_role The incoming user role to be modeled
+	 * @param array<string,mixed> $user_role The incoming user role to be modeled
 	 *
 	 * @return void
 	 * @throws \Exception
@@ -37,9 +37,7 @@ class UserRole extends Model {
 	}
 
 	/**
-	 * Method for determining if the data should be considered private or not
-	 *
-	 * @return bool
+	 * {@inheritDoc}
 	 */
 	protected function is_private() {
 		if ( current_user_can( 'list_users' ) ) {
@@ -56,9 +54,7 @@ class UserRole extends Model {
 	}
 
 	/**
-	 * Initializes the object
-	 *
-	 * @return void
+	 * {@inheritDoc}
 	 */
 	protected function init() {
 		if ( empty( $this->fields ) ) {

--- a/src/Mutation/CommentCreate.php
+++ b/src/Mutation/CommentCreate.php
@@ -28,7 +28,7 @@ class CommentCreate {
 	/**
 	 * Defines the mutation input field configuration.
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_input_fields() {
 		return [
@@ -79,7 +79,7 @@ class CommentCreate {
 	/**
 	 * Defines the mutation output field configuration.
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_output_fields() {
 		return [

--- a/src/Mutation/CommentDelete.php
+++ b/src/Mutation/CommentDelete.php
@@ -28,7 +28,7 @@ class CommentDelete {
 	/**
 	 * Defines the mutation input field configuration.
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_input_fields() {
 		return [
@@ -48,7 +48,7 @@ class CommentDelete {
 	/**
 	 * Defines the mutation output field configuration.
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_output_fields() {
 		return [

--- a/src/Mutation/CommentRestore.php
+++ b/src/Mutation/CommentRestore.php
@@ -32,7 +32,7 @@ class CommentRestore {
 	/**
 	 * Defines the mutation input field configuration.
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_input_fields() {
 		return [
@@ -48,7 +48,7 @@ class CommentRestore {
 	/**
 	 * Defines the mutation output field configuration.
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_output_fields() {
 		return [

--- a/src/Mutation/CommentUpdate.php
+++ b/src/Mutation/CommentUpdate.php
@@ -34,7 +34,7 @@ class CommentUpdate {
 	/**
 	 * Defines the mutation input field configuration.
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_input_fields() {
 		return array_merge(
@@ -53,7 +53,7 @@ class CommentUpdate {
 	/**
 	 * Defines the mutation output field configuration.
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_output_fields() {
 		return CommentCreate::get_output_fields();

--- a/src/Mutation/MediaItemCreate.php
+++ b/src/Mutation/MediaItemCreate.php
@@ -29,7 +29,7 @@ class MediaItemCreate {
 	/**
 	 * Defines the mutation input field configuration.
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_input_fields() {
 		return [
@@ -95,7 +95,7 @@ class MediaItemCreate {
 	/**
 	 * Defines the mutation output field configuration.
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_output_fields() {
 		return [

--- a/src/Mutation/MediaItemDelete.php
+++ b/src/Mutation/MediaItemDelete.php
@@ -27,7 +27,7 @@ class MediaItemDelete {
 	/**
 	 * Defines the mutation input field configuration.
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_input_fields() {
 		return [
@@ -47,7 +47,7 @@ class MediaItemDelete {
 	/**
 	 * Defines the mutation output field configuration.
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_output_fields() {
 		return [

--- a/src/Mutation/MediaItemUpdate.php
+++ b/src/Mutation/MediaItemUpdate.php
@@ -29,7 +29,7 @@ class MediaItemUpdate {
 	/**
 	 * Defines the mutation input field configuration.
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_input_fields() {
 		/** @var \WP_Post_Type $post_type_object */
@@ -51,7 +51,7 @@ class MediaItemUpdate {
 	/**
 	 * Defines the mutation output field configuration.
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_output_fields() {
 		return MediaItemCreate::get_output_fields();

--- a/src/Mutation/PostObjectCreate.php
+++ b/src/Mutation/PostObjectCreate.php
@@ -40,7 +40,7 @@ class PostObjectCreate {
 	 *
 	 * @param \WP_Post_Type $post_type_object The post type of the mutation.
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_input_fields( $post_type_object ) {
 		$fields = [
@@ -169,7 +169,7 @@ class PostObjectCreate {
 	 *
 	 * @param \WP_Post_Type $post_type_object The post type of the mutation.
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_output_fields( WP_Post_Type $post_type_object ) {
 		return [

--- a/src/Mutation/PostObjectCreate.php
+++ b/src/Mutation/PostObjectCreate.php
@@ -326,7 +326,7 @@ class PostObjectCreate {
 			 * be deferred (cron or whatever), and when those actions complete they could come back and set
 			 * the $intended_status.
 			 *
-			 * @param boolean      $should_set_intended_status Whether to set the intended post_status or not. Default true.
+			 * @param bool      $should_set_intended_status Whether to set the intended post_status or not. Default true.
 			 * @param \WP_Post_Type $post_type_object The Post Type Object for the post being mutated
 			 * @param string       $mutation_name              The name of the mutation currently in progress
 			 * @param \WPGraphQL\AppContext $context The AppContext passed down to all resolvers

--- a/src/Mutation/PostObjectDelete.php
+++ b/src/Mutation/PostObjectDelete.php
@@ -37,7 +37,7 @@ class PostObjectDelete {
 	 *
 	 * @param \WP_Post_Type $post_type_object The post type of the mutation.
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_input_fields( $post_type_object ) {
 		return [
@@ -64,7 +64,7 @@ class PostObjectDelete {
 	 *
 	 * @param \WP_Post_Type $post_type_object The post type of the mutation.
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_output_fields( WP_Post_Type $post_type_object ) {
 		return [

--- a/src/Mutation/PostObjectUpdate.php
+++ b/src/Mutation/PostObjectUpdate.php
@@ -35,7 +35,7 @@ class PostObjectUpdate {
 	 *
 	 * @param \WP_Post_Type $post_type_object The post type of the mutation.
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_input_fields( $post_type_object ) {
 		return array_merge(
@@ -61,7 +61,7 @@ class PostObjectUpdate {
 	 *
 	 * @param \WP_Post_Type $post_type_object The post type of the mutation.
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_output_fields( $post_type_object ) {
 		return PostObjectCreate::get_output_fields( $post_type_object );

--- a/src/Mutation/ResetUserPassword.php
+++ b/src/Mutation/ResetUserPassword.php
@@ -25,7 +25,7 @@ class ResetUserPassword {
 	/**
 	 * Defines the mutation input field configuration.
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_input_fields() {
 		return [
@@ -47,7 +47,7 @@ class ResetUserPassword {
 	/**
 	 * Defines the mutation output field configuration.
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_output_fields() {
 		return UserCreate::get_output_fields();

--- a/src/Mutation/SendPasswordResetEmail.php
+++ b/src/Mutation/SendPasswordResetEmail.php
@@ -65,8 +65,6 @@ class SendPasswordResetEmail {
 
 	/**
 	 * Defines the mutation data modification closure.
-	 *
-	 * @return callable
 	 */
 	public static function mutate_and_get_payload(): callable {
 		return static function ( $input ) {

--- a/src/Mutation/SendPasswordResetEmail.php
+++ b/src/Mutation/SendPasswordResetEmail.php
@@ -28,7 +28,7 @@ class SendPasswordResetEmail {
 	/**
 	 * Defines the mutation input field configuration.
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_input_fields(): array {
 		return [
@@ -44,7 +44,7 @@ class SendPasswordResetEmail {
 	/**
 	 * Defines the mutation output field configuration.
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_output_fields(): array {
 		return [
@@ -126,7 +126,7 @@ class SendPasswordResetEmail {
 	/**
 	 * Was a username or email address provided?
 	 *
-	 * @param array $input The input args.
+	 * @param array<string,mixed> $input The input args.
 	 *
 	 * @return bool
 	 */
@@ -137,7 +137,7 @@ class SendPasswordResetEmail {
 	/**
 	 * Get WP_User object representing this user
 	 *
-	 * @param  string $username The user's username or email address.
+	 * @param string $username The user's username or email address.
 	 *
 	 * @return \WP_User|false WP_User object on success, false on failure.
 	 */
@@ -158,7 +158,7 @@ class SendPasswordResetEmail {
 	/**
 	 * Get the error message indicating why the user wasn't found
 	 *
-	 * @param  string $username The user's username or email address.
+	 * @param string $username The user's username or email address.
 	 *
 	 * @return string
 	 */
@@ -173,7 +173,7 @@ class SendPasswordResetEmail {
 	/**
 	 * Is the provided username arg an email address?
 	 *
-	 * @param  string $username The user's username or email address.
+	 * @param string $username The user's username or email address.
 	 *
 	 * @return bool
 	 */

--- a/src/Mutation/TermObjectCreate.php
+++ b/src/Mutation/TermObjectCreate.php
@@ -45,7 +45,7 @@ class TermObjectCreate {
 	 *
 	 * @param \WP_Taxonomy $taxonomy The taxonomy type of the mutation.
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_input_fields( WP_Taxonomy $taxonomy ) {
 		$fields = [
@@ -84,7 +84,7 @@ class TermObjectCreate {
 	 *
 	 * @param \WP_Taxonomy $taxonomy The taxonomy type of the mutation.
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_output_fields( WP_Taxonomy $taxonomy ) {
 		return [

--- a/src/Mutation/TermObjectDelete.php
+++ b/src/Mutation/TermObjectDelete.php
@@ -39,7 +39,7 @@ class TermObjectDelete {
 	 *
 	 * @param \WP_Taxonomy $taxonomy The taxonomy type of the mutation.
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_input_fields( WP_Taxonomy $taxonomy ) {
 		return [
@@ -58,7 +58,7 @@ class TermObjectDelete {
 	 *
 	 * @param \WP_Taxonomy $taxonomy The taxonomy type of the mutation.
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_output_fields( WP_Taxonomy $taxonomy ) {
 		return [

--- a/src/Mutation/TermObjectUpdate.php
+++ b/src/Mutation/TermObjectUpdate.php
@@ -38,7 +38,7 @@ class TermObjectUpdate {
 	 *
 	 * @param \WP_Taxonomy $taxonomy The taxonomy type of the mutation.
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_input_fields( WP_Taxonomy $taxonomy ) {
 		return array_merge(
@@ -65,7 +65,7 @@ class TermObjectUpdate {
 	 *
 	 * @param \WP_Taxonomy $taxonomy The taxonomy type of the mutation.
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_output_fields( WP_Taxonomy $taxonomy ) {
 		return TermObjectCreate::get_output_fields( $taxonomy );

--- a/src/Mutation/UpdateSettings.php
+++ b/src/Mutation/UpdateSettings.php
@@ -46,7 +46,7 @@ class UpdateSettings {
 	 *
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The WPGraphQL TypeRegistry
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_input_fields( TypeRegistry $type_registry ) {
 		$allowed_settings = DataSource::get_allowed_settings( $type_registry );
@@ -105,7 +105,7 @@ class UpdateSettings {
 	 *
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The WPGraphQL TypeRegistry
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_output_fields( TypeRegistry $type_registry ) {
 
@@ -148,10 +148,10 @@ class UpdateSettings {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @param array                            $input The mutation input
+	 * @param array<string,mixed>              $input The mutation input
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The WPGraphQL TypeRegistry
 	 *
-	 * @return array
+	 * @return array<string,array<string,string>>
 	 *
 	 * @throws \GraphQL\Error\UserError
 	 */

--- a/src/Mutation/UserCreate.php
+++ b/src/Mutation/UserCreate.php
@@ -43,7 +43,7 @@ class UserCreate {
 	/**
 	 * Defines the mutation input field configuration.
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_input_fields() {
 		return [
@@ -119,7 +119,7 @@ class UserCreate {
 	/**
 	 * Defines the mutation output field configuration.
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_output_fields() {
 		return [

--- a/src/Mutation/UserDelete.php
+++ b/src/Mutation/UserDelete.php
@@ -32,7 +32,7 @@ class UserDelete {
 	/**
 	 * Defines the mutation input field configuration.
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_input_fields() {
 		return [
@@ -52,7 +52,7 @@ class UserDelete {
 	/**
 	 * Defines the mutation output field configuration.
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_output_fields() {
 		return [

--- a/src/Mutation/UserRegister.php
+++ b/src/Mutation/UserRegister.php
@@ -27,7 +27,7 @@ class UserRegister {
 	/**
 	 * Defines the mutation input field configuration.
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_input_fields() {
 		$input_fields = array_merge(
@@ -58,7 +58,7 @@ class UserRegister {
 	/**
 	 * Defines the mutation output field configuration.
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_output_fields() {
 		return UserCreate::get_output_fields();

--- a/src/Mutation/UserUpdate.php
+++ b/src/Mutation/UserUpdate.php
@@ -28,7 +28,7 @@ class UserUpdate {
 	/**
 	 * Defines the mutation input field configuration.
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_input_fields() {
 		return array_merge(
@@ -48,7 +48,7 @@ class UserUpdate {
 	/**
 	 * Defines the mutation output field configuration.
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_output_fields() {
 		return UserCreate::get_output_fields();

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -138,7 +138,7 @@ class TypeRegistry {
 	/**
 	 * The registered Types
 	 *
-	 * @var array
+	 * @var array<string,mixed>
 	 */
 	protected $types;
 
@@ -146,7 +146,7 @@ class TypeRegistry {
 	/**
 	 * The loaders needed to register types
 	 *
-	 * @var array
+	 * @var array<string,Callable>
 	 */
 	protected $type_loaders;
 
@@ -156,7 +156,7 @@ class TypeRegistry {
 	 * Types that exist in the Schema but are only part of a Union/Interface ResolveType but not
 	 * referenced directly need to be eagerly loaded.
 	 *
-	 * @var array
+	 * @var array<string,string>
 	 */
 	protected $eager_type_map;
 
@@ -165,7 +165,7 @@ class TypeRegistry {
 	 *
 	 * Type names are filtered by `graphql_excluded_types` and normalized using strtolower(), to avoid case sensitivity issues.
 	 *
-	 * @var array
+	 * @var string[]
 	 */
 	protected $excluded_types = null;
 
@@ -217,7 +217,7 @@ class TypeRegistry {
 	 * Types can add "eagerlyLoadType => true" when being registered to be included
 	 * in the eager_type_map.
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 */
 	protected function get_eager_type_map() {
 		if ( ! empty( $this->eager_type_map ) ) {
@@ -611,8 +611,8 @@ class TypeRegistry {
 	/**
 	 * Given a config for a custom Scalar, this adds the Scalar for use in the Schema.
 	 *
-	 * @param string $type_name The name of the Type to register
-	 * @param array  $config    The config for the scalar type to register
+	 * @param string              $type_name The name of the Type to register
+	 * @param array<string,mixed> $config    The config for the scalar type to register
 	 *
 	 * @throws \Exception
 	 *
@@ -626,7 +626,7 @@ class TypeRegistry {
 	/**
 	 * Registers connections that were passed through the Type registration config
 	 *
-	 * @param array $config Type config
+	 * @param array<string,mixed> $config Type config
 	 *
 	 * @return void
 	 *
@@ -653,8 +653,8 @@ class TypeRegistry {
 	/**
 	 * Add a Type to the Registry
 	 *
-	 * @param string                                    $type_name The name of the type to register
-	 * @param mixed|array|\GraphQL\Type\Definition\Type $config The config for the type
+	 * @param string                                                  $type_name The name of the type to register
+	 * @param mixed|array<string,mixed>|\GraphQL\Type\Definition\Type $config The config for the type
 	 *
 	 * @throws \Exception
 	 */
@@ -721,8 +721,8 @@ class TypeRegistry {
 	/**
 	 * Add an Object Type to the Registry
 	 *
-	 * @param string $type_name The name of the type to register
-	 * @param array  $config The configuration of the type
+	 * @param string              $type_name The name of the type to register
+	 * @param array<string,mixed> $config The configuration of the type
 	 *
 	 * @throws \Exception
 	 */
@@ -734,8 +734,8 @@ class TypeRegistry {
 	/**
 	 * Add an Interface Type to the registry
 	 *
-	 * @param string                                    $type_name The name of the type to register
-	 * @param mixed|array|\GraphQL\Type\Definition\Type $config The configuration of the type
+	 * @param string                                                  $type_name The name of the type to register
+	 * @param mixed|array<string,mixed>|\GraphQL\Type\Definition\Type $config The configuration of the type
 	 *
 	 * @throws \Exception
 	 */
@@ -747,8 +747,8 @@ class TypeRegistry {
 	/**
 	 * Add an Enum Type to the registry
 	 *
-	 * @param string $type_name The name of the type to register
-	 * @param array  $config he configuration of the type
+	 * @param string              $type_name The name of the type to register
+	 * @param array<string,mixed> $config he configuration of the type
 	 *
 	 * @throws \Exception
 	 */
@@ -760,8 +760,8 @@ class TypeRegistry {
 	/**
 	 * Add an Input Type to the Registry
 	 *
-	 * @param string $type_name The name of the type to register
-	 * @param array  $config he configuration of the type
+	 * @param string              $type_name The name of the type to register
+	 * @param array<string,mixed> $config he configuration of the type
 	 *
 	 * @throws \Exception
 	 */
@@ -773,8 +773,8 @@ class TypeRegistry {
 	/**
 	 * Add a Union Type to the Registry
 	 *
-	 * @param string $type_name The name of the type to register
-	 * @param array  $config he configuration of the type
+	 * @param string              $type_name The name of the type to register
+	 * @param array<string,mixed> $config he configuration of the type
 	 *
 	 * @throws \Exception
 	 */
@@ -784,10 +784,10 @@ class TypeRegistry {
 	}
 
 	/**
-	 * @param string                                    $type_name The name of the type to register
-	 * @param mixed|array|\GraphQL\Type\Definition\Type $config he configuration of the type
+	 * @param string                                                  $type_name The name of the type to register
+	 * @param mixed|array<string,mixed>|\GraphQL\Type\Definition\Type $config he configuration of the type
 	 *
-	 * @return mixed|array|\GraphQL\Type\Definition\Type|null
+	 * @return mixed|array<string,mixed>|\GraphQL\Type\Definition\Type|null
 	 * @throws \Exception
 	 */
 	public function prepare_type( string $type_name, $config ) {
@@ -864,7 +864,7 @@ class TypeRegistry {
 	/**
 	 * Return the Types in the registry
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 */
 	public function get_types(): array {
 
@@ -879,10 +879,10 @@ class TypeRegistry {
 	/**
 	 * Wrapper for prepare_field to prepare multiple fields for registration at once
 	 *
-	 * @param array  $fields    Array of fields and their settings to register on a Type
-	 * @param string $type_name Name of the Type to register the fields to
+	 * @param array<string,mixed> $fields    Array of fields and their settings to register on a Type
+	 * @param string              $type_name Name of the Type to register the fields to
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 * @throws \Exception
 	 */
 	public function prepare_fields( array $fields, string $type_name ): array {
@@ -904,11 +904,11 @@ class TypeRegistry {
 	/**
 	 * Prepare the field to be registered on the type
 	 *
-	 * @param string $field_name   Friendly name of the field
-	 * @param array  $field_config Config data about the field to prepare
-	 * @param string $type_name    Name of the type to prepare the field for
+	 * @param string              $field_name   Friendly name of the field
+	 * @param array<string,mixed> $field_config Config data about the field to prepare
+	 * @param string              $type_name    Name of the type to prepare the field for
 	 *
-	 * @return array|null
+	 * @return ?array<string,mixed>
 	 * @throws \Exception
 	 */
 	protected function prepare_field( string $field_name, array $field_config, string $type_name ): ?array {
@@ -997,7 +997,7 @@ class TypeRegistry {
 	 * Processes type modifiers (e.g., "non-null"). Loads types immediately, so do
 	 * not call before types are ready to be loaded.
 	 *
-	 * @param mixed|string|array $type The type definition
+	 * @param mixed|string|array<string,mixed> $type The type definition to process.
 	 *
 	 * @return mixed
 	 * @throws \Exception
@@ -1025,8 +1025,8 @@ class TypeRegistry {
 	/**
 	 * Wrapper for the register_field method to register multiple fields at once
 	 *
-	 * @param string $type_name Name of the type in the Type Registry to add the fields to
-	 * @param array  $fields    Fields to register
+	 * @param string                            $type_name Name of the type in the Type Registry to add the fields to
+	 * @param array<string,array<string,mixed>> $fields    Fields to register
 	 *
 	 * @throws \Exception
 	 */
@@ -1043,10 +1043,10 @@ class TypeRegistry {
 	/**
 	 * Add a field to a Type in the Type Registry
 	 *
-	 * @param string $type_name                       Name of the type in the Type Registry to add
-	 *                                                the fields to
-	 * @param string $field_name                      Name of the field to add to the type
-	 * @param array  $config                          Info about the field to register to the type
+	 * @param string              $type_name  Name of the type in the Type Registry to add
+	 *                                        the fields to
+	 * @param string              $field_name Name of the field to add to the type
+	 * @param array<string,mixed> $config     Info about the field to register to the type
 	 *
 	 * @throws \Exception
 	 */
@@ -1134,7 +1134,7 @@ class TypeRegistry {
 	/**
 	 * Method to register a new connection in the Type registry
 	 *
-	 * @param array $config The info about the connection being registered
+	 * @param array<string,mixed> $config The info about the connection being registered
 	 *
 	 * @throws \InvalidArgumentException
 	 * @throws \Exception
@@ -1146,8 +1146,8 @@ class TypeRegistry {
 	/**
 	 * Handles registration of a mutation to the Type registry
 	 *
-	 * @param string $mutation_name Name of the mutation being registered
-	 * @param array  $config        Info about the mutation being registered
+	 * @param string              $mutation_name Name of the mutation being registered
+	 * @param array<string,mixed> $config        Info about the mutation being registered
 	 *
 	 * @throws \Exception
 	 */
@@ -1258,6 +1258,8 @@ class TypeRegistry {
 	 * Type names are normalized using `strtolower()`, to avoid case sensitivity issues.
 	 *
 	 * @since 1.13.0
+	 *
+	 * @return string[]
 	 */
 	public function get_excluded_types(): array {
 		if ( null === $this->excluded_types ) {
@@ -1285,6 +1287,8 @@ class TypeRegistry {
 	 *
 	 * Type names are normalized using `strtolower()`, to avoid case sensitivity issues.
 	 *
+	 * @return string[]
+	 *
 	 * @since 1.14.0
 	 */
 	public function get_excluded_connections(): array {
@@ -1310,6 +1314,7 @@ class TypeRegistry {
 	 *
 	 * Mutation names are normalized using `strtolower()`, to avoid case sensitivity issues.
 	 *
+	 * @return string[]
 	 * @since 1.14.0
 	 */
 	public function get_excluded_mutations(): array {
@@ -1335,7 +1340,7 @@ class TypeRegistry {
 	 *
 	 * Returns an empty string if the type modifiers are malformed.
 	 *
-	 * @param string|array $type The (possibly-wrapped) type name.
+	 * @param string|array<string|int,mixed> $type The (possibly-wrapped) type name.
 	 */
 	protected function get_unmodified_type_name( $type ): string {
 		if ( ! is_array( $type ) ) {

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -1043,8 +1043,7 @@ class TypeRegistry {
 	/**
 	 * Add a field to a Type in the Type Registry
 	 *
-	 * @param string              $type_name  Name of the type in the Type Registry to add
-	 *                                        the fields to
+	 * @param string              $type_name  Name of the type in the Type Registry to add the fields to
 	 * @param string              $field_name Name of the field to add to the type
 	 * @param array<string,mixed> $config     Info about the field to register to the type
 	 *

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -657,8 +657,6 @@ class TypeRegistry {
 	 * @param mixed|array|\GraphQL\Type\Definition\Type $config The config for the type
 	 *
 	 * @throws \Exception
-	 *
-	 * @return void
 	 */
 	public function register_type( string $type_name, $config ): void {
 		/**
@@ -727,7 +725,6 @@ class TypeRegistry {
 	 * @param array  $config The configuration of the type
 	 *
 	 * @throws \Exception
-	 * @return void
 	 */
 	public function register_object_type( string $type_name, array $config ): void {
 		$config['kind'] = 'object';
@@ -741,7 +738,6 @@ class TypeRegistry {
 	 * @param mixed|array|\GraphQL\Type\Definition\Type $config The configuration of the type
 	 *
 	 * @throws \Exception
-	 * @return void
 	 */
 	public function register_interface_type( string $type_name, $config ): void {
 		$config['kind'] = 'interface';
@@ -754,7 +750,6 @@ class TypeRegistry {
 	 * @param string $type_name The name of the type to register
 	 * @param array  $config he configuration of the type
 	 *
-	 * @return void
 	 * @throws \Exception
 	 */
 	public function register_enum_type( string $type_name, array $config ): void {
@@ -768,7 +763,6 @@ class TypeRegistry {
 	 * @param string $type_name The name of the type to register
 	 * @param array  $config he configuration of the type
 	 *
-	 * @return void
 	 * @throws \Exception
 	 */
 	public function register_input_type( string $type_name, array $config ): void {
@@ -781,8 +775,6 @@ class TypeRegistry {
 	 *
 	 * @param string $type_name The name of the type to register
 	 * @param array  $config he configuration of the type
-	 *
-	 * @return void
 	 *
 	 * @throws \Exception
 	 */
@@ -864,8 +856,6 @@ class TypeRegistry {
 	 * Given a type name, determines if the type is already present in the Type Loader
 	 *
 	 * @param string $type_name The name of the type to check the registry for
-	 *
-	 * @return bool
 	 */
 	public function has_type( string $type_name ): bool {
 		return isset( $this->type_loaders[ $this->format_key( $type_name ) ] );
@@ -1038,7 +1028,6 @@ class TypeRegistry {
 	 * @param string $type_name Name of the type in the Type Registry to add the fields to
 	 * @param array  $fields    Fields to register
 	 *
-	 * @return void
 	 * @throws \Exception
 	 */
 	public function register_fields( string $type_name, array $fields = [] ): void {
@@ -1059,7 +1048,6 @@ class TypeRegistry {
 	 * @param string $field_name                      Name of the field to add to the type
 	 * @param array  $config                          Info about the field to register to the type
 	 *
-	 * @return void
 	 * @throws \Exception
 	 */
 	public function register_field( string $type_name, string $field_name, array $config ): void {
@@ -1148,7 +1136,6 @@ class TypeRegistry {
 	 *
 	 * @param array $config The info about the connection being registered
 	 *
-	 * @return void
 	 * @throws \InvalidArgumentException
 	 * @throws \Exception
 	 */
@@ -1162,7 +1149,6 @@ class TypeRegistry {
 	 * @param string $mutation_name Name of the mutation being registered
 	 * @param array  $config        Info about the mutation being registered
 	 *
-	 * @return void
 	 * @throws \Exception
 	 */
 	public function register_mutation( string $mutation_name, array $config ): void {

--- a/src/Registry/Utils/PostObject.php
+++ b/src/Registry/Utils/PostObject.php
@@ -105,7 +105,7 @@ class PostObject {
 	 *
 	 * @param \WP_Post_Type $post_type_object
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	protected static function get_connections( WP_Post_Type $post_type_object ) {
 		$connections = [];
@@ -254,7 +254,7 @@ class PostObject {
 	 *
 	 * @param \WP_Post_Type $post_type_object Post type.
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	protected static function get_interfaces( WP_Post_Type $post_type_object ) {
 		$interfaces = [ 'Node', 'ContentNode', 'DatabaseIdentifier', 'NodeWithTemplate' ];
@@ -337,7 +337,7 @@ class PostObject {
 	 *
 	 * @param \WP_Post_Type $post_type_object Post type.
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 * @todo make protected after \Type\ObjectType\PostObject::get_fields() is removed.
 	 */
 	public static function get_fields( WP_Post_Type $post_type_object ) {

--- a/src/Registry/Utils/TermObject.php
+++ b/src/Registry/Utils/TermObject.php
@@ -102,7 +102,7 @@ class TermObject {
 	 *
 	 * @param \WP_Taxonomy $tax_object
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	protected static function get_connections( WP_Taxonomy $tax_object ) {
 		$connections = [];
@@ -272,7 +272,7 @@ class TermObject {
 	 *
 	 * @param \WP_Taxonomy $tax_object Taxonomy.
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	protected static function get_interfaces( WP_Taxonomy $tax_object ) {
 		$interfaces = [ 'Node', 'TermNode', 'DatabaseIdentifier' ];
@@ -307,7 +307,7 @@ class TermObject {
 	 *
 	 * @param \WP_Taxonomy $tax_object Taxonomy.
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>[]
 	 */
 	protected static function get_fields( WP_Taxonomy $tax_object ) {
 		$single_name = $tax_object->graphql_single_name;

--- a/src/Request.php
+++ b/src/Request.php
@@ -37,7 +37,7 @@ class Request {
 	/**
 	 * Request data.
 	 *
-	 * @var mixed|array|\GraphQL\Server\OperationParams
+	 * @var mixed|array<string,mixed>|\GraphQL\Server\OperationParams
 	 */
 	public $data;
 
@@ -87,7 +87,7 @@ class Request {
 	/**
 	 * Validation rules for execution.
 	 *
-	 * @var array
+	 * @var array<int|string,\GraphQL\Validator\Rules\ValidationRule>
 	 */
 	protected $validation_rules;
 
@@ -113,7 +113,7 @@ class Request {
 	/**
 	 * Constructor
 	 *
-	 * @param array $data The request data (for non-HTTP requests).
+	 * @param array<string,mixed> $data The request data.
 	 *
 	 * @return void
 	 *
@@ -199,7 +199,7 @@ class Request {
 	/**
 	 * Return the validation rules to use in the request
 	 *
-	 * @return array
+	 * @return array<int|string,\GraphQL\Validator\Rules\ValidationRule>
 	 */
 	protected function get_validation_rules(): array {
 		$validation_rules = GraphQL::getStandardValidationRules();
@@ -211,8 +211,8 @@ class Request {
 		/**
 		 * Return the validation rules to use in the request
 		 *
-		 * @param array   $validation_rules The validation rules to use in the request
-		 * @param \WPGraphQL\Request $request The Request instance
+		 * @param array<int|string,\GraphQL\Validator\Rules\ValidationRule> $validation_rules The validation rules to use in the request
+		 * @param \WPGraphQL\Request                                        $request          The Request instance
 		 */
 		return apply_filters( 'graphql_validation_rules', $validation_rules, $this );
 	}
@@ -404,10 +404,10 @@ class Request {
 	/**
 	 * Performs actions and runs filters after execution completes
 	 *
-	 * @param mixed|array|object $response The response from execution. Array for batch requests,
+	 * @param mixed|array<string,mixed>|object $response The response from execution. Array for batch requests,
 	 *                                     single object for individual requests
 	 *
-	 * @return array
+	 * @return mixed[]
 	 *
 	 * @throws \Exception
 	 */
@@ -459,8 +459,8 @@ class Request {
 		/**
 		 * Run an action after GraphQL Execution
 		 *
-		 * @param array   $filtered_response The response of the entire operation. Could be a single operation or a batch operation
-		 * @param \WPGraphQL\Request $request Instance of the Request being executed
+		 * @param mixed[] $filtered_response The response of the entire operation. Could be a single operation or a batch operation
+		 * @param \WPGraphQL\Request  $request Instance of the Request being executed
 		 */
 		do_action( 'graphql_after_execute', $filtered_response, $this );
 
@@ -473,10 +473,10 @@ class Request {
 	/**
 	 * Apply filters and do actions after GraphQL execution
 	 *
-	 * @param mixed|array|object $response The response for your GraphQL request
-	 * @param mixed|int|null     $key      The array key of the params for batch requests
+	 * @param mixed|array<string,mixed>|object $response The response for your GraphQL request
+	 * @param mixed|int|null                   $key      The array key of the params for batch requests
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 */
 	private function after_execute_actions( $response, $key = null ) {
 
@@ -598,7 +598,7 @@ class Request {
 	/**
 	 * Execute an internal request (graphql() function call).
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 * @throws \Exception
 	 */
 	public function execute() {
@@ -677,7 +677,7 @@ class Request {
 	/**
 	 * Execute an HTTP request.
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 * @throws \Exception
 	 */
 	public function execute_http() {

--- a/src/Request.php
+++ b/src/Request.php
@@ -183,7 +183,7 @@ class Request {
 	}
 
 	/**
-	 * @return \WPGraphQL\Utils\QueryAnalyzer
+	 * Get the instance of the Query Analyzer
 	 */
 	public function get_query_analyzer(): QueryAnalyzer {
 		return $this->query_analyzer;
@@ -240,7 +240,6 @@ class Request {
 	/**
 	 * Apply filters and do actions before GraphQL execution
 	 *
-	 * @return void
 	 * @throws \GraphQL\Error\Error
 	 */
 	private function before_execute(): void {

--- a/src/Request.php
+++ b/src/Request.php
@@ -310,7 +310,7 @@ class Request {
 	 * Anything else (true, WP_Error, thrown exception, etc) will prevent execution of the GraphQL
 	 * request.
 	 *
-	 * @return boolean
+	 * @return bool
 	 * @throws \Exception
 	 */
 	protected function has_authentication_errors() {
@@ -384,10 +384,10 @@ class Request {
 	 * Filter Authentication errors. Allows plugins that authenticate to hook in and prevent
 	 * execution if Authentication errors exist.
 	 *
-	 * @param boolean $authentication_errors Whether there are authentication errors with the
+	 * @param bool $authentication_errors Whether there are authentication errors with the
 	 *                                       request
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	protected function filtered_authentication_errors( $authentication_errors = false ) {
 
@@ -395,7 +395,7 @@ class Request {
 		 * If false, there are no authentication errors. If true, execution of the
 		 * GraphQL request will be prevented and an error will be thrown.
 		 *
-		 * @param boolean $authentication_errors Whether there are authentication errors with the request
+		 * @param bool $authentication_errors Whether there are authentication errors with the request
 		 * @param \WPGraphQL\Request $request Instance of the Request
 		 */
 		return apply_filters( 'graphql_authentication_errors', $authentication_errors, $this );
@@ -750,7 +750,7 @@ class Request {
 		/**
 		 * Filter whether batch queries are supported or not
 		 *
-		 * @param boolean         $batch_queries_enabled Whether Batch Queries should be enabled
+		 * @param bool         $batch_queries_enabled Whether Batch Queries should be enabled
 		 * @param \GraphQL\Server\OperationParams $params Request operation params
 		 */
 		return apply_filters( 'graphql_is_batch_queries_enabled', $batch_queries_enabled, $this->params );

--- a/src/Request.php
+++ b/src/Request.php
@@ -384,8 +384,7 @@ class Request {
 	 * Filter Authentication errors. Allows plugins that authenticate to hook in and prevent
 	 * execution if Authentication errors exist.
 	 *
-	 * @param bool $authentication_errors Whether there are authentication errors with the
-	 *                                       request
+	 * @param bool $authentication_errors Whether there are authentication errors with the request.
 	 *
 	 * @return bool
 	 */
@@ -404,8 +403,7 @@ class Request {
 	/**
 	 * Performs actions and runs filters after execution completes
 	 *
-	 * @param mixed|array<string,mixed>|object $response The response from execution. Array for batch requests,
-	 *                                     single object for individual requests
+	 * @param mixed|array<string,mixed>|object $response The response from execution. Array for batch requests, single object for individual requests.
 	 *
 	 * @return mixed[]
 	 *

--- a/src/Router.php
+++ b/src/Router.php
@@ -79,8 +79,6 @@ class Router {
 
 	/**
 	 * Returns the GraphQL Request being executed
-	 *
-	 * @return \WPGraphQL\Request | null
 	 */
 	public static function get_request(): ?Request {
 		return self::$request;

--- a/src/Router.php
+++ b/src/Router.php
@@ -133,7 +133,7 @@ class Router {
 	 * need to affect _all_ GraphQL requests, including internal requests using the `graphql()`
 	 * function, so be careful how you use this to check your conditions.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public static function is_graphql_http_request() {
 
@@ -194,7 +194,7 @@ class Router {
 		 * Different servers _might_ have different needs to determine whether a request
 		 * is a GraphQL request.
 		 *
-		 * @param boolean $is_graphql_http_request Whether the request is a GraphQL HTTP Request. Default false.
+		 * @param bool $is_graphql_http_request Whether the request is a GraphQL HTTP Request. Default false.
 		 */
 		return apply_filters( 'graphql_is_graphql_http_request', $is_graphql_http_request );
 	}
@@ -206,7 +206,7 @@ class Router {
 	 * won't be able to use this to properly determine if the request is a GraphQL request
 	 * or not.
 	 *
-	 * @return boolean
+	 * @return bool
 	 * @deprecated 0.4.1 Use Router::is_graphql_http_request instead. This now resolves to it
 	 */
 	public static function is_graphql_request() {

--- a/src/Router.php
+++ b/src/Router.php
@@ -115,9 +115,9 @@ class Router {
 	/**
 	 * Adds the query_var for the route
 	 *
-	 * @param array $query_vars The array of whitelisted query variables.
+	 * @param string[] $query_vars The array of whitelisted query variables.
 	 *
-	 * @return array
+	 * @return string[]
 	 * @since  0.0.1
 	 */
 	public static function add_query_var( $query_vars ) {
@@ -292,7 +292,7 @@ class Router {
 	/**
 	 * Returns an array of headers to send with the HTTP response
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 */
 	protected static function get_response_headers() {
 
@@ -528,12 +528,12 @@ class Router {
 	/**
 	 * Prepare headers for response
 	 *
-	 * @param mixed|array|\GraphQL\Executor\ExecutionResult $response The response of the GraphQL Request.
-	 * @param mixed|array|\GraphQL\Executor\ExecutionResult $graphql_results The results of the GraphQL execution.
-	 * @param string                                        $query           The GraphQL query.
-	 * @param string                                        $operation_name  The operation name of the GraphQL Request.
-	 * @param mixed|array|null                              $variables       The variables applied to the GraphQL Request.
-	 * @param mixed|\WP_User|null                           $user The current user object.
+	 * @param mixed|array<string,mixed>|\GraphQL\Executor\ExecutionResult $response        The response of the GraphQL Request.
+	 * @param mixed|array<string,mixed>|\GraphQL\Executor\ExecutionResult $graphql_results The results of the GraphQL execution.
+	 * @param string                                                      $query           The GraphQL query.
+	 * @param string                                                      $operation_name  The operation name of the GraphQL Request.
+	 * @param mixed|array<string,mixed>|null                              $variables       The variables applied to the GraphQL Request.
+	 * @param mixed|\WP_User|null                                         $user            The current user object.
 	 *
 	 * @return void
 	 */

--- a/src/Server/ValidationRules/DisableIntrospection.php
+++ b/src/Server/ValidationRules/DisableIntrospection.php
@@ -10,6 +10,8 @@ namespace WPGraphQL\Server\ValidationRules;
 class DisableIntrospection extends \GraphQL\Validator\Rules\DisableIntrospection {
 
 	/**
+	 * Whether the rule is enabled or not.
+	 *
 	 * @return bool
 	 */
 	public function isEnabled() {

--- a/src/Server/ValidationRules/QueryDepth.php
+++ b/src/Server/ValidationRules/QueryDepth.php
@@ -22,6 +22,8 @@ use function sprintf;
 class QueryDepth extends QuerySecurityRule {
 
 	/**
+	 * The max query depth allowed.
+	 *
 	 * @var int
 	 */
 	private $maxQueryDepth;
@@ -36,9 +38,11 @@ class QueryDepth extends QuerySecurityRule {
 	}
 
 	/**
+	 * {@inheritDoc}
+	 *
 	 * @param \GraphQL\Validator\ValidationContext $context
 	 *
-	 * @return callable[]|mixed[]
+	 * @return callable[]
 	 */
 	public function getVisitor( ValidationContext $context ) {
 		return $this->invokeIfNeeded(

--- a/src/Server/ValidationRules/RequireAuthentication.php
+++ b/src/Server/ValidationRules/RequireAuthentication.php
@@ -17,6 +17,8 @@ use GraphQL\Validator\ValidationContext;
 class RequireAuthentication extends QuerySecurityRule {
 
 	/**
+	 * Whether the rule is enabled or not.
+	 *
 	 * @return bool
 	 */
 	protected function isEnabled() {
@@ -57,9 +59,11 @@ class RequireAuthentication extends QuerySecurityRule {
 	}
 
 	/**
+	 * {@inheritDoc}
+	 *
 	 * @param \GraphQL\Validator\ValidationContext $context
 	 *
-	 * @return callable[]|mixed[]
+	 * @return callable[]
 	 */
 	public function getVisitor( ValidationContext $context ) {
 		$allowed_root_fields = [];

--- a/src/Server/WPHelper.php
+++ b/src/Server/WPHelper.php
@@ -15,9 +15,10 @@ class WPHelper extends Helper {
 	 * Parses normalized request params and returns instance of OperationParams
 	 * or array of OperationParams in case of batch operation.
 	 *
-	 * @param string $method The method of the request (GET, POST, etc).
-	 * @param array  $bodyParams The params passed to the body of the request.
-	 * @param array  $queryParams The query params passed to the request.
+	 * @param string  $method The method of the request (GET, POST, etc).
+	 * @param mixed[] $bodyParams The params passed to the body of the request.
+	 * @param mixed[] $queryParams The query params passed to the request.
+	 *
 	 * @return \GraphQL\Server\OperationParams|\GraphQL\Server\OperationParams[]
 	 * @throws \GraphQL\Server\RequestError Throws RequestError.
 	 */
@@ -63,8 +64,8 @@ class WPHelper extends Helper {
 	/**
 	 * Parse parameters and proxy to parse_extensions.
 	 *
-	 * @param  array $params Request parameters.
-	 * @return array
+	 * @param  mixed[] $params Request parameters.
+	 * @return mixed[]
 	 */
 	private function parse_params( $params ) {
 		if ( isset( $params[0] ) ) {
@@ -77,8 +78,8 @@ class WPHelper extends Helper {
 	/**
 	 * Parse query extensions.
 	 *
-	 * @param  array $params Request parameters.
-	 * @return array
+	 * @param  mixed[] $params Request parameters.
+	 * @return mixed[]
 	 */
 	private function parse_extensions( $params ) {
 		if ( isset( $params['extensions'] ) && is_string( $params['extensions'] ) ) {

--- a/src/Type/Connection/Comments.php
+++ b/src/Type/Connection/Comments.php
@@ -87,9 +87,9 @@ class Comments {
 	 * Given an array of $args, this returns the connection config, merging the provided args
 	 * with the defaults
 	 *
-	 * @param array $args
+	 * @param array<string,mixed> $args
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 */
 	public static function get_connection_config( $args = [] ) {
 		$defaults = [
@@ -108,7 +108,7 @@ class Comments {
 	/**
 	 * This returns the connection args for the Comment connection
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_connection_args() {
 		return [

--- a/src/Type/Connection/MenuItems.php
+++ b/src/Type/Connection/MenuItems.php
@@ -87,9 +87,9 @@ class MenuItems {
 	/**
 	 * Given an array of $args, returns the args for the connection with the provided args merged
 	 *
-	 * @param array $args
+	 * @param array<string,mixed> $args
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 */
 	public static function get_connection_config( $args = [] ) {
 		return array_merge(

--- a/src/Type/Connection/PostObjects.php
+++ b/src/Type/Connection/PostObjects.php
@@ -229,9 +229,9 @@ class PostObjects {
 	 *
 	 * @param mixed|\WP_Post_Type|\WP_Taxonomy $graphql_object The post type object for the post_type having a
 	 * connection registered to it
-	 * @param array                            $args           The custom args to modify the connection registration
+	 * @param array<string,mixed>              $args           The custom args to modify the connection registration
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 */
 	public static function get_connection_config( $graphql_object, $args = [] ) {
 		$connection_args = self::get_connection_args( [], $graphql_object );
@@ -259,10 +259,10 @@ class PostObjects {
 	/**
 	 * Given an optional array of args, this returns the args to be used in the connection
 	 *
-	 * @param array                            $args             The args to modify the defaults
-	 * @param mixed|\WP_Post_Type|\WP_Taxonomy $post_type_object The post type the connection is going to
+	 * @param array<string,array<string,mixed>> $args             The args to modify the defaults
+	 * @param mixed|\WP_Post_Type|\WP_Taxonomy  $post_type_object The post type the connection is going to
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_connection_args( $args = [], $post_type_object = null ) {
 		$fields = [

--- a/src/Type/Connection/TermObjects.php
+++ b/src/Type/Connection/TermObjects.php
@@ -80,8 +80,7 @@ class TermObjects {
 	 * Given the Taxonomy Object and an array of args, this returns an array of args for use in
 	 * registering a connection.
 	 *
-	 * @param \WP_Taxonomy        $tax_object        The taxonomy object for the taxonomy having a
-	 *                                               connection registered to it
+	 * @param \WP_Taxonomy        $tax_object        The taxonomy object for the taxonomy having a connection registered to it
 	 * @param array<string,mixed> $args              The custom args to modify the connection registration
 	 *
 	 * @return array<string,mixed>

--- a/src/Type/Connection/TermObjects.php
+++ b/src/Type/Connection/TermObjects.php
@@ -80,11 +80,11 @@ class TermObjects {
 	 * Given the Taxonomy Object and an array of args, this returns an array of args for use in
 	 * registering a connection.
 	 *
-	 * @param \WP_Taxonomy $tax_object        The taxonomy object for the taxonomy having a
-	 *                                        connection registered to it
-	 * @param array        $args              The custom args to modify the connection registration
+	 * @param \WP_Taxonomy        $tax_object        The taxonomy object for the taxonomy having a
+	 *                                               connection registered to it
+	 * @param array<string,mixed> $args              The custom args to modify the connection registration
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 */
 	public static function get_connection_config( $tax_object, $args = [] ) {
 		$defaults = [
@@ -104,9 +104,9 @@ class TermObjects {
 	/**
 	 * Given an optional array of args, this returns the args to be used in the connection
 	 *
-	 * @param array $args The args to modify the defaults
+	 * @param array<string,array<string,mixed>> $args The args to modify the defaults
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_connection_args( $args = [] ) {
 		return array_merge(

--- a/src/Type/Connection/Users.php
+++ b/src/Type/Connection/Users.php
@@ -116,7 +116,7 @@ class Users {
 	/**
 	 * Returns the connection args for use in the connection
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_connection_args() {
 		return [

--- a/src/Type/Enum/ContentNodeIdTypeEnum.php
+++ b/src/Type/Enum/ContentNodeIdTypeEnum.php
@@ -57,7 +57,7 @@ class ContentNodeIdTypeEnum {
 	/**
 	 * Get the values for the Enum definitions
 	 *
-	 * @return array
+	 * @return array<string,array<string,string>>
 	 */
 	public static function get_values() {
 		return [

--- a/src/Type/Enum/PluginStatusEnum.php
+++ b/src/Type/Enum/PluginStatusEnum.php
@@ -23,7 +23,7 @@ class PluginStatusEnum {
 	/**
 	 * Returns the array configuration for the GraphQL enum values.
 	 *
-	 * @return array
+	 * @return array<string,array<string,string>>
 	 */
 	protected static function get_enum_values() {
 		$values = [

--- a/src/Type/Enum/TermNodeIdTypeEnum.php
+++ b/src/Type/Enum/TermNodeIdTypeEnum.php
@@ -40,7 +40,7 @@ class TermNodeIdTypeEnum {
 	/**
 	 * Get the values for the Enum definitions
 	 *
-	 * @return array
+	 * @return array<string,array<string,string>>
 	 */
 	public static function get_values() {
 		return [

--- a/src/Type/Enum/UserNodeIdTypeEnum.php
+++ b/src/Type/Enum/UserNodeIdTypeEnum.php
@@ -21,7 +21,7 @@ class UserNodeIdTypeEnum {
 	/**
 	 * Returns the values for the Enum.
 	 *
-	 * @return array
+	 * @return array<string,array<string,string>>
 	 */
 	public static function get_values() {
 		return [

--- a/src/Type/InterfaceType/Connection.php
+++ b/src/Type/InterfaceType/Connection.php
@@ -10,7 +10,6 @@ class Connection {
 	 *
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
-	 * @return void
 	 * @throws \Exception
 	 */
 	public static function register_type( TypeRegistry $type_registry ): void {

--- a/src/Type/InterfaceType/Edge.php
+++ b/src/Type/InterfaceType/Edge.php
@@ -10,7 +10,6 @@ class Edge {
 	 *
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
-	 * @return void
 	 * @throws \Exception
 	 */
 	public static function register_type( TypeRegistry $type_registry ): void {

--- a/src/Type/InterfaceType/HierarchicalContentNode.php
+++ b/src/Type/InterfaceType/HierarchicalContentNode.php
@@ -15,7 +15,6 @@ class HierarchicalContentNode {
 	 *
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
-	 * @return void
 	 * @throws \Exception
 	 */
 	public static function register_type( TypeRegistry $type_registry ): void {

--- a/src/Type/InterfaceType/HierarchicalNode.php
+++ b/src/Type/InterfaceType/HierarchicalNode.php
@@ -16,7 +16,6 @@ class HierarchicalNode {
 	 *
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
-	 * @return void
 	 * @throws \Exception
 	 */
 	public static function register_type( TypeRegistry $type_registry ): void {

--- a/src/Type/InterfaceType/HierarchicalTermNode.php
+++ b/src/Type/InterfaceType/HierarchicalTermNode.php
@@ -15,7 +15,6 @@ class HierarchicalTermNode {
 	 *
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
-	 * @return void
 	 * @throws \Exception
 	 */
 	public static function register_type( TypeRegistry $type_registry ): void {

--- a/src/Type/InterfaceType/MenuItemLinkable.php
+++ b/src/Type/InterfaceType/MenuItemLinkable.php
@@ -13,7 +13,6 @@ class MenuItemLinkable {
 	 *
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry Instance of the WPGraphQL Type Registry
 	 *
-	 * @return void
 	 * @throws \Exception
 	 */
 	public static function register_type( TypeRegistry $type_registry ): void {

--- a/src/Type/InterfaceType/OneToOneConnection.php
+++ b/src/Type/InterfaceType/OneToOneConnection.php
@@ -10,7 +10,6 @@ class OneToOneConnection {
 	 *
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
-	 * @return void
 	 * @throws \Exception
 	 */
 	public static function register_type( TypeRegistry $type_registry ): void {

--- a/src/Type/InterfaceType/PageInfo.php
+++ b/src/Type/InterfaceType/PageInfo.php
@@ -34,7 +34,7 @@ class PageInfo {
 	/**
 	 * Get the fields for the PageInfo Type
 	 *
-	 * @return array[]
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_fields(): array {
 		return [

--- a/src/Type/InterfaceType/PageInfo.php
+++ b/src/Type/InterfaceType/PageInfo.php
@@ -10,7 +10,6 @@ class PageInfo {
 	 *
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
-	 * @return void
 	 * @throws \Exception
 	 */
 	public static function register_type( TypeRegistry $type_registry ): void {

--- a/src/Type/InterfaceType/Previewable.php
+++ b/src/Type/InterfaceType/Previewable.php
@@ -12,7 +12,6 @@ class Previewable {
 	 *
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
-	 * @return void
 	 * @throws \Exception
 	 */
 	public static function register_type( TypeRegistry $type_registry ): void {

--- a/src/Type/ObjectType/PostObject.php
+++ b/src/Type/ObjectType/PostObject.php
@@ -38,7 +38,7 @@ class PostObject {
 	 *
 	 * @deprecated 1.12.0
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_fields( $post_type_object, $type_registry ) {
 		_deprecated_function( __FUNCTION__, '1.12.0', esc_attr( \WPGraphQL\Registry\Utils\PostObject::class ) . '::get_fields()' );

--- a/src/Type/ObjectType/SettingGroup.php
+++ b/src/Type/ObjectType/SettingGroup.php
@@ -47,7 +47,7 @@ class SettingGroup {
 	 * @param string                           $group      The settings group config
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The WPGraphQL TypeRegistry
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>|null
 	 */
 	public static function get_settings_group_fields( string $group_name, string $group, TypeRegistry $type_registry ) {
 		$setting_fields = DataSource::get_setting_group_fields( $group, $type_registry );

--- a/src/Type/ObjectType/Settings.php
+++ b/src/Type/ObjectType/Settings.php
@@ -42,7 +42,7 @@ class Settings {
 	 *
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The WPGraphQL TypeRegistry
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_fields( TypeRegistry $type_registry ) {
 		$registered_settings = DataSource::get_allowed_settings( $type_registry );

--- a/src/Type/Union/MenuItemObjectUnion.php
+++ b/src/Type/Union/MenuItemObjectUnion.php
@@ -55,7 +55,7 @@ class MenuItemObjectUnion {
 	/**
 	 * Returns a list of possible types for the union
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	public static function get_possible_types() {
 

--- a/src/Type/Union/PostObjectUnion.php
+++ b/src/Type/Union/PostObjectUnion.php
@@ -17,7 +17,6 @@ class PostObjectUnion {
 	 *
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
-	 * @return void
 	 * @throws \Exception
 	 */
 	public static function register_type( TypeRegistry $type_registry ): void {

--- a/src/Type/Union/PostObjectUnion.php
+++ b/src/Type/Union/PostObjectUnion.php
@@ -46,7 +46,7 @@ class PostObjectUnion {
 	/**
 	 * Returns a list of possible types for the union
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	public static function get_possible_types() {
 		$possible_types = [];

--- a/src/Type/Union/TermObjectUnion.php
+++ b/src/Type/Union/TermObjectUnion.php
@@ -45,7 +45,7 @@ class TermObjectUnion {
 	/**
 	 * Returns a list of possible types for the union
 	 *
-	 * @return array
+	 * @return array<string,string>
 	 */
 	public static function get_possible_types() {
 		$possible_types = [];

--- a/src/Type/Union/TermObjectUnion.php
+++ b/src/Type/Union/TermObjectUnion.php
@@ -16,7 +16,6 @@ class TermObjectUnion {
 	 *
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
-	 * @return void
 	 * @throws \Exception
 	 */
 	public static function register_type( TypeRegistry $type_registry ): void {

--- a/src/Type/WPConnectionType.php
+++ b/src/Type/WPConnectionType.php
@@ -16,33 +16,33 @@ class WPConnectionType {
 	/**
 	 * Configuration for how auth should be handled on the connection field
 	 *
-	 * @var array
+	 * @var array<string,mixed>
 	 */
 	protected $auth;
 
 	/**
 	 * The config for the connection
 	 *
-	 * @var array
+	 * @var array<string,mixed>
 	 */
 	protected $config;
 
 	/**
 	 * The args configured for the connection
 	 *
-	 * @var array
+	 * @var array<string,array<string,mixed>>
 	 */
 	protected $connection_args;
 
 	/**
 	 * The fields to show on the connection
 	 *
-	 * @var array
+	 * @var array<string,mixed>
 	 */
 	protected $connection_fields;
 
 	/**
-	 * @var array|null
+	 * @var string[]|null
 	 */
 	protected $connection_interfaces;
 
@@ -56,7 +56,7 @@ class WPConnectionType {
 	/**
 	 * The fields to expose on the edge of the connection
 	 *
-	 * @var array
+	 * @var array<string,array<string,mixed>>
 	 */
 	protected $edge_fields;
 
@@ -124,16 +124,15 @@ class WPConnectionType {
 	/**
 	 * The where args for the connection
 	 *
-	 * @var array
+	 * @var array<string,array<string,mixed>>
 	 */
 	protected $where_args;
 
 	/**
 	 * WPConnectionType constructor.
 	 *
-	 * @param array                            $config        The config array for the connection
-	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry Instance of the WPGraphQL Type
-	 *                                                        Registry
+	 * @param array<string,mixed>              $config        The config array for the connection
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry Instance of the WPGraphQL Type Registry
 	 *
 	 * @throws \Exception
 	 */
@@ -202,7 +201,7 @@ class WPConnectionType {
 	/**
 	 * Validates that essential key/value pairs are passed to the connection config.
 	 *
-	 * @param array $config
+	 * @param array<string,mixed> $config The config array for the connection.
 	 *
 	 * @throws \GraphQL\Exception\InvalidArgument If the config is invalid.
 	 */
@@ -223,9 +222,9 @@ class WPConnectionType {
 	/**
 	 * Get edge interfaces
 	 *
-	 * @param array $interfaces
+	 * @param string[] $interfaces Array of interfaces to add to the edge.
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	protected function get_edge_interfaces( array $interfaces = [] ): array {
 
@@ -446,7 +445,7 @@ class WPConnectionType {
 	/**
 	 * Returns fields to be used on the connection
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	protected function get_connection_fields(): array {
 		return array_merge(
@@ -472,7 +471,7 @@ class WPConnectionType {
 	/**
 	 * Get the args used for pagination on connections
 	 *
-	 * @return array|array[]
+	 * @return array<string,array<string,mixed>>
 	 */
 	protected function get_pagination_args(): array {
 		if ( true === $this->one_to_one ) {

--- a/src/Type/WPConnectionType.php
+++ b/src/Type/WPConnectionType.php
@@ -204,7 +204,6 @@ class WPConnectionType {
 	 *
 	 * @param array $config
 	 *
-	 * @return void
 	 * @throws \GraphQL\Exception\InvalidArgument If the config is invalid.
 	 */
 	protected function validate_config( array $config ): void {
@@ -250,8 +249,6 @@ class WPConnectionType {
 	 * @param string $from_type        Name of the Type the connection is coming from
 	 * @param string $to_type          Name of the Type the connection is going to
 	 * @param string $from_field_name  Acts as an alternative "toType" if connection type already defined using $to_type.
-	 *
-	 * @return string
 	 */
 	public function get_connection_name( string $from_type, string $to_type, string $from_field_name ): string {
 
@@ -310,8 +307,6 @@ class WPConnectionType {
 	/**
 	 * Registers the One to One Connection Edge type to the Schema
 	 *
-	 * @return void
-	 *
 	 * @throws \Exception
 	 */
 	protected function register_one_to_one_connection_edge_type(): void {
@@ -353,8 +348,6 @@ class WPConnectionType {
 	/**
 	 * Registers the PageInfo type for the connection
 	 *
-	 * @return void
-	 *
 	 * @throws \Exception
 	 */
 	public function register_connection_page_info_type(): void {
@@ -378,8 +371,6 @@ class WPConnectionType {
 
 	/**
 	 * Registers the Connection Edge type to the Schema
-	 *
-	 * @return void
 	 *
 	 * @throws \Exception
 	 */
@@ -420,8 +411,6 @@ class WPConnectionType {
 
 	/**
 	 * Registers the Connection Type to the Schema
-	 *
-	 * @return void
 	 *
 	 * @throws \Exception
 	 */
@@ -515,7 +504,6 @@ class WPConnectionType {
 	/**
 	 * Registers the connection in the Graph
 	 *
-	 * @return void
 	 * @throws \Exception
 	 */
 	public function register_connection_field(): void {
@@ -558,7 +546,6 @@ class WPConnectionType {
 	}
 
 	/**
-	 * @return void
 	 * @throws \Exception
 	 */
 	public function register_connection_interfaces(): void {
@@ -630,8 +617,6 @@ class WPConnectionType {
 	 * Registers the connection Types and field to the Schema.
 	 *
 	 * @todo change to 'Protected'. This is public for now to allow for backwards compatibility.
-	 *
-	 * @return void
 	 *
 	 * @throws \Exception
 	 */

--- a/src/Type/WPEnumType.php
+++ b/src/Type/WPEnumType.php
@@ -15,7 +15,7 @@ class WPEnumType extends EnumType {
 	/**
 	 * WPEnumType constructor.
 	 *
-	 * @param array $config
+	 * @param array<string,mixed> $config
 	 */
 	public function __construct( $config ) {
 		$name             = ucfirst( $config['name'] );
@@ -52,9 +52,9 @@ class WPEnumType extends EnumType {
 	 * This function sorts the values and applies a filter to allow for easily
 	 * extending/modifying the shape of the Schema for the enum.
 	 *
-	 * @param array  $values
-	 * @param string $type_name
-	 * @return mixed
+	 * @param array<string,mixed> $values
+	 * @param string              $type_name
+	 * @return array<string,mixed>
 	 * @since 0.0.5
 	 */
 	private static function prepare_values( $values, $type_name ) {

--- a/src/Type/WPInputObjectType.php
+++ b/src/Type/WPInputObjectType.php
@@ -48,11 +48,11 @@ class WPInputObjectType extends InputObjectType {
 	 * This function sorts the fields and applies a filter to allow for easily
 	 * extending/modifying the shape of the Schema for the type.
 	 *
-	 * @param array                            $fields
-	 * @param string                           $type_name
-	 * @param array                            $config
-	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
-	 * @return mixed
+	 * @param array<string,array<string,mixed>> $fields
+	 * @param string                            $type_name
+	 * @param array<string,mixed>               $config
+	 * @param \WPGraphQL\Registry\TypeRegistry  $type_registry
+	 * @return array<string,array<string,mixed>>
 	 * @since 0.0.5
 	 */
 	public function prepare_fields( array $fields, string $type_name, array $config, TypeRegistry $type_registry ) {

--- a/src/Type/WPInterfaceTrait.php
+++ b/src/Type/WPInterfaceTrait.php
@@ -14,10 +14,9 @@ use GraphQL\Type\Definition\InterfaceType;
 trait WPInterfaceTrait {
 
 	/**
-	 * Given an array of interfaces, this gets the Interfaces the Type should implement including
-	 * inherited interfaces.
+	 * Given an array of interfaces, this gets the Interfaces the Type should implement including inherited interfaces.
 	 *
-	 * @return array
+	 * @return \GraphQL\Type\Definition\InterfaceType[]
 	 */
 	protected function get_implemented_interfaces(): array {
 		if ( ! isset( $this->config['interfaces'] ) || ! is_array( $this->config['interfaces'] ) || empty( $this->config['interfaces'] ) ) {
@@ -29,8 +28,8 @@ trait WPInterfaceTrait {
 		/**
 		 * Filters the interfaces applied to an object type
 		 *
-		 * @param array        $interfaces     List of interfaces applied to the Object Type
-		 * @param array        $config         The config for the Object Type
+		 * @param string[]                   $interfaces     List of interfaces applied to the Object Type
+		 * @param array<string,mixed>        $config         The config for the Object Type
 		 * @param mixed|\WPGraphQL\Type\WPInterfaceType|\WPGraphQL\Type\WPObjectType $type The Type instance
 		 */
 		$interfaces = apply_filters( 'graphql_type_interfaces', $interfaces, $this->config, $this );

--- a/src/Type/WPInterfaceType.php
+++ b/src/Type/WPInterfaceType.php
@@ -17,14 +17,14 @@ class WPInterfaceType extends InterfaceType {
 	public $type_registry;
 
 	/**
-	 * @var array
+	 * @var array<string,mixed>
 	 */
 	public $config;
 
 	/**
 	 * WPInterfaceType constructor.
 	 *
-	 * @param array                            $config
+	 * @param array<string,mixed>              $config
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
 	 * @throws \Exception
@@ -108,7 +108,7 @@ class WPInterfaceType extends InterfaceType {
 	/**
 	 * Get interfaces implemented by this Interface
 	 *
-	 * @return array
+	 * @return \GraphQL\Type\Definition\InterfaceType[]
 	 */
 	public function getInterfaces(): array {
 		return $this->get_implemented_interfaces();
@@ -118,8 +118,8 @@ class WPInterfaceType extends InterfaceType {
 	 * This function sorts the fields and applies a filter to allow for easily
 	 * extending/modifying the shape of the Schema for the type.
 	 *
-	 * @param array  $fields
-	 * @param string $type_name
+	 * @param array<string,array<string,mixed>> $fields The array of fields for the object config
+	 * @param string                            $type_name
 	 *
 	 * @return mixed
 	 * @since 0.0.5

--- a/src/Type/WPMutationType.php
+++ b/src/Type/WPMutationType.php
@@ -14,14 +14,14 @@ class WPMutationType {
 	/**
 	 * Configuration for how auth should be handled on the connection field
 	 *
-	 * @var array
+	 * @var array<string,mixed>
 	 */
 	protected $auth;
 
 	/**
 	 * The config for the connection
 	 *
-	 * @var array
+	 * @var array<string,mixed>
 	 */
 	protected $config;
 
@@ -42,14 +42,14 @@ class WPMutationType {
 	/**
 	 * The mutation input field config.
 	 *
-	 * @var array
+	 * @var array<string,array<string,mixed>>
 	 */
 	protected $input_fields;
 
 	/**
 	 * The mutation output field config.
 	 *
-	 * @var array
+	 * @var array<string,array<string,mixed>>
 	 */
 	protected $output_fields;
 
@@ -70,7 +70,7 @@ class WPMutationType {
 	/**
 	 * WPMutationType constructor.
 	 *
-	 * @param array                            $config        The config array for the mutation
+	 * @param array<string,mixed>              $config        The config array for the mutation
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry Instance of the WPGraphQL Type Registry
 	 *
 	 * @throws \Exception
@@ -122,7 +122,7 @@ class WPMutationType {
 	/**
 	 * Validates that essential key/value pairs are passed to the connection config.
 	 *
-	 * @param array $config
+	 * @param array<string,mixed> $config The config array for the mutation
 	 */
 	protected function is_config_valid( array $config ): bool {
 		$is_valid = true;
@@ -152,6 +152,8 @@ class WPMutationType {
 
 	/**
 	 * Gets the mutation input fields.
+	 *
+	 * @return array<string,array<string,mixed>>
 	 */
 	protected function get_input_fields(): array {
 		$input_fields = [
@@ -170,6 +172,8 @@ class WPMutationType {
 
 	/**
 	 * Gets the mutation output fields.
+	 *
+	 * @return array<string,array<string,mixed>>
 	 */
 	protected function get_output_fields(): array {
 		$output_fields = [

--- a/src/Type/WPMutationType.php
+++ b/src/Type/WPMutationType.php
@@ -123,8 +123,6 @@ class WPMutationType {
 	 * Validates that essential key/value pairs are passed to the connection config.
 	 *
 	 * @param array $config
-	 *
-	 * @return bool
 	 */
 	protected function is_config_valid( array $config ): bool {
 		$is_valid = true;

--- a/src/Type/WPObjectType.php
+++ b/src/Type/WPObjectType.php
@@ -25,7 +25,7 @@ class WPObjectType extends ObjectType {
 	 * to easily define themselves as a node type by implementing
 	 * self::$node_interface
 	 *
-	 * @var array|\WPGraphQL\Type\InterfaceType\Node $node_interface
+	 * @var array<string,mixed>|\WPGraphQL\Type\InterfaceType\Node $node_interface
 	 * @since 0.0.5
 	 */
 	private static $node_interface;
@@ -38,14 +38,14 @@ class WPObjectType extends ObjectType {
 	public $type_registry;
 
 	/**
-	 * @var array
+	 * @var array<string,mixed>
 	 */
 	public $config;
 
 	/**
 	 * WPObjectType constructor.
 	 *
-	 * @param array                            $config
+	 * @param array<string,mixed>              $config
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
 	 * @throws \Exception
@@ -61,7 +61,7 @@ class WPObjectType extends ObjectType {
 		/**
 		 * Filter the config of WPObjectType
 		 *
-		 * @param array        $config         Array of configuration options passed to the WPObjectType when instantiating a new type
+		 * @param array<string,mixed>          $config         Array of configuration options passed to the WPObjectType when instantiating a new type
 		 * @param \WPGraphQL\Type\WPObjectType $wp_object_type The instance of the WPObjectType class
 		 */
 		$config = apply_filters( 'graphql_wp_object_type_config', $config, $this );
@@ -124,7 +124,7 @@ class WPObjectType extends ObjectType {
 		/**
 		 * Run an action when the WPObjectType is instantiating
 		 *
-		 * @param array        $config         Array of configuration options passed to the WPObjectType when instantiating a new type
+		 * @param array                        $config         Array of configuration options passed to the WPObjectType when instantiating a new type
 		 * @param \WPGraphQL\Type\WPObjectType $wp_object_type The instance of the WPObjectType class
 		 */
 		do_action( 'graphql_wp_object_type', $config, $this );
@@ -135,7 +135,7 @@ class WPObjectType extends ObjectType {
 	/**
 	 * Get the interfaces implemented by the ObjectType
 	 *
-	 * @return array
+	 * @return \GraphQL\Type\Definition\InterfaceType[]
 	 */
 	public function getInterfaces(): array {
 		return $this->get_implemented_interfaces();
@@ -147,7 +147,7 @@ class WPObjectType extends ObjectType {
 	 * This returns the node_interface definition allowing
 	 * WPObjectTypes to easily implement the node_interface
 	 *
-	 * @return array|\WPGraphQL\Type\InterfaceType\Node
+	 * @return array<string,mixed>|\WPGraphQL\Type\InterfaceType\Node
 	 * @since 0.0.5
 	 */
 	public static function node_interface() {
@@ -163,9 +163,9 @@ class WPObjectType extends ObjectType {
 	 * This function sorts the fields and applies a filter to allow for easily
 	 * extending/modifying the shape of the Schema for the type.
 	 *
-	 * @param array  $fields
-	 * @param string $type_name
-	 * @param array  $config
+	 * @param array<string,mixed> $fields         The array of fields for the object config
+	 * @param string              $type_name
+	 * @param array<string,mixed> $config         The config for the Object Type
 	 *
 	 * @return mixed
 	 * @since 0.0.5

--- a/src/Type/WPScalar.php
+++ b/src/Type/WPScalar.php
@@ -14,7 +14,7 @@ class WPScalar extends CustomScalarType {
 	/**
 	 * WPScalar constructor.
 	 *
-	 * @param array                            $config
+	 * @param array<string,mixed>              $config
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 */
 	public function __construct( array $config, TypeRegistry $type_registry ) {

--- a/src/Type/WPUnionType.php
+++ b/src/Type/WPUnionType.php
@@ -24,7 +24,7 @@ class WPUnionType extends UnionType {
 	/**
 	 * WPUnionType constructor.
 	 *
-	 * @param array                            $config The Config to setup a Union Type
+	 * @param array<string,mixed>              $config The Config to setup a Union Type
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
 	 * @since 0.0.30

--- a/src/Types.php
+++ b/src/Types.php
@@ -17,10 +17,10 @@ class Types {
 	/**
 	 * @deprecated since v0.6.0. Use Utils:map_input instead
 	 *
-	 * @param array $args The raw query args from the GraphQL query.
-	 * @param array $map  The mapping of where each of the args should go.
+	 * @param mixed[] $args The raw query args from the GraphQL query.
+	 * @param mixed[] $map  The mapping of where each of the args should go.
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 */
 	public static function map_input( $args, $map ) {
 		_deprecated_function( __METHOD__, '0.6.0', 'WPGraphQL\Utils\Utils::map_input()' );

--- a/src/Utils/DebugLog.php
+++ b/src/Utils/DebugLog.php
@@ -18,7 +18,7 @@ class DebugLog {
 	/**
 	 * Whether logs are enabled
 	 *
-	 * @var boolean
+	 * @var bool
 	 */
 	protected $logs_enabled;
 

--- a/src/Utils/DebugLog.php
+++ b/src/Utils/DebugLog.php
@@ -9,7 +9,9 @@ namespace WPGraphQL\Utils;
 class DebugLog {
 
 	/**
-	 * @var array
+	 * The log items.
+	 *
+	 * @var array<string,mixed>[]
 	 */
 	protected $logs;
 
@@ -43,10 +45,10 @@ class DebugLog {
 	/**
 	 * Given a message and a config, a log entry is added to the log
 	 *
-	 * @param mixed|string|array $message The debug log message
-	 * @param array              $config Config for the debug log. Set type and any additional information to log
+	 * @param mixed|string|mixed[] $message The debug log message
+	 * @param array<string,mixed>  $config Config for the debug log. Set type and any additional information to log
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 */
 	public function add_log_entry( $message, $config = [] ) {
 		if ( empty( $message ) ) {
@@ -99,7 +101,7 @@ class DebugLog {
 	/**
 	 * Returns the debug log
 	 *
-	 * @return array
+	 * @return array<string,mixed>[]
 	 */
 	public function get_logs() {
 

--- a/src/Utils/InstrumentSchema.php
+++ b/src/Utils/InstrumentSchema.php
@@ -19,8 +19,6 @@ class InstrumentSchema {
 	/**
 	 * @param \GraphQL\Type\Definition\Type $type Instance of the Schema.
 	 * @param string                        $type_name Name of the Type
-	 *
-	 * @return \GraphQL\Type\Definition\Type
 	 */
 	public static function instrument_resolvers( Type $type, string $type_name ): Type {
 		if ( ! method_exists( $type, 'getFields' ) ) {

--- a/src/Utils/InstrumentSchema.php
+++ b/src/Utils/InstrumentSchema.php
@@ -41,8 +41,8 @@ class InstrumentSchema {
 	 * This wraps fields to provide sanitization on fields output by introspection queries
 	 * (description/deprecation reason) and provides hooks to resolvers.
 	 *
-	 * @param array  $fields    The fields configured for a Type
-	 * @param string $type_name The Type name
+	 * @param mixed[] $fields    The fields configured for a Type
+	 * @param string  $type_name The Type name
 	 *
 	 * @return mixed
 	 */
@@ -192,13 +192,13 @@ class InstrumentSchema {
 	 * This takes into account auth params defined in the Schema
 	 *
 	 * @param mixed                                    $source         The source passed down the Resolve Tree
-	 * @param array                                    $args           The args for the field
-	 * @param \WPGraphQL\AppContext                    $context The AppContext passed down the ResolveTree
-	 * @param \GraphQL\Type\Definition\ResolveInfo     $info The ResolveInfo passed down the ResolveTree
+	 * @param array<string,mixed>                      $args           The args for the field
+	 * @param \WPGraphQL\AppContext                    $context        The AppContext passed down the ResolveTree
+	 * @param \GraphQL\Type\Definition\ResolveInfo     $info           The ResolveInfo passed down the ResolveTree
 	 * @param mixed|callable|string                    $field_resolver The Resolve function for the field
 	 * @param string                                   $type_name      The name of the type the fields belong to
 	 * @param string                                   $field_key      The name of the field
-	 * @param \GraphQL\Type\Definition\FieldDefinition $field The Field Definition for the resolving field
+	 * @param \GraphQL\Type\Definition\FieldDefinition $field          The Field Definition for the resolving field
 	 *
 	 * @return void
 	 *

--- a/src/Utils/QueryAnalyzer.php
+++ b/src/Utils/QueryAnalyzer.php
@@ -114,14 +114,14 @@ class QueryAnalyzer {
 	}
 
 	/**
-	 * @return \WPGraphQL\Request
+	 * Gets the request object.
 	 */
 	public function get_request(): Request {
 		return $this->request;
 	}
 
 	/**
-	 * @return void
+	 * Initialize the QueryAnalyzer.
 	 */
 	public function init(): void {
 
@@ -189,7 +189,6 @@ class QueryAnalyzer {
 	 * @param \GraphQL\Server\OperationParams $params The Operation Params. This includes any extra params,
 	 * such as extensions or any other modifications to the request body
 	 *
-	 * @return void
 	 * @throws \Exception
 	 */
 	public function determine_graphql_keys( ?string $query, ?string $operation, ?array $variables, OperationParams $params ): void {
@@ -255,7 +254,7 @@ class QueryAnalyzer {
 	}
 
 	/**
-	 * @return string
+	 * Get the root operation of the query.
 	 */
 	public function get_root_operation(): string {
 		return $this->root_operation;
@@ -263,8 +262,6 @@ class QueryAnalyzer {
 
 	/**
 	 * Returns the operation name of the query, if there is one
-	 *
-	 * @return string|null
 	 */
 	public function get_operation_name(): ?string {
 		$operation_name = ! empty( $this->request->params->operation ) ? $this->request->params->operation : null;
@@ -288,7 +285,7 @@ class QueryAnalyzer {
 	}
 
 	/**
-	 * @return string|null
+	 * Get the query id.
 	 */
 	public function get_query_id(): ?string {
 		return $this->query_id;

--- a/src/Utils/QueryAnalyzer.php
+++ b/src/Utils/QueryAnalyzer.php
@@ -38,7 +38,7 @@ class QueryAnalyzer {
 	/**
 	 * Types that are referenced in the query
 	 *
-	 * @var array
+	 * @var string[]
 	 */
 	protected $queried_types = [];
 
@@ -50,24 +50,24 @@ class QueryAnalyzer {
 	/**
 	 * Models that are referenced in the query
 	 *
-	 * @var array
+	 * @var string[]
 	 */
 	protected $models = [];
 
 	/**
 	 * Types in the query that are lists
 	 *
-	 * @var array
+	 * @var string[]
 	 */
 	protected $list_types = [];
 
 	/**
-	 * @var array
+	 * @var string[]|int[]
 	 */
 	protected $runtime_nodes = [];
 
 	/**
-	 * @var array
+	 * @var array<string,int[]|string[]>
 	 */
 	protected $runtime_nodes_by_type = [];
 
@@ -92,12 +92,12 @@ class QueryAnalyzer {
 	protected $skipped_keys = '';
 
 	/**
-	 * @var array The GraphQL keys to return in the X-GraphQL-Keys header.
+	 * @var string[] The GraphQL keys to return in the X-GraphQL-Keys header.
 	 */
 	protected $graphql_keys = [];
 
 	/**
-	 * @var array Track all Types that were queried as a list
+	 * @var mixed[] Track all Types that were queried as a list
 	 */
 	protected $queried_list_types = [];
 
@@ -185,7 +185,7 @@ class QueryAnalyzer {
 	 *
 	 * @param ?string                         $query     The GraphQL query
 	 * @param ?string                         $operation The name of the operation
-	 * @param ?array                          $variables Variables to be passed to your GraphQL request
+	 * @param ?array<string,mixed>            $variables Variables to be passed to your GraphQL request
 	 * @param \GraphQL\Server\OperationParams $params The Operation Params. This includes any extra params,
 	 * such as extensions or any other modifications to the request body
 	 *
@@ -221,32 +221,32 @@ class QueryAnalyzer {
 	}
 
 	/**
-	 * @return array
+	 * @return string[]
 	 */
 	public function get_list_types(): array {
 		return array_unique( $this->list_types );
 	}
 
 	/**
-	 * @return array
+	 * @return string[]
 	 */
 	public function get_query_types(): array {
 		return array_unique( $this->queried_types );
 	}
 
 	/**
-	 * @return array
+	 * @return string[]
 	 */
 	public function get_query_models(): array {
 		return array_unique( $this->models );
 	}
 
 	/**
-	 * @return array
+	 * @return string[]|int[]
 	 */
 	public function get_runtime_nodes(): array {
 		/**
-		 * @param array $runtime_nodes Nodes that were resolved during execution
+		 * @param string[]|int[] $runtime_nodes Nodes that were resolved during execution
 		 */
 		$runtime_nodes = apply_filters( 'graphql_query_analyzer_get_runtime_nodes', $this->runtime_nodes );
 
@@ -353,7 +353,7 @@ class QueryAnalyzer {
 	 * @param ?\GraphQL\Type\Schema $schema The WPGraphQL Schema
 	 * @param ?string               $query  The query string
 	 *
-	 * @return array
+	 * @return string[]
 	 * @throws \GraphQL\Error\SyntaxError|\Exception
 	 */
 	public function set_list_types( ?Schema $schema, ?string $query ): array {
@@ -452,7 +452,7 @@ class QueryAnalyzer {
 	 * @param ?\GraphQL\Type\Schema $schema The WPGraphQL Schema
 	 * @param ?string               $query  The query string
 	 *
-	 * @return array
+	 * @return string[]
 	 * @throws \Exception
 	 */
 	public function set_query_types( ?Schema $schema, ?string $query ): array {
@@ -530,7 +530,7 @@ class QueryAnalyzer {
 	 * @param ?\GraphQL\Type\Schema $schema The WPGraphQL Schema
 	 * @param ?string               $query  The query string
 	 *
-	 * @return array
+	 * @return string[]
 	 * @throws \GraphQL\Error\SyntaxError|\Exception
 	 */
 	public function set_query_models( ?Schema $schema, ?string $query ): array {
@@ -629,7 +629,7 @@ class QueryAnalyzer {
 	/**
 	 * Returns graphql keys for use in debugging and headers.
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	public function get_graphql_keys() {
 		if ( ! empty( $this->graphql_keys ) ) {
@@ -736,9 +736,9 @@ class QueryAnalyzer {
 	/**
 	 * Return headers
 	 *
-	 * @param array $headers The array of headers being returned
+	 * @param array<string,mixed> $headers The array of headers being returned
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 */
 	public function get_headers( array $headers = [] ): array {
 		$keys = $this->get_graphql_keys();
@@ -754,13 +754,13 @@ class QueryAnalyzer {
 	/**
 	 * Outputs Query Analyzer data in the extensions response
 	 *
-	 * @param mixed               $response
-	 * @param \WPGraphQL\WPSchema $schema The WPGraphQL Schema
-	 * @param string|null         $operation_name The operation name being executed
-	 * @param string|null         $request        The GraphQL Request being made
-	 * @param array|null          $variables      The variables sent with the request
+	 * @param mixed                    $response
+	 * @param \WPGraphQL\WPSchema      $schema         The WPGraphQL Schema
+	 * @param string|null              $operation_name The operation name being executed
+	 * @param string|null              $request        The GraphQL Request being made
+	 * @param array<string,mixed>|null $variables      The variables sent with the request
 	 *
-	 * @return array|object|null
+	 * @return array<string,mixed>|object|null
 	 */
 	public function show_query_analyzer_in_extensions( $response, WPSchema $schema, ?string $operation_name, ?string $request, ?array $variables ) {
 		$should = \WPGraphQL::debug();
@@ -770,7 +770,7 @@ class QueryAnalyzer {
 		 * @param mixed       $response       The response of the WPGraphQL Request being executed
 		 * @param \WPGraphQL\WPSchema $schema The WPGraphQL Schema
 		 * @param string|null $operation_name The operation name being executed
-		 * @param string|null      $request        The GraphQL Request being made
+		 * @param string|null $request        The GraphQL Request being made
 		 * @param array|null  $variables      The variables sent with the request
 		 */
 		$should_show_query_analyzer_in_extensions = apply_filters( 'graphql_should_show_query_analyzer_in_extensions', $should, $response, $schema, $operation_name, $request, $variables );

--- a/src/Utils/QueryLog.php
+++ b/src/Utils/QueryLog.php
@@ -12,7 +12,7 @@ class QueryLog {
 	/**
 	 * Whether Query Logs are enabled
 	 *
-	 * @var boolean
+	 * @var bool
 	 */
 	protected $query_logs_enabled;
 
@@ -60,7 +60,7 @@ class QueryLog {
 	/**
 	 * Determine if the requesting user can see logs
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function user_can_see_logs() {
 		$can_see = false;
@@ -85,7 +85,7 @@ class QueryLog {
 		/**
 		 * Filter whether the logs can be seen in the request results or not
 		 *
-		 * @param boolean $can_see Whether the requester can see the logs or not
+		 * @param bool $can_see Whether the requester can see the logs or not
 		 */
 		return apply_filters( 'graphql_user_can_see_query_logs', $can_see );
 	}

--- a/src/Utils/QueryLog.php
+++ b/src/Utils/QueryLog.php
@@ -97,9 +97,9 @@ class QueryLog {
 	 * @param \WPGraphQL\WPSchema $schema The WPGraphQL Schema
 	 * @param string              $operation_name The operation name being executed
 	 * @param string              $request        The GraphQL Request being made
-	 * @param array               $variables      The variables sent with the request
+	 * @param array<string,mixed> $variables      The variables sent with the request
 	 *
-	 * @return array
+	 * @return mixed[]
 	 */
 	public function show_results( $response, $schema, $operation_name, $request, $variables ) {
 		$query_log = $this->get_query_log();
@@ -124,7 +124,7 @@ class QueryLog {
 	/**
 	 * Return the query log produced from the logs stored by WPDB.
 	 *
-	 * @return array
+	 * @return mixed[]
 	 */
 	public function get_query_log() {
 		global $wpdb;

--- a/src/Utils/Tracing.php
+++ b/src/Utils/Tracing.php
@@ -217,7 +217,7 @@ class Tracing {
 	 *
 	 * @param mixed $input The input to sanitize
 	 *
-	 * @return int|null|string
+	 * @return int|string|null
 	 */
 	public static function sanitize_trace_resolver_path( $input ) {
 		$sanitized_input = null;

--- a/src/Utils/Tracing.php
+++ b/src/Utils/Tracing.php
@@ -24,7 +24,7 @@ class Tracing {
 	/**
 	 * Stores the logs for the trace
 	 *
-	 * @var array
+	 * @var array<string,mixed>[]
 	 */
 	public $trace_logs = [];
 
@@ -59,7 +59,7 @@ class Tracing {
 	/**
 	 * The trace for the current field being resolved
 	 *
-	 * @var array
+	 * @var array<string,mixed>
 	 */
 	public $field_trace = [];
 
@@ -136,7 +136,7 @@ class Tracing {
 	 * Initialize tracing for an individual field
 	 *
 	 * @param mixed                                $source         The source passed down the Resolve Tree
-	 * @param array                                $args           The args for the field
+	 * @param array<string,mixed>                  $args           The args for the field
 	 * @param \WPGraphQL\AppContext                $context The AppContext passed down the ResolveTree
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the ResolveTree
 	 *
@@ -190,9 +190,9 @@ class Tracing {
 	/**
 	 * Given a trace, sanitizes the values and returns the sanitized_trace
 	 *
-	 * @param array $trace
+	 * @param array<string,mixed> $trace
 	 *
-	 * @return mixed
+	 * @return array<string,mixed>
 	 */
 	public function sanitize_resolver_trace( array $trace ) {
 		$sanitized_trace                = [];
@@ -250,22 +250,22 @@ class Tracing {
 	 * Filter the headers that WPGraphQL returns to include headers that indicate the WPGraphQL
 	 * server supports Apollo Tracing and Credentials
 	 *
-	 * @param array $headers The headers to return
+	 * @param string[] $headers The headers to return
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	public function return_tracing_headers( array $headers ) {
 		$headers[] = 'X-Insights-Include-Tracing';
 		$headers[] = 'X-Apollo-Tracing';
 		$headers[] = 'Credentials';
 
-		return (array) $headers;
+		return $headers;
 	}
 
 	/**
 	 * Filter the results of the GraphQL Response to include the Query Log
 	 *
-	 * @param mixed|array|object $response       The response of the GraphQL Request
+	 * @param mixed|array<string,mixed>|object $response       The response of the GraphQL Request
 	 *
 	 * @return mixed $response
 	 */
@@ -332,7 +332,7 @@ class Tracing {
 	/**
 	 * Get the trace to add to the response
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 */
 	public function get_trace(): array {
 
@@ -350,9 +350,9 @@ class Tracing {
 		/**
 		 * Filter the trace
 		 *
-		 * @param array   $trace     The trace to return
+		 * @param array<string,mixed>      $trace     The trace to return
 		 * @param \WPGraphQL\Utils\Tracing $instance The Tracing class instance
 		 */
-		return apply_filters( 'graphql_tracing_response', (array) $trace, $this );
+		return apply_filters( 'graphql_tracing_response', $trace, $this );
 	}
 }

--- a/src/Utils/Tracing.php
+++ b/src/Utils/Tracing.php
@@ -17,7 +17,7 @@ class Tracing {
 	/**
 	 * Whether Tracing is enabled
 	 *
-	 * @var boolean
+	 * @var bool
 	 */
 	public $tracing_enabled;
 
@@ -324,7 +324,7 @@ class Tracing {
 		/**
 		 * Filter whether the logs can be seen in the request results or not
 		 *
-		 * @param boolean $can_see Whether the requester can see the logs or not
+		 * @param bool $can_see Whether the requester can see the logs or not
 		 */
 		return apply_filters( 'graphql_user_can_see_trace_data', $can_see );
 	}

--- a/src/Utils/Tracing.php
+++ b/src/Utils/Tracing.php
@@ -301,8 +301,6 @@ class Tracing {
 
 	/**
 	 * Determine if the requesting user can see trace data
-	 *
-	 * @return boolean
 	 */
 	public function user_can_see_trace_data(): bool {
 		$can_see = false;

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -127,7 +127,7 @@ class Utils {
 		 *
 		 * Useful for providing custom transliteration rules that will convert non ASCII characters to ASCII.
 		 *
-		 * @param null|string $formatted_name The name to format. If not null, the result will be returned as the formatted name.
+		 * @param string|null $formatted_name The name to format. If not null, the result will be returned as the formatted name.
 		 * @param string $original_name       The name to format.
 		 * @param string $replacement         The replacement character for invalid characters. Defaults to '_'.
 		 * @param string $regex               The regex to use to match invalid characters. Defaults to '/[^A-Za-z0-9_]/i'.

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -34,11 +34,11 @@ class Utils {
 	/**
 	 * Maps new input query args and sanitizes the input
 	 *
-	 * @param mixed|array|string $args The raw query args from the GraphQL query
-	 * @param mixed|array|string $map  The mapping of where each of the args should go
-	 * @param string[]           $skip Fields to skipped and not be added to the output array.
+	 * @param mixed|mixed[]|string $args The raw query args from the GraphQL query
+	 * @param mixed|mixed[]|string $map  The mapping of where each of the args should go
+	 * @param string[]             $skip Fields to skipped and not be added to the output array.
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 * @since  0.5.0
 	 */
 	public static function map_input( $args, $map, $skip = [] ) {
@@ -253,7 +253,7 @@ class Utils {
 	/**
 	 * Helper function that defines the allowed HTML to use on the Settings pages
 	 *
-	 * @return array
+	 * @return array<string,array<string,mixed>>
 	 */
 	public static function get_allowed_wp_kses_html() {
 		$allowed_atts = [
@@ -352,7 +352,7 @@ class Utils {
 	 *
 	 * @param int|string $id The encoded Node ID.
 	 *
-	 * @return bool|null
+	 * @return ?string
 	 */
 	public static function get_node_type_from_id( $id ) {
 		if ( is_numeric( $id ) ) {

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -171,8 +171,6 @@ class Utils {
 	 *
 	 * @param string $field_name         The field name to format
 	 * @param bool   $allow_underscores  Whether the field should be formatted with underscores allowed. Default false.
-	 *
-	 * @return string
 	 */
 	public static function format_field_name( string $field_name, bool $allow_underscores = false ): string {
 		// Bail if empty.

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -510,8 +510,7 @@ final class WPGraphQL {
 	 * This gets all post_types that are set to show_in_graphql, but allows for external code
 	 * (plugins/theme) to filter the list of allowed_post_types to add/remove additional post_types
 	 *
-	 * @param string|mixed[]      $output Optional. The type of output to return. Accepts post type
-	 *                                  'names' or 'objects'. Default 'names'.
+	 * @param string|mixed[]      $output Optional. The type of output to return. Accepts post type 'names' or 'objects'. Default 'names'.
 	 * @param array<string,mixed> $args   Optional. Arguments to filter allowed post types
 	 *
 	 * @return array<string,mixed>

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -61,7 +61,7 @@ final class WPGraphQL {
 	protected static $allowed_taxonomies;
 
 	/**
-	 * @var boolean
+	 * @var bool
 	 */
 	protected static $is_graphql_request;
 

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -33,14 +33,14 @@ final class WPGraphQL {
 	/**
 	 * Holds the Schema def
 	 *
-	 * @var mixed|null|\WPGraphQL\WPSchema $schema The Schema used for the GraphQL API
+	 * @var mixed|\WPGraphQL\WPSchema|null $schema The Schema used for the GraphQL API
 	 */
 	protected static $schema;
 
 	/**
 	 * Holds the TypeRegistry instance
 	 *
-	 * @var mixed|null|\WPGraphQL\Registry\TypeRegistry $type_registry The registry that holds all GraphQL Types
+	 * @var mixed|\WPGraphQL\Registry\TypeRegistry|null $type_registry The registry that holds all GraphQL Types
 	 */
 	protected static $type_registry;
 
@@ -787,7 +787,7 @@ final class WPGraphQL {
 	/**
 	 * Return the static schema if there is one
 	 *
-	 * @return null|string
+	 * @return string|null
 	 */
 	public static function get_static_schema() {
 		$schema = null;

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -366,10 +366,10 @@ final class WPGraphQL {
 	/**
 	 * Sets up the default post types to show_in_graphql.
 	 *
-	 * @param array  $args      Array of arguments for registering a post type.
-	 * @param string $post_type Post type key.
+	 * @param array<string,mixed> $args      Array of arguments for registering a post type.
+	 * @param string              $post_type Post type key.
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 */
 	public static function setup_default_post_types( $args, $post_type ) {
 		// Adds GraphQL support for attachments.
@@ -393,10 +393,10 @@ final class WPGraphQL {
 	/**
 	 * Sets up the default taxonomies to show_in_graphql.
 	 *
-	 * @param array  $args     Array of arguments for registering a taxonomy.
-	 * @param string $taxonomy Taxonomy key.
+	 * @param array<string,mixed> $args     Array of arguments for registering a taxonomy.
+	 * @param string              $taxonomy Taxonomy key.
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 * @since 1.12.0
 	 */
 	public static function setup_default_taxonomies( $args, $taxonomy ) {
@@ -421,10 +421,10 @@ final class WPGraphQL {
 	/**
 	 * Set the GraphQL Post Type Args and pass them through a filter.
 	 *
-	 * @param array  $args           The graphql specific args for the post type
-	 * @param string $post_type_name The name of the post type being registered
+	 * @param array<string,mixed> $args           The graphql specific args for the post type
+	 * @param string              $post_type_name The name of the post type being registered
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 * @throws \Exception
 	 * @since 1.12.0
 	 */
@@ -450,10 +450,10 @@ final class WPGraphQL {
 	/**
 	 * Set the GraphQL Taxonomy Args and pass them through a filter.
 	 *
-	 * @param array  $args          The graphql specific args for the taxonomy
-	 * @param string $taxonomy_name The name of the taxonomy being registered
+	 * @param array<string,mixed> $args          The graphql specific args for the taxonomy
+	 * @param string              $taxonomy_name The name of the taxonomy being registered
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 * @throws \Exception
 	 * @since 1.12.0
 	 */
@@ -480,6 +480,8 @@ final class WPGraphQL {
 	 * This sets the post type /taxonomy GraphQL properties.
 	 *
 	 * @since 1.12.0
+	 *
+	 * @return array<string,mixed>
 	 */
 	public static function get_default_graphql_type_args(): array {
 		return [
@@ -508,11 +510,11 @@ final class WPGraphQL {
 	 * This gets all post_types that are set to show_in_graphql, but allows for external code
 	 * (plugins/theme) to filter the list of allowed_post_types to add/remove additional post_types
 	 *
-	 * @param string|array $output Optional. The type of output to return. Accepts post type
-	 *                             'names' or 'objects'. Default 'names'.
-	 * @param array        $args   Optional. Arguments to filter allowed post types
+	 * @param string|mixed[]      $output Optional. The type of output to return. Accepts post type
+	 *                                  'names' or 'objects'. Default 'names'.
+	 * @param array<string,mixed> $args   Optional. Arguments to filter allowed post types
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 * @since  0.0.4
 	 * @since  1.8.1 adds $output as first param, and stores post type objects in class property.
 	 */
@@ -602,10 +604,10 @@ final class WPGraphQL {
 	 * (plugins/themes) to filter the list of allowed_taxonomies to add/remove additional
 	 * taxonomies
 	 *
-	 * @param string $output Optional. The type of output to return. Accepts taxonomy 'names' or 'objects'. Default 'names'.
-	 * @param array  $args   Optional. Arguments to filter allowed taxonomies.
+	 * @param string              $output Optional. The type of output to return. Accepts taxonomy 'names' or 'objects'. Default 'names'.
+	 * @param array<string,mixed> $args   Optional. Arguments to filter allowed taxonomies.
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 * @since  0.0.4
 	 */
 	public static function get_allowed_taxonomies( $output = 'names', $args = [] ) {

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -124,7 +124,6 @@ final class WPGraphQL {
 	 * Include required files.
 	 * Uses composer's autoload
 	 *
-	 * @return void
 	 * @since  0.0.1
 	 */
 	private function includes(): void {
@@ -151,8 +150,6 @@ final class WPGraphQL {
 	/**
 	 * Sets up actions to run at certain spots throughout WordPress and the WPGraphQL execution
 	 * cycle
-	 *
-	 * @return void
 	 */
 	private function actions(): void {
 		/**
@@ -285,8 +282,6 @@ final class WPGraphQL {
 
 	/**
 	 * Setup filters
-	 *
-	 * @return void
 	 */
 	private function filters(): void {
 		// Filter the post_types and taxonomies to show in the GraphQL Schema
@@ -737,8 +732,6 @@ final class WPGraphQL {
 
 	/**
 	 * Whether WPGraphQL is operating in Debug mode
-	 *
-	 * @return bool
 	 */
 	public static function debug(): bool {
 		if ( defined( 'GRAPHQL_DEBUG' ) ) {

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -34,8 +34,6 @@ if ( file_exists( __DIR__ . '/c3.php' ) ) {
 
 /**
  * Load files that are required even if the composer autoloader isn't installed
- *
- * @return void
  */
 function graphql_require_bootstrap_files(): void {
 	if ( file_exists( __DIR__ . '/constants.php' ) ) {
@@ -70,8 +68,6 @@ function graphql_require_bootstrap_files(): void {
  * Normal (.org repo install)
  * - WPGRAPHQL_AUTOLOAD: not defined
  * - composer deps installed INSIDE the plugin
- *
- * @return bool
  */
 function graphql_can_load_plugin(): bool {
 
@@ -143,8 +139,6 @@ register_activation_hook( __FILE__, 'graphql_activation_callback' );
 
 /**
  * Render an admin notice if the plugin cannot load
- *
- * @return void
  */
 function graphql_cannot_load_admin_notice_callback(): void {
 	if ( ! current_user_can( 'manage_options' ) ) {


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR implements stricter phpdoc type hinting, and adds the `SlevomatCodingStandard.TypeHints`.

The primary change here is replacing the use of `array` with a traversable type (e.g. `string[]`, `array<int|string,string|array<mixed>>` etc). Additionally, more overloaded methods now use `{@inheritDoc}`, and there are some auto-fixable formatting patterns (e.g. using the short type name instead of the long syntax) to make the codebase easier to dedupe/refactor.

As a result of these changes, we were also able to change the phpstan ruleset to scan for valid traversable types.

**Note: No production code has been changed.**

Based on (and requires) #2976 . ([Filtered diff of this PR](https://github.com/wp-graphql/wp-graphql/pull/2978/files/8c8b0958ecc46817eadf12cb7008171043be41e7..f562b373de8e3b0990827416fea81772905c2af7))

Does this close any currently open issues?
------------------------------------------
<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
<!-- (If it’s long, please paste to https://ghostbin.com/ and insert the link here.) -->


Any other comments?
-------------------
- No real attempts were made to decrease type specificity from unions or `mixed` types. This sort of refactor work would be a huge code quality win but is a huge endeavor that will require code changes and should be broken up over several PRs.
- The fixed types will likely cause phpcs/phpstan smells in downstream projects, but _this is a good thing_ as it means they're now being notified that they're doing something that was _already_ wrong. Since only phpdocs have been altered these are _not_ breaking changes.


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php8.1.15)

**WordPress Version:** 6.3.2
