### PR TITLE
refactor: add `AbstractConnectionResolver::get_unfiltered_args()` public getter

### DIFF
--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -25,7 +25,16 @@ abstract class AbstractConnectionResolver {
 	protected $source;
 
 	/**
+	 * The args input before it is filtered and prepared by the constructor.
+	 *
+	 * @var array<string,mixed>
+	 */
+	protected $unfiltered_args;
+
+	/**
 	 * The args input on the field calling the connection.
+	 *
+	 * Filterable by `graphql_connection_args`.
 	 *
 	 * @var array<string,mixed>
 	 */
@@ -134,10 +143,16 @@ abstract class AbstractConnectionResolver {
 	 */
 	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info ) {
 		// Set the source (the root object), context, resolveInfo, and unfiltered args for the resolver.
-		$this->source  = $source;
-		$this->args    = $args;
-		$this->context = $context;
-		$this->info    = $info;
+		$this->source          = $source;
+		$this->unfiltered_args = $args;
+		$this->context         = $context;
+		$this->info            = $info;
+
+		/**
+		 * @todo This exists for b/c, where extenders may be directly accessing `$this->args` in ::get_loader() or even `::get_args()`.
+		 * We can remove this once the rest of lifecyle has been updated.
+		 */
+		$this->args = $args; 
 
 		// Bail if the Post->ID is empty, as that indicates a private post.
 		if ( $source instanceof Post && empty( $source->ID ) ) {
@@ -157,7 +172,7 @@ abstract class AbstractConnectionResolver {
 		 *
 		 * @since 1.11.0
 		 */
-		$this->args = apply_filters( 'graphql_connection_args', $this->get_args(), $this, $args );
+		$this->args = apply_filters( 'graphql_connection_args', $this->get_args(), $this, $this->get_unfiltered_args() );
 
 		/**
 		 * Determine the query amount for the resolver.
@@ -354,6 +369,15 @@ abstract class AbstractConnectionResolver {
 	 */
 	protected function is_valid_model( $model ) {
 		return isset( $model->fields ) && ! empty( $model->fields );
+	}
+
+	/**
+	 * Returns the $args passed to the connection, before any modifications.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public function get_unfiltered_args(): array {
+		return $this->unfiltered_args;
 	}
 
 	/**

--- a/src/Data/Connection/CommentConnectionResolver.php
+++ b/src/Data/Connection/CommentConnectionResolver.php
@@ -183,7 +183,7 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 	 * @return array<string,mixed>
 	 */
 	public function get_args(): array {
-		$args = $this->args;
+		$args = $this->get_unfiltered_args();
 
 		if ( ! empty( $args['where'] ) ) {
 			// Ensure all IDs are converted to database IDs.

--- a/src/Data/Connection/MenuItemConnectionResolver.php
+++ b/src/Data/Connection/MenuItemConnectionResolver.php
@@ -80,7 +80,7 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 	 * {@inheritDoc}
 	 */
 	public function get_args(): array {
-		$args = $this->args;
+		$args = $this->get_unfiltered_args();
 
 		if ( ! empty( $args['where'] ) ) {
 			// Ensure all IDs are converted to database IDs.
@@ -106,6 +106,6 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 		 *
 		 * @since 1.11.0
 		 */
-		return apply_filters( 'graphql_menu_item_connection_args', $args, $this->args );
+		return apply_filters( 'graphql_menu_item_connection_args', $args, $this->get_unfiltered_args() );
 	}
 }

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -533,7 +533,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	 * {@inheritDoc}
 	 */
 	public function get_args(): array {
-		$args = $this->args;
+		$args = $this->get_unfiltered_args();
 
 		if ( ! empty( $args['where'] ) ) {
 			// Ensure all IDs are converted to database IDs.
@@ -580,7 +580,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		 *
 		 * @since 1.11.0
 		 */
-		return apply_filters( 'graphql_post_object_connection_args', $args, $this, $this->args );
+		return apply_filters( 'graphql_post_object_connection_args', $args, $this, $this->get_unfiltered_args() );
 	}
 
 	/**

--- a/src/Data/Connection/TermObjectConnectionResolver.php
+++ b/src/Data/Connection/TermObjectConnectionResolver.php
@@ -243,7 +243,7 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 	 * {@inheritDoc}
 	 */
 	public function get_args(): array {
-		$args = $this->args;
+		$args = $this->get_unfiltered_args();
 
 		if ( ! empty( $args['where'] ) ) {
 			// Ensure all IDs are converted to database IDs.
@@ -284,7 +284,7 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 		 *
 		 * @since 1.11.0
 		 */
-		return apply_filters( 'graphql_term_object_connection_args', $args, $this, $this->args );
+		return apply_filters( 'graphql_term_object_connection_args', $args, $this, $this->get_unfiltered_args() );
 	}
 
 	/**


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR adds the public `get_unfiltered_args()` method to `AbstractConnectionResolver` for fetching the GraphQL `$args` before they have been modified by any filters/side effects.

Additionally child classes that were using an unmodified local copy of `$args` have been updated to use `::get_unfiltered_args()` instead.


Does this close any currently open issues?
------------------------------------------
<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Part of #2749

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
<!-- (If it’s long, please paste to https://ghostbin.com/ and insert the link here.) -->


Any other comments?
-------------------
- This PR is based on https://github.com/wp-graphql/wp-graphql/pull/3082 , which should be merged first.
- Despite the new `AbstractConnectionResolver::$unfiltered_args` property/getter, we are still setting `$this->args` in the constructor multiple times (for backwards compatibility). This will be addressed in a future PR.
- Similarly, the new public getter obviates the need for the `$unfiltered_args` parameter on several filters, and those will be deprecated in a future PR as well.


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php 8.1.15)

**WordPress Version:** 6.4.3
