### PR TITLE
feat: introduce actions and filters for GraphQL Admin Notices

### DIFF
--- a/src/Admin/AdminNotices.php
+++ b/src/Admin/AdminNotices.php
@@ -249,6 +249,16 @@ class AdminNotices {
 		</style>
 		<?php
 		$count = 0;
+
+		/**
+		 * Fires before the admin notices are rendered.
+		 *
+		 * @param array<mixed> $notices The notices to be rendered
+		 *
+		 * @since todo
+		 */
+		do_action( 'graphql_admin_notices_render_notices', $notices );
+
 		foreach ( $notices as $notice_slug => $notice ) {
 			$type = $notice['type'] ?? 'info';
 			?>
@@ -260,7 +270,7 @@ class AdminNotices {
 			<div id="wpgraphql-admin-notice-<?php echo esc_attr( $notice_slug ); ?>" class="wpgraphql-admin-notice notice notice-<?php echo esc_attr( $type ); ?> <?php echo $this->is_notice_dismissable( $notice ) ? 'is-dismissable' : ''; ?>">
 				<p><?php echo ! empty( $notice['message'] ) ? wp_kses_post( $notice['message'] ) : ''; ?></p>
 				<?php
-				if ( $this->is_notice_dismissable( $notice ) ) {
+				if ( $is_dismissable = $this->is_notice_dismissable( $notice ) ) {
 					$dismiss_acf_nonce = wp_create_nonce( 'wpgraphql_disable_notice_nonce' );
 					$dismiss_url       = add_query_arg(
 						[
@@ -275,6 +285,17 @@ class AdminNotices {
 				<?php } ?>
 			</div>
 			<?php
+			/**
+			 * Fires for each admin notice that is rendered.
+			 *
+			 * @param string $notice_slug The slug of the notice
+			 * @param array<mixed> $notice The notice to be rendered
+			 * @param bool $is_dismissable Whether the notice is dismissable or not
+			 * @param int $count The count of the notice
+			 *
+			 * @since todo
+			 */
+			do_action( 'graphql_admin_notices_render_notice', $notice_slug, $notice, $is_dismissable, $count );
 			++$count;
 		}
 	}
@@ -301,7 +322,19 @@ class AdminNotices {
 
 		$current_page_id = $screen->id;
 
-		return in_array( $current_page_id, $allowed_pages, true );
+		$is_plugin_scoped_page = in_array( $current_page_id, $allowed_pages, true );
+
+		/**
+		 * Filter to determine if the current admin page is within the scope of the plugin's own pages.
+		 * This filter can be used to add additional pages to the list of allowed pages.
+		 *
+		 * The filter receives the following arguments:
+		 *
+		 * @param bool $is_plugin_scoped_page True if the current page is within scope of the plugin's pages.
+		 * @param string $current_page_id The ID of the current admin page.
+		 * @param array<string> $allowed_pages The list of allowed pages.
+		 */
+		return apply_filters( 'graphql_admin_notices_is_plugin_scoped_page', $is_plugin_scoped_page, $current_page_id, $allowed_pages );
 	}
 
 	/**

--- a/src/Admin/AdminNotices.php
+++ b/src/Admin/AdminNotices.php
@@ -323,7 +323,7 @@ class AdminNotices {
 
 		$current_page_id = $screen->id;
 
-		$is_plugin_scoped_page = in_array( $current_page_id, $allowed_pages, true );
+		$is_allowed_admin_page = in_array( $current_page_id, $allowed_pages, true );
 
 		/**
 		 * Filter to determine if the current admin page is within the scope of the plugin's own pages.
@@ -335,7 +335,7 @@ class AdminNotices {
 		 * @param string $current_page_id The ID of the current admin page.
 		 * @param array<string> $allowed_pages The list of allowed pages.
 		 */
-		return apply_filters( 'graphql_admin_notices_is_plugin_scoped_page', $is_plugin_scoped_page, $current_page_id, $allowed_pages );
+		return apply_filters( 'graphql_admin_notices_is_allowed_admin_page', $is_allowed_admin_page, $current_page_id, $allowed_pages );
 	}
 
 	/**

--- a/src/Admin/AdminNotices.php
+++ b/src/Admin/AdminNotices.php
@@ -270,7 +270,8 @@ class AdminNotices {
 			<div id="wpgraphql-admin-notice-<?php echo esc_attr( $notice_slug ); ?>" class="wpgraphql-admin-notice notice notice-<?php echo esc_attr( $type ); ?> <?php echo $this->is_notice_dismissable( $notice ) ? 'is-dismissable' : ''; ?>">
 				<p><?php echo ! empty( $notice['message'] ) ? wp_kses_post( $notice['message'] ) : ''; ?></p>
 				<?php
-				if ( $is_dismissable = $this->is_notice_dismissable( $notice ) ) {
+				$is_dismissable = $this->is_notice_dismissable( $notice );
+				if ( $is_dismissable ) {
 					$dismiss_acf_nonce = wp_create_nonce( 'wpgraphql_disable_notice_nonce' );
 					$dismiss_url       = add_query_arg(
 						[

--- a/src/Admin/AdminNotices.php
+++ b/src/Admin/AdminNotices.php
@@ -253,7 +253,7 @@ class AdminNotices {
 		/**
 		 * Fires before the admin notices are rendered.
 		 *
-		 * @param array<mixed> $notices The notices to be rendered
+		 * @param array<string,mixed> $notices The notices to be rendered
 		 *
 		 * @since todo
 		 */


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR introduces the following:

- `graphql_admin_notices_render_notices` action
- `graphql_admin_notices_render_notice` action
- `graphql_admin_notices_is_plugin_scoped_page` filter

These actions and filters enable 3rd party codebases to hook into the rendering of admin notices registered via `register_graphql_admin_notice` and modify things like: 

- which page(s) the notices can be displayed on
- styles applied to the notices

Does this close any currently open issues?
------------------------------------------
closes #3090 

Any other comments?
-------------------
While working on the new WPGraphQL IDE (https://github.com/wp-graphql/wpgraphql-ide) I wanted to add support for the admin notices registered via `register_graphql_admin_notice()` but because of the lack of actions/filters I was not able to add proper support without modifying core WPGraphQL. 

By introducing these actions/filters I can now add support for GraphQL Admin Notices to additional pages, such as the new IDE.

ex: 

![CleanShot 2024-04-03 at 12 16 24](https://github.com/wp-graphql/wp-graphql/assets/1260765/86d56133-d056-4d55-bfeb-909ce740e989)
