### PR TITLE
release: v1.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.22.1
+
+### Chores / Bugfixes
+
+- [#3067](https://github.com/wp-graphql/wp-graphql/pull/3067): fix: respect show avatar setting
+- [#3063](https://github.com/wp-graphql/wp-graphql/pull/3063): fix: fixes a bug in cursor stability filters that could lead to empty order
+- [#3070](https://github.com/wp-graphql/wp-graphql/pull/3070): test(3063): Adds test for [#3063](https://github.com/wp-graphql/wp-graphql/pull/3063)
+
 ## 1.22.0
 
 ### New Features

--- a/constants.php
+++ b/constants.php
@@ -18,7 +18,7 @@ function graphql_setup_constants() {
 
 	// Plugin version.
 	if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-		define( 'WPGRAPHQL_VERSION', '1.22.0' );
+		define( 'WPGRAPHQL_VERSION', '1.22.1' );
 	}
 
 	// Plugin Folder Path.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, JSON, API, Gatsby, Faust, Headless, Decoupled, Svelte, React, Nex
 Requires at least: 5.0
 Tested up to: 6.4.3
 Requires PHP: 7.1
-Stable tag: 1.22.0
+Stable tag: 1.22.1
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -251,6 +251,14 @@ The `uri` field was non-null on some Types in the Schema but has been changed to
 Composer dependencies are no longer versioned in Github. Recommended install source is WordPress.org or using Composer to get the code from Packagist.org or WPackagist.org.
 
 == Changelog ==
+
+= 1.22.1 =
+
+**Chores / Bugfixes**
+
+- [#3067](https://github.com/wp-graphql/wp-graphql/pull/3067): fix: respect show avatar setting
+- [#3063](https://github.com/wp-graphql/wp-graphql/pull/3063): fix: fixes a bug in cursor stability filters that could lead to empty order
+- [#3070](https://github.com/wp-graphql/wp-graphql/pull/3070): test(3063): Adds test for [#3063](https://github.com/wp-graphql/wp-graphql/pull/3063)
 
 = 1.22.0 =
 

--- a/src/Data/Config.php
+++ b/src/Data/Config.php
@@ -205,7 +205,7 @@ class Config {
 		$key    = $cursor->get_cursor_id_key();
 
 		// If there is a cursor compare in the arguments, use it as the stablizer for cursors.
-		return "{$orderby}, {$key} {$order}";
+		return ( $orderby ? "{$orderby}, " : '' ) . "{$key} {$order}";
 	}
 
 	/**
@@ -307,7 +307,7 @@ class Config {
 		$cursor = new UserCursor( $query->query_vars );
 		$key    = $cursor->get_cursor_id_key();
 
-		return "{$orderby}, {$key} {$order}";
+		return ( $orderby ? "{$orderby}, " : '' ) . "{$key} {$order}";
 	}
 
 	/**
@@ -420,7 +420,7 @@ class Config {
 			$pieces['where'] = $pieces['where'] . $before_cursor->get_where();
 		}
 
-		// Check the cursor compare order
+		// Check the cursor compare order.
 		$order = '>' === $args['graphql_cursor_compare'] ? 'ASC' : 'DESC';
 
 		// Get Cursor ID key.
@@ -428,8 +428,13 @@ class Config {
 		$key    = $cursor->get_cursor_id_key();
 
 		// If there is a cursor compare in the arguments, use it as the stabilizer for cursors.
-		$pieces['orderby'] = "{$pieces['orderby']} {$pieces['order']}, {$key} {$order}";
-		$pieces['order']   = '';
+		if ( ! empty( $pieces['orderby'] ) ) {
+			$pieces['orderby'] = "{$pieces['orderby']} {$pieces['order']}, {$key} {$order}";
+		} else {
+			$pieces['orderby'] = "ORDER BY {$key} {$order}";
+		}
+
+		$pieces['order'] = '';
 
 		return $pieces;
 	}

--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -352,7 +352,13 @@ class DataSource {
 			return null;
 		}
 
-		return new Avatar( $avatar );
+		$avatar = new Avatar( $avatar );
+
+		if ( 'private' === $avatar->get_visibility() ) {
+			return null;
+		}
+
+		return $avatar;
 	}
 
 	/**

--- a/src/Model/Avatar.php
+++ b/src/Model/Avatar.php
@@ -38,6 +38,14 @@ class Avatar extends Model {
 	}
 
 	/**
+	 * @return bool
+	 */
+	protected function is_private() {
+		$show_avatars = get_option( 'show_avatars' );
+		return ! (bool) $show_avatars;
+	}
+
+	/**
 	 * {@inheritDoc}
 	 */
 	protected function init() {

--- a/src/Utils/QueryAnalyzer.php
+++ b/src/Utils/QueryAnalyzer.php
@@ -14,9 +14,9 @@ use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Schema;
 use GraphQL\Utils\TypeInfo;
+use WPGraphQL;
 use WPGraphQL\Request;
 use WPGraphQL\WPSchema;
-use WPGraphQL;
 
 /**
  * This class is used to identify "keys" relevant to the GraphQL Request.

--- a/tests/wpunit/AvatarObjectQueriesTest.php
+++ b/tests/wpunit/AvatarObjectQueriesTest.php
@@ -95,6 +95,12 @@ class AvatarObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->assertEquals( $expected, $actual['data'] );
 
+		// set the option to false
+		update_option( 'show_avatars', 0 );
+		$actual = do_graphql_request( $query );
+		$this->assertEquals( null, $actual['data']['user']['avatar'] );
+
+		update_option( 'show_avatars', 1 );
 		// Clean up filter usage.
 		remove_filter( 'get_avatar_url', [ $this, 'avatar_test_url' ] );
 	}

--- a/tests/wpunit/TermObjectCursorTest.php
+++ b/tests/wpunit/TermObjectCursorTest.php
@@ -40,7 +40,7 @@ class TermObjectCursorTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 				'resolve'       => static function ( $source, $args, $context, $info ) {
 					global $wpdb;
 					$resolver = new TermObjectConnectionResolver( $source, $args, $context, $info, 'letter' );
-					
+
 					// Get cursor node
 					$cursor  = $args['after'] ?? null;
 					$cursor  = $cursor ?: ( $args['before'] ?? null );

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.22.0
+ * Version: 1.22.1
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.22.0
+ * @version  1.22.1
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
## Release Notes

### Chores / Bugfixes

- [#3067](https://github.com/wp-graphql/wp-graphql/pull/3067): fix: respect show avatar setting
- [#3063](https://github.com/wp-graphql/wp-graphql/pull/3063): fix: fixes a bug in cursor stability filters that could lead to empty order
- [#3070](https://github.com/wp-graphql/wp-graphql/pull/3070): test(3063): Adds test for [#3063](https://github.com/wp-graphql/wp-graphql/pull/3063)
