### PR TITLE
feat: output GRAPHQL_DEBUG message if requested amount is larger than connection limit

### DIFF
--- a/tests/wpunit/PostObjectConnectionQueriesTest.php
+++ b/tests/wpunit/PostObjectConnectionQueriesTest.php
@@ -195,6 +195,7 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 
 		$this->assertCount( 20, $actual['data']['posts']['edges'] );
 		$this->assertTrue( $actual['data']['posts']['pageInfo']['hasNextPage'] );
+		$this->assertStringContainsString( 'The number of items requested by the connection (150) exceeds the max query amount.', $actual['extensions']['debug'][0]['message'] );
 	}
 
 	/**


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR adds a debug message to the GraphQL response when the requested amount (`first`, `last`) is greater than the `graphql_connection_max_query_amount` filter value set on the server.

### Why 
This addition provides developers with an important indication that they're not actually getting the full results requested, which is particularly important to new users coming from traditional WP-PHP for whom setting `WP_Query( [ 'posts_per_page' => -1 ] )` is discouraged, but commonplace.

A debug message was chosen over throwing a `GraphQLError`, both to preserve back-compat, and because IMO this is the ideal GraphQL pattern: a too-large `first` isnt a schema error, it's something that gets filtered on the backend (ostensibly even based on user role). 

More importantly, it keeps the frontend code reusable and server-agnostic. E.g. a pagination pattern uses the last returned item to fetch the next page of results no matter what the server-limit is, whereas if a `GraphQLError` was thrown, users would need to manually update their frontend code and eschew component libraries / framework starters).


Does this close any currently open issues?
------------------------------------------
<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Closes #3012 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
![image](https://github.com/wp-graphql/wp-graphql/assets/29322304/c1ed708c-ff1e-494b-be6c-099ffe2fa9ab)

Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php 8.1.15)

**WordPress Version:** 6.4.2
