### PR TITLE
feat: provide better error when field references a type that does not exist

### DIFF
--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -948,7 +948,7 @@ class TypeRegistry {
 				$type = $this->get_type( $field_config['type'] );
 				if ( ! $type ) {
 					$message = sprintf(
-					/* translators: %s is the Field name. */
+					/* translators: %1$s is the Field name, %2$s is the type name the field belongs to. %3$s is the non-existent type name being referenced. */
 						__( 'The field \'%1$s\' on Type \'%2$s\' is configured to return \'%3$s\' which is a non-existent Type in the Schema. Make sure to define a valid type for all fields. This might occur if there was a typo with \'%3$s\', or it needs to be registered to the Schema.', 'wp-graphql' ),
 						$field_config['name'],
 						$type_name,
@@ -956,7 +956,7 @@ class TypeRegistry {
 					);
 					// We throw an error here instead of graphql_debug message, as an error would already be thrown if a type didn't exist at this point,
 					// but now it will have a more helpful error message.
-					throw new Error( $message );
+					throw new Error( esc_html( $message ) );
 				}
 				return $type;
 			};

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -2,6 +2,7 @@
 
 namespace WPGraphQL\Registry;
 
+use GraphQL\Error\Error;
 use GraphQL\Type\Definition\Type;
 use WPGraphQL\Data\DataSource;
 use WPGraphQL\Mutation\CommentCreate;
@@ -943,8 +944,21 @@ class TypeRegistry {
 				return null;
 			}
 
-			$field_config['type'] = function () use ( $field_config ) {
-				return $this->get_type( $field_config['type'] );
+			$field_config['type'] = function () use ( $field_config, $type_name ) {
+				$type = $this->get_type( $field_config['type'] );
+				if ( ! $type ) {
+					$message = sprintf(
+					/* translators: %s is the Field name. */
+						__( 'The field \'%1$s\' on Type \'%2$s\' is configured to return \'%3$s\' which is a non-existent Type in the Schema. Make sure to define a valid type for all fields. This might occur if there was a typo with \'%3$s\', or it needs to be registered to the Schema.', 'wp-graphql' ),
+						$field_config['name'],
+						$type_name,
+						$field_config['type']
+					);
+					// We throw an error here instead of graphql_debug message, as an error would already be thrown if a type didn't exist at this point,
+					// but now it will have a more helpful error message.
+					throw new Error( $message );
+				}
+				return $type;
 			};
 		}
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This introduces a more helpful error when a field in the Schema references a GraphQL Type that has not been registered to the Schema.

Does this close any currently open issues?
------------------------------------------
closes #3034 


Any other comments?
-------------------

When registering a field that references a Type that doesn't exist: 

```php
<?php
add_action( 'graphql_register_types', function() {
  register_graphql_field( 'User', 'fakeField', [
	  'type' => 'NonExistingType'
  ]);
} );
```

Then querying for the field like so: 

```graphql
{
  users {
    nodes {
      id
      fakeField
    }
  }
}
```

### Before

A vague error was returned with limited information to quickly identify the issue. 

![CleanShot 2024-02-05 at 10 13 53](https://github.com/wp-graphql/wp-graphql/assets/1260765/7b440d5c-d1d6-4d8a-828f-7934250afdd5)


### After

A clearer Error is returned

![CleanShot 2024-02-05 at 10 14 47](https://github.com/wp-graphql/wp-graphql/assets/1260765/54be6efe-03c3-4c84-83eb-0a01349c2bdb)

