### PR TITLE
release: v1.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 1.20.0
+
+### New Features
+
+- [#3013](https://github.com/wp-graphql/wp-graphql/pull/3013): feat: output GRAPHQL_DEBUG message if requested amount is larger than connection limit. Thanks @justlevine!
+- [#3008](https://github.com/wp-graphql/wp-graphql/pull/3008): perf: Expose graphql_should_analyze_queries as setting. Thanks @justlevine!
+
+### Chores / Bugfixes
+
+- [#3022](https://github.com/wp-graphql/wp-graphql/pull/3022): chore: add @justlevine to list of contributors! 🙌 🥳
+- [#3011](https://github.com/wp-graphql/wp-graphql/pull/3011): chore: update composer dev-dependencies and use php-compatibility:develop branch to 8.0+ lints. Thanks @justlevine! 
+- [#3010](https://github.com/wp-graphql/wp-graphql/pull/3010): chore: implement stricter PHPDoc types. Thanks @justlevine!
+- [#3009](https://github.com/wp-graphql/wp-graphql/pull/3009): chore: implement stricter PHPStan config and clean up unnecessary type-guards. Thanks @justlevine!
+- [#3007](https://github.com/wp-graphql/wp-graphql/pull/3007): fix: call html_entity_decode() with explicit flags and decode single-quotes. Thanks @justlevine!
+- [#3006](https://github.com/wp-graphql/wp-graphql/pull/3006): fix: replace deprecated AbstractConnectionResolver::setQueryArg() call with ::set_query_arg(). Thanks @justlevine!
+- [#3004](https://github.com/wp-graphql/wp-graphql/pull/3004): docs: Update using-data-from-custom-database-tables.md
+- [#2998](https://github.com/wp-graphql/wp-graphql/pull/2998): docs: Update build-your-first-wpgraphql-extension.md. Thanks @Jacob-Daniel!
+- [#2997](https://github.com/wp-graphql/wp-graphql/pull/2997): docs: update wpgraphql-concepts.md. Thanks @Jacob-Daniel!
+- [#2996](https://github.com/wp-graphql/wp-graphql/pull/2996): fix: Field id duplicates uri field description. Thanks @marcinkrzeminski!
+
 ## 1.19.0
 
 ### New Features

--- a/access-functions.php
+++ b/access-functions.php
@@ -150,8 +150,8 @@ function get_graphql_register_action() {
  *
  * Should be used at the `graphql_register_types` hook.
  *
- * @param mixed|string|array<string> $interface_names Array of one or more names of the GraphQL Interfaces to apply to the GraphQL Types
- * @param mixed|string|array<string> $type_names      Array of one or more names of the GraphQL Types to apply the interfaces to.
+ * @param string|string[] $interface_names Array of one or more names of the GraphQL Interfaces to apply to the GraphQL Types
+ * @param string|string[] $type_names      Array of one or more names of the GraphQL Types to apply the interfaces to.
  *
  * Example:
  * The following would register the "MyNewInterface" interface to the Post and Page type in the
@@ -819,10 +819,10 @@ function get_graphql_setting( string $option_name, $default_value = '', $section
 
 	/**
 	 * Filter the section fields
-	 *
-	 * @param array  $section_fields The values of the fields stored for the section
-	 * @param string $section_name   The name of the section
-	 * @param mixed  $default_value  The default value for the option being retrieved
+	 
+	 * @param array<string,mixed> $section_fields The values of the fields stored for the section
+	 * @param string              $section_name   The name of the section
+	 * @param mixed               $default_value  The default value for the option being retrieved
 	 */
 	$section_fields = apply_filters( 'graphql_get_setting_section_fields', $section_fields, $section_name, $default_value );
 
@@ -834,11 +834,11 @@ function get_graphql_setting( string $option_name, $default_value = '', $section
 	/**
 	 * Filter the value before returning it
 	 *
-	 * @param mixed  $value          The value of the field
-	 * @param mixed  $default_value  The default value if there is no value set
-	 * @param string $option_name    The name of the option
-	 * @param array  $section_fields The setting values within the section
-	 * @param string $section_name   The name of the section the setting belongs to
+	 * @param mixed               $value          The value of the field
+	 * @param mixed               $default_value  The default value if there is no value set
+	 * @param string              $option_name    The name of the option
+	 * @param array<string,mixed> $section_fields The setting values within the section
+	 * @param string              $section_name   The name of the section the setting belongs to
 	 */
 	return apply_filters( 'graphql_get_setting_section_field_value', $value, $default_value, $option_name, $section_fields, $section_name );
 }

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
 		"codeception/util-universalframework": "^1.0",
 		"lucatume/wp-browser": "^3.1.6",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
+		"phpcompatibility/php-compatibility": "dev-develop as 9.9.9",
 		"phpstan/extension-installer": "^1.1",
 		"phpstan/phpstan": "~1.10.18",
 		"phpunit/phpunit": "^9.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e4233d9d1c831bf27939e187620292ff",
+    "content-hash": "3bd8f09a8a131fbadbfe66f9581f17ee",
     "packages": [
         {
             "name": "appsero/client",
@@ -166,16 +166,16 @@
     "packages-dev": [
         {
             "name": "antecedent/patchwork",
-            "version": "2.1.26",
+            "version": "2.1.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/antecedent/patchwork.git",
-                "reference": "f2dae0851b2eae4c51969af740fdd0356d7f8f55"
+                "reference": "16a1ab81559aabf14acb616141e801b32777f085"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/f2dae0851b2eae4c51969af740fdd0356d7f8f55",
-                "reference": "f2dae0851b2eae4c51969af740fdd0356d7f8f55",
+                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/16a1ab81559aabf14acb616141e801b32777f085",
+                "reference": "16a1ab81559aabf14acb616141e801b32777f085",
                 "shasum": ""
             },
             "require": {
@@ -196,7 +196,7 @@
                 }
             ],
             "description": "Method redefinition (monkey-patching) functionality for PHP.",
-            "homepage": "http://patchwork2.org/",
+            "homepage": "https://antecedent.github.io/patchwork/",
             "keywords": [
                 "aop",
                 "aspect",
@@ -208,9 +208,9 @@
             ],
             "support": {
                 "issues": "https://github.com/antecedent/patchwork/issues",
-                "source": "https://github.com/antecedent/patchwork/tree/2.1.26"
+                "source": "https://github.com/antecedent/patchwork/tree/2.1.27"
             },
-            "time": "2023-09-18T08:18:37+00:00"
+            "time": "2023-12-03T18:46:49+00:00"
         },
         {
             "name": "automattic/vipwpcs",
@@ -384,6 +384,75 @@
                 "source": "https://github.com/bordoni/phpass/tree/0.3.6"
             },
             "time": "2012-08-31T00:00:00+00:00"
+        },
+        {
+            "name": "carbonphp/carbon-doctrine-types",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/CarbonPHP/carbon-doctrine-types.git",
+                "reference": "3c430083d0b41ceed84ecccf9dac613241d7305d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon-doctrine-types/zipball/3c430083d0b41ceed84ecccf9dac613241d7305d",
+                "reference": "3c430083d0b41ceed84ecccf9dac613241d7305d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.8 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/dbal": ">=3.7.0"
+            },
+            "require-dev": {
+                "doctrine/dbal": ">=2.0.0",
+                "nesbot/carbon": "^2.71.0 || ^3.0.0",
+                "phpunit/phpunit": "^10.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Carbon\\Doctrine\\": "src/Carbon/Doctrine/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "KyleKatarn",
+                    "email": "kylekatarnls@gmail.com"
+                }
+            ],
+            "description": "Types to use Carbon in Doctrine",
+            "keywords": [
+                "carbon",
+                "date",
+                "datetime",
+                "doctrine",
+                "time"
+            ],
+            "support": {
+                "issues": "https://github.com/CarbonPHP/carbon-doctrine-types/issues",
+                "source": "https://github.com/CarbonPHP/carbon-doctrine-types/tree/1.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kylekatarnls",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/Carbon",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/nesbot/carbon",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-10-01T12:35:29+00:00"
         },
         {
             "name": "codeception/codeception",
@@ -1097,16 +1166,16 @@
         },
         {
             "name": "composer/ca-bundle",
-            "version": "1.3.7",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "76e46335014860eec1aa5a724799a00a2e47cc85"
+                "reference": "b66d11b7479109ab547f9405b97205640b17d385"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/76e46335014860eec1aa5a724799a00a2e47cc85",
-                "reference": "76e46335014860eec1aa5a724799a00a2e47cc85",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/b66d11b7479109ab547f9405b97205640b17d385",
+                "reference": "b66d11b7479109ab547f9405b97205640b17d385",
                 "shasum": ""
             },
             "require": {
@@ -1118,7 +1187,7 @@
                 "phpstan/phpstan": "^0.12.55",
                 "psr/log": "^1.0",
                 "symfony/phpunit-bridge": "^4.2 || ^5",
-                "symfony/process": "^2.5 || ^3.0 || ^4.0 || ^5.0 || ^6.0"
+                "symfony/process": "^2.5 || ^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "type": "library",
             "extra": {
@@ -1153,7 +1222,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/ca-bundle/issues",
-                "source": "https://github.com/composer/ca-bundle/tree/1.3.7"
+                "source": "https://github.com/composer/ca-bundle/tree/1.4.0"
             },
             "funding": [
                 {
@@ -1169,7 +1238,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-30T09:31:38+00:00"
+            "time": "2023-12-18T12:05:55+00:00"
         },
         {
             "name": "composer/composer",
@@ -1493,16 +1562,16 @@
         },
         {
             "name": "composer/spdx-licenses",
-            "version": "1.5.7",
+            "version": "1.5.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/spdx-licenses.git",
-                "reference": "c848241796da2abf65837d51dce1fae55a960149"
+                "reference": "560bdcf8deb88ae5d611c80a2de8ea9d0358cc0a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/c848241796da2abf65837d51dce1fae55a960149",
-                "reference": "c848241796da2abf65837d51dce1fae55a960149",
+                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/560bdcf8deb88ae5d611c80a2de8ea9d0358cc0a",
+                "reference": "560bdcf8deb88ae5d611c80a2de8ea9d0358cc0a",
                 "shasum": ""
             },
             "require": {
@@ -1551,9 +1620,9 @@
                 "validator"
             ],
             "support": {
-                "irc": "irc://irc.freenode.org/composer",
+                "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/spdx-licenses/issues",
-                "source": "https://github.com/composer/spdx-licenses/tree/1.5.7"
+                "source": "https://github.com/composer/spdx-licenses/tree/1.5.8"
             },
             "funding": [
                 {
@@ -1569,7 +1638,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-23T07:37:50+00:00"
+            "time": "2023-11-20T07:44:33+00:00"
         },
         {
             "name": "composer/xdebug-handler",
@@ -2719,16 +2788,16 @@
         },
         {
             "name": "lucatume/wp-browser",
-            "version": "3.2.1",
+            "version": "3.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lucatume/wp-browser.git",
-                "reference": "95a189fda634fd52cb44eebbbda3fabe0fdabdb2"
+                "reference": "88456c4d73ded85132c6bfa594f685a90952630c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lucatume/wp-browser/zipball/95a189fda634fd52cb44eebbbda3fabe0fdabdb2",
-                "reference": "95a189fda634fd52cb44eebbbda3fabe0fdabdb2",
+                "url": "https://api.github.com/repos/lucatume/wp-browser/zipball/88456c4d73ded85132c6bfa594f685a90952630c",
+                "reference": "88456c4d73ded85132c6bfa594f685a90952630c",
                 "shasum": ""
             },
             "require": {
@@ -2818,7 +2887,7 @@
             ],
             "support": {
                 "issues": "https://github.com/lucatume/wp-browser/issues",
-                "source": "https://github.com/lucatume/wp-browser/tree/3.2.1"
+                "source": "https://github.com/lucatume/wp-browser/tree/3.2.2"
             },
             "funding": [
                 {
@@ -2826,7 +2895,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-21T06:36:09+00:00"
+            "time": "2023-11-20T15:05:37+00:00"
         },
         {
             "name": "mck89/peast",
@@ -3144,19 +3213,20 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "2.71.0",
+            "version": "2.72.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/briannesbitt/Carbon.git",
-                "reference": "98276233188583f2ff845a0f992a235472d9466a"
+                "reference": "2b3b3db0a2d0556a177392ff1a3bf5608fa09f78"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/98276233188583f2ff845a0f992a235472d9466a",
-                "reference": "98276233188583f2ff845a0f992a235472d9466a",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/2b3b3db0a2d0556a177392ff1a3bf5608fa09f78",
+                "reference": "2b3b3db0a2d0556a177392ff1a3bf5608fa09f78",
                 "shasum": ""
             },
             "require": {
+                "carbonphp/carbon-doctrine-types": "*",
                 "ext-json": "*",
                 "php": "^7.1.8 || ^8.0",
                 "psr/clock": "^1.0",
@@ -3168,8 +3238,8 @@
                 "psr/clock-implementation": "1.0"
             },
             "require-dev": {
-                "doctrine/dbal": "^2.0 || ^3.1.4",
-                "doctrine/orm": "^2.7",
+                "doctrine/dbal": "^2.0 || ^3.1.4 || ^4.0",
+                "doctrine/orm": "^2.7 || ^3.0",
                 "friendsofphp/php-cs-fixer": "^3.0",
                 "kylekatarnls/multi-tester": "^2.0",
                 "ondrejmirtes/better-reflection": "*",
@@ -3246,20 +3316,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-09-25T11:31:05+00:00"
+            "time": "2023-12-08T23:47:49+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.17.1",
+            "version": "v4.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d"
+                "reference": "1bcbb2179f97633e98bbbc87044ee2611c7d7999"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d",
-                "reference": "a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/1bcbb2179f97633e98bbbc87044ee2611c7d7999",
+                "reference": "1bcbb2179f97633e98bbbc87044ee2611c7d7999",
                 "shasum": ""
             },
             "require": {
@@ -3300,9 +3370,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.17.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.18.0"
             },
-            "time": "2023-08-13T19:53:39+00:00"
+            "time": "2023-12-10T21:03:43+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -3417,25 +3487,27 @@
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v6.3.2",
+            "version": "v6.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "f22b00cacd3b9addc2b07ff48290084503c48574"
+                "reference": "6d6063cf9464a306ca2a0529705d41312b08500b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/f22b00cacd3b9addc2b07ff48290084503c48574",
-                "reference": "f22b00cacd3b9addc2b07ff48290084503c48574",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/6d6063cf9464a306ca2a0529705d41312b08500b",
+                "reference": "6d6063cf9464a306ca2a0529705d41312b08500b",
                 "shasum": ""
             },
             "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
                 "nikic/php-parser": "^4.13",
                 "php": "^7.4 || ~8.0.0",
                 "php-stubs/generator": "^0.8.3",
                 "phpdocumentor/reflection-docblock": "^5.3",
                 "phpstan/phpstan": "^1.10.12",
-                "phpunit/phpunit": "^9.5"
+                "phpunit/phpunit": "^9.5",
+                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^0.8"
             },
             "suggest": {
                 "paragonie/sodium_compat": "Pure PHP implementation of libsodium",
@@ -3456,9 +3528,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.3.2"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.4.1"
             },
-            "time": "2023-10-14T10:08:05+00:00"
+            "time": "2023-11-10T00:33:47+00:00"
         },
         {
             "name": "php-webdriver/webdriver",
@@ -3528,33 +3600,45 @@
         },
         {
             "name": "phpcompatibility/php-compatibility",
-            "version": "9.3.5",
+            "version": "dev-develop",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
-                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
+                "reference": "34a67f7eb4ec715df26d90429ea8cce88e0b38ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
-                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/34a67f7eb4ec715df26d90429ea8cce88e0b38ff",
+                "reference": "34a67f7eb4ec715df26d90429ea8cce88e0b38ff",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3",
-                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+                "php": ">=5.4",
+                "phpcsstandards/phpcsutils": "^1.0.5",
+                "squizlabs/php_codesniffer": "^3.7.1"
             },
-            "conflict": {
-                "squizlabs/php_codesniffer": "2.6.2"
+            "replace": {
+                "wimg/php-compatibility": "*"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcsstandards/phpcsdevcs": "^1.1.3",
+                "phpcsstandards/phpcsdevtools": "^1.2.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4 || ^10.1.0",
+                "yoast/phpunit-polyfills": "^1.0.5 || ^2.0.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
                 "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
+            "default-branch": true,
             "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.x-dev",
+                    "dev-develop": "10.x-dev"
+                }
+            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "LGPL-3.0-or-later"
@@ -3580,13 +3664,15 @@
             "keywords": [
                 "compatibility",
                 "phpcs",
-                "standards"
+                "standards",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/PHPCompatibility/PHPCompatibility/issues",
+                "security": "https://github.com/PHPCompatibility/PHPCompatibility/security/policy",
                 "source": "https://github.com/PHPCompatibility/PHPCompatibility"
             },
-            "time": "2019-12-27T09:44:58+00:00"
+            "time": "2023-12-04T17:28:03+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-paragonie",
@@ -3702,29 +3788,29 @@
         },
         {
             "name": "phpcsstandards/phpcsextra",
-            "version": "1.1.2",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
-                "reference": "746c3190ba8eb2f212087c947ba75f4f5b9a58d5"
+                "reference": "11d387c6642b6e4acaf0bd9bf5203b8cca1ec489"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/746c3190ba8eb2f212087c947ba75f4f5b9a58d5",
-                "reference": "746c3190ba8eb2f212087c947ba75f4f5b9a58d5",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/11d387c6642b6e4acaf0bd9bf5203b8cca1ec489",
+                "reference": "11d387c6642b6e4acaf0bd9bf5203b8cca1ec489",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4",
-                "phpcsstandards/phpcsutils": "^1.0.8",
-                "squizlabs/php_codesniffer": "^3.7.1"
+                "phpcsstandards/phpcsutils": "^1.0.9",
+                "squizlabs/php_codesniffer": "^3.8.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0",
                 "php-parallel-lint/php-parallel-lint": "^1.3.2",
                 "phpcsstandards/phpcsdevcs": "^1.1.6",
                 "phpcsstandards/phpcsdevtools": "^1.2.1",
-                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0"
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -3759,35 +3845,50 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSExtra/security/policy",
                 "source": "https://github.com/PHPCSStandards/PHPCSExtra"
             },
-            "time": "2023-09-20T22:06:18+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2023-12-08T16:49:07+00:00"
         },
         {
             "name": "phpcsstandards/phpcsutils",
-            "version": "1.0.8",
+            "version": "1.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "69465cab9d12454e5e7767b9041af0cd8cd13be7"
+                "reference": "908247bc65010c7b7541a9551e002db12e9dae70"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/69465cab9d12454e5e7767b9041af0cd8cd13be7",
-                "reference": "69465cab9d12454e5e7767b9041af0cd8cd13be7",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/908247bc65010c7b7541a9551e002db12e9dae70",
+                "reference": "908247bc65010c7b7541a9551e002db12e9dae70",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.7.1 || 4.0.x-dev@dev"
+                "squizlabs/php_codesniffer": "^3.8.0 || 4.0.x-dev@dev"
             },
             "require-dev": {
                 "ext-filter": "*",
                 "php-parallel-lint/php-console-highlighter": "^1.0",
                 "php-parallel-lint/php-parallel-lint": "^1.3.2",
                 "phpcsstandards/phpcsdevcs": "^1.1.6",
-                "yoast/phpunit-polyfills": "^1.0.5 || ^2.0.0"
+                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -3832,9 +3933,24 @@
             "support": {
                 "docs": "https://phpcsutils.com/",
                 "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSUtils/security/policy",
                 "source": "https://github.com/PHPCSStandards/PHPCSUtils"
             },
-            "time": "2023-07-16T21:39:41+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2023-12-08T14:50:00+00:00"
         },
         {
             "name": "phpstan/extension-installer",
@@ -3882,16 +3998,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.24.2",
+            "version": "1.24.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "bcad8d995980440892759db0c32acae7c8e79442"
+                "reference": "fedf211ff14ec8381c9bf5714e33a7a552dd1acc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/bcad8d995980440892759db0c32acae7c8e79442",
-                "reference": "bcad8d995980440892759db0c32acae7c8e79442",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/fedf211ff14ec8381c9bf5714e33a7a552dd1acc",
+                "reference": "fedf211ff14ec8381c9bf5714e33a7a552dd1acc",
                 "shasum": ""
             },
             "require": {
@@ -3923,22 +4039,22 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.24.2"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.24.5"
             },
-            "time": "2023-09-26T12:28:12+00:00"
+            "time": "2023-12-16T09:33:33+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.40",
+            "version": "1.10.50",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "93c84b5bf7669920d823631e39904d69b9c7dc5d"
+                "reference": "06a98513ac72c03e8366b5a0cb00750b487032e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/93c84b5bf7669920d823631e39904d69b9c7dc5d",
-                "reference": "93c84b5bf7669920d823631e39904d69b9c7dc5d",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/06a98513ac72c03e8366b5a0cb00750b487032e4",
+                "reference": "06a98513ac72c03e8366b5a0cb00750b487032e4",
                 "shasum": ""
             },
             "require": {
@@ -3987,27 +4103,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-10-30T14:48:31+00:00"
+            "time": "2023-12-13T10:59:42+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.29",
+            "version": "9.2.30",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "6a3a87ac2bbe33b25042753df8195ba4aa534c76"
+                "reference": "ca2bd87d2f9215904682a9cb9bb37dda98e76089"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/6a3a87ac2bbe33b25042753df8195ba4aa534c76",
-                "reference": "6a3a87ac2bbe33b25042753df8195ba4aa534c76",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ca2bd87d2f9215904682a9cb9bb37dda98e76089",
+                "reference": "ca2bd87d2f9215904682a9cb9bb37dda98e76089",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.15",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "php": ">=7.3",
                 "phpunit/php-file-iterator": "^3.0.3",
                 "phpunit/php-text-template": "^2.0.2",
@@ -4057,7 +4173,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.29"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.30"
             },
             "funding": [
                 {
@@ -4065,7 +4181,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-19T04:57:46+00:00"
+            "time": "2023-12-22T06:47:57+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -4310,16 +4426,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.13",
+            "version": "9.6.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "f3d767f7f9e191eab4189abe41ab37797e30b1be"
+                "reference": "05017b80304e0eb3f31d90194a563fd53a6021f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f3d767f7f9e191eab4189abe41ab37797e30b1be",
-                "reference": "f3d767f7f9e191eab4189abe41ab37797e30b1be",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/05017b80304e0eb3f31d90194a563fd53a6021f1",
+                "reference": "05017b80304e0eb3f31d90194a563fd53a6021f1",
                 "shasum": ""
             },
             "require": {
@@ -4393,7 +4509,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.13"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.15"
             },
             "funding": [
                 {
@@ -4409,7 +4525,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-09-19T05:39:22+00:00"
+            "time": "2023-12-01T16:55:19+00:00"
         },
         {
             "name": "psr/clock",
@@ -4757,23 +4873,23 @@
         },
         {
             "name": "react/promise",
-            "version": "v2.10.0",
+            "version": "v2.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/promise.git",
-                "reference": "f913fb8cceba1e6644b7b90c4bfb678ed8a3ef38"
+                "reference": "1a8460931ea36dc5c76838fec5734d55c88c6831"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/promise/zipball/f913fb8cceba1e6644b7b90c4bfb678ed8a3ef38",
-                "reference": "f913fb8cceba1e6644b7b90c4bfb678ed8a3ef38",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/1a8460931ea36dc5c76838fec5734d55c88c6831",
+                "reference": "1a8460931ea36dc5c76838fec5734d55c88c6831",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.36"
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
             },
             "type": "library",
             "autoload": {
@@ -4817,7 +4933,7 @@
             ],
             "support": {
                 "issues": "https://github.com/reactphp/promise/issues",
-                "source": "https://github.com/reactphp/promise/tree/v2.10.0"
+                "source": "https://github.com/reactphp/promise/tree/v2.11.0"
             },
             "funding": [
                 {
@@ -4825,7 +4941,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2023-05-02T15:15:43+00:00"
+            "time": "2023-11-16T16:16:50+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -5070,20 +5186,20 @@
         },
         {
             "name": "sebastian/complexity",
-            "version": "2.0.2",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.7",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "php": ">=7.3"
             },
             "require-dev": {
@@ -5115,7 +5231,7 @@
             "homepage": "https://github.com/sebastianbergmann/complexity",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
             },
             "funding": [
                 {
@@ -5123,7 +5239,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T15:52:27+00:00"
+            "time": "2023-12-22T06:19:30+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -5397,20 +5513,20 @@
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.6",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "php": ">=7.3"
             },
             "require-dev": {
@@ -5442,7 +5558,7 @@
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.3"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
             },
             "funding": [
                 {
@@ -5450,7 +5566,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-28T06:42:11+00:00"
+            "time": "2023-12-22T06:20:34+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -5793,16 +5909,16 @@
         },
         {
             "name": "seld/jsonlint",
-            "version": "1.10.0",
+            "version": "1.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/jsonlint.git",
-                "reference": "594fd6462aad8ecee0b45ca5045acea4776667f1"
+                "reference": "76d449a358ece77d6f1d6331c68453e657172202"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/594fd6462aad8ecee0b45ca5045acea4776667f1",
-                "reference": "594fd6462aad8ecee0b45ca5045acea4776667f1",
+                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/76d449a358ece77d6f1d6331c68453e657172202",
+                "reference": "76d449a358ece77d6f1d6331c68453e657172202",
                 "shasum": ""
             },
             "require": {
@@ -5829,7 +5945,7 @@
                 {
                     "name": "Jordi Boggiano",
                     "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
+                    "homepage": "https://seld.be"
                 }
             ],
             "description": "JSON Linter",
@@ -5841,7 +5957,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/jsonlint/issues",
-                "source": "https://github.com/Seldaek/jsonlint/tree/1.10.0"
+                "source": "https://github.com/Seldaek/jsonlint/tree/1.10.1"
             },
             "funding": [
                 {
@@ -5853,7 +5969,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-11T13:16:46+00:00"
+            "time": "2023-12-18T13:03:25+00:00"
         },
         {
             "name": "seld/phar-utils",
@@ -6184,16 +6300,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.7.2",
+            "version": "3.8.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "5805f7a4e4958dbb5e944ef1e6edae0a303765e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
-                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/5805f7a4e4958dbb5e944ef1e6edae0a303765e7",
+                "reference": "5805f7a4e4958dbb5e944ef1e6edae0a303765e7",
                 "shasum": ""
             },
             "require": {
@@ -6203,7 +6319,7 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
             },
             "bin": [
                 "bin/phpcs",
@@ -6222,35 +6338,58 @@
             "authors": [
                 {
                     "name": "Greg Sherwood",
-                    "role": "lead"
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards",
                 "static analysis"
             ],
             "support": {
-                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
-                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
-                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
             },
-            "time": "2023-02-22T23:07:41+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2023-12-08T12:32:31+00:00"
         },
         {
             "name": "symfony/browser-kit",
-            "version": "v5.4.21",
+            "version": "v5.4.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/browser-kit.git",
-                "reference": "a866ca7e396f15d7efb6d74a8a7d364d4e05b704"
+                "reference": "0ed1f634a36606f2065eec221b3975e05016cbbe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/a866ca7e396f15d7efb6d74a8a7d364d4e05b704",
-                "reference": "a866ca7e396f15d7efb6d74a8a7d364d4e05b704",
+                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/0ed1f634a36606f2065eec221b3975e05016cbbe",
+                "reference": "0ed1f634a36606f2065eec221b3975e05016cbbe",
                 "shasum": ""
             },
             "require": {
@@ -6293,7 +6432,7 @@
             "description": "Simulates the behavior of a web browser, allowing you to make requests, click on links and submit forms programmatically",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/browser-kit/tree/v5.4.21"
+                "source": "https://github.com/symfony/browser-kit/tree/v5.4.31"
             },
             "funding": [
                 {
@@ -6309,20 +6448,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-14T08:03:56+00:00"
+            "time": "2023-10-31T07:58:33+00:00"
         },
         {
             "name": "symfony/config",
-            "version": "v5.4.26",
+            "version": "v5.4.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "8109892f27beed9252bd1f1c1880aeb4ad842650"
+                "reference": "dd5ea39de228813aba0c23c3a4153da2a4cf3cd9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/8109892f27beed9252bd1f1c1880aeb4ad842650",
-                "reference": "8109892f27beed9252bd1f1c1880aeb4ad842650",
+                "url": "https://api.github.com/repos/symfony/config/zipball/dd5ea39de228813aba0c23c3a4153da2a4cf3cd9",
+                "reference": "dd5ea39de228813aba0c23c3a4153da2a4cf3cd9",
                 "shasum": ""
             },
             "require": {
@@ -6372,7 +6511,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v5.4.26"
+                "source": "https://github.com/symfony/config/tree/v5.4.31"
             },
             "funding": [
                 {
@@ -6388,20 +6527,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-19T20:21:11+00:00"
+            "time": "2023-11-09T08:22:43+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v5.4.28",
+            "version": "v5.4.34",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "f4f71842f24c2023b91237c72a365306f3c58827"
+                "reference": "4b4d8cd118484aa604ec519062113dd87abde18c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/f4f71842f24c2023b91237c72a365306f3c58827",
-                "reference": "f4f71842f24c2023b91237c72a365306f3c58827",
+                "url": "https://api.github.com/repos/symfony/console/zipball/4b4d8cd118484aa604ec519062113dd87abde18c",
+                "reference": "4b4d8cd118484aa604ec519062113dd87abde18c",
                 "shasum": ""
             },
             "require": {
@@ -6471,7 +6610,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.28"
+                "source": "https://github.com/symfony/console/tree/v5.4.34"
             },
             "funding": [
                 {
@@ -6487,7 +6626,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-07T06:12:30+00:00"
+            "time": "2023-12-08T13:33:03+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -6624,16 +6763,16 @@
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v5.4.25",
+            "version": "v5.4.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dom-crawler.git",
-                "reference": "d2aefa5a7acc5511422792931d14d1be96fe9fea"
+                "reference": "728f1fc136252a626ba5a69c02bd66a3697ff201"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/d2aefa5a7acc5511422792931d14d1be96fe9fea",
-                "reference": "d2aefa5a7acc5511422792931d14d1be96fe9fea",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/728f1fc136252a626ba5a69c02bd66a3697ff201",
+                "reference": "728f1fc136252a626ba5a69c02bd66a3697ff201",
                 "shasum": ""
             },
             "require": {
@@ -6679,7 +6818,7 @@
             "description": "Eases DOM navigation for HTML and XML documents",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dom-crawler/tree/v5.4.25"
+                "source": "https://github.com/symfony/dom-crawler/tree/v5.4.32"
             },
             "funding": [
                 {
@@ -6695,20 +6834,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-06-05T08:05:41+00:00"
+            "time": "2023-11-17T20:43:48+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v5.4.26",
+            "version": "v5.4.34",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "5dcc00e03413f05c1e7900090927bb7247cb0aac"
+                "reference": "e3bca343efeb613f843c254e7718ef17c9bdf7a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/5dcc00e03413f05c1e7900090927bb7247cb0aac",
-                "reference": "5dcc00e03413f05c1e7900090927bb7247cb0aac",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/e3bca343efeb613f843c254e7718ef17c9bdf7a3",
+                "reference": "e3bca343efeb613f843c254e7718ef17c9bdf7a3",
                 "shasum": ""
             },
             "require": {
@@ -6764,7 +6903,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v5.4.26"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v5.4.34"
             },
             "funding": [
                 {
@@ -6780,7 +6919,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-06T06:34:20+00:00"
+            "time": "2023-12-27T21:12:56+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -7724,16 +7863,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v5.4.28",
+            "version": "v5.4.34",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "45261e1fccad1b5447a8d7a8e67aa7b4a9798b7b"
+                "reference": "8fa22178dfc368911dbd513b431cd9b06f9afe7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/45261e1fccad1b5447a8d7a8e67aa7b4a9798b7b",
-                "reference": "45261e1fccad1b5447a8d7a8e67aa7b4a9798b7b",
+                "url": "https://api.github.com/repos/symfony/process/zipball/8fa22178dfc368911dbd513b431cd9b06f9afe7a",
+                "reference": "8fa22178dfc368911dbd513b431cd9b06f9afe7a",
                 "shasum": ""
             },
             "require": {
@@ -7766,7 +7905,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v5.4.28"
+                "source": "https://github.com/symfony/process/tree/v5.4.34"
             },
             "funding": [
                 {
@@ -7782,7 +7921,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-07T10:36:04+00:00"
+            "time": "2023-12-02T08:41:43+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -7931,16 +8070,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v5.4.29",
+            "version": "v5.4.34",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "e41bdc93def20eaf3bfc1537c4e0a2b0680a152d"
+                "reference": "e3f98bfc7885c957488f443df82d97814a3ce061"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/e41bdc93def20eaf3bfc1537c4e0a2b0680a152d",
-                "reference": "e41bdc93def20eaf3bfc1537c4e0a2b0680a152d",
+                "url": "https://api.github.com/repos/symfony/string/zipball/e3f98bfc7885c957488f443df82d97814a3ce061",
+                "reference": "e3f98bfc7885c957488f443df82d97814a3ce061",
                 "shasum": ""
             },
             "require": {
@@ -7997,7 +8136,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.4.29"
+                "source": "https://github.com/symfony/string/tree/v5.4.34"
             },
             "funding": [
                 {
@@ -8013,20 +8152,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-09-13T11:47:41+00:00"
+            "time": "2023-12-09T13:20:28+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v5.4.30",
+            "version": "v5.4.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "8560dc532e4e48d331937532a7cbfd2a9f9f53ce"
+                "reference": "ba72f72fceddf36f00bd495966b5873f2d17ad8f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/8560dc532e4e48d331937532a7cbfd2a9f9f53ce",
-                "reference": "8560dc532e4e48d331937532a7cbfd2a9f9f53ce",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/ba72f72fceddf36f00bd495966b5873f2d17ad8f",
+                "reference": "ba72f72fceddf36f00bd495966b5873f2d17ad8f",
                 "shasum": ""
             },
             "require": {
@@ -8094,7 +8233,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v5.4.30"
+                "source": "https://github.com/symfony/translation/tree/v5.4.31"
             },
             "funding": [
                 {
@@ -8110,7 +8249,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-10-28T09:19:54+00:00"
+            "time": "2023-11-03T16:16:43+00:00"
         },
         {
             "name": "symfony/translation-contracts",
@@ -8192,16 +8331,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v5.4.30",
+            "version": "v5.4.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "c6980e82a6656f6ebfabfd82f7585794cb122554"
+                "reference": "f387675d7f5fc4231f7554baa70681f222f73563"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/c6980e82a6656f6ebfabfd82f7585794cb122554",
-                "reference": "c6980e82a6656f6ebfabfd82f7585794cb122554",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/f387675d7f5fc4231f7554baa70681f222f73563",
+                "reference": "f387675d7f5fc4231f7554baa70681f222f73563",
                 "shasum": ""
             },
             "require": {
@@ -8247,7 +8386,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v5.4.30"
+                "source": "https://github.com/symfony/yaml/tree/v5.4.31"
             },
             "funding": [
                 {
@@ -8263,7 +8402,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-10-27T18:36:14+00:00"
+            "time": "2023-11-03T14:41:28+00:00"
         },
         {
             "name": "szepeviktor/phpstan-wordpress",
@@ -8329,16 +8468,16 @@
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
+                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
-                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
+                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
                 "shasum": ""
             },
             "require": {
@@ -8367,7 +8506,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.2"
             },
             "funding": [
                 {
@@ -8375,7 +8514,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-07-28T10:34:58+00:00"
+            "time": "2023-11-20T00:12:19+00:00"
         },
         {
             "name": "voku/portable-ascii",
@@ -8581,16 +8720,16 @@
         },
         {
             "name": "wp-cli/checksum-command",
-            "version": "v2.2.4",
+            "version": "v2.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/checksum-command.git",
-                "reference": "7ae020192bc6ee9042be0bf664bd998b1861e994"
+                "reference": "f6911998734018da08f75464a168feb0d07b4475"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/checksum-command/zipball/7ae020192bc6ee9042be0bf664bd998b1861e994",
-                "reference": "7ae020192bc6ee9042be0bf664bd998b1861e994",
+                "url": "https://api.github.com/repos/wp-cli/checksum-command/zipball/f6911998734018da08f75464a168feb0d07b4475",
+                "reference": "f6911998734018da08f75464a168feb0d07b4475",
                 "shasum": ""
             },
             "require": {
@@ -8634,22 +8773,22 @@
             "homepage": "https://github.com/wp-cli/checksum-command",
             "support": {
                 "issues": "https://github.com/wp-cli/checksum-command/issues",
-                "source": "https://github.com/wp-cli/checksum-command/tree/v2.2.4"
+                "source": "https://github.com/wp-cli/checksum-command/tree/v2.2.5"
             },
-            "time": "2023-08-30T13:34:47+00:00"
+            "time": "2023-11-10T21:54:15+00:00"
         },
         {
             "name": "wp-cli/config-command",
-            "version": "v2.3.2",
+            "version": "v2.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/config-command.git",
-                "reference": "9de6ce3536a2db56ae5264c61b6f1a35e9132e01"
+                "reference": "890b6e3c8fd945dcad2bff4bf565ba6dfb33e35d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/config-command/zipball/9de6ce3536a2db56ae5264c61b6f1a35e9132e01",
-                "reference": "9de6ce3536a2db56ae5264c61b6f1a35e9132e01",
+                "url": "https://api.github.com/repos/wp-cli/config-command/zipball/890b6e3c8fd945dcad2bff4bf565ba6dfb33e35d",
+                "reference": "890b6e3c8fd945dcad2bff4bf565ba6dfb33e35d",
                 "shasum": ""
             },
             "require": {
@@ -8658,7 +8797,7 @@
             },
             "require-dev": {
                 "wp-cli/db-command": "^1.3 || ^2",
-                "wp-cli/wp-cli-tests": "^4"
+                "wp-cli/wp-cli-tests": "^4.2.8"
             },
             "type": "wp-cli-package",
             "extra": {
@@ -8708,22 +8847,22 @@
             "homepage": "https://github.com/wp-cli/config-command",
             "support": {
                 "issues": "https://github.com/wp-cli/config-command/issues",
-                "source": "https://github.com/wp-cli/config-command/tree/v2.3.2"
+                "source": "https://github.com/wp-cli/config-command/tree/v2.3.3"
             },
-            "time": "2023-10-20T10:15:46+00:00"
+            "time": "2023-12-21T10:01:16+00:00"
         },
         {
             "name": "wp-cli/core-command",
-            "version": "v2.1.15",
+            "version": "v2.1.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/core-command.git",
-                "reference": "7a81a8658620078bf5f2785836cb33aa382e8bb4"
+                "reference": "9d6ebb4545df0b8bc7e688a49910ddcdd86dbe93"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/core-command/zipball/7a81a8658620078bf5f2785836cb33aa382e8bb4",
-                "reference": "7a81a8658620078bf5f2785836cb33aa382e8bb4",
+                "url": "https://api.github.com/repos/wp-cli/core-command/zipball/9d6ebb4545df0b8bc7e688a49910ddcdd86dbe93",
+                "reference": "9d6ebb4545df0b8bc7e688a49910ddcdd86dbe93",
                 "shasum": ""
             },
             "require": {
@@ -8779,9 +8918,9 @@
             "homepage": "https://github.com/wp-cli/core-command",
             "support": {
                 "issues": "https://github.com/wp-cli/core-command/issues",
-                "source": "https://github.com/wp-cli/core-command/tree/v2.1.15"
+                "source": "https://github.com/wp-cli/core-command/tree/v2.1.16"
             },
-            "time": "2023-08-30T15:54:16+00:00"
+            "time": "2023-11-10T23:54:33+00:00"
         },
         {
             "name": "wp-cli/cron-command",
@@ -8854,16 +8993,16 @@
         },
         {
             "name": "wp-cli/db-command",
-            "version": "v2.0.26",
+            "version": "v2.0.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/db-command.git",
-                "reference": "0908bf5182b830c302199037070292e20d9f4ea6"
+                "reference": "eea28dd115fb381c82641a2a3060856d3a67242d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/db-command/zipball/0908bf5182b830c302199037070292e20d9f4ea6",
-                "reference": "0908bf5182b830c302199037070292e20d9f4ea6",
+                "url": "https://api.github.com/repos/wp-cli/db-command/zipball/eea28dd115fb381c82641a2a3060856d3a67242d",
+                "reference": "eea28dd115fb381c82641a2a3060856d3a67242d",
                 "shasum": ""
             },
             "require": {
@@ -8922,9 +9061,9 @@
             "homepage": "https://github.com/wp-cli/db-command",
             "support": {
                 "issues": "https://github.com/wp-cli/db-command/issues",
-                "source": "https://github.com/wp-cli/db-command/tree/v2.0.26"
+                "source": "https://github.com/wp-cli/db-command/tree/v2.0.27"
             },
-            "time": "2023-08-30T15:50:59+00:00"
+            "time": "2023-11-13T12:34:44+00:00"
         },
         {
             "name": "wp-cli/embed-command",
@@ -9327,16 +9466,16 @@
         },
         {
             "name": "wp-cli/extension-command",
-            "version": "v2.1.15",
+            "version": "v2.1.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/extension-command.git",
-                "reference": "1fe271c5ebb1815732a8cf6bb6979c9261ee6375"
+                "reference": "71183254b1e403bc0f9b4a97fab48e284cfe1367"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/extension-command/zipball/1fe271c5ebb1815732a8cf6bb6979c9261ee6375",
-                "reference": "1fe271c5ebb1815732a8cf6bb6979c9261ee6375",
+                "url": "https://api.github.com/repos/wp-cli/extension-command/zipball/71183254b1e403bc0f9b4a97fab48e284cfe1367",
+                "reference": "71183254b1e403bc0f9b4a97fab48e284cfe1367",
                 "shasum": ""
             },
             "require": {
@@ -9419,22 +9558,22 @@
             "homepage": "https://github.com/wp-cli/extension-command",
             "support": {
                 "issues": "https://github.com/wp-cli/extension-command/issues",
-                "source": "https://github.com/wp-cli/extension-command/tree/v2.1.15"
+                "source": "https://github.com/wp-cli/extension-command/tree/v2.1.16"
             },
-            "time": "2023-10-11T14:55:49+00:00"
+            "time": "2023-11-10T12:24:35+00:00"
         },
         {
             "name": "wp-cli/i18n-command",
-            "version": "v2.4.4",
+            "version": "v2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/i18n-command.git",
-                "reference": "7d82e675f271359b1af614e6325d8eeaeb7d7474"
+                "reference": "9cf9b40f6bad64ade8660cc26bf1f28f2d223268"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/i18n-command/zipball/7d82e675f271359b1af614e6325d8eeaeb7d7474",
-                "reference": "7d82e675f271359b1af614e6325d8eeaeb7d7474",
+                "url": "https://api.github.com/repos/wp-cli/i18n-command/zipball/9cf9b40f6bad64ade8660cc26bf1f28f2d223268",
+                "reference": "9cf9b40f6bad64ade8660cc26bf1f28f2d223268",
                 "shasum": ""
             },
             "require": {
@@ -9487,9 +9626,9 @@
             "homepage": "https://github.com/wp-cli/i18n-command",
             "support": {
                 "issues": "https://github.com/wp-cli/i18n-command/issues",
-                "source": "https://github.com/wp-cli/i18n-command/tree/v2.4.4"
+                "source": "https://github.com/wp-cli/i18n-command/tree/v2.5.0"
             },
-            "time": "2023-08-30T18:00:10+00:00"
+            "time": "2023-11-16T17:09:37+00:00"
         },
         {
             "name": "wp-cli/import-command",
@@ -9553,16 +9692,16 @@
         },
         {
             "name": "wp-cli/language-command",
-            "version": "v2.0.16",
+            "version": "v2.0.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/language-command.git",
-                "reference": "829cdf985fc1fdbe0572ef9a281b8a590aa4ee29"
+                "reference": "24f76e35f477887d09f1fd40a60d9011a6da18bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/language-command/zipball/829cdf985fc1fdbe0572ef9a281b8a590aa4ee29",
-                "reference": "829cdf985fc1fdbe0572ef9a281b8a590aa4ee29",
+                "url": "https://api.github.com/repos/wp-cli/language-command/zipball/24f76e35f477887d09f1fd40a60d9011a6da18bf",
+                "reference": "24f76e35f477887d09f1fd40a60d9011a6da18bf",
                 "shasum": ""
             },
             "require": {
@@ -9626,22 +9765,22 @@
             "homepage": "https://github.com/wp-cli/language-command",
             "support": {
                 "issues": "https://github.com/wp-cli/language-command/issues",
-                "source": "https://github.com/wp-cli/language-command/tree/v2.0.16"
+                "source": "https://github.com/wp-cli/language-command/tree/v2.0.18"
             },
-            "time": "2023-10-18T21:57:04+00:00"
+            "time": "2023-11-10T13:27:16+00:00"
         },
         {
             "name": "wp-cli/maintenance-mode-command",
-            "version": "v2.0.10",
+            "version": "v2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/maintenance-mode-command.git",
-                "reference": "599f8f08045ed2ef26a53d1432a4845b39d54f7d"
+                "reference": "2e9845a1cd1678b960dd8d0dd0c936648113788c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/maintenance-mode-command/zipball/599f8f08045ed2ef26a53d1432a4845b39d54f7d",
-                "reference": "599f8f08045ed2ef26a53d1432a4845b39d54f7d",
+                "url": "https://api.github.com/repos/wp-cli/maintenance-mode-command/zipball/2e9845a1cd1678b960dd8d0dd0c936648113788c",
+                "reference": "2e9845a1cd1678b960dd8d0dd0c936648113788c",
                 "shasum": ""
             },
             "require": {
@@ -9687,22 +9826,22 @@
             "homepage": "https://github.com/wp-cli/maintenance-mode-command",
             "support": {
                 "issues": "https://github.com/wp-cli/maintenance-mode-command/issues",
-                "source": "https://github.com/wp-cli/maintenance-mode-command/tree/v2.0.10"
+                "source": "https://github.com/wp-cli/maintenance-mode-command/tree/v2.1.0"
             },
-            "time": "2023-08-30T14:54:15+00:00"
+            "time": "2023-11-06T14:04:13+00:00"
         },
         {
             "name": "wp-cli/media-command",
-            "version": "v2.0.20",
+            "version": "v2.0.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/media-command.git",
-                "reference": "49ef52c657de7ac1e50010ce3f6b0cdc40c02dc7"
+                "reference": "4950ed4ded35c52068d30fec080d545a33baa85c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/media-command/zipball/49ef52c657de7ac1e50010ce3f6b0cdc40c02dc7",
-                "reference": "49ef52c657de7ac1e50010ce3f6b0cdc40c02dc7",
+                "url": "https://api.github.com/repos/wp-cli/media-command/zipball/4950ed4ded35c52068d30fec080d545a33baa85c",
+                "reference": "4950ed4ded35c52068d30fec080d545a33baa85c",
                 "shasum": ""
             },
             "require": {
@@ -9749,9 +9888,9 @@
             "homepage": "https://github.com/wp-cli/media-command",
             "support": {
                 "issues": "https://github.com/wp-cli/media-command/issues",
-                "source": "https://github.com/wp-cli/media-command/tree/v2.0.20"
+                "source": "https://github.com/wp-cli/media-command/tree/v2.0.21"
             },
-            "time": "2023-09-01T13:08:38+00:00"
+            "time": "2023-11-10T21:56:52+00:00"
         },
         {
             "name": "wp-cli/mustangostang-spyc",
@@ -9806,20 +9945,20 @@
         },
         {
             "name": "wp-cli/package-command",
-            "version": "v2.4.0",
+            "version": "v2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/package-command.git",
-                "reference": "f295538382b970cca506172b892f5f1c8adbedb2"
+                "reference": "71683195f8c27ad97009628e2a72d2a4155503b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/package-command/zipball/f295538382b970cca506172b892f5f1c8adbedb2",
-                "reference": "f295538382b970cca506172b892f5f1c8adbedb2",
+                "url": "https://api.github.com/repos/wp-cli/package-command/zipball/71683195f8c27ad97009628e2a72d2a4155503b2",
+                "reference": "71683195f8c27ad97009628e2a72d2a4155503b2",
                 "shasum": ""
             },
             "require": {
-                "composer/composer": "^1.10.23 || ~2.2.17",
+                "composer/composer": "^1.10.23 || ^2.2.17",
                 "ext-json": "*",
                 "wp-cli/wp-cli": "^2.8"
             },
@@ -9865,22 +10004,22 @@
             "homepage": "https://github.com/wp-cli/package-command",
             "support": {
                 "issues": "https://github.com/wp-cli/package-command/issues",
-                "source": "https://github.com/wp-cli/package-command/tree/v2.4.0"
+                "source": "https://github.com/wp-cli/package-command/tree/v2.5.0"
             },
-            "time": "2023-09-06T21:10:16+00:00"
+            "time": "2023-12-08T10:38:16+00:00"
         },
         {
             "name": "wp-cli/php-cli-tools",
-            "version": "v0.11.21",
+            "version": "v0.11.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/php-cli-tools.git",
-                "reference": "b3457a8d60cd0b1c48cab76ad95df136d266f0b6"
+                "reference": "a6bb94664ca36d0962f9c2ff25591c315a550c51"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/php-cli-tools/zipball/b3457a8d60cd0b1c48cab76ad95df136d266f0b6",
-                "reference": "b3457a8d60cd0b1c48cab76ad95df136d266f0b6",
+                "url": "https://api.github.com/repos/wp-cli/php-cli-tools/zipball/a6bb94664ca36d0962f9c2ff25591c315a550c51",
+                "reference": "a6bb94664ca36d0962f9c2ff25591c315a550c51",
                 "shasum": ""
             },
             "require": {
@@ -9928,9 +10067,9 @@
             ],
             "support": {
                 "issues": "https://github.com/wp-cli/php-cli-tools/issues",
-                "source": "https://github.com/wp-cli/php-cli-tools/tree/v0.11.21"
+                "source": "https://github.com/wp-cli/php-cli-tools/tree/v0.11.22"
             },
-            "time": "2023-09-29T15:28:10+00:00"
+            "time": "2023-12-03T19:25:05+00:00"
         },
         {
             "name": "wp-cli/rewrite-command",
@@ -10061,16 +10200,16 @@
         },
         {
             "name": "wp-cli/scaffold-command",
-            "version": "v2.1.3",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/scaffold-command.git",
-                "reference": "4125a31134e1bad3d28cff71c178dcee1393f605"
+                "reference": "8aa906c3ec6ae7d95f38c962fc2561714f9c7145"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/scaffold-command/zipball/4125a31134e1bad3d28cff71c178dcee1393f605",
-                "reference": "4125a31134e1bad3d28cff71c178dcee1393f605",
+                "url": "https://api.github.com/repos/wp-cli/scaffold-command/zipball/8aa906c3ec6ae7d95f38c962fc2561714f9c7145",
+                "reference": "8aa906c3ec6ae7d95f38c962fc2561714f9c7145",
                 "shasum": ""
             },
             "require": {
@@ -10121,22 +10260,22 @@
             "homepage": "https://github.com/wp-cli/scaffold-command",
             "support": {
                 "issues": "https://github.com/wp-cli/scaffold-command/issues",
-                "source": "https://github.com/wp-cli/scaffold-command/tree/v2.1.3"
+                "source": "https://github.com/wp-cli/scaffold-command/tree/v2.2.0"
             },
-            "time": "2023-08-30T14:29:02+00:00"
+            "time": "2023-11-16T15:25:33+00:00"
         },
         {
             "name": "wp-cli/search-replace-command",
-            "version": "v2.1.3",
+            "version": "v2.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/search-replace-command.git",
-                "reference": "0b662a372483224fe93f113c2a4fa2089e951d34"
+                "reference": "88c9f23eda4eff4803a3eeeabd46d1a99cd17340"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/search-replace-command/zipball/0b662a372483224fe93f113c2a4fa2089e951d34",
-                "reference": "0b662a372483224fe93f113c2a4fa2089e951d34",
+                "url": "https://api.github.com/repos/wp-cli/search-replace-command/zipball/88c9f23eda4eff4803a3eeeabd46d1a99cd17340",
+                "reference": "88c9f23eda4eff4803a3eeeabd46d1a99cd17340",
                 "shasum": ""
             },
             "require": {
@@ -10181,9 +10320,9 @@
             "homepage": "https://github.com/wp-cli/search-replace-command",
             "support": {
                 "issues": "https://github.com/wp-cli/search-replace-command/issues",
-                "source": "https://github.com/wp-cli/search-replace-command/tree/v2.1.3"
+                "source": "https://github.com/wp-cli/search-replace-command/tree/v2.1.4"
             },
-            "time": "2023-09-01T12:41:32+00:00"
+            "time": "2023-12-19T12:41:53+00:00"
         },
         {
             "name": "wp-cli/server-command",
@@ -10574,16 +10713,16 @@
         },
         {
             "name": "wp-cli/wp-config-transformer",
-            "version": "v1.3.4",
+            "version": "v1.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/wp-config-transformer.git",
-                "reference": "1f80df413c0d779a813223d9dd5dd58358eee60c"
+                "reference": "202aa80528939159d52bc4026cee5453aec382db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/wp-config-transformer/zipball/1f80df413c0d779a813223d9dd5dd58358eee60c",
-                "reference": "1f80df413c0d779a813223d9dd5dd58358eee60c",
+                "url": "https://api.github.com/repos/wp-cli/wp-config-transformer/zipball/202aa80528939159d52bc4026cee5453aec382db",
+                "reference": "202aa80528939159d52bc4026cee5453aec382db",
                 "shasum": ""
             },
             "require": {
@@ -10612,9 +10751,9 @@
             "homepage": "https://github.com/wp-cli/wp-config-transformer",
             "support": {
                 "issues": "https://github.com/wp-cli/wp-config-transformer/issues",
-                "source": "https://github.com/wp-cli/wp-config-transformer/tree/v1.3.4"
+                "source": "https://github.com/wp-cli/wp-config-transformer/tree/v1.3.5"
             },
-            "time": "2023-08-31T10:11:36+00:00"
+            "time": "2023-11-10T14:28:03+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -10806,9 +10945,18 @@
             "time": "2021-07-11T04:52:41+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "package": "phpcompatibility/php-compatibility",
+            "version": "dev-develop",
+            "alias": "9.9.9",
+            "alias_normalized": "9.9.9.0"
+        }
+    ],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "phpcompatibility/php-compatibility": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/constants.php
+++ b/constants.php
@@ -18,7 +18,7 @@ function graphql_setup_constants() {
 
 	// Plugin version.
 	if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-		define( 'WPGRAPHQL_VERSION', '1.16.0' );
+		define( 'WPGRAPHQL_VERSION', '1.20.0' );
 	}
 
 	// Plugin Folder Path.

--- a/docs/build-your-first-wpgraphql-extension.md
+++ b/docs/build-your-first-wpgraphql-extension.md
@@ -17,8 +17,6 @@ The following written tutorial should be helpful for developers of any experienc
 
 It's similar, but not identical, to the video tutorial above.
 
-This tutorial should be helpful for developers of any experience level, but it will be most useful for developers that have some previous experience building WordPress plugins.
-
 Before starting this tutorial, you should have a [local WordPress development environment](https://getflywheel.com/layout/local-wordpress-development-environment-how-to/) setup with [WPGraphQL installed and activated](/docs/quick-start/).
 
 ## What we're building

--- a/docs/categories-and-tags.md
+++ b/docs/categories-and-tags.md
@@ -5,7 +5,7 @@ title: "Categories and Tags"
 
 WPGraphQL provides support for querying Categories, Tags and Custom Taxonomies in various ways.
 
-This page will be most useful for users what are familiar with [GraphQL Concepts](/docs/intro-to-graphql/) and understand the basics of [writing GraphQL Queries](/docs/intro-to-graphql/#queries-and-mutation).
+This page will be most useful for users who are familiar with [GraphQL Concepts](/docs/intro-to-graphql/) and understand the basics of [writing GraphQL Queries](/docs/intro-to-graphql/#queries-and-mutation).
 
 ## Querying Categories and Tags
 

--- a/docs/using-data-from-custom-database-tables.md
+++ b/docs/using-data-from-custom-database-tables.md
@@ -7,16 +7,631 @@ This is an advanced guide that will be most useful for developers with experienc
 
 ## Overview
 
-WordPress can do a lot of things with [Custom Post Types](/docs/custom-post-types/) and [Custom Taxonomies](/docs/custom-taxonomies/), but sometimes you need to use Custom Database Tables.
+WPGraphQL makes use of core WordPress registries, such as the Post Type and Taxonomy registry, to generate the GraphQL Schema for your WordPress instance. 
+
+Since WordPress doesn't have a formal "Custom Database Registry", WPGraphQL is unable to programatically expose data stored in custom databse tables to the WPGraphQL Schema. 
 
 In this guide, we will look into how to use data from Custom Database Tables with WPGraphQL.
 
-After reading this guide, you should be familiar with how WPGraphQL handles data and have a better understanding of WPGraphQL APIs to [register object types](/functions/register_graphql_object_type/), [register connections](/functions/register_graphql_connection/), create custom Data Loaders and custom Connection Resolvers.
+After reading this guide, you should be familiar with how WPGraphQL's schema is designed, how WPGraphQL handles data, how to leverage WPGraphQL functions extend the WPGraphQL Schema, how to create custom Data Loaders and custom Connection Resolvers.
 
 ## Thinking in Graphs
 
-WPGraphQL treats WordPress data like an application data graph. What that means, is that each post, page, term, comment, user or other object that can be uniquely identified is considered a "Node".
+When it comes to adding support for custom database tables, it's important to understand some conventions of GraphQL, and how WPGraphQL implements its Schema. 
 
-Each Node can have properties. For example, a Post can have a Title, such as "Hello World"
+WPGraphQL treats WordPress data like an application data graph and follows the [Relay Specification for GraphQL Schemas](https://relay.dev/docs/guides/graphql-server-specification/).
+
+Any uniquely identifiable object is considered a "Node".
+
+In WordPress, that would mean a Post, a Page, a User, a Category, a Tag, a Media Item (attachment), etc. 
+
+Each Node can have properties, exposed in the GraphQL Schema as "fields". 
+
+Each Node can also have "connections" to other nodes. 
+
+In GraphQL, Connections are a mechanism to facilitate relationships between Nodes. Either the relationship between an individual node and one or more nodes, or the relationship between the root of the graph and one or more nodes.
+
+The image below helps visualize WordPress "Nodes" and "Connections" in an application data graph. 
 
 ![WordPress as an Application Data Graph](./images/application-data-graph.png)
+
+There are "Post" nodes and "Category" nodes, each node has fields and connections to other nodes.
+
+GraphQL allows you to pluck nodes and fields out of the graph.
+
+Below, we'll look at how we can expose data stored in custom database tables to the GraphQL schema using the concepts of "Nodes" and "Connections".
+
+## What we're building
+
+To put these concepts into action, we will be building a notifications system that stores messages associated with specific users. These notifications can be queried from the Root of the Graph, or in connection with the user that the notification is associate with. 
+
+This is a simple example that likely wouldn't need a custom database table to accomplish, and is only intended to show the possibilities and concepts of using custom database tables with WPGraphQL. You will need to apply these concepts to your specific needs.
+
+The final result will allow us to make GraphQL queries to get data out of a custom "notifications" table, like so: 
+
+```graphql
+query GetAllNotifications {
+  notifications {
+    nodes {
+      __typename
+      id
+      message
+      date
+      user {
+        node {
+          __typename
+          id
+          name
+        }
+      }
+    }
+  }
+}
+```
+
+or: 
+
+```graphql
+query GetCurrentUserNotifications {
+  viewer {
+    id
+    name
+    notifications {
+      nodes {
+        __typename
+        id
+        message
+        date
+      }
+    }
+  }
+}
+```
+
+or: 
+
+```graphql
+query GetNotificationNode {
+  node( id: "bm90aWZpY2F0aW9uOjE=" ) {
+    __typename
+    ...on Notification {
+      __typename
+      id
+      message
+      date
+    }
+  }
+}
+```
+
+If you want to skip ahead and see the final code, you can find it here: [https://github.com/wp-graphql/wp-graphql-notifications-connection-example](https://github.com/wp-graphql/wp-graphql-notifications-connection-example)
+
+## Set up the Plugin
+
+Create a new directory in your WordPress installations `wp-content/plugins` directory named `wp-graphql-notifications-example`. 
+
+Add a new file named `wp-graphql-notifications-example.php` and add the following: 
+
+```php
+<?php
+/**
+ * Plugin Name: WPGraphQL Notifications Example
+ * Description: Example plugin showing how to use custom database tables with WPGraphQL
+ * Version: 1.0
+ * Author: Your Name
+ */
+
+// Prevent direct access
+if (!defined('ABSPATH')) {
+    exit;
+}
+```
+
+This is the most basic code needed to create a WordPress plugin. 
+
+In the following sections we'll add more code to this file to extend WordPress and WPGraphQL.
+
+## Creating Custom Database Table
+
+If you already have a custom database table you're working with, go ahead and skip to the next sections, and apply the concepts to your database structure.
+
+Our goal is to be able to query a list of notifications, each with an ID, date, message and associated user.
+
+### Database Table Structure
+
+Our database table will be structured as follows: 
+
+| Column   | Type            | Description                                 |
+|----------|-----------------|---------------------------------------------|
+| id       | mediumint(9)    | The primary key, auto-incremented           |
+| user_id  | mediumint(9)    | The ID of the user                          |
+| message  | text            | The notification message                    |
+| date     | datetime        | The date and time when the notification was created |
+
+We can add the following code to our PHP file to create this database table for us when our plugin is activated: 
+
+### Install the database table on plugin activation
+
+The code below will execute when the plugin is activated, adding our custom database table. If your plugin is already active when you add this code, you will need to de-activate and re-activate to trigger the database table creation.
+
+```php
+register_activation_hook( __FILE__, 'wpgraphql_notifications_example_create_notifications_table' );
+
+function wpgraphql_notifications_example_create_notifications_table() {
+    global $wpdb;
+    $table_name = $wpdb->prefix . 'notifications';
+
+    $charset_collate = $wpdb->get_charset_collate();
+
+    $sql = "CREATE TABLE $table_name (
+        id mediumint(9) NOT NULL AUTO_INCREMENT,
+        user_id mediumint(9) NOT NULL,
+        message text NOT NULL,
+        date datetime DEFAULT CURRENT_TIMESTAMP NOT NULL,
+        PRIMARY KEY  (id)
+    ) $charset_collate;";
+
+    require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
+    dbDelta($sql);
+}
+```
+
+## Inserting Data
+
+Unlike Custom Post Types and Custom Taxonomies, our custom database table doesn't have any Admin User Interfaces to interact with in the WordPress dashboard, and adding User Interfaces is beyond the scope of this tutorial. 
+
+You can use a database administration tool like [TablePlus](https://tableplus.com/) or Adminer if you're using [LocalWP](https://localwp.com) and insert a few rows of data to the notifications table we created. 
+
+Or, you can use the following PHP snippet in your plugin file to insert some entries. This code will fire when you refresh any page in WordPress, so be sure you delete the code after it's inserted the entries.
+
+
+```php
+add_action( 'init', function() { 
+
+  global $wpdb;
+  $table_name = $wpdb->prefix . 'notifications';
+  
+  // Sample data to be inserted
+  $notifications = [
+      ['user_id' => 1, 'message' => 'Lorem ipsum dolor sit amet'],
+      ['user_id' => 1, 'message' => 'Consectetur adipiscing elit'],
+      ['user_id' => 1, 'message' => 'Sed do eiusmod tempor incididunt']
+  ];
+  
+  // Inserting the data
+  foreach ($notifications as $notification) {
+      $wpdb->insert(
+          $table_name,
+          array(
+              'user_id' => $notification['user_id'],
+              'message' => $notification['message'],
+              'date'    => current_time('mysql') // WordPress function for current date-time
+          ),
+          array(
+              '%d', // user_id is an integer
+              '%s', // message is a string
+              '%s'  // date is a string (formatted date)
+          )
+      );
+  }
+
+} );
+```
+
+With some dummy data in the custom table table, we can move on to exposing the data to the GraphQL Schema.
+
+## Registering the Node Type
+
+The WPGraphQL Schema centers around "Nodes" and "Connections". 
+
+We will apply these concepts by adding the Notifications to the Graph as "Nodes" that have "Connections" from the Root of the Graph and "Connections" to/from the associated user the notification is assigned to.
+
+The following code will register the `Notification` GraphQL Object Type to the GraphQL Schema. 
+
+**NOTE:** Type names must be unique across the Schema. The more explicit you name a Type, the more self-documenting it becomes and the less likely it will conflict with future Types in the Schema.
+
+```php
+
+// Hook into WPGraphQL as it builds the Schema
+add_action( 'graphql_register_types', 'wpgraphql_notifications_example_register_types' );
+
+function wpgraphql_notifications_example_register_types() {
+
+  // Register the GraphQL Object Type to the Schema
+  register_graphql_object_type( 'Notification', [
+    // Be sure to replace your-text-domain for i18n of your plugin
+    'description' => __( 'Notification messages for a user', 'your-text-domain' ),
+    // By implementing the "Node" interface the Notification Object Type will automaticaly have an "id" field.
+    // By implementing the "DatabaseIdentifier" interface, the Notification Object Type will automatically have a "databaseId" field
+    'interfaces' => [ 'Node', 'DatabaseIdentifier' ],
+    // The fields that can be queried for on the Notification type
+    'fields' => [
+       'id' => [
+         'resolve' => function( $source ) {
+            return base64_encode( 'notification', $source->id );
+         }
+       ],
+       'userDatabaseId' => [
+         'type' => 'Int',
+         'description' => __( 'The databaseId of the user the message belongs to', 'your-text-domain' ),
+       ],
+       'message' => [
+         'type' => 'String',
+         'description' => __( 'The notification message', 'your-text-domain' ),
+       ],
+       'date' => [
+         'type' => 'String',
+         'description' => __( 'The date the message was created', 'your-text-domain' ),
+       ],
+    ]
+  ] );
+
+}
+```
+
+The "Notification" Object Type is now registered to the GraphQL Schema, however if you search the Schema using the GraphiQL IDE, you won't see the Type in the Schema. 
+
+This is because there are no fields in the Schema that return the `Notification` Type.
+
+Let's fix that.
+
+## Registering a Root Connection
+
+We want to be able to query a list of "Notification" nodes from the root of the Graph. 
+
+By registering a GraphQL Connection, we will get a lot of features, with minimal effort.
+
+The following code will generate several GraphQL Types in the Schema, allowing us to now find the "Notification" Type in the GraphQL Schema, and allow us to query for lists of "Notification" nodes.
+
+Within the `wpgraphql_notifications_example_register_types` function, add the following code:
+
+```php
+register_graphql_connection([
+  // The GraphQL Type that will have a field added to it to query a connection from
+  'fromType' => 'RootQuery',
+  // The GraphQL Type the connection will return Nodes of. This type MUST implement the "Node" interface
+  'toType' => 'Notification',
+  // The field name to represent the connection on the "from" Type
+  'fromFieldName' => 'notifications',
+  // How to resolve the connection. For now we will return null, but will visit this below.
+  'resolve' => function( $root, $args, $context, $info ) {
+    // we will revisit this shortly
+    return null;
+  } 
+]);
+```
+
+Now, if you refresh the GraphiQL IDE and search for "Notification" again, you should see it. This is because there is now field (`notifications`) that returns a Connection to the `Notification` Type. 
+
+You should now be able to execute the following query and it would be a valid, without throwing any errors: 
+
+```graphql
+query GetAllNotifications {
+  notifications {
+    nodes {
+      __typename
+      id
+      message
+      date
+    }
+  }
+}
+```
+
+While it doesn't return errors, it also doesn't return data. This is because we left the resolve function as `return null;`.
+
+Let's move on to fixing that so we can resolve data from the custom database Table.
+
+## Creating a Notification Loader
+
+Under the hood, WPGraphQL uses a Loader concept, where we centralize logic regarding how WPGraphQL should load data. 
+
+In an application Data Graph, nodes can be accessed from many different entry points, such as the Root of the Graph or connections from various other Types of node, so a Loader concept reduces duplicate code for fetching objects. 
+
+Let's create a "Notification" loader and register it to WPGraphQL.
+
+In our PHP file we can add the following: 
+
+```php
+add_action( 'graphql_init', function() {
+
+	/**
+	 * Class NotificationLoader
+	 *
+	 * This is a custom loader that extends the WPGraphQL Abstract Data Loader.
+	 */
+	class NotificationLoader extends \WPGraphQL\Data\Loader\AbstractDataLoader {
+
+		/**
+		 * Given an array of one or more keys (ids) load the corresponding notifications
+		 *
+		 * @param array $keys Array of keys to identify nodes by
+		 *
+		 * @return array
+		 */
+		public function loadKeys( array $keys ): array {
+			if ( empty( $keys ) ) {
+				return [];
+			}
+
+			global $wpdb;
+
+			// Prepare a SQL query to select rows that match the given IDs
+			$table_name = $wpdb->prefix . 'notifications';
+			$ids        = implode( ', ', $keys );
+			$query      = $wpdb->prepare( "SELECT * FROM $table_name WHERE id IN ($ids) ORDER BY id ASC", $ids );
+			$results    = $wpdb->get_results($query);
+
+			if ( empty( $results ) ) {
+				return [];
+			}
+
+			// Convert the array of notifications to an associative array keyed by their IDs
+			$notificationsById = [];
+			foreach ( $results as $result ) {
+				// ensure the notification is returned with the Notification __typename
+				$result->__typename = 'Notification';
+				$notificationsById[ $result->id ] = $result;
+			}
+
+			// Create an ordered array based on the ordered IDs
+			$orderedNotifications = [];
+			foreach ( $keys as $key ) {
+				if ( array_key_exists( $key, $notificationsById ) ) {
+					$orderedNotifications[ $key ] = $notificationsById[ $key ];
+				}
+			}
+
+			return $orderedNotifications;
+
+		}
+	}
+
+  // Add the notifications loader to be used under the hood by WPGraphQL when loading nodes
+	add_filter( 'graphql_data_loaders', function( $loaders, $context ) {
+		$loaders['notification'] = new NotificationLoader( $context );
+		return $loaders;
+	}, 10, 2 );
+
+  // Filter so nodes that have a __typename will return that typename
+	add_filter( 'graphql_resolve_node_type', function( $type, $node ) {
+		return $node->__typename ?? $type;
+	}, 10, 2 );
+
+});
+```
+
+This adds a `NotificationLoader` class, extending the WPGraphQL `AbstractDataLoader` class. 
+
+This tells WPGraphQL how to resolve data of the `Notification` Type when it's being asked for given 1 or more IDs.
+
+Then, using the `graphql_data_loaders` filter, we let WPGraphQL know about our new custom `NotificationLoader` so that it can be used when resolving data.
+
+And last, using the `graphql_resolve_node_type` filter, we allow the notifications `__typename` property to determine which type of node to return. 
+
+Now, as long as you have a notification in the database with id `1`, you should be able to execute the following query and get a result: 
+
+```graphql
+query GetNotificationNode {
+  node( id: "bm90aWZpY2F0aW9uOjE=" ) {
+    __typename
+    ...on Notification {
+      __typename
+      id
+      message
+      date
+    }
+  }
+}
+```
+
+## Creating a Connection Resolver Class
+
+We're able to query for an individual Notification node by ID now, however we're still getting `null` results if we query for the notifications connection. 
+
+We need to have the connection resolver return something other than null.
+
+WPGraphQL has an AbstractConnectionResolver that helps facilitate resolving connections. 
+
+You can see all the ConnectionResolvers in core WPGraphQL here: https://github.com/wp-graphql/wp-graphql/tree/develop/src/Data/Connection
+
+Let's define a `NotificationConnectionResolver` class to help resolve connection queries for Notifications.
+
+Add the following code to the php file:
+
+```php
+add_action( 'graphql_init', function() {
+
+	class NotificationConnectionResolver extends \WPGraphQL\Data\Connection\AbstractConnectionResolver {
+
+    // Tell WPGraphQL which Loader to use. We define the `notification` loader that we registered already.
+		public function get_loader_name(): string {
+			return 'notification';
+		}
+
+    // Get the arguments to pass to the query.
+    // We're defaulting to an empty array as we're not supporting pagination/filtering/sorting in this example
+		public function get_query_args(): array {
+			return [];
+		}
+
+    // Determine the query to run. Since we're interacting with a custom database Table, we
+    // use $wpdb to execute a query against the table.
+    // This is where logic needs to be mapped to account for any arguments the user inputs, such as pagination, filtering, sorting, etc.
+    // For this example, we are only executing the most basic query without support for pagination, etc.
+    // You could use an ORM to access data or whatever else you like here.
+		public function get_query(): array|bool|null {
+			global $wpdb;
+			$current_user_id = get_current_user_id();
+
+			$user_id = $this->query_args['user_id'] ?? $current_user_id;
+
+			$ids_array = $wpdb->get_results(
+				$wpdb->prepare(
+					sprintf(
+						'SELECT id FROM %1$snotifications WHERE user_id=%2$d LIMIT 10',
+						$wpdb->prefix,
+						$user_id
+					)
+				)
+			);
+
+			return ! empty( $ids_array ) ? array_values( array_column( $ids_array, 'id' ) ) : [];
+		}
+
+    // This determines how to get IDs. In our case, the query itself returns IDs
+    // But sometimes queries, such as WP_Query might return an object with IDs as a property (i.e. $wp_query->posts )
+		public function get_ids(): array|bool|null {
+			return $this->get_query();
+		}
+
+    // This allows for validation on the offset. If your data set needs specific data to determine the offset, you can validate that here.
+		public function is_valid_offset( $offset ): bool {
+			return true;
+		}
+
+    // This gives a chance to validate that the Model being resolved is valid.
+    // We're skipping this and always saying the data is valid, but this is a good
+    // place to add some validation before returning data
+		public function is_valid_model( $model ): bool {
+			return true;
+		}
+
+    // You can implement logic here to determine whether or not to execute.
+    // for example, if the data is private you could set to false if the user is not logged in, etc
+		public function should_execute(): bool {
+			return true;
+		}
+
+	}
+
+});
+```
+
+This creates a `NotificationConnectionResolver` class, extending the `\WPGraphQL\Data\Connection\AbstractConnectionResolver` class. 
+
+The code comments should help clarify how to customize the class and add support for more advanced, production use cases.
+
+Now, we need to implement this resolver. 
+
+In our `register_graphql_connection()` that we already added, let's replace the `resolve` function with the following: 
+
+```php
+'resolve' => function( $root, $args, $context, $info ) {
+	  // we will revisit this shortly
+	  $resolver = new NotificationConnectionResolver( $root, $args, $context, $info );
+    return $resolver->get_connection();
+}
+```
+
+Now, our connection isn't returning `null`, it's returning the results of the `NotificationConnectionResolver`. 
+
+We can now query the following, and we should see results:
+
+```graphql
+query GetAllNotifications {
+  notifications {
+    nodes {
+      __typename
+      id
+      message
+      date
+    }
+  }
+}
+```
+
+## Registering Connections to other Nodes
+
+Let's now take a look at how to register a connection between the `Notification` type and the `User` Type. 
+
+Notifications each have 1 user ID, so we want a One-to-One connection between a Notification and the related user. 
+
+With the following snippet added just below our other `register_graphql_connection()`, we can register a connection from the `Notification` Type to the `User` type:
+
+```php
+register_graphql_connection([
+	'fromType' => 'Notification',
+	'toType' => 'User',
+	'fromFieldName' => 'user',
+	'oneToOne' => true,
+  'resolve' => function( $root, $args, $context, $info ) {
+		$resolver = new \WPGraphQL\Data\Connection\UserConnectionResolver( $root, $args, $context, $info );
+		$resolver->set_query_arg( 'include', $root->user_id );
+	  return $resolver->one_to_one()->get_connection();
+  }
+]);
+```
+
+Let's also add a Connection from the User to the Notification:
+
+```php
+register_graphql_connection([
+	'fromType' => 'User',
+	'toType' => 'Noticication',
+	'fromFieldName' => 'notifications',
+	'oneToOne' => true,
+  'resolve' => function( $root, $args, $context, $info ) {
+		$resolver = new NotificationConnectionResolver( $root, $args, $context, $info );
+		$resolver->set_query_arg( 'user_id', $root->ID );
+	  return $resolver->one_to_one()->get_connection();
+  }
+]);
+```
+
+Now, all 3 of the queries we set out to have work are working with data from our custom database table:
+
+```graphql
+query GetAllNotifications {
+  notifications {
+    nodes {
+      __typename
+      id
+      message
+      date
+      user {
+        node {
+          __typename
+          id
+          name
+        }
+      }
+    }
+  }
+}
+```
+
+or: 
+
+```graphql
+query GetCurrentUserNotifications {
+  viewer {
+    id
+    name
+    notifications {
+      nodes {
+        __typename
+        id
+        message
+        date
+      }
+    }
+  }
+}
+```
+
+or: 
+
+```graphql
+query GetNotificationNode {
+  node( id: "bm90aWZpY2F0aW9uOjE=" ) {
+    __typename
+    ...on Notification {
+      __typename
+      id
+      message
+      date
+    }
+  }
+}
+```

--- a/docs/wpgraphql-concepts.md
+++ b/docs/wpgraphql-concepts.md
@@ -96,7 +96,7 @@ Actions and Filters are types of "Hooks", a convention provided by WordPress, th
 
 ## The Model Layer
 
-WPGraphQL has a "Model Layer", or a series of PHP Classes that take WordPress objects, such as `WP_Post`, `WP_Comment`, etc and normalize the data to a GraphQL-friendly shape, and also applies logic to ensure the requested data is allowed to be seen be the requesting user.
+WPGraphQL has a "Model Layer", or a series of PHP Classes that take WordPress objects, such as `WP_Post`, `WP_Comment`, etc and normalize the data to a GraphQL-friendly shape, and also applies logic to ensure the requested data is allowed to be seen by the requesting user.
 
 For example, WordPress uses `snake_case` naming conventions, but GraphQL fields use `camelCase` naming conventions. WordPress also makes use of prefixes that don't necessarily make sense in the context of an API. For example, WordPress `$post->post_content` becomes $post->`content` in the WPGraphQL Post Model.
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,8 +1,22 @@
 parameters:
     level: 8
-    inferPrivatePropertyTypeFromConstructor: true
-    checkMissingIterableValueType: true
+    dynamicConstantNames:
+        - WPGRAPHQL_AUTOLOAD
     treatPhpDocTypesAsCertain: false
+    inferPrivatePropertyTypeFromConstructor: true
+    checkAlwaysTrueCheckTypeFunctionCall: true
+    checkAlwaysTrueInstanceof: true
+    checkAlwaysTrueStrictComparison: true
+    checkExplicitMixedMissingReturn: true
+    checkFunctionNameCase: true
+    checkInternalClassCaseSensitivity: true
+    checkMissingIterableValueType: true
+    checkTooWideReturnTypesInProtectedAndPublicMethods: true
+    polluteScopeWithAlwaysIterableForeach: false
+    polluteScopeWithLoopInitialAssignments: false
+    reportAlwaysTrueInLastCondition: true
+    reportStaticMethodSignatures: true
+    reportWrongPhpDocTypeInVarTag: true
     stubFiles:
         # Simulate added properties
         - phpstan/class-wp-post-type.php

--- a/phpstan/constants.php
+++ b/phpstan/constants.php
@@ -4,9 +4,6 @@
  */
 
 define( 'WP_LANG_DIR', true );
-define( 'SAVEQUERIES', true );
 define( 'WPGRAPHQL_PLUGIN_URL', true );
-define( 'WP_CONTENT_DIR', true );
-define( 'WP_PLUGIN_DIR', true );
 define( 'WPGRAPHQL_AUTOLOAD', false );
 define( 'PHPSTAN', true );

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === WPGraphQL ===
-Contributors: jasonbahl, tylerbarnes1, ryankanner, hughdevore, chopinbach, kidunot89
+Contributors: jasonbahl, tylerbarnes1, ryankanner, hughdevore, chopinbach, kidunot89, justlevine
 Tags: GraphQL, JSON, API, Gatsby, Faust, Headless, Decoupled, Svelte, React, Nextjs, Vue, Apollo, REST, JSON, HTTP, Remote, Query Language
 Requires at least: 5.0
 Tested up to: 6.4.1

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, JSON, API, Gatsby, Faust, Headless, Decoupled, Svelte, React, Nex
 Requires at least: 5.0
 Tested up to: 6.4.1
 Requires PHP: 7.1
-Stable tag: 1.19.0
+Stable tag: 1.20.0
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -251,6 +251,27 @@ The `uri` field was non-null on some Types in the Schema but has been changed to
 Composer dependencies are no longer versioned in Github. Recommended install source is WordPress.org or using Composer to get the code from Packagist.org or WPackagist.org.
 
 == Changelog ==
+
+= 1.20.0=
+
+**New Features**
+
+- [#3013](https://github.com/wp-graphql/wp-graphql/pull/3013): feat: output GRAPHQL_DEBUG message if requested amount is larger than connection limit. Thanks @justlevine!
+- [#3008](https://github.com/wp-graphql/wp-graphql/pull/3008): perf: Expose graphql_should_analyze_queries as setting. Thanks @justlevine!
+
+**Chores / Bugfixes**
+
+- [#3022](https://github.com/wp-graphql/wp-graphql/pull/3022): chore: add @justlevine to list of contributors! 🙌 🥳
+- [#3011](https://github.com/wp-graphql/wp-graphql/pull/3011): chore: update composer dev-dependencies and use php-compatibility:develop branch to 8.0+ lints. Thanks @justlevine!
+- [#3010](https://github.com/wp-graphql/wp-graphql/pull/3010): chore: implement stricter PHPDoc types. Thanks @justlevine!
+- [#3009](https://github.com/wp-graphql/wp-graphql/pull/3009): chore: implement stricter PHPStan config and clean up unnecessary type-guards. Thanks @justlevine!
+- [#3007](https://github.com/wp-graphql/wp-graphql/pull/3007): fix: call html_entity_decode() with explicit flags and decode single-quotes. Thanks @justlevine!
+- [#3006](https://github.com/wp-graphql/wp-graphql/pull/3006): fix: replace deprecated AbstractConnectionResolver::setQueryArg() call with ::set_query_arg(). Thanks @justlevine!
+- [#3004](https://github.com/wp-graphql/wp-graphql/pull/3004): docs: Update using-data-from-custom-database-tables.md
+- [#2998](https://github.com/wp-graphql/wp-graphql/pull/2998): docs: Update build-your-first-wpgraphql-extension.md. Thanks @Jacob-Daniel!
+- [#2997](https://github.com/wp-graphql/wp-graphql/pull/2997): docs: update wpgraphql-concepts.md. Thanks @Jacob-Daniel!
+- [#2996](https://github.com/wp-graphql/wp-graphql/pull/2996): fix: Field id duplicates uri field description. Thanks @marcinkrzeminski!
+
 
 = 1.19.0=
 

--- a/src/Admin/Settings/Settings.php
+++ b/src/Admin/Settings/Settings.php
@@ -165,6 +165,18 @@ class Settings {
 					},
 				],
 				[
+					'name'     => 'query_analyzer_enabled',
+					'label'    => __( 'Enable GraphQL Type Tracking', 'wp-graphql' ),
+					'desc'     => sprintf(
+						// translators: %s is either empty or a string with a note about force enabling.
+						__( 'When enabled, WPGraphQL will track the Types, Models, and Nodes used in the request, and return those values in the headers for use in debugging or header-based cache invalidation. %s', 'wp-graphql' ),
+						true === \WPGraphQL::debug() ? '<br /><strong>' . __( 'NOTE: This setting is force enabled because GraphQL Debug Mode is enabled. ', 'wp-graphql' ) . '</strong>' : ''
+					),
+					'type'     => 'checkbox',
+					'disabled' => true === \WPGraphQL::debug(),
+					'value'    => true === \WPGraphQL\Utils\QueryAnalyzer::is_enabled() ? 'on' : get_graphql_setting( 'query_analyzer_enabled', 'off' ),
+				],
+				[
 					'name'    => 'graphiql_enabled',
 					'label'   => __( 'Enable GraphiQL IDE', 'wp-graphql' ),
 					'desc'    => __( 'GraphiQL IDE is a tool for exploring the GraphQL Schema and test GraphQL operations. Uncheck this to disable GraphiQL in the Dashboard.', 'wp-graphql' ),
@@ -195,6 +207,7 @@ class Settings {
 					'type'     => 'checkbox',
 					'value'    => true === \WPGraphQL::debug() ? 'on' : get_graphql_setting( 'debug_mode_enabled', 'off' ),
 					'disabled' => defined( 'GRAPHQL_DEBUG' ),
+					'default'  => 'off',
 				],
 				[
 					'name'    => 'tracing_enabled',

--- a/src/Admin/Settings/SettingsRegistry.php
+++ b/src/Admin/Settings/SettingsRegistry.php
@@ -128,9 +128,9 @@ class SettingsRegistry {
 		/**
 		 * Filter the setting field config
 		 *
-		 * @param array  $field_config The field config for the setting
-		 * @param string $field_name   The name of the field (unfilterable in the config)
-		 * @param string $section      The slug of the section the field is registered to
+		 * @param array<string,mixed>  $field_config The field config for the setting
+		 * @param string               $field_name   The name of the field (unfilterable in the config)
+		 * @param string               $section      The slug of the section the field is registered to
 		 */
 		$field = apply_filters( 'graphql_setting_field_config', $field_config, $field_name, $section );
 
@@ -160,7 +160,7 @@ class SettingsRegistry {
 		/**
 		 * Filter the settings sections
 		 *
-		 * @param array $setting_sections The registered settings sections
+		 * @param array<string,array<string,mixed>> $setting_sections The registered settings sections
 		 */
 		$setting_sections = apply_filters( 'graphql_settings_sections', $this->settings_sections );
 
@@ -551,7 +551,7 @@ class SettingsRegistry {
 	 *
 	 * @param array<string,mixed> $options settings field args
 	 *
-	 * @return mixed
+	 * @return array<string,mixed>
 	 */
 	public function sanitize_options( array $options ) {
 		if ( ! $options ) {
@@ -576,7 +576,7 @@ class SettingsRegistry {
 	 *
 	 * @param string $slug option slug
 	 *
-	 * @return mixed string or bool false
+	 * @return callable|false
 	 */
 	public function get_sanitize_callback( $slug = '' ) {
 		if ( empty( $slug ) ) {

--- a/src/AppContext.php
+++ b/src/AppContext.php
@@ -66,7 +66,7 @@ class AppContext {
 	/**
 	 * Passes context about the current connection being resolved
 	 *
-	 * @var mixed|String|null
+	 * @var mixed|string|null
 	 */
 	public $currentConnection = null;
 
@@ -148,7 +148,7 @@ class AppContext {
 	 *
 	 * @param string $key The name of the loader to get
 	 *
-	 * @return mixed
+	 * @return \WPGraphQL\Data\Loader\AbstractDataLoader|mixed
 	 *
 	 * @deprecated Use get_loader instead.
 	 */

--- a/src/Data/CommentMutation.php
+++ b/src/Data/CommentMutation.php
@@ -103,9 +103,9 @@ class CommentMutation {
 		/**
 		 * Filter the $insert_post_args
 		 *
-		 * @param array  $output_args   The array of $input_post_args that will be passed to wp_new_comment
-		 * @param array  $input         The data that was entered as input for the mutation
-		 * @param string $mutation_type The type of mutation being performed ( create, edit, etc )
+		 * @param array<string,mixed> $output_args   The array of $input_post_args that will be passed to wp_new_comment
+		 * @param array<string,mixed> $input         The data that was entered as input for the mutation
+		 * @param string              $mutation_type The type of mutation being performed ( create, edit, etc )
 		 */
 		$output_args = apply_filters( 'graphql_comment_insert_post_args', $output_args, $input, $mutation_name );
 

--- a/src/Data/Config.php
+++ b/src/Data/Config.php
@@ -382,12 +382,10 @@ class Config {
 		/**
 		 * If pre-filter hooked, return $pre_pieces.
 		 *
-		 * @param array<string, mixed>|null $pre_pieces The pre-filtered term query SQL clauses.
-		 * @param array<string,mixed>      $pieces     Terms query SQL clauses.
-		 * @param string[]                 $taxonomies An array of taxonomies.
-		 * @param array<string,mixed>      $args       An array of terms query arguments.
-		 *
-		 * @return array|null
+		 * @param ?array<string,mixed> $pre_pieces The pre-filtered term query SQL clauses.
+		 * @param array<string,mixed>  $pieces     Terms query SQL clauses.
+		 * @param string[]             $taxonomies An array of taxonomies.
+		 * @param array<string,mixed>  $args       An array of terms query arguments.
 		 */
 		$pre_pieces = apply_filters( 'graphql_pre_wp_term_query_cursor_pagination_support', null, $pieces, $taxonomies, $args );
 		if ( null !== $pre_pieces ) {
@@ -455,11 +453,9 @@ class Config {
 		/**
 		 * If pre-filter hooked, return $pre_pieces.
 		 *
-		 * @param array|null        $pre_pieces The pre-filtered comment query clauses.
-		 * @param array             $pieces     A compacted array of comment query clauses.
-		 * @param \WP_Comment_Query $query      Current instance of WP_Comment_Query, passed by reference.
-		 *
-		 * @return array|null
+		 * @param ?array<string,mixed> $pre_pieces The pre-filtered comment query clauses.
+		 * @param array<string,mixed>  $pieces     A compacted array of comment query clauses.
+		 * @param \WP_Comment_Query    $query      Current instance of WP_Comment_Query, passed by reference.
 		 */
 		$pre_pieces = apply_filters( 'graphql_pre_wp_comments_query_cursor_pagination_support', null, $pieces, $query );
 		if ( null !== $pre_pieces ) {

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -102,7 +102,7 @@ abstract class AbstractConnectionResolver {
 	protected $ids;
 
 	/**
-	 * @var array<string,mixed>
+	 * @var mixed[]
 	 */
 	protected $nodes;
 
@@ -162,9 +162,9 @@ abstract class AbstractConnectionResolver {
 		 *
 		 * Filters the GraphQL args before they are used in get_query_args().
 		 *
-		 * @param array                      $args                The GraphQL args passed to the resolver.
+		 * @param array<string,mixed>                                   $args                The GraphQL args passed to the resolver.
 		 * @param \WPGraphQL\Data\Connection\AbstractConnectionResolver $connection_resolver Instance of the ConnectionResolver.
-		 * @param array                      $unfiltered_args     Array of arguments input in the field as part of the GraphQL query.
+		 * @param array<string,mixed>                                   $unfiltered_args     Array of arguments input in the field as part of the GraphQL query.
 		 *
 		 * @since 1.11.0
 		 */
@@ -188,10 +188,9 @@ abstract class AbstractConnectionResolver {
 		 *
 		 * Filters the args
 		 *
-		 * @param array                      $query_args          The query args to be used with the executable query to get data.
-		 *                                                        This should take in the GraphQL args and return args for use in fetching the data.
+		 * @param array<string,mixed>                                   $query_args          The query args to be used with the executable query to get data.
 		 * @param \WPGraphQL\Data\Connection\AbstractConnectionResolver $connection_resolver Instance of the ConnectionResolver
-		 * @param array                      $unfiltered_args Array of arguments input in the field as part of the GraphQL query.
+		 * @param array<string,mixed>                                   $unfiltered_args Array of arguments input in the field as part of the GraphQL query.
 		 */
 		$this->query_args = apply_filters( 'graphql_connection_query_args', $this->get_query_args(), $this, $args );
 	}
@@ -415,8 +414,9 @@ abstract class AbstractConnectionResolver {
 	/**
 	 * Get_query_amount
 	 *
-	 * Returns the max between what was requested and what is defined as the $max_query_amount to
-	 * ensure that queries don't exceed unwanted limits when querying data.
+	 * Returns the max between what was requested and what is defined as the $max_query_amount to ensure that queries don't exceed unwanted limits when querying data.
+	 *
+	 * If the amount requested is greater than the max query amount, a debug message will be included in the GraphQL response.
 	 *
 	 * @return int
 	 * @throws \Exception
@@ -429,17 +429,26 @@ abstract class AbstractConnectionResolver {
 		 *
 		 * This filter is intentionally applied AFTER the query_args filter, as
 		 *
-		 * @param int         $max_posts  the maximum number of posts per page.
-		 * @param mixed       $source     source passed down from the resolve tree
-		 * @param array       $args       array of arguments input in the field as part of the GraphQL query
-		 * @param \WPGraphQL\AppContext $context Object containing app context that gets passed down the resolve tree
-		 * @param \GraphQL\Type\Definition\ResolveInfo $info Info about fields passed down the resolve tree
+		 * @param int                                  $max_posts  the maximum number of posts per page.
+		 * @param mixed                                $source     source passed down from the resolve tree
+		 * @param array<string,mixed>                  $args       array of arguments input in the field as part of the GraphQL query
+		 * @param \WPGraphQL\AppContext                $context    Object containing app context that gets passed down the resolve tree
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info       Info about fields passed down the resolve tree
 		 *
 		 * @since 0.0.6
 		 */
 		$max_query_amount = apply_filters( 'graphql_connection_max_query_amount', 100, $this->source, $this->args, $this->context, $this->info );
+		
+		$requested_amount = $this->get_amount_requested();
 
-		return min( $max_query_amount, absint( $this->get_amount_requested() ) );
+		if ( $requested_amount > $max_query_amount ) {
+			graphql_debug(
+				sprintf( 'The number of items requested by the connection (%s) exceeds the max query amount. Only the first %s items will be returned.', $requested_amount, $max_query_amount ),
+				[ 'connection' => static::class ]
+			);
+		}
+
+		return min( $max_query_amount, $requested_amount );
 	}
 
 	/**
@@ -447,7 +456,7 @@ abstract class AbstractConnectionResolver {
 	 *
 	 * This checks the $args to determine the amount requested, and if
 	 *
-	 * @return int|null
+	 * @return int
 	 * @throws \GraphQL\Error\UserError If there is an issue with the pagination $args.
 	 */
 	public function get_amount_requested() {
@@ -495,7 +504,7 @@ abstract class AbstractConnectionResolver {
 		 * @param int                        $amount   the requested amount
 		 * @param \WPGraphQL\Data\Connection\AbstractConnectionResolver $resolver Instance of the connection resolver class
 		 */
-		return max( 0, apply_filters( 'graphql_connection_amount_requested', $amount_requested, $this ) );
+		return (int) max( 0, apply_filters( 'graphql_connection_amount_requested', $amount_requested, $this ) );
 	}
 
 	/**
@@ -820,7 +829,7 @@ abstract class AbstractConnectionResolver {
 			/**
 			 * Create the edge, pass it through a filter.
 			 *
-			 * @param array                      $edge                The edge within the connection
+			 * @param array<string,mixed>                                   $edge                The edge within the connection
 			 * @param \WPGraphQL\Data\Connection\AbstractConnectionResolver $connection_resolver Instance of the connection resolver class
 			 */
 			$edge = apply_filters(
@@ -940,7 +949,7 @@ abstract class AbstractConnectionResolver {
 		/**
 		 * Filter the connection IDs
 		 *
-		 * @param array                      $ids                 Array of IDs this connection will be resolving
+		 * @param int[]|string[]                                        $ids                 Array of IDs this connection will be resolving
 		 * @param \WPGraphQL\Data\Connection\AbstractConnectionResolver $connection_resolver Instance of the Connection Resolver
 		 */
 		$this->ids = apply_filters( 'graphql_connection_ids', $this->get_ids(), $this );
@@ -984,7 +993,7 @@ abstract class AbstractConnectionResolver {
 				 *
 				 * Filters the nodes in the connection
 				 *
-				 * @param array                      $nodes               The nodes in the connection
+				 * @param array<int|string,mixed|\WPGraphQL\Model\Model|null>   $nodes               The nodes in the connection
 				 * @param \WPGraphQL\Data\Connection\AbstractConnectionResolver $connection_resolver Instance of the Connection Resolver
 				 */
 				$this->nodes = apply_filters( 'graphql_connection_nodes', $this->get_nodes(), $this );
@@ -992,7 +1001,7 @@ abstract class AbstractConnectionResolver {
 				/**
 				 * Filters the edges in the connection
 				 *
-				 * @param array                      $nodes               The nodes in the connection
+				 * @param array<int|string,mixed|\WPGraphQL\Model\Model|null>   $nodes               The nodes in the connection
 				 * @param \WPGraphQL\Data\Connection\AbstractConnectionResolver $connection_resolver Instance of the Connection Resolver
 				 */
 				$this->edges = apply_filters( 'graphql_connection_edges', $this->get_edges(), $this );
@@ -1015,7 +1024,7 @@ abstract class AbstractConnectionResolver {
 				 *
 				 * This filter allows additional fields to be returned to the connection resolver
 				 *
-				 * @param array                      $connection          The connection data being returned
+				 * @param array<string,mixed>                                   $connection          The connection data being returned
 				 * @param \WPGraphQL\Data\Connection\AbstractConnectionResolver $connection_resolver The instance of the connection resolver
 				 */
 				return apply_filters( 'graphql_connection', $connection, $this );

--- a/src/Data/Connection/CommentConnectionResolver.php
+++ b/src/Data/Connection/CommentConnectionResolver.php
@@ -135,10 +135,10 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 		 * Filter the query_args that should be applied to the query. This filter is applied AFTER the input args from
 		 * the GraphQL Query have been applied and has the potential to override the GraphQL Query Input Args.
 		 *
-		 * @param array       $query_args array of query_args being passed to the
-		 * @param mixed       $source     source passed down from the resolve tree
-		 * @param array       $args       array of arguments input in the field as part of the GraphQL query
-		 * @param \WPGraphQL\AppContext $context object passed down the resolve tree
+		 * @param array<string,mixed>                  $query_args array of query_args being passed to the
+		 * @param mixed                                $source     source passed down from the resolve tree
+		 * @param array<string,mixed>                  $args       array of arguments input in the field as part of the GraphQL query
+		 * @param \WPGraphQL\AppContext                $context object passed down the resolve tree
 		 * @param \GraphQL\Type\Definition\ResolveInfo $info info about fields passed down the resolve tree
 		 *
 		 * @since 0.0.6
@@ -256,7 +256,7 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 		 *
 		 * Filters the GraphQL args before they are used in get_query_args().
 		 *
-		 * @param array                     $args                The GraphQL args passed to the resolver.
+		 * @param array<string,mixed>                                  $args                The GraphQL args passed to the resolver.
 		 * @param \WPGraphQL\Data\Connection\CommentConnectionResolver $connection_resolver Instance of the ConnectionResolver
 		 *
 		 * @since 1.11.0

--- a/src/Data/Connection/MenuItemConnectionResolver.php
+++ b/src/Data/Connection/MenuItemConnectionResolver.php
@@ -61,7 +61,7 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 		}
 
 		// Only query for menu items in assigned locations.
-		if ( ! empty( $locations ) && is_array( $locations ) ) {
+		if ( ! empty( $locations ) ) {
 
 			// unset the location arg
 			// we don't need this passed as a taxonomy parameter to wp_query
@@ -104,8 +104,8 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 		 *
 		 * Filters the GraphQL args before they are used in get_query_args().
 		 *
-		 * @param array $args            The GraphQL args passed to the resolver.
-		 * @param array $unfiltered_args Array of arguments input in the field as part of the GraphQL query.
+		 * @param array<string,mixed> $args            The GraphQL args passed to the resolver.
+		 * @param array<string,mixed> $unfiltered_args Array of arguments input in the field as part of the GraphQL query.
 		 *
 		 * @since 1.11.0
 		 */

--- a/src/Data/Connection/PluginConnectionResolver.php
+++ b/src/Data/Connection/PluginConnectionResolver.php
@@ -85,7 +85,7 @@ class PluginConnectionResolver extends AbstractConnectionResolver {
 		$recently_activated_list = isset( $active_stati['recently_activated'] ) ? get_site_option( 'recently_activated', [] ) : [];
 
 		// Loop through the plugins, add additional data, and store them in $plugins_by_status.
-		foreach ( (array) $all_plugins as $plugin_file => $plugin_data ) {
+		foreach ( $all_plugins as $plugin_file => $plugin_data ) {
 			if ( ! file_exists( WP_PLUGIN_DIR . '/' . $plugin_file ) ) {
 				unset( $all_plugins[ $plugin_file ] );
 				continue;

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -18,7 +18,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * The name of the post type, or array of post types the connection resolver is resolving for
 	 *
-	 * @var mixed string|array
+	 * @var mixed|string|string[]
 	 */
 	protected $post_type;
 
@@ -352,11 +352,11 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		/**
 		 * Filter the $query args to allow folks to customize queries programmatically
 		 *
-		 * @param array       $query_args The args that will be passed to the WP_Query
-		 * @param mixed       $source     The source that's passed down the GraphQL queries
-		 * @param array       $args       The inputArgs on the field
-		 * @param \WPGraphQL\AppContext $context The AppContext passed down the GraphQL tree
-		 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the GraphQL tree
+		 * @param array<string,mixed>                  $query_args The args that will be passed to the WP_Query
+		 * @param mixed                                $source     The source that's passed down the GraphQL queries
+		 * @param array<string,mixed>                  $args       The inputArgs on the field
+		 * @param \WPGraphQL\AppContext                $context    The AppContext passed down the GraphQL tree
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info       The ResolveInfo passed down the GraphQL tree
 		 */
 		return apply_filters( 'graphql_post_object_connection_query_args', $query_args, $this->source, $this->args, $this->context, $this->info );
 	}
@@ -419,15 +419,14 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		 * This allows plugins/themes to hook in and alter what $args should be allowed to be passed
 		 * from a GraphQL Query to the WP_Query
 		 *
-		 * @param array              $query_args The mapped query arguments
-		 * @param array              $args       Query "where" args
-		 * @param mixed              $source     The query results for a query calling this
-		 * @param array              $all_args   All of the arguments for the query (not just the "where" args)
-		 * @param \WPGraphQL\AppContext $context The AppContext object
-		 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object
-		 * @param mixed|string|array $post_type  The post type for the query
+		 * @param array<string,mixed>                  $query_args The mapped query arguments
+		 * @param array<string,mixed>                  $args       Query "where" args
+		 * @param mixed                                $source     The query results for a query calling this
+		 * @param array<string,mixed>                  $all_args   All of the arguments for the query (not just the "where" args)
+		 * @param \WPGraphQL\AppContext                $context    The AppContext object
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info       The ResolveInfo object
+		 * @param mixed|string|string[]                $post_type  The post type for the query
 		 *
-		 * @return array
 		 * @since 0.0.5
 		 */
 		$query_args = apply_filters( 'graphql_map_input_fields_to_wp_query', $query_args, $where_args, $this->source, $this->args, $this->context, $this->info, $this->post_type );
@@ -446,7 +445,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	 * This strips the status from the query_args if the user doesn't have permission to query for
 	 * posts of that status.
 	 *
-	 * @param mixed $stati The status(es) to sanitize
+	 * @param string[]|string $stati The status(es) to sanitize.
 	 *
 	 * @return string[]|null
 	 */
@@ -576,9 +575,9 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		 *
 		 * Filters the GraphQL args before they are used in get_query_args().
 		 *
-		 * @param array                        $args                The GraphQL args passed to the resolver.
+		 * @param array<string,mixed>                                     $args                The GraphQL args passed to the resolver.
 		 * @param \WPGraphQL\Data\Connection\PostObjectConnectionResolver $connection_resolver Instance of the ConnectionResolver.
-		 * @param array                        $unfiltered_args     Array of arguments input in the field as part of the GraphQL query.
+		 * @param array<string,mixed>                                     $unfiltered_args     Array of arguments input in the field as part of the GraphQL query.
 		 *
 		 * @since 1.11.0
 		 */

--- a/src/Data/Connection/TermObjectConnectionResolver.php
+++ b/src/Data/Connection/TermObjectConnectionResolver.php
@@ -134,11 +134,11 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 		 * Filter the query_args that should be applied to the query. This filter is applied AFTER the input args from
 		 * the GraphQL Query have been applied and has the potential to override the GraphQL Query Input Args.
 		 *
-		 * @param array       $query_args array of query_args being passed to the
-		 * @param mixed       $source     source passed down from the resolve tree
-		 * @param array       $args       array of arguments input in the field as part of the GraphQL query
-		 * @param \WPGraphQL\AppContext $context object passed down the resolve tree
-		 * @param \GraphQL\Type\Definition\ResolveInfo $info info about fields passed down the resolve tree
+		 * @param array<string,mixed>                  $query_args array of query_args being passed to the
+		 * @param mixed                                $source     source passed down from the resolve tree
+		 * @param array<string,mixed>                  $args       array of arguments input in the field as part of the GraphQL query
+		 * @param \WPGraphQL\AppContext                $context    object passed down the resolve tree
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info       info about fields passed down the resolve tree
 		 *
 		 * @since 0.0.6
 		 */
@@ -234,16 +234,15 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 		 * This allows plugins/themes to hook in and alter what $args should be allowed to be passed
 		 * from a GraphQL Query to the get_terms query
 		 *
-		 * @param array       $query_args Array of mapped query args
-		 * @param array       $where_args Array of query "where" args
-		 * @param string      $taxonomy   The name of the taxonomy
-		 * @param mixed       $source     The query results
-		 * @param array       $all_args   All of the query arguments (not just the "where" args)
-		 * @param \WPGraphQL\AppContext $context The AppContext object
-		 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object
+		 * @param array<string,mixed>                  $query_args Array of mapped query args
+		 * @param array<string,mixed>                  $where_args Array of query "where" args
+		 * @param string                               $taxonomy   The name of the taxonomy
+		 * @param mixed                                $source     The query results
+		 * @param array<string,mixed>                  $all_args   All of the query arguments (not just the "where" args)
+		 * @param \WPGraphQL\AppContext                $context   The AppContext object
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info      The ResolveInfo object
 		 *
 		 * @since 0.0.5
-		 * @return array
 		 */
 		$query_args = apply_filters( 'graphql_map_input_fields_to_get_terms', $query_args, $where_args, $this->taxonomy, $this->source, $this->args, $this->context, $this->info );
 
@@ -290,9 +289,9 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 		 *
 		 * Filters the GraphQL args before they are used in get_query_args().
 		 *
-		 * @param array                        $args                The GraphQL args passed to the resolver.
+		 * @param array<string,mixed>                                     $args                The GraphQL args passed to the resolver.
 		 * @param \WPGraphQL\Data\Connection\TermObjectConnectionResolver $connection_resolver Instance of the ConnectionResolver
-		 * @param array                        $unfiltered_args     Array of arguments input in the field as part of the GraphQL query.
+		 * @param array<string,mixed>                                     $unfiltered_args     Array of arguments input in the field as part of the GraphQL query.
 		 *
 		 * @since 1.11.0
 		 */

--- a/src/Data/Connection/UserConnectionResolver.php
+++ b/src/Data/Connection/UserConnectionResolver.php
@@ -266,14 +266,13 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 		 * This allows plugins/themes to hook in and alter what $args should be allowed to be passed
 		 * from a GraphQL Query to the WP_User_Query
 		 *
-		 * @param array       $query_args The mapped query args
-		 * @param array       $args       The query "where" args
-		 * @param mixed       $source     The query results of the query calling this relation
-		 * @param array       $all_args   Array of all the query args (not just the "where" args)
-		 * @param \WPGraphQL\AppContext $context The AppContext object
+		 * @param array<string,mixed>                  $query_args The mapped query args
+		 * @param array<string,mixed>                  $args       The query "where" args
+		 * @param mixed                                $source     The query results of the query calling this relation
+		 * @param array<string,mixed>                  $all_args   Array of all the query args (not just the "where" args)
+		 * @param \WPGraphQL\AppContext                $context The AppContext object
 		 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object
 		 *
-		 * @return array
 		 * @since 0.0.5
 		 */
 		$query_args = apply_filters( 'graphql_map_input_fields_to_wp_user_query', $query_args, $args, $this->source, $this->args, $this->context, $this->info );

--- a/src/Data/Cursor/AbstractCursor.php
+++ b/src/Data/Cursor/AbstractCursor.php
@@ -224,7 +224,7 @@ abstract class AbstractCursor {
 	/**
 	 * Returns the ID key.
 	 *
-	 * @return mixed
+	 * @return string
 	 */
 	public function get_cursor_id_key() {
 		$key = $this->get_query_var( 'graphql_cursor_id_key' );

--- a/src/Data/Cursor/CursorBuilder.php
+++ b/src/Data/Cursor/CursorBuilder.php
@@ -51,9 +51,9 @@ class CursorBuilder {
 		/**
 		 * Filters the field used for ordering when cursors are used for pagination
 		 *
-		 * @param array         $field          The field key, value, type and order
+		 * @param array<string,mixed>                  $field          The field key, value, type and order
 		 * @param \WPGraphQL\Data\Cursor\CursorBuilder $cursor_builder The CursorBuilder class
-		 * @param ?object        $object_cursor  The Cursor class
+		 * @param ?object                              $object_cursor  The Cursor class
 		 */
 		$field = apply_filters(
 			'graphql_cursor_ordering_field',

--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -74,7 +74,7 @@ class DataSource {
 	 *
 	 * @param int $comment_id The ID of the comment the comment author is associated with.
 	 *
-	 * @return mixed|\WPGraphQL\Model\CommentAuthor|null
+	 * @return \WPGraphQL\Model\CommentAuthor|null
 	 * @throws \Exception Throws Exception.
 	 */
 	public static function resolve_comment_author( int $comment_id ) {
@@ -91,7 +91,7 @@ class DataSource {
 	 * @param \WPGraphQL\AppContext                $context The context of the query to pass along
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object
 	 *
-	 * @return mixed
+	 * @return \GraphQL\Deferred
 	 * @throws \Exception
 	 * @since 0.0.5
 	 */
@@ -160,7 +160,7 @@ class DataSource {
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object
 	 * @param mixed|string|string[]                $post_type Post type of the post we are trying to resolve
 	 *
-	 * @return mixed
+	 * @return \GraphQL\Deferred
 	 * @throws \Exception
 	 * @since  0.0.5
 	 */
@@ -209,7 +209,7 @@ class DataSource {
 	 * @param int                   $id      ID of the term you are trying to retrieve the object for
 	 * @param \WPGraphQL\AppContext $context The context of the GraphQL Request
 	 *
-	 * @return mixed
+	 * @return \GraphQL\Deferred
 	 * @throws \Exception
 	 * @since      0.0.5
 	 *
@@ -458,12 +458,12 @@ class DataSource {
 		/**
 		 * Set the setting groups that are allowed
 		 */
-		$allowed_settings_by_group = ! empty( $allowed_settings_by_group ) && is_array( $allowed_settings_by_group ) ? $allowed_settings_by_group : [];
+		$allowed_settings_by_group = ! empty( $allowed_settings_by_group ) ? $allowed_settings_by_group : [];
 
 		/**
 		 * Filter the $allowed_settings_by_group to allow enabling or disabling groups in the GraphQL Schema.
 		 *
-		 * @param array $allowed_settings_by_group
+		 * @param array<string,array<string,mixed>> $allowed_settings_by_group
 		 */
 		return apply_filters( 'graphql_allowed_settings_by_group', $allowed_settings_by_group );
 	}
@@ -513,7 +513,7 @@ class DataSource {
 		/**
 		 * Verify that we have the allowed settings
 		 */
-		$allowed_settings = ! empty( $allowed_settings ) && is_array( $allowed_settings ) ? $allowed_settings : [];
+		$allowed_settings = ! empty( $allowed_settings ) ? $allowed_settings : [];
 
 		/**
 		 * Filter the $allowed_settings to allow some to be enabled or disabled from showing in
@@ -714,7 +714,7 @@ class DataSource {
 	 * @param \WPGraphQL\AppContext                $context The AppContext passed through the GraphQL Resolve Tree
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed through the GraphQL Resolve tree
 	 *
-	 * @return mixed
+	 * @return \GraphQL\Deferred
 	 * @throws \Exception
 	 */
 	public static function resolve_resource_by_uri( $uri, $context, $info ) {

--- a/src/Data/Loader/AbstractDataLoader.php
+++ b/src/Data/Loader/AbstractDataLoader.php
@@ -109,9 +109,9 @@ abstract class AbstractDataLoader {
 	 * Loads a key and returns value represented by this key.
 	 * Internally this method will load all currently buffered items and cache them locally.
 	 *
-	 * @param mixed $key
+	 * @param int|string|mixed $key
 	 *
-	 * @return mixed
+	 * @return ?\WPGraphQL\Model\Model
 	 * @throws \Exception
 	 */
 	public function load( $key ) {
@@ -418,7 +418,7 @@ abstract class AbstractDataLoader {
 	/**
 	 * Returns a cached data object by key.
 	 *
-	 * @param mixed $key  Key.
+	 * @param int|string $key Key.
 	 *
 	 * @return mixed
 	 */
@@ -431,10 +431,10 @@ abstract class AbstractDataLoader {
 		/**
 		 * Use this filter to retrieving cached data objects from third-party caching system.
 		 *
-		 * @param mixed  $value         Value to be cached.
-		 * @param mixed  $key           Key identifying object.
-		 * @param string $loader_class  Loader class name.
-		 * @param mixed  $loader        Loader instance.
+		 * @param mixed       $value        Value to be cached.
+		 * @param int|string  $key          Key identifying object.
+		 * @param string      $loader_class Loader class name.
+		 * @param mixed       $loader       Loader instance.
 		 */
 		$value = apply_filters(
 			'graphql_dataloader_get_cached',

--- a/src/Data/Loader/PluginLoader.php
+++ b/src/Data/Loader/PluginLoader.php
@@ -44,7 +44,7 @@ class PluginLoader extends AbstractDataLoader {
 		$plugins = array_merge( $site_plugins, $mu_plugins, $dropin_plugins );
 
 		$loaded = [];
-		if ( ! empty( $plugins ) && is_array( $plugins ) ) {
+		if ( ! empty( $plugins ) ) {
 			foreach ( $keys as $key ) {
 				if ( isset( $plugins[ $key ] ) ) {
 					$plugin         = $plugins[ $key ];

--- a/src/Data/Loader/PostObjectLoader.php
+++ b/src/Data/Loader/PostObjectLoader.php
@@ -57,7 +57,7 @@ class PostObjectLoader extends AbstractDataLoader {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @return array<string|int, \WP_Post|null>
+	 * @return array<string|int,\WP_Post|null>
 	 */
 	public function loadKeys( array $keys ) {
 		if ( empty( $keys ) ) {

--- a/src/Data/Loader/TermObjectLoader.php
+++ b/src/Data/Loader/TermObjectLoader.php
@@ -50,7 +50,7 @@ class TermObjectLoader extends AbstractDataLoader {
 	 *
 	 * @param int[] $keys
 	 *
-	 * @return array<int, mixed>
+	 * @return array<int,\WP_Term|\WP_Error|null>
 	 */
 	public function loadKeys( array $keys ) {
 		if ( empty( $keys ) ) {

--- a/src/Data/Loader/UserLoader.php
+++ b/src/Data/Loader/UserLoader.php
@@ -43,7 +43,7 @@ class UserLoader extends AbstractDataLoader {
 	 *
 	 * @param int[] $keys Array of author IDs (int).
 	 *
-	 * @return array<int, bool> Associative array of author IDs (int) to boolean.
+	 * @return array<int,bool> Associative array of author IDs (int) to boolean.
 	 */
 	public function get_public_users( array $keys ) {
 
@@ -109,7 +109,7 @@ class UserLoader extends AbstractDataLoader {
 	 *
 	 * @param int[] $keys
 	 *
-	 * @return array<int, \WP_User|null>
+	 * @return array<int,\WP_User|null>
 	 */
 	public function loadKeys( array $keys ) {
 		if ( empty( $keys ) ) {

--- a/src/Data/MediaItemMutation.php
+++ b/src/Data/MediaItemMutation.php
@@ -17,10 +17,10 @@ class MediaItemMutation {
 	/**
 	 * This prepares the media item for insertion
 	 *
-	 * @param array<string,mixed> $input            The input for the mutation from the GraphQL request
-	 * @param \WP_Post_Type       $post_type_object The post_type_object for the mediaItem (attachment)
-	 * @param string              $mutation_name    The name of the mutation being performed (create, update, etc.)
-	 * @param mixed               $file             The mediaItem (attachment) file
+	 * @param array<string,mixed>       $input            The input for the mutation from the GraphQL request
+	 * @param \WP_Post_Type             $post_type_object The post_type_object for the mediaItem (attachment)
+	 * @param string                    $mutation_name    The name of the mutation being performed (create, update, etc.)
+	 * @param array<string,mixed>|false $file             The mediaItem (attachment) file
 	 *
 	 * @return array<string,mixed>
 	 */
@@ -95,10 +95,10 @@ class MediaItemMutation {
 		/**
 		 * Filter the $insert_post_args
 		 *
-		 * @param array        $insert_post_args The array of $input_post_args that will be passed to wp_insert_attachment
-		 * @param array        $input            The data that was entered as input for the mutation
-		 * @param \WP_Post_Type $post_type_object The post_type_object that the mutation is affecting
-		 * @param string       $mutation_type    The type of mutation being performed (create, update, delete)
+		 * @param array<string,mixed> $insert_post_args The array of $input_post_args that will be passed to wp_insert_attachment
+		 * @param array<string,mixed> $input            The data that was entered as input for the mutation
+		 * @param \WP_Post_Type       $post_type_object The post_type_object that the mutation is affecting
+		 * @param string              $mutation_type    The type of mutation being performed (create, update, delete)
 		 */
 		$insert_post_args = apply_filters( 'graphql_media_item_insert_post_args', $insert_post_args, $input, $post_type_object, $mutation_name );
 
@@ -131,11 +131,11 @@ class MediaItemMutation {
 		 * update additional data related to mediaItems, such as updating additional postmeta,
 		 * or sending emails to Kevin. . .whatever you need to do with the mediaItem.
 		 *
-		 * @param int          $media_item_id    The ID of the mediaItem being mutated
-		 * @param array        $input            The input for the mutation
-		 * @param \WP_Post_Type $post_type_object The Post Type Object for the type of post being mutated
-		 * @param string       $mutation_name    The name of the mutation (ex: create, update, delete)
-		 * @param \WPGraphQL\AppContext $context The AppContext that is passed down the resolve tree
+		 * @param int                                  $media_item_id    The ID of the mediaItem being mutated
+		 * @param array<string,mixed>                  $input            The input for the mutation
+		 * @param \WP_Post_Type                        $post_type_object The Post Type Object for the type of post being mutated
+		 * @param string                               $mutation_name    The name of the mutation (ex: create, update, delete)
+		 * @param \WPGraphQL\AppContext                $context The AppContext that is passed down the resolve tree
 		 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo that is passed down the resolve tree
 		 */
 		do_action( 'graphql_media_item_mutation_update_additional_data', $media_item_id, $input, $post_type_object, $mutation_name, $context, $info );

--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -122,7 +122,7 @@ class NodeResolver {
 		 * @param string $uri The uri being searched.
 		 * @param \WPGraphQL\AppContext $content The app context.
 		 * @param \WP $wp WP object.
-		 * @param mixed|array<string,mixed>|string $extra_query_vars Any extra query vars to consider.
+		 * @param array<string,mixed>|string $extra_query_vars Any extra query vars to consider.
 		 */
 		$node = apply_filters( 'graphql_pre_resolve_uri', null, $uri, $this->context, $this->wp, $extra_query_vars );
 
@@ -155,11 +155,11 @@ class NodeResolver {
 		 *
 		 * This can be used by Extensions which use a different query class to resolve data.
 		 *
-		 * @param class-string          $query_class The query class used to resolve the URI. Defaults to WP_Query.
-		 * @param ?string               $uri The uri being searched.
-		 * @param \WPGraphQL\AppContext $content The app context.
-		 * @param \WP                   $wp WP object.
-		 * @param mixed|array|string    $extra_query_vars Any extra query vars to consider.
+		 * @param class-string               $query_class The query class used to resolve the URI. Defaults to WP_Query.
+		 * @param ?string                    $uri The uri being searched.
+		 * @param \WPGraphQL\AppContext      $content The app context.
+		 * @param \WP                        $wp WP object.
+		 * @param array<string,mixed>|string $extra_query_vars Any extra query vars to consider.
 		 */
 		$query_class = apply_filters( 'graphql_resolve_uri_query_class', 'WP_Query', $uri, $this->context, $this->wp, $extra_query_vars );
 
@@ -202,7 +202,7 @@ class NodeResolver {
 		 * @param \WP_Query                                     $query            The query object.
 		 * @param \WPGraphQL\AppContext                         $content          The app context.
 		 * @param \WP                                           $wp               WP object.
-		 * @param mixed|array|string                            $extra_query_vars Any extra query vars to consider.
+		 * @param array<string,mixed>|string                    $extra_query_vars Any extra query vars to consider.
 		 */
 		$node = apply_filters( 'graphql_resolve_uri', null, $uri, $queried_object, $query, $this->context, $this->wp, $extra_query_vars );
 
@@ -297,7 +297,7 @@ class NodeResolver {
 		 * @param \WP_Query                                     $query            The query object.
 		 * @param \WPGraphQL\AppContext                         $content          The app context.
 		 * @param \WP                                           $wp               WP object.
-		 * @param mixed|array|string                            $extra_query_vars Any extra query vars to consider.
+		 * @param array<string,mixed>|string                    $extra_query_vars Any extra query vars to consider.
 		 */
 		return apply_filters( 'graphql_post_resolve_uri', $node, $uri, $queried_object, $query, $this->context, $this->wp, $extra_query_vars );
 	}
@@ -593,7 +593,7 @@ class NodeResolver {
 		/**
 		 * Filters the array of parsed query variables.
 		 *
-		 * @param array $query_vars The array of requested query variables.
+		 * @param array<string,mixed> $query_vars The array of requested query variables.
 		 *
 		 * @since 2.1.0
 		 */

--- a/src/Data/PostObjectMutation.php
+++ b/src/Data/PostObjectMutation.php
@@ -104,10 +104,10 @@ class PostObjectMutation {
 		/**
 		 * Filter the $insert_post_args
 		 *
-		 * @param array        $insert_post_args The array of $input_post_args that will be passed to wp_insert_post
-		 * @param array        $input            The data that was entered as input for the mutation
-		 * @param \WP_Post_Type $post_type_object The post_type_object that the mutation is affecting
-		 * @param string       $mutation_type    The type of mutation being performed (create, edit, etc)
+		 * @param array<string,mixed> $insert_post_args The array of $input_post_args that will be passed to wp_insert_post
+		 * @param array<string,mixed> $input            The data that was entered as input for the mutation
+		 * @param \WP_Post_Type       $post_type_object The post_type_object that the mutation is affecting
+		 * @param string              $mutation_type    The type of mutation being performed (create, edit, etc)
 		 */
 		$insert_post_args = apply_filters( 'graphql_post_object_insert_post_args', $insert_post_args, $input, $post_type_object, $mutation_name );
 
@@ -137,17 +137,15 @@ class PostObjectMutation {
 		/**
 		 * Sets the post lock
 		 *
-		 * @param bool         $is_locked            Whether the post is locked
-		 * @param int          $post_id              The ID of the postObject being mutated
-		 * @param array        $input                The input for the mutation
-		 * @param \WP_Post_Type $post_type_object The Post Type Object for the type of post being mutated
-		 * @param string       $mutation_name        The name of the mutation (ex: create, update, delete)
-		 * @param \WPGraphQL\AppContext $context The AppContext passed down to all resolvers
+		 * @param bool                                 $is_locked            Whether the post is locked
+		 * @param int                                  $post_id              The ID of the postObject being mutated
+		 * @param array<string,mixed>                  $input                The input for the mutation
+		 * @param \WP_Post_Type                        $post_type_object The Post Type Object for the type of post being mutated
+		 * @param string                               $mutation_name        The name of the mutation (ex: create, update, delete)
+		 * @param \WPGraphQL\AppContext                $context The AppContext passed down to all resolvers
 		 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down to all resolvers
-		 * @param ?string      $intended_post_status The intended post_status the post should have according to the mutation input
-		 * @param ?string      $default_post_status  The default status posts should use if an intended status wasn't set
-		 *
-		 * @return bool
+		 * @param ?string                              $intended_post_status The intended post_status the post should have according to the mutation input
+		 * @param ?string                              $default_post_status  The default status posts should use if an intended status wasn't set
 		 */
 		if ( true === apply_filters( 'graphql_post_object_mutation_set_edit_lock', true, $post_id, $input, $post_type_object, $mutation_name, $context, $info, $default_post_status, $intended_post_status ) ) {
 			/**
@@ -171,10 +169,10 @@ class PostObjectMutation {
 		/**
 		 * Set the object terms
 		 *
-		 * @param int          $post_id          The ID of the postObject being mutated
-		 * @param array        $input            The input for the mutation
-		 * @param \WP_Post_Type $post_type_object The Post Type Object for the type of post being mutated
-		 * @param string       $mutation_name    The name of the mutation (ex: create, update, delete)
+		 * @param int                 $post_id          The ID of the postObject being mutated
+		 * @param array<string,mixed> $input            The input for the mutation
+		 * @param \WP_Post_Type       $post_type_object The Post Type Object for the type of post being mutated
+		 * @param string              $mutation_name    The name of the mutation (ex: create, update, delete)
 		 */
 		self::set_object_terms( $post_id, $input, $post_type_object, $mutation_name );
 
@@ -183,29 +181,29 @@ class PostObjectMutation {
 		 * update additional data related to postObjects, such as setting relationships, updating additional postmeta,
 		 * or sending emails to Kevin. . .whatever you need to do with the postObject.
 		 *
-		 * @param int          $post_id              The ID of the postObject being mutated
-		 * @param array        $input                The input for the mutation
-		 * @param \WP_Post_Type $post_type_object The Post Type Object for the type of post being mutated
-		 * @param string       $mutation_name        The name of the mutation (ex: create, update, delete)
-		 * @param \WPGraphQL\AppContext $context The AppContext passed down to all resolvers
-		 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down to all resolvers
-		 * @param ?string      $intended_post_status The intended post_status the post should have according to the mutation input
-		 * @param ?string      $default_post_status  The default status posts should use if an intended status wasn't set
+		 * @param int                                  $post_id              The ID of the postObject being mutated
+		 * @param array<string,mixed>                  $input                The input for the mutation
+		 * @param \WP_Post_Type                        $post_type_object     The Post Type Object for the type of post being mutated
+		 * @param string                               $mutation_name        The name of the mutation (ex: create, update, delete)
+		 * @param \WPGraphQL\AppContext                $context              The AppContext passed down to all resolvers
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info                 The ResolveInfo passed down to all resolvers
+		 * @param ?string                              $intended_post_status The intended post_status the post should have according to the mutation input
+		 * @param ?string                              $default_post_status  The default status posts should use if an intended status wasn't set
 		 */
 		do_action( 'graphql_post_object_mutation_update_additional_data', $post_id, $input, $post_type_object, $mutation_name, $context, $info, $default_post_status, $intended_post_status );
 
 		/**
 		 * Sets the post lock
 		 *
-		 * @param bool         $is_locked            Whether the post is locked.
-		 * @param int          $post_id              The ID of the postObject being mutated
-		 * @param array        $input                The input for the mutation
-		 * @param \WP_Post_Type $post_type_object The Post Type Object for the type of post being mutated
-		 * @param string       $mutation_name        The name of the mutation (ex: create, update, delete)
-		 * @param \WPGraphQL\AppContext $context The AppContext passed down to all resolvers
-		 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down to all resolvers
-		 * @param ?string      $intended_post_status The intended post_status the post should have according to the mutation input
-		 * @param ?string      $default_post_status  The default status posts should use if an intended status wasn't set
+		 * @param bool                                 $is_locked            Whether the post is locked.
+		 * @param int                                  $post_id              The ID of the postObject being mutated
+		 * @param array<string,mixed>                  $input                The input for the mutation
+		 * @param \WP_Post_Type                        $post_type_object     The Post Type Object for the type of post being mutated
+		 * @param string                               $mutation_name        The name of the mutation (ex: create, update, delete)
+		 * @param \WPGraphQL\AppContext                $context              The AppContext passed down to all resolvers
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info                 The ResolveInfo passed down to all resolvers
+		 * @param ?string                              $intended_post_status The intended post_status the post should have according to the mutation input
+		 * @param ?string                              $default_post_status  The default status posts should use if an intended status wasn't set
 		 *
 		 * @return bool
 		 */
@@ -235,10 +233,10 @@ class PostObjectMutation {
 		 *
 		 * One example use for this hook would be to create terms from the input that may not exist yet, so that they can be set as a relation below.
 		 *
-		 * @param int          $post_id          The ID of the postObject being mutated
-		 * @param array        $input            The input for the mutation
-		 * @param \WP_Post_Type $post_type_object The Post Type Object for the type of post being mutated
-		 * @param string       $mutation_name    The name of the mutation (ex: create, update, delete)
+		 * @param int                 $post_id          The ID of the postObject being mutated
+		 * @param array<string,mixed> $input            The input for the mutation
+		 * @param \WP_Post_Type       $post_type_object The Post Type Object for the type of post being mutated
+		 * @param string              $mutation_name    The name of the mutation (ex: create, update, delete)
 		 */
 		do_action( 'graphql_post_object_mutation_set_object_terms', $post_id, $input, $post_type_object, $mutation_name );
 

--- a/src/Data/TermObjectMutation.php
+++ b/src/Data/TermObjectMutation.php
@@ -77,10 +77,10 @@ class TermObjectMutation {
 		/**
 		 * Filter the $insert_args
 		 *
-		 * @param array $insert_args The array of input args that will be passed to the functions that insert terms
-		 * @param array $input The data that was entered as input for the mutation
-		 * @param \WP_Taxonomy $taxonomy The taxonomy object of the term being mutated
-		 * @param string $mutation_name The name of the mutation being performed (create, edit, etc)
+		 * @param array<string,mixed> $insert_args   The array of input args that will be passed to the functions that insert terms
+		 * @param array<string,mixed> $input         The data that was entered as input for the mutation
+		 * @param \WP_Taxonomy        $taxonomy      The taxonomy object of the term being mutated
+		 * @param string              $mutation_name The name of the mutation being performed (create, edit, etc)
 		 */
 		return apply_filters( 'graphql_term_object_insert_term_args', $insert_args, $input, $taxonomy, $mutation_name );
 	}

--- a/src/Data/UserMutation.php
+++ b/src/Data/UserMutation.php
@@ -193,9 +193,9 @@ class UserMutation {
 		/**
 		 * Filters the mappings for input to arguments
 		 *
-		 * @param array  $insert_user_args The arguments to ultimately be passed to the WordPress function
-		 * @param array  $input            Input data from the GraphQL mutation
-		 * @param string $mutation_name    What user mutation is being performed for context
+		 * @param array<string,mixed> $insert_user_args The arguments to ultimately be passed to the WordPress function
+		 * @param array<string,mixed> $input            Input data from the GraphQL mutation
+		 * @param string              $mutation_name    What user mutation is being performed for context
 		 */
 		$insert_user_args = apply_filters( 'graphql_user_insert_post_args', $insert_user_args, $input, $mutation_name );
 
@@ -224,11 +224,11 @@ class UserMutation {
 		 * update additional data related to users, such as setting relationships, updating additional usermeta,
 		 * or sending emails to Kevin... whatever you need to do with the userObject.
 		 *
-		 * @param int         $user_id       The ID of the user being mutated
-		 * @param array       $input         The input for the mutation
-		 * @param string      $mutation_name The name of the mutation (ex: create, update, delete)
-		 * @param \WPGraphQL\AppContext $context The AppContext passed down the resolve tree
-		 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the Resolve Tree
+		 * @param int                                  $user_id       The ID of the user being mutated
+		 * @param array<string,mixed>                  $input         The input for the mutation
+		 * @param string                               $mutation_name The name of the mutation (ex: create, update, delete)
+		 * @param \WPGraphQL\AppContext                $context       The AppContext passed down the resolve tree
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info          The ResolveInfo passed down the Resolve Tree
 		 */
 		do_action( 'graphql_user_object_mutation_update_additional_data', $user_id, $input, $mutation_name, $context, $info );
 	}
@@ -272,7 +272,7 @@ class UserMutation {
 	 * @param string $role    Name of the role trying to get added to a user object
 	 * @param int    $user_id The ID of the user being mutated
 	 *
-	 * @return mixed|bool|\WP_Error
+	 * @return bool|\WP_Error
 	 */
 	private static function verify_user_role( $role, $user_id ) {
 		global $wp_roles;

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -319,8 +319,6 @@ abstract class Model {
 			 * @param string|null $visibility                The visibility that has currently been set for the data at this point
 			 * @param int|null    $owner                     The user ID for the owner of this piece of data
 			 * @param \WP_User $current_user The current user for the session
-			 *
-			 * @return array
 			 */
 				apply_filters( 'graphql_allowed_fields_on_restricted_type', $this->allowed_restricted_fields, $this->get_model_name(), $this->data, $this->visibility, $this->owner, $this->current_user )
 			)
@@ -338,9 +336,8 @@ abstract class Model {
 		}
 
 		$clean_array = [];
-		$self        = $this;
 		foreach ( $this->fields as $key => $data ) {
-			$clean_array[ $key ] = function () use ( $key, $data, $self ) {
+			$clean_array[ $key ] = function () use ( $key, $data ) {
 				if ( is_array( $data ) ) {
 					$callback = ( ! empty( $data['callback'] ) ) ? $data['callback'] : null;
 
@@ -380,7 +377,7 @@ abstract class Model {
 				 * @param int|null $owner        The user ID for the owner of this piece of data
 				 * @param \WP_User $current_user The current user for the session
 				 *
-				 * @return callable|int|string|array|mixed|null
+				 * @return callable|int|string|mixed[]|mixed|null
 				 */
 				$pre = apply_filters( 'graphql_pre_return_field_from_model', null, $key, $this->get_model_name(), $this->data, $this->visibility, $this->owner, $this->current_user );
 
@@ -388,9 +385,9 @@ abstract class Model {
 					$result = $pre;
 				} else {
 					if ( is_callable( $callback ) ) {
-						$self->setup();
+						$this->setup();
 						$field = call_user_func( $callback );
-						$self->tear_down();
+						$this->tear_down();
 					} else {
 						$field = $callback;
 					}
@@ -465,13 +462,11 @@ abstract class Model {
 		/**
 		 * Add support for the deprecated "graphql_return_modeled_data" filter.
 		 *
-		 * @param array    $fields       The array of fields for the model
-		 * @param string   $model_name   Name of the model the filter is currently being executed in
-		 * @param string   $visibility   The visibility setting for this piece of data
-		 * @param int|null $owner        The user ID for the owner of this piece of data
-		 * @param \WP_User $current_user The current user for the session
-		 *
-		 * @return array
+		 * @param array<string,mixed>    $fields       The array of fields for the model
+		 * @param string                 $model_name   Name of the model the filter is currently being executed in
+		 * @param string                 $visibility   The visibility setting for this piece of data
+		 * @param ?int                   $owner        The user ID for the owner of this piece of data
+		 * @param \WP_User               $current_user The current user for the session
 		 *
 		 * @deprecated 1.7.0 use "graphql_model_prepare_fields" filter instead, which passes additional context to the filter
 		 */
@@ -480,14 +475,12 @@ abstract class Model {
 		/**
 		 * Filter the array of fields for the Model before the object is hydrated with it
 		 *
-		 * @param array    $fields       The array of fields for the model
-		 * @param string   $model_name   Name of the model the filter is currently being executed in
-		 * @param mixed    $data         The un-modeled incoming data
-		 * @param string   $visibility   The visibility setting for this piece of data
-		 * @param int|null $owner        The user ID for the owner of this piece of data
-		 * @param \WP_User $current_user The current user for the session
-		 *
-		 * @return array
+		 * @param array<string,mixed>    $fields       The array of fields for the model
+		 * @param string                 $model_name   Name of the model the filter is currently being executed in
+		 * @param mixed                  $data         The un-modeled incoming data
+		 * @param string                 $visibility   The visibility setting for this piece of data
+		 * @param ?int                   $owner        The user ID for the owner of this piece of data
+		 * @param \WP_User               $current_user The current user for the session
 		 */
 		$this->fields = apply_filters( 'graphql_model_prepare_fields', $this->fields, $this->get_model_name(), $this->data, $this->visibility, $this->owner, $this->current_user );
 		$this->wrap_fields();
@@ -520,7 +513,7 @@ abstract class Model {
 			return $str;
 		}
 
-		return html_entity_decode( $str );
+		return html_entity_decode( $str, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401, 'UTF-8' );
 	}
 
 	/**

--- a/src/Mutation/CommentCreate.php
+++ b/src/Mutation/CommentCreate.php
@@ -117,7 +117,7 @@ class CommentCreate {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @return callable
+	 * @return callable(array<string,mixed>$input,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info):array<string,mixed>
 	 */
 	public static function mutate_and_get_payload() {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) {

--- a/src/Mutation/CommentDelete.php
+++ b/src/Mutation/CommentDelete.php
@@ -74,7 +74,7 @@ class CommentDelete {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @return callable
+	 * @return callable(array<string,mixed>$input,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info):array<string,mixed>
 	 */
 	public static function mutate_and_get_payload() {
 		return static function ( $input ) {

--- a/src/Mutation/CommentRestore.php
+++ b/src/Mutation/CommentRestore.php
@@ -77,7 +77,7 @@ class CommentRestore {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @return callable
+	 * @return callable(array<string,mixed>$input,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info):array<string,mixed>
 	 */
 	public static function mutate_and_get_payload() {
 		return static function ( $input ) {

--- a/src/Mutation/CommentUpdate.php
+++ b/src/Mutation/CommentUpdate.php
@@ -62,7 +62,7 @@ class CommentUpdate {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @return callable
+	 * @return callable(array<string,mixed>$input,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info):array<string,mixed>
 	 */
 	public static function mutate_and_get_payload() {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) {

--- a/src/Mutation/MediaItemCreate.php
+++ b/src/Mutation/MediaItemCreate.php
@@ -116,7 +116,7 @@ class MediaItemCreate {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @return callable
+	 * @return callable(array<string,mixed>$input,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info):array<string,mixed>
 	 */
 	public static function mutate_and_get_payload() {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) {
@@ -171,9 +171,9 @@ class MediaItemCreate {
 			/**
 			 * Filter the allowed protocols for the mutation
 			 *
-			 * @param array                                $allowed_protocols The allowed protocols for filePaths to be submitted
+			 * @param string[]                             $allowed_protocols The allowed protocols for filePaths to be submitted
 			 * @param mixed                                $protocol          The current protocol of the filePath
-			 * @param array                                $input             The input of the current mutation
+			 * @param array<string,mixed>                  $input             The input of the current mutation
 			 * @param \WPGraphQL\AppContext                $context           The context of the current request
 			 * @param \GraphQL\Type\Definition\ResolveInfo $info              The ResolveInfo of the current field
 			 */

--- a/src/Mutation/MediaItemDelete.php
+++ b/src/Mutation/MediaItemDelete.php
@@ -76,7 +76,7 @@ class MediaItemDelete {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @return callable
+	 * @return callable(array<string,mixed>$input,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info):array<string,mixed>
 	 */
 	public static function mutate_and_get_payload() {
 		return static function ( $input ) {

--- a/src/Mutation/MediaItemUpdate.php
+++ b/src/Mutation/MediaItemUpdate.php
@@ -60,14 +60,14 @@ class MediaItemUpdate {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @return callable
+	 * @return callable(array<string,mixed>$input,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info):array<string,mixed>
 	 */
 	public static function mutate_and_get_payload() {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) {
 			$post_type_object = get_post_type_object( 'attachment' );
 
 			if ( empty( $post_type_object ) ) {
-				return null;
+				return [];
 			}
 
 			// Get the database ID for the comment.

--- a/src/Mutation/PostObjectCreate.php
+++ b/src/Mutation/PostObjectCreate.php
@@ -193,7 +193,7 @@ class PostObjectCreate {
 	 * @param \WP_Post_Type $post_type_object The post type of the mutation.
 	 * @param string        $mutation_name    The mutation name.
 	 *
-	 * @return callable
+	 * @return callable(array<string,mixed>$input,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info):array<string,mixed>
 	 */
 	public static function mutate_and_get_payload( $post_type_object, $mutation_name ) {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) use ( $post_type_object, $mutation_name ) {

--- a/src/Mutation/PostObjectDelete.php
+++ b/src/Mutation/PostObjectDelete.php
@@ -97,7 +97,7 @@ class PostObjectDelete {
 	 * @param \WP_Post_Type $post_type_object The post type of the mutation.
 	 * @param string        $mutation_name    The mutation name.
 	 *
-	 * @return callable
+	 * @return callable(array<string,mixed>$input,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info):array<string,mixed>
 	 */
 	public static function mutate_and_get_payload( WP_Post_Type $post_type_object, string $mutation_name ) {
 		return static function ( $input ) use ( $post_type_object ) {

--- a/src/Mutation/PostObjectUpdate.php
+++ b/src/Mutation/PostObjectUpdate.php
@@ -73,7 +73,7 @@ class PostObjectUpdate {
 	 * @param \WP_Post_Type $post_type_object The post type of the mutation.
 	 * @param string        $mutation_name      The mutation name.
 	 *
-	 * @return callable
+	 * @return callable(array<string,mixed>$input,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info):array<string,mixed>
 	 */
 	public static function mutate_and_get_payload( $post_type_object, $mutation_name ) {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) use ( $post_type_object, $mutation_name ) {
@@ -185,10 +185,10 @@ class PostObjectUpdate {
 			 *
 			 * The dynamic portion of the hook name, `$taxonomy->name` refers to the taxonomy of the term being mutated
 			 *
-			 * @param int    $post_id       Inserted post ID
-			 * @param \WP_Post_Type $post_type_object The Post Type object for the post being mutated
-			 * @param array  $args          The args used to insert the term
-			 * @param string $mutation_name The name of the mutation being performed
+			 * @param int                 $post_id          Inserted post ID
+			 * @param \WP_Post_Type       $post_type_object The Post Type object for the post being mutated
+			 * @param array<string,mixed> $args             The args used to insert the term
+			 * @param string              $mutation_name    The name of the mutation being performed
 			 */
 			do_action( 'graphql_insert_post_object', absint( $post_id ), $post_type_object, $post_args, $mutation_name );
 
@@ -197,9 +197,9 @@ class PostObjectUpdate {
 			 *
 			 * The dynamic portion of the hook name, `$taxonomy->name` refers to the taxonomy of the term being mutated
 			 *
-			 * @param int    $post_id       Inserted post ID
-			 * @param array  $args          The args used to insert the term
-			 * @param string $mutation_name The name of the mutation being performed
+			 * @param int                 $post_id       Inserted post ID
+			 * @param array<string,mixed> $args          The args used to insert the term
+			 * @param string              $mutation_name The name of the mutation being performed
 			 */
 			do_action( "graphql_insert_{$post_type_object->name}", absint( $post_id ), $post_args, $mutation_name );
 

--- a/src/Mutation/ResetUserPassword.php
+++ b/src/Mutation/ResetUserPassword.php
@@ -56,7 +56,7 @@ class ResetUserPassword {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @return callable
+	 * @return callable(array<string,mixed>$input,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info):array<string,mixed>
 	 */
 	public static function mutate_and_get_payload() {
 		return static function ( $input, AppContext $context ) {

--- a/src/Mutation/SendPasswordResetEmail.php
+++ b/src/Mutation/SendPasswordResetEmail.php
@@ -65,6 +65,8 @@ class SendPasswordResetEmail {
 
 	/**
 	 * Defines the mutation data modification closure.
+	 *
+	 * @return callable(array<string,mixed>$input,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info):array<string,mixed>
 	 */
 	public static function mutate_and_get_payload(): callable {
 		return static function ( $input ) {

--- a/src/Mutation/TermObjectCreate.php
+++ b/src/Mutation/TermObjectCreate.php
@@ -107,7 +107,7 @@ class TermObjectCreate {
 	 * @param \WP_Taxonomy $taxonomy The taxonomy type of the mutation.
 	 * @param string       $mutation_name The name of the mutation.
 	 *
-	 * @return callable
+	 * @return callable(array<string,mixed>$input,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info):array<string,mixed>
 	 */
 	public static function mutate_and_get_payload( WP_Taxonomy $taxonomy, string $mutation_name ) {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) use ( $taxonomy, $mutation_name ) {
@@ -167,12 +167,12 @@ class TermObjectCreate {
 			/**
 			 * Fires after a single term is created or updated via a GraphQL mutation
 			 *
-			 * @param int         $term_id       Inserted term object
-			 * @param \WP_Taxonomy $taxonomy The taxonomy of the term being updated
-			 * @param array       $args          The args used to insert the term
-			 * @param string      $mutation_name The name of the mutation being performed
-			 * @param \WPGraphQL\AppContext $context The AppContext passed down the resolve tree
-			 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the resolve tree
+			 * @param int                                  $term_id       Inserted term object
+			 * @param \WP_Taxonomy                         $taxonomy      The taxonomy of the term being updated
+			 * @param array<string,mixed>                  $args          The args used to insert the term
+			 * @param string                               $mutation_name The name of the mutation being performed
+			 * @param \WPGraphQL\AppContext                $context       The AppContext passed down the resolve tree
+			 * @param \GraphQL\Type\Definition\ResolveInfo $info          The ResolveInfo passed down the resolve tree
 			 */
 			do_action( 'graphql_insert_term', $term['term_id'], $taxonomy, $args, $mutation_name, $context, $info );
 
@@ -181,11 +181,11 @@ class TermObjectCreate {
 			 *
 			 * The dynamic portion of the hook name, `$taxonomy->name` refers to the taxonomy of the term being mutated
 			 *
-			 * @param int         $term_id       Inserted term object
-			 * @param array       $args          The args used to insert the term
-			 * @param string      $mutation_name The name of the mutation being performed
-			 * @param \WPGraphQL\AppContext $context The AppContext passed down the resolve tree
-			 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the resolve tree
+			 * @param int                                  $term_id       Inserted term object
+			 * @param array<string,mixed>                  $args          The args used to insert the term
+			 * @param string                               $mutation_name The name of the mutation being performed
+			 * @param \WPGraphQL\AppContext                $context       The AppContext passed down the resolve tree
+			 * @param \GraphQL\Type\Definition\ResolveInfo $info          The ResolveInfo passed down the resolve tree
 			 */
 			do_action( "graphql_insert_{$taxonomy->name}", $term['term_id'], $args, $mutation_name, $context, $info );
 

--- a/src/Mutation/TermObjectDelete.php
+++ b/src/Mutation/TermObjectDelete.php
@@ -87,7 +87,7 @@ class TermObjectDelete {
 	 * @param \WP_Taxonomy $taxonomy The taxonomy type of the mutation.
 	 * @param string       $mutation_name The name of the mutation.
 	 *
-	 * @return callable
+	 * @return callable(array<string,mixed>$input,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info):array<string,mixed>
 	 */
 	public static function mutate_and_get_payload( WP_Taxonomy $taxonomy, string $mutation_name ) {
 		return static function ( $input ) use ( $taxonomy ) {

--- a/src/Mutation/TermObjectUpdate.php
+++ b/src/Mutation/TermObjectUpdate.php
@@ -77,7 +77,7 @@ class TermObjectUpdate {
 	 * @param \WP_Taxonomy $taxonomy The taxonomy type of the mutation.
 	 * @param string       $mutation_name  The name of the mutation.
 	 *
-	 * @return callable
+	 * @return callable(array<string,mixed>$input,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info):array<string,mixed>
 	 */
 	public static function mutate_and_get_payload( WP_Taxonomy $taxonomy, $mutation_name ) {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) use ( $taxonomy, $mutation_name ) {
@@ -151,23 +151,23 @@ class TermObjectUpdate {
 			/**
 			 * Fires an action when a term is updated via a GraphQL Mutation
 			 *
-			 * @param int         $term_id       The ID of the term object that was mutated
-			 * @param \WP_Taxonomy $taxonomy The taxonomy of the term being updated
-			 * @param array       $args          The args used to update the term
-			 * @param string      $mutation_name The name of the mutation being performed (create, update, delete, etc)
-			 * @param \WPGraphQL\AppContext $context The AppContext passed down the resolve tree
-			 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the resolve tree
+			 * @param int                                  $term_id       The ID of the term object that was mutated
+			 * @param \WP_Taxonomy                         $taxonomy      The taxonomy of the term being updated
+			 * @param array<string,mixed>                  $args          The args used to update the term
+			 * @param string                               $mutation_name The name of the mutation being performed (create, update, delete, etc)
+			 * @param \WPGraphQL\AppContext                $context       The AppContext passed down the resolve tree
+			 * @param \GraphQL\Type\Definition\ResolveInfo $info          The ResolveInfo passed down the resolve tree
 			 */
 			do_action( 'graphql_update_term', $existing_term->term_id, $taxonomy, $args, $mutation_name, $context, $info );
 
 			/**
 			 * Fires an action when a term is updated via a GraphQL Mutation
 			 *
-			 * @param int         $term_id       The ID of the term object that was mutated
-			 * @param array       $args          The args used to update the term
-			 * @param string      $mutation_name The name of the mutation being performed (create, update, delete, etc)
-			 * @param \WPGraphQL\AppContext $context The AppContext passed down the resolve tree
-			 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the resolve tree
+			 * @param int                                  $term_id       The ID of the term object that was mutated
+			 * @param array<string,mixed>                  $args          The args used to update the term
+			 * @param string                               $mutation_name The name of the mutation being performed (create, update, delete, etc)
+			 * @param \WPGraphQL\AppContext                $context       The AppContext passed down the resolve tree
+			 * @param \GraphQL\Type\Definition\ResolveInfo $info          The ResolveInfo passed down the resolve tree
 			 */
 			do_action( "graphql_update_{$taxonomy->name}", $existing_term->term_id, $args, $mutation_name, $context, $info );
 

--- a/src/Mutation/UserCreate.php
+++ b/src/Mutation/UserCreate.php
@@ -133,7 +133,7 @@ class UserCreate {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @return callable
+	 * @return callable(array<string,mixed>$input,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info):array<string,mixed>
 	 */
 	public static function mutate_and_get_payload() {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) {

--- a/src/Mutation/UserDelete.php
+++ b/src/Mutation/UserDelete.php
@@ -77,7 +77,7 @@ class UserDelete {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @return callable
+	 * @return callable(array<string,mixed>$input,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info):array<string,mixed>
 	 */
 	public static function mutate_and_get_payload() {
 		return static function ( $input ) {

--- a/src/Mutation/UserRegister.php
+++ b/src/Mutation/UserRegister.php
@@ -67,7 +67,7 @@ class UserRegister {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @return callable
+	 * @return callable(array<string,mixed>$input,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info):array<string,mixed>
 	 */
 	public static function mutate_and_get_payload() {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) {

--- a/src/Mutation/UserUpdate.php
+++ b/src/Mutation/UserUpdate.php
@@ -57,7 +57,7 @@ class UserUpdate {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @return callable
+	 * @return callable(array<string,mixed>$input,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info):array<string,mixed>
 	 */
 	public static function mutate_and_get_payload() {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) {

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -147,7 +147,7 @@ class TypeRegistry {
 	/**
 	 * The loaders needed to register types
 	 *
-	 * @var array<string,Callable>
+	 * @var array<string,callable():(mixed|array<string,mixed>|\GraphQL\Type\Definition\Type|null)>
 	 */
 	protected $type_loaders;
 
@@ -839,8 +839,7 @@ class TypeRegistry {
 	 *
 	 * @param string $type_name The name of the Type to get from the registry
 	 *
-	 * @return mixed
-	 * |null
+	 * @return mixed|array<string,mixed>|\GraphQL\Type\Definition\Type|null
 	 */
 	public function get_type( string $type_name ) {
 		$key = $this->format_key( $type_name );
@@ -889,13 +888,11 @@ class TypeRegistry {
 	 */
 	public function prepare_fields( array $fields, string $type_name ): array {
 		$prepared_fields = [];
-		if ( ! empty( $fields ) && is_array( $fields ) ) {
-			foreach ( $fields as $field_name => $field_config ) {
-				if ( is_array( $field_config ) && isset( $field_config['type'] ) ) {
-					$prepared_field = $this->prepare_field( $field_name, $field_config, $type_name );
-					if ( ! empty( $prepared_field ) ) {
-						$prepared_fields[ $this->format_key( $field_name ) ] = $prepared_field;
-					}
+		foreach ( $fields as $field_name => $field_config ) {
+			if ( is_array( $field_config ) && isset( $field_config['type'] ) ) {
+				$prepared_field = $this->prepare_field( $field_name, $field_config, $type_name );
+				if ( ! empty( $prepared_field ) ) {
+					$prepared_fields[ $this->format_key( $field_name ) ] = $prepared_field;
 				}
 			}
 		}
@@ -1001,7 +998,7 @@ class TypeRegistry {
 	 *
 	 * @param mixed|string|array<string,mixed> $type The type definition to process.
 	 *
-	 * @return mixed
+	 * @return \GraphQL\Type\Definition\Type|string|array<string,mixed>|mixed
 	 * @throws \Exception
 	 */
 	public function setup_type_modifiers( $type ) {
@@ -1218,7 +1215,7 @@ class TypeRegistry {
 	/**
 	 * Given a Type, this returns an instance of a NonNull of that type
 	 *
-	 * @param mixed $type The Type being wrapped
+	 * @param string|callable|\GraphQL\Type\Definition\NullableType $type The Type being wrapped
 	 *
 	 * @return \GraphQL\Type\Definition\NonNull
 	 */
@@ -1235,7 +1232,7 @@ class TypeRegistry {
 	/**
 	 * Given a Type, this returns an instance of a listOf of that type
 	 *
-	 * @param mixed $type The Type being wrapped
+	 * @param string|\GraphQL\Type\Definition\Type $type The Type being wrapped
 	 *
 	 * @return \GraphQL\Type\Definition\ListOfType
 	 */

--- a/src/Registry/Utils/TermObject.php
+++ b/src/Registry/Utils/TermObject.php
@@ -170,10 +170,6 @@ class TermObject {
 				'description'        => __( 'The ancestors of the node. Default ordered as lowest (closest to the child) to highest (closest to the root).', 'wp-graphql' ),
 				'connectionTypeName' => ucfirst( $tax_object->graphql_single_name ) . 'ToAncestors' . ucfirst( $tax_object->graphql_single_name ) . 'Connection',
 				'resolve'            => static function ( Term $term, $args, AppContext $context, $info ) use ( $tax_object ) {
-					if ( ! $tax_object instanceof WP_Taxonomy ) {
-						return null;
-					}
-
 					$ancestor_ids = get_ancestors( absint( $term->term_id ), $term->taxonomyName, 'taxonomy' );
 
 					if ( empty( $ancestor_ids ) ) {

--- a/src/Request.php
+++ b/src/Request.php
@@ -59,7 +59,7 @@ class Request {
 	 * GraphQL operation parameters for this request. Can also be an array of
 	 * OperationParams.
 	 *
-	 * @var mixed|array|\GraphQL\Server\OperationParams|\GraphQL\Server\OperationParams[]
+	 * @var mixed|mixed[]|\GraphQL\Server\OperationParams|\GraphQL\Server\OperationParams[]
 	 */
 	public $params;
 
@@ -94,7 +94,7 @@ class Request {
 	/**
 	 * The default field resolver function. Default null
 	 *
-	 * @var mixed|callable|null
+	 * @var callable|null
 	 */
 	protected $field_resolver;
 
@@ -190,7 +190,7 @@ class Request {
 	}
 
 	/**
-	 * @return mixed
+	 * @return callable|null
 	 */
 	protected function get_field_resolver() {
 		return $this->field_resolver;
@@ -231,8 +231,8 @@ class Request {
 		/**
 		 * Return the filtered root value
 		 *
-		 * @param mixed   $root_value The root value the Schema should use to resolve with. Default null.
-		 * @param \WPGraphQL\Request $request The Request instance
+		 * @param mixed              $root_value The root value the Schema should use to resolve with. Default null.
+		 * @param \WPGraphQL\Request $request    The Request instance
 		 */
 		return apply_filters( 'graphql_root_value', $root_value, $this );
 	}
@@ -474,7 +474,7 @@ class Request {
 	 * @param mixed|array<string,mixed>|object $response The response for your GraphQL request
 	 * @param mixed|int|null                   $key      The array key of the params for batch requests
 	 *
-	 * @return array<string,mixed>
+	 * @return mixed|array<string,mixed>|object
 	 */
 	private function after_execute_actions( $response, $key = null ) {
 
@@ -501,12 +501,12 @@ class Request {
 		/**
 		 * Run an action. This is a good place for debug tools to hook in to log things, etc.
 		 *
-		 * @param mixed|array $response  The response your GraphQL request
-		 * @param \WPGraphQL\WPSchema $schema The schema object for the root request
-		 * @param mixed|string|null      $operation The name of the operation
-		 * @param string      $query     The query that GraphQL executed
-		 * @param array|null  $variables Variables to passed to your GraphQL query
-		 * @param \WPGraphQL\Request $request Instance of the Request
+		 * @param mixed|array<string,mixed>|object $response  The response your GraphQL request
+		 * @param \WPGraphQL\WPSchema              $schema The schema object for the root request
+		 * @param mixed|string|null                $operation The name of the operation
+		 * @param string                           $query     The query that GraphQL executed
+		 * @param mixed[]|null                     $variables Variables to passed to your GraphQL query
+		 * @param \WPGraphQL\Request               $request Instance of the Request
 		 *
 		 * @since 0.0.4
 		 */
@@ -537,13 +537,13 @@ class Request {
 		 * every response, regardless of the request that was sent to it, this could allow for that
 		 * to be hooked in and included in the $response.
 		 *
-		 * @param array      $response  The response for your GraphQL query
-		 * @param \WPGraphQL\WPSchema $schema The schema object for the root query
-		 * @param string     $operation The name of the operation
-		 * @param string     $query     The query that GraphQL executed
-		 * @param array|null $variables Variables to passed to your GraphQL request
-		 * @param \WPGraphQL\Request $request Instance of the Request
-		 * @param string|null $query_id The query id that GraphQL executed
+		 * @param mixed|array<string,mixed>|object $response  The response for your GraphQL query
+		 * @param \WPGraphQL\WPSchema              $schema    The schema object for the root query
+		 * @param string                           $operation The name of the operation
+		 * @param string                           $query     The query that GraphQL executed
+		 * @param mixed[]|null                     $variables Variables to passed to your GraphQL request
+		 * @param \WPGraphQL\Request               $request   Instance of the Request
+		 * @param ?string                          $query_id  The query id that GraphQL executed
 		 *
 		 * @since 0.0.5
 		 */
@@ -553,14 +553,14 @@ class Request {
 		 * Run an action after the response has been filtered, as the response is being returned.
 		 * This is a good place for debug tools to hook in to log things, etc.
 		 *
-		 * @param array      $filtered_response The filtered response for the GraphQL request
-		 * @param array      $response          The response for your GraphQL request
-		 * @param \WPGraphQL\WPSchema $schema The schema object for the root request
-		 * @param string     $operation         The name of the operation
-		 * @param string     $query             The query that GraphQL executed
-		 * @param array|null $variables         Variables to passed to your GraphQL query
-		 * @param \WPGraphQL\Request $request Instance of the Request
-		 * @param string|null $query_id          The query id that GraphQL executed
+		 * @param mixed|array<string,mixed>|object $filtered_response The filtered response for the GraphQL request
+		 * @param mixed|array<string,mixed>|object $response          The response for your GraphQL request
+		 * @param \WPGraphQL\WPSchema              $schema            The schema object for the root request
+		 * @param string                           $operation         The name of the operation
+		 * @param string                           $query             The query that GraphQL executed
+		 * @param mixed[]|null                     $variables         Variables to passed to your GraphQL query
+		 * @param \WPGraphQL\Request               $request           Instance of the Request
+		 * @param ?string                          $query_id          The query id that GraphQL executed
 		 */
 		do_action( 'graphql_return_response', $filtered_response, $response, $this->schema, $operation, $query, $variables, $this, $query_id );
 

--- a/src/Router.php
+++ b/src/Router.php
@@ -3,7 +3,6 @@
 namespace WPGraphQL;
 
 use GraphQL\Error\FormattedError;
-use WPGraphQL\Utils\QueryAnalyzer;
 use WP_User;
 
 /**
@@ -299,7 +298,7 @@ class Router {
 		/**
 		 * Filtered list of access control headers.
 		 *
-		 * @param array $access_control_headers Array of headers to allow.
+		 * @param string[] $access_control_headers Array of headers to allow.
 		 */
 		$access_control_allow_headers = apply_filters(
 			'graphql_access_control_allow_headers',
@@ -327,7 +326,7 @@ class Router {
 
 		// If the Query Analyzer was instantiated
 		// Get the headers determined from its Analysis
-		if ( self::get_request() instanceof Request && self::get_request()->get_query_analyzer() instanceof QueryAnalyzer ) {
+		if ( self::get_request() instanceof Request && self::get_request()->get_query_analyzer()->is_enabled_for_query() ) {
 			$headers = self::get_request()->get_query_analyzer()->get_headers( $headers );
 		}
 
@@ -386,7 +385,7 @@ class Router {
 			/**
 			 * Fire an action when the headers are set
 			 *
-			 * @param array $headers The headers sent in the response
+			 * @param array<string,mixed> $headers The headers sent in the response
 			 */
 			do_action( 'graphql_response_set_headers', $headers );
 		}
@@ -410,7 +409,7 @@ class Router {
 	/**
 	 * This processes the graphql requests that come into the /graphql endpoint via an HTTP request
 	 *
-	 * @return mixed
+	 * @return void
 	 * @throws \Exception Throws Exception.
 	 * @throws \Throwable Throws Exception.
 	 * @global WP_User $current_user The currently authenticated user.
@@ -483,7 +482,7 @@ class Router {
 			/**
 			 * Filter thrown GraphQL errors
 			 *
-			 * @param array               $errors  Formatted errors object.
+			 * @param mixed[]             $errors  Formatted errors object.
 			 * @param \Throwable          $error   Thrown error.
 			 * @param \WPGraphQL\Request  $request WPGraphQL Request object.
 			 */
@@ -508,12 +507,12 @@ class Router {
 		 * to hook in to track metrics, such as how long the process took from `graphql_process_http_request`
 		 * to here, etc.
 		 *
-		 * @param array  $response       The GraphQL response
-		 * @param array  $result         The result of the GraphQL Query
-		 * @param string $operation_name The name of the operation
-		 * @param string $query          The request that GraphQL executed
-		 * @param ?array $variables      Variables to passed to your GraphQL query
-		 * @param mixed  $status_code    The status code for the response
+		 * @param array<string,mixed> $response       The GraphQL response
+		 * @param array<string,mixed> $result         The result of the GraphQL Query
+		 * @param string              $operation_name The name of the operation
+		 * @param string              $query          The request that GraphQL executed
+		 * @param ?array              $variables      Variables to passed to your GraphQL query
+		 * @param int|string          $status_code    The status code for the response
 		 *
 		 * @since 0.0.5
 		 */
@@ -542,12 +541,12 @@ class Router {
 		/**
 		 * Filter the $status_code before setting the headers
 		 *
-		 * @param int     $status_code     The status code to apply to the headers
-		 * @param array   $response        The response of the GraphQL Request
-		 * @param array   $graphql_results The results of the GraphQL execution
-		 * @param string  $query           The GraphQL query
-		 * @param string  $operation_name  The operation name of the GraphQL Request
-		 * @param array   $variables       The variables applied to the GraphQL Request
+		 * @param int      $status_code     The status code to apply to the headers
+		 * @param array    $response        The response of the GraphQL Request
+		 * @param array    $graphql_results The results of the GraphQL execution
+		 * @param string   $query           The GraphQL query
+		 * @param string   $operation_name  The operation name of the GraphQL Request
+		 * @param mixed[]  $variables       The variables applied to the GraphQL Request
 		 * @param \WP_User $user The current user object
 		 */
 		self::$http_status_code = apply_filters( 'graphql_response_status_code', self::$http_status_code, $response, $graphql_results, $query, $operation_name, $variables, $user );

--- a/src/Server/ValidationRules/QueryDepth.php
+++ b/src/Server/ValidationRules/QueryDepth.php
@@ -143,7 +143,7 @@ class QueryDepth extends QuerySecurityRule {
 	public function setMaxQueryDepth( int $maxQueryDepth ) {
 		$this->checkIfGreaterOrEqualToZero( 'maxQueryDepth', $maxQueryDepth );
 
-		$this->maxQueryDepth = (int) $maxQueryDepth;
+		$this->maxQueryDepth = $maxQueryDepth;
 	}
 
 	/**

--- a/src/Server/ValidationRules/RequireAuthentication.php
+++ b/src/Server/ValidationRules/RequireAuthentication.php
@@ -71,7 +71,7 @@ class RequireAuthentication extends QuerySecurityRule {
 		/**
 		 * Filters the allowed
 		 *
-		 * @param array             $allowed_root_fields The Root fields allowed to be requested without authentication
+		 * @param string[]                             $allowed_root_fields The Root fields allowed to be requested without authentication
 		 * @param \GraphQL\Validator\ValidationContext $context The Validation context of the field being executed.
 		 */
 		$allowed_root_fields = apply_filters( 'graphql_require_authentication_allowed_fields', $allowed_root_fields, $context );

--- a/src/Server/WPHelper.php
+++ b/src/Server/WPHelper.php
@@ -45,8 +45,8 @@ class WPHelper extends Helper {
 		 * persisted queries (and ends up being a bit more flexible than
 		 * graphql-php's built-in persistentQueryLoader).
 		 *
-		 * @param array $data An array containing the pieces of the data of the GraphQL request
-		 * @param array $request_context An array containing the both body and query params
+		 * @param mixed[] $data            An array containing the pieces of the data of the GraphQL request
+		 * @param mixed[] $request_context An array containing the both body and query params
 		 */
 		if ( 'GET' === $method ) {
 			$parsed_query_params = apply_filters( 'graphql_request_data', $parsed_query_params, $request_context );
@@ -64,8 +64,8 @@ class WPHelper extends Helper {
 	/**
 	 * Parse parameters and proxy to parse_extensions.
 	 *
-	 * @param  mixed[] $params Request parameters.
-	 * @return mixed[]
+	 * @param array<string,mixed>|array<string,mixed>[] $params Request parameters.
+	 * @return array<string,mixed>|array<string,mixed>[]
 	 */
 	private function parse_params( $params ) {
 		if ( isset( $params[0] ) ) {
@@ -78,8 +78,8 @@ class WPHelper extends Helper {
 	/**
 	 * Parse query extensions.
 	 *
-	 * @param  mixed[] $params Request parameters.
-	 * @return mixed[]
+	 * @param  array<string,mixed> $params Request parameters.
+	 * @return array<string,mixed>
 	 */
 	private function parse_extensions( $params ) {
 		if ( isset( $params['extensions'] ) && is_string( $params['extensions'] ) ) {

--- a/src/Type/Connection/Taxonomies.php
+++ b/src/Type/Connection/Taxonomies.php
@@ -35,7 +35,7 @@ class Taxonomies {
 						return null;
 					}
 					$resolver = new TaxonomyConnectionResolver( $source, $args, $context, $info );
-					$resolver->setQueryArg( 'in', $source->taxonomies );
+					$resolver->set_query_arg( 'in', $source->taxonomies );
 					return $resolver->get_connection();
 				},
 			]

--- a/src/Type/InterfaceType/UniformResourceIdentifiable.php
+++ b/src/Type/InterfaceType/UniformResourceIdentifiable.php
@@ -29,7 +29,7 @@ class UniformResourceIdentifiable {
 					],
 					'id'            => [
 						'type'        => [ 'non_null' => 'ID' ],
-						'description' => __( 'The unique resource identifier path', 'wp-graphql' ),
+						'description' => __( 'The globally unique ID for the object', 'wp-graphql' ),
 					],
 					'isContentNode' => [
 						'type'        => [ 'non_null' => 'Boolean' ],

--- a/src/Type/ObjectType/EnqueuedScript.php
+++ b/src/Type/ObjectType/EnqueuedScript.php
@@ -59,9 +59,10 @@ class EnqueuedScript {
 					'version'      => [
 						'description' => __( 'The version of the enqueued script', 'wp-graphql' ),
 						'resolve'     => static function ( \_WP_Dependency $script ) {
+							/** @var \WP_Scripts $wp_scripts */
 							global $wp_scripts;
 
-							return ! empty( $script->ver ) && is_string( $script->ver ) ? (string) $script->ver : $wp_scripts->default_version;
+							return ! empty( $script->ver ) && is_string( $script->ver ) ? $script->ver : $wp_scripts->default_version;
 						},
 					],
 				],

--- a/src/Type/ObjectType/MenuItem.php
+++ b/src/Type/ObjectType/MenuItem.php
@@ -171,12 +171,12 @@ class MenuItem {
 							 * but would prefer to represent the menu item in other ways,
 							 * e.g., a linked post object (or vice-versa).
 							 *
-							 * @param \WP_Post|\WP_Term $resolved_object Post or term connected to MenuItem
-							 * @param array             $args            Array of arguments input in the field as part of the GraphQL query
-							 * @param \WPGraphQL\AppContext $context Object containing app context that gets passed down the resolve tree
-							 * @param \GraphQL\Type\Definition\ResolveInfo $info Info about fields passed down the resolve tree
-							 * @param int               $object_id       Post or term ID of connected object
-							 * @param string            $object_type     Type of connected object ("post_type" or "taxonomy")
+							 * @param \WP_Post|\WP_Term                    $resolved_object Post or term connected to MenuItem
+							 * @param array<string,mixed>                  $args            Array of arguments input in the field as part of the GraphQL query
+							 * @param \WPGraphQL\AppContext                $context         Object containing app context that gets passed down the resolve tree
+							 * @param \GraphQL\Type\Definition\ResolveInfo $info            Info about fields passed down the resolve tree
+							 * @param int                                  $object_id       Post or term ID of connected object
+							 * @param string                               $object_type     Type of connected object ("post_type" or "taxonomy")
 							 *
 							 * @since 0.0.30
 							 */

--- a/src/Type/WPConnectionType.php
+++ b/src/Type/WPConnectionType.php
@@ -91,7 +91,7 @@ class WPConnectionType {
 	/**
 	 * The resolver function to resolve the connection
 	 *
-	 * @var callable|\Closure
+	 * @var callable(mixed $root,array<string,mixed> $args,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info):mixed
 	 */
 	protected $resolve_connection;
 
@@ -142,7 +142,7 @@ class WPConnectionType {
 		/**
 		 * Filter the config of WPConnectionType
 		 *
-		 * @param array        $config         Array of configuration options passed to the WPConnectionType when instantiating a new type
+		 * @param array<string,mixed>              $config             Array of configuration options passed to the WPConnectionType when instantiating a new type
 		 * @param \WPGraphQL\Type\WPConnectionType $wp_connection_type The instance of the WPConnectionType class
 		 */
 		$config = apply_filters( 'graphql_wp_connection_type_config', $config, $this );
@@ -188,7 +188,7 @@ class WPConnectionType {
 		/**
 		 * Run an action when the WPConnectionType is instantiating.
 		 *
-		 * @param array        $config         Array of configuration options passed to the WPObjectType when instantiating a new type
+		 * @param array<string,mixed>              $config             Array of configuration options passed to the WPObjectType when instantiating a new type
 		 * @param \WPGraphQL\Type\WPConnectionType $wp_connection_type The instance of the WPConnectionType class
 		 *
 		 * @since 1.13.0

--- a/src/Type/WPEnumType.php
+++ b/src/Type/WPEnumType.php
@@ -64,7 +64,7 @@ class WPEnumType extends EnumType {
 		 * This is useful when several different types need to be easily filtered at once. . .for example,
 		 * if ALL types with a field of a certain name needed to be adjusted, or something to that tune
 		 *
-		 * @param array $values
+		 * @param array<string,mixed> $values
 		 */
 		$values = apply_filters( 'graphql_enum_values', $values );
 
@@ -76,7 +76,7 @@ class WPEnumType extends EnumType {
 		 * This is useful for more targeted filtering, and is applied after the general filter, to allow for
 		 * more specific overrides
 		 *
-		 * @param array $values
+		 * @param array<string,mixed> $values
 		 *
 		 * @since 0.0.5
 		 */

--- a/src/Type/WPInputObjectType.php
+++ b/src/Type/WPInputObjectType.php
@@ -28,7 +28,7 @@ class WPInputObjectType extends InputObjectType {
 		/**
 		 * Setup the fields
 		 *
-		 * @return array|mixed
+		 * @return array<string,array<string,mixed>>
 		 */
 		if ( ! empty( $config['fields'] ) && is_array( $config['fields'] ) ) {
 			$config['fields'] = function () use ( $config, $type_registry ) {
@@ -63,11 +63,10 @@ class WPInputObjectType extends InputObjectType {
 		 * This is useful when several different types need to be easily filtered at once. . .for example,
 		 * if ALL types with a field of a certain name needed to be adjusted, or something to that tune
 		 *
-		 * @param array  $fields    The array of fields for the object config
-		 * @param string $type_name The name of the object type
-		 * @param array  $config    The type config
-		 *
-		 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The TypeRegistry instance
+		 * @param array<string,array<string,mixed>> $fields        The array of fields for the object config
+		 * @param string                            $type_name     The name of the object type
+		 * @param array<string,mixed>               $config        The type config
+		 * @param \WPGraphQL\Registry\TypeRegistry  $type_registry The TypeRegistry instance
 		 */
 		$fields = apply_filters( 'graphql_input_fields', $fields, $type_name, $config, $type_registry );
 
@@ -83,8 +82,8 @@ class WPInputObjectType extends InputObjectType {
 		 * This is useful for more targeted filtering, and is applied after the general filter, to allow for
 		 * more specific overrides
 		 *
-		 * @param array $fields The array of fields for the object config
-		 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The TypeRegistry instance
+		 * @param array<string,array<string,mixed>> $fields        The array of fields for the object config
+		 * @param \WPGraphQL\Registry\TypeRegistry  $type_registry The TypeRegistry instance
 		 */
 		$fields = apply_filters( "graphql_{$lc_type_name}_fields", $fields, $type_registry );
 
@@ -94,8 +93,8 @@ class WPInputObjectType extends InputObjectType {
 		 * This is useful for more targeted filtering, and is applied after the general filter, to allow for
 		 * more specific overrides
 		 *
-		 * @param array $fields The array of fields for the object config
-		 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The TypeRegistry instance
+		 * @param array<string,array<string,mixed>> $fields        The array of fields for the object config
+		 * @param \WPGraphQL\Registry\TypeRegistry  $type_registry The TypeRegistry instance
 		 */
 		$fields = apply_filters( "graphql_{$uc_type_name}_fields", $fields, $type_registry );
 

--- a/src/Type/WPInterfaceType.php
+++ b/src/Type/WPInterfaceType.php
@@ -58,7 +58,7 @@ class WPInterfaceType extends InterfaceType {
 
 					$interface_config_fields = $interface_type->getFields();
 
-					if ( empty( $interface_config_fields ) || ! is_array( $interface_config_fields ) ) {
+					if ( empty( $interface_config_fields ) ) {
 						continue;
 					}
 
@@ -97,7 +97,7 @@ class WPInterfaceType extends InterfaceType {
 		/**
 		 * Filter the config of WPInterfaceType
 		 *
-		 * @param array           $config Array of configuration options passed to the WPInterfaceType when instantiating a new type
+		 * @param array<string,mixed>             $config Array of configuration options passed to the WPInterfaceType when instantiating a new type
 		 * @param \WPGraphQL\Type\WPInterfaceType $wp_interface_type The instance of the WPInterfaceType class
 		 */
 		$config = apply_filters( 'graphql_wp_interface_type_config', $config, $this );
@@ -121,7 +121,7 @@ class WPInterfaceType extends InterfaceType {
 	 * @param array<string,array<string,mixed>> $fields The array of fields for the object config
 	 * @param string                            $type_name
 	 *
-	 * @return mixed
+	 * @return array<string,array<string,mixed>>
 	 * @since 0.0.5
 	 */
 	public function prepare_fields( array $fields, string $type_name ) {
@@ -132,8 +132,8 @@ class WPInterfaceType extends InterfaceType {
 		 * This is useful when several different types need to be easily filtered at once. . .for example,
 		 * if ALL types with a field of a certain name needed to be adjusted, or something to that tune
 		 *
-		 * @param array  $fields    The array of fields for the object config
-		 * @param string $type_name The name of the object type
+		 * @param array<string,array<string,mixed>> $fields    The array of fields for the object config
+		 * @param string                            $type_name The name of the object type
 		 */
 		$fields = apply_filters( 'graphql_interface_fields', $fields, $type_name );
 
@@ -149,7 +149,7 @@ class WPInterfaceType extends InterfaceType {
 		 * This is useful for more targeted filtering, and is applied after the general filter, to allow for
 		 * more specific overrides
 		 *
-		 * @param array $fields The array of fields for the object config
+		 * @param array<string,array<string,mixed>> $fields The array of fields for the object config
 		 */
 		$fields = apply_filters( "graphql_{$lc_type_name}_fields", $fields );
 
@@ -159,7 +159,7 @@ class WPInterfaceType extends InterfaceType {
 		 * This is useful for more targeted filtering, and is applied after the general filter, to allow for
 		 * more specific overrides
 		 *
-		 * @param array $fields The array of fields for the object config
+		 * @param array<string,array<string,mixed>> $fields The array of fields for the object config
 		 */
 		$fields = apply_filters( "graphql_{$uc_type_name}_fields", $fields );
 

--- a/src/Type/WPMutationType.php
+++ b/src/Type/WPMutationType.php
@@ -56,7 +56,7 @@ class WPMutationType {
 	/**
 	 * The resolver function to resolve the mutation
 	 *
-	 * @var callable|\Closure
+	 * @var callable(mixed $root,array<string,mixed> $args,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info): array<string,mixed>
 	 */
 	protected $resolve_mutation;
 
@@ -80,7 +80,7 @@ class WPMutationType {
 		/**
 		 * Filter the config of WPMutationType
 		 *
-		 * @param array        $config         Array of configuration options passed to the WPMutationType when instantiating a new type
+		 * @param array<string,mixed>            $config           Array of configuration options passed to the WPMutationType when instantiating a new type
 		 * @param \WPGraphQL\Type\WPMutationType $wp_mutation_type The instance of the WPMutationType class
 		 *
 		 * @since 1.13.0
@@ -109,7 +109,7 @@ class WPMutationType {
 		/**
 		 * Run an action when the WPMutationType is instantiating.
 		 *
-		 * @param array        $config         Array of configuration options passed to the WPObjectType when instantiating a new type
+		 * @param array<string,mixed>            $config           Array of configuration options passed to the WPObjectType when instantiating a new type
 		 * @param \WPGraphQL\Type\WPMutationType $wp_mutation_type The instance of the WPMutationType class
 		 *
 		 * @since 1.13.0
@@ -147,7 +147,7 @@ class WPMutationType {
 			$is_valid = false;
 		}
 
-		return (bool) $is_valid;
+		return $is_valid;
 	}
 
 	/**
@@ -192,6 +192,8 @@ class WPMutationType {
 
 	/**
 	 * Gets the resolver callable for the mutation.
+	 *
+	 * @return callable(mixed $root,array<string,mixed> $args,\WPGraphQL\AppContext $context,\GraphQL\Type\Definition\ResolveInfo $info): array<string,mixed>
 	 */
 	protected function get_resolver(): callable {
 		return function ( $root, array $args, AppContext $context, ResolveInfo $info ) {
@@ -202,10 +204,10 @@ class WPMutationType {
 			/**
 			 * Filters the mutation input before it's passed to the `mutateAndGetPayload` callback.
 			 *
-			 * @param array $input The mutation input args.
-			 * @param \WPGraphQL\AppContext $context The AppContext object.
-			 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object.
-			 * @param string $mutation_name The name of the mutation field.
+			 * @param array<string,mixed>                  $input         The mutation input args.
+			 * @param \WPGraphQL\AppContext                $context       The AppContext object.
+			 * @param \GraphQL\Type\Definition\ResolveInfo $info          The ResolveInfo object.
+			 * @param string                               $mutation_name The name of the mutation field.
 			 */
 			$input = apply_filters( 'graphql_mutation_input', $unfiltered_input, $context, $info, $this->mutation_name );
 
@@ -214,11 +216,11 @@ class WPMutationType {
 			 * Returning anything other than null will stop the callback for the mutation from executing,
 			 * and will return your data or execute your callback instead.
 			 *
-			 * @param array|callable|null $payload. The payload returned from the callback. Null by default.
-			 * @param string $mutation_name The name of the mutation field.
-			 * @param callable|\Closure $mutateAndGetPayload The callback for the mutation.
-			 * @param array $input The mutation input args.
-			 * @param \WPGraphQL\AppContext $context The AppContext object.
+			 * @param array<string,mixed>|callable|null   $payload.            The payload returned from the callback. Null by default.
+			 * @param string                $mutation_name       The name of the mutation field.
+			 * @param callable|\Closure     $mutateAndGetPayload The callback for the mutation.
+			 * @param array<string,mixed>   $input               The mutation input args.
+			 * @param \WPGraphQL\AppContext $context             The AppContext object.
 			 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object.
 			 */
 			$pre = apply_filters( 'graphql_pre_mutate_and_get_payload', null, $this->mutation_name, $this->config['mutateAndGetPayload'], $input, $context, $info );
@@ -231,9 +233,9 @@ class WPMutationType {
 				/**
 				 * Filters the payload returned from the default mutateAndGetPayload callback.
 				 *
-				 * @param array $payload The payload returned from the callback.
-				 * @param string $mutation_name The name of the mutation field.
-				 * @param array $input The mutation input args.
+				 * @param array<string,mixed>   $payload The payload returned from the callback.
+				 * @param string                $mutation_name The name of the mutation field.
+				 * @param array<string,mixed>   $input The mutation input args.
 				 * @param \WPGraphQL\AppContext $context The AppContext object.
 				 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object.
 				 */
@@ -243,12 +245,12 @@ class WPMutationType {
 			/**
 			 * Fires after the mutation payload has been returned from the `mutateAndGetPayload` callback.
 			 *
-			 * @param array $payload The Payload returned from the mutation.
-			 * @param array $input The mutation input args, after being filtered by 'graphql_mutation_input'.
-			 * @param array $unfiltered_input The unfiltered input args of the mutation
-			 * @param \WPGraphQL\AppContext $context The AppContext object.
-			 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object.
-			 * @param string $mutation_name The name of the mutation field.
+			 * @param array<string,mixed>                  $payload          The Payload returned from the mutation.
+			 * @param array<string,mixed>                  $input            The mutation input args, after being filtered by 'graphql_mutation_input'.
+			 * @param array<string,mixed>                  $unfiltered_input The unfiltered input args of the mutation
+			 * @param \WPGraphQL\AppContext                $context          The AppContext object.
+			 * @param \GraphQL\Type\Definition\ResolveInfo $info             The ResolveInfo object.
+			 * @param string                               $mutation_name    The name of the mutation field.
 			 */
 			do_action( 'graphql_mutation_response', $payload, $input, $unfiltered_input, $context, $info, $this->mutation_name );
 

--- a/src/Type/WPObjectType.php
+++ b/src/Type/WPObjectType.php
@@ -77,7 +77,7 @@ class WPObjectType extends ObjectType {
 		/**
 		 * Setup the fields
 		 *
-		 * @return array|mixed
+		 * @return array<string, array<string, mixed>> $fields
 		 */
 		$config['fields'] = function () use ( $config ) {
 			$fields = $config['fields'];
@@ -101,7 +101,7 @@ class WPObjectType extends ObjectType {
 
 					$interface_config_fields = $interface_type->getFields();
 
-					if ( empty( $interface_config_fields ) || ! is_array( $interface_config_fields ) ) {
+					if ( empty( $interface_config_fields ) ) {
 						continue;
 					}
 
@@ -124,7 +124,7 @@ class WPObjectType extends ObjectType {
 		/**
 		 * Run an action when the WPObjectType is instantiating
 		 *
-		 * @param array                        $config         Array of configuration options passed to the WPObjectType when instantiating a new type
+		 * @param array<string,mixed>          $config         Array of configuration options passed to the WPObjectType when instantiating a new type
 		 * @param \WPGraphQL\Type\WPObjectType $wp_object_type The instance of the WPObjectType class
 		 */
 		do_action( 'graphql_wp_object_type', $config, $this );
@@ -163,11 +163,11 @@ class WPObjectType extends ObjectType {
 	 * This function sorts the fields and applies a filter to allow for easily
 	 * extending/modifying the shape of the Schema for the type.
 	 *
-	 * @param array<string,mixed> $fields         The array of fields for the object config
+	 * @param array<string,mixed> $fields    The array of fields for the object config
 	 * @param string              $type_name
-	 * @param array<string,mixed> $config         The config for the Object Type
+	 * @param array<string,mixed> $config    The config for the Object Type
 	 *
-	 * @return mixed
+	 * @return array<string,mixed>
 	 * @since 0.0.5
 	 */
 	public function prepare_fields( $fields, $type_name, $config ) {
@@ -178,10 +178,10 @@ class WPObjectType extends ObjectType {
 		 * This is useful when several different types need to be easily filtered at once. . .for example,
 		 * if ALL types with a field of a certain name needed to be adjusted, or something to that tune
 		 *
-		 * @param array        $fields         The array of fields for the object config
-		 * @param string       $type_name      The name of the object type
-		 * @param \WPGraphQL\Type\WPObjectType $wp_object_type The WPObjectType Class
-		 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The Type Registry
+		 * @param array<string,mixed>              $fields         The array of fields for the object config
+		 * @param string                           $type_name      The name of the object type
+		 * @param \WPGraphQL\Type\WPObjectType     $wp_object_type The WPObjectType Class
+		 * @param \WPGraphQL\Registry\TypeRegistry $type_registry  The Type Registry
 		 */
 		$fields = apply_filters( 'graphql_object_fields', $fields, $type_name, $this, $this->type_registry );
 
@@ -197,9 +197,9 @@ class WPObjectType extends ObjectType {
 		 * This is useful for more targeted filtering, and is applied after the general filter, to allow for
 		 * more specific overrides
 		 *
-		 * @param array        $fields         The array of fields for the object config
-		 * @param \WPGraphQL\Type\WPObjectType $wp_object_type The WPObjectType Class
-		 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The Type Registry
+		 * @param array<string,mixed>              $fields         The array of fields for the object config
+		 * @param \WPGraphQL\Type\WPObjectType     $wp_object_type The WPObjectType Class
+		 * @param \WPGraphQL\Registry\TypeRegistry $type_registry  The Type Registry
 		 */
 		$fields = apply_filters( "graphql_{$lc_type_name}_fields", $fields, $this, $this->type_registry );
 
@@ -209,9 +209,9 @@ class WPObjectType extends ObjectType {
 		 * This is useful for more targeted filtering, and is applied after the general filter, to allow for
 		 * more specific overrides
 		 *
-		 * @param array        $fields         The array of fields for the object config
-		 * @param \WPGraphQL\Type\WPObjectType $wp_object_type The WPObjectType Class
-		 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The Type Registry
+		 * @param array<string,mixed>              $fields         The array of fields for the object config
+		 * @param \WPGraphQL\Type\WPObjectType     $wp_object_type The WPObjectType Class
+		 * @param \WPGraphQL\Registry\TypeRegistry $type_registry  The Type Registry
 		 */
 		$fields = apply_filters( "graphql_{$uc_type_name}_fields", $fields, $this, $this->type_registry );
 

--- a/src/Type/WPUnionType.php
+++ b/src/Type/WPUnionType.php
@@ -76,8 +76,8 @@ class WPUnionType extends UnionType {
 		/**
 		 * Filter the possible_types to allow systems to add to the possible resolveTypes.
 		 *
-		 * @param mixed       $types         The possible types for the Union
-		 * @param array       $config        The config for the Union Type
+		 * @param mixed                       $types         The possible types for the Union
+		 * @param array<string,mixed>         $config        The config for the Union Type
 		 * @param \WPGraphQL\Type\WPUnionType $wp_union_type The WPUnionType instance
 		 *
 		 * @return mixed|array
@@ -87,7 +87,7 @@ class WPUnionType extends UnionType {
 		/**
 		 * Filter the config of WPUnionType
 		 *
-		 * @param array       $config        Array of configuration options passed to the WPUnionType when instantiating a new type
+		 * @param array<string,mixed>         $config        Array of configuration options passed to the WPUnionType when instantiating a new type
 		 * @param \WPGraphQL\Type\WPUnionType $wp_union_type The instance of the WPUnionType class
 		 *
 		 * @since 0.0.30
@@ -97,7 +97,7 @@ class WPUnionType extends UnionType {
 		/**
 		 * Run an action when the WPUnionType is instantiating
 		 *
-		 * @param array       $config        Array of configuration options passed to the WPUnionType when instantiating a new type
+		 * @param array<string,mixed>       $config        Array of configuration options passed to the WPUnionType when instantiating a new type
 		 * @param \WPGraphQL\Type\WPUnionType $wp_union_type The instance of the WPUnionType class
 		 */
 		do_action( 'graphql_wp_union_type', $config, $this );

--- a/src/Utils/DebugLog.php
+++ b/src/Utils/DebugLog.php
@@ -89,8 +89,8 @@ class DebugLog {
 			/**
 			 * Filter the log entry for the debug log
 			 *
-			 * @param array $log The log entry
-			 * @param array $config The config passed in with the log entry
+			 * @param array<string,mixed> $log    The log entry
+			 * @param array<string,mixed> $config The config passed in with the log entry
 			 */
 			return apply_filters( 'graphql_debug_log_entry', $log_entry, $config );
 		}
@@ -125,7 +125,7 @@ class DebugLog {
 		/**
 		 * Return the filtered debug log
 		 *
-		 * @param array    $logs     The logs to be output with the request
+		 * @param array<string,mixed>[]     $logs     The logs to be output with the request
 		 * @param \WPGraphQL\Utils\DebugLog $instance The Debug Log class
 		 */
 		return apply_filters( 'graphql_debug_log', array_values( $this->logs ), $this );

--- a/src/Utils/InstrumentSchema.php
+++ b/src/Utils/InstrumentSchema.php
@@ -44,10 +44,10 @@ class InstrumentSchema {
 	 * @param mixed[] $fields    The fields configured for a Type
 	 * @param string  $type_name The Type name
 	 *
-	 * @return mixed
+	 * @return mixed[]
 	 */
 	protected static function wrap_fields( array $fields, string $type_name ) {
-		if ( empty( $fields ) || ! is_array( $fields ) ) {
+		if ( empty( $fields ) ) {
 			return $fields;
 		}
 
@@ -82,9 +82,9 @@ class InstrumentSchema {
 			 * Replace the existing field resolve method with a new function that captures data about
 			 * the resolver to be stored in the resolver_report
 			 *
-			 * @param mixed       $source  The source passed down the Resolve Tree
-			 * @param array       $args    The args for the field
-			 * @param \WPGraphQL\AppContext $context The AppContext passed down the ResolveTree
+			 * @param mixed                                $source  The source passed down the Resolve Tree
+			 * @param array<string,mixed>                  $args    The args for the field
+			 * @param \WPGraphQL\AppContext                $context The AppContext passed down the ResolveTree
 			 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the ResolveTree
 			 *
 			 * @return mixed
@@ -96,14 +96,14 @@ class InstrumentSchema {
 				/**
 				 * Fire an action BEFORE the field resolves
 				 *
-				 * @param mixed           $source         The source passed down the Resolve Tree
-				 * @param array           $args           The args for the field
-				 * @param \WPGraphQL\AppContext $context The AppContext passed down the ResolveTree
-				 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the ResolveTree
-				 * @param ?callable       $field_resolver The Resolve function for the field
-				 * @param string          $type_name      The name of the type the fields belong to
-				 * @param string          $field_key      The name of the field
-				 * @param \GraphQL\Type\Definition\FieldDefinition $field The Field Definition for the resolving field
+				 * @param mixed                                    $source         The source passed down the Resolve Tree
+				 * @param array<string,mixed>                      $args           The args for the field
+				 * @param \WPGraphQL\AppContext                    $context        The AppContext passed down the ResolveTree
+				 * @param \GraphQL\Type\Definition\ResolveInfo     $info           The ResolveInfo passed down the ResolveTree
+				 * @param ?callable                                $field_resolver The Resolve function for the field
+				 * @param string                                   $type_name      The name of the type the fields belong to
+				 * @param string                                   $field_key      The name of the field
+				 * @param \GraphQL\Type\Definition\FieldDefinition $field          The Field Definition for the resolving field
 				 */
 				do_action( 'graphql_before_resolve_field', $source, $args, $context, $info, $field_resolver, $type_name, $field_key, $field );
 
@@ -119,15 +119,15 @@ class InstrumentSchema {
 				 * and the execution of the actual resolved is skipped. This filter can be used to implement
 				 * field level caches or for efficiently hiding data by returning null.
 				 *
-				 * @param mixed           $nil            Unique nil value
-				 * @param mixed           $source         The source passed down the Resolve Tree
-				 * @param array           $args           The args for the field
-				 * @param \WPGraphQL\AppContext $context The AppContext passed down the ResolveTree
-				 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the ResolveTree
-				 * @param string          $type_name      The name of the type the fields belong to
-				 * @param string          $field_key      The name of the field
-				 * @param \GraphQL\Type\Definition\FieldDefinition $field The Field Definition for the resolving field
-				 * @param mixed           $field_resolver The default field resolver
+				 * @param mixed                                    $nil            Unique nil value
+				 * @param mixed                                    $source         The source passed down the Resolve Tree
+				 * @param array<string,mixed>                      $args           The args for the field
+				 * @param \WPGraphQL\AppContext                    $context        The AppContext passed down the ResolveTree
+				 * @param \GraphQL\Type\Definition\ResolveInfo     $info           The ResolveInfo passed down the ResolveTree
+				 * @param string                                   $type_name      The name of the type the fields belong to
+				 * @param string                                   $field_key      The name of the field
+				 * @param \GraphQL\Type\Definition\FieldDefinition $field          The Field Definition for the resolving field
+				 * @param ?callable                                $field_resolver The default field resolver
 				 */
 				$result = apply_filters( 'graphql_pre_resolve_field', $nil, $source, $args, $context, $info, $type_name, $field_key, $field, $field_resolver );
 
@@ -139,7 +139,7 @@ class InstrumentSchema {
 					 * If the current field doesn't have a resolve function, use the defaultFieldResolver,
 					 * otherwise use the $field_resolver
 					 */
-					if ( null === $field_resolver || ! is_callable( $field_resolver ) ) {
+					if ( null === $field_resolver ) {
 						$result = Executor::defaultFieldResolver( $source, $args, $context, $info );
 					} else {
 						$result = $field_resolver( $source, $args, $context, $info );
@@ -149,30 +149,30 @@ class InstrumentSchema {
 				/**
 				 * Fire an action before the field resolves
 				 *
-				 * @param mixed           $result         The result of the field resolution
-				 * @param mixed           $source         The source passed down the Resolve Tree
-				 * @param array           $args           The args for the field
-				 * @param \WPGraphQL\AppContext $context The AppContext passed down the ResolveTree
-				 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the ResolveTree
-				 * @param string          $type_name      The name of the type the fields belong to
-				 * @param string          $field_key      The name of the field
+				 * @param mixed                                    $result          The result of the field resolution
+				 * @param mixed                                    $source          The source passed down the Resolve Tree
+				 * @param array<string,mixed>                      $args            The args for the field
+				 * @param \WPGraphQL\AppContext                    $context         The AppContext passed down the ResolveTree
+				 * @param \GraphQL\Type\Definition\ResolveInfo     $info            The ResolveInfo passed down the ResolveTree
+				 * @param string                                   $type_name       The name of the type the fields belong to
+				 * @param string                                   $field_key       The name of the field
 				 * @param \GraphQL\Type\Definition\FieldDefinition $field The Field Definition for the resolving field
-				 * @param mixed           $field_resolver The default field resolver
+				 * @param ?callable                                $field_resolver  The default field resolver
 				 */
 				$result = apply_filters( 'graphql_resolve_field', $result, $source, $args, $context, $info, $type_name, $field_key, $field, $field_resolver );
 
 				/**
 				 * Fire an action AFTER the field resolves
 				 *
-				 * @param mixed           $source         The source passed down the Resolve Tree
-				 * @param array           $args           The args for the field
-				 * @param \WPGraphQL\AppContext $context The AppContext passed down the ResolveTree
-				 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the ResolveTree
-				 * @param ?callable        $field_resolver The Resolve function for the field
-				 * @param string          $type_name      The name of the type the fields belong to
-				 * @param string          $field_key      The name of the field
-				 * @param \GraphQL\Type\Definition\FieldDefinition $field The Field Definition for the resolving field
-				 * @param mixed           $result         The result of the field resolver
+				 * @param mixed                                    $source         The source passed down the Resolve Tree
+				 * @param array<string,mixed>                      $args           The args for the field
+				 * @param \WPGraphQL\AppContext                    $context        The AppContext passed down the ResolveTree
+				 * @param \GraphQL\Type\Definition\ResolveInfo     $info           The ResolveInfo passed down the ResolveTree
+				 * @param ?callable                                $field_resolver The Resolve function for the field
+				 * @param string                                   $type_name      The name of the type the fields belong to
+				 * @param string                                   $field_key      The name of the field
+				 * @param \GraphQL\Type\Definition\FieldDefinition $field          The Field Definition for the resolving field
+				 * @param mixed                                    $result         The result of the field resolver
 				 */
 				do_action( 'graphql_after_resolve_field', $source, $args, $context, $info, $field_resolver, $type_name, $field_key, $field, $result );
 

--- a/src/Utils/QueryLog.php
+++ b/src/Utils/QueryLog.php
@@ -124,7 +124,7 @@ class QueryLog {
 	/**
 	 * Return the query log produced from the logs stored by WPDB.
 	 *
-	 * @return mixed[]
+	 * @return array<string,mixed>
 	 */
 	public function get_query_log() {
 		global $wpdb;
@@ -163,8 +163,8 @@ class QueryLog {
 		/**
 		 * Filter the trace
 		 *
-		 * @param array    $trace     The trace to return
-		 * @param \WPGraphQL\Utils\QueryLog $instance The QueryLog class instance
+		 * @param mixed[]                   $trace     The trace to return
+		 * @param \WPGraphQL\Utils\QueryLog $instance  The QueryLog class instance
 		 */
 		return apply_filters( 'graphql_tracing_response', $trace, $this );
 	}

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -324,9 +324,9 @@ final class WPGraphQL {
 					/**
 					 * Filters the interfaces applied to an object type
 					 *
-					 * @param array                              $interfaces List of interfaces applied to the Object Type
-					 * @param array                              $config     The config for the Object Type
-					 * @param mixed|\WPGraphQL\Type\WPInterfaceType|\WPGraphQL\Type\WPObjectType $type The Type instance
+					 * @param string[]                                                           $interfaces List of interfaces applied to the Object Type
+					 * @param array<string,mixed>                                                $config     The config for the Object Type
+					 * @param mixed|\WPGraphQL\Type\WPInterfaceType|\WPGraphQL\Type\WPObjectType $type       The Type instance
 					 */
 					return apply_filters_deprecated( 'graphql_object_type_interfaces', [ $interfaces, $config, $type ], '1.4.1', 'graphql_type_interfaces' );
 				}
@@ -439,8 +439,8 @@ final class WPGraphQL {
 		/**
 		 * Filters the graphql args set on a post type
 		 *
-		 * @param array  $args           The graphql specific args for the post type
-		 * @param string $post_type_name The name of the post type being registered
+		 * @param array<string,mixed> $args           The graphql specific args for the post type
+		 * @param string              $post_type_name The name of the post type being registered
 		 */
 		$graphql_args = apply_filters( 'register_graphql_post_type_args', $graphql_args, $post_type_name );
 
@@ -468,8 +468,8 @@ final class WPGraphQL {
 		/**
 		 * Filters the graphql args set on a taxonomy
 		 *
-		 * @param array  $args          The graphql specific args for the taxonomy
-		 * @param string $taxonomy_name The name of the taxonomy being registered
+		 * @param array<string,mixed> $args          The graphql specific args for the taxonomy
+		 * @param string              $taxonomy_name The name of the taxonomy being registered
 		 */
 		$graphql_args = apply_filters( 'register_graphql_taxonomy_args', $graphql_args, $taxonomy_name );
 
@@ -543,12 +543,10 @@ final class WPGraphQL {
 			 * Pass through a filter to allow the post_types to be modified.
 			 * For example if a certain post_type should not be exposed to the GraphQL API.
 			 *
-			 * @param array $post_type_names   Array of post type names.
-			 * @param array $post_type_objects Array of post type objects.
+			 * @param string[]        $post_type_names   Array of post type names.
+			 * @param \WP_Post_Type[] $post_type_objects Array of post type objects.
 			 *
-			 * @return array
 			 * @since 1.8.1 add $post_type_objects parameter.
-			 *
 			 * @since 0.0.2
 			 */
 			$allowed_post_type_names = apply_filters( 'graphql_post_entities_allowed_post_types', $post_type_names, $post_type_objects );
@@ -629,12 +627,10 @@ final class WPGraphQL {
 			 * Pass through a filter to allow the taxonomies to be modified.
 			 * For example if a certain taxonomy should not be exposed to the GraphQL API.
 			 *
-			 * @param array $tax_names   Array of taxonomy names
-			 * @param array $tax_objects Array of taxonomy objects.
+			 * @param string[]       $tax_names   Array of taxonomy names
+			 * @param \WP_Taxonomy[] $tax_objects Array of taxonomy objects.
 			 *
-			 * @return array
 			 * @since 1.8.1 add $tax_names and $tax_objects parameters.
-			 *
 			 * @since 0.0.2
 			 */
 			$allowed_tax_names = apply_filters( 'graphql_term_entities_allowed_taxonomies', $tax_names, $tax_objects );

--- a/tests/wpunit/PostObjectConnectionQueriesTest.php
+++ b/tests/wpunit/PostObjectConnectionQueriesTest.php
@@ -195,6 +195,7 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 
 		$this->assertCount( 20, $actual['data']['posts']['edges'] );
 		$this->assertTrue( $actual['data']['posts']['pageInfo']['hasNextPage'] );
+		$this->assertStringContainsString( 'The number of items requested by the connection (150) exceeds the max query amount.', $actual['extensions']['debug'][0]['message'] );
 	}
 
 	/**

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.19.0
+ * Version: 1.20.0
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.19.0
+ * @version  1.20.0
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
## 1.20.0

### New Features

- [#3013](https://github.com/wp-graphql/wp-graphql/pull/3013): feat: output GRAPHQL_DEBUG message if requested amount is larger than connection limit. Thanks @justlevine!
- [#3008](https://github.com/wp-graphql/wp-graphql/pull/3008): perf: Expose graphql_should_analyze_queries as setting. Thanks @justlevine!

### Chores / Bugfixes

- [#3022](https://github.com/wp-graphql/wp-graphql/pull/3022): chore: add @justlevine to list of contributors! 🙌 🥳
- [#3011](https://github.com/wp-graphql/wp-graphql/pull/3011): chore: update composer dev-dependencies and use php-compatibility:develop branch to 8.0+ lints. Thanks @justlevine! 
- [#3010](https://github.com/wp-graphql/wp-graphql/pull/3010): chore: implement stricter PHPDoc types. Thanks @justlevine!
- [#3009](https://github.com/wp-graphql/wp-graphql/pull/3009): chore: implement stricter PHPStan config and clean up unnecessary type-guards. Thanks @justlevine!
- [#3007](https://github.com/wp-graphql/wp-graphql/pull/3007): fix: call html_entity_decode() with explicit flags and decode single-quotes. Thanks @justlevine!
- [#3006](https://github.com/wp-graphql/wp-graphql/pull/3006): fix: replace deprecated AbstractConnectionResolver::setQueryArg() call with ::set_query_arg(). Thanks @justlevine!
- [#3004](https://github.com/wp-graphql/wp-graphql/pull/3004): docs: Update using-data-from-custom-database-tables.md
- [#2998](https://github.com/wp-graphql/wp-graphql/pull/2998): docs: Update build-your-first-wpgraphql-extension.md. Thanks @Jacob-Daniel!
- [#2997](https://github.com/wp-graphql/wp-graphql/pull/2997): docs: update wpgraphql-concepts.md. Thanks @Jacob-Daniel!
- [#2996](https://github.com/wp-graphql/wp-graphql/pull/2996): fix: Field id duplicates uri field description. Thanks @marcinkrzeminski!
