### PR TITLE
feat: add `graphql_pre_resolve_menu_item_connected_node` filter

### DIFF
--- a/src/Type/ObjectType/MenuItem.php
+++ b/src/Type/ObjectType/MenuItem.php
@@ -36,7 +36,27 @@ class MenuItem {
 							$object_id   = (int) get_post_meta( $menu_item->databaseId, '_menu_item_object_id', true );
 							$object_type = get_post_meta( $menu_item->databaseId, '_menu_item_type', true );
 
-							$resolver = null;
+							/**
+							 * When this filter returns anything other than null it will be used as the resolved connection for the menu item's connected node, short-circuiting the default resolution.
+							 *
+							 * This is useful since we often add taxonomy terms to menus but would prefer to represent the menu item in other ways.
+							 * E.g., a linked post object (or vice-versa).
+							 *
+							 * @param ?\GraphQL\Deferred                   $deferred_connection The AbstractConnectionResolver's connection, or null to continue with the default resolution.
+							 * @param \WPGraphQL\Model\MenuItem            $menu_item           The MenuItem model.
+							 * @param array<string,mixed>                  $args                The GraphQL args for the connection.
+							 * @param \WPGraphQL\AppContext                $context             The AppContext object.
+							 * @param \GraphQL\Type\Definition\ResolveInfo $info                The ResolveInfo object.
+							 * @param int                                  $object_id           The ID of the connected object.
+							 * @param string                               $object_type         The type of the connected object.
+							 */
+							$deferred_connection = apply_filters( 'graphql_pre_resolve_menu_item_connected_node', null, $menu_item, $args, $context, $info, $object_id, $object_type );
+
+							if ( null !== $deferred_connection ) {
+								return $deferred_connection;
+							}
+
+							// Handle the default resolution.
 							switch ( $object_type ) {
 								// Post object
 								case 'post_type':
@@ -53,6 +73,7 @@ class MenuItem {
 									$resolver->set_query_arg( 'include', $object_id );
 									break;
 								default:
+									$resolver = null;
 									break;
 							}
 
@@ -180,14 +201,19 @@ class MenuItem {
 							 *
 							 * @since 0.0.30
 							 */
-							return apply_filters(
+							return apply_filters_deprecated(
 								'graphql_resolve_menu_item',
-								$resolved_object,
-								$args,
-								$context,
-								$info,
-								$object_id,
-								$object_type
+								[
+									$resolved_object,
+									$args,
+									$context,
+									$info,
+									$object_id,
+									$object_type,
+								],
+								'@todo',
+								'graphql_pre_resolve_menu_item_connected_node',
+								__( 'Use the `graphql_pre_resolve_menu_item_connected_node` filter on `connectedNode` instead.', 'wp-graphql' )
 							);
 						},
 					],

--- a/tests/wpunit/MenuItemQueriesTest.php
+++ b/tests/wpunit/MenuItemQueriesTest.php
@@ -100,6 +100,125 @@ class MenuItemQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->assertEquals( $menu_item_relay_id, $actual['data']['menuItem']['id'] );
 	}
 
+	public function testMenuItemQueryWithTermObject() {
+		$term_id = $this->factory()->term->create( [ 'taxonomy' => 'category' ] );
+		$permalink = get_term_link( $term_id );
+
+		$menu_args = [
+			'menu-item-attr-title'  => 'Menu item',
+			'menu-item-classes'     => 'my-class my-other-class',
+			'menu-item-description' => 'Some description',
+			'menu-item-object-id'   => $term_id,
+			'menu-item-object'      => 'category',
+			'menu-item-position'    => 1,
+			'menu-item-status'      => 'publish',
+			'menu-item-title'       => 'Menu item',
+			'menu-item-type'        => 'taxonomy',
+			'menu-item-target'      => '_blank',
+		];
+
+		$menu_item_id = wp_update_nav_menu_item( $this->menu_id, 0, $menu_args );
+
+		$menu_item_relay_id = Relay::toGlobalId( 'post', $menu_item_id );
+
+		codecept_debug( get_theme_mod( 'nav_menu_locations' ) );
+
+		// test with database ID.
+		$query = $this->get_query();
+
+		$variables = [
+			'id'     => $menu_item_id,
+			'idType' => 'DATABASE_ID',
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertEquals( explode( ' ', $menu_args['menu-item-classes'] ), $actual['data']['menuItem']['cssClasses'] );
+		$this->assertEquals( $term_id, $actual['data']['menuItem']['connectedNode']['node']['databaseId'] );
+		$this->assertEquals( $menu_item_id, $actual['data']['menuItem']['databaseId'] );
+		$this->assertEquals( $menu_args['menu-item-description'], $actual['data']['menuItem']['description'] );
+		$this->assertEquals( $menu_item_relay_id, $actual['data']['menuItem']['id'] );
+		$this->assertEquals( $menu_args['menu-item-title'], $actual['data']['menuItem']['label'] );
+		$this->assertEquals( [ \WPGraphQL\Type\WPEnumType::get_safe_name( $this->location_name ) ], $actual['data']['menuItem']['locations'] );
+		$this->assertEquals( [ \WPGraphQL\Type\WPEnumType::get_safe_name( $this->location_name ) ], $actual['data']['menuItem']['menu']['node']['locations'] );
+		$this->assertEquals( $this->menu_slug, $actual['data']['menuItem']['menu']['node']['slug'] );
+		$this->assertEquals( $menu_args['menu-item-position'], $actual['data']['menuItem']['order'] );
+		$this->assertEquals( $menu_args['menu-item-target'], $actual['data']['menuItem']['target'] );
+		$this->assertEquals( $menu_args['menu-item-attr-title'], $actual['data']['menuItem']['title'] );
+		$this->assertEquals( str_ireplace( home_url(), '', $permalink ), $actual['data']['menuItem']['uri'] );
+		$this->assertEquals( $permalink, $actual['data']['menuItem']['url'] );
+
+		// Test with relay Id.
+		$variables = [
+			'id'     => $menu_item_relay_id,
+			'idType' => 'ID',
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertEquals( $menu_item_id, $actual['data']['menuItem']['databaseId'] );
+		$this->assertEquals( $menu_item_relay_id, $actual['data']['menuItem']['id'] );
+	}
+
+	public function testMenuItemWithCustomFilters() {
+		$term_id   = $this->factory()->term->create( [ 'taxonomy' => 'category' ] );
+		$post_id   = $this->factory()->post->create(); // We'll resolve to this.
+		$permalink = get_term_link( $term_id ); // The menu permalink stays the same.
+
+		$menu_args = [
+			'menu-item-attr-title'  => 'Menu item',
+			'menu-item-classes'     => 'my-class my-other-class',
+			'menu-item-description' => 'Some description',
+			'menu-item-object-id'   => $term_id,
+			'menu-item-object'      => 'category',
+			'menu-item-position'    => 1,
+			'menu-item-status'      => 'publish',
+			'menu-item-title'       => 'Menu item',
+			'menu-item-type'        => 'taxonomy',
+			'menu-item-target'      => '_blank',
+		];
+
+		$menu_item_id = wp_update_nav_menu_item( $this->menu_id, 0, $menu_args );
+
+		$menu_item_relay_id = Relay::toGlobalId( 'post', $menu_item_id );
+
+		// Filter the resolver.
+		add_filter( 'graphql_pre_resolve_menu_item_connected_node', static function ( $deferred_connection, $source, $args, $context, $info ) use ( $post_id ) {
+			$resolver = new \WPGraphQL\Data\Connection\PostObjectConnectionResolver( $source, [], $context, $info, 'any' );
+			$resolver->set_query_arg( 'p', $post_id );
+
+			return $resolver->one_to_one()->get_connection();
+		}, 10, 7 );
+
+		// test with database ID.
+		$query = $this->get_query();
+
+		$variables = [
+			'id'     => $menu_item_id,
+			'idType' => 'DATABASE_ID',
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertEquals( explode( ' ', $menu_args['menu-item-classes'] ), $actual['data']['menuItem']['cssClasses'] );
+		$this->assertEquals( $post_id, $actual['data']['menuItem']['connectedNode']['node']['databaseId'] );
+		$this->assertEquals( $menu_item_id, $actual['data']['menuItem']['databaseId'] );
+		$this->assertEquals( $menu_args['menu-item-description'], $actual['data']['menuItem']['description'] );
+		$this->assertEquals( $menu_item_relay_id, $actual['data']['menuItem']['id'] );
+		$this->assertEquals( $menu_args['menu-item-title'], $actual['data']['menuItem']['label'] );
+		$this->assertEquals( [ \WPGraphQL\Type\WPEnumType::get_safe_name( $this->location_name ) ], $actual['data']['menuItem']['locations'] );
+		$this->assertEquals( [ \WPGraphQL\Type\WPEnumType::get_safe_name( $this->location_name ) ], $actual['data']['menuItem']['menu']['node']['locations'] );
+		$this->assertEquals( $this->menu_slug, $actual['data']['menuItem']['menu']['node']['slug'] );
+		$this->assertEquals( $menu_args['menu-item-position'], $actual['data']['menuItem']['order'] );
+		$this->assertEquals( $menu_args['menu-item-target'], $actual['data']['menuItem']['target'] );
+		$this->assertEquals( $menu_args['menu-item-attr-title'], $actual['data']['menuItem']['title'] );
+		$this->assertEquals( str_ireplace( home_url(), '', $permalink ), $actual['data']['menuItem']['uri'] );
+		$this->assertEquals( $permalink, $actual['data']['menuItem']['url'] );
+
+		// Cleanup
+		remove_all_filters( 'graphql_pre_resolve_menu_item_connected_node' );
+	}
+
 	public function testCustomMenuItemWithChildren() {
 		$parent_args = [
 			'menu-item-title'     => 'Parent Item',
@@ -152,7 +271,12 @@ class MenuItemQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 					}
 					connectedNode {
 						node {
+							__typename
 							... on Post {
+								id
+								databaseId
+							}
+							... on TermNode {
 								id
 								databaseId
 							}


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR adds the `graphql_pre_resolve_menu_item_connected_node` filter to the `MenuItem.connectedNode` resolver, allowing one to short-circuit the resolver logic and use a custom `AbstractConnectionResolver->get_connection()` as the result.

Additionally, the `graphql_resolve_menu_item` filter on the deprecated `MenuItem.connectedObject` resolver has been `deprecated`.

This change brings parity between `connectedNode` and `connectedObject`, and will allow developers still relying on the latter to finally migrate.

Tests have been added both to cover the new filter, and to cover resolving `TermObject`s (since that was missing).


Does this close any currently open issues?
------------------------------------------
<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #2484 

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
<!-- (If it’s long, please paste to https://ghostbin.com/ and insert the link here.) -->


Any other comments?
-------------------
- Theres a `@todo` tag that will need to be replaced on release and will need to be replaced manually (its not in the usual `@since @todo` format.


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php8.1.14)

**WordPress Version:** 6.4.3
