### PR TITLE
fix: make `User.url` public

### DIFF
--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -80,6 +80,7 @@ class User extends Model {
 			'description',
 			'slug',
 			'uri',
+			'url',
 			'enqueuedScriptsQueue',
 			'enqueuedStylesheetsQueue',
 		];

--- a/tests/wpunit/UserObjectQueriesTest.php
+++ b/tests/wpunit/UserObjectQueriesTest.php
@@ -55,14 +55,9 @@ class UserObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase 
 		$args = array_merge( $defaults, $args );
 
 		/**
-		 * Create the page
+		 * Create the user.
 		 */
-		$user_id = $this->factory()->user->create( $args );
-
-		/**
-		 * Return the $id of the post_object that was created
-		 */
-		return $user_id;
+		return $this->factory()->user->create( $args );
 	}
 
 	/**
@@ -304,11 +299,19 @@ class UserObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase 
 	 * @since 0.0.5
 	 */
 	public function testWithPosts() {
+		$user_args = [
+			'description' => 'This is a test user.',
+			'first_name'  => 'Test',
+			'nickname'    => 'test', // private
+			'user_url'    => 'https://example.com',
+		];
 
 		/**
 		 * Create a user
 		 */
-		$user_id = $this->createUserObject();
+		$user_id = $this->createUserObject( $user_args );
+		$user    = get_user_by( 'id', $user_id );
+
 
 		$post_id = $this->factory->post->create( [ 'post_author' => $user_id ] );
 
@@ -323,30 +326,70 @@ class UserObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase 
 		$query = "
 		query {
 			user(id: \"{$global_id}\") {
+				avatar {
+					size
+				}
+				capKey
+				capabilities
+				description
+				email
+				extraCapabilities
+				firstName
+				id
+				locale
+				name
+				nickname
 				posts {
 					edges {
 						node {
-							postId
+							databaseId
 						}
 					}
 				}
+				registeredDate
+				roles {
+					nodes {
+						name
+					}
+				}
+				slug
+				url
+				username
 			}
 		}";
 
-		/// Run the graphql query as a logged out user.
+		// Run the graphql query as a logged out user.
 		$actual = $this->graphql( compact( 'query' ) );
 
 		$expected = [
 			'user' => [
-				'posts' => [
+				'avatar'            => [
+					'size' => 96,
+				],
+				'capKey'            => null,
+				'capabilities'      => null,
+				'description'       => $user_args['description'],
+				'email'             => null,
+				'extraCapabilities' => null,
+				'firstName'         => $user_args['first_name'],
+				'id'                => $global_id,
+				'locale'            => null,
+				'name'              => $user->data->display_name,
+				'nickname'          => null,
+				'posts'             => [
 					'edges' => [
 						[
 							'node' => [
-								'postId' => $post_id,
+								'databaseId' => $post_id,
 							],
 						],
 					],
 				],
+				'registeredDate'    => null,
+				'roles'             => null,
+				'slug'              => $user->data->user_nicename,
+				'url'               => $user_args['user_url'],
+				'username'          => null,
 			],
 		];
 


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR makes the `User.url` field public, as it is intended to be public (and is so on the REST API).

Tests have been updated to check for public/private fields on an unauthenticated query of a `user`.


Does this close any currently open issues?
------------------------------------------
<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Fixes #2766 

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
<!-- (If it’s long, please paste to https://ghostbin.com/ and insert the link here.) -->


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 +devilbox + php 8.1.15)

**WordPress Version:** 6.4.1
