### PR TITLE
fix: taking care about the case of empty order by

### DIFF
--- a/src/Data/Config.php
+++ b/src/Data/Config.php
@@ -205,7 +205,7 @@ class Config {
 		$key    = $cursor->get_cursor_id_key();
 
 		// If there is a cursor compare in the arguments, use it as the stablizer for cursors.
-		return "{$orderby}, {$key} {$order}";
+		return ( $orderby ? "{$orderby}, " : '' ) . "{$key} {$order}";
 	}
 
 	/**
@@ -307,7 +307,7 @@ class Config {
 		$cursor = new UserCursor( $query->query_vars );
 		$key    = $cursor->get_cursor_id_key();
 
-		return "{$orderby}, {$key} {$order}";
+		return ( $orderby ? "{$orderby}, " : '' ) . "{$key} {$order}";
 	}
 
 	/**
@@ -420,7 +420,7 @@ class Config {
 			$pieces['where'] = $pieces['where'] . $before_cursor->get_where();
 		}
 
-		// Check the cursor compare order
+		// Check the cursor compare order.
 		$order = '>' === $args['graphql_cursor_compare'] ? 'ASC' : 'DESC';
 
 		// Get Cursor ID key.
@@ -428,8 +428,13 @@ class Config {
 		$key    = $cursor->get_cursor_id_key();
 
 		// If there is a cursor compare in the arguments, use it as the stabilizer for cursors.
-		$pieces['orderby'] = "{$pieces['orderby']} {$pieces['order']}, {$key} {$order}";
-		$pieces['order']   = '';
+		if ( ! empty( $pieces['orderby'] ) ) {
+			$pieces['orderby'] = "{$pieces['orderby']} {$pieces['order']}, {$key} {$order}";
+		} else {
+			$pieces['orderby'] = "ORDER BY {$key} {$order}";
+		}
+
+		$pieces['order'] = '';
 
 		return $pieces;
 	}


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [ ] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This fix resolves the issue when the 'ORDER BY' is missing in cursor pagination.


Does this close any currently open issues?
------------------------------------------
<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
<!-- (If it’s long, please paste to https://ghostbin.com/ and insert the link here.) -->

#### Reproduce Link

I have installed WPGraphQL Version 1.21.0 in addition to this version of an offset pagination plugin <https://github.com/alaa-alshamy/wp-graphql-offset-pagination/releases/tag/v0.2.0.2>. 
I have the following categories for example as parent, child
![image](https://github.com/wp-graphql/wp-graphql/assets/299527/8728dec1-1838-4fc0-888f-8f10c25e0e23)
When I run the following GraphQL query to count total of children of the targeted parent that id is `38`.
  ```graphql
  query terms {
    categories(where: {
      parent: 38
    }) {
      pageInfo {
        offsetPagination {
          total
        }
      }
      nodes {
        name
        databaseId
        slug      
      }
    }
  }
  ```
Then the total is returning `null` as you can see in the image below:
![image](https://github.com/wp-graphql/wp-graphql/assets/299527/b37cdfeb-ac7b-49ae-87e8-ab3065148432)

After Applying the fix of this pull request the issue resolves:
![image](https://github.com/wp-graphql/wp-graphql/assets/299527/7f807b7a-7755-4d60-a149-82b7ac8fe5c7)

Any other comments?
-------------------
I believe the following testing environment should help you to reproduce the issue, this is hosted in local by flywheel:
<https://probable-tendency.localsite.io/wp-admin/admin.php?page=graphiql-ide>
**Basic Authentication:** 
**Username:** pattern
**Password:** unusual

**Admin Panel:**
**Username:** admin
**Password:** password

Where has this been tested?
---------------------------
**Operating System:** …
Ubuntu 22.04.4 LTS

**WordPress Version:** …
6.4.3
