### PR TITLE
release: v1.18.1

### DIFF
--- a/.github/workflows/graphiql-e2e-tests.yml
+++ b/.github/workflows/graphiql-e2e-tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['14']
+        node: ['16.13.0']
 
     steps:
       - name: Cancel previous runs of this workflow (pull requests only)

--- a/.github/workflows/testing-integration.yml
+++ b/.github/workflows/testing-integration.yml
@@ -27,8 +27,8 @@ jobs:
           - php: '8.1'
             wordpress: '6.2'
             multisite: true
-          - php: '8.1'
-            wordpress: '6.2'
+          - php: '8.2'
+            wordpress: '6.4'
             coverage: 1
           - php: '8.1'
             wordpress: '6.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.18.1
+
+### Chores / Bugfixes
+
+- [#2984](https://github.com/wp-graphql/wp-graphql/pull/2984): ci: update tests to run against WordPress 6.4. Update README, plugin file's "tested up to" to reflect.
+
 ## 1.18.0
 
 ### New Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -33075,8 +33075,8 @@
         "@types/react-dom": "^17.0.11",
         "@wordpress/escape-html": "^2.13.0",
         "lodash": "^4.17.21",
-        "react": "18.2.0",
-        "react-dom": "18.2.0"
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2"
       },
       "dependencies": {
         "@types/react-dom": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: jasonbahl, tylerbarnes1, ryankanner, hughdevore, chopinbach, kidunot89
 Tags: GraphQL, JSON, API, Gatsby, Faust, Headless, Decoupled, Svelte, React, Nextjs, Vue, Apollo, REST, JSON, HTTP, Remote, Query Language
 Requires at least: 5.0
-Tested up to: 6.2
+Tested up to: 6.4
 Requires PHP: 7.1
 Stable tag: 1.18.1
 License: GPL-3

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, JSON, API, Gatsby, Faust, Headless, Decoupled, Svelte, React, Nex
 Requires at least: 5.0
 Tested up to: 6.2
 Requires PHP: 7.1
-Stable tag: 1.18.0
+Stable tag: 1.18.1
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -251,6 +251,13 @@ The `uri` field was non-null on some Types in the Schema but has been changed to
 Composer dependencies are no longer versioned in Github. Recommended install source is WordPress.org or using Composer to get the code from Packagist.org or WPackagist.org.
 
 == Changelog ==
+
+= 1.18.1 =
+
+**Chores / Bugfixes**
+
+- [#2984](https://github.com/wp-graphql/wp-graphql/pull/2984): ci: update tests to run against WordPress 6.4. Update README, plugin file's "tested up to" to reflect.
+
 
 = 1.18.0 =
 

--- a/tests/e2e/setup-test-framework.js
+++ b/tests/e2e/setup-test-framework.js
@@ -249,7 +249,7 @@ beforeAll( async () => {
     enablePageDialogAccept();
     observeConsoleLogging();
     await simulateAdverseConditions();
-    await activateTheme( 'twentytwentyone' );
+    await activateTheme( 'twentytwentythree' );
     await trashAllPosts();
     await trashAllPosts( 'wp_block' );
     await setupBrowser();

--- a/tests/wpunit/PostTypeObjectQueriesTest.php
+++ b/tests/wpunit/PostTypeObjectQueriesTest.php
@@ -163,8 +163,8 @@ class PostTypeObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 								'labels'              => [
 									'name'                => 'Posts',
 									'singularName'        => 'Post',
-									'addNew'              => 'Add New',
-									'addNewItem'          => 'Add New Post',
+									'addNew'              => $post_type_object->labels->add_new,
+									'addNewItem'          => $post_type_object->labels->add_new_item,
 									'editItem'            => 'Edit Post',
 									'newItem'             => 'New Post',
 									'viewItem'            => 'View Post',

--- a/tests/wpunit/ThemeObjectQueriesTest.php
+++ b/tests/wpunit/ThemeObjectQueriesTest.php
@@ -86,7 +86,7 @@ class ThemeObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		$expected = [
 			'theme' => [
 				'author'      => $theme->author,
-				'authorUri'   => 'https://wordpress.org/',
+				'authorUri'   => $theme->get( 'AuthorURI' ),
 				'description' => $theme->description,
 				'id'          => $active_global_id,
 				'name'        => $theme->get( 'Name' ),

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -10,7 +10,7 @@
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
- * Tested up to: 6.2
+ * Tested up to: 6.4
  * Requires PHP: 7.1
  * License: GPL-3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.18.0
+ * Version: 1.18.1
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.18.0
+ * @version  1.18.1
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
# Release Notes

## Chores / Bugfixes

- [#2984](https://github.com/wp-graphql/wp-graphql/pull/2984): ci: update tests to run against WordPress 6.4. Update README, plugin file's "tested up to" to reflect.
