### PR TITLE
chore: implement stricter PHPDoc types

### DIFF
--- a/access-functions.php
+++ b/access-functions.php
@@ -150,8 +150,8 @@ function get_graphql_register_action() {
  *
  * Should be used at the `graphql_register_types` hook.
  *
- * @param mixed|string|array<string> $interface_names Array of one or more names of the GraphQL Interfaces to apply to the GraphQL Types
- * @param mixed|string|array<string> $type_names      Array of one or more names of the GraphQL Types to apply the interfaces to.
+ * @param string|string[] $interface_names Array of one or more names of the GraphQL Interfaces to apply to the GraphQL Types
+ * @param string|string[] $type_names      Array of one or more names of the GraphQL Types to apply the interfaces to.
  *
  * Example:
  * The following would register the "MyNewInterface" interface to the Post and Page type in the

--- a/access-functions.php
+++ b/access-functions.php
@@ -819,10 +819,10 @@ function get_graphql_setting( string $option_name, $default_value = '', $section
 
 	/**
 	 * Filter the section fields
-	 *
-	 * @param array  $section_fields The values of the fields stored for the section
-	 * @param string $section_name   The name of the section
-	 * @param mixed  $default_value  The default value for the option being retrieved
+	 
+	 * @param array<string,mixed> $section_fields The values of the fields stored for the section
+	 * @param string              $section_name   The name of the section
+	 * @param mixed               $default_value  The default value for the option being retrieved
 	 */
 	$section_fields = apply_filters( 'graphql_get_setting_section_fields', $section_fields, $section_name, $default_value );
 
@@ -834,11 +834,11 @@ function get_graphql_setting( string $option_name, $default_value = '', $section
 	/**
 	 * Filter the value before returning it
 	 *
-	 * @param mixed  $value          The value of the field
-	 * @param mixed  $default_value  The default value if there is no value set
-	 * @param string $option_name    The name of the option
-	 * @param array  $section_fields The setting values within the section
-	 * @param string $section_name   The name of the section the setting belongs to
+	 * @param mixed               $value          The value of the field
+	 * @param mixed               $default_value  The default value if there is no value set
+	 * @param string              $option_name    The name of the option
+	 * @param array<string,mixed> $section_fields The setting values within the section
+	 * @param string              $section_name   The name of the section the setting belongs to
 	 */
 	return apply_filters( 'graphql_get_setting_section_field_value', $value, $default_value, $option_name, $section_fields, $section_name );
 }

--- a/src/Admin/Settings/SettingsRegistry.php
+++ b/src/Admin/Settings/SettingsRegistry.php
@@ -551,7 +551,7 @@ class SettingsRegistry {
 	 *
 	 * @param array<string,mixed> $options settings field args
 	 *
-	 * @return mixed
+	 * @return array<string,mixed>
 	 */
 	public function sanitize_options( array $options ) {
 		if ( ! $options ) {
@@ -576,7 +576,7 @@ class SettingsRegistry {
 	 *
 	 * @param string $slug option slug
 	 *
-	 * @return mixed string or bool false
+	 * @return callable|false
 	 */
 	public function get_sanitize_callback( $slug = '' ) {
 		if ( empty( $slug ) ) {

--- a/src/Admin/Settings/SettingsRegistry.php
+++ b/src/Admin/Settings/SettingsRegistry.php
@@ -128,9 +128,9 @@ class SettingsRegistry {
 		/**
 		 * Filter the setting field config
 		 *
-		 * @param array  $field_config The field config for the setting
-		 * @param string $field_name   The name of the field (unfilterable in the config)
-		 * @param string $section      The slug of the section the field is registered to
+		 * @param array<string,mixed>  $field_config The field config for the setting
+		 * @param string               $field_name   The name of the field (unfilterable in the config)
+		 * @param string               $section      The slug of the section the field is registered to
 		 */
 		$field = apply_filters( 'graphql_setting_field_config', $field_config, $field_name, $section );
 
@@ -160,7 +160,7 @@ class SettingsRegistry {
 		/**
 		 * Filter the settings sections
 		 *
-		 * @param array $setting_sections The registered settings sections
+		 * @param array<string,array<string,mixed>> $setting_sections The registered settings sections
 		 */
 		$setting_sections = apply_filters( 'graphql_settings_sections', $this->settings_sections );
 

--- a/src/AppContext.php
+++ b/src/AppContext.php
@@ -66,7 +66,7 @@ class AppContext {
 	/**
 	 * Passes context about the current connection being resolved
 	 *
-	 * @var mixed|String|null
+	 * @var mixed|string|null
 	 */
 	public $currentConnection = null;
 
@@ -148,7 +148,7 @@ class AppContext {
 	 *
 	 * @param string $key The name of the loader to get
 	 *
-	 * @return mixed
+	 * @return \WPGraphQL\Data\Loader\AbstractDataLoader|mixed
 	 *
 	 * @deprecated Use get_loader instead.
 	 */

--- a/src/Data/CommentMutation.php
+++ b/src/Data/CommentMutation.php
@@ -103,9 +103,9 @@ class CommentMutation {
 		/**
 		 * Filter the $insert_post_args
 		 *
-		 * @param array  $output_args   The array of $input_post_args that will be passed to wp_new_comment
-		 * @param array  $input         The data that was entered as input for the mutation
-		 * @param string $mutation_type The type of mutation being performed ( create, edit, etc )
+		 * @param array<string,mixed> $output_args   The array of $input_post_args that will be passed to wp_new_comment
+		 * @param array<string,mixed> $input         The data that was entered as input for the mutation
+		 * @param string              $mutation_type The type of mutation being performed ( create, edit, etc )
 		 */
 		$output_args = apply_filters( 'graphql_comment_insert_post_args', $output_args, $input, $mutation_name );
 

--- a/src/Data/Config.php
+++ b/src/Data/Config.php
@@ -382,12 +382,10 @@ class Config {
 		/**
 		 * If pre-filter hooked, return $pre_pieces.
 		 *
-		 * @param array<string,mixed>|null $pre_pieces The pre-filtered term query SQL clauses.
-		 * @param array<string,mixed>      $pieces     Terms query SQL clauses.
-		 * @param string[]                 $taxonomies An array of taxonomies.
-		 * @param array<string,mixed>      $args       An array of terms query arguments.
-		 *
-		 * @return array|null
+		 * @param ?array<string,mixed> $pre_pieces The pre-filtered term query SQL clauses.
+		 * @param array<string,mixed>  $pieces     Terms query SQL clauses.
+		 * @param string[]             $taxonomies An array of taxonomies.
+		 * @param array<string,mixed>  $args       An array of terms query arguments.
 		 */
 		$pre_pieces = apply_filters( 'graphql_pre_wp_term_query_cursor_pagination_support', null, $pieces, $taxonomies, $args );
 		if ( null !== $pre_pieces ) {
@@ -455,11 +453,9 @@ class Config {
 		/**
 		 * If pre-filter hooked, return $pre_pieces.
 		 *
-		 * @param array|null        $pre_pieces The pre-filtered comment query clauses.
-		 * @param array             $pieces     A compacted array of comment query clauses.
-		 * @param \WP_Comment_Query $query      Current instance of WP_Comment_Query, passed by reference.
-		 *
-		 * @return array|null
+		 * @param ?array<string,mixed> $pre_pieces The pre-filtered comment query clauses.
+		 * @param array<string,mixed>  $pieces     A compacted array of comment query clauses.
+		 * @param \WP_Comment_Query    $query      Current instance of WP_Comment_Query, passed by reference.
 		 */
 		$pre_pieces = apply_filters( 'graphql_pre_wp_comments_query_cursor_pagination_support', null, $pieces, $query );
 		if ( null !== $pre_pieces ) {

--- a/src/Data/Config.php
+++ b/src/Data/Config.php
@@ -382,7 +382,7 @@ class Config {
 		/**
 		 * If pre-filter hooked, return $pre_pieces.
 		 *
-		 * @param array<string, mixed>|null $pre_pieces The pre-filtered term query SQL clauses.
+		 * @param array<string,mixed>|null $pre_pieces The pre-filtered term query SQL clauses.
 		 * @param array<string,mixed>      $pieces     Terms query SQL clauses.
 		 * @param string[]                 $taxonomies An array of taxonomies.
 		 * @param array<string,mixed>      $args       An array of terms query arguments.

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -102,7 +102,7 @@ abstract class AbstractConnectionResolver {
 	protected $ids;
 
 	/**
-	 * @var array<string,mixed>
+	 * @var mixed[]
 	 */
 	protected $nodes;
 
@@ -162,9 +162,9 @@ abstract class AbstractConnectionResolver {
 		 *
 		 * Filters the GraphQL args before they are used in get_query_args().
 		 *
-		 * @param array                      $args                The GraphQL args passed to the resolver.
+		 * @param array<string,mixed>                                   $args                The GraphQL args passed to the resolver.
 		 * @param \WPGraphQL\Data\Connection\AbstractConnectionResolver $connection_resolver Instance of the ConnectionResolver.
-		 * @param array                      $unfiltered_args     Array of arguments input in the field as part of the GraphQL query.
+		 * @param array<string,mixed>                                   $unfiltered_args     Array of arguments input in the field as part of the GraphQL query.
 		 *
 		 * @since 1.11.0
 		 */
@@ -188,10 +188,9 @@ abstract class AbstractConnectionResolver {
 		 *
 		 * Filters the args
 		 *
-		 * @param array                      $query_args          The query args to be used with the executable query to get data.
-		 *                                                        This should take in the GraphQL args and return args for use in fetching the data.
+		 * @param array<string,mixed>                                   $query_args          The query args to be used with the executable query to get data.
 		 * @param \WPGraphQL\Data\Connection\AbstractConnectionResolver $connection_resolver Instance of the ConnectionResolver
-		 * @param array                      $unfiltered_args Array of arguments input in the field as part of the GraphQL query.
+		 * @param array<string,mixed>                                   $unfiltered_args Array of arguments input in the field as part of the GraphQL query.
 		 */
 		$this->query_args = apply_filters( 'graphql_connection_query_args', $this->get_query_args(), $this, $args );
 	}
@@ -429,11 +428,11 @@ abstract class AbstractConnectionResolver {
 		 *
 		 * This filter is intentionally applied AFTER the query_args filter, as
 		 *
-		 * @param int         $max_posts  the maximum number of posts per page.
-		 * @param mixed       $source     source passed down from the resolve tree
-		 * @param array       $args       array of arguments input in the field as part of the GraphQL query
-		 * @param \WPGraphQL\AppContext $context Object containing app context that gets passed down the resolve tree
-		 * @param \GraphQL\Type\Definition\ResolveInfo $info Info about fields passed down the resolve tree
+		 * @param int                                  $max_posts  the maximum number of posts per page.
+		 * @param mixed                                $source     source passed down from the resolve tree
+		 * @param array<string,mixed>                  $args       array of arguments input in the field as part of the GraphQL query
+		 * @param \WPGraphQL\AppContext                $context    Object containing app context that gets passed down the resolve tree
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info       Info about fields passed down the resolve tree
 		 *
 		 * @since 0.0.6
 		 */
@@ -820,7 +819,7 @@ abstract class AbstractConnectionResolver {
 			/**
 			 * Create the edge, pass it through a filter.
 			 *
-			 * @param array                      $edge                The edge within the connection
+			 * @param array<string,mixed>                                   $edge                The edge within the connection
 			 * @param \WPGraphQL\Data\Connection\AbstractConnectionResolver $connection_resolver Instance of the connection resolver class
 			 */
 			$edge = apply_filters(
@@ -940,7 +939,7 @@ abstract class AbstractConnectionResolver {
 		/**
 		 * Filter the connection IDs
 		 *
-		 * @param array                      $ids                 Array of IDs this connection will be resolving
+		 * @param int[]|string[]                                        $ids                 Array of IDs this connection will be resolving
 		 * @param \WPGraphQL\Data\Connection\AbstractConnectionResolver $connection_resolver Instance of the Connection Resolver
 		 */
 		$this->ids = apply_filters( 'graphql_connection_ids', $this->get_ids(), $this );
@@ -984,7 +983,7 @@ abstract class AbstractConnectionResolver {
 				 *
 				 * Filters the nodes in the connection
 				 *
-				 * @param array                      $nodes               The nodes in the connection
+				 * @param array<int|string,mixed|\WPGraphQL\Model\Model|null>   $nodes               The nodes in the connection
 				 * @param \WPGraphQL\Data\Connection\AbstractConnectionResolver $connection_resolver Instance of the Connection Resolver
 				 */
 				$this->nodes = apply_filters( 'graphql_connection_nodes', $this->get_nodes(), $this );
@@ -992,7 +991,7 @@ abstract class AbstractConnectionResolver {
 				/**
 				 * Filters the edges in the connection
 				 *
-				 * @param array                      $nodes               The nodes in the connection
+				 * @param array<int|string,mixed|\WPGraphQL\Model\Model|null>   $nodes               The nodes in the connection
 				 * @param \WPGraphQL\Data\Connection\AbstractConnectionResolver $connection_resolver Instance of the Connection Resolver
 				 */
 				$this->edges = apply_filters( 'graphql_connection_edges', $this->get_edges(), $this );
@@ -1015,7 +1014,7 @@ abstract class AbstractConnectionResolver {
 				 *
 				 * This filter allows additional fields to be returned to the connection resolver
 				 *
-				 * @param array                      $connection          The connection data being returned
+				 * @param array<string,mixed>                                   $connection          The connection data being returned
 				 * @param \WPGraphQL\Data\Connection\AbstractConnectionResolver $connection_resolver The instance of the connection resolver
 				 */
 				return apply_filters( 'graphql_connection', $connection, $this );

--- a/src/Data/Connection/CommentConnectionResolver.php
+++ b/src/Data/Connection/CommentConnectionResolver.php
@@ -135,10 +135,10 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 		 * Filter the query_args that should be applied to the query. This filter is applied AFTER the input args from
 		 * the GraphQL Query have been applied and has the potential to override the GraphQL Query Input Args.
 		 *
-		 * @param array       $query_args array of query_args being passed to the
-		 * @param mixed       $source     source passed down from the resolve tree
-		 * @param array       $args       array of arguments input in the field as part of the GraphQL query
-		 * @param \WPGraphQL\AppContext $context object passed down the resolve tree
+		 * @param array<string,mixed>                  $query_args array of query_args being passed to the
+		 * @param mixed                                $source     source passed down from the resolve tree
+		 * @param array<string,mixed>                  $args       array of arguments input in the field as part of the GraphQL query
+		 * @param \WPGraphQL\AppContext                $context object passed down the resolve tree
 		 * @param \GraphQL\Type\Definition\ResolveInfo $info info about fields passed down the resolve tree
 		 *
 		 * @since 0.0.6
@@ -256,7 +256,7 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 		 *
 		 * Filters the GraphQL args before they are used in get_query_args().
 		 *
-		 * @param array                     $args                The GraphQL args passed to the resolver.
+		 * @param array<string,mixed>                                  $args                The GraphQL args passed to the resolver.
 		 * @param \WPGraphQL\Data\Connection\CommentConnectionResolver $connection_resolver Instance of the ConnectionResolver
 		 *
 		 * @since 1.11.0

--- a/src/Data/Connection/MenuItemConnectionResolver.php
+++ b/src/Data/Connection/MenuItemConnectionResolver.php
@@ -104,8 +104,8 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 		 *
 		 * Filters the GraphQL args before they are used in get_query_args().
 		 *
-		 * @param array $args            The GraphQL args passed to the resolver.
-		 * @param array $unfiltered_args Array of arguments input in the field as part of the GraphQL query.
+		 * @param array<string,mixed> $args            The GraphQL args passed to the resolver.
+		 * @param array<string,mixed> $unfiltered_args Array of arguments input in the field as part of the GraphQL query.
 		 *
 		 * @since 1.11.0
 		 */

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -18,7 +18,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * The name of the post type, or array of post types the connection resolver is resolving for
 	 *
-	 * @var mixed string|array
+	 * @var mixed|string|string[]
 	 */
 	protected $post_type;
 
@@ -352,11 +352,11 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		/**
 		 * Filter the $query args to allow folks to customize queries programmatically
 		 *
-		 * @param array       $query_args The args that will be passed to the WP_Query
-		 * @param mixed       $source     The source that's passed down the GraphQL queries
-		 * @param array       $args       The inputArgs on the field
-		 * @param \WPGraphQL\AppContext $context The AppContext passed down the GraphQL tree
-		 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the GraphQL tree
+		 * @param array<string,mixed>                  $query_args The args that will be passed to the WP_Query
+		 * @param mixed                                $source     The source that's passed down the GraphQL queries
+		 * @param array<string,mixed>                  $args       The inputArgs on the field
+		 * @param \WPGraphQL\AppContext                $context    The AppContext passed down the GraphQL tree
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info       The ResolveInfo passed down the GraphQL tree
 		 */
 		return apply_filters( 'graphql_post_object_connection_query_args', $query_args, $this->source, $this->args, $this->context, $this->info );
 	}
@@ -419,15 +419,14 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		 * This allows plugins/themes to hook in and alter what $args should be allowed to be passed
 		 * from a GraphQL Query to the WP_Query
 		 *
-		 * @param array              $query_args The mapped query arguments
-		 * @param array              $args       Query "where" args
-		 * @param mixed              $source     The query results for a query calling this
-		 * @param array              $all_args   All of the arguments for the query (not just the "where" args)
-		 * @param \WPGraphQL\AppContext $context The AppContext object
-		 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object
-		 * @param mixed|string|array $post_type  The post type for the query
+		 * @param array<string,mixed>                  $query_args The mapped query arguments
+		 * @param array<string,mixed>                  $args       Query "where" args
+		 * @param mixed                                $source     The query results for a query calling this
+		 * @param array<string,mixed>                  $all_args   All of the arguments for the query (not just the "where" args)
+		 * @param \WPGraphQL\AppContext                $context    The AppContext object
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info       The ResolveInfo object
+		 * @param mixed|string|string[]                $post_type  The post type for the query
 		 *
-		 * @return array
 		 * @since 0.0.5
 		 */
 		$query_args = apply_filters( 'graphql_map_input_fields_to_wp_query', $query_args, $where_args, $this->source, $this->args, $this->context, $this->info, $this->post_type );
@@ -576,9 +575,9 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		 *
 		 * Filters the GraphQL args before they are used in get_query_args().
 		 *
-		 * @param array                        $args                The GraphQL args passed to the resolver.
+		 * @param array<string,mixed>                                     $args                The GraphQL args passed to the resolver.
 		 * @param \WPGraphQL\Data\Connection\PostObjectConnectionResolver $connection_resolver Instance of the ConnectionResolver.
-		 * @param array                        $unfiltered_args     Array of arguments input in the field as part of the GraphQL query.
+		 * @param array<string,mixed>                                     $unfiltered_args     Array of arguments input in the field as part of the GraphQL query.
 		 *
 		 * @since 1.11.0
 		 */

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -446,7 +446,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	 * This strips the status from the query_args if the user doesn't have permission to query for
 	 * posts of that status.
 	 *
-	 * @param mixed $stati The status(es) to sanitize
+	 * @param string[]|string $stati The status(es) to sanitize.
 	 *
 	 * @return string[]|null
 	 */

--- a/src/Data/Connection/TermObjectConnectionResolver.php
+++ b/src/Data/Connection/TermObjectConnectionResolver.php
@@ -134,11 +134,11 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 		 * Filter the query_args that should be applied to the query. This filter is applied AFTER the input args from
 		 * the GraphQL Query have been applied and has the potential to override the GraphQL Query Input Args.
 		 *
-		 * @param array       $query_args array of query_args being passed to the
-		 * @param mixed       $source     source passed down from the resolve tree
-		 * @param array       $args       array of arguments input in the field as part of the GraphQL query
-		 * @param \WPGraphQL\AppContext $context object passed down the resolve tree
-		 * @param \GraphQL\Type\Definition\ResolveInfo $info info about fields passed down the resolve tree
+		 * @param array<string,mixed>                  $query_args array of query_args being passed to the
+		 * @param mixed                                $source     source passed down from the resolve tree
+		 * @param array<string,mixed>                  $args       array of arguments input in the field as part of the GraphQL query
+		 * @param \WPGraphQL\AppContext                $context    object passed down the resolve tree
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info       info about fields passed down the resolve tree
 		 *
 		 * @since 0.0.6
 		 */
@@ -234,16 +234,15 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 		 * This allows plugins/themes to hook in and alter what $args should be allowed to be passed
 		 * from a GraphQL Query to the get_terms query
 		 *
-		 * @param array       $query_args Array of mapped query args
-		 * @param array       $where_args Array of query "where" args
-		 * @param string      $taxonomy   The name of the taxonomy
-		 * @param mixed       $source     The query results
-		 * @param array       $all_args   All of the query arguments (not just the "where" args)
-		 * @param \WPGraphQL\AppContext $context The AppContext object
-		 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object
+		 * @param array<string,mixed>                  $query_args Array of mapped query args
+		 * @param array<string,mixed>                  $where_args Array of query "where" args
+		 * @param string                               $taxonomy   The name of the taxonomy
+		 * @param mixed                                $source     The query results
+		 * @param array<string,mixed>                  $all_args   All of the query arguments (not just the "where" args)
+		 * @param \WPGraphQL\AppContext                $context   The AppContext object
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info      The ResolveInfo object
 		 *
 		 * @since 0.0.5
-		 * @return array
 		 */
 		$query_args = apply_filters( 'graphql_map_input_fields_to_get_terms', $query_args, $where_args, $this->taxonomy, $this->source, $this->args, $this->context, $this->info );
 
@@ -290,9 +289,9 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 		 *
 		 * Filters the GraphQL args before they are used in get_query_args().
 		 *
-		 * @param array                        $args                The GraphQL args passed to the resolver.
+		 * @param array<string,mixed>                                     $args                The GraphQL args passed to the resolver.
 		 * @param \WPGraphQL\Data\Connection\TermObjectConnectionResolver $connection_resolver Instance of the ConnectionResolver
-		 * @param array                        $unfiltered_args     Array of arguments input in the field as part of the GraphQL query.
+		 * @param array<string,mixed>                                     $unfiltered_args     Array of arguments input in the field as part of the GraphQL query.
 		 *
 		 * @since 1.11.0
 		 */

--- a/src/Data/Connection/UserConnectionResolver.php
+++ b/src/Data/Connection/UserConnectionResolver.php
@@ -266,14 +266,13 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 		 * This allows plugins/themes to hook in and alter what $args should be allowed to be passed
 		 * from a GraphQL Query to the WP_User_Query
 		 *
-		 * @param array       $query_args The mapped query args
-		 * @param array       $args       The query "where" args
-		 * @param mixed       $source     The query results of the query calling this relation
-		 * @param array       $all_args   Array of all the query args (not just the "where" args)
-		 * @param \WPGraphQL\AppContext $context The AppContext object
+		 * @param array<string,mixed>                  $query_args The mapped query args
+		 * @param array<string,mixed>                  $args       The query "where" args
+		 * @param mixed                                $source     The query results of the query calling this relation
+		 * @param array<string,mixed>                  $all_args   Array of all the query args (not just the "where" args)
+		 * @param \WPGraphQL\AppContext                $context The AppContext object
 		 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object
 		 *
-		 * @return array
 		 * @since 0.0.5
 		 */
 		$query_args = apply_filters( 'graphql_map_input_fields_to_wp_user_query', $query_args, $args, $this->source, $this->args, $this->context, $this->info );

--- a/src/Data/Cursor/AbstractCursor.php
+++ b/src/Data/Cursor/AbstractCursor.php
@@ -224,7 +224,7 @@ abstract class AbstractCursor {
 	/**
 	 * Returns the ID key.
 	 *
-	 * @return mixed
+	 * @return string
 	 */
 	public function get_cursor_id_key() {
 		$key = $this->get_query_var( 'graphql_cursor_id_key' );

--- a/src/Data/Cursor/CursorBuilder.php
+++ b/src/Data/Cursor/CursorBuilder.php
@@ -51,9 +51,9 @@ class CursorBuilder {
 		/**
 		 * Filters the field used for ordering when cursors are used for pagination
 		 *
-		 * @param array         $field          The field key, value, type and order
+		 * @param array<string,mixed>                  $field          The field key, value, type and order
 		 * @param \WPGraphQL\Data\Cursor\CursorBuilder $cursor_builder The CursorBuilder class
-		 * @param ?object        $object_cursor  The Cursor class
+		 * @param ?object                              $object_cursor  The Cursor class
 		 */
 		$field = apply_filters(
 			'graphql_cursor_ordering_field',

--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -463,7 +463,7 @@ class DataSource {
 		/**
 		 * Filter the $allowed_settings_by_group to allow enabling or disabling groups in the GraphQL Schema.
 		 *
-		 * @param array $allowed_settings_by_group
+		 * @param array<string,array<string,mixed>> $allowed_settings_by_group
 		 */
 		return apply_filters( 'graphql_allowed_settings_by_group', $allowed_settings_by_group );
 	}

--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -74,7 +74,7 @@ class DataSource {
 	 *
 	 * @param int $comment_id The ID of the comment the comment author is associated with.
 	 *
-	 * @return mixed|\WPGraphQL\Model\CommentAuthor|null
+	 * @return \WPGraphQL\Model\CommentAuthor|null
 	 * @throws \Exception Throws Exception.
 	 */
 	public static function resolve_comment_author( int $comment_id ) {
@@ -91,7 +91,7 @@ class DataSource {
 	 * @param \WPGraphQL\AppContext                $context The context of the query to pass along
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object
 	 *
-	 * @return mixed
+	 * @return \GraphQL\Deferred
 	 * @throws \Exception
 	 * @since 0.0.5
 	 */
@@ -160,7 +160,7 @@ class DataSource {
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object
 	 * @param mixed|string|string[]                $post_type Post type of the post we are trying to resolve
 	 *
-	 * @return mixed
+	 * @return \GraphQL\Deferred
 	 * @throws \Exception
 	 * @since  0.0.5
 	 */
@@ -209,7 +209,7 @@ class DataSource {
 	 * @param int                   $id      ID of the term you are trying to retrieve the object for
 	 * @param \WPGraphQL\AppContext $context The context of the GraphQL Request
 	 *
-	 * @return mixed
+	 * @return \GraphQL\Deferred
 	 * @throws \Exception
 	 * @since      0.0.5
 	 *
@@ -714,7 +714,7 @@ class DataSource {
 	 * @param \WPGraphQL\AppContext                $context The AppContext passed through the GraphQL Resolve Tree
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed through the GraphQL Resolve tree
 	 *
-	 * @return mixed
+	 * @return \GraphQL\Deferred
 	 * @throws \Exception
 	 */
 	public static function resolve_resource_by_uri( $uri, $context, $info ) {

--- a/src/Data/Loader/AbstractDataLoader.php
+++ b/src/Data/Loader/AbstractDataLoader.php
@@ -109,9 +109,9 @@ abstract class AbstractDataLoader {
 	 * Loads a key and returns value represented by this key.
 	 * Internally this method will load all currently buffered items and cache them locally.
 	 *
-	 * @param mixed $key
+	 * @param int|string|mixed $key
 	 *
-	 * @return mixed
+	 * @return ?\WPGraphQL\Model\Model
 	 * @throws \Exception
 	 */
 	public function load( $key ) {
@@ -418,7 +418,7 @@ abstract class AbstractDataLoader {
 	/**
 	 * Returns a cached data object by key.
 	 *
-	 * @param mixed $key  Key.
+	 * @param int|string $key Key.
 	 *
 	 * @return mixed
 	 */
@@ -431,10 +431,10 @@ abstract class AbstractDataLoader {
 		/**
 		 * Use this filter to retrieving cached data objects from third-party caching system.
 		 *
-		 * @param mixed  $value         Value to be cached.
-		 * @param mixed  $key           Key identifying object.
-		 * @param string $loader_class  Loader class name.
-		 * @param mixed  $loader        Loader instance.
+		 * @param mixed       $value        Value to be cached.
+		 * @param int|string  $key          Key identifying object.
+		 * @param string      $loader_class Loader class name.
+		 * @param mixed       $loader       Loader instance.
 		 */
 		$value = apply_filters(
 			'graphql_dataloader_get_cached',

--- a/src/Data/Loader/PostObjectLoader.php
+++ b/src/Data/Loader/PostObjectLoader.php
@@ -57,7 +57,7 @@ class PostObjectLoader extends AbstractDataLoader {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @return array<string|int, \WP_Post|null>
+	 * @return array<string|int,\WP_Post|null>
 	 */
 	public function loadKeys( array $keys ) {
 		if ( empty( $keys ) ) {

--- a/src/Data/Loader/TermObjectLoader.php
+++ b/src/Data/Loader/TermObjectLoader.php
@@ -50,7 +50,7 @@ class TermObjectLoader extends AbstractDataLoader {
 	 *
 	 * @param int[] $keys
 	 *
-	 * @return array<int, mixed>
+	 * @return array<int,\WP_Term|\WP_Error|null>
 	 */
 	public function loadKeys( array $keys ) {
 		if ( empty( $keys ) ) {

--- a/src/Data/Loader/UserLoader.php
+++ b/src/Data/Loader/UserLoader.php
@@ -43,7 +43,7 @@ class UserLoader extends AbstractDataLoader {
 	 *
 	 * @param int[] $keys Array of author IDs (int).
 	 *
-	 * @return array<int, bool> Associative array of author IDs (int) to boolean.
+	 * @return array<int,bool> Associative array of author IDs (int) to boolean.
 	 */
 	public function get_public_users( array $keys ) {
 
@@ -109,7 +109,7 @@ class UserLoader extends AbstractDataLoader {
 	 *
 	 * @param int[] $keys
 	 *
-	 * @return array<int, \WP_User|null>
+	 * @return array<int,\WP_User|null>
 	 */
 	public function loadKeys( array $keys ) {
 		if ( empty( $keys ) ) {

--- a/src/Data/MediaItemMutation.php
+++ b/src/Data/MediaItemMutation.php
@@ -17,10 +17,10 @@ class MediaItemMutation {
 	/**
 	 * This prepares the media item for insertion
 	 *
-	 * @param array<string,mixed> $input            The input for the mutation from the GraphQL request
-	 * @param \WP_Post_Type       $post_type_object The post_type_object for the mediaItem (attachment)
-	 * @param string              $mutation_name    The name of the mutation being performed (create, update, etc.)
-	 * @param mixed               $file             The mediaItem (attachment) file
+	 * @param array<string,mixed>       $input            The input for the mutation from the GraphQL request
+	 * @param \WP_Post_Type             $post_type_object The post_type_object for the mediaItem (attachment)
+	 * @param string                    $mutation_name    The name of the mutation being performed (create, update, etc.)
+	 * @param array<string,mixed>|false $file             The mediaItem (attachment) file
 	 *
 	 * @return array<string,mixed>
 	 */

--- a/src/Data/MediaItemMutation.php
+++ b/src/Data/MediaItemMutation.php
@@ -95,10 +95,10 @@ class MediaItemMutation {
 		/**
 		 * Filter the $insert_post_args
 		 *
-		 * @param array        $insert_post_args The array of $input_post_args that will be passed to wp_insert_attachment
-		 * @param array        $input            The data that was entered as input for the mutation
-		 * @param \WP_Post_Type $post_type_object The post_type_object that the mutation is affecting
-		 * @param string       $mutation_type    The type of mutation being performed (create, update, delete)
+		 * @param array<string,mixed> $insert_post_args The array of $input_post_args that will be passed to wp_insert_attachment
+		 * @param array<string,mixed> $input            The data that was entered as input for the mutation
+		 * @param \WP_Post_Type       $post_type_object The post_type_object that the mutation is affecting
+		 * @param string              $mutation_type    The type of mutation being performed (create, update, delete)
 		 */
 		$insert_post_args = apply_filters( 'graphql_media_item_insert_post_args', $insert_post_args, $input, $post_type_object, $mutation_name );
 
@@ -131,11 +131,11 @@ class MediaItemMutation {
 		 * update additional data related to mediaItems, such as updating additional postmeta,
 		 * or sending emails to Kevin. . .whatever you need to do with the mediaItem.
 		 *
-		 * @param int          $media_item_id    The ID of the mediaItem being mutated
-		 * @param array        $input            The input for the mutation
-		 * @param \WP_Post_Type $post_type_object The Post Type Object for the type of post being mutated
-		 * @param string       $mutation_name    The name of the mutation (ex: create, update, delete)
-		 * @param \WPGraphQL\AppContext $context The AppContext that is passed down the resolve tree
+		 * @param int                                  $media_item_id    The ID of the mediaItem being mutated
+		 * @param array<string,mixed>                  $input            The input for the mutation
+		 * @param \WP_Post_Type                        $post_type_object The Post Type Object for the type of post being mutated
+		 * @param string                               $mutation_name    The name of the mutation (ex: create, update, delete)
+		 * @param \WPGraphQL\AppContext                $context The AppContext that is passed down the resolve tree
 		 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo that is passed down the resolve tree
 		 */
 		do_action( 'graphql_media_item_mutation_update_additional_data', $media_item_id, $input, $post_type_object, $mutation_name, $context, $info );

--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -122,7 +122,7 @@ class NodeResolver {
 		 * @param string $uri The uri being searched.
 		 * @param \WPGraphQL\AppContext $content The app context.
 		 * @param \WP $wp WP object.
-		 * @param mixed|array<string,mixed>|string $extra_query_vars Any extra query vars to consider.
+		 * @param array<string,mixed>|string $extra_query_vars Any extra query vars to consider.
 		 */
 		$node = apply_filters( 'graphql_pre_resolve_uri', null, $uri, $this->context, $this->wp, $extra_query_vars );
 
@@ -155,11 +155,11 @@ class NodeResolver {
 		 *
 		 * This can be used by Extensions which use a different query class to resolve data.
 		 *
-		 * @param class-string          $query_class The query class used to resolve the URI. Defaults to WP_Query.
-		 * @param ?string               $uri The uri being searched.
-		 * @param \WPGraphQL\AppContext $content The app context.
-		 * @param \WP                   $wp WP object.
-		 * @param mixed|array|string    $extra_query_vars Any extra query vars to consider.
+		 * @param class-string               $query_class The query class used to resolve the URI. Defaults to WP_Query.
+		 * @param ?string                    $uri The uri being searched.
+		 * @param \WPGraphQL\AppContext      $content The app context.
+		 * @param \WP                        $wp WP object.
+		 * @param array<string,mixed>|string $extra_query_vars Any extra query vars to consider.
 		 */
 		$query_class = apply_filters( 'graphql_resolve_uri_query_class', 'WP_Query', $uri, $this->context, $this->wp, $extra_query_vars );
 
@@ -202,7 +202,7 @@ class NodeResolver {
 		 * @param \WP_Query                                     $query            The query object.
 		 * @param \WPGraphQL\AppContext                         $content          The app context.
 		 * @param \WP                                           $wp               WP object.
-		 * @param mixed|array|string                            $extra_query_vars Any extra query vars to consider.
+		 * @param array<string,mixed>|string                    $extra_query_vars Any extra query vars to consider.
 		 */
 		$node = apply_filters( 'graphql_resolve_uri', null, $uri, $queried_object, $query, $this->context, $this->wp, $extra_query_vars );
 
@@ -297,7 +297,7 @@ class NodeResolver {
 		 * @param \WP_Query                                     $query            The query object.
 		 * @param \WPGraphQL\AppContext                         $content          The app context.
 		 * @param \WP                                           $wp               WP object.
-		 * @param mixed|array|string                            $extra_query_vars Any extra query vars to consider.
+		 * @param array<string,mixed>|string                    $extra_query_vars Any extra query vars to consider.
 		 */
 		return apply_filters( 'graphql_post_resolve_uri', $node, $uri, $queried_object, $query, $this->context, $this->wp, $extra_query_vars );
 	}
@@ -593,7 +593,7 @@ class NodeResolver {
 		/**
 		 * Filters the array of parsed query variables.
 		 *
-		 * @param array $query_vars The array of requested query variables.
+		 * @param array<string,mixed> $query_vars The array of requested query variables.
 		 *
 		 * @since 2.1.0
 		 */

--- a/src/Data/PostObjectMutation.php
+++ b/src/Data/PostObjectMutation.php
@@ -104,10 +104,10 @@ class PostObjectMutation {
 		/**
 		 * Filter the $insert_post_args
 		 *
-		 * @param array        $insert_post_args The array of $input_post_args that will be passed to wp_insert_post
-		 * @param array        $input            The data that was entered as input for the mutation
-		 * @param \WP_Post_Type $post_type_object The post_type_object that the mutation is affecting
-		 * @param string       $mutation_type    The type of mutation being performed (create, edit, etc)
+		 * @param array<string,mixed> $insert_post_args The array of $input_post_args that will be passed to wp_insert_post
+		 * @param array<string,mixed> $input            The data that was entered as input for the mutation
+		 * @param \WP_Post_Type       $post_type_object The post_type_object that the mutation is affecting
+		 * @param string              $mutation_type    The type of mutation being performed (create, edit, etc)
 		 */
 		$insert_post_args = apply_filters( 'graphql_post_object_insert_post_args', $insert_post_args, $input, $post_type_object, $mutation_name );
 
@@ -137,17 +137,15 @@ class PostObjectMutation {
 		/**
 		 * Sets the post lock
 		 *
-		 * @param bool         $is_locked            Whether the post is locked
-		 * @param int          $post_id              The ID of the postObject being mutated
-		 * @param array        $input                The input for the mutation
-		 * @param \WP_Post_Type $post_type_object The Post Type Object for the type of post being mutated
-		 * @param string       $mutation_name        The name of the mutation (ex: create, update, delete)
-		 * @param \WPGraphQL\AppContext $context The AppContext passed down to all resolvers
+		 * @param bool                                 $is_locked            Whether the post is locked
+		 * @param int                                  $post_id              The ID of the postObject being mutated
+		 * @param array<string,mixed>                  $input                The input for the mutation
+		 * @param \WP_Post_Type                        $post_type_object The Post Type Object for the type of post being mutated
+		 * @param string                               $mutation_name        The name of the mutation (ex: create, update, delete)
+		 * @param \WPGraphQL\AppContext                $context The AppContext passed down to all resolvers
 		 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down to all resolvers
-		 * @param ?string      $intended_post_status The intended post_status the post should have according to the mutation input
-		 * @param ?string      $default_post_status  The default status posts should use if an intended status wasn't set
-		 *
-		 * @return bool
+		 * @param ?string                              $intended_post_status The intended post_status the post should have according to the mutation input
+		 * @param ?string                              $default_post_status  The default status posts should use if an intended status wasn't set
 		 */
 		if ( true === apply_filters( 'graphql_post_object_mutation_set_edit_lock', true, $post_id, $input, $post_type_object, $mutation_name, $context, $info, $default_post_status, $intended_post_status ) ) {
 			/**
@@ -171,10 +169,10 @@ class PostObjectMutation {
 		/**
 		 * Set the object terms
 		 *
-		 * @param int          $post_id          The ID of the postObject being mutated
-		 * @param array        $input            The input for the mutation
-		 * @param \WP_Post_Type $post_type_object The Post Type Object for the type of post being mutated
-		 * @param string       $mutation_name    The name of the mutation (ex: create, update, delete)
+		 * @param int                 $post_id          The ID of the postObject being mutated
+		 * @param array<string,mixed> $input            The input for the mutation
+		 * @param \WP_Post_Type       $post_type_object The Post Type Object for the type of post being mutated
+		 * @param string              $mutation_name    The name of the mutation (ex: create, update, delete)
 		 */
 		self::set_object_terms( $post_id, $input, $post_type_object, $mutation_name );
 
@@ -183,29 +181,29 @@ class PostObjectMutation {
 		 * update additional data related to postObjects, such as setting relationships, updating additional postmeta,
 		 * or sending emails to Kevin. . .whatever you need to do with the postObject.
 		 *
-		 * @param int          $post_id              The ID of the postObject being mutated
-		 * @param array        $input                The input for the mutation
-		 * @param \WP_Post_Type $post_type_object The Post Type Object for the type of post being mutated
-		 * @param string       $mutation_name        The name of the mutation (ex: create, update, delete)
-		 * @param \WPGraphQL\AppContext $context The AppContext passed down to all resolvers
-		 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down to all resolvers
-		 * @param ?string      $intended_post_status The intended post_status the post should have according to the mutation input
-		 * @param ?string      $default_post_status  The default status posts should use if an intended status wasn't set
+		 * @param int                                  $post_id              The ID of the postObject being mutated
+		 * @param array<string,mixed>                  $input                The input for the mutation
+		 * @param \WP_Post_Type                        $post_type_object     The Post Type Object for the type of post being mutated
+		 * @param string                               $mutation_name        The name of the mutation (ex: create, update, delete)
+		 * @param \WPGraphQL\AppContext                $context              The AppContext passed down to all resolvers
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info                 The ResolveInfo passed down to all resolvers
+		 * @param ?string                              $intended_post_status The intended post_status the post should have according to the mutation input
+		 * @param ?string                              $default_post_status  The default status posts should use if an intended status wasn't set
 		 */
 		do_action( 'graphql_post_object_mutation_update_additional_data', $post_id, $input, $post_type_object, $mutation_name, $context, $info, $default_post_status, $intended_post_status );
 
 		/**
 		 * Sets the post lock
 		 *
-		 * @param bool         $is_locked            Whether the post is locked.
-		 * @param int          $post_id              The ID of the postObject being mutated
-		 * @param array        $input                The input for the mutation
-		 * @param \WP_Post_Type $post_type_object The Post Type Object for the type of post being mutated
-		 * @param string       $mutation_name        The name of the mutation (ex: create, update, delete)
-		 * @param \WPGraphQL\AppContext $context The AppContext passed down to all resolvers
-		 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down to all resolvers
-		 * @param ?string      $intended_post_status The intended post_status the post should have according to the mutation input
-		 * @param ?string      $default_post_status  The default status posts should use if an intended status wasn't set
+		 * @param bool                                 $is_locked            Whether the post is locked.
+		 * @param int                                  $post_id              The ID of the postObject being mutated
+		 * @param array<string,mixed>                  $input                The input for the mutation
+		 * @param \WP_Post_Type                        $post_type_object     The Post Type Object for the type of post being mutated
+		 * @param string                               $mutation_name        The name of the mutation (ex: create, update, delete)
+		 * @param \WPGraphQL\AppContext                $context              The AppContext passed down to all resolvers
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info                 The ResolveInfo passed down to all resolvers
+		 * @param ?string                              $intended_post_status The intended post_status the post should have according to the mutation input
+		 * @param ?string                              $default_post_status  The default status posts should use if an intended status wasn't set
 		 *
 		 * @return bool
 		 */
@@ -235,10 +233,10 @@ class PostObjectMutation {
 		 *
 		 * One example use for this hook would be to create terms from the input that may not exist yet, so that they can be set as a relation below.
 		 *
-		 * @param int          $post_id          The ID of the postObject being mutated
-		 * @param array        $input            The input for the mutation
-		 * @param \WP_Post_Type $post_type_object The Post Type Object for the type of post being mutated
-		 * @param string       $mutation_name    The name of the mutation (ex: create, update, delete)
+		 * @param int                 $post_id          The ID of the postObject being mutated
+		 * @param array<string,mixed> $input            The input for the mutation
+		 * @param \WP_Post_Type       $post_type_object The Post Type Object for the type of post being mutated
+		 * @param string              $mutation_name    The name of the mutation (ex: create, update, delete)
 		 */
 		do_action( 'graphql_post_object_mutation_set_object_terms', $post_id, $input, $post_type_object, $mutation_name );
 

--- a/src/Data/TermObjectMutation.php
+++ b/src/Data/TermObjectMutation.php
@@ -77,10 +77,10 @@ class TermObjectMutation {
 		/**
 		 * Filter the $insert_args
 		 *
-		 * @param array $insert_args The array of input args that will be passed to the functions that insert terms
-		 * @param array $input The data that was entered as input for the mutation
-		 * @param \WP_Taxonomy $taxonomy The taxonomy object of the term being mutated
-		 * @param string $mutation_name The name of the mutation being performed (create, edit, etc)
+		 * @param array<string,mixed> $insert_args   The array of input args that will be passed to the functions that insert terms
+		 * @param array<string,mixed> $input         The data that was entered as input for the mutation
+		 * @param \WP_Taxonomy        $taxonomy      The taxonomy object of the term being mutated
+		 * @param string              $mutation_name The name of the mutation being performed (create, edit, etc)
 		 */
 		return apply_filters( 'graphql_term_object_insert_term_args', $insert_args, $input, $taxonomy, $mutation_name );
 	}

--- a/src/Data/UserMutation.php
+++ b/src/Data/UserMutation.php
@@ -193,9 +193,9 @@ class UserMutation {
 		/**
 		 * Filters the mappings for input to arguments
 		 *
-		 * @param array  $insert_user_args The arguments to ultimately be passed to the WordPress function
-		 * @param array  $input            Input data from the GraphQL mutation
-		 * @param string $mutation_name    What user mutation is being performed for context
+		 * @param array<string,mixed> $insert_user_args The arguments to ultimately be passed to the WordPress function
+		 * @param array<string,mixed> $input            Input data from the GraphQL mutation
+		 * @param string              $mutation_name    What user mutation is being performed for context
 		 */
 		$insert_user_args = apply_filters( 'graphql_user_insert_post_args', $insert_user_args, $input, $mutation_name );
 
@@ -224,11 +224,11 @@ class UserMutation {
 		 * update additional data related to users, such as setting relationships, updating additional usermeta,
 		 * or sending emails to Kevin... whatever you need to do with the userObject.
 		 *
-		 * @param int         $user_id       The ID of the user being mutated
-		 * @param array       $input         The input for the mutation
-		 * @param string      $mutation_name The name of the mutation (ex: create, update, delete)
-		 * @param \WPGraphQL\AppContext $context The AppContext passed down the resolve tree
-		 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the Resolve Tree
+		 * @param int                                  $user_id       The ID of the user being mutated
+		 * @param array<string,mixed>                  $input         The input for the mutation
+		 * @param string                               $mutation_name The name of the mutation (ex: create, update, delete)
+		 * @param \WPGraphQL\AppContext                $context       The AppContext passed down the resolve tree
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info          The ResolveInfo passed down the Resolve Tree
 		 */
 		do_action( 'graphql_user_object_mutation_update_additional_data', $user_id, $input, $mutation_name, $context, $info );
 	}

--- a/src/Data/UserMutation.php
+++ b/src/Data/UserMutation.php
@@ -272,7 +272,7 @@ class UserMutation {
 	 * @param string $role    Name of the role trying to get added to a user object
 	 * @param int    $user_id The ID of the user being mutated
 	 *
-	 * @return mixed|bool|\WP_Error
+	 * @return bool|\WP_Error
 	 */
 	private static function verify_user_role( $role, $user_id ) {
 		global $wp_roles;

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -319,8 +319,6 @@ abstract class Model {
 			 * @param string|null $visibility                The visibility that has currently been set for the data at this point
 			 * @param int|null    $owner                     The user ID for the owner of this piece of data
 			 * @param \WP_User $current_user The current user for the session
-			 *
-			 * @return array
 			 */
 				apply_filters( 'graphql_allowed_fields_on_restricted_type', $this->allowed_restricted_fields, $this->get_model_name(), $this->data, $this->visibility, $this->owner, $this->current_user )
 			)
@@ -380,7 +378,7 @@ abstract class Model {
 				 * @param int|null $owner        The user ID for the owner of this piece of data
 				 * @param \WP_User $current_user The current user for the session
 				 *
-				 * @return callable|int|string|array|mixed|null
+				 * @return callable|int|string|mixed[]|mixed|null
 				 */
 				$pre = apply_filters( 'graphql_pre_return_field_from_model', null, $key, $this->get_model_name(), $this->data, $this->visibility, $this->owner, $this->current_user );
 
@@ -465,13 +463,11 @@ abstract class Model {
 		/**
 		 * Add support for the deprecated "graphql_return_modeled_data" filter.
 		 *
-		 * @param array    $fields       The array of fields for the model
-		 * @param string   $model_name   Name of the model the filter is currently being executed in
-		 * @param string   $visibility   The visibility setting for this piece of data
-		 * @param int|null $owner        The user ID for the owner of this piece of data
-		 * @param \WP_User $current_user The current user for the session
-		 *
-		 * @return array
+		 * @param array<string,mixed>    $fields       The array of fields for the model
+		 * @param string                 $model_name   Name of the model the filter is currently being executed in
+		 * @param string                 $visibility   The visibility setting for this piece of data
+		 * @param ?int                   $owner        The user ID for the owner of this piece of data
+		 * @param \WP_User               $current_user The current user for the session
 		 *
 		 * @deprecated 1.7.0 use "graphql_model_prepare_fields" filter instead, which passes additional context to the filter
 		 */
@@ -480,14 +476,12 @@ abstract class Model {
 		/**
 		 * Filter the array of fields for the Model before the object is hydrated with it
 		 *
-		 * @param array    $fields       The array of fields for the model
-		 * @param string   $model_name   Name of the model the filter is currently being executed in
-		 * @param mixed    $data         The un-modeled incoming data
-		 * @param string   $visibility   The visibility setting for this piece of data
-		 * @param int|null $owner        The user ID for the owner of this piece of data
-		 * @param \WP_User $current_user The current user for the session
-		 *
-		 * @return array
+		 * @param array<string,mixed>    $fields       The array of fields for the model
+		 * @param string                 $model_name   Name of the model the filter is currently being executed in
+		 * @param mixed                  $data         The un-modeled incoming data
+		 * @param string                 $visibility   The visibility setting for this piece of data
+		 * @param ?int                   $owner        The user ID for the owner of this piece of data
+		 * @param \WP_User               $current_user The current user for the session
 		 */
 		$this->fields = apply_filters( 'graphql_model_prepare_fields', $this->fields, $this->get_model_name(), $this->data, $this->visibility, $this->owner, $this->current_user );
 		$this->wrap_fields();

--- a/src/Mutation/CommentCreate.php
+++ b/src/Mutation/CommentCreate.php
@@ -117,7 +117,7 @@ class CommentCreate {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @return callable
+	 * @return callable(array<string,mixed>$input,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info):array<string,mixed>
 	 */
 	public static function mutate_and_get_payload() {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) {

--- a/src/Mutation/CommentDelete.php
+++ b/src/Mutation/CommentDelete.php
@@ -74,7 +74,7 @@ class CommentDelete {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @return callable
+	 * @return callable(array<string,mixed>$input,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info):array<string,mixed>
 	 */
 	public static function mutate_and_get_payload() {
 		return static function ( $input ) {

--- a/src/Mutation/CommentRestore.php
+++ b/src/Mutation/CommentRestore.php
@@ -77,7 +77,7 @@ class CommentRestore {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @return callable
+	 * @return callable(array<string,mixed>$input,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info):array<string,mixed>
 	 */
 	public static function mutate_and_get_payload() {
 		return static function ( $input ) {

--- a/src/Mutation/CommentUpdate.php
+++ b/src/Mutation/CommentUpdate.php
@@ -62,7 +62,7 @@ class CommentUpdate {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @return callable
+	 * @return callable(array<string,mixed>$input,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info):array<string,mixed>
 	 */
 	public static function mutate_and_get_payload() {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) {

--- a/src/Mutation/MediaItemCreate.php
+++ b/src/Mutation/MediaItemCreate.php
@@ -171,9 +171,9 @@ class MediaItemCreate {
 			/**
 			 * Filter the allowed protocols for the mutation
 			 *
-			 * @param array                                $allowed_protocols The allowed protocols for filePaths to be submitted
+			 * @param string[]                             $allowed_protocols The allowed protocols for filePaths to be submitted
 			 * @param mixed                                $protocol          The current protocol of the filePath
-			 * @param array                                $input             The input of the current mutation
+			 * @param array<string,mixed>                  $input             The input of the current mutation
 			 * @param \WPGraphQL\AppContext                $context           The context of the current request
 			 * @param \GraphQL\Type\Definition\ResolveInfo $info              The ResolveInfo of the current field
 			 */

--- a/src/Mutation/MediaItemCreate.php
+++ b/src/Mutation/MediaItemCreate.php
@@ -116,7 +116,7 @@ class MediaItemCreate {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @return callable
+	 * @return callable(array<string,mixed>$input,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info):array<string,mixed>
 	 */
 	public static function mutate_and_get_payload() {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) {

--- a/src/Mutation/MediaItemDelete.php
+++ b/src/Mutation/MediaItemDelete.php
@@ -76,7 +76,7 @@ class MediaItemDelete {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @return callable
+	 * @return callable(array<string,mixed>$input,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info):array<string,mixed>
 	 */
 	public static function mutate_and_get_payload() {
 		return static function ( $input ) {

--- a/src/Mutation/MediaItemUpdate.php
+++ b/src/Mutation/MediaItemUpdate.php
@@ -60,14 +60,14 @@ class MediaItemUpdate {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @return callable
+	 * @return callable(array<string,mixed>$input,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info):array<string,mixed>
 	 */
 	public static function mutate_and_get_payload() {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) {
 			$post_type_object = get_post_type_object( 'attachment' );
 
 			if ( empty( $post_type_object ) ) {
-				return null;
+				return [];
 			}
 
 			// Get the database ID for the comment.

--- a/src/Mutation/PostObjectCreate.php
+++ b/src/Mutation/PostObjectCreate.php
@@ -193,7 +193,7 @@ class PostObjectCreate {
 	 * @param \WP_Post_Type $post_type_object The post type of the mutation.
 	 * @param string        $mutation_name    The mutation name.
 	 *
-	 * @return callable
+	 * @return callable(array<string,mixed>$input,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info):array<string,mixed>
 	 */
 	public static function mutate_and_get_payload( $post_type_object, $mutation_name ) {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) use ( $post_type_object, $mutation_name ) {

--- a/src/Mutation/PostObjectDelete.php
+++ b/src/Mutation/PostObjectDelete.php
@@ -97,7 +97,7 @@ class PostObjectDelete {
 	 * @param \WP_Post_Type $post_type_object The post type of the mutation.
 	 * @param string        $mutation_name    The mutation name.
 	 *
-	 * @return callable
+	 * @return callable(array<string,mixed>$input,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info):array<string,mixed>
 	 */
 	public static function mutate_and_get_payload( WP_Post_Type $post_type_object, string $mutation_name ) {
 		return static function ( $input ) use ( $post_type_object ) {

--- a/src/Mutation/PostObjectUpdate.php
+++ b/src/Mutation/PostObjectUpdate.php
@@ -185,10 +185,10 @@ class PostObjectUpdate {
 			 *
 			 * The dynamic portion of the hook name, `$taxonomy->name` refers to the taxonomy of the term being mutated
 			 *
-			 * @param int    $post_id       Inserted post ID
-			 * @param \WP_Post_Type $post_type_object The Post Type object for the post being mutated
-			 * @param array  $args          The args used to insert the term
-			 * @param string $mutation_name The name of the mutation being performed
+			 * @param int                 $post_id          Inserted post ID
+			 * @param \WP_Post_Type       $post_type_object The Post Type object for the post being mutated
+			 * @param array<string,mixed> $args             The args used to insert the term
+			 * @param string              $mutation_name    The name of the mutation being performed
 			 */
 			do_action( 'graphql_insert_post_object', absint( $post_id ), $post_type_object, $post_args, $mutation_name );
 
@@ -197,9 +197,9 @@ class PostObjectUpdate {
 			 *
 			 * The dynamic portion of the hook name, `$taxonomy->name` refers to the taxonomy of the term being mutated
 			 *
-			 * @param int    $post_id       Inserted post ID
-			 * @param array  $args          The args used to insert the term
-			 * @param string $mutation_name The name of the mutation being performed
+			 * @param int                 $post_id       Inserted post ID
+			 * @param array<string,mixed> $args          The args used to insert the term
+			 * @param string              $mutation_name The name of the mutation being performed
 			 */
 			do_action( "graphql_insert_{$post_type_object->name}", absint( $post_id ), $post_args, $mutation_name );
 

--- a/src/Mutation/PostObjectUpdate.php
+++ b/src/Mutation/PostObjectUpdate.php
@@ -73,7 +73,7 @@ class PostObjectUpdate {
 	 * @param \WP_Post_Type $post_type_object The post type of the mutation.
 	 * @param string        $mutation_name      The mutation name.
 	 *
-	 * @return callable
+	 * @return callable(array<string,mixed>$input,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info):array<string,mixed>
 	 */
 	public static function mutate_and_get_payload( $post_type_object, $mutation_name ) {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) use ( $post_type_object, $mutation_name ) {

--- a/src/Mutation/ResetUserPassword.php
+++ b/src/Mutation/ResetUserPassword.php
@@ -56,7 +56,7 @@ class ResetUserPassword {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @return callable
+	 * @return callable(array<string,mixed>$input,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info):array<string,mixed>
 	 */
 	public static function mutate_and_get_payload() {
 		return static function ( $input, AppContext $context ) {

--- a/src/Mutation/SendPasswordResetEmail.php
+++ b/src/Mutation/SendPasswordResetEmail.php
@@ -65,6 +65,8 @@ class SendPasswordResetEmail {
 
 	/**
 	 * Defines the mutation data modification closure.
+	 *
+	 * @return callable(array<string,mixed>$input,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info):array<string,mixed>
 	 */
 	public static function mutate_and_get_payload(): callable {
 		return static function ( $input ) {

--- a/src/Mutation/TermObjectCreate.php
+++ b/src/Mutation/TermObjectCreate.php
@@ -107,7 +107,7 @@ class TermObjectCreate {
 	 * @param \WP_Taxonomy $taxonomy The taxonomy type of the mutation.
 	 * @param string       $mutation_name The name of the mutation.
 	 *
-	 * @return callable
+	 * @return callable(array<string,mixed>$input,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info):array<string,mixed>
 	 */
 	public static function mutate_and_get_payload( WP_Taxonomy $taxonomy, string $mutation_name ) {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) use ( $taxonomy, $mutation_name ) {

--- a/src/Mutation/TermObjectCreate.php
+++ b/src/Mutation/TermObjectCreate.php
@@ -167,12 +167,12 @@ class TermObjectCreate {
 			/**
 			 * Fires after a single term is created or updated via a GraphQL mutation
 			 *
-			 * @param int         $term_id       Inserted term object
-			 * @param \WP_Taxonomy $taxonomy The taxonomy of the term being updated
-			 * @param array       $args          The args used to insert the term
-			 * @param string      $mutation_name The name of the mutation being performed
-			 * @param \WPGraphQL\AppContext $context The AppContext passed down the resolve tree
-			 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the resolve tree
+			 * @param int                                  $term_id       Inserted term object
+			 * @param \WP_Taxonomy                         $taxonomy      The taxonomy of the term being updated
+			 * @param array<string,mixed>                  $args          The args used to insert the term
+			 * @param string                               $mutation_name The name of the mutation being performed
+			 * @param \WPGraphQL\AppContext                $context       The AppContext passed down the resolve tree
+			 * @param \GraphQL\Type\Definition\ResolveInfo $info          The ResolveInfo passed down the resolve tree
 			 */
 			do_action( 'graphql_insert_term', $term['term_id'], $taxonomy, $args, $mutation_name, $context, $info );
 
@@ -181,11 +181,11 @@ class TermObjectCreate {
 			 *
 			 * The dynamic portion of the hook name, `$taxonomy->name` refers to the taxonomy of the term being mutated
 			 *
-			 * @param int         $term_id       Inserted term object
-			 * @param array       $args          The args used to insert the term
-			 * @param string      $mutation_name The name of the mutation being performed
-			 * @param \WPGraphQL\AppContext $context The AppContext passed down the resolve tree
-			 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the resolve tree
+			 * @param int                                  $term_id       Inserted term object
+			 * @param array<string,mixed>                  $args          The args used to insert the term
+			 * @param string                               $mutation_name The name of the mutation being performed
+			 * @param \WPGraphQL\AppContext                $context       The AppContext passed down the resolve tree
+			 * @param \GraphQL\Type\Definition\ResolveInfo $info          The ResolveInfo passed down the resolve tree
 			 */
 			do_action( "graphql_insert_{$taxonomy->name}", $term['term_id'], $args, $mutation_name, $context, $info );
 

--- a/src/Mutation/TermObjectDelete.php
+++ b/src/Mutation/TermObjectDelete.php
@@ -87,7 +87,7 @@ class TermObjectDelete {
 	 * @param \WP_Taxonomy $taxonomy The taxonomy type of the mutation.
 	 * @param string       $mutation_name The name of the mutation.
 	 *
-	 * @return callable
+	 * @return callable(array<string,mixed>$input,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info):array<string,mixed>
 	 */
 	public static function mutate_and_get_payload( WP_Taxonomy $taxonomy, string $mutation_name ) {
 		return static function ( $input ) use ( $taxonomy ) {

--- a/src/Mutation/TermObjectUpdate.php
+++ b/src/Mutation/TermObjectUpdate.php
@@ -151,23 +151,23 @@ class TermObjectUpdate {
 			/**
 			 * Fires an action when a term is updated via a GraphQL Mutation
 			 *
-			 * @param int         $term_id       The ID of the term object that was mutated
-			 * @param \WP_Taxonomy $taxonomy The taxonomy of the term being updated
-			 * @param array       $args          The args used to update the term
-			 * @param string      $mutation_name The name of the mutation being performed (create, update, delete, etc)
-			 * @param \WPGraphQL\AppContext $context The AppContext passed down the resolve tree
-			 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the resolve tree
+			 * @param int                                  $term_id       The ID of the term object that was mutated
+			 * @param \WP_Taxonomy                         $taxonomy      The taxonomy of the term being updated
+			 * @param array<string,mixed>                  $args          The args used to update the term
+			 * @param string                               $mutation_name The name of the mutation being performed (create, update, delete, etc)
+			 * @param \WPGraphQL\AppContext                $context       The AppContext passed down the resolve tree
+			 * @param \GraphQL\Type\Definition\ResolveInfo $info          The ResolveInfo passed down the resolve tree
 			 */
 			do_action( 'graphql_update_term', $existing_term->term_id, $taxonomy, $args, $mutation_name, $context, $info );
 
 			/**
 			 * Fires an action when a term is updated via a GraphQL Mutation
 			 *
-			 * @param int         $term_id       The ID of the term object that was mutated
-			 * @param array       $args          The args used to update the term
-			 * @param string      $mutation_name The name of the mutation being performed (create, update, delete, etc)
-			 * @param \WPGraphQL\AppContext $context The AppContext passed down the resolve tree
-			 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the resolve tree
+			 * @param int                                  $term_id       The ID of the term object that was mutated
+			 * @param array<string,mixed>                  $args          The args used to update the term
+			 * @param string                               $mutation_name The name of the mutation being performed (create, update, delete, etc)
+			 * @param \WPGraphQL\AppContext                $context       The AppContext passed down the resolve tree
+			 * @param \GraphQL\Type\Definition\ResolveInfo $info          The ResolveInfo passed down the resolve tree
 			 */
 			do_action( "graphql_update_{$taxonomy->name}", $existing_term->term_id, $args, $mutation_name, $context, $info );
 

--- a/src/Mutation/TermObjectUpdate.php
+++ b/src/Mutation/TermObjectUpdate.php
@@ -77,7 +77,7 @@ class TermObjectUpdate {
 	 * @param \WP_Taxonomy $taxonomy The taxonomy type of the mutation.
 	 * @param string       $mutation_name  The name of the mutation.
 	 *
-	 * @return callable
+	 * @return callable(array<string,mixed>$input,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info):array<string,mixed>
 	 */
 	public static function mutate_and_get_payload( WP_Taxonomy $taxonomy, $mutation_name ) {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) use ( $taxonomy, $mutation_name ) {

--- a/src/Mutation/UserCreate.php
+++ b/src/Mutation/UserCreate.php
@@ -133,7 +133,7 @@ class UserCreate {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @return callable
+	 * @return callable(array<string,mixed>$input,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info):array<string,mixed>
 	 */
 	public static function mutate_and_get_payload() {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) {

--- a/src/Mutation/UserDelete.php
+++ b/src/Mutation/UserDelete.php
@@ -77,7 +77,7 @@ class UserDelete {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @return callable
+	 * @return callable(array<string,mixed>$input,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info):array<string,mixed>
 	 */
 	public static function mutate_and_get_payload() {
 		return static function ( $input ) {

--- a/src/Mutation/UserRegister.php
+++ b/src/Mutation/UserRegister.php
@@ -67,7 +67,7 @@ class UserRegister {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @return callable
+	 * @return callable(array<string,mixed>$input,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info):array<string,mixed>
 	 */
 	public static function mutate_and_get_payload() {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) {

--- a/src/Mutation/UserUpdate.php
+++ b/src/Mutation/UserUpdate.php
@@ -57,7 +57,7 @@ class UserUpdate {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @return callable
+	 * @return callable(array<string,mixed>$input,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info):array<string,mixed>
 	 */
 	public static function mutate_and_get_payload() {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) {

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -147,7 +147,7 @@ class TypeRegistry {
 	/**
 	 * The loaders needed to register types
 	 *
-	 * @var array<string,Callable>
+	 * @var array<string,callable():(mixed|array<string,mixed>|\GraphQL\Type\Definition\Type|null)>
 	 */
 	protected $type_loaders;
 

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -839,8 +839,7 @@ class TypeRegistry {
 	 *
 	 * @param string $type_name The name of the Type to get from the registry
 	 *
-	 * @return mixed
-	 * |null
+	 * @return mixed|array<string,mixed>|\GraphQL\Type\Definition\Type|null
 	 */
 	public function get_type( string $type_name ) {
 		$key = $this->format_key( $type_name );
@@ -1001,7 +1000,7 @@ class TypeRegistry {
 	 *
 	 * @param mixed|string|array<string,mixed> $type The type definition to process.
 	 *
-	 * @return mixed
+	 * @return \GraphQL\Type\Definition\Type|string|array<string,mixed>|mixed
 	 * @throws \Exception
 	 */
 	public function setup_type_modifiers( $type ) {
@@ -1218,7 +1217,7 @@ class TypeRegistry {
 	/**
 	 * Given a Type, this returns an instance of a NonNull of that type
 	 *
-	 * @param mixed $type The Type being wrapped
+	 * @param string|callable|\GraphQL\Type\Definition\NullableType $type The Type being wrapped
 	 *
 	 * @return \GraphQL\Type\Definition\NonNull
 	 */
@@ -1235,7 +1234,7 @@ class TypeRegistry {
 	/**
 	 * Given a Type, this returns an instance of a listOf of that type
 	 *
-	 * @param mixed $type The Type being wrapped
+	 * @param string|\GraphQL\Type\Definition\Type $type The Type being wrapped
 	 *
 	 * @return \GraphQL\Type\Definition\ListOfType
 	 */

--- a/src/Request.php
+++ b/src/Request.php
@@ -94,7 +94,7 @@ class Request {
 	/**
 	 * The default field resolver function. Default null
 	 *
-	 * @var mixed|callable|null
+	 * @var callable|null
 	 */
 	protected $field_resolver;
 
@@ -190,7 +190,7 @@ class Request {
 	}
 
 	/**
-	 * @return mixed
+	 * @return callable|null
 	 */
 	protected function get_field_resolver() {
 		return $this->field_resolver;
@@ -231,8 +231,8 @@ class Request {
 		/**
 		 * Return the filtered root value
 		 *
-		 * @param mixed   $root_value The root value the Schema should use to resolve with. Default null.
-		 * @param \WPGraphQL\Request $request The Request instance
+		 * @param mixed              $root_value The root value the Schema should use to resolve with. Default null.
+		 * @param \WPGraphQL\Request $request    The Request instance
 		 */
 		return apply_filters( 'graphql_root_value', $root_value, $this );
 	}

--- a/src/Request.php
+++ b/src/Request.php
@@ -59,7 +59,7 @@ class Request {
 	 * GraphQL operation parameters for this request. Can also be an array of
 	 * OperationParams.
 	 *
-	 * @var mixed|array|\GraphQL\Server\OperationParams|\GraphQL\Server\OperationParams[]
+	 * @var mixed|mixed[]|\GraphQL\Server\OperationParams|\GraphQL\Server\OperationParams[]
 	 */
 	public $params;
 
@@ -474,7 +474,7 @@ class Request {
 	 * @param mixed|array<string,mixed>|object $response The response for your GraphQL request
 	 * @param mixed|int|null                   $key      The array key of the params for batch requests
 	 *
-	 * @return array<string,mixed>
+	 * @return mixed|array<string,mixed>|object
 	 */
 	private function after_execute_actions( $response, $key = null ) {
 
@@ -501,12 +501,12 @@ class Request {
 		/**
 		 * Run an action. This is a good place for debug tools to hook in to log things, etc.
 		 *
-		 * @param mixed|array $response  The response your GraphQL request
-		 * @param \WPGraphQL\WPSchema $schema The schema object for the root request
-		 * @param mixed|string|null      $operation The name of the operation
-		 * @param string      $query     The query that GraphQL executed
-		 * @param array|null  $variables Variables to passed to your GraphQL query
-		 * @param \WPGraphQL\Request $request Instance of the Request
+		 * @param mixed|array<string,mixed>|object $response  The response your GraphQL request
+		 * @param \WPGraphQL\WPSchema              $schema The schema object for the root request
+		 * @param mixed|string|null                $operation The name of the operation
+		 * @param string                           $query     The query that GraphQL executed
+		 * @param mixed[]|null                     $variables Variables to passed to your GraphQL query
+		 * @param \WPGraphQL\Request               $request Instance of the Request
 		 *
 		 * @since 0.0.4
 		 */
@@ -537,13 +537,13 @@ class Request {
 		 * every response, regardless of the request that was sent to it, this could allow for that
 		 * to be hooked in and included in the $response.
 		 *
-		 * @param array      $response  The response for your GraphQL query
-		 * @param \WPGraphQL\WPSchema $schema The schema object for the root query
-		 * @param string     $operation The name of the operation
-		 * @param string     $query     The query that GraphQL executed
-		 * @param array|null $variables Variables to passed to your GraphQL request
-		 * @param \WPGraphQL\Request $request Instance of the Request
-		 * @param string|null $query_id The query id that GraphQL executed
+		 * @param mixed|array<string,mixed>|object $response  The response for your GraphQL query
+		 * @param \WPGraphQL\WPSchema              $schema    The schema object for the root query
+		 * @param string                           $operation The name of the operation
+		 * @param string                           $query     The query that GraphQL executed
+		 * @param mixed[]|null                     $variables Variables to passed to your GraphQL request
+		 * @param \WPGraphQL\Request               $request   Instance of the Request
+		 * @param ?string                          $query_id  The query id that GraphQL executed
 		 *
 		 * @since 0.0.5
 		 */
@@ -553,14 +553,14 @@ class Request {
 		 * Run an action after the response has been filtered, as the response is being returned.
 		 * This is a good place for debug tools to hook in to log things, etc.
 		 *
-		 * @param array      $filtered_response The filtered response for the GraphQL request
-		 * @param array      $response          The response for your GraphQL request
-		 * @param \WPGraphQL\WPSchema $schema The schema object for the root request
-		 * @param string     $operation         The name of the operation
-		 * @param string     $query             The query that GraphQL executed
-		 * @param array|null $variables         Variables to passed to your GraphQL query
-		 * @param \WPGraphQL\Request $request Instance of the Request
-		 * @param string|null $query_id          The query id that GraphQL executed
+		 * @param mixed|array<string,mixed>|object $filtered_response The filtered response for the GraphQL request
+		 * @param mixed|array<string,mixed>|object $response          The response for your GraphQL request
+		 * @param \WPGraphQL\WPSchema              $schema            The schema object for the root request
+		 * @param string                           $operation         The name of the operation
+		 * @param string                           $query             The query that GraphQL executed
+		 * @param mixed[]|null                     $variables         Variables to passed to your GraphQL query
+		 * @param \WPGraphQL\Request               $request           Instance of the Request
+		 * @param ?string                          $query_id          The query id that GraphQL executed
 		 */
 		do_action( 'graphql_return_response', $filtered_response, $response, $this->schema, $operation, $query, $variables, $this, $query_id );
 

--- a/src/Router.php
+++ b/src/Router.php
@@ -299,7 +299,7 @@ class Router {
 		/**
 		 * Filtered list of access control headers.
 		 *
-		 * @param array $access_control_headers Array of headers to allow.
+		 * @param string[] $access_control_headers Array of headers to allow.
 		 */
 		$access_control_allow_headers = apply_filters(
 			'graphql_access_control_allow_headers',
@@ -386,7 +386,7 @@ class Router {
 			/**
 			 * Fire an action when the headers are set
 			 *
-			 * @param array $headers The headers sent in the response
+			 * @param array<string,mixed> $headers The headers sent in the response
 			 */
 			do_action( 'graphql_response_set_headers', $headers );
 		}
@@ -483,7 +483,7 @@ class Router {
 			/**
 			 * Filter thrown GraphQL errors
 			 *
-			 * @param array               $errors  Formatted errors object.
+			 * @param mixed[]             $errors  Formatted errors object.
 			 * @param \Throwable          $error   Thrown error.
 			 * @param \WPGraphQL\Request  $request WPGraphQL Request object.
 			 */
@@ -508,12 +508,12 @@ class Router {
 		 * to hook in to track metrics, such as how long the process took from `graphql_process_http_request`
 		 * to here, etc.
 		 *
-		 * @param array      $response       The GraphQL response
-		 * @param array      $result         The result of the GraphQL Query
-		 * @param string     $operation_name The name of the operation
-		 * @param string     $query          The request that GraphQL executed
-		 * @param ?array     $variables      Variables to passed to your GraphQL query
-		 * @param int|string $status_code    The status code for the response
+		 * @param array<string,mixed> $response       The GraphQL response
+		 * @param array<string,mixed> $result         The result of the GraphQL Query
+		 * @param string              $operation_name The name of the operation
+		 * @param string              $query          The request that GraphQL executed
+		 * @param ?array              $variables      Variables to passed to your GraphQL query
+		 * @param int|string          $status_code    The status code for the response
 		 *
 		 * @since 0.0.5
 		 */
@@ -542,12 +542,12 @@ class Router {
 		/**
 		 * Filter the $status_code before setting the headers
 		 *
-		 * @param int     $status_code     The status code to apply to the headers
-		 * @param array   $response        The response of the GraphQL Request
-		 * @param array   $graphql_results The results of the GraphQL execution
-		 * @param string  $query           The GraphQL query
-		 * @param string  $operation_name  The operation name of the GraphQL Request
-		 * @param array   $variables       The variables applied to the GraphQL Request
+		 * @param int      $status_code     The status code to apply to the headers
+		 * @param array    $response        The response of the GraphQL Request
+		 * @param array    $graphql_results The results of the GraphQL execution
+		 * @param string   $query           The GraphQL query
+		 * @param string   $operation_name  The operation name of the GraphQL Request
+		 * @param mixed[]  $variables       The variables applied to the GraphQL Request
 		 * @param \WP_User $user The current user object
 		 */
 		self::$http_status_code = apply_filters( 'graphql_response_status_code', self::$http_status_code, $response, $graphql_results, $query, $operation_name, $variables, $user );

--- a/src/Router.php
+++ b/src/Router.php
@@ -410,7 +410,7 @@ class Router {
 	/**
 	 * This processes the graphql requests that come into the /graphql endpoint via an HTTP request
 	 *
-	 * @return mixed
+	 * @return void
 	 * @throws \Exception Throws Exception.
 	 * @throws \Throwable Throws Exception.
 	 * @global WP_User $current_user The currently authenticated user.
@@ -508,12 +508,12 @@ class Router {
 		 * to hook in to track metrics, such as how long the process took from `graphql_process_http_request`
 		 * to here, etc.
 		 *
-		 * @param array  $response       The GraphQL response
-		 * @param array  $result         The result of the GraphQL Query
-		 * @param string $operation_name The name of the operation
-		 * @param string $query          The request that GraphQL executed
-		 * @param ?array $variables      Variables to passed to your GraphQL query
-		 * @param mixed  $status_code    The status code for the response
+		 * @param array      $response       The GraphQL response
+		 * @param array      $result         The result of the GraphQL Query
+		 * @param string     $operation_name The name of the operation
+		 * @param string     $query          The request that GraphQL executed
+		 * @param ?array     $variables      Variables to passed to your GraphQL query
+		 * @param int|string $status_code    The status code for the response
 		 *
 		 * @since 0.0.5
 		 */

--- a/src/Server/ValidationRules/RequireAuthentication.php
+++ b/src/Server/ValidationRules/RequireAuthentication.php
@@ -71,7 +71,7 @@ class RequireAuthentication extends QuerySecurityRule {
 		/**
 		 * Filters the allowed
 		 *
-		 * @param array             $allowed_root_fields The Root fields allowed to be requested without authentication
+		 * @param string[]                             $allowed_root_fields The Root fields allowed to be requested without authentication
 		 * @param \GraphQL\Validator\ValidationContext $context The Validation context of the field being executed.
 		 */
 		$allowed_root_fields = apply_filters( 'graphql_require_authentication_allowed_fields', $allowed_root_fields, $context );

--- a/src/Server/WPHelper.php
+++ b/src/Server/WPHelper.php
@@ -45,8 +45,8 @@ class WPHelper extends Helper {
 		 * persisted queries (and ends up being a bit more flexible than
 		 * graphql-php's built-in persistentQueryLoader).
 		 *
-		 * @param array $data An array containing the pieces of the data of the GraphQL request
-		 * @param array $request_context An array containing the both body and query params
+		 * @param mixed[] $data            An array containing the pieces of the data of the GraphQL request
+		 * @param mixed[] $request_context An array containing the both body and query params
 		 */
 		if ( 'GET' === $method ) {
 			$parsed_query_params = apply_filters( 'graphql_request_data', $parsed_query_params, $request_context );

--- a/src/Server/WPHelper.php
+++ b/src/Server/WPHelper.php
@@ -64,8 +64,8 @@ class WPHelper extends Helper {
 	/**
 	 * Parse parameters and proxy to parse_extensions.
 	 *
-	 * @param  mixed[] $params Request parameters.
-	 * @return mixed[]
+	 * @param array<string,mixed>|array<string,mixed>[] $params Request parameters.
+	 * @return array<string,mixed>|array<string,mixed>[]
 	 */
 	private function parse_params( $params ) {
 		if ( isset( $params[0] ) ) {
@@ -78,8 +78,8 @@ class WPHelper extends Helper {
 	/**
 	 * Parse query extensions.
 	 *
-	 * @param  mixed[] $params Request parameters.
-	 * @return mixed[]
+	 * @param  array<string,mixed> $params Request parameters.
+	 * @return array<string,mixed>
 	 */
 	private function parse_extensions( $params ) {
 		if ( isset( $params['extensions'] ) && is_string( $params['extensions'] ) ) {

--- a/src/Type/ObjectType/MenuItem.php
+++ b/src/Type/ObjectType/MenuItem.php
@@ -171,12 +171,12 @@ class MenuItem {
 							 * but would prefer to represent the menu item in other ways,
 							 * e.g., a linked post object (or vice-versa).
 							 *
-							 * @param \WP_Post|\WP_Term $resolved_object Post or term connected to MenuItem
-							 * @param array             $args            Array of arguments input in the field as part of the GraphQL query
-							 * @param \WPGraphQL\AppContext $context Object containing app context that gets passed down the resolve tree
-							 * @param \GraphQL\Type\Definition\ResolveInfo $info Info about fields passed down the resolve tree
-							 * @param int               $object_id       Post or term ID of connected object
-							 * @param string            $object_type     Type of connected object ("post_type" or "taxonomy")
+							 * @param \WP_Post|\WP_Term                    $resolved_object Post or term connected to MenuItem
+							 * @param array<string,mixed>                  $args            Array of arguments input in the field as part of the GraphQL query
+							 * @param \WPGraphQL\AppContext                $context         Object containing app context that gets passed down the resolve tree
+							 * @param \GraphQL\Type\Definition\ResolveInfo $info            Info about fields passed down the resolve tree
+							 * @param int                                  $object_id       Post or term ID of connected object
+							 * @param string                               $object_type     Type of connected object ("post_type" or "taxonomy")
 							 *
 							 * @since 0.0.30
 							 */

--- a/src/Type/WPConnectionType.php
+++ b/src/Type/WPConnectionType.php
@@ -142,7 +142,7 @@ class WPConnectionType {
 		/**
 		 * Filter the config of WPConnectionType
 		 *
-		 * @param array        $config         Array of configuration options passed to the WPConnectionType when instantiating a new type
+		 * @param array<string,mixed>              $config             Array of configuration options passed to the WPConnectionType when instantiating a new type
 		 * @param \WPGraphQL\Type\WPConnectionType $wp_connection_type The instance of the WPConnectionType class
 		 */
 		$config = apply_filters( 'graphql_wp_connection_type_config', $config, $this );
@@ -188,7 +188,7 @@ class WPConnectionType {
 		/**
 		 * Run an action when the WPConnectionType is instantiating.
 		 *
-		 * @param array        $config         Array of configuration options passed to the WPObjectType when instantiating a new type
+		 * @param array<string,mixed>              $config             Array of configuration options passed to the WPObjectType when instantiating a new type
 		 * @param \WPGraphQL\Type\WPConnectionType $wp_connection_type The instance of the WPConnectionType class
 		 *
 		 * @since 1.13.0

--- a/src/Type/WPConnectionType.php
+++ b/src/Type/WPConnectionType.php
@@ -91,7 +91,7 @@ class WPConnectionType {
 	/**
 	 * The resolver function to resolve the connection
 	 *
-	 * @var callable|\Closure
+	 * @var callable(mixed $root,array<string,mixed> $args,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info):mixed
 	 */
 	protected $resolve_connection;
 

--- a/src/Type/WPEnumType.php
+++ b/src/Type/WPEnumType.php
@@ -64,7 +64,7 @@ class WPEnumType extends EnumType {
 		 * This is useful when several different types need to be easily filtered at once. . .for example,
 		 * if ALL types with a field of a certain name needed to be adjusted, or something to that tune
 		 *
-		 * @param array $values
+		 * @param array<string,mixed> $values
 		 */
 		$values = apply_filters( 'graphql_enum_values', $values );
 
@@ -76,7 +76,7 @@ class WPEnumType extends EnumType {
 		 * This is useful for more targeted filtering, and is applied after the general filter, to allow for
 		 * more specific overrides
 		 *
-		 * @param array $values
+		 * @param array<string,mixed> $values
 		 *
 		 * @since 0.0.5
 		 */

--- a/src/Type/WPInputObjectType.php
+++ b/src/Type/WPInputObjectType.php
@@ -28,7 +28,7 @@ class WPInputObjectType extends InputObjectType {
 		/**
 		 * Setup the fields
 		 *
-		 * @return array|mixed
+		 * @return array<string,array<string,mixed>>
 		 */
 		if ( ! empty( $config['fields'] ) && is_array( $config['fields'] ) ) {
 			$config['fields'] = function () use ( $config, $type_registry ) {
@@ -63,11 +63,10 @@ class WPInputObjectType extends InputObjectType {
 		 * This is useful when several different types need to be easily filtered at once. . .for example,
 		 * if ALL types with a field of a certain name needed to be adjusted, or something to that tune
 		 *
-		 * @param array  $fields    The array of fields for the object config
-		 * @param string $type_name The name of the object type
-		 * @param array  $config    The type config
-		 *
-		 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The TypeRegistry instance
+		 * @param array<string,array<string,mixed>> $fields        The array of fields for the object config
+		 * @param string                            $type_name     The name of the object type
+		 * @param array<string,mixed>               $config        The type config
+		 * @param \WPGraphQL\Registry\TypeRegistry  $type_registry The TypeRegistry instance
 		 */
 		$fields = apply_filters( 'graphql_input_fields', $fields, $type_name, $config, $type_registry );
 
@@ -83,8 +82,8 @@ class WPInputObjectType extends InputObjectType {
 		 * This is useful for more targeted filtering, and is applied after the general filter, to allow for
 		 * more specific overrides
 		 *
-		 * @param array $fields The array of fields for the object config
-		 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The TypeRegistry instance
+		 * @param array<string,array<string,mixed>> $fields        The array of fields for the object config
+		 * @param \WPGraphQL\Registry\TypeRegistry  $type_registry The TypeRegistry instance
 		 */
 		$fields = apply_filters( "graphql_{$lc_type_name}_fields", $fields, $type_registry );
 
@@ -94,8 +93,8 @@ class WPInputObjectType extends InputObjectType {
 		 * This is useful for more targeted filtering, and is applied after the general filter, to allow for
 		 * more specific overrides
 		 *
-		 * @param array $fields The array of fields for the object config
-		 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The TypeRegistry instance
+		 * @param array<string,array<string,mixed>> $fields        The array of fields for the object config
+		 * @param \WPGraphQL\Registry\TypeRegistry  $type_registry The TypeRegistry instance
 		 */
 		$fields = apply_filters( "graphql_{$uc_type_name}_fields", $fields, $type_registry );
 

--- a/src/Type/WPInterfaceType.php
+++ b/src/Type/WPInterfaceType.php
@@ -121,7 +121,7 @@ class WPInterfaceType extends InterfaceType {
 	 * @param array<string,array<string,mixed>> $fields The array of fields for the object config
 	 * @param string                            $type_name
 	 *
-	 * @return mixed
+	 * @return array<string,array<string,mixed>>
 	 * @since 0.0.5
 	 */
 	public function prepare_fields( array $fields, string $type_name ) {

--- a/src/Type/WPInterfaceType.php
+++ b/src/Type/WPInterfaceType.php
@@ -97,7 +97,7 @@ class WPInterfaceType extends InterfaceType {
 		/**
 		 * Filter the config of WPInterfaceType
 		 *
-		 * @param array           $config Array of configuration options passed to the WPInterfaceType when instantiating a new type
+		 * @param array<string,mixed>             $config Array of configuration options passed to the WPInterfaceType when instantiating a new type
 		 * @param \WPGraphQL\Type\WPInterfaceType $wp_interface_type The instance of the WPInterfaceType class
 		 */
 		$config = apply_filters( 'graphql_wp_interface_type_config', $config, $this );
@@ -132,8 +132,8 @@ class WPInterfaceType extends InterfaceType {
 		 * This is useful when several different types need to be easily filtered at once. . .for example,
 		 * if ALL types with a field of a certain name needed to be adjusted, or something to that tune
 		 *
-		 * @param array  $fields    The array of fields for the object config
-		 * @param string $type_name The name of the object type
+		 * @param array<string,array<string,mixed>> $fields    The array of fields for the object config
+		 * @param string                            $type_name The name of the object type
 		 */
 		$fields = apply_filters( 'graphql_interface_fields', $fields, $type_name );
 
@@ -149,7 +149,7 @@ class WPInterfaceType extends InterfaceType {
 		 * This is useful for more targeted filtering, and is applied after the general filter, to allow for
 		 * more specific overrides
 		 *
-		 * @param array $fields The array of fields for the object config
+		 * @param array<string,array<string,mixed>> $fields The array of fields for the object config
 		 */
 		$fields = apply_filters( "graphql_{$lc_type_name}_fields", $fields );
 
@@ -159,7 +159,7 @@ class WPInterfaceType extends InterfaceType {
 		 * This is useful for more targeted filtering, and is applied after the general filter, to allow for
 		 * more specific overrides
 		 *
-		 * @param array $fields The array of fields for the object config
+		 * @param array<string,array<string,mixed>> $fields The array of fields for the object config
 		 */
 		$fields = apply_filters( "graphql_{$uc_type_name}_fields", $fields );
 

--- a/src/Type/WPMutationType.php
+++ b/src/Type/WPMutationType.php
@@ -56,7 +56,7 @@ class WPMutationType {
 	/**
 	 * The resolver function to resolve the mutation
 	 *
-	 * @var callable|\Closure
+	 * @var callable(mixed $root,array<string,mixed> $args,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info): array<string,mixed>
 	 */
 	protected $resolve_mutation;
 
@@ -192,6 +192,8 @@ class WPMutationType {
 
 	/**
 	 * Gets the resolver callable for the mutation.
+	 *
+	 * @return callable(mixed $root,array<string,mixed> $args,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info): array<string,mixed>
 	 */
 	protected function get_resolver(): callable {
 		return function ( $root, array $args, AppContext $context, ResolveInfo $info ) {

--- a/src/Type/WPMutationType.php
+++ b/src/Type/WPMutationType.php
@@ -80,7 +80,7 @@ class WPMutationType {
 		/**
 		 * Filter the config of WPMutationType
 		 *
-		 * @param array        $config         Array of configuration options passed to the WPMutationType when instantiating a new type
+		 * @param array<string,mixed>            $config           Array of configuration options passed to the WPMutationType when instantiating a new type
 		 * @param \WPGraphQL\Type\WPMutationType $wp_mutation_type The instance of the WPMutationType class
 		 *
 		 * @since 1.13.0
@@ -109,7 +109,7 @@ class WPMutationType {
 		/**
 		 * Run an action when the WPMutationType is instantiating.
 		 *
-		 * @param array        $config         Array of configuration options passed to the WPObjectType when instantiating a new type
+		 * @param array<string,mixed>            $config           Array of configuration options passed to the WPObjectType when instantiating a new type
 		 * @param \WPGraphQL\Type\WPMutationType $wp_mutation_type The instance of the WPMutationType class
 		 *
 		 * @since 1.13.0
@@ -204,10 +204,10 @@ class WPMutationType {
 			/**
 			 * Filters the mutation input before it's passed to the `mutateAndGetPayload` callback.
 			 *
-			 * @param array $input The mutation input args.
-			 * @param \WPGraphQL\AppContext $context The AppContext object.
-			 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object.
-			 * @param string $mutation_name The name of the mutation field.
+			 * @param array<string,mixed>                  $input         The mutation input args.
+			 * @param \WPGraphQL\AppContext                $context       The AppContext object.
+			 * @param \GraphQL\Type\Definition\ResolveInfo $info          The ResolveInfo object.
+			 * @param string                               $mutation_name The name of the mutation field.
 			 */
 			$input = apply_filters( 'graphql_mutation_input', $unfiltered_input, $context, $info, $this->mutation_name );
 
@@ -216,11 +216,11 @@ class WPMutationType {
 			 * Returning anything other than null will stop the callback for the mutation from executing,
 			 * and will return your data or execute your callback instead.
 			 *
-			 * @param array|callable|null $payload. The payload returned from the callback. Null by default.
-			 * @param string $mutation_name The name of the mutation field.
-			 * @param callable|\Closure $mutateAndGetPayload The callback for the mutation.
-			 * @param array $input The mutation input args.
-			 * @param \WPGraphQL\AppContext $context The AppContext object.
+			 * @param array<string,mixed>|callable|null   $payload.            The payload returned from the callback. Null by default.
+			 * @param string                $mutation_name       The name of the mutation field.
+			 * @param callable|\Closure     $mutateAndGetPayload The callback for the mutation.
+			 * @param array<string,mixed>   $input               The mutation input args.
+			 * @param \WPGraphQL\AppContext $context             The AppContext object.
 			 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object.
 			 */
 			$pre = apply_filters( 'graphql_pre_mutate_and_get_payload', null, $this->mutation_name, $this->config['mutateAndGetPayload'], $input, $context, $info );
@@ -233,9 +233,9 @@ class WPMutationType {
 				/**
 				 * Filters the payload returned from the default mutateAndGetPayload callback.
 				 *
-				 * @param array $payload The payload returned from the callback.
-				 * @param string $mutation_name The name of the mutation field.
-				 * @param array $input The mutation input args.
+				 * @param array<string,mixed>   $payload The payload returned from the callback.
+				 * @param string                $mutation_name The name of the mutation field.
+				 * @param array<string,mixed>   $input The mutation input args.
 				 * @param \WPGraphQL\AppContext $context The AppContext object.
 				 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object.
 				 */
@@ -245,12 +245,12 @@ class WPMutationType {
 			/**
 			 * Fires after the mutation payload has been returned from the `mutateAndGetPayload` callback.
 			 *
-			 * @param array $payload The Payload returned from the mutation.
-			 * @param array $input The mutation input args, after being filtered by 'graphql_mutation_input'.
-			 * @param array $unfiltered_input The unfiltered input args of the mutation
-			 * @param \WPGraphQL\AppContext $context The AppContext object.
-			 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object.
-			 * @param string $mutation_name The name of the mutation field.
+			 * @param array<string,mixed>                  $payload          The Payload returned from the mutation.
+			 * @param array<string,mixed>                  $input            The mutation input args, after being filtered by 'graphql_mutation_input'.
+			 * @param array<string,mixed>                  $unfiltered_input The unfiltered input args of the mutation
+			 * @param \WPGraphQL\AppContext                $context          The AppContext object.
+			 * @param \GraphQL\Type\Definition\ResolveInfo $info             The ResolveInfo object.
+			 * @param string                               $mutation_name    The name of the mutation field.
 			 */
 			do_action( 'graphql_mutation_response', $payload, $input, $unfiltered_input, $context, $info, $this->mutation_name );
 

--- a/src/Type/WPObjectType.php
+++ b/src/Type/WPObjectType.php
@@ -167,7 +167,7 @@ class WPObjectType extends ObjectType {
 	 * @param string              $type_name
 	 * @param array<string,mixed> $config         The config for the Object Type
 	 *
-	 * @return mixed
+	 * @return array<string,mixed>
 	 * @since 0.0.5
 	 */
 	public function prepare_fields( $fields, $type_name, $config ) {

--- a/src/Type/WPObjectType.php
+++ b/src/Type/WPObjectType.php
@@ -77,7 +77,7 @@ class WPObjectType extends ObjectType {
 		/**
 		 * Setup the fields
 		 *
-		 * @return array|mixed
+		 * @return array<string, array<string, mixed>> $fields
 		 */
 		$config['fields'] = function () use ( $config ) {
 			$fields = $config['fields'];
@@ -124,7 +124,7 @@ class WPObjectType extends ObjectType {
 		/**
 		 * Run an action when the WPObjectType is instantiating
 		 *
-		 * @param array                        $config         Array of configuration options passed to the WPObjectType when instantiating a new type
+		 * @param array<string,mixed>          $config         Array of configuration options passed to the WPObjectType when instantiating a new type
 		 * @param \WPGraphQL\Type\WPObjectType $wp_object_type The instance of the WPObjectType class
 		 */
 		do_action( 'graphql_wp_object_type', $config, $this );
@@ -163,9 +163,9 @@ class WPObjectType extends ObjectType {
 	 * This function sorts the fields and applies a filter to allow for easily
 	 * extending/modifying the shape of the Schema for the type.
 	 *
-	 * @param array<string,mixed> $fields         The array of fields for the object config
+	 * @param array<string,mixed> $fields    The array of fields for the object config
 	 * @param string              $type_name
-	 * @param array<string,mixed> $config         The config for the Object Type
+	 * @param array<string,mixed> $config    The config for the Object Type
 	 *
 	 * @return array<string,mixed>
 	 * @since 0.0.5
@@ -178,10 +178,10 @@ class WPObjectType extends ObjectType {
 		 * This is useful when several different types need to be easily filtered at once. . .for example,
 		 * if ALL types with a field of a certain name needed to be adjusted, or something to that tune
 		 *
-		 * @param array        $fields         The array of fields for the object config
-		 * @param string       $type_name      The name of the object type
-		 * @param \WPGraphQL\Type\WPObjectType $wp_object_type The WPObjectType Class
-		 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The Type Registry
+		 * @param array<string,mixed>              $fields         The array of fields for the object config
+		 * @param string                           $type_name      The name of the object type
+		 * @param \WPGraphQL\Type\WPObjectType     $wp_object_type The WPObjectType Class
+		 * @param \WPGraphQL\Registry\TypeRegistry $type_registry  The Type Registry
 		 */
 		$fields = apply_filters( 'graphql_object_fields', $fields, $type_name, $this, $this->type_registry );
 
@@ -197,9 +197,9 @@ class WPObjectType extends ObjectType {
 		 * This is useful for more targeted filtering, and is applied after the general filter, to allow for
 		 * more specific overrides
 		 *
-		 * @param array        $fields         The array of fields for the object config
-		 * @param \WPGraphQL\Type\WPObjectType $wp_object_type The WPObjectType Class
-		 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The Type Registry
+		 * @param array<string,mixed>              $fields         The array of fields for the object config
+		 * @param \WPGraphQL\Type\WPObjectType     $wp_object_type The WPObjectType Class
+		 * @param \WPGraphQL\Registry\TypeRegistry $type_registry  The Type Registry
 		 */
 		$fields = apply_filters( "graphql_{$lc_type_name}_fields", $fields, $this, $this->type_registry );
 
@@ -209,9 +209,9 @@ class WPObjectType extends ObjectType {
 		 * This is useful for more targeted filtering, and is applied after the general filter, to allow for
 		 * more specific overrides
 		 *
-		 * @param array        $fields         The array of fields for the object config
-		 * @param \WPGraphQL\Type\WPObjectType $wp_object_type The WPObjectType Class
-		 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The Type Registry
+		 * @param array<string,mixed>              $fields         The array of fields for the object config
+		 * @param \WPGraphQL\Type\WPObjectType     $wp_object_type The WPObjectType Class
+		 * @param \WPGraphQL\Registry\TypeRegistry $type_registry  The Type Registry
 		 */
 		$fields = apply_filters( "graphql_{$uc_type_name}_fields", $fields, $this, $this->type_registry );
 

--- a/src/Type/WPUnionType.php
+++ b/src/Type/WPUnionType.php
@@ -76,8 +76,8 @@ class WPUnionType extends UnionType {
 		/**
 		 * Filter the possible_types to allow systems to add to the possible resolveTypes.
 		 *
-		 * @param mixed       $types         The possible types for the Union
-		 * @param array       $config        The config for the Union Type
+		 * @param mixed                       $types         The possible types for the Union
+		 * @param array<string,mixed>         $config        The config for the Union Type
 		 * @param \WPGraphQL\Type\WPUnionType $wp_union_type The WPUnionType instance
 		 *
 		 * @return mixed|array
@@ -87,7 +87,7 @@ class WPUnionType extends UnionType {
 		/**
 		 * Filter the config of WPUnionType
 		 *
-		 * @param array       $config        Array of configuration options passed to the WPUnionType when instantiating a new type
+		 * @param array<string,mixed>         $config        Array of configuration options passed to the WPUnionType when instantiating a new type
 		 * @param \WPGraphQL\Type\WPUnionType $wp_union_type The instance of the WPUnionType class
 		 *
 		 * @since 0.0.30
@@ -97,7 +97,7 @@ class WPUnionType extends UnionType {
 		/**
 		 * Run an action when the WPUnionType is instantiating
 		 *
-		 * @param array       $config        Array of configuration options passed to the WPUnionType when instantiating a new type
+		 * @param array<string,mixed>       $config        Array of configuration options passed to the WPUnionType when instantiating a new type
 		 * @param \WPGraphQL\Type\WPUnionType $wp_union_type The instance of the WPUnionType class
 		 */
 		do_action( 'graphql_wp_union_type', $config, $this );

--- a/src/Utils/DebugLog.php
+++ b/src/Utils/DebugLog.php
@@ -89,8 +89,8 @@ class DebugLog {
 			/**
 			 * Filter the log entry for the debug log
 			 *
-			 * @param array $log The log entry
-			 * @param array $config The config passed in with the log entry
+			 * @param array<string,mixed> $log    The log entry
+			 * @param array<string,mixed> $config The config passed in with the log entry
 			 */
 			return apply_filters( 'graphql_debug_log_entry', $log_entry, $config );
 		}
@@ -125,7 +125,7 @@ class DebugLog {
 		/**
 		 * Return the filtered debug log
 		 *
-		 * @param array    $logs     The logs to be output with the request
+		 * @param array<string,mixed>[]     $logs     The logs to be output with the request
 		 * @param \WPGraphQL\Utils\DebugLog $instance The Debug Log class
 		 */
 		return apply_filters( 'graphql_debug_log', array_values( $this->logs ), $this );

--- a/src/Utils/InstrumentSchema.php
+++ b/src/Utils/InstrumentSchema.php
@@ -44,7 +44,7 @@ class InstrumentSchema {
 	 * @param mixed[] $fields    The fields configured for a Type
 	 * @param string  $type_name The Type name
 	 *
-	 * @return mixed
+	 * @return mixed[]
 	 */
 	protected static function wrap_fields( array $fields, string $type_name ) {
 		if ( empty( $fields ) || ! is_array( $fields ) ) {
@@ -119,15 +119,15 @@ class InstrumentSchema {
 				 * and the execution of the actual resolved is skipped. This filter can be used to implement
 				 * field level caches or for efficiently hiding data by returning null.
 				 *
-				 * @param mixed           $nil            Unique nil value
-				 * @param mixed           $source         The source passed down the Resolve Tree
-				 * @param array           $args           The args for the field
-				 * @param \WPGraphQL\AppContext $context The AppContext passed down the ResolveTree
-				 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the ResolveTree
-				 * @param string          $type_name      The name of the type the fields belong to
-				 * @param string          $field_key      The name of the field
-				 * @param \GraphQL\Type\Definition\FieldDefinition $field The Field Definition for the resolving field
-				 * @param mixed           $field_resolver The default field resolver
+				 * @param mixed                                    $nil            Unique nil value
+				 * @param mixed                                    $source         The source passed down the Resolve Tree
+				 * @param array                                    $args           The args for the field
+				 * @param \WPGraphQL\AppContext                    $context        The AppContext passed down the ResolveTree
+				 * @param \GraphQL\Type\Definition\ResolveInfo     $info           The ResolveInfo passed down the ResolveTree
+				 * @param string                                   $type_name      The name of the type the fields belong to
+				 * @param string                                   $field_key      The name of the field
+				 * @param \GraphQL\Type\Definition\FieldDefinition $field          The Field Definition for the resolving field
+				 * @param ?callable                                $field_resolver The default field resolver
 				 */
 				$result = apply_filters( 'graphql_pre_resolve_field', $nil, $source, $args, $context, $info, $type_name, $field_key, $field, $field_resolver );
 
@@ -149,15 +149,15 @@ class InstrumentSchema {
 				/**
 				 * Fire an action before the field resolves
 				 *
-				 * @param mixed           $result         The result of the field resolution
-				 * @param mixed           $source         The source passed down the Resolve Tree
-				 * @param array           $args           The args for the field
-				 * @param \WPGraphQL\AppContext $context The AppContext passed down the ResolveTree
-				 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the ResolveTree
-				 * @param string          $type_name      The name of the type the fields belong to
-				 * @param string          $field_key      The name of the field
+				 * @param mixed                                    $result          The result of the field resolution
+				 * @param mixed                                    $source          The source passed down the Resolve Tree
+				 * @param array                                    $args            The args for the field
+				 * @param \WPGraphQL\AppContext                    $context         The AppContext passed down the ResolveTree
+				 * @param \GraphQL\Type\Definition\ResolveInfo     $info            The ResolveInfo passed down the ResolveTree
+				 * @param string                                   $type_name       The name of the type the fields belong to
+				 * @param string                                   $field_key       The name of the field
 				 * @param \GraphQL\Type\Definition\FieldDefinition $field The Field Definition for the resolving field
-				 * @param mixed           $field_resolver The default field resolver
+				 * @param ?callable                                $field_resolver  The default field resolver
 				 */
 				$result = apply_filters( 'graphql_resolve_field', $result, $source, $args, $context, $info, $type_name, $field_key, $field, $field_resolver );
 

--- a/src/Utils/InstrumentSchema.php
+++ b/src/Utils/InstrumentSchema.php
@@ -82,9 +82,9 @@ class InstrumentSchema {
 			 * Replace the existing field resolve method with a new function that captures data about
 			 * the resolver to be stored in the resolver_report
 			 *
-			 * @param mixed       $source  The source passed down the Resolve Tree
-			 * @param array       $args    The args for the field
-			 * @param \WPGraphQL\AppContext $context The AppContext passed down the ResolveTree
+			 * @param mixed                                $source  The source passed down the Resolve Tree
+			 * @param array<string,mixed>                  $args    The args for the field
+			 * @param \WPGraphQL\AppContext                $context The AppContext passed down the ResolveTree
 			 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the ResolveTree
 			 *
 			 * @return mixed
@@ -96,14 +96,14 @@ class InstrumentSchema {
 				/**
 				 * Fire an action BEFORE the field resolves
 				 *
-				 * @param mixed           $source         The source passed down the Resolve Tree
-				 * @param array           $args           The args for the field
-				 * @param \WPGraphQL\AppContext $context The AppContext passed down the ResolveTree
-				 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the ResolveTree
-				 * @param ?callable       $field_resolver The Resolve function for the field
-				 * @param string          $type_name      The name of the type the fields belong to
-				 * @param string          $field_key      The name of the field
-				 * @param \GraphQL\Type\Definition\FieldDefinition $field The Field Definition for the resolving field
+				 * @param mixed                                    $source         The source passed down the Resolve Tree
+				 * @param array<string,mixed>                      $args           The args for the field
+				 * @param \WPGraphQL\AppContext                    $context        The AppContext passed down the ResolveTree
+				 * @param \GraphQL\Type\Definition\ResolveInfo     $info           The ResolveInfo passed down the ResolveTree
+				 * @param ?callable                                $field_resolver The Resolve function for the field
+				 * @param string                                   $type_name      The name of the type the fields belong to
+				 * @param string                                   $field_key      The name of the field
+				 * @param \GraphQL\Type\Definition\FieldDefinition $field          The Field Definition for the resolving field
 				 */
 				do_action( 'graphql_before_resolve_field', $source, $args, $context, $info, $field_resolver, $type_name, $field_key, $field );
 
@@ -121,7 +121,7 @@ class InstrumentSchema {
 				 *
 				 * @param mixed                                    $nil            Unique nil value
 				 * @param mixed                                    $source         The source passed down the Resolve Tree
-				 * @param array                                    $args           The args for the field
+				 * @param array<string,mixed>                      $args           The args for the field
 				 * @param \WPGraphQL\AppContext                    $context        The AppContext passed down the ResolveTree
 				 * @param \GraphQL\Type\Definition\ResolveInfo     $info           The ResolveInfo passed down the ResolveTree
 				 * @param string                                   $type_name      The name of the type the fields belong to
@@ -151,7 +151,7 @@ class InstrumentSchema {
 				 *
 				 * @param mixed                                    $result          The result of the field resolution
 				 * @param mixed                                    $source          The source passed down the Resolve Tree
-				 * @param array                                    $args            The args for the field
+				 * @param array<string,mixed>                      $args            The args for the field
 				 * @param \WPGraphQL\AppContext                    $context         The AppContext passed down the ResolveTree
 				 * @param \GraphQL\Type\Definition\ResolveInfo     $info            The ResolveInfo passed down the ResolveTree
 				 * @param string                                   $type_name       The name of the type the fields belong to
@@ -164,15 +164,15 @@ class InstrumentSchema {
 				/**
 				 * Fire an action AFTER the field resolves
 				 *
-				 * @param mixed           $source         The source passed down the Resolve Tree
-				 * @param array           $args           The args for the field
-				 * @param \WPGraphQL\AppContext $context The AppContext passed down the ResolveTree
-				 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the ResolveTree
-				 * @param ?callable        $field_resolver The Resolve function for the field
-				 * @param string          $type_name      The name of the type the fields belong to
-				 * @param string          $field_key      The name of the field
-				 * @param \GraphQL\Type\Definition\FieldDefinition $field The Field Definition for the resolving field
-				 * @param mixed           $result         The result of the field resolver
+				 * @param mixed                                    $source         The source passed down the Resolve Tree
+				 * @param array<string,mixed>                      $args           The args for the field
+				 * @param \WPGraphQL\AppContext                    $context        The AppContext passed down the ResolveTree
+				 * @param \GraphQL\Type\Definition\ResolveInfo     $info           The ResolveInfo passed down the ResolveTree
+				 * @param ?callable                                $field_resolver The Resolve function for the field
+				 * @param string                                   $type_name      The name of the type the fields belong to
+				 * @param string                                   $field_key      The name of the field
+				 * @param \GraphQL\Type\Definition\FieldDefinition $field          The Field Definition for the resolving field
+				 * @param mixed                                    $result         The result of the field resolver
 				 */
 				do_action( 'graphql_after_resolve_field', $source, $args, $context, $info, $field_resolver, $type_name, $field_key, $field, $result );
 

--- a/src/Utils/QueryAnalyzer.php
+++ b/src/Utils/QueryAnalyzer.php
@@ -359,9 +359,9 @@ class QueryAnalyzer {
 	public function set_list_types( ?Schema $schema, ?string $query ): array {
 
 		/**
-		 * @param array|null $null   Default value for the filter
+		 * @param string[]|null         $null   Default value for the filter
 		 * @param ?\GraphQL\Type\Schema $schema The WPGraphQL Schema for the current request
-		 * @param ?string    $query  The query string being requested
+		 * @param ?string               $query  The query string being requested
 		 */
 		$null               = null;
 		$pre_get_list_types = apply_filters( 'graphql_pre_query_analyzer_get_list_types', $null, $schema, $query );
@@ -458,9 +458,9 @@ class QueryAnalyzer {
 	public function set_query_types( ?Schema $schema, ?string $query ): array {
 
 		/**
-		 * @param array|null $null   Default value for the filter
+		 * @param string[]|null         $null   Default value for the filter
 		 * @param ?\GraphQL\Type\Schema $schema The WPGraphQL Schema for the current request
-		 * @param ?string    $query  The query string being requested
+		 * @param ?string               $query  The query string being requested
 		 */
 		$null                = null;
 		$pre_get_query_types = apply_filters( 'graphql_pre_query_analyzer_get_query_types', $null, $schema, $query );
@@ -536,9 +536,9 @@ class QueryAnalyzer {
 	public function set_query_models( ?Schema $schema, ?string $query ): array {
 
 		/**
-		 * @param array|null $null   Default value for the filter
+		 * @param string[]|null         $null   Default value for the filter
 		 * @param ?\GraphQL\Type\Schema $schema The WPGraphQL Schema for the current request
-		 * @param ?string    $query  The query string being requested
+		 * @param ?string               $query  The query string being requested
 		 */
 		$null           = null;
 		$pre_get_models = apply_filters( 'graphql_pre_query_analyzer_get_models', $null, $schema, $query );
@@ -608,9 +608,9 @@ class QueryAnalyzer {
 			/**
 			 * Filter the node ID before returning to the list of resolved nodes
 			 *
-			 * @param int    $model_id      The ID of the model (node) being returned
-			 * @param object $model         The Model object being returned
-			 * @param array  $runtime_nodes The runtimes nodes already collected
+			 * @param int             $model_id      The ID of the model (node) being returned
+			 * @param object          $model         The Model object being returned
+			 * @param string[]|int[]  $runtime_nodes The runtimes nodes already collected
 			 */
 			$node_id = apply_filters( 'graphql_query_analyzer_runtime_node', $model->id, $model, $this->runtime_nodes );
 
@@ -706,11 +706,11 @@ class QueryAnalyzer {
 		}
 
 		/**
-		 * @param array  $graphql_keys       Information about the keys and skipped keys returned by the Query Analyzer
-		 * @param string $return_keys        The keys returned to the X-GraphQL-Keys header
-		 * @param string $skipped_keys       The Keys that were skipped (truncated due to size limit) from the X-GraphQL-Keys header
-		 * @param array  $return_keys_array  The keys returned to the X-GraphQL-Keys header, in array instead of string
-		 * @param array  $skipped_keys_array The keys skipped, in array instead of string
+		 * @param array<string,mixed> $graphql_keys       Information about the keys and skipped keys returned by the Query Analyzer
+		 * @param string              $return_keys        The keys returned to the X-GraphQL-Keys header
+		 * @param string              $skipped_keys       The Keys that were skipped (truncated due to size limit) from the X-GraphQL-Keys header
+		 * @param string[]            $return_keys_array  The keys returned to the X-GraphQL-Keys header, in array instead of string
+		 * @param string[]            $skipped_keys_array The keys skipped, in array instead of string
 		 */
 		$this->graphql_keys = apply_filters(
 			'graphql_query_analyzer_graphql_keys',
@@ -766,12 +766,12 @@ class QueryAnalyzer {
 		$should = \WPGraphQL::debug();
 
 		/**
-		 * @param bool        $should         Whether the query analyzer output should be displayed in the Extensions output. Default to the value of WPGraphQL Debug.
-		 * @param mixed       $response       The response of the WPGraphQL Request being executed
-		 * @param \WPGraphQL\WPSchema $schema The WPGraphQL Schema
-		 * @param string|null $operation_name The operation name being executed
-		 * @param string|null $request        The GraphQL Request being made
-		 * @param array|null  $variables      The variables sent with the request
+		 * @param bool                     $should         Whether the query analyzer output should be displayed in the Extensions output. Default to the value of WPGraphQL Debug.
+		 * @param mixed                    $response       The response of the WPGraphQL Request being executed
+		 * @param \WPGraphQL\WPSchema      $schema The WPGraphQL Schema
+		 * @param string|null              $operation_name The operation name being executed
+		 * @param string|null              $request        The GraphQL Request being made
+		 * @param array<string,mixed>|null $variables      The variables sent with the request
 		 */
 		$should_show_query_analyzer_in_extensions = apply_filters( 'graphql_should_show_query_analyzer_in_extensions', $should, $response, $schema, $operation_name, $request, $variables );
 

--- a/src/Utils/QueryLog.php
+++ b/src/Utils/QueryLog.php
@@ -163,8 +163,8 @@ class QueryLog {
 		/**
 		 * Filter the trace
 		 *
-		 * @param array    $trace     The trace to return
-		 * @param \WPGraphQL\Utils\QueryLog $instance The QueryLog class instance
+		 * @param mixed[]                   $trace     The trace to return
+		 * @param \WPGraphQL\Utils\QueryLog $instance  The QueryLog class instance
 		 */
 		return apply_filters( 'graphql_tracing_response', $trace, $this );
 	}

--- a/src/Utils/QueryLog.php
+++ b/src/Utils/QueryLog.php
@@ -124,7 +124,7 @@ class QueryLog {
 	/**
 	 * Return the query log produced from the logs stored by WPDB.
 	 *
-	 * @return mixed[]
+	 * @return array<string,mixed>
 	 */
 	public function get_query_log() {
 		global $wpdb;

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -324,9 +324,9 @@ final class WPGraphQL {
 					/**
 					 * Filters the interfaces applied to an object type
 					 *
-					 * @param array                              $interfaces List of interfaces applied to the Object Type
-					 * @param array                              $config     The config for the Object Type
-					 * @param mixed|\WPGraphQL\Type\WPInterfaceType|\WPGraphQL\Type\WPObjectType $type The Type instance
+					 * @param string[]                                                           $interfaces List of interfaces applied to the Object Type
+					 * @param array<string,mixed>                                                $config     The config for the Object Type
+					 * @param mixed|\WPGraphQL\Type\WPInterfaceType|\WPGraphQL\Type\WPObjectType $type       The Type instance
 					 */
 					return apply_filters_deprecated( 'graphql_object_type_interfaces', [ $interfaces, $config, $type ], '1.4.1', 'graphql_type_interfaces' );
 				}
@@ -439,8 +439,8 @@ final class WPGraphQL {
 		/**
 		 * Filters the graphql args set on a post type
 		 *
-		 * @param array  $args           The graphql specific args for the post type
-		 * @param string $post_type_name The name of the post type being registered
+		 * @param array<string,mixed> $args           The graphql specific args for the post type
+		 * @param string              $post_type_name The name of the post type being registered
 		 */
 		$graphql_args = apply_filters( 'register_graphql_post_type_args', $graphql_args, $post_type_name );
 
@@ -468,8 +468,8 @@ final class WPGraphQL {
 		/**
 		 * Filters the graphql args set on a taxonomy
 		 *
-		 * @param array  $args          The graphql specific args for the taxonomy
-		 * @param string $taxonomy_name The name of the taxonomy being registered
+		 * @param array<string,mixed> $args          The graphql specific args for the taxonomy
+		 * @param string              $taxonomy_name The name of the taxonomy being registered
 		 */
 		$graphql_args = apply_filters( 'register_graphql_taxonomy_args', $graphql_args, $taxonomy_name );
 
@@ -543,12 +543,10 @@ final class WPGraphQL {
 			 * Pass through a filter to allow the post_types to be modified.
 			 * For example if a certain post_type should not be exposed to the GraphQL API.
 			 *
-			 * @param array $post_type_names   Array of post type names.
-			 * @param array $post_type_objects Array of post type objects.
+			 * @param string[]        $post_type_names   Array of post type names.
+			 * @param \WP_Post_Type[] $post_type_objects Array of post type objects.
 			 *
-			 * @return array
 			 * @since 1.8.1 add $post_type_objects parameter.
-			 *
 			 * @since 0.0.2
 			 */
 			$allowed_post_type_names = apply_filters( 'graphql_post_entities_allowed_post_types', $post_type_names, $post_type_objects );
@@ -629,12 +627,10 @@ final class WPGraphQL {
 			 * Pass through a filter to allow the taxonomies to be modified.
 			 * For example if a certain taxonomy should not be exposed to the GraphQL API.
 			 *
-			 * @param array $tax_names   Array of taxonomy names
-			 * @param array $tax_objects Array of taxonomy objects.
+			 * @param string[]       $tax_names   Array of taxonomy names
+			 * @param \WP_Taxonomy[] $tax_objects Array of taxonomy objects.
 			 *
-			 * @return array
 			 * @since 1.8.1 add $tax_names and $tax_objects parameters.
-			 *
 			 * @since 0.0.2
 			 */
 			$allowed_tax_names = apply_filters( 'graphql_term_entities_allowed_taxonomies', $tax_names, $tax_objects );


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR adds stricter PHPDoc type definitions where possible and obvious.

More specifically:
- Added PHPDoc shapes to multiple `callable` types.
- Replaced the use of the `mixed` type with a more specific typedef wherever possible.
- Gave `array` types traversable definitions wherever possible.

**No actual code has been changed.** If 3rd-party code is using an incorrect type, their IDE/linter will now show the type-smells (versus waiting for unexpected behavior and hoping the logs catch something).


Does this close any currently open issues?
------------------------------------------
<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
<!-- (If it’s long, please paste to https://ghostbin.com/ and insert the link here.) -->


Any other comments?
-------------------
💭The stricter we can get our doc-blocks the easier itl be when work begins on V2 💭


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php 8.1.15)

**WordPress Version:** 6.4.2
