### PR TITLE
feat: add `UniformResourceIdentifiable` interface to `Comment` type

### DIFF
--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -130,15 +130,13 @@ class NodeResolver {
 			return $node;
 		}
 
-		codecept_debug( 'parsed => ' );
-		codecept_debug( $uri );
-
 		/**
 		 * Comments are embedded as a #comment-{$id} in the post's content.
+		 *
+		 * If the URI is for a comment, we can resolve it now.
 		 */
 		$comment_id = $this->maybe_parse_comment_uri( $uri );
 		if ( null !== $comment_id ) {
-			codecept_debug( $comment_id );
 			return $this->context->get_loader( 'comment' )->load_deferred( $comment_id );
 		}
 

--- a/src/Model/Comment.php
+++ b/src/Model/Comment.php
@@ -24,9 +24,11 @@ use WP_Comment;
  * @property string $dateGmt
  * @property string $id
  * @property string $karma
+ * @property string $link
  * @property string $parentId
  * @property string $status
  * @property string $type
+ * @property string $uri
  *
  * @package WPGraphQL\Model
  */
@@ -54,6 +56,7 @@ class Comment extends Model {
 			'date',
 			'dateGmt',
 			'karma',
+			'link',
 			'type',
 			'commentedOnId',
 			'comment_post_ID',
@@ -63,6 +66,7 @@ class Comment extends Model {
 			'parentId',
 			'parentDatabaseId',
 			'isRestricted',
+			'uri',
 			'userId',
 		];
 
@@ -161,6 +165,11 @@ class Comment extends Model {
 				'karma'              => function () {
 					return ! empty( $this->data->comment_karma ) ? $this->data->comment_karma : null;
 				},
+				'link'               => function () {
+					$link = get_comment_link( $this->data );
+
+					return ! empty( $link ) ? urldecode( $link ) : null;
+				},
 				'approved'           => function () {
 					_doing_it_wrong( __METHOD__, 'The approved field is deprecated in favor of `status`', '1.13.0' );
 					return ! empty( $this->data->comment_approved ) && 'hold' !== $this->data->comment_approved;
@@ -177,6 +186,11 @@ class Comment extends Model {
 				},
 				'type'               => function () {
 					return ! empty( $this->data->comment_type ) ? $this->data->comment_type : null;
+				},
+				'uri'                => function () {
+					$uri = $this->link;
+
+					return ! empty( $uri ) ? str_ireplace( home_url(), '', $uri ) : null;
 				},
 				'userId'             => function () {
 					return ! empty( $this->data->user_id ) ? absint( $this->data->user_id ) : null;

--- a/src/Type/InterfaceType/UniformResourceIdentifiable.php
+++ b/src/Type/InterfaceType/UniformResourceIdentifiable.php
@@ -2,6 +2,7 @@
 
 namespace WPGraphQL\Type\InterfaceType;
 
+use WPGraphQL\Model\Comment;
 use WPGraphQL\Model\Post;
 use WPGraphQL\Model\PostType;
 use WPGraphQL\Model\Term;
@@ -45,6 +46,13 @@ class UniformResourceIdentifiable {
 							return $node instanceof Term;
 						},
 					],
+					'isComment'     => [
+						'type'        => [ 'non_null' => 'Boolean' ],
+						'description' => __( 'Whether the node is a Comment', 'wp-graphql' ),
+						'resolve'     => static function ( $node ) {
+							return $node instanceof Comment;
+						},
+					],
 				],
 				'resolveType' => static function ( $node ) use ( $type_registry ) {
 					switch ( true ) {
@@ -63,6 +71,9 @@ class UniformResourceIdentifiable {
 							break;
 						case $node instanceof PostType:
 							$type = $type_registry->get_type( 'ContentType' );
+							break;
+						case $node instanceof Comment:
+							$type = $type_registry->get_type( 'Comment' );
 							break;
 						default:
 							$type = null;

--- a/src/Type/ObjectType/Comment.php
+++ b/src/Type/ObjectType/Comment.php
@@ -23,7 +23,7 @@ class Comment {
 			[
 				'description' => __( 'A Comment object', 'wp-graphql' ),
 				'model'       => CommentModel::class,
-				'interfaces'  => [ 'Node', 'DatabaseIdentifier' ],
+				'interfaces'  => [ 'Node', 'DatabaseIdentifier', 'UniformResourceIdentifiable' ],
 				'connections' => [
 					'author' => [
 						'toType'      => 'Commenter',
@@ -107,6 +107,10 @@ class Comment {
 					'karma'            => [
 						'type'        => 'Int',
 						'description' => __( 'Karma value for the comment. This field is equivalent to WP_Comment->comment_karma and the value matching the "comment_karma" column in SQL.', 'wp-graphql' ),
+					],
+					'link'             => [
+						'type'        => 'String',
+						'description' => __( 'The permalink of the comment', 'wp-graphql' ),
 					],
 					'parentId'         => [
 						'type'        => 'ID',

--- a/tests/wpunit/CommentObjectQueriesTest.php
+++ b/tests/wpunit/CommentObjectQueriesTest.php
@@ -131,12 +131,14 @@ class CommentObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 				dateGmt
 				id
 				karma
+				link
 				parent {
 					node {
 						id
 					}
 				}
 				status
+				uri
 			}
 		}';
 
@@ -178,8 +180,10 @@ class CommentObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 				'dateGmt'     => $this->current_date_gmt,
 				'id'          => $global_id,
 				'karma'       => null,
+				'link'        => get_comment_link( $comment_id ),
 				'parent'      => null,
 				'status'      => 'APPROVE',
+				'uri'         => str_ireplace( home_url(), '', get_comment_link( $comment_id ) ),
 			],
 		];
 
@@ -484,6 +488,8 @@ class CommentObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 				karma
 				content
 				status
+				link
+				uri
 				commentedOn{
 					node {
 						... on Post{
@@ -515,6 +521,10 @@ class CommentObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 
 		$this->assertEquals( apply_filters( 'comment_text', $subscriber_args['comment_content'] ), $subscriber_actual['data']['comment']['content'] );
 		$this->assertEquals( apply_filters( 'comment_text', $admin_args['comment_content'] ), $admin_actual['data']['comment']['content'] );
+
+		$expected_link = get_comment_link( $admin_comment );
+		$this->assertEquals( $expected_link, $admin_actual['data']['comment']['link'] );
+		$this->assertEquals( str_ireplace( home_url(), '', $expected_link ), $admin_actual['data']['comment']['uri'] );
 
 		if ( true === $should_display ) {
 			$this->assertNotNull( $admin_actual['data']['comment']['authorIp'] );

--- a/tests/wpunit/NodeByUriTest.php
+++ b/tests/wpunit/NodeByUriTest.php
@@ -252,7 +252,11 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		// Clean up
 		wp_delete_comment( $comment_one_id, true );
+		wp_delete_comment( $comment_two_id, true );
+		wp_delete_comment( $comment_three_id, true );
+		wp_delete_comment( $child_comment_id, true );
 		wp_delete_post( $post_one_id, true );
+		wp_delete_post( $post_two_id, true );
 	}
 
 	/**

--- a/tests/wpunit/NodeByUriTest.php
+++ b/tests/wpunit/NodeByUriTest.php
@@ -76,6 +76,186 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 	}
 
 	/**
+	 * Test Comment URIs
+	 */
+	public function testCommentByUri(): void {
+		$post_one_id = $this->factory()->post->create(
+			[
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+				'post_title'  => 'Test commentByUri 1',
+				'post_author' => $this->user,
+			]
+		);
+
+		$post_two_id = $this->factory()->post->create(
+			[
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+				'post_title'  => 'Test commentByUri 2',
+				'post_author' => $this->user,
+			]
+		);
+
+		$comment_one_id = $this->factory()->comment->create(
+			[
+				'comment_post_ID' => $post_one_id,
+				'comment_content' => 'Test comment 1',
+				'comment_author'  => 'Test Author 1',
+				'comment_author_email' => 'info@test-comment-author1.test',
+			]
+		);
+
+		$comment_two_id = $this->factory()->comment->create(
+			[
+				'comment_post_ID' => $post_one_id,
+				'comment_content' => 'Test comment 2',
+				'comment_author'  => 'Test Author 2',
+				'comment_author_email' => 'info@test-comment-author2.test',
+			]
+		);
+
+		$comment_three_id = $this->factory()->comment->create(
+			[
+				'comment_post_ID' => $post_two_id,
+				'comment_content' => 'Test comment 3',
+				'comment_author'  => 'Test Author 3',
+				'comment_author_email' => 'info@test-comment-author3.test',
+			]
+		);
+
+		$child_comment_id = $this->factory()->comment->create(
+			[
+				'comment_post_ID' => $post_two_id,
+				'comment_content' => 'Test child comment',
+				'comment_author'  => 'Test Child Author',
+				'comment_parent'  => $comment_three_id,
+			]
+		);
+
+		$query = $this->getQuery();
+
+		// Test bad URI should return null.
+		$uri = '/2022/12/31/bad-uri/#comment-99999999';
+
+		$actual = $this->graphql(
+			[
+				'query'     => $query,
+				'variables' => [
+					'uri' => $uri,
+				],
+			]
+		);
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertNull( $actual['data']['nodeByUri'], 'nodeByUri should return null when no comment is found' );
+
+		// Test Bad comment on good Post returns null.
+		$uri = wp_make_link_relative( get_permalink( $post_one_id ) ) . '#comment-99999999';
+
+		$actual = $this->graphql(
+			[
+				'query'     => $query,
+				'variables' => [
+					'uri' => $uri,
+				],
+			]
+		);
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertNull( $actual['data']['nodeByUri'], 'nodeByUri should return null when no comment is found, even if the post is valid' );
+
+		// Test Fake comment on good post returns Post.
+		$uri = wp_make_link_relative( get_permalink( $post_one_id ) ) . '#comment-NaN';
+
+		$actual = $this->graphql(
+			[
+				'query'     => $query,
+				'variables' => [
+					'uri' => $uri,
+				],
+			]
+		);
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertSame( 'Post', $actual['data']['nodeByUri']['__typename'] );
+		$this->assertSame( $post_one_id, $actual['data']['nodeByUri']['databaseId'] );
+		$this->assertSame( wp_make_link_relative( get_permalink( $post_one_id ) ), $actual['data']['nodeByUri']['uri'] );
+
+		// Test with good comment on good post.
+		$uri = wp_make_link_relative( get_comment_link( $comment_one_id ) );
+
+		$actual = $this->graphql(
+			[
+				'query'     => $query,
+				'variables' => [
+					'uri' => $uri,
+				],
+			]
+		);
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertSame( 'Comment', $actual['data']['nodeByUri']['__typename'] );
+		$this->assertSame( $comment_one_id, $actual['data']['nodeByUri']['databaseId'] );
+		$this->assertSame( $uri, $actual['data']['nodeByUri']['uri'] );
+
+		// Test multiple comments on the same post.
+		$uri = wp_make_link_relative( get_comment_link( $comment_two_id ) );
+
+		$actual = $this->graphql(
+			[
+				'query'     => $query,
+				'variables' => [
+					'uri' => $uri,
+				],
+			]
+		);
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertSame( 'Comment', $actual['data']['nodeByUri']['__typename'] );
+		$this->assertSame( $comment_two_id, $actual['data']['nodeByUri']['databaseId'] );
+		$this->assertSame( $uri, $actual['data']['nodeByUri']['uri'] );
+
+		// Test comments on another post.
+		$uri = wp_make_link_relative( get_comment_link( $comment_three_id ) );
+
+		$actual = $this->graphql(
+			[
+				'query'     => $query,
+				'variables' => [
+					'uri' => $uri,
+				],
+			]
+		);
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertSame( 'Comment', $actual['data']['nodeByUri']['__typename'] );
+		$this->assertSame( $comment_three_id, $actual['data']['nodeByUri']['databaseId'] );
+		$this->assertSame( $uri, $actual['data']['nodeByUri']['uri'] );
+
+		// Test child comment on another post.
+		$uri = wp_make_link_relative( get_comment_link( $child_comment_id ) );
+
+		$actual = $this->graphql(
+			[
+				'query'     => $query,
+				'variables' => [
+					'uri' => $uri,
+				],
+			]
+		);
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertSame( 'Comment', $actual['data']['nodeByUri']['__typename'] );
+		$this->assertSame( $child_comment_id, $actual['data']['nodeByUri']['databaseId'] );
+		$this->assertSame( $uri, $actual['data']['nodeByUri']['uri'] );
+
+		// Clean up
+		wp_delete_comment( $comment_one_id, true );
+		wp_delete_post( $post_one_id, true );
+	}
+
+	/**
 	 * Test Post URIs
 	 */
 	public function testPostByUri(): void {


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR add the `UniformResourceIdentifiable` interface to the `Comment` object type. More specifically:

- `Comment` types now implement `UniformResourceIdentifiable`, which exposes the `uri` field.
- Added the `Comment.link` field, for parity with the [REST API](https://developer.wordpress.org/rest-api/reference/comments/#schema)
- Added support to `nodeByUri` for querying Comment URIs (`{post_link}#comment-{id}`}.

Does this close any currently open issues?
------------------------------------------
<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
<!-- (If it’s long, please paste to https://ghostbin.com/ and insert the link here.) -->


Any other comments?
-------------------
`nodeByUri` does *not* validate that the `#comment-{$id}` is actually associated with the PostObject referenced in the URL for performance reasons. This means that `$uri = "/fake-post#comment-{$real-comment-id}" will resolve to the correct `Comment`.

This quirk doesnt present a security risk, and since the use case for using `nodeByUri` to get a comment is so small I think this is fine.


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php8.1.14)

**WordPress Version:** 6.4.3
