### PR TITLE
feat: expose `hasPassword` and `password` fields on Post objects

### DIFF
--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -51,6 +51,7 @@ use WP_Post;
  * @property array   $editLock
  * @property string  $enclosure
  * @property string  $guid
+ * @property bool    $hasPassword
  * @property int     $menuOrder
  * @property string  $link
  * @property string  $uri
@@ -58,6 +59,7 @@ use WP_Post;
  * @property string  $featuredImageId
  * @property int     $featuredImageDatabaseId
  * @property string  $pageTemplate
+ * @property string  $password
  * @property int     $previewRevisionDatabaseId
  *
  * @property string  $captionRaw
@@ -152,6 +154,7 @@ class Post extends Model {
 			'isPostsPage',
 			'isFrontPage',
 			'isPrivacyPage',
+			'hasPassword',
 		];
 
 		if ( isset( $this->post_type_object->graphql_single_name ) ) {

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -595,6 +595,12 @@ class Post extends Model {
 
 					return false;
 				},
+				'hasPassword'               => function () {
+					return ! empty( $this->data->post_password );
+				},
+				'password'                  => function () {
+					return ! empty( $this->data->post_password ) ? $this->data->post_password : null;
+				},
 				'toPing'                    => function () {
 					$to_ping = get_to_ping( $this->databaseId );
 
@@ -690,12 +696,6 @@ class Post extends Model {
 
 					return ! empty( $thumbnail_id ) ? absint( $thumbnail_id ) : null;
 				},
-				'password'                  => [
-					'callback'   => function () {
-						return ! empty( $this->data->post_password ) ? $this->data->post_password : null;
-					},
-					'capability' => isset( $this->post_type_object->cap->edit_others_posts ) ?: 'edit_others_posts',
-				],
 				'enqueuedScriptsQueue'      => static function () {
 					global $wp_scripts;
 					do_action( 'wp_enqueue_scripts' );

--- a/src/Registry/Utils/PostObject.php
+++ b/src/Registry/Utils/PostObject.php
@@ -360,6 +360,22 @@ class PostObject {
 					return absint( $post->ID );
 				},
 			],
+			'hasPassword'       => [
+				'type'        => 'Boolean',
+				'description' => sprintf(
+					// translators: %s: custom post-type name.
+					__( 'Whether the %s object is password protected.', 'wp-graphql' ),
+					$post_type_object->name
+				),
+			],
+			'password'          => [
+				'type'        => 'String',
+				'description' => sprintf(
+					// translators: %s: custom post-type name.
+					__( 'The password for the %s object.', 'wp-graphql' ),
+					$post_type_object->name
+				),
+			],
 		];
 
 		if ( 'page' === $post_type_object->name ) {

--- a/tests/wpunit/PostObjectQueriesTest.php
+++ b/tests/wpunit/PostObjectQueriesTest.php
@@ -2447,6 +2447,7 @@ class PostObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase 
 				content
 				status
 				password
+				hasPassword
 			}
 		}
 		';
@@ -2464,6 +2465,7 @@ class PostObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase 
 		$this->assertEquals( 'publish', $actual['data']['post']['status'], 'Status should be "publish" when unauthenticated' );
 		$this->assertNull( $actual['data']['post']['content'], 'Content should be null when unauthenticated' );
 		$this->assertNull( $actual['data']['post']['password'], 'Password should be null when unauthenticated' );
+		$this->assertTrue( $actual['data']['post']['hasPassword'], 'hasPassword should be true when unauthenticated' );
 
 		// Test password protected post as a subscriber.
 		wp_set_current_user( $subscriber );
@@ -2479,6 +2481,7 @@ class PostObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase 
 		$this->assertEquals( 'publish', $actual['data']['post']['status'], 'Status should be "publish" when lacking permissions' );
 		$this->assertNull( $actual['data']['post']['content'], 'Content should be null when lacking permissions' );
 		$this->assertNull( $actual['data']['post']['password'], 'Password should be null when lacking permissions' );
+		$this->assertTrue( $actual['data']['post']['hasPassword'], 'hasPassword should be true when lacking permissions' );
 
 		// Test password protected post as different author.
 		wp_set_current_user( $post_author_two );
@@ -2494,6 +2497,7 @@ class PostObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase 
 		$this->assertEquals( 'publish', $actual['data']['post']['status'], 'Status should be "publish" when lacking permissions' );
 		$this->assertNull( $actual['data']['post']['content'], 'Content should be null when lacking permissions' );
 		$this->assertNull( $actual['data']['post']['password'], 'Password should be null when lacking permissions' );
+		$this->assertTrue( $actual['data']['post']['hasPassword'], 'hasPassword should be true when lacking permissions' );
 
 		// Test password protected post as current author.
 		wp_set_current_user( $post_author_one );
@@ -2510,6 +2514,7 @@ class PostObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase 
 		$this->assertEquals( 'publish', $actual['data']['post']['status'], 'Status should be "publish" when authenticated' );
 		$this->assertNotEmpty( $actual['data']['post']['content'], 'Content should be returned when authenticated' );
 		$this->assertEquals( $post->post_password, $actual['data']['post']['password'], 'Password should be returned when authenticated' );
+		$this->assertTrue( $actual['data']['post']['hasPassword'], 'hasPassword should be true when authenticated' );
 
 		// Test password protected post as admin.
 		wp_set_current_user( $this->admin );
@@ -2526,6 +2531,7 @@ class PostObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase 
 		$this->assertEquals( 'publish', $actual['data']['post']['status'], 'Status should be "publish" when authenticated' );
 		$this->assertNotEmpty( $actual['data']['post']['content'], 'Content should be returned when authenticated' );
 		$this->assertEquals( $post->post_password, $actual['data']['post']['password'], 'Password should be returned when authenticated' );
+		$this->assertTrue( $actual['data']['post']['hasPassword'], 'hasPassword should be true when authenticated' );
 
 		// @todo add case with password supplied once supported.
 		// @see https://github.com/wp-graphql/wp-graphql/issues/930


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR exposes the `hasPassword` and `password` fields on Post objects.

It **does not** provide a mechanism to _provide_ a password, which will be handled in a separate PR.


Does this close any currently open issues?
------------------------------------------
<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

closes #3069 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
<!-- (If it’s long, please paste to https://ghostbin.com/ and insert the link here.) -->


Any other comments?
-------------------
Until #930 is addressed, password-protected posts require a WP cookie or the `edit_posts` capability. You can see that ticket for workarounds.


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (Wsl2 + devilbox + php 8.1.19)

**WordPress Version:** 6.4.3
