### PR TITLE
ci: run tests against WordPress 6.4

### DIFF
--- a/.github/workflows/graphiql-e2e-tests.yml
+++ b/.github/workflows/graphiql-e2e-tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['16']
+        node: ['16.13.0']
 
     steps:
       - name: Cancel previous runs of this workflow (pull requests only)

--- a/.github/workflows/graphiql-e2e-tests.yml
+++ b/.github/workflows/graphiql-e2e-tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['14']
+        node: ['16']
 
     steps:
       - name: Cancel previous runs of this workflow (pull requests only)

--- a/.github/workflows/testing-integration.yml
+++ b/.github/workflows/testing-integration.yml
@@ -27,8 +27,8 @@ jobs:
           - php: '8.1'
             wordpress: '6.2'
             multisite: true
-          - php: '8.1'
-            wordpress: '6.2'
+          - php: '8.2'
+            wordpress: '6.4'
             coverage: 1
           - php: '8.1'
             wordpress: '6.0'

--- a/package-lock.json
+++ b/package-lock.json
@@ -33075,8 +33075,8 @@
         "@types/react-dom": "^17.0.11",
         "@wordpress/escape-html": "^2.13.0",
         "lodash": "^4.17.21",
-        "react": "18.2.0",
-        "react-dom": "18.2.0"
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2"
       },
       "dependencies": {
         "@types/react-dom": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: jasonbahl, tylerbarnes1, ryankanner, hughdevore, chopinbach, kidunot89
 Tags: GraphQL, JSON, API, Gatsby, Faust, Headless, Decoupled, Svelte, React, Nextjs, Vue, Apollo, REST, JSON, HTTP, Remote, Query Language
 Requires at least: 5.0
-Tested up to: 6.2
+Tested up to: 6.4
 Requires PHP: 7.1
 Stable tag: 1.18.0
 License: GPL-3

--- a/tests/e2e/setup-test-framework.js
+++ b/tests/e2e/setup-test-framework.js
@@ -249,7 +249,7 @@ beforeAll( async () => {
     enablePageDialogAccept();
     observeConsoleLogging();
     await simulateAdverseConditions();
-    await activateTheme( 'twentytwentyone' );
+    await activateTheme( 'twentytwentythree' );
     await trashAllPosts();
     await trashAllPosts( 'wp_block' );
     await setupBrowser();

--- a/tests/wpunit/PostTypeObjectQueriesTest.php
+++ b/tests/wpunit/PostTypeObjectQueriesTest.php
@@ -163,8 +163,8 @@ class PostTypeObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 								'labels'              => [
 									'name'                => 'Posts',
 									'singularName'        => 'Post',
-									'addNew'              => 'Add New',
-									'addNewItem'          => 'Add New Post',
+									'addNew'              => $post_type_object->labels->add_new,
+									'addNewItem'          => $post_type_object->labels->add_new_item,
 									'editItem'            => 'Edit Post',
 									'newItem'             => 'New Post',
 									'viewItem'            => 'View Post',

--- a/tests/wpunit/ThemeObjectQueriesTest.php
+++ b/tests/wpunit/ThemeObjectQueriesTest.php
@@ -86,7 +86,7 @@ class ThemeObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		$expected = [
 			'theme' => [
 				'author'      => $theme->author,
-				'authorUri'   => 'https://wordpress.org/',
+				'authorUri'   => $theme->get( 'AuthorURI' ),
 				'description' => $theme->description,
 				'id'          => $active_global_id,
 				'name'        => $theme->get( 'Name' ),

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -10,7 +10,7 @@
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
- * Tested up to: 6.2
+ * Tested up to: 6.4
  * Requires PHP: 7.1
  * License: GPL-3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Updates the test matrix to run tests against WP 6.4 and updates README and main plugin file to indicate that.

Does this close any currently open issues?
------------------------------------------
closes #2983 