### PR TITLE
refactor: improve `loader` handling in `AbstractConnectionResolver`

### DIFF
--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -60,9 +60,18 @@ abstract class AbstractConnectionResolver {
 	protected $should_execute = true;
 
 	/**
+	 * The loader name.
+	 *
+	 * Defaults to `loader_name()` and filterable by `graphql_connection_loader_name`.
+	 *
+	 * @var ?string
+	 */
+	protected $loader_name;
+
+	/**
 	 * The loader the resolver is configured to use.
 	 *
-	 * @var \WPGraphQL\Data\Loader\AbstractDataLoader
+	 * @var ?\WPGraphQL\Data\Loader\AbstractDataLoader
 	 */
 	protected $loader;
 
@@ -185,6 +194,17 @@ abstract class AbstractConnectionResolver {
 	}
 
 	/**
+	 * The name of the loader to use for this connection.
+	 *
+	 * Filterable by `graphql_connection_loader_name`.
+	 *
+	 * @todo This is protected for backwards compatibility, but should be abstract and implemented by the child classes.
+	 */
+	protected function loader_name(): string {
+		return '';
+	}
+
+	/**
 	 * Returns the $args passed to the connection.
 	 *
 	 * Useful for modifying the $args before they are passed to $this->get_query_args().
@@ -194,15 +214,6 @@ abstract class AbstractConnectionResolver {
 	public function get_args(): array {
 		return $this->args;
 	}
-
-	/**
-	 * Get_loader_name
-	 *
-	 * Return the name of the loader to be used with the connection resolver
-	 *
-	 * @return string
-	 */
-	abstract public function get_loader_name();
 
 	/**
 	 * Get_query_args
@@ -346,6 +357,51 @@ abstract class AbstractConnectionResolver {
 	 */
 	public function get_info(): ResolveInfo {
 		return $this->info;
+	}
+
+	/**
+	 * Returns the loader name.
+	 *
+	 * If $loader_name is not initialized, this plugin will initialize it.
+	 *
+	 * @return string
+	 *
+	 * @throws \Exception
+	 */
+	public function get_loader_name() {
+		// Only initialize the loader_name property once.
+		if ( ! isset( $this->loader_name ) ) {
+			$name = $this->loader_name();
+
+			// This is a b/c check because `loader_name()` is not abstract.
+			if ( empty( $name ) ) {
+				throw new \Exception(
+					sprintf(
+						// translators: %s is the name of the connection resolver class.
+						esc_html__( 'Class %s does not implement a valid method `loader_name()`.', 'wp-graphql' ),
+						esc_html( static::class )
+					)
+				);
+			}
+
+			/**
+			 * Filters the loader name.
+			 * This is the name of the registered DataLoader that will be used to load the data for the connection.
+			 *
+			 * @param string $loader_name The name of the loader.
+			 * @param self   $resolver    The AbstractConnectionResolver instance.
+			 */
+			$name = apply_filters( 'graphql_connection_loader_name', $name, $this );
+
+			// Bail if the loader name is invalid.
+			if ( empty( $name ) || ! is_string( $name ) ) {
+				throw new \Exception( esc_html__( 'The Connection Resolver needs to define a loader name', 'wp-graphql' ) );
+			}
+
+			$this->loader_name = $name;
+		}
+
+		return $this->loader_name;
 	}
 
 	/**
@@ -551,16 +607,19 @@ abstract class AbstractConnectionResolver {
 	/**
 	 * Returns the loader.
 	 *
+	 * If $loader is not initialized, this method will initialize it.
+	 *
 	 * @return \WPGraphQL\Data\Loader\AbstractDataLoader
-	 * @throws \Exception
 	 */
 	protected function get_loader() {
-		$name = $this->get_loader_name();
-		if ( empty( $name ) || ! is_string( $name ) ) {
-			throw new Exception( esc_html__( 'The Connection Resolver needs to define a loader name', 'wp-graphql' ) );
+		// If the loader isn't set, set it.
+		if ( ! isset( $this->loader ) ) {
+			$name = $this->get_loader_name();
+
+			$this->loader = $this->context->get_loader( $name );
 		}
 
-		return $this->context->get_loader( $name );
+		return $this->loader;
 	}
 
 	/**
@@ -634,7 +693,7 @@ abstract class AbstractConnectionResolver {
 		return new Deferred(
 			function () {
 				if ( ! empty( $this->ids ) ) {
-					$this->loader->load_many( $this->ids );
+					$this->get_loader()->load_many( $this->ids );
 				}
 
 				/**
@@ -748,7 +807,7 @@ abstract class AbstractConnectionResolver {
 		/**
 		 * Buffer the IDs for deferred resolution
 		 */
-		$this->loader->buffer( $this->ids );
+		$this->get_loader()->buffer( $this->ids );
 
 		return $this->ids;
 	}
@@ -846,7 +905,7 @@ abstract class AbstractConnectionResolver {
 	 * @throws \Exception
 	 */
 	public function get_node_by_id( $id ) {
-		return $this->loader->load( $id );
+		return $this->get_loader()->load( $id );
 	}
 
 	/**

--- a/src/Data/Connection/CommentConnectionResolver.php
+++ b/src/Data/Connection/CommentConnectionResolver.php
@@ -158,7 +158,7 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function get_loader_name() {
+	protected function loader_name(): string {
 		return 'comment';
 	}
 

--- a/src/Data/Connection/ContentTypeConnectionResolver.php
+++ b/src/Data/Connection/ContentTypeConnectionResolver.php
@@ -61,7 +61,7 @@ class ContentTypeConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function get_loader_name() {
+	protected function loader_name(): string {
 		return 'post_type';
 	}
 

--- a/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
@@ -72,7 +72,7 @@ class EnqueuedScriptsConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function get_loader_name() {
+	protected function loader_name(): string {
 		return 'enqueued_script';
 	}
 

--- a/src/Data/Connection/EnqueuedStylesheetConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedStylesheetConnectionResolver.php
@@ -78,7 +78,7 @@ class EnqueuedStylesheetConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function get_loader_name() {
+	protected function loader_name(): string {
 		return 'enqueued_stylesheet';
 	}
 

--- a/src/Data/Connection/PluginConnectionResolver.php
+++ b/src/Data/Connection/PluginConnectionResolver.php
@@ -222,7 +222,7 @@ class PluginConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function get_loader_name() {
+	protected function loader_name(): string {
 		return 'plugin';
 	}
 

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -69,7 +69,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function get_loader_name() {
+	protected function loader_name(): string {
 		return 'post';
 	}
 

--- a/src/Data/Connection/TaxonomyConnectionResolver.php
+++ b/src/Data/Connection/TaxonomyConnectionResolver.php
@@ -62,7 +62,7 @@ class TaxonomyConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function get_loader_name() {
+	protected function loader_name(): string {
 		return 'taxonomy';
 	}
 

--- a/src/Data/Connection/TermObjectConnectionResolver.php
+++ b/src/Data/Connection/TermObjectConnectionResolver.php
@@ -174,7 +174,7 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function get_loader_name() {
+	protected function loader_name(): string {
 		return 'term';
 	}
 

--- a/src/Data/Connection/ThemeConnectionResolver.php
+++ b/src/Data/Connection/ThemeConnectionResolver.php
@@ -56,7 +56,7 @@ class ThemeConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function get_loader_name() {
+	protected function loader_name(): string {
 		return 'theme';
 	}
 

--- a/src/Data/Connection/UserConnectionResolver.php
+++ b/src/Data/Connection/UserConnectionResolver.php
@@ -23,7 +23,7 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function get_loader_name() {
+	protected function loader_name(): string {
 		return 'user';
 	}
 

--- a/src/Data/Connection/UserRoleConnectionResolver.php
+++ b/src/Data/Connection/UserRoleConnectionResolver.php
@@ -57,14 +57,14 @@ class UserRoleConnectionResolver extends AbstractConnectionResolver {
 	 */
 	public function get_query() {
 		$wp_roles = wp_roles();
-		
+
 		return ! empty( $wp_roles->get_names() ) ? array_keys( $wp_roles->get_names() ) : [];
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public function get_loader_name() {
+	protected function loader_name(): string {
 		return 'user_role';
 	}
 


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR refactors the way `AbstractConnectionResolver` handles `DataLoader`s. More specifically:
- Child classes now define their loader names in `::loader_name()`
- `::get_loader_name()` is no longer an `abstract` method, and instead calls `::loader_name()` if it has not already been set as a class property.
- Added a new `graphql_connection_loader_name` filter to more easily apply custom data loaders to an existing Connection Resolver (e.g. CPT-specific).
- The `AbstractConnectionResolver::$loader` property now only gets instantiated once, no matter how many times `::get_loader()` is called. As a result, all direct calls to `::$loader` have been replaced with `::get_loader()`.
- The overloaded `::get_loader_name()` methods in the child classes have been replaced with `::loader_name()`.

There are *no breaking changes* in this PR.


Does this close any currently open issues?
------------------------------------------
<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Part of #2749 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
<!-- (If it’s long, please paste to https://ghostbin.com/ and insert the link here.) -->


Any other comments?
-------------------
- This PR is based on #3083 , which should be merged first.
- Due to the way these changes are implemented, this PR is fully backwards compatible. Developers will be able to update their classes at their leisure to "opt in" to the new features like no instantiation, global filters, etc.


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + 8.1.15)

**WordPress Version:** 6.4.3
