### PR TITLE
feat: improve query amount handling in `AbstractConnectionResolver`

### DIFF
--- a/src/Data/Connection/CommentConnectionResolver.php
+++ b/src/Data/Connection/CommentConnectionResolver.php
@@ -29,8 +29,7 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 		/**
 		 * Prepare for later use
 		 */
-		$last  = ! empty( $this->args['last'] ) ? $this->args['last'] : null;
-		$first = ! empty( $this->args['first'] ) ? $this->args['first'] : null;
+		$last = ! empty( $this->args['last'] ) ? $this->args['last'] : null;
 
 		$query_args = [];
 
@@ -49,7 +48,7 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 		 *
 		 * @since 0.0.6
 		 */
-		$query_args['number'] = min( max( absint( $first ), absint( $last ), 10 ), $this->get_query_amount() ) + 1;
+		$query_args['number'] = $this->get_query_amount() + 1;
 
 		/**
 		 * Set the default order

--- a/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
@@ -1,39 +1,12 @@
 <?php
 namespace WPGraphQL\Data\Connection;
 
-use GraphQL\Type\Definition\ResolveInfo;
-use WPGraphQL\AppContext;
-
 /**
  * Class EnqueuedScriptsConnectionResolver
  *
  * @package WPGraphQL\Data\Connection
  */
 class EnqueuedScriptsConnectionResolver extends AbstractConnectionResolver {
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info ) {
-
-		/**
-		 * Filter the query amount to be 1000 for
-		 */
-		add_filter(
-			'graphql_connection_max_query_amount',
-			static function ( $max, $source, $args, $context, ResolveInfo $info ) {
-				if ( 'enqueuedScripts' === $info->fieldName || 'registeredScripts' === $info->fieldName ) {
-					return 1000;
-				}
-				return $max;
-			},
-			10,
-			5
-		);
-
-		parent::__construct( $source, $args, $context, $info );
-	}
-
 	/**
 	 * {@inheritDoc}
 	 */
