### PR TITLE
refactor: deprecate `camelCase` methods in `AbstractConnectionResolver` for `snake_case` equivalents

### DIFF
--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -145,7 +145,7 @@ abstract class AbstractConnectionResolver {
 		}
 
 		// Get the loader for the Connection.
-		$this->loader = $this->getLoader();
+		$this->loader = $this->get_loader();
 
 		/**
 		 *
@@ -185,15 +185,6 @@ abstract class AbstractConnectionResolver {
 	}
 
 	/**
-	 * Returns the source of the connection
-	 *
-	 * @return mixed
-	 */
-	public function getSource() {
-		return $this->source;
-	}
-
-	/**
 	 * Returns the $args passed to the connection.
 	 *
 	 * Useful for modifying the $args before they are passed to $this->get_query_args().
@@ -202,27 +193,6 @@ abstract class AbstractConnectionResolver {
 	 */
 	public function get_args(): array {
 		return $this->args;
-	}
-
-	/**
-	 * Returns the AppContext of the connection
-	 */
-	public function getContext(): AppContext {
-		return $this->context;
-	}
-
-	/**
-	 * Returns the ResolveInfo of the connection
-	 */
-	public function getInfo(): ResolveInfo {
-		return $this->info;
-	}
-
-	/**
-	 * Returns whether the connection should execute
-	 */
-	public function getShouldExecute(): bool {
-		return $this->should_execute;
 	}
 
 	/**
@@ -341,7 +311,6 @@ abstract class AbstractConnectionResolver {
 		return is_numeric( $offset ) ? absint( $offset ) : $offset;
 	}
 
-
 	/**
 	 * Validates Model.
 	 *
@@ -354,6 +323,36 @@ abstract class AbstractConnectionResolver {
 	 */
 	protected function is_valid_model( $model ) {
 		return isset( $model->fields ) && ! empty( $model->fields );
+	}
+
+	/**
+	 * Returns the source of the connection
+	 *
+	 * @return mixed
+	 */
+	public function get_source() {
+		return $this->source;
+	}
+
+	/**
+	 * Returns the AppContext of the connection.
+	 */
+	public function get_context(): AppContext {
+		return $this->context;
+	}
+
+	/**
+	 * Returns the ResolveInfo of the connection.
+	 */
+	public function get_info(): ResolveInfo {
+		return $this->info;
+	}
+
+	/**
+	 * Returns whether the connection should execute.
+	 */
+	public function get_should_execute(): bool {
+		return $this->should_execute;
 	}
 
 	/**
@@ -555,7 +554,7 @@ abstract class AbstractConnectionResolver {
 	 * @return \WPGraphQL\Data\Loader\AbstractDataLoader
 	 * @throws \Exception
 	 */
