### PR TITLE
fix: return empty when filtering `menuItems` by a `location` with no assigned items

### DIFF
--- a/src/Data/Connection/MenuItemConnectionResolver.php
+++ b/src/Data/Connection/MenuItemConnectionResolver.php
@@ -44,24 +44,21 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 			$query_args['meta_value'] = $this->args['where']['parentId']; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 		}
 
-		// Get unique list of locations as the default limitation of
-		// locations to allow public queries for.
-		// Public queries should only be allowed to query for
-		// Menu Items assigned to a Menu Location
+		// Get unique list of location term IDs as the default limitation of locations to allow public queries for.
+		// Public queries should only be allowed to query for Menu Items assigned to a Menu Location.
 		$locations = is_array( $menu_locations ) && ! empty( $menu_locations ) ? array_unique( array_values( $menu_locations ) ) : [];
 
 		// If the location argument is set, set the argument to the input argument
-		if ( isset( $this->args['where']['location'], $menu_locations[ $this->args['where']['location'] ] ) ) {
-			$locations = [ $menu_locations[ $this->args['where']['location'] ] ];
+		if ( ! empty( $this->args['where']['location'] ) ) {
+			$locations = isset( $menu_locations[ $this->args['where']['location'] ] ) ? [ $menu_locations[ $this->args['where']['location'] ] ] : []; // We use an empty array to prevent fetching all media items if the location has no items assigned.
 
-			// if the $locations are NOT set and the user has proper capabilities, let the user query
-			// all menu items connected to any menu
 		} elseif ( current_user_can( 'edit_theme_options' ) ) {
+			// If the $locations are NOT set, let a user with proper capability query all menu items.
 			$locations = null;
 		}
 
 		// Only query for menu items in assigned locations.
-		if ( ! empty( $locations ) ) {
+		if ( isset( $locations ) ) {
 
 			// unset the location arg
 			// we don't need this passed as a taxonomy parameter to wp_query

--- a/tests/wpunit/MenuItemConnectionQueriesTest.php
+++ b/tests/wpunit/MenuItemConnectionQueriesTest.php
@@ -67,7 +67,12 @@ class MenuItemConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 		}
 
 		// Assign menu to location.
-		set_theme_mod( 'nav_menu_locations', [ $location => $menu_id ] );
+		if( ! empty( $location ) ) {
+			$menus = get_theme_mod( 'nav_menu_locations' );
+			$menus[ $location ] = $menu_id;
+
+			set_theme_mod( 'nav_menu_locations', $menus );
+		}
 
 		// Make sure menu items were created.
 		$this->assertEquals( $count, count( $menu_item_ids ) );
@@ -423,9 +428,11 @@ class MenuItemConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 
 		$menu_location = 'my-menu-items-location';
 		register_nav_menu( $menu_location, 'My MenuItems' );
-		WPGraphQL::clear_schema();
 
-		$created = $this->create_menu_items( 'menu-for-location-test', $menu_location, 1 );
+		$ignored_location = 'ignored-menu-items-location';
+		register_nav_menu( $ignored_location, 'Ignored MenuItems' );
+
+		WPGraphQL::clear_schema();
 
 		$query = $this->getQuery();
 
@@ -435,10 +442,32 @@ class MenuItemConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 			],
 		];
 
+		// Test with no menu assigned.
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertEmpty( $actual['data']['menuItems']['edges'], 'An empty menuItem location should return empty' );
+
+		// Test with menu assigned.
+		$created = $this->create_menu_items( 'menu-for-location-test', $menu_location, 1 );
+
+		// // These should be filtered out.
+		$ignored = $this->create_menu_items( 'ignored-menu-for-test', $ignored_location, 3 );
+
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
 		// The returned menu items have the expected number.
-		$this->assertEquals( 1, count( $actual['data']['menuItems']['edges'] ) );
+		$this->assertEquals( 1, count( $actual['data']['menuItems']['edges'] ), 'The menu items should only return for the location' );
+
+		// Perform some common assertions.
+		$this->compareResults( $created['menu_item_ids'], $created['post_ids'], $actual );
+
+		// Test as authenticated user still returns the same number of menu items.
+		wp_set_current_user( $this->admin );
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		// The returned menu items have the expected number.
+		$this->assertEquals( 1, count( $actual['data']['menuItems']['edges'] ), 'The menu items should only return for the location' );
 
 		// Perform some common assertions.
 		$this->compareResults( $created['menu_item_ids'], $created['post_ids'], $actual );

--- a/tests/wpunit/MenuItemConnectionQueriesTest.php
+++ b/tests/wpunit/MenuItemConnectionQueriesTest.php
@@ -429,7 +429,9 @@ class MenuItemConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 		$menu_location = 'my-menu-items-location';
 		register_nav_menu( $menu_location, 'My MenuItems' );
 
+		// // These should be filtered out.
 		$ignored_location = 'ignored-menu-items-location';
+		$ignored = $this->create_menu_items( 'ignored-menu-for-test', $ignored_location, 3 );
 		register_nav_menu( $ignored_location, 'Ignored MenuItems' );
 
 		WPGraphQL::clear_schema();
@@ -449,9 +451,6 @@ class MenuItemConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 
 		// Test with menu assigned.
 		$created = $this->create_menu_items( 'menu-for-location-test', $menu_location, 1 );
-
-		// // These should be filtered out.
-		$ignored = $this->create_menu_items( 'ignored-menu-for-test', $ignored_location, 3 );
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR fixes an issue in the `MenuItemConnectionResolver` logic, where querying a `menuItem` by a `location` with unset terms would return _all_ menu items, instead of _none_.

Logic has been changed so the `tax_query` args are given a `'term_id' => []`.

Tests have been added to cover:
- A `location` with no menu items returns null.
- A `location` with no menu items returns null _as an admin_.
- A `location` with menu items, doesn't return items from a different `location` (either public or as an admin).


Does this close any currently open issues?
------------------------------------------
<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Fixes #3029 

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
<!-- (If it’s long, please paste to https://ghostbin.com/ and insert the link here.) -->


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php 8.1.14)

**WordPress Version:** 6.4.3
