### PR TITLE
fix: replace deprecated `AbstractConnectionResolver::setQueryArg()` call with `::set_query_arg()`

### DIFF
--- a/src/Type/Connection/Taxonomies.php
+++ b/src/Type/Connection/Taxonomies.php
@@ -35,7 +35,7 @@ class Taxonomies {
 						return null;
 					}
 					$resolver = new TaxonomyConnectionResolver( $source, $args, $context, $info );
-					$resolver->setQueryArg( 'in', $source->taxonomies );
+					$resolver->set_query_arg( 'in', $source->taxonomies );
 					return $resolver->get_connection();
 				},
 			]


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR replaces the deprecated call to `AbstractConnectionResolver::setQueryArg()` in `ContentType.connectedTaxonomies` resolver with `AbstractConnectionResolver::set_query_arg()`.


Does this close any currently open issues?
------------------------------------------
<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
<!-- (If it’s long, please paste to https://ghostbin.com/ and insert the link here.) -->


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php8.1.15)

**WordPress Version:** 6.4.2
