### PR TITLE
fix: respect show avatar setting

### DIFF
--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -352,13 +352,7 @@ class DataSource {
 			return null;
 		}
 
-		$avatar = new Avatar( $avatar );
-
-		if ( 'private' === $avatar->get_visibility() ) {
-			return null;
-		}
-
-		return $avatar;
+		return new Avatar( $avatar );
 	}
 
 	/**

--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -352,7 +352,13 @@ class DataSource {
 			return null;
 		}
 
-		return new Avatar( $avatar );
+		$avatar = new Avatar( $avatar );
+
+		if ( 'private' === $avatar->get_visibility() ) {
+			return null;
+		}
+
+		return $avatar;
 	}
 
 	/**

--- a/src/Model/Avatar.php
+++ b/src/Model/Avatar.php
@@ -38,6 +38,14 @@ class Avatar extends Model {
 	}
 
 	/**
+	 * @return bool
+	 */
+	protected function is_private() {
+		$show_avatars = get_option( 'show_avatars' );
+		return ! (bool) $show_avatars;
+	}
+
+	/**
 	 * {@inheritDoc}
 	 */
 	protected function init() {

--- a/src/Model/Avatar.php
+++ b/src/Model/Avatar.php
@@ -38,14 +38,6 @@ class Avatar extends Model {
 	}
 
 	/**
-	 * @return bool
-	 */
-	protected function is_private() {
-		$show_avatars = get_option( 'show_avatars' );
-		return ! (bool) $show_avatars;
-	}
-
-	/**
 	 * {@inheritDoc}
 	 */
 	protected function init() {

--- a/src/Utils/QueryAnalyzer.php
+++ b/src/Utils/QueryAnalyzer.php
@@ -14,9 +14,9 @@ use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Schema;
 use GraphQL\Utils\TypeInfo;
+use WPGraphQL;
 use WPGraphQL\Request;
 use WPGraphQL\WPSchema;
-use WPGraphQL;
 
 /**
  * This class is used to identify "keys" relevant to the GraphQL Request.

--- a/tests/wpunit/AvatarObjectQueriesTest.php
+++ b/tests/wpunit/AvatarObjectQueriesTest.php
@@ -95,6 +95,12 @@ class AvatarObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->assertEquals( $expected, $actual['data'] );
 
+		// set the option to false
+		update_option( 'show_avatars', 0 );
+		$actual = do_graphql_request( $query );
+		$this->assertEquals( null, $actual['data']['user']['avatar'] );
+
+		update_option( 'show_avatars', 1 );
 		// Clean up filter usage.
 		remove_filter( 'get_avatar_url', [ $this, 'avatar_test_url' ] );
 	}


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This fixes a bug where avatar information would be returned even if the "show_avatars" setting is turned "off" under Settings > Discussion. 

- [x] failing tests: https://github.com/wp-graphql/wp-graphql/actions/runs/8168069455
- [x] passing tests: https://github.com/wp-graphql/wp-graphql/actions/runs/8168073152

Does this close any currently open issues?
------------------------------------------
closes #3064 


Any other comments?
-------------------
This doesn't change the schema, just the resolve logic. 

Since the Avatar field is already nullable, responsible consumers should already be prepared to expect null values for avatars, so preventing avatars from being returned is not considered a breaking change.
