### PR TITLE
release: v1.18.2

### DIFF
--- a/.github/workflows/deploy-docker-image.yml
+++ b/.github/workflows/deploy-docker-image.yml
@@ -21,6 +21,8 @@ jobs:
           - php: '8.2'
             wordpress: '6.2'
           - php: '8.2'
+            wordpress: '6.4.1'
+          - php: '8.2'
             wordpress: '6.3'
           - php: '8.1'
             wordpress: '6.3'

--- a/.github/workflows/deploy-docker-image.yml
+++ b/.github/workflows/deploy-docker-image.yml
@@ -21,7 +21,7 @@ jobs:
           - php: '8.2'
             wordpress: '6.2'
           - php: '8.2'
-            wordpress: '6.4.1'
+            wordpress: '6.4.0'
           - php: '8.2'
             wordpress: '6.3'
           - php: '8.1'

--- a/.github/workflows/testing-integration.yml
+++ b/.github/workflows/testing-integration.yml
@@ -28,7 +28,7 @@ jobs:
             wordpress: '6.2'
             multisite: true
           - php: '8.2'
-            wordpress: '6.4.1'
+            wordpress: '6.4.0'
             coverage: 1
           - php: '8.1'
             wordpress: '6.0'

--- a/.github/workflows/testing-integration.yml
+++ b/.github/workflows/testing-integration.yml
@@ -28,7 +28,7 @@ jobs:
             wordpress: '6.2'
             multisite: true
           - php: '8.2'
-            wordpress: '6.4'
+            wordpress: '6.4.1'
             coverage: 1
           - php: '8.1'
             wordpress: '6.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.18.2
+
+### Chores / Bugfixes
+
+- ci: update tests to run against WordPress 6.4.1. Update Docker Deploy to include WP 6.4.1. Update README, plugin file's "tested up to" to reflect.
+
+
 ## 1.18.1
 
 ### Chores / Bugfixes

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: jasonbahl, tylerbarnes1, ryankanner, hughdevore, chopinbach, kidunot89
 Tags: GraphQL, JSON, API, Gatsby, Faust, Headless, Decoupled, Svelte, React, Nextjs, Vue, Apollo, REST, JSON, HTTP, Remote, Query Language
 Requires at least: 5.0
-Tested up to: 6.4
+Tested up to: 6.4.1
 Requires PHP: 7.1
-Stable tag: 1.18.1
+Stable tag: 1.18.2
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -251,6 +251,12 @@ The `uri` field was non-null on some Types in the Schema but has been changed to
 Composer dependencies are no longer versioned in Github. Recommended install source is WordPress.org or using Composer to get the code from Packagist.org or WPackagist.org.
 
 == Changelog ==
+
+= 1.18.2 =
+
+**Chores / Bugfixes**
+
+- ci: update tests to run against WordPress 6.4.1. Update Docker Deploy to include WP 6.4.1. Update README, plugin file's "tested up to" to reflect.
 
 = 1.18.1 =
 

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,11 +6,11 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.18.1
+ * Version: 1.18.2
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
- * Tested up to: 6.4
+ * Tested up to: 6.4.1
  * Requires PHP: 7.1
  * License: GPL-3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.18.1
+ * @version  1.18.2
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
# Release Notes

## Chores / Bugfixes

- ci: update tests to run against WordPress 6.4.1. Update Docker Deploy to include WP 6.4.1. Update README, plugin file's "tested up to" to reflect.