### PR TITLE
perf: Expose `graphql_should_analyze_queries` as setting

### DIFF
--- a/activation.php
+++ b/activation.php
@@ -12,40 +12,6 @@ function graphql_activation_callback() {
 		return;
 	}
 
-	// Run any activation scripts before updating the version.
-	graphql_migrate_1_20_0();
-
 	// store the current version of WPGraphQL
 	update_option( 'wp_graphql_version', WPGRAPHQL_VERSION );
-}
-
-
-/**
- * Handles compatibility when updating from pre-v1.20.0 versions of WPGraphQL.
- *
- * @todo Remove this function in v2.0.0, when the default value for `query_analyzer_enabled` is set to `true`.
- */
-function graphql_migrate_1_20_0(): void {
-	// If the version is already set, we don't need to do anything.
-	$version = get_option( 'wp_graphql_version' );
-	if ( ! $version ) {
-		return;
-	}
-
-	// If the previous version is higher than 1.20.0, we don't need to do anything.
-	if ( version_compare( $version, '1.20.0', '>=' ) ) {
-		return;
-	}
-
-	/**
-	 * Set `query_analyzer_enabled` to `true` for preexisting installs.
-	 *
-	 * This is to prevent breaking changes in caching solutions that rely on the Query Analyzer, but aren't insuring that the `graphql_should_analyze_queries` filter is set to true.
-	 */
-
-	$graphql_settings = get_option( 'graphql_general_settings', [] );
-
-	$graphql_settings['query_analyzer_enabled'] = 'on';
-
-	update_option( 'graphql_general_settings', $graphql_settings );
 }

--- a/activation.php
+++ b/activation.php
@@ -12,6 +12,40 @@ function graphql_activation_callback() {
 		return;
 	}
 
+	// Run any activation scripts before updating the version.
+	graphql_migrate_1_20_0();
+
 	// store the current version of WPGraphQL
 	update_option( 'wp_graphql_version', WPGRAPHQL_VERSION );
+}
+
+
+/**
+ * Handles compatibility when updating from pre-v1.20.0 versions of WPGraphQL.
+ *
+ * @todo Remove this function in v2.0.0, when the default value for `query_analyzer_enabled` is set to `true`.
+ */
+function graphql_migrate_1_20_0(): void {
+	// If the version is already set, we don't need to do anything.
+	$version = get_option( 'wp_graphql_version' );
+	if ( ! $version ) {
+		return;
+	}
+
+	// If the previous version is higher than 1.20.0, we don't need to do anything.
+	if ( version_compare( $version, '1.20.0', '>=' ) ) {
+		return;
+	}
+
+	/**
+	 * Set `query_analyzer_enabled` to `true` for preexisting installs.
+	 *
+	 * This is to prevent breaking changes in caching solutions that rely on the Query Analyzer, but aren't insuring that the `graphql_should_analyze_queries` filter is set to true.
+	 */
+
+	$graphql_settings = get_option( 'graphql_general_settings' );
+
+	$graphql_settings['query_analyzer_enabled'] = 'on';
+
+	update_option( 'graphql_general_settings', $graphql_settings );
 }

--- a/activation.php
+++ b/activation.php
@@ -43,7 +43,7 @@ function graphql_migrate_1_20_0(): void {
 	 * This is to prevent breaking changes in caching solutions that rely on the Query Analyzer, but aren't insuring that the `graphql_should_analyze_queries` filter is set to true.
 	 */
 
-	$graphql_settings = get_option( 'graphql_general_settings' );
+	$graphql_settings = get_option( 'graphql_general_settings', [] );
 
 	$graphql_settings['query_analyzer_enabled'] = 'on';
 

--- a/src/Admin/Settings/Settings.php
+++ b/src/Admin/Settings/Settings.php
@@ -173,7 +173,6 @@ class Settings {
 						true === \WPGraphQL::debug() ? '<br /><strong>' . __( 'NOTE: This setting is force enabled because GraphQL Debug Mode is enabled. ', 'wp-graphql' ) . '</strong>' : ''
 					),
 					'type'     => 'checkbox',
-					'default'  => 'off',
 					'disabled' => true === \WPGraphQL::debug(),
 					'value'    => true === \WPGraphQL\Utils\QueryAnalyzer::is_enabled() ? 'on' : get_graphql_setting( 'query_analyzer_enabled', 'off' ),
 				],