@@ -74,6 +47,13 @@ class EnqueuedScriptsConnectionResolver extends AbstractConnectionResolver {
 	 */
 	public function get_loader_name() {
 		return 'enqueued_script';
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function max_query_amount(): int {
+		return 1000;
 	}
 
 	/**

--- a/src/Data/Connection/EnqueuedStylesheetConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedStylesheetConnectionResolver.php
@@ -1,9 +1,6 @@
 <?php
 namespace WPGraphQL\Data\Connection;
 
-use GraphQL\Type\Definition\ResolveInfo;
-use WPGraphQL\AppContext;
-
 /**
  * Class EnqueuedStylesheetConnectionResolver
  *
@@ -16,29 +13,6 @@ class EnqueuedStylesheetConnectionResolver extends AbstractConnectionResolver {
 	 * @var string[]
 	 */
 	protected $query;
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info ) {
-
-		/**
-		 * Filter the query amount to be 1000 for
-		 */
-		add_filter(
-			'graphql_connection_max_query_amount',
-			static function ( $max, $source, $args, $context, ResolveInfo $info ) {
-				if ( 'enqueuedStylesheets' === $info->fieldName || 'registeredStylesheets' === $info->fieldName ) {
-					return 1000;
-				}
-				return $max;
-			},
-			10,
-			5
-		);
-
-		parent::__construct( $source, $args, $context, $info );
-	}
 
 	/**
 	 * {@inheritDoc}
@@ -80,6 +54,13 @@ class EnqueuedStylesheetConnectionResolver extends AbstractConnectionResolver {
 	 */
 	public function get_loader_name() {
 		return 'enqueued_stylesheet';
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function max_query_amount(): int {
+		return 1000;
 	}
 
 	/**

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -149,8 +149,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		/**
 		 * Prepare for later use
 		 */
-		$last  = ! empty( $this->args['last'] ) ? $this->args['last'] : null;
-		$first = ! empty( $this->args['first'] ) ? $this->args['first'] : null;
+		$last = ! empty( $this->args['last'] ) ? $this->args['last'] : null;
 
 		$query_args = [];
 		/**
@@ -176,10 +175,10 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		/**
 		 * Set posts_per_page the highest value of $first and $last, with a (filterable) max of 100
 		 */
-		$query_args['posts_per_page'] = $this->one_to_one ? 1 : min( max( absint( $first ), absint( $last ), 10 ), $this->query_amount ) + 1;
+		$query_args['posts_per_page'] = $this->one_to_one ? 1 : $this->get_query_amount() + 1;
 
 		// set the graphql cursor args
-		$query_args['graphql_cursor_compare'] = ( ! empty( $last ) ) ? '>' : '<';
+		$query_args['graphql_cursor_compare'] = ! empty( $last ) ? '>' : '<';
 		$query_args['graphql_after_cursor']   = $this->get_after_offset();
 		$query_args['graphql_before_cursor']  = $this->get_before_offset();
 

--- a/src/Data/Connection/TermObjectConnectionResolver.php
+++ b/src/Data/Connection/TermObjectConnectionResolver.php
@@ -59,8 +59,7 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 		/**
 		 * Prepare for later use
 		 */
-		$last  = ! empty( $this->args['last'] ) ? $this->args['last'] : null;
-		$first = ! empty( $this->args['first'] ) ? $this->args['first'] : null;
+		$last = ! empty( $this->args['last'] ) ? $this->args['last'] : null;
 
 		/**
 		 * Set hide_empty as false by default
@@ -70,7 +69,7 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 		/**
 		 * Set the number, ensuring it doesn't exceed the amount set as the $max_query_amount
 		 */
-		$query_args['number'] = min( max( absint( $first ), absint( $last ), 10 ), $this->query_amount ) + 1;
+		$query_args['number'] = $this->get_query_amount() + 1;
 
 		/**
 		 * Don't calculate the total rows, it's not needed and can be expensive

--- a/tests/wpunit/PostObjectConnectionQueriesTest.php
+++ b/tests/wpunit/PostObjectConnectionQueriesTest.php
@@ -153,7 +153,7 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 
 	public function testMaxQueryAmount() {
 		// Create some additional posts to test a large query.
-		$this->create_posts( 150 );
+		$post_ids = $this->create_posts( 150 );
 
 		$query = $this->getQuery();
 
@@ -186,16 +186,65 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		add_filter(
-			'graphql_connection_max_query_amount',
-			static function () {
-				return 100;
-			}
-		);
-
 		$this->assertCount( 20, $actual['data']['posts']['edges'] );
 		$this->assertTrue( $actual['data']['posts']['pageInfo']['hasNextPage'] );
 		$this->assertStringContainsString( 'The number of items requested by the connection (150) exceeds the max query amount.', $actual['extensions']['debug'][0]['message'] );
+
+		// Cleanup
+		remove_all_filters( 'graphql_connection_max_query_amount' );
+		foreach( $post_ids as $post_id ) {
+			wp_delete_post( $post_id, true );
+		}
+	}
+
+	public function testDefaultQueryAmount() {
+		// Create some additional posts to test a large query.
+		$post_ids = $this->create_posts( 25 );
+
+		$query = $this->getQuery();
+
+		$variables = [
+			'first' => null,
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+		$this->assertNotEmpty( $actual );
+
+		/**
+		 * The default that can be queried by default is 10 items
+		 */
+		$this->assertCount( 10, $actual['data']['posts']['edges'], '10 items should be returned by default' );
+
+		/**
+		 * Test the filter to make sure it's defaulting the results properly
+		 */
+		add_filter(
+			'graphql_connection_default_query_amount',
+			static function () {
+				return 20;
+			}
+		);
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertCount( 20, $actual['data']['posts']['edges'], '20 items should be returned by default' );
+
+		add_filter(
+			'graphql_connection_default_query_amount',
+			static function () {
+				return 5;
+			}
+		);
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertCount( 5, $actual['data']['posts']['edges'], '5 items should be returned by default' );
+
+		// Cleanup
+		remove_all_filters( 'graphql_connection_max_query_amount' );
+		foreach( $post_ids as $post_id ) {
+			wp_delete_post( $post_id, true );
+		}
 	}
 
 	/**


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR refactors how `AbstractConnectionResolver` calculates the query amount in the following ways:
- Refactor `::get_query_amount()`  to only calculate the query amount 1x in the lifecycle, by checking if `AbstractConnectionResolver::$query_amount` is set.
- Source the default `$max_query_amount` from `::max_query_amount()`, allowing child classes to overload the max amount without using the `graphql_connection_max_query_amount` filter. Child classes using that filter have been updated to set `::max_query_amount()` instead.
- Move the `graphql_connection_amount_requested` filter into `::get_query_amount()` to improve DX. The filter will only be applied once due to the aformentioned `isset()`.
- Add a `graphql_connection_default_query_amount` filter, for changing the default query amount when no `first` or `last` argument is passed to the query.
- DRYout `::get_amount_requested()`.
- Replace direct calls to `::$query_amount` with `::get_query_amount()`.
- Fixed logic in several `::get_query_args()` child methods to rely on `::get_query_amount()` and avoid unnecessary `min()`/`max()`ing.

There are **no breaking changes** in this release.


Does this close any currently open issues?
------------------------------------------
<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Part of #2749 

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
<!-- (If it’s long, please paste to https://ghostbin.com/ and insert the link here.) -->


Any other comments?
-------------------
- The reason this is _not_ a breaking change is that `get_query_amount()` is called both in `::get_args()` and in the constructor, so there is no possibility of `::$query_amount` being `null` in the child class. Since the types and method signatures, overloaded classes will work as they do currently, making the enhancements in this PR essentially opt-in (i.e. devs can refactor at their leisure).
- This PR is based on https://github.com/wp-graphql/wp-graphql/pull/3082 , which should be merged first.


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php 8.1.15)

**WordPress Version:** 6.4.3