-	protected function getLoader() {
+	protected function get_loader() {
 		$name = $this->get_loader_name();
 		if ( empty( $name ) || ! is_string( $name ) ) {
 			throw new Exception( esc_html__( 'The Connection Resolver needs to define a loader name', 'wp-graphql' ) );
@@ -1008,5 +1007,65 @@ abstract class AbstractConnectionResolver {
 		$cursor = $cursor ?: ( $this->args['before'] ?? null );
 
 		return $this->get_offset_for_cursor( $cursor );
+	}
+
+	/**
+	 * Returns the source of the connection.
+	 *
+	 * @deprecated @todo in favor of $this->get_source().
+	 *
+	 * @return mixed
+	 */
+	public function getSource() {
+		_deprecated_function( __METHOD__, '@todo', static::class . '::get_source()' );
+
+		return $this->get_source();
+	}
+
+	/**
+	 * Returns the AppContext of the connection.
+	 *
+	 * @deprecated @todo in favor of $this->get_context().
+	 */
+	public function getContext(): AppContext {
+		_deprecated_function( __METHOD__, '@todo', static::class . '::get_context()' );
+
+		return $this->get_context();
+	}
+
+	/**
+	 * Returns the ResolveInfo of the connection.
+	 *
+	 * @deprecated @todo in favor of $this->get_info().
+	 */
+	public function getInfo(): ResolveInfo {
+		_deprecated_function( __METHOD__, '@todo', static::class . '::get_info()' );
+
+		return $this->get_info();
+	}
+
+	/**
+	 * Returns whether the connection should execute.
+	 *
+	 * @deprecated @todo in favor of $this->get_should_execute().
+	 */
+	public function getShouldExecute(): bool {
+		_deprecated_function( __METHOD__, '@todo', static::class . '::should_execute()' );
+
+		return $this->get_should_execute();
+	}
+
+	/**
+	 * Returns the loader.
+	 *
+	 * @deprecated @todo in favor of $this->get_loader().
+	 *
+	 * @return \WPGraphQL\Data\Loader\AbstractDataLoader
+	 * @throws \Exception
+	 */
+	protected function getLoader() {
+		_deprecated_function( __METHOD__, '@todo', static::class . '::get_loader()' );
+
+		return $this->get_loader();
 	}
 }

--- a/src/Data/Connection/CommentConnectionResolver.php
+++ b/src/Data/Connection/CommentConnectionResolver.php
@@ -12,7 +12,6 @@ use WP_Comment_Query;
  * @package WPGraphQL\Data\Connection
  */
 class CommentConnectionResolver extends AbstractConnectionResolver {
-
 	/**
 	 * {@inheritDoc}
 	 *
@@ -23,7 +22,7 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @throws \GraphQL\Error\UserError If there is a problem with the $args.
+	 * @throws \GraphQL\Error\UserError
 	 */
 	public function get_query_args() {
 
@@ -179,21 +178,6 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * {@inheritDoc}
-	 *
-	 * For example, if the $source were a post_type that didn't support comments, we could prevent
-	 * the connection query from even executing. In our case, we prevent comments from even showing
-	 * in the Schema for post types that don't have comment support, so we don't need to worry
-	 * about that, but there may be other situations where we'd need to prevent it.
-	 *
-	 * @return bool
-	 */
-	public function should_execute() {
-		return true;
-	}
-
-
-	/**
 	 * Filters the GraphQL args before they are used in get_query_args().
 	 *
 	 * @return array<string,mixed>
@@ -253,7 +237,6 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 		}
 
 		/**
-		 *
 		 * Filters the GraphQL args before they are used in get_query_args().
 		 *
 		 * @param array<string,mixed>                                  $args                The GraphQL args passed to the resolver.
@@ -328,5 +311,12 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 	 */
 	public function is_valid_offset( $offset ) {
 		return ! empty( get_comment( $offset ) );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function should_execute() {
+		return true;
 	}
 }

--- a/src/Data/Connection/ContentTypeConnectionResolver.php
+++ b/src/Data/Connection/ContentTypeConnectionResolver.php
@@ -40,7 +40,6 @@ class ContentTypeConnectionResolver extends AbstractConnectionResolver {
 		return [];
 	}
 
-
 	/**
 	 * {@inheritDoc}
 	 *

--- a/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
@@ -60,7 +60,6 @@ class EnqueuedScriptsConnectionResolver extends AbstractConnectionResolver {
 		return [];
 	}
 
-
 	/**
 	 * {@inheritDoc}
 	 *
@@ -78,11 +77,9 @@ class EnqueuedScriptsConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * Determine if the model is valid
+	 * {@inheritDoc}
 	 *
-	 * @param ?\_WP_Dependency $model
-	 *
-	 * @return bool
+	 * @param ?\_WP_Dependency $model The model to check.
 	 */
 	protected function is_valid_model( $model ) {
 		return isset( $model->handle );

--- a/src/Data/Connection/EnqueuedStylesheetConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedStylesheetConnectionResolver.php
@@ -41,9 +41,7 @@ class EnqueuedStylesheetConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * Get the IDs from the source
-	 *
-	 * @return mixed[]
+	 * {@inheritDoc}
 	 */
 	public function get_ids_from_query() {
 		$ids     = [];
@@ -68,9 +66,8 @@ class EnqueuedStylesheetConnectionResolver extends AbstractConnectionResolver {
 		return [];
 	}
 
-
 	/**
-	 * Get the items from the source
+	 * {@inheritDoc}
 	 *
 	 * @return string[]
 	 */
@@ -79,20 +76,16 @@ class EnqueuedStylesheetConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * The name of the loader to load the data
-	 *
-	 * @return string
+	 * {@inheritDoc}
 	 */
 	public function get_loader_name() {
 		return 'enqueued_stylesheet';
 	}
 
 	/**
-	 * Determine if the model is valid
+	 * {@inheritDoc}
 	 *
 	 * @param ?\_WP_Dependency $model
-	 *
-	 * @return bool
 	 */
 	protected function is_valid_model( $model ) {
 		return isset( $model->handle );
@@ -107,7 +100,7 @@ class EnqueuedStylesheetConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * D{@inheritDoc}
+	 * {@inheritDoc}
 	 */
 	public function should_execute() {
 		return true;

--- a/src/Data/Connection/PluginConnectionResolver.php
+++ b/src/Data/Connection/PluginConnectionResolver.php
@@ -4,7 +4,7 @@ namespace WPGraphQL\Data\Connection;
 /**
  * Class PluginConnectionResolver - Connects plugins to other objects
  *
- * @package WPGraphQL\Data\Resolvers
+ * @package WPGraphQL\Data\Connection
  * @since 0.0.5
  */
 class PluginConnectionResolver extends AbstractConnectionResolver {

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -28,6 +28,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	 * @var \WP_Query|object
 	 */
 	protected $query;
+
 	/**
 	 * {@inheritDoc}
 	 *
@@ -450,7 +451,6 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	 * @return string[]|null
 	 */
 	public function sanitize_post_stati( $stati ) {
-
 		/**
 		 * If no stati is explicitly set by the input, default to publish. This will be the
 		 * most common scenario.
@@ -572,7 +572,6 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		}
 
 		/**
-		 *
 		 * Filters the GraphQL args before they are used in get_query_args().
 		 *
 		 * @param array<string,mixed>                                     $args                The GraphQL args passed to the resolver.

--- a/src/Data/Connection/TaxonomyConnectionResolver.php
+++ b/src/Data/Connection/TaxonomyConnectionResolver.php
@@ -36,13 +36,13 @@ class TaxonomyConnectionResolver extends AbstractConnectionResolver {
 	 * {@inheritDoc}
 	 */
 	public function get_query_args() {
-		// If any args are added to filter/sort the connection
+		// If any args are added to filter/sort the connection.
 		return [];
 	}
 
 
 	/**
-	 * Get the items from the source
+	 * {@inheritDoc}
 	 *
 	 * @return string[]
 	 */

--- a/src/Data/Connection/TermObjectConnectionResolver.php
+++ b/src/Data/Connection/TermObjectConnectionResolver.php
@@ -52,7 +52,6 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 			$taxonomy             = array_intersect( $all_taxonomies, $requested_taxonomies );
 		}
 
-
 		$query_args = [
 			'taxonomy' => $taxonomy,
 		];
@@ -180,15 +179,6 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * {@inheritDoc}
-	 *
-	 * Default is true, meaning any time a TermObjectConnection resolver is asked for, it will execute.
-	 */
-	public function should_execute() {
-		return true;
-	}
-
-	/**
 	 * This maps the GraphQL "friendly" args to get_terms $args.
 	 * There's probably a cleaner/more dynamic way to approach this, but this was quick. I'd be down
 	 * to explore more dynamic ways to map this, but for now this gets the job done.
@@ -286,7 +276,6 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 		}
 
 		/**
-		 *
 		 * Filters the GraphQL args before they are used in get_query_args().
 		 *
 		 * @param array<string,mixed>                                     $args                The GraphQL args passed to the resolver.
@@ -305,5 +294,14 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 	 */
 	public function is_valid_offset( $offset ) {
 		return get_term( absint( $offset ) ) instanceof \WP_Term;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * Default is true, meaning any time a TermObjectConnection resolver is asked for, it will execute.
+	 */
+	public function should_execute() {
+		return true;
 	}
 }

--- a/src/Data/Connection/ThemeConnectionResolver.php
+++ b/src/Data/Connection/ThemeConnectionResolver.php
@@ -42,9 +42,8 @@ class ThemeConnectionResolver extends AbstractConnectionResolver {
 		];
 	}
 
-
 	/**
-	 * Get the items from the source
+	 * {@inheritDoc}
 	 *
 	 * @return string[]
 	 */

--- a/src/Data/Connection/UserConnectionResolver.php
+++ b/src/Data/Connection/UserConnectionResolver.php
@@ -23,13 +23,6 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function should_execute() {
-		return true;
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
 	public function get_loader_name() {
 		return 'user';
 	}
@@ -185,7 +178,7 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * Return an instance of the WP_User_Query with the args for the connection being executed
+	 * {@inheritDoc}
 	 *
 	 * @return object|\WP_User_Query
 	 * @throws \Exception
@@ -283,11 +276,16 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @param int $offset The ID of the node used as the offset in the cursor
-	 *
-	 * @return bool
+	 * @param int $offset The ID of the node used as the offset in the cursor.
 	 */
 	public function is_valid_offset( $offset ) {
 		return (bool) get_user_by( 'ID', absint( $offset ) );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function should_execute() {
+		return true;
 	}
 }


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR deprecates the following camelCased methods in `AbstractConnectionResolver` for their `snake_cased` equivalents. More specifically:

- `::getSource()` => `::get_source()`
- `::getContext()` => `::get_context()`
- `::getLoader()` => `::get_loader()`
- `::getInfo()`   => `::get_info()`
- `::getShouldExecute()` => `::get_should_execute()`

Does this close any currently open issues?
------------------------------------------
<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Part of #2749 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
<!-- (If it’s long, please paste to https://ghostbin.com/ and insert the link here.) -->


Any other comments?
-------------------

- 🚨 Don't forget to replace `@todo` with the version number before release.

> [!IMPORTANT]
> As these deprecation warnings will prompt developers to update code, we should **wait** to merge until other changes warrant their need to edit things (e.g. `prepare_*` methods), such as #3088.
>
> _After_ #3082 is merged to `develop`, it might make sense to create a ConnectionResolver-specific branch, so we can group this PR with others that recommend developers update their code, so they don't need to update their child classes in multiple successive releases.

Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php 8.1.15)

**WordPress Version:** 6.4.3