--- a/src/Admin/Settings/Settings.php
+++ b/src/Admin/Settings/Settings.php
@@ -208,6 +208,7 @@ class Settings {
 					'type'     => 'checkbox',
 					'value'    => true === \WPGraphQL::debug() ? 'on' : get_graphql_setting( 'debug_mode_enabled', 'off' ),
 					'disabled' => defined( 'GRAPHQL_DEBUG' ),
+					'default'  => 'off',
 				],
 				[
 					'name'    => 'tracing_enabled',

--- a/src/Admin/Settings/Settings.php
+++ b/src/Admin/Settings/Settings.php
@@ -165,6 +165,19 @@ class Settings {
 					},
 				],
 				[
+					'name'     => 'query_analyzer_enabled',
+					'label'    => __( 'Enable GraphQL Type Tracking', 'wp-graphql' ),
+					'desc'     => sprintf(
+						// translators: %s is either empty or a string with a note about force enabling.
+						__( 'When enabled, WPGraphQL will track the Types, Models, and Nodes used in the request, and return those values in the headers for use in debugging or header-based cache invalidation. %s', 'wp-graphql' ),
+						true === \WPGraphQL::debug() ? '<br /><strong>' . __( 'NOTE: This setting is force enabled because GraphQL Debug Mode is enabled. ', 'wp-graphql' ) . '</strong>' : ''
+					),
+					'type'     => 'checkbox',
+					'default'  => 'off',
+					'disabled' => true === \WPGraphQL::debug(),
+					'value'    => true === \WPGraphQL\Utils\QueryAnalyzer::is_enabled() ? 'on' : get_graphql_setting( 'query_analyzer_enabled', 'off' ),
+				],
+				[
 					'name'    => 'graphiql_enabled',
 					'label'   => __( 'Enable GraphiQL IDE', 'wp-graphql' ),
 					'desc'    => __( 'GraphiQL IDE is a tool for exploring the GraphQL Schema and test GraphQL operations. Uncheck this to disable GraphiQL in the Dashboard.', 'wp-graphql' ),

--- a/src/Router.php
+++ b/src/Router.php
@@ -3,7 +3,6 @@
 namespace WPGraphQL;
 
 use GraphQL\Error\FormattedError;
-use WPGraphQL\Utils\QueryAnalyzer;
 use WP_User;
 
 /**
@@ -327,7 +326,7 @@ class Router {
 
 		// If the Query Analyzer was instantiated
 		// Get the headers determined from its Analysis
-		if ( self::get_request() instanceof Request && self::get_request()->get_query_analyzer() instanceof QueryAnalyzer ) {
+		if ( self::get_request() instanceof Request && self::get_request()->get_query_analyzer()->is_enabled() ) {
 			$headers = self::get_request()->get_query_analyzer()->get_headers( $headers );
 		}
 

--- a/src/Router.php
+++ b/src/Router.php
@@ -326,7 +326,7 @@ class Router {
 
 		// If the Query Analyzer was instantiated
 		// Get the headers determined from its Analysis
-		if ( self::get_request() instanceof Request && self::get_request()->get_query_analyzer()->is_enabled() ) {
+		if ( self::get_request() instanceof Request && self::get_request()->get_query_analyzer()->is_enabled_for_query() ) {
 			$headers = self::get_request()->get_query_analyzer()->get_headers( $headers );
 		}
 

--- a/src/Utils/QueryAnalyzer.php
+++ b/src/Utils/QueryAnalyzer.php
@@ -14,6 +14,7 @@ use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Schema;
 use GraphQL\Utils\TypeInfo;
+use WPGraphQL;
 use WPGraphQL\Request;
 use WPGraphQL\WPSchema;
 
@@ -124,14 +125,15 @@ class QueryAnalyzer {
 	 * Initialize the QueryAnalyzer.
 	 */
 	public function init(): void {
+		$is_debug_enabled = WPGraphQL::debug();
 
 		/**
 		 * Filters whether to analyze queries or not
 		 *
-		 * @param bool          $should_analyze_queries Whether to analyze queries or not. Default true
+		 * @param bool          $should_analyze_queries Whether to analyze queries or not. Defaults to `true` if GraphQL Debugging is enabled, otherwise `false`.
 		 * @param \WPGraphQL\Utils\QueryAnalyzer $query_analyzer The QueryAnalyzer instance
 		 */
-		$should_analyze_queries = apply_filters( 'graphql_should_analyze_queries', true, $this );
+		$should_analyze_queries = apply_filters( 'graphql_should_analyze_queries', $is_debug_enabled, $this );
 
 		// If query analyzer is disabled, bail
 		if ( true !== $should_analyze_queries ) {

--- a/src/Utils/QueryAnalyzer.php
+++ b/src/Utils/QueryAnalyzer.php
@@ -113,9 +113,12 @@ class QueryAnalyzer {
 	 * @uses `graphql_query_analyzer_enabled` filter.
 	 */
 	public static function is_enabled(): bool {
-		$query_analyzer_enabled = false;
-		$is_debug_enabled       = WPGraphQL::debug();
+		$is_debug_enabled = WPGraphQL::debug();
 
+		// The query analyzer is enabled if WPGraphQL Debugging is enabled
+		$query_analyzer_enabled = $is_debug_enabled;
+
+		// If WPGraphQL Debugging is not enabled, check the setting
 		if ( ! $is_debug_enabled ) {
 			$query_analyzer_enabled = get_graphql_setting( 'query_analyzer_enabled', 'off' );
 			$query_analyzer_enabled = 'on' === $query_analyzer_enabled;
@@ -807,10 +810,10 @@ class QueryAnalyzer {
 	 * @return array<string,mixed>|object|null
 	 */
 	public function show_query_analyzer_in_extensions( $response, WPSchema $schema, ?string $operation_name, ?string $request, ?array $variables ) {
-		$should = \WPGraphQL::debug();
+		$should = $this->is_enabled_for_query() && \WPGraphQL::debug();
 
 		/**
-		 * @param bool                     $should         Whether the query analyzer output should be displayed in the Extensions output. Default to the value of WPGraphQL Debug.
+		 * @param bool                     $should         Whether the query analyzer output should be displayed in the Extensions output. Defaults to true if the query analyzer is enabled for the request and WPGraphQL Debugging is enabled.
 		 * @param mixed                    $response       The response of the WPGraphQL Request being executed
 		 * @param \WPGraphQL\WPSchema      $schema The WPGraphQL Schema
 		 * @param string|null              $operation_name The operation name being executed

--- a/tests/functional/GraphQLHeadersCept.php
+++ b/tests/functional/GraphQLHeadersCept.php
@@ -3,6 +3,11 @@
 $I = new FunctionalTester( $scenario );
 $I->wantTo( 'Test GraphQL Keys returned in headers' );
 
+// First test with Query_analyzer disabled
+$graphql_general_settings = get_option( 'graphql_general_settings' );
+$graphql_general_settings['query_analyzer_enabled'] = 'off';
+update_option( 'graphql_general_settings', $graphql_general_settings );
+
 $admin_id = $I->haveUserInDatabase( 'admin', 'administrator' );
 $post_id  = $I->havePostInDatabase(
 	[
@@ -32,9 +37,8 @@ $I->seeResponseIsJson();
 $x_graphql_keys = $I->grabHttpHeader( 'X-GraphQL-Keys' );
 $I->assertEmpty( $x_graphql_keys );
 
-// Test with GraphQL Debugging enabled
-$graphql_general_settings = get_option( 'graphql_general_settings' );
-$graphql_general_settings['debug_mode_enabled'] = 'on';
+// Then test with Query Analyzer enabled.
+$graphql_general_settings['query_analyzer_enabled'] = 'on';
 update_option( 'graphql_general_settings', $graphql_general_settings );
 
 $I->sendGet( 'http://localhost/graphql?query=' . $query );
@@ -91,5 +95,6 @@ $list_post_key = 'list:post';
 $I->assertContains( $list_post_key, explode( ' ', $x_graphql_keys ) );
 
 // cleanup
-$graphql_general_settings['debug_mode_enabled'] = 'off';
+$graphql_general_settings['query_analyzer_enabled'] = 'off';
+update_option( 'graphql_general_settings', $graphql_general_settings );
 

--- a/tests/functional/GraphQLHeadersCept.php
+++ b/tests/functional/GraphQLHeadersCept.php
@@ -30,6 +30,18 @@ $I->sendGet( 'http://localhost/graphql?query=' . $query );
 $I->seeResponseCodeIs( 200 );
 $I->seeResponseIsJson();
 $x_graphql_keys = $I->grabHttpHeader( 'X-GraphQL-Keys' );
+$I->assertEmpty( $x_graphql_keys );
+
+// Test with GraphQL Debugging enabled
+$graphql_general_settings = get_option( 'graphql_general_settings' );
+$graphql_general_settings['debug_mode_enabled'] = 'on';
+update_option( 'graphql_general_settings', $graphql_general_settings );
+
+$I->sendGet( 'http://localhost/graphql?query=' . $query );
+
+$I->seeResponseCodeIs( 200 );
+$I->seeResponseIsJson();
+$x_graphql_keys = $I->grabHttpHeader( 'X-GraphQL-Keys' );
 $x_graphql_url  = $I->grabHttpHeader( 'X-GraphQL-URL' );
 
 $I->assertNotEmpty( $x_graphql_keys );
@@ -77,3 +89,7 @@ $post_cache_key = base64_encode( 'post:' . $post_id );
 $I->assertContains( $post_cache_key, explode( ' ', $x_graphql_keys ) );
 $list_post_key = 'list:post';
 $I->assertContains( $list_post_key, explode( ' ', $x_graphql_keys ) );
+
+// cleanup
+$graphql_general_settings['debug_mode_enabled'] = 'off';
+

--- a/tests/wpunit/QueryAnalyzerTest.php
+++ b/tests/wpunit/QueryAnalyzerTest.php
@@ -2,8 +2,6 @@
 
 use WPGraphQL\Utils\QueryAnalyzer;
 
-use function Codeception\Extension\codecept_log;
-
 class QueryAnalyzerTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 	public $post_id;
@@ -50,19 +48,6 @@ class QueryAnalyzerTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		add_filter( 'graphql_debug_enabled', '__return_false' );
 
 		$query = '{ posts { nodes { id, title } } }';
-
-		/** Test default behavior */
-		$this->toggle_query_analyzer( null );
-		$actual = QueryAnalyzer::is_enabled();
-		$this->assertFalse( $actual, 'Query Analyzer should be disabled by default' );
-
-		$request = graphql( ['query' => $query ], true );
-		$actual_response = $request->execute();
-		$actual_analyzer = $request->get_query_analyzer();
-
-		$this->assertFalse( $actual_analyzer->is_enabled(), 'Query Analyzer should be disabled by default' );
-		$this->assertFalse( $actual_analyzer->is_enabled_for_query(), 'Query Analyzer should be disabled for query' );
-		$this->assertArrayNotHasKey( 'queryAnalyzer', $actual_response['extensions'], 'There should be no extension output if Query Analyzer is disabled ' );
 
 		/** Test with Query Analyzer toggled on */
 		$this->toggle_query_analyzer( true );

--- a/tests/wpunit/QueryAnalyzerTest.php
+++ b/tests/wpunit/QueryAnalyzerTest.php
@@ -1,4 +1,9 @@
 <?php
+
+use WPGraphQL\Utils\QueryAnalyzer;
+
+use function Codeception\Extension\codecept_log;
+
 class QueryAnalyzerTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 	public $post_id;
@@ -18,7 +23,90 @@ class QueryAnalyzerTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 	public function _tearDown(): void {
 		wp_delete_post( $this->post_id, true );
+
 		parent::_tearDown();
+	}
+
+	/**
+	 * Sets the query analyzer setting. If null is passed, the setting is unset.
+	 */
+	protected function toggle_query_analyzer( ?bool $toggle ): void {
+		$settings = get_option( 'graphql_general_settings', [] );
+
+		// Unset the setting if null is passed
+		if ( null === $toggle ) {
+			unset( $settings['query_analyzer_enabled'] );
+			update_option( 'graphql_general_settings', $settings );
+			return;
+		}
+
+		$settings['query_analyzer_enabled'] = $toggle === true ? 'on' : 'off';
+
+		update_option( 'graphql_general_settings', $settings );
+	}
+
+	public function testEnableQueryAnalyzer(): void {
+		// Unset GraphQL Debugging.
+		add_filter( 'graphql_debug_enabled', '__return_false' );
+
+		$query = '{ posts { nodes { id, title } } }';
+
+		/** Test default behavior */
+		$this->toggle_query_analyzer( null );
+		$actual = QueryAnalyzer::is_enabled();
+		$this->assertFalse( $actual, 'Query Analyzer should be disabled by default' );
+
+		$request = graphql( ['query' => $query ], true );
+		$actual_response = $request->execute();
+		$actual_analyzer = $request->get_query_analyzer();
+
+		$this->assertFalse( $actual_analyzer->is_enabled(), 'Query Analyzer should be disabled by default' );
+		$this->assertFalse( $actual_analyzer->is_enabled_for_query(), 'Query Analyzer should be disabled for query' );
+		$this->assertArrayNotHasKey( 'queryAnalyzer', $actual_response['extensions'], 'There should be no extension output if Query Analyzer is disabled ' );
+
+		/** Test with Query Analyzer toggled on */
+		$this->toggle_query_analyzer( true );
+		$actual = QueryAnalyzer::is_enabled();
+		$this->assertTrue( $actual, 'Query Analyzer should be enabled when turned "on"' );
+
+		$request = graphql( ['query' => $query ], true );
+		$actual_response = $request->execute();
+		$actual_analyzer = $request->get_query_analyzer();
+
+		$this->assertTrue( $actual_analyzer->is_enabled(), 'Query Analyzer should be enabled when turned "on"' );
+		$this->assertTrue( $actual_analyzer->is_enabled_for_query(), 'Query Analyzer should be enabled for query when turned "on"' );
+		$this->assertArrayNotHasKey( 'queryAnalyzer', $actual_response['extensions'], 'There should be no extension output if GraphQL debugging is disabled ' );
+
+		/** Test with Query Analyzer toggled off */
+		$this->toggle_query_analyzer( false );
+		$actual = QueryAnalyzer::is_enabled();
+		$this->assertFalse( $actual, 'Query Analyzer should be disabled when turned "off".' );
+
+		$request = graphql( ['query' => $query ], true );
+		$actual_response = $request->execute();
+		$actual_analyzer = $request->get_query_analyzer();
+
+		$this->assertFalse( $actual_analyzer->is_enabled(), 'Query Analyzer should be disabled when turned "off"' );
+		$this->assertFalse( $actual_analyzer->is_enabled_for_query(), 'Query Analyzer should be disabled for query when turned "off"' );
+		$this->assertArrayNotHasKey( 'queryAnalyzer', $actual_response['extensions'], 'There should be no extension output if GraphQL debugging is disabled ' );
+
+		/** Test with GraphQL Debugging Enabled */
+		add_filter( 'graphql_debug_enabled', '__return_true' );
+		$actual = QueryAnalyzer::is_enabled();
+		$this->assertTrue( $actual, 'Query Analyzer should be enabled when the "graphql_debug_enabled" filter is set to true.' );
+
+		$request = graphql( ['query' => $query ], true );
+		$actual_response = $request->execute();
+		$actual_analyzer = $request->get_query_analyzer();
+
+		$this->assertTrue( $actual_analyzer->is_enabled(), 'Query Analyzer should be enabled when GraphQL Debugging is on' );
+		$this->assertTrue( $actual_analyzer->is_enabled_for_query(), 'Query Analyzer should be enabled for query when GraphQL Debugging is on' );
+		$this->assertNotEmpty( $actual_response['extensions']['queryAnalyzer'], 'There should be extension output if GraphQL debugging and Query Analyzer are enabled.' );
+
+		// Clean up
+		$this->toggle_query_analyzer( null );
+		remove_filter( 'graphql_debug_enabled', '__return_true' );
+		remove_filter( 'graphql_debug_enabled', '__return_false' );
 	}
 
 	public function testListTypes() {


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR adds an admin setting for enabling/disabling the Query Analyzer, and defaults the setting value to `off` on new installs, unless GraphQL Debugging is enabled. In other words **by default, the QueryAnalyzer will only be enabled when GraphQL Debugging is also enabled**.

The reason for this is the overhead caused by having QueryAnalyzer enabled. While this cost is justified during debugging, or when needed to cache future responses, on vanilla WPGraphQL setups there is no need to pay for that extra processing.

More specifically:
- Adds a new `query_analyzer_enabled` setting to the WPGraphQL Settings page. The setting control is _disabled_ if `GraphQL::debug()` is true.
- Adds a new `QueryAnalyzer::is_enabled()` _static_ method that can be used to check whether the QA is disabled site wide. The return value in order of priority is:
  - GraphQL Debugging enabled => `true`
  - The filtered value of the existing `graphql_should_analyze_queries` filter.
  - The stored setting value.
- Adds a new `QueryAnalyzer::is_enabled_for_query()` _instance_ method that uses a new `graphql_should_analyze_query` filter which passes the `\WPGraphQL\Request` object as a parameter, and can be used to enable/disable the QueryAnalyzer for specific requests.
- Sets the default `query_analyzer_enabled` value of _`true`_ for existing WPGraphQL installs on upgrade, to prevent back-compat issues.
- Outputting the data to `response.extensions` now requires _both_ `QueryAnalyzer::is_enabled_for_query()` and `\WPGraphQL::debug()` to be true.


Does this close any currently open issues?
------------------------------------------
<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Related #1873 

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
<!-- (If it’s long, please paste to https://ghostbin.com/ and insert the link here.) -->
Per the below screenshots TTFB decreased from `165.68ms` => `125.93ms` on a simple query with very few types to analyze.

### Before (Query Analyzer enabled by default)
![qa-enabled](https://github.com/wp-graphql/wp-graphql/assets/29322304/f0bd7ab4-5124-44d6-b659-eedd24073926)

### After (Query Analyzer disabled by default)
![qa-disabled](https://github.com/wp-graphql/wp-graphql/assets/29322304/fdb90a5a-4289-4c57-9514-5d589f90f7bc)

### Settings toggle:
- GraphQL Debugging enabled
![image](https://github.com/wp-graphql/wp-graphql/assets/29322304/24289e2d-c341-4a08-927d-678a641aa969)

- GraphQL Debugging disabled
![image](https://github.com/wp-graphql/wp-graphql/assets/29322304/f30aae9b-9f66-4d67-b709-3c3063d6a2c2)



Any other comments?
-------------------
> [!IMPORTANT]
> Plugins that rely on the Query Analyzer should update their code with `add_action( 'graphql_should_analyze_queries', true );` or do a check around the `QueryAnalyzer::is_enabled()` method.

- I went with a Setting Label of `Enable GraphQL Type Tracking`, since "Query Analyzer" is the internal feature name, and not self-documenting for end users.

- Made the assumption that this will be part of the 1.20.0 release. If not the `activation.php` method should be updated.

- The future potential of `graphql_should_analyze_query` should make it easier to exclude or set custom rules around caching specific types/models/or even named queries. 


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + 8.1.15)

**WordPress Version:** 6.4.2
