### PR TITLE
fix: admin_enqueue_scripts callback should expect a possible null value passed to it

### DIFF
--- a/src/Admin/Settings/Settings.php
+++ b/src/Admin/Settings/Settings.php
@@ -269,9 +269,14 @@ class Settings {
 	/**
 	 * Initialize the styles and scripts used on the settings admin page
 	 *
-	 * @param string $hook_suffix The current admin page.
+	 * @param ?string $hook_suffix The current admin page.
 	 */
-	public function initialize_settings_page_scripts( string $hook_suffix ): void {
+	public function initialize_settings_page_scripts( ?string $hook_suffix ): void {
+
+        if ( ! $hook_suffix ) {
+            return;
+        }
+
 		$this->settings_api->admin_enqueue_scripts( $hook_suffix );
 	}
 

--- a/src/Admin/Settings/Settings.php
+++ b/src/Admin/Settings/Settings.php
@@ -273,9 +273,9 @@ class Settings {
 	 */
 	public function initialize_settings_page_scripts( ?string $hook_suffix ): void {
 
-        if ( ! $hook_suffix ) {
-            return;
-        }
+		if ( ! $hook_suffix ) {
+			return;
+		}
 
 		$this->settings_api->admin_enqueue_scripts( $hook_suffix );
 	}


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This updates the enqueue_admin_assets callback to expect a possible null value for the argument passed from `do_action( 'admin_enqueue_scripts' );`


Does this close any currently open issues?
------------------------------------------
closes #3056  