### PR TITLE
refactor: rearranged params/arguments for consistency sake in filters

### DIFF
--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -430,7 +430,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		 * @return array
 		 * @since 0.0.5
 		 */
-		$query_args = apply_filters( 'graphql_map_input_fields_to_wp_query', $query_args, $where_args, $this->source, $this->args, $this->context, $this->info, $this->post_type );
+		$query_args = apply_filters( 'graphql_map_input_fields_to_wp_query', $query_args, $where_args, $this->post_type, $this->source, $this->args, $this->context, $this->info );
 
 		/**
 		 * Return the Query Args


### PR DESCRIPTION
**What does this implement/fix? Explain your changes.**
 This PR fixes the inconsistency of the  graphql_map_input_fields_* filters .
Fixes #1588


**Does this close any currently open issues?**
It closes #{1588}





**Any other comments?**
I rearranged the $post_type parameter in graphql_map_input_fields_to_wp_query filter for the consistency sake with the rest of filters. I switched its position from last to third from the beginning.This makes all the filters to have $context and $info as the last two parameters making it consistent.



**Operating System:** macOS

**WordPress Version:**6.2


