### PR TITLE
fix: prevent wpml from redirecting in WPGraphQL requests

### DIFF
--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -341,14 +341,19 @@ final class WPGraphQL {
 		 * Prevent WPML from redirecting within WPGraphQL requests
 		 *
 		 * @see https://github.com/wp-graphql/wp-graphql/issues/1626#issue-769089073
-	 * @since @todo
+		 * @since @todo
 		 */
-add_filter( 'wpml_is_redirected', static function( bool $is_redirect ) {
-	if ( is_graphql_request() ) {
-			return false;
-			}
-		return $is_redirect;
-		});
+		add_filter(
+			'wpml_is_redirected',
+			static function ( bool $is_redirect ) {
+				if ( is_graphql_request() ) {
+					return false;
+				}
+				return $is_redirect;
+			},
+			10,
+			1
+		);
 	}
 
 	/**

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -336,6 +336,19 @@ final class WPGraphQL {
 			10,
 			3
 		);
+
+		/**
+		 * Prevent WPML from redirecting within WPGraphQL requests
+		 *
+		 * @see https://github.com/wp-graphql/wp-graphql/issues/1626#issue-769089073
+	 * @since @todo
+		 */
+add_filter( 'wpml_is_redirected', static function( bool $is_redirect ) {
+	if ( is_graphql_request() ) {
+			return false;
+			}
+		return $is_redirect;
+		});
 	}
 
 	/**


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

This adds a filter to prevent WPML from redirecting within WPGraphQL requests. 

Also, this tests the modified Github Workflow intended to run phpcbf to fix changes and commit them back to the PR. 

Does this close any currently open issues?
------------------------------------------
no


Any other comments?
-------------------
I've referred folks to this snippet many times. Adding it to core leads to a reduced support burden.
