### PR TITLE
release: v1.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 1.24.0
+
+### Upgrade Notice
+
+The AbstractConnectionResolver has undergone some refactoring. Some methods using `snakeCase` have been deprecated in favor of their `camel_case` equivalent. While we've preserved the deprecated methods to prevent breaking changes, you might begin seeing PHP notices about the deprecations. Any plugin that extends the AbstractConnectionResolver should update the following methods:
+
+- `getSource` -> `get_source`
+- `getContext` -> `get_context`
+- `getInfo` -> `get_info`
+- `getShouldExecute` -> `get_should_execute`
+- `getLoader` -> `getLoader`
+
+### New Features
+
+- [#3084](https://github.com/wp-graphql/wp-graphql/pull/3084): perf: refactor PluginConnectionResolver to only fetch plugins once. Thanks @justlevine!
+- [#3088](https://github.com/wp-graphql/wp-graphql/pull/3088): refactor: improve loader handling in AbstractConnectionResolver. Thanks @justlevine!
+- [#3087](https://github.com/wp-graphql/wp-graphql/pull/3087): feat: improve query amount handling in AbstractConnectionResolver. Thanks @justlevine!
+- [#3086](https://github.com/wp-graphql/wp-graphql/pull/3086): refactor: add AbstractConnectionResolver::get_unfiltered_args() public getter. Thanks @justlevine!
+- [#3085](https://github.com/wp-graphql/wp-graphql/pull/3085): refactor: add AbstractConnectionResolver::prepare_page_info()and only instantiate once. Thanks @justlevine!
+- [#3083](https://github.com/wp-graphql/wp-graphql/pull/3083): refactor: deprecate camelCase methods in AbstractConnectionResolver for snake_case equivalents. Thanks @justlevine!
+
+
+### Chores / Bugfixes
+
+- [#3095](https://github.com/wp-graphql/wp-graphql/pull/3095): chore: lint for superfluous whitespace. Thanks @justlevine!
+- [#3100](https://github.com/wp-graphql/wp-graphql/pull/3100): fix: recursion issues with interfaces
+- [#3082](https://github.com/wp-graphql/wp-graphql/pull/3082): chore: prepare ConnectionResolver classes for v2 backport
+
 ## 1.23.0
 
 ### New Features

--- a/constants.php
+++ b/constants.php
@@ -18,7 +18,7 @@ function graphql_setup_constants() {
 
 	// Plugin version.
 	if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-		define( 'WPGRAPHQL_VERSION', '1.23.0' );
+		define( 'WPGRAPHQL_VERSION', '1.24.0' );
 	}
 
 	// Plugin Folder Path.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -115,6 +115,17 @@
 	<!-- Enforce short array syntax -->
 	<rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
 
+	<!-- Check for superfluous whitespace - These are suppressed in VIP-GO.-->
+	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
+		<severity>5</severity>
+	</rule>
+	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines">
+		<severity>5</severity>
+	</rule>
+	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EndLine">
+		<severity>5</severity>
+	</rule>
+
 	<!-- Slevomat Coding Standards-->
 	<rule ref="SlevomatCodingStandard.Arrays">
 		<!-- Conflicts with WPCS -->

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, JSON, API, Gatsby, Faust, Headless, Decoupled, Svelte, React, Nex
 Requires at least: 5.0
 Tested up to: 6.5
 Requires PHP: 7.1
-Stable tag: 1.23.0
+Stable tag: 1.24.0
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -86,6 +86,16 @@ Integrating Appsero SDK **DOES NOT IMMEDIATELY** start gathering data, **without
 Learn more about how [Appsero collects and uses this data](https://appsero.com/privacy-policy/).
 
 == Upgrade Notice ==
+
+= 1.24.0 =
+
+The AbstractConnectionResolver has undergone some refactoring. Some methods using `snakeCase` have been deprecated in favor of their `camel_case` equivalent. While we've preserved the deprecated methods to prevent breaking changes, you might begin seeing PHP notices about the deprecations. Any plugin that extends the AbstractConnectionResolver should update the following methods:
+
+- `getSource` -> `get_source`
+- `getContext` -> `get_context`
+- `getInfo` -> `get_info`
+- `getShouldExecute` -> `get_should_execute`
+- `getLoader` -> `getLoader`
 
 = 1.16.0 =
 
@@ -251,6 +261,24 @@ The `uri` field was non-null on some Types in the Schema but has been changed to
 Composer dependencies are no longer versioned in Github. Recommended install source is WordPress.org or using Composer to get the code from Packagist.org or WPackagist.org.
 
 == Changelog ==
+
+= 1.24.0 =
+
+**New Features**
+
+- [#3084](https://github.com/wp-graphql/wp-graphql/pull/3084): perf: refactor PluginConnectionResolver to only fetch plugins once. Thanks @justlevine!
+- [#3088](https://github.com/wp-graphql/wp-graphql/pull/3088): refactor: improve loader handling in AbstractConnectionResolver. Thanks @justlevine!
+- [#3087](https://github.com/wp-graphql/wp-graphql/pull/3087): feat: improve query amount handling in AbstractConnectionResolver. Thanks @justlevine!
+- [#3086](https://github.com/wp-graphql/wp-graphql/pull/3086): refactor: add AbstractConnectionResolver::get_unfiltered_args() public getter. Thanks @justlevine!
+- [#3085](https://github.com/wp-graphql/wp-graphql/pull/3085): refactor: add AbstractConnectionResolver::prepare_page_info()and only instantiate once. Thanks @justlevine!
+- [#3083](https://github.com/wp-graphql/wp-graphql/pull/3083): refactor: deprecate camelCase methods in AbstractConnectionResolver for snake_case equivalents. Thanks @justlevine!
+
+**Chores / Bugfixes**
+
+- [#3095](https://github.com/wp-graphql/wp-graphql/pull/3095): chore: lint for superfluous whitespace. Thanks @justlevine!
+- [#3100](https://github.com/wp-graphql/wp-graphql/pull/3100): fix: recursion issues with interfaces
+- [#3082](https://github.com/wp-graphql/wp-graphql/pull/3082): chore: prepare ConnectionResolver classes for v2 backport
+
 
 = 1.23.0 =
 

--- a/src/Admin/Settings/SettingsRegistry.php
+++ b/src/Admin/Settings/SettingsRegistry.php
@@ -509,7 +509,7 @@ class SettingsRegistry {
 				'id'       => $args['section'] . '[' . $args['id'] . ']',
 				'echo'     => 0,
 			],
-			$args 
+			$args
 		);
 
 		$clean_args = [];

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -12,22 +12,29 @@ use WPGraphQL\Model\Post;
 /**
  * Class AbstractConnectionResolver
  *
- * ConnectionResolvers should extend this to make returning data in proper shape for
- * connections easier, ensure data is passed through consistent filters, etc.
+ * Individual Connection Resolvers should extend this to make returning data in proper shape for Relay-compliant connections easier, ensure data is passed through consistent filters, etc.
  *
  * @package WPGraphQL\Data\Connection
  */
 abstract class AbstractConnectionResolver {
-
 	/**
-	 * The source from the field calling the connection
+	 * The source from the field calling the connection.
 	 *
-	 * @var mixed
+	 * @var \WPGraphQL\Model\Model|mixed[]|mixed
 	 */
 	protected $source;
 
 	/**
-	 * The args input on the field calling the connection
+	 * The args input before it is filtered and prepared by the constructor.
+	 *
+	 * @var array<string,mixed>
+	 */
+	protected $unfiltered_args;
+
+	/**
+	 * The args input on the field calling the connection.
+	 *
+	 * Filterable by `graphql_connection_args`.
 	 *
 	 * @var array<string,mixed>
 	 */
@@ -48,23 +55,32 @@ abstract class AbstractConnectionResolver {
 	protected $info;
 
 	/**
-	 * The query args used to query for data to resolve the connection
+	 * The query args used to query for data to resolve the connection.
 	 *
 	 * @var array<string,mixed>
 	 */
 	protected $query_args;
 
 	/**
-	 * Whether the connection resolver should execute
+	 * Whether the connection resolver should execute.
 	 *
 	 * @var bool
 	 */
 	protected $should_execute = true;
 
 	/**
+	 * The loader name.
+	 *
+	 * Defaults to `loader_name()` and filterable by `graphql_connection_loader_name`.
+	 *
+	 * @var ?string
+	 */
+	protected $loader_name;
+
+	/**
 	 * The loader the resolver is configured to use.
 	 *
-	 * @var \WPGraphQL\Data\Loader\AbstractDataLoader
+	 * @var ?\WPGraphQL\Data\Loader\AbstractDataLoader
 	 */
 	protected $loader;
 
@@ -87,7 +103,7 @@ abstract class AbstractConnectionResolver {
 	 * have context from what was queried and can make adjustments as needed, such
 	 * as exposing `totalCount` in pageInfo, etc.
 	 *
-	 * @var mixed
+	 * @var mixed[]|object|mixed
 	 */
 	protected $query;
 
@@ -97,66 +113,72 @@ abstract class AbstractConnectionResolver {
 	protected $items;
 
 	/**
+	 * The IDs returned from the query.
+	 *
 	 * @var int[]|string[]
 	 */
 	protected $ids;
 
 	/**
-	 * @var mixed[]
+	 * The nodes (usually GraphQL models) returned from the query.
+	 *
+	 * @var \WPGraphQL\Model\Model[]|mixed[]
 	 */
 	protected $nodes;
 
 	/**
+	 * The edges for the connection.
+	 *
 	 * @var array<string,mixed>[]
 	 */
 	protected $edges;
 
 	/**
-	 * @var int
+	 * The page info for the connection.
+	 *
+	 * Filterable by `graphql_connection_page_info`.
+	 *
+	 * @var ?array<string,mixed>
+	 */
+	protected $page_info;
+
+	/**
+	 * The query amount to return for the connection.
+	 *
+	 * @var ?int
 	 */
 	protected $query_amount;
 
 	/**
 	 * ConnectionResolver constructor.
 	 *
-	 * @param mixed                                $source  source passed down from the resolve tree
-	 * @param array<string,mixed>                  $args    array of arguments input in the field as part of the GraphQL query
-	 * @param \WPGraphQL\AppContext                $context Object containing app context that gets passed down the resolve tree
-	 * @param \GraphQL\Type\Definition\ResolveInfo $info Info about fields passed down the resolve tree
+	 * @param mixed                                $source  Source passed down from the resolve tree
+	 * @param array<string,mixed>                  $args    Array of arguments input in the field as part of the GraphQL query.
+	 * @param \WPGraphQL\AppContext                $context The app context that gets passed down the resolve tree.
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info    Info about fields passed down the resolve tree.
 	 *
 	 * @throws \Exception
 	 */
 	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info ) {
+		// Set the source (the root object), context, resolveInfo, and unfiltered args for the resolver.
+		$this->source          = $source;
+		$this->unfiltered_args = $args;
+		$this->context         = $context;
+		$this->info            = $info;
+
+		/**
+		 * @todo This exists for b/c, where extenders may be directly accessing `$this->args` in ::get_loader() or even `::get_args()`.
+		 * We can remove this once the rest of lifecycle has been updated.
+		 */
+		$this->args = $args;
 
 		// Bail if the Post->ID is empty, as that indicates a private post.
 		if ( $source instanceof Post && empty( $source->ID ) ) {
 			$this->should_execute = false;
 		}
 
-		/**
-		 * Set the source (the root object) for the resolver
-		 */
-		$this->source = $source;
-
-		/**
-		 * Set the context of the resolver
-		 */
-		$this->context = $context;
-
-		/**
-		 * Set the resolveInfo for the resolver
-		 */
-		$this->info = $info;
-
-		/**
-		 * Get the loader for the Connection
-		 */
-		$this->loader = $this->getLoader();
-
-		/**
-		 * Set the args for the resolver
-		 */
-		$this->args = $args;
+		// Get the loader for the Connection.
+		$this->loader = $this->get_loader();
 
 		/**
 		 *
@@ -168,18 +190,9 @@ abstract class AbstractConnectionResolver {
 		 *
 		 * @since 1.11.0
 		 */
-		$this->args = apply_filters( 'graphql_connection_args', $this->get_args(), $this, $args );
+		$this->args = apply_filters( 'graphql_connection_args', $this->get_args(), $this, $this->get_unfiltered_args() );
 
-		/**
-		 * Determine the query amount for the resolver.
-		 *
-		 * This is the amount of items to query from the database. We determine this by
-		 * determining how many items were asked for (first/last), then compare with the
-		 * max amount allowed to query (default is 100), and then we fetch 1 more than
-		 * that amount, so we know whether hasNextPage/hasPreviousPage should be true.
-		 *
-		 * If there are more items than were asked for, then there's another page.
-		 */
+		// Get the query amount for the connection.
 		$this->query_amount = $this->get_query_amount();
 
 		/**
@@ -196,41 +209,14 @@ abstract class AbstractConnectionResolver {
 	}
 
 	/**
-	 * Returns the source of the connection
+	 * The name of the loader to use for this connection.
 	 *
-	 * @return mixed
+	 * Filterable by `graphql_connection_loader_name`.
+	 *
+	 * @todo This is protected for backwards compatibility, but should be abstract and implemented by the child classes.
 	 */
-	public function getSource() {
-		return $this->source;
-	}
-
-	/**
-	 * Get the loader name
-	 *
-	 * @return \WPGraphQL\Data\Loader\AbstractDataLoader
-	 * @throws \Exception
-	 */
-	protected function getLoader() {
-		$name = $this->get_loader_name();
-		if ( empty( $name ) || ! is_string( $name ) ) {
-			throw new Exception( esc_html__( 'The Connection Resolver needs to define a loader name', 'wp-graphql' ) );
-		}
-
-		return $this->context->get_loader( $name );
-	}
-
-	/**
-	 * Returns the $args passed to the connection
-	 *
-	 * @deprecated Deprecated since v1.11.0 in favor of $this->get_args();
-	 *
-	 * @return array<string,mixed>
-	 *
-	 * @codeCoverageIgnore
-	 */
-	public function getArgs(): array {
-		_deprecated_function( __METHOD__, '1.11.0', static::class . '::get_args()' );
-		return $this->get_args();
+	protected function loader_name(): string {
+		return '';
 	}
 
 	/**
@@ -243,78 +229,6 @@ abstract class AbstractConnectionResolver {
 	public function get_args(): array {
 		return $this->args;
 	}
-
-	/**
-	 * Returns the AppContext of the connection
-	 */
-	public function getContext(): AppContext {
-		return $this->context;
-	}
-
-	/**
-	 * Returns the ResolveInfo of the connection
-	 */
-	public function getInfo(): ResolveInfo {
-		return $this->info;
-	}
-
-	/**
-	 * Returns whether the connection should execute
-	 */
-	public function getShouldExecute(): bool {
-		return $this->should_execute;
-	}
-
-	/**
-	 * @param string $key   The key of the query arg to set
-	 * @param mixed  $value The value of the query arg to set
-	 *
-	 * @return \WPGraphQL\Data\Connection\AbstractConnectionResolver
-	 *
-	 * @deprecated 0.3.0
-	 *
-	 * @codeCoverageIgnore
-	 */
-	public function setQueryArg( $key, $value ) {
-		_deprecated_function( __METHOD__, '0.3.0', static::class . '::set_query_arg()' );
-
-		return $this->set_query_arg( $key, $value );
-	}
-
-	/**
-	 * Given a key and value, this sets a query_arg which will modify the query_args used by
-	 * the connection resolvers get_query();
-	 *
-	 * @param string $key   The key of the query arg to set
-	 * @param mixed  $value The value of the query arg to set
-	 *
-	 * @return \WPGraphQL\Data\Connection\AbstractConnectionResolver
-	 */
-	public function set_query_arg( $key, $value ) {
-		$this->query_args[ $key ] = $value;
-
-		return $this;
-	}
-
-	/**
-	 * Whether the connection should resolve as a one-to-one connection.
-	 *
-	 * @return \WPGraphQL\Data\Connection\AbstractConnectionResolver
-	 */
-	public function one_to_one() {
-		$this->one_to_one = true;
-
-		return $this;
-	}
-
-	/**
-	 * Get_loader_name
-	 *
-	 * Return the name of the loader to be used with the connection resolver
-	 *
-	 * @return string
-	 */
-	abstract public function get_loader_name();
 
 	/**
 	 * Get_query_args
@@ -361,6 +275,15 @@ abstract class AbstractConnectionResolver {
 	abstract public function should_execute();
 
 	/**
+	 * The maximum number of items that should be returned by the query.
+	 *
+	 * This is filtered by `graphql_connection_max_query_amount` in ::get_query_amount().
+	 */
+	protected function max_query_amount(): int {
+		return 100;
+	}
+
+	/**
 	 * Is_valid_offset
 	 *
 	 * Determine whether or not the the offset is valid, i.e the item corresponding to the offset
@@ -400,236 +323,6 @@ abstract class AbstractConnectionResolver {
 	}
 
 	/**
-	 * Given an ID, return the model for the entity or null
-	 *
-	 * @param mixed $id The ID to identify the object by. Could be a database ID or an in-memory ID (like post_type name)
-	 *
-	 * @return mixed|\WPGraphQL\Model\Model|null
-	 * @throws \Exception
-	 */
-	public function get_node_by_id( $id ) {
-		return $this->loader->load( $id );
-	}
-
-	/**
-	 * Get_query_amount
-	 *
-	 * Returns the max between what was requested and what is defined as the $max_query_amount to ensure that queries don't exceed unwanted limits when querying data.
-	 *
-	 * If the amount requested is greater than the max query amount, a debug message will be included in the GraphQL response.
-	 *
-	 * @return int
-	 * @throws \Exception
-	 */
-	public function get_query_amount() {
-
-		/**
-		 * Filter the maximum number of posts per page that should be queried. The default is 100 to prevent queries from
-		 * being exceedingly resource intensive, however individual systems can override this for their specific needs.
-		 *
-		 * This filter is intentionally applied AFTER the query_args filter, as
-		 *
-		 * @param int                                  $max_posts  the maximum number of posts per page.
-		 * @param mixed                                $source     source passed down from the resolve tree
-		 * @param array<string,mixed>                  $args       array of arguments input in the field as part of the GraphQL query
-		 * @param \WPGraphQL\AppContext                $context    Object containing app context that gets passed down the resolve tree
-		 * @param \GraphQL\Type\Definition\ResolveInfo $info       Info about fields passed down the resolve tree
-		 *
-		 * @since 0.0.6
-		 */
-		$max_query_amount = apply_filters( 'graphql_connection_max_query_amount', 100, $this->source, $this->args, $this->context, $this->info );
-		
-		$requested_amount = $this->get_amount_requested();
-
-		if ( $requested_amount > $max_query_amount ) {
-			graphql_debug(
-				sprintf( 'The number of items requested by the connection (%s) exceeds the max query amount. Only the first %s items will be returned.', $requested_amount, $max_query_amount ),
-				[ 'connection' => static::class ]
-			);
-		}
-
-		return min( $max_query_amount, $requested_amount );
-	}
-
-	/**
-	 * Get_amount_requested
-	 *
-	 * This checks the $args to determine the amount requested, and if
-	 *
-	 * @return int
-	 * @throws \GraphQL\Error\UserError If there is an issue with the pagination $args.
-	 */
-	public function get_amount_requested() {
-
-		/**
-		 * Set the default amount
-		 */
-		$amount_requested = 10;
-
-		/**
-		 * If both first & last are used in the input args, throw an exception as that won't
-		 * work properly
-		 */
-		if ( ! empty( $this->args['first'] ) && ! empty( $this->args['last'] ) ) {
-			throw new UserError( esc_html__( 'first and last cannot be used together. For forward pagination, use first & after. For backward pagination, use last & before.', 'wp-graphql' ) );
-		}
-
-		/**
-		 * If first is set, and is a positive integer, use it for the $amount_requested
-		 * but if it's set to anything that isn't a positive integer, throw an exception
-		 */
-		if ( ! empty( $this->args['first'] ) && is_int( $this->args['first'] ) ) {
-			if ( 0 > $this->args['first'] ) {
-				throw new UserError( esc_html__( 'first must be a positive integer.', 'wp-graphql' ) );
-			}
-
-			$amount_requested = $this->args['first'];
-		}
-
-		/**
-		 * If last is set, and is a positive integer, use it for the $amount_requested
-		 * but if it's set to anything that isn't a positive integer, throw an exception
-		 */
-		if ( ! empty( $this->args['last'] ) && is_int( $this->args['last'] ) ) {
-			if ( 0 > $this->args['last'] ) {
-				throw new UserError( esc_html__( 'last must be a positive integer.', 'wp-graphql' ) );
-			}
-
-			$amount_requested = $this->args['last'];
-		}
-
-		/**
-		 * This filter allows to modify the requested connection page size
-		 *
-		 * @param int                        $amount   the requested amount
-		 * @param \WPGraphQL\Data\Connection\AbstractConnectionResolver $resolver Instance of the connection resolver class
-		 */
-		return (int) max( 0, apply_filters( 'graphql_connection_amount_requested', $amount_requested, $this ) );
-	}
-
-	/**
-	 * Gets the offset for the `after` cursor.
-	 *
-	 * @return int|string|null
-	 */
-	public function get_after_offset() {
-		if ( ! empty( $this->args['after'] ) ) {
-			return $this->get_offset_for_cursor( $this->args['after'] );
-		}
-
-		return null;
-	}
-
-	/**
-	 * Gets the offset for the `before` cursor.
-	 *
-	 * @return int|string|null
-	 */
-	public function get_before_offset() {
-		if ( ! empty( $this->args['before'] ) ) {
-			return $this->get_offset_for_cursor( $this->args['before'] );
-		}
-
-		return null;
-	}
-
-	/**
-	 * Gets the array index for the given offset.
-	 *
-	 * @param int|string|false $offset The cursor pagination offset.
-	 * @param int[]|string[]   $ids    The array of ids from the query.
-	 *
-	 * @return int|false $index The array index of the offset.
-	 */
-	public function get_array_index_for_offset( $offset, $ids ) {
-		if ( false === $offset ) {
-			return false;
-		}
-
-		// We use array_values() to ensure we're getting a positional index, and not a key.
-		return array_search( $offset, array_values( $ids ), true );
-	}
-
-	/**
-	 * Returns an array slice of IDs, per the Relay Cursor Connection spec.
-	 *
-	 * The resulting array should be overfetched by 1.
-	 *
-	 * @see https://relay.dev/graphql/connections.htm#sec-Pagination-algorithm
-	 *
-	 * @param int[]|string[] $ids The array of IDs from the query to slice, ordered as expected by the GraphQL query.
-	 *
-	 * @since 1.9.0
-	 *
-	 * @return int[]|string[]
-	 */
-	public function apply_cursors_to_ids( array $ids ) {
-		if ( empty( $ids ) ) {
-			return [];
-		}
-
-		// First we slice the array from the front.
-		if ( ! empty( $this->args['after'] ) ) {
-			$offset = $this->get_offset_for_cursor( $this->args['after'] );
-			$index  = $this->get_array_index_for_offset( $offset, $ids );
-
-			if ( false !== $index ) {
-				// We want to start with the first id after the index.
-				$ids = array_slice( $ids, $index + 1, null, true );
-			}
-		}
-
-		// Then we slice the array from the back.
-		if ( ! empty( $this->args['before'] ) ) {
-			$offset = $this->get_offset_for_cursor( $this->args['before'] );
-			$index  = $this->get_array_index_for_offset( $offset, $ids );
-
-			if ( false !== $index ) {
-				// Because array indexes start at 0, we can overfetch without adding 1 to $index.
-				$ids = array_slice( $ids, 0, $index, true );
-			}
-		}
-
-		return $ids;
-	}
-
-	/**
-	 * Returns an array of IDs for the connection.
-	 *
-	 * These IDs have been fetched from the query with all the query args applied,
-	 * then sliced (overfetching by 1) by pagination args.
-	 *
-	 * @return int[]|string[]
-	 */
-	public function get_ids() {
-		$ids = $this->get_ids_from_query();
-
-		return $this->apply_cursors_to_ids( $ids );
-	}
-
-	/**
-	 * Get_offset
-	 *
-	 * This returns the offset to be used in the $query_args based on the $args passed to the
-	 * GraphQL query.
-	 *
-	 * @deprecated 1.9.0
-	 *
-	 * @codeCoverageIgnore
-	 *
-	 * @return int|mixed
-	 */
-	public function get_offset() {
-		_deprecated_function( __METHOD__, '1.9.0', static::class . '::get_offset_for_cursor()' );
-
-		// Using shorthand since this is for deprecated code.
-		$cursor = $this->args['after'] ?? null;
-		$cursor = $cursor ?: ( $this->args['before'] ?? null );
-
-		return $this->get_offset_for_cursor( $cursor );
-	}
-
-	/**
 	 * Returns the offset for a given cursor.
 	 *
 	 * Connections that use a string-based offset should override this method.
@@ -654,111 +347,177 @@ abstract class AbstractConnectionResolver {
 	}
 
 	/**
-	 * Has_next_page
+	 * Validates Model.
 	 *
-	 * Whether there is a next page in the connection.
+	 * If model isn't a class with a `fields` member, this function with have be overridden in
+	 * the Connection class.
 	 *
-	 * If there are more "items" than were asked for in the "first" argument
-	 * ore if there are more "items" after the "before" argument, has_next_page()
-	 * will be set to true
-	 *
-	 * @return bool
-	 */
-	public function has_next_page() {
-		if ( ! empty( $this->args['first'] ) ) {
-			return ! empty( $this->ids ) && count( $this->ids ) > $this->query_amount;
-		}
-
-		$before_offset = $this->get_before_offset();
-
-		if ( $before_offset ) {
-			return $this->is_valid_offset( $before_offset );
-		}
-
-		return false;
-	}
-
-	/**
-	 * Has_previous_page
-	 *
-	 * Whether there is a previous page in the connection.
-	 *
-	 * If there are more "items" than were asked for in the "last" argument
-	 * or if there are more "items" before the "after" argument, has_previous_page()
-	 * will be set to true.
+	 * @param \WPGraphQL\Model\Model|mixed $model The model being validated
 	 *
 	 * @return bool
 	 */
-	public function has_previous_page() {
-		if ( ! empty( $this->args['last'] ) ) {
-			return ! empty( $this->ids ) && count( $this->ids ) > $this->query_amount;
+	protected function is_valid_model( $model ) {
+		return isset( $model->fields ) && ! empty( $model->fields );
+	}
+
+	/**
+	 * Returns the source of the connection
+	 *
+	 * @return mixed
+	 */
+	public function get_source() {
+		return $this->source;
+	}
+
+	/**
+	 * Returns the AppContext of the connection.
+	 */
+	public function get_context(): AppContext {
+		return $this->context;
+	}
+
+	/**
+	 * Returns the ResolveInfo of the connection.
+	 */
+	public function get_info(): ResolveInfo {
+		return $this->info;
+	}
+
+	/**
+	 * Returns the loader name.
+	 *
+	 * If $loader_name is not initialized, this plugin will initialize it.
+	 *
+	 * @return string
+	 *
+	 * @throws \Exception
+	 */
+	public function get_loader_name() {
+		// Only initialize the loader_name property once.
+		if ( ! isset( $this->loader_name ) ) {
+			$name = $this->loader_name();
+
+			// This is a b/c check because `loader_name()` is not abstract.
+			if ( empty( $name ) ) {
+				throw new \Exception(
+					sprintf(
+						// translators: %s is the name of the connection resolver class.
+						esc_html__( 'Class %s does not implement a valid method `loader_name()`.', 'wp-graphql' ),
+						esc_html( static::class )
+					)
+				);
+			}
+
+			/**
+			 * Filters the loader name.
+			 * This is the name of the registered DataLoader that will be used to load the data for the connection.
+			 *
+			 * @param string $loader_name The name of the loader.
+			 * @param self   $resolver    The AbstractConnectionResolver instance.
+			 */
+			$name = apply_filters( 'graphql_connection_loader_name', $name, $this );
+
+			// Bail if the loader name is invalid.
+			if ( empty( $name ) || ! is_string( $name ) ) {
+				throw new \Exception( esc_html__( 'The Connection Resolver needs to define a loader name', 'wp-graphql' ) );
+			}
+
+			$this->loader_name = $name;
 		}
 
-		$after_offset = $this->get_after_offset();
-		if ( $after_offset ) {
-			return $this->is_valid_offset( $after_offset );
+		return $this->loader_name;
+	}
+
+	/**
+	 * Returns whether the connection should execute.
+	 */
+	public function get_should_execute(): bool {
+		return $this->should_execute;
+	}
+
+	/**
+	 * Returns the $args passed to the connection, before any modifications.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public function get_unfiltered_args(): array {
+		return $this->unfiltered_args;
+	}
+
+	/**
+	 * Returns the amount of items to query from the database.
+	 *
+	 * The amount is calculated as the the max between what was requested and what is defined as the $max_query_amount to ensure that queries don't exceed unwanted limits when querying data.
+	 *
+	 * If the amount requested is greater than the max query amount, a debug message will be included in the GraphQL response.
+	 *
+	 * @return int
+	 * @throws \Exception
+	 */
+	public function get_query_amount() {
+		if ( ! isset( $this->query_amount ) ) {
+			/**
+			 * Filter the maximum number of posts per page that should be queried. This prevents queries from being exceedingly resource intensive.
+			 *
+			 * The default is 100 - unless overloaded by ::max_query_amount() in the child class.
+			 *
+			 * @param int                                  $max_posts  the maximum number of posts per page.
+			 * @param mixed                                $source     source passed down from the resolve tree
+			 * @param array<string,mixed>                  $args       array of arguments input in the field as part of the GraphQL query
+			 * @param \WPGraphQL\AppContext                $context    Object containing app context that gets passed down the resolve tree
+			 * @param \GraphQL\Type\Definition\ResolveInfo $info       Info about fields passed down the resolve tree
+			 *
+			 * @since 0.0.6
+			 */
+			$max_query_amount = (int) apply_filters( 'graphql_connection_max_query_amount', $this->max_query_amount(), $this->source, $this->args, $this->context, $this->info );
+
+			// We don't want the requested amount to be lower than 0.
+			$requested_query_amount = (int) max(
+				0,
+				/**
+				 * This filter allows to modify the number of nodes the connection should return.
+				 *
+				 * @param int                        $amount   the requested amount
+				 * @param self $resolver Instance of the connection resolver class
+				 */
+				apply_filters( 'graphql_connection_amount_requested', $this->get_amount_requested(), $this )
+			);
+
+			if ( $requested_query_amount > $max_query_amount ) {
+				graphql_debug(
+					sprintf( 'The number of items requested by the connection (%s) exceeds the max query amount. Only the first %s items will be returned.', $requested_query_amount, $max_query_amount ),
+					[ 'connection' => static::class ]
+				);
+			}
+
+			$this->query_amount = (int) min( $max_query_amount, $requested_query_amount );
 		}
 
-		return false;
+		return $this->query_amount;
 	}
 
-	/**
-	 * Get_start_cursor
-	 *
-	 * Determine the start cursor from the connection
-	 *
-	 * @return mixed|string|null
-	 */
-	public function get_start_cursor() {
-		$first_edge = $this->edges && ! empty( $this->edges ) ? $this->edges[0] : null;
-
-		return isset( $first_edge['cursor'] ) ? $first_edge['cursor'] : null;
-	}
 
 	/**
-	 * Get_end_cursor
+	 * Returns an array of IDs for the connection.
 	 *
-	 * Determine the end cursor from the connection
-	 *
-	 * @return mixed|string|null
-	 */
-	public function get_end_cursor() {
-		$last_edge = ! empty( $this->edges ) ? $this->edges[ count( $this->edges ) - 1 ] : null;
-
-		return isset( $last_edge['cursor'] ) ? $last_edge['cursor'] : null;
-	}
-
-	/**
-	 * Gets the IDs for the currently-paginated slice of nodes.
-	 *
-	 * We slice the array to match the amount of items that was asked for, as we over-fetched by 1 item to calculate pageInfo.
-	 *
-	 * @used-by AbstractConnectionResolver::get_nodes()
+	 * These IDs have been fetched from the query with all the query args applied,
+	 * then sliced (overfetching by 1) by pagination args.
 	 *
 	 * @return int[]|string[]
 	 */
-	public function get_ids_for_nodes() {
-		if ( empty( $this->ids ) ) {
-			return [];
-		}
+	public function get_ids() {
+		$ids = $this->get_ids_from_query();
 
-		// If we're going backwards then our overfetched ID is at the front.
-		if ( ! empty( $this->args['last'] ) && count( $this->ids ) > absint( $this->args['last'] ) ) {
-			return array_slice( $this->ids, count( $this->ids ) - absint( $this->args['last'] ), $this->query_amount, true );
-		}
-
-		// If we're going forwards, our overfetched ID is at the back.
-		return array_slice( $this->ids, 0, $this->query_amount, true );
+		return $this->apply_cursors_to_ids( $ids );
 	}
 
 	/**
-	 * Get_nodes
-	 *
 	 * Get the nodes from the query.
 	 *
 	 * @uses AbstractConnectionResolver::get_ids_for_nodes()
 	 *
 	 * @return array<int|string,mixed|\WPGraphQL\Model\Model|null>
+	 *
 	 * @throws \Exception
 	 */
 	public function get_nodes() {
@@ -778,34 +537,7 @@ abstract class AbstractConnectionResolver {
 	}
 
 	/**
-	 * Validates Model.
-	 *
-	 * If model isn't a class with a `fields` member, this function with have be overridden in
-	 * the Connection class.
-	 *
-	 * @param \WPGraphQL\Model\Model|mixed $model The model being validated
-	 *
-	 * @return bool
-	 */
-	protected function is_valid_model( $model ) {
-		return isset( $model->fields ) && ! empty( $model->fields );
-	}
-
-	/**
-	 * Given an ID, a cursor is returned
-	 *
-	 * @param int|string $id
-	 *
-	 * @return string
-	 */
-	protected function get_cursor_for_node( $id ) {
-		return base64_encode( 'arrayconnection:' . (string) $id );
-	}
-
-	/**
-	 * Get_edges
-	 *
-	 * This iterates over the nodes and returns edges
+	 * Get the edges from the nodes.
 	 *
 	 * @return array<string,mixed>[]
 	 */
@@ -850,48 +582,206 @@ abstract class AbstractConnectionResolver {
 	}
 
 	/**
-	 * Get_page_info
-	 *
 	 * Returns pageInfo for the connection
 	 *
 	 * @return array<string,mixed>
 	 */
 	public function get_page_info() {
-		$page_info = [
-			'startCursor'     => $this->get_start_cursor(),
-			'endCursor'       => $this->get_end_cursor(),
-			'hasNextPage'     => (bool) $this->has_next_page(),
-			'hasPreviousPage' => (bool) $this->has_previous_page(),
-		];
+		if ( ! isset( $this->page_info ) ) {
+			$page_info = $this->prepare_page_info();
+
+			/**
+			 * Filter the pageInfo that is returned to the connection.
+			 *
+			 * This filter allows for additional fields to be filtered into the pageInfo
+			 * of a connection, such as "totalCount", etc, because the filter has enough
+			 * context of the query, args, request, etc to be able to calcuate and return
+			 * that information.
+			 *
+			 * example:
+			 *
+			 * You would want to register a "total" field to the PageInfo type, then filter
+			 * the pageInfo to return the total for the query, something to this tune:
+			 *
+			 * add_filter( 'graphql_connection_page_info', function( $page_info, $connection ) {
+			 *
+			 *   $page_info['total'] = null;
+			 *
+			 *   if ( $connection->query instanceof WP_Query ) {
+			 *      if ( isset( $connection->query->found_posts ) {
+			 *          $page_info['total'] = (int) $connection->query->found_posts;
+			 *      }
+			 *   }
+			 *
+			 *   return $page_info;
+			 *
+			 * });
+			 */
+			$this->page_info = apply_filters( 'graphql_connection_page_info', $page_info, $this );
+		}
+
+		return $this->page_info;
+	}
+
+	/**
+	 * Given a key and value, this sets a query_arg which will modify the query_args used by
+	 * the connection resolvers get_query();
+	 *
+	 * @param string $key   The key of the query arg to set
+	 * @param mixed  $value The value of the query arg to set
+	 *
+	 * @return self
+	 */
+	public function set_query_arg( $key, $value ) {
+		$this->query_args[ $key ] = $value;
+
+		return $this;
+	}
+
+	/**
+	 * Whether the connection should resolve as a one-to-one connection.
+	 *
+	 * @return self
+	 */
+	public function one_to_one() {
+		$this->one_to_one = true;
+
+		return $this;
+	}
+
+	/**
+	 * Returns the loader.
+	 *
+	 * If $loader is not initialized, this method will initialize it.
+	 *
+	 * @return \WPGraphQL\Data\Loader\AbstractDataLoader
+	 */
+	protected function get_loader() {
+		// If the loader isn't set, set it.
+		if ( ! isset( $this->loader ) ) {
+			$name = $this->get_loader_name();
+
+			$this->loader = $this->context->get_loader( $name );
+		}
+
+		return $this->loader;
+	}
+
+	/**
+	 * Returns the amount of items requested from the connection.
+	 *
+	 * @return int
+	 *
+	 * @throws \GraphQL\Error\UserError If the `first` or `last` args are used together.
+	 */
+	public function get_amount_requested() {
+		/**
+		 * Filters the default query amount for a connection, if no `first` or `last` GraphQL argument is supplied.
+		 *
+		 * @param int  $amount_requested The default query amount for a connection.
+		 * @param self $resolver         Instance of the Connection Resolver.
+		 */
+		$amount_requested = apply_filters( 'graphql_connection_default_query_amount', 10, $this );
 
 		/**
-		 * Filter the pageInfo that is returned to the connection.
-		 *
-		 * This filter allows for additional fields to be filtered into the pageInfo
-		 * of a connection, such as "totalCount", etc, because the filter has enough
-		 * context of the query, args, request, etc to be able to calculate and return
-		 * that information.
-		 *
-		 * example:
-		 *
-		 * You would want to register a "total" field to the PageInfo type, then filter
-		 * the pageInfo to return the total for the query, something to this tune:
-		 *
-		 * add_filter( 'graphql_connection_page_info', function( $page_info, $connection ) {
-		 *
-		 *   $page_info['total'] = null;
-		 *
-		 *   if ( $connection->query instanceof WP_Query ) {
-		 *      if ( isset( $connection->query->found_posts ) {
-		 *          $page_info['total'] = (int) $connection->query->found_posts;
-		 *      }
-		 *   }
-		 *
-		 *   return $page_info;
-		 *
-		 * });
+		 * If both first & last are used in the input args, throw an exception.
 		 */
-		return apply_filters( 'graphql_connection_page_info', $page_info, $this );
+		if ( ! empty( $this->args['first'] ) && ! empty( $this->args['last'] ) ) {
+			throw new UserError( esc_html__( 'The `first` and `last` connection args cannot be used together. For forward pagination, use `first` & `after`. For backward pagination, use `last` & `before`.', 'wp-graphql' ) );
+		}
+
+		/**
+		 * Get the key to use for the query amount.
+		 * We avoid a ternary here for unit testing.
+		 */
+		$args_key = ! empty( $this->args['first'] ) && is_int( $this->args['first'] ) ? 'first' : null;
+		if ( null === $args_key ) {
+			$args_key = ! empty( $this->args['last'] ) && is_int( $this->args['last'] ) ? 'last' : null;
+		}
+
+		/**
+		 * If the key is set, and is a positive integer, use it for the $amount_requested
+		 * but if it's set to anything that isn't a positive integer, throw an exception
+		 */
+		if ( null !== $args_key && isset( $this->args[ $args_key ] ) ) {
+			if ( 0 > $this->args[ $args_key ] ) {
+				throw new UserError(
+					sprintf(
+						// translators: %s: The name of the arg that was invalid
+						esc_html__( '%s must be a positive integer.', 'wp-graphql' ),
+						esc_html( $args_key )
+					)
+				);
+			}
+
+			$amount_requested = $this->args[ $args_key ];
+		}
+
+		return (int) $amount_requested;
+	}
+
+	/**
+	 * Get the connection to return to the Connection Resolver
+	 *
+	 * @return \GraphQL\Deferred
+	 *
+	 * @throws \Exception
+	 */
+	public function get_connection() {
+		$this->execute_and_get_ids();
+
+		/**
+		 * Return a Deferred function to load all buffered nodes before
+		 * returning the connection.
+		 */
+		return new Deferred(
+			function () {
+				if ( ! empty( $this->ids ) ) {
+					$this->get_loader()->load_many( $this->ids );
+				}
+
+				/**
+				 * Set the items. These are the "nodes" that make up the connection.
+				 *
+				 * Filters the nodes in the connection
+				 *
+				 * @param array<int|string,mixed|\WPGraphQL\Model\Model|null>   $nodes               The nodes in the connection
+				 * @param \WPGraphQL\Data\Connection\AbstractConnectionResolver $connection_resolver Instance of the Connection Resolver
+				 */
+				$this->nodes = apply_filters( 'graphql_connection_nodes', $this->get_nodes(), $this );
+
+				/**
+				 * Filters the edges in the connection
+				 *
+				 * @param array<int|string,mixed|\WPGraphQL\Model\Model|null>   $nodes               The nodes in the connection
+				 * @param \WPGraphQL\Data\Connection\AbstractConnectionResolver $connection_resolver Instance of the Connection Resolver
+				 */
+				$this->edges = apply_filters( 'graphql_connection_edges', $this->get_edges(), $this );
+
+				if ( true === $this->one_to_one ) {
+					// For one to one connections, return the first edge.
+					$connection = ! empty( $this->edges[ array_key_first( $this->edges ) ] ) ? $this->edges[ array_key_first( $this->edges ) ] : null;
+				} else {
+					// For plural connections (default) return edges/nodes/pageInfo
+					$connection = [
+						'nodes'    => $this->nodes,
+						'edges'    => $this->edges,
+						'pageInfo' => $this->get_page_info(),
+					];
+				}
+
+				/**
+				 * Filter the connection. In some cases, connections will want to provide
+				 * additional information other than edges, nodes, and pageInfo
+				 *
+				 * This filter allows additional fields to be returned to the connection resolver
+				 *
+				 * @param array<string,mixed>                                   $connection          The connection data being returned
+				 * @param \WPGraphQL\Data\Connection\AbstractConnectionResolver $connection_resolver The instance of the connection resolver
+				 */
+				return apply_filters( 'graphql_connection', $connection, $this );
+			}
+		);
 	}
 
 	/**
@@ -961,74 +851,340 @@ abstract class AbstractConnectionResolver {
 		/**
 		 * Buffer the IDs for deferred resolution
 		 */
-		$this->loader->buffer( $this->ids );
+		$this->get_loader()->buffer( $this->ids );
 
 		return $this->ids;
 	}
 
+
 	/**
-	 * Get_connection
+	 * Returns an array slice of IDs, per the Relay Cursor Connection spec.
 	 *
-	 * Get the connection to return to the Connection Resolver
+	 * The resulting array should be overfetched by 1.
 	 *
-	 * @return \GraphQL\Deferred
+	 * @see https://relay.dev/graphql/connections.htm#sec-Pagination-algorithm
 	 *
+	 * @param int[]|string[] $ids The array of IDs from the query to slice, ordered as expected by the GraphQL query.
+	 *
+	 * @since 1.9.0
+	 *
+	 * @return int[]|string[]
+	 */
+	public function apply_cursors_to_ids( array $ids ) {
+		if ( empty( $ids ) ) {
+			return [];
+		}
+
+		// First we slice the array from the front.
+		if ( ! empty( $this->args['after'] ) ) {
+			$offset = $this->get_offset_for_cursor( $this->args['after'] );
+			$index  = $this->get_array_index_for_offset( $offset, $ids );
+
+			if ( false !== $index ) {
+				// We want to start with the first id after the index.
+				$ids = array_slice( $ids, $index + 1, null, true );
+			}
+		}
+
+		// Then we slice the array from the back.
+		if ( ! empty( $this->args['before'] ) ) {
+			$offset = $this->get_offset_for_cursor( $this->args['before'] );
+			$index  = $this->get_array_index_for_offset( $offset, $ids );
+
+			if ( false !== $index ) {
+				// Because array indexes start at 0, we can overfetch without adding 1 to $index.
+				$ids = array_slice( $ids, 0, $index, true );
+			}
+		}
+
+		return $ids;
+	}
+
+	/**
+	 * Gets the array index for the given offset.
+	 *
+	 * @param int|string|false $offset The cursor pagination offset.
+	 * @param int[]|string[]   $ids    The array of ids from the query.
+	 *
+	 * @return int|false $index The array index of the offset.
+	 */
+	public function get_array_index_for_offset( $offset, $ids ) {
+		if ( false === $offset ) {
+			return false;
+		}
+
+		// We use array_values() to ensure we're getting a positional index, and not a key.
+		return array_search( $offset, array_values( $ids ), true );
+	}
+
+	/**
+	 * Gets the IDs for the currently-paginated slice of nodes.
+	 *
+	 * We slice the array to match the amount of items that was asked for, as we over-fetched by 1 item to calculate pageInfo.
+	 *
+	 * @used-by AbstractConnectionResolver::get_nodes()
+	 *
+	 * @return int[]|string[]
+	 */
+	public function get_ids_for_nodes() {
+		if ( empty( $this->ids ) ) {
+			return [];
+		}
+
+		// If we're going backwards then our overfetched ID is at the front.
+		if ( ! empty( $this->args['last'] ) && count( $this->ids ) > absint( $this->args['last'] ) ) {
+			return array_slice( $this->ids, count( $this->ids ) - absint( $this->args['last'] ), $this->get_query_amount(), true );
+		}
+
+		// If we're going forwards, our overfetched ID is at the back.
+		return array_slice( $this->ids, 0, $this->get_query_amount(), true );
+	}
+
+	/**
+	 * Given an ID, return the model for the entity or null
+	 *
+	 * @param int|string|mixed $id The ID to identify the object by. Could be a database ID or an in-memory ID (like post_type name)
+	 *
+	 * @return mixed|\WPGraphQL\Model\Model|null
 	 * @throws \Exception
 	 */
-	public function get_connection() {
-		$this->execute_and_get_ids();
+	public function get_node_by_id( $id ) {
+		return $this->get_loader()->load( $id );
+	}
 
-		/**
-		 * Return a Deferred function to load all buffered nodes before
-		 * returning the connection.
-		 */
-		return new Deferred(
-			function () {
-				if ( ! empty( $this->ids ) ) {
-					$this->loader->load_many( $this->ids );
-				}
+	/**
+	 * Given an ID, a cursor is returned.
+	 *
+	 * @param int|string $id The ID to get the cursor for.
+	 *
+	 * @return string
+	 */
+	protected function get_cursor_for_node( $id ) {
+		return base64_encode( 'arrayconnection:' . (string) $id );
+	}
 
-				/**
-				 * Set the items. These are the "nodes" that make up the connection.
-				 *
-				 * Filters the nodes in the connection
-				 *
-				 * @param array<int|string,mixed|\WPGraphQL\Model\Model|null>   $nodes               The nodes in the connection
-				 * @param \WPGraphQL\Data\Connection\AbstractConnectionResolver $connection_resolver Instance of the Connection Resolver
-				 */
-				$this->nodes = apply_filters( 'graphql_connection_nodes', $this->get_nodes(), $this );
+	/**
+	 * Prepares the page info for the connection.
+	 *
+	 * @used-by self::get_page_info()
+	 *
+	 * @return array<string,mixed>
+	 */
+	protected function prepare_page_info(): array {
+		return [
+			'startCursor'     => $this->get_start_cursor(),
+			'endCursor'       => $this->get_end_cursor(),
+			'hasNextPage'     => $this->has_next_page(),
+			'hasPreviousPage' => $this->has_previous_page(),
+		];
+	}
 
-				/**
-				 * Filters the edges in the connection
-				 *
-				 * @param array<int|string,mixed|\WPGraphQL\Model\Model|null>   $nodes               The nodes in the connection
-				 * @param \WPGraphQL\Data\Connection\AbstractConnectionResolver $connection_resolver Instance of the Connection Resolver
-				 */
-				$this->edges = apply_filters( 'graphql_connection_edges', $this->get_edges(), $this );
+	/**
+	 * Determine the start cursor from the connection
+	 *
+	 * @return mixed|string|null
+	 */
+	public function get_start_cursor() {
+		$first_edge = $this->edges && ! empty( $this->edges ) ? $this->edges[0] : null;
 
-				if ( true === $this->one_to_one ) {
-					// For one to one connections, return the first edge.
-					$connection = ! empty( $this->edges[ array_key_first( $this->edges ) ] ) ? $this->edges[ array_key_first( $this->edges ) ] : null;
-				} else {
-					// For plural connections (default) return edges/nodes/pageInfo
-					$connection = [
-						'nodes'    => $this->nodes,
-						'edges'    => $this->edges,
-						'pageInfo' => $this->get_page_info(),
-					];
-				}
+		return isset( $first_edge['cursor'] ) ? $first_edge['cursor'] : null;
+	}
 
-				/**
-				 * Filter the connection. In some cases, connections will want to provide
-				 * additional information other than edges, nodes, and pageInfo
-				 *
-				 * This filter allows additional fields to be returned to the connection resolver
-				 *
-				 * @param array<string,mixed>                                   $connection          The connection data being returned
-				 * @param \WPGraphQL\Data\Connection\AbstractConnectionResolver $connection_resolver The instance of the connection resolver
-				 */
-				return apply_filters( 'graphql_connection', $connection, $this );
-			}
-		);
+	/**
+	 * Determine the end cursor from the connection
+	 *
+	 * @return mixed|string|null
+	 */
+	public function get_end_cursor() {
+		$last_edge = ! empty( $this->edges ) ? $this->edges[ count( $this->edges ) - 1 ] : null;
+
+		return isset( $last_edge['cursor'] ) ? $last_edge['cursor'] : null;
+	}
+
+	/**
+	 * Gets the offset for the `after` cursor.
+	 *
+	 * @return int|string|null
+	 */
+	public function get_after_offset() {
+		if ( ! empty( $this->args['after'] ) ) {
+			return $this->get_offset_for_cursor( $this->args['after'] );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Gets the offset for the `before` cursor.
+	 *
+	 * @return int|string|null
+	 */
+	public function get_before_offset() {
+		if ( ! empty( $this->args['before'] ) ) {
+			return $this->get_offset_for_cursor( $this->args['before'] );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Whether there is a next page in the connection.
+	 *
+	 * If there are more "items" than were asked for in the "first" argument
+	 * ore if there are more "items" after the "before" argument, has_next_page() will be set to true.
+	 *
+	 * @return bool
+	 */
+	public function has_next_page() {
+		if ( ! empty( $this->args['first'] ) ) {
+			return ! empty( $this->ids ) && count( $this->ids ) > $this->get_query_amount();
+		}
+
+		$before_offset = $this->get_before_offset();
+
+		if ( $before_offset ) {
+			return $this->is_valid_offset( $before_offset );
+		}
+
+		return false;
+	}
+
+	/**
+	 * Whether there is a previous page in the connection.
+	 *
+	 * If there are more "items" than were asked for in the "last" argument
+	 * or if there are more "items" before the "after" argument, has_previous_page() will be set to true.
+	 *
+	 * @return bool
+	 */
+	public function has_previous_page() {
+		if ( ! empty( $this->args['last'] ) ) {
+			return ! empty( $this->ids ) && count( $this->ids ) > $this->get_query_amount();
+		}
+
+		$after_offset = $this->get_after_offset();
+		if ( $after_offset ) {
+			return $this->is_valid_offset( $after_offset );
+		}
+
+		return false;
+	}
+
+	/**
+	 * DEPRECATED METHODS
+	 *
+	 * These methods are deprecated and will be removed in a future release.
+	 */
+
+	/**
+	 * Returns the $args passed to the connection
+	 *
+	 * @deprecated Deprecated since v1.11.0 in favor of $this->get_args();
+	 *
+	 * @return array<string,mixed>
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public function getArgs(): array {
+		_deprecated_function( __METHOD__, '1.11.0', static::class . '::get_args()' );
+		return $this->get_args();
+	}
+
+	/**
+	 * @param string $key   The key of the query arg to set
+	 * @param mixed  $value The value of the query arg to set
+	 *
+	 * @return \WPGraphQL\Data\Connection\AbstractConnectionResolver
+	 *
+	 * @deprecated 0.3.0
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public function setQueryArg( $key, $value ) {
+		_deprecated_function( __METHOD__, '0.3.0', static::class . '::set_query_arg()' );
+
+		return $this->set_query_arg( $key, $value );
+	}
+
+	/**
+	 * Get_offset
+	 *
+	 * This returns the offset to be used in the $query_args based on the $args passed to the
+	 * GraphQL query.
+	 *
+	 * @deprecated 1.9.0
+	 *
+	 * @codeCoverageIgnore
+	 *
+	 * @return int|mixed
+	 */
+	public function get_offset() {
+		_deprecated_function( __METHOD__, '1.9.0', static::class . '::get_offset_for_cursor()' );
+
+		// Using shorthand since this is for deprecated code.
+		$cursor = $this->args['after'] ?? null;
+		$cursor = $cursor ?: ( $this->args['before'] ?? null );
+
+		return $this->get_offset_for_cursor( $cursor );
+	}
+
+	/**
+	 * Returns the source of the connection.
+	 *
+	 * @deprecated 1.24.0 in favor of $this->get_source().
+	 *
+	 * @return mixed
+	 */
+	public function getSource() {
+		_deprecated_function( __METHOD__, '1.24.0', static::class . '::get_source()' );
+
+		return $this->get_source();
+	}
+
+	/**
+	 * Returns the AppContext of the connection.
+	 *
+	 * @deprecated 1.24.0 in favor of $this->get_context().
+	 */
+	public function getContext(): AppContext {
+		_deprecated_function( __METHOD__, '1.24.0', static::class . '::get_context()' );
+
+		return $this->get_context();
+	}
+
+	/**
+	 * Returns the ResolveInfo of the connection.
+	 *
+	 * @deprecated 1.24.0 in favor of $this->get_info().
+	 */
+	public function getInfo(): ResolveInfo {
+		_deprecated_function( __METHOD__, '1.24.0', static::class . '::get_info()' );
+
+		return $this->get_info();
+	}
+
+	/**
+	 * Returns whether the connection should execute.
+	 *
+	 * @deprecated 1.24.0 in favor of $this->get_should_execute().
+	 */
+	public function getShouldExecute(): bool {
+		_deprecated_function( __METHOD__, '1.24.0', static::class . '::should_execute()' );
+
+		return $this->get_should_execute();
+	}
+
+	/**
+	 * Returns the loader.
+	 *
+	 * @deprecated 1.24.0 in favor of $this->get_loader().
+	 *
+	 * @return \WPGraphQL\Data\Loader\AbstractDataLoader
+	 * @throws \Exception
+	 */
+	protected function getLoader() {
+		_deprecated_function( __METHOD__, '1.24.0', static::class . '::get_loader()' );
+
+		return $this->get_loader();
 	}
 }

--- a/src/Data/Connection/CommentConnectionResolver.php
+++ b/src/Data/Connection/CommentConnectionResolver.php
@@ -12,7 +12,6 @@ use WP_Comment_Query;
  * @package WPGraphQL\Data\Connection
  */
 class CommentConnectionResolver extends AbstractConnectionResolver {
-
 	/**
 	 * {@inheritDoc}
 	 *
@@ -23,15 +22,14 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @throws \GraphQL\Error\UserError If there is a problem with the $args.
+	 * @throws \GraphQL\Error\UserError
 	 */
 	public function get_query_args() {
 
 		/**
 		 * Prepare for later use
 		 */
-		$last  = ! empty( $this->args['last'] ) ? $this->args['last'] : null;
-		$first = ! empty( $this->args['first'] ) ? $this->args['first'] : null;
+		$last = ! empty( $this->args['last'] ) ? $this->args['last'] : null;
 
 		$query_args = [];
 
@@ -50,7 +48,7 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 		 *
 		 * @since 0.0.6
 		 */
-		$query_args['number'] = min( max( absint( $first ), absint( $last ), 10 ), $this->get_query_amount() ) + 1;
+		$query_args['number'] = $this->get_query_amount() + 1;
 
 		/**
 		 * Set the default order
@@ -159,7 +157,7 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function get_loader_name() {
+	protected function loader_name(): string {
 		return 'comment';
 	}
 
@@ -179,27 +177,12 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * {@inheritDoc}
-	 *
-	 * For example, if the $source were a post_type that didn't support comments, we could prevent
-	 * the connection query from even executing. In our case, we prevent comments from even showing
-	 * in the Schema for post types that don't have comment support, so we don't need to worry
-	 * about that, but there may be other situations where we'd need to prevent it.
-	 *
-	 * @return bool
-	 */
-	public function should_execute() {
-		return true;
-	}
-
-
-	/**
 	 * Filters the GraphQL args before they are used in get_query_args().
 	 *
 	 * @return array<string,mixed>
 	 */
 	public function get_args(): array {
-		$args = $this->args;
+		$args = $this->get_unfiltered_args();
 
 		if ( ! empty( $args['where'] ) ) {
 			// Ensure all IDs are converted to database IDs.
@@ -253,7 +236,6 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 		}
 
 		/**
-		 *
 		 * Filters the GraphQL args before they are used in get_query_args().
 		 *
 		 * @param array<string,mixed>                                  $args                The GraphQL args passed to the resolver.
@@ -328,5 +310,12 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 	 */
 	public function is_valid_offset( $offset ) {
 		return ! empty( get_comment( $offset ) );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function should_execute() {
+		return true;
 	}
 }

--- a/src/Data/Connection/ContentTypeConnectionResolver.php
+++ b/src/Data/Connection/ContentTypeConnectionResolver.php
@@ -40,7 +40,6 @@ class ContentTypeConnectionResolver extends AbstractConnectionResolver {
 		return [];
 	}
 
-
 	/**
 	 * {@inheritDoc}
 	 *
@@ -62,7 +61,7 @@ class ContentTypeConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function get_loader_name() {
+	protected function loader_name(): string {
 		return 'post_type';
 	}
 

--- a/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
@@ -1,39 +1,12 @@
 <?php
 namespace WPGraphQL\Data\Connection;
 
-use GraphQL\Type\Definition\ResolveInfo;
-use WPGraphQL\AppContext;
-
 /**
  * Class EnqueuedScriptsConnectionResolver
  *
  * @package WPGraphQL\Data\Connection
  */
 class EnqueuedScriptsConnectionResolver extends AbstractConnectionResolver {
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info ) {
-
-		/**
-		 * Filter the query amount to be 1000 for
-		 */
-		add_filter(
-			'graphql_connection_max_query_amount',
-			static function ( $max, $source, $args, $context, ResolveInfo $info ) {
-				if ( 'enqueuedScripts' === $info->fieldName || 'registeredScripts' === $info->fieldName ) {
-					return 1000;
-				}
-				return $max;
-			},
-			10,
-			5
-		);
-
-		parent::__construct( $source, $args, $context, $info );
-	}
-
 	/**
 	 * {@inheritDoc}
 	 */
@@ -60,7 +33,6 @@ class EnqueuedScriptsConnectionResolver extends AbstractConnectionResolver {
 		return [];
 	}
 
-
 	/**
 	 * {@inheritDoc}
 	 *
@@ -73,16 +45,21 @@ class EnqueuedScriptsConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function get_loader_name() {
+	protected function loader_name(): string {
 		return 'enqueued_script';
 	}
 
 	/**
-	 * Determine if the model is valid
+	 * {@inheritDoc}
+	 */
+	protected function max_query_amount(): int {
+		return 1000;
+	}
+
+	/**
+	 * {@inheritDoc}
 	 *
-	 * @param ?\_WP_Dependency $model
-	 *
-	 * @return bool
+	 * @param ?\_WP_Dependency $model The model to check.
 	 */
 	protected function is_valid_model( $model ) {
 		return isset( $model->handle );

--- a/src/Data/Connection/EnqueuedStylesheetConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedStylesheetConnectionResolver.php
@@ -1,9 +1,6 @@
 <?php
 namespace WPGraphQL\Data\Connection;
 
-use GraphQL\Type\Definition\ResolveInfo;
-use WPGraphQL\AppContext;
-
 /**
  * Class EnqueuedStylesheetConnectionResolver
  *
@@ -19,31 +16,6 @@ class EnqueuedStylesheetConnectionResolver extends AbstractConnectionResolver {
 
 	/**
 	 * {@inheritDoc}
-	 */
-	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info ) {
-
-		/**
-		 * Filter the query amount to be 1000 for
-		 */
-		add_filter(
-			'graphql_connection_max_query_amount',
-			static function ( $max, $source, $args, $context, ResolveInfo $info ) {
-				if ( 'enqueuedStylesheets' === $info->fieldName || 'registeredStylesheets' === $info->fieldName ) {
-					return 1000;
-				}
-				return $max;
-			},
-			10,
-			5
-		);
-
-		parent::__construct( $source, $args, $context, $info );
-	}
-
-	/**
-	 * Get the IDs from the source
-	 *
-	 * @return mixed[]
 	 */
 	public function get_ids_from_query() {
 		$ids     = [];
@@ -68,9 +40,8 @@ class EnqueuedStylesheetConnectionResolver extends AbstractConnectionResolver {
 		return [];
 	}
 
-
 	/**
-	 * Get the items from the source
+	 * {@inheritDoc}
 	 *
 	 * @return string[]
 	 */
@@ -79,20 +50,23 @@ class EnqueuedStylesheetConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * The name of the loader to load the data
-	 *
-	 * @return string
+	 * {@inheritDoc}
 	 */
-	public function get_loader_name() {
+	protected function loader_name(): string {
 		return 'enqueued_stylesheet';
 	}
 
 	/**
-	 * Determine if the model is valid
+	 * {@inheritDoc}
+	 */
+	protected function max_query_amount(): int {
+		return 1000;
+	}
+
+	/**
+	 * {@inheritDoc}
 	 *
 	 * @param ?\_WP_Dependency $model
-	 *
-	 * @return bool
 	 */
 	protected function is_valid_model( $model ) {
 		return isset( $model->handle );
@@ -107,7 +81,7 @@ class EnqueuedStylesheetConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * D{@inheritDoc}
+	 * {@inheritDoc}
 	 */
 	public function should_execute() {
 		return true;

--- a/src/Data/Connection/MenuItemConnectionResolver.php
+++ b/src/Data/Connection/MenuItemConnectionResolver.php
@@ -80,7 +80,7 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 	 * {@inheritDoc}
 	 */
 	public function get_args(): array {
-		$args = $this->args;
+		$args = $this->get_unfiltered_args();
 
 		if ( ! empty( $args['where'] ) ) {
 			// Ensure all IDs are converted to database IDs.
@@ -106,6 +106,6 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 		 *
 		 * @since 1.11.0
 		 */
-		return apply_filters( 'graphql_menu_item_connection_args', $args, $this->args );
+		return apply_filters( 'graphql_menu_item_connection_args', $args, $this->get_unfiltered_args() );
 	}
 }

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -28,6 +28,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	 * @var \WP_Query|object
 	 */
 	protected $query;
+
 	/**
 	 * {@inheritDoc}
 	 *
@@ -68,7 +69,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function get_loader_name() {
+	protected function loader_name(): string {
 		return 'post';
 	}
 
@@ -148,8 +149,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		/**
 		 * Prepare for later use
 		 */
-		$last  = ! empty( $this->args['last'] ) ? $this->args['last'] : null;
-		$first = ! empty( $this->args['first'] ) ? $this->args['first'] : null;
+		$last = ! empty( $this->args['last'] ) ? $this->args['last'] : null;
 
 		$query_args = [];
 		/**
@@ -175,10 +175,10 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		/**
 		 * Set posts_per_page the highest value of $first and $last, with a (filterable) max of 100
 		 */
-		$query_args['posts_per_page'] = $this->one_to_one ? 1 : min( max( absint( $first ), absint( $last ), 10 ), $this->query_amount ) + 1;
+		$query_args['posts_per_page'] = $this->one_to_one ? 1 : $this->get_query_amount() + 1;
 
 		// set the graphql cursor args
-		$query_args['graphql_cursor_compare'] = ( ! empty( $last ) ) ? '>' : '<';
+		$query_args['graphql_cursor_compare'] = ! empty( $last ) ? '>' : '<';
 		$query_args['graphql_after_cursor']   = $this->get_after_offset();
 		$query_args['graphql_before_cursor']  = $this->get_before_offset();
 
@@ -253,7 +253,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 				static function ( $id ) {
 					return absint( $id );
 				},
-				$post_in 
+				$post_in
 			);
 
 			// If we're coming backwards, let's reverse the IDs
@@ -450,7 +450,6 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	 * @return string[]|null
 	 */
 	public function sanitize_post_stati( $stati ) {
-
 		/**
 		 * If no stati is explicitly set by the input, default to publish. This will be the
 		 * most common scenario.
@@ -533,7 +532,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 	 * {@inheritDoc}
 	 */
 	public function get_args(): array {
-		$args = $this->args;
+		$args = $this->get_unfiltered_args();
 
 		if ( ! empty( $args['where'] ) ) {
 			// Ensure all IDs are converted to database IDs.
@@ -560,7 +559,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 								static function ( $id ) {
 									return Utils::get_database_id_from_id( $id );
 								},
-								$input_value 
+								$input_value
 							);
 							break;
 						}
@@ -572,7 +571,6 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		}
 
 		/**
-		 *
 		 * Filters the GraphQL args before they are used in get_query_args().
 		 *
 		 * @param array<string,mixed>                                     $args                The GraphQL args passed to the resolver.
@@ -581,7 +579,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		 *
 		 * @since 1.11.0
 		 */
-		return apply_filters( 'graphql_post_object_connection_args', $args, $this, $this->args );
+		return apply_filters( 'graphql_post_object_connection_args', $args, $this, $this->get_unfiltered_args() );
 	}
 
 	/**

--- a/src/Data/Connection/TaxonomyConnectionResolver.php
+++ b/src/Data/Connection/TaxonomyConnectionResolver.php
@@ -36,13 +36,13 @@ class TaxonomyConnectionResolver extends AbstractConnectionResolver {
 	 * {@inheritDoc}
 	 */
 	public function get_query_args() {
-		// If any args are added to filter/sort the connection
+		// If any args are added to filter/sort the connection.
 		return [];
 	}
 
 
 	/**
-	 * Get the items from the source
+	 * {@inheritDoc}
 	 *
 	 * @return string[]
 	 */
@@ -62,7 +62,7 @@ class TaxonomyConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function get_loader_name() {
+	protected function loader_name(): string {
 		return 'taxonomy';
 	}
 

--- a/src/Data/Connection/TermObjectConnectionResolver.php
+++ b/src/Data/Connection/TermObjectConnectionResolver.php
@@ -52,7 +52,6 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 			$taxonomy             = array_intersect( $all_taxonomies, $requested_taxonomies );
 		}
 
-
 		$query_args = [
 			'taxonomy' => $taxonomy,
 		];
@@ -60,8 +59,7 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 		/**
 		 * Prepare for later use
 		 */
-		$last  = ! empty( $this->args['last'] ) ? $this->args['last'] : null;
-		$first = ! empty( $this->args['first'] ) ? $this->args['first'] : null;
+		$last = ! empty( $this->args['last'] ) ? $this->args['last'] : null;
 
 		/**
 		 * Set hide_empty as false by default
@@ -71,7 +69,7 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 		/**
 		 * Set the number, ensuring it doesn't exceed the amount set as the $max_query_amount
 		 */
-		$query_args['number'] = min( max( absint( $first ), absint( $last ), 10 ), $this->query_amount ) + 1;
+		$query_args['number'] = $this->get_query_amount() + 1;
 
 		/**
 		 * Don't calculate the total rows, it's not needed and can be expensive
@@ -175,17 +173,8 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function get_loader_name() {
+	protected function loader_name(): string {
 		return 'term';
-	}
-
-	/**
-	 * {@inheritDoc}
-	 *
-	 * Default is true, meaning any time a TermObjectConnection resolver is asked for, it will execute.
-	 */
-	public function should_execute() {
-		return true;
 	}
 
 	/**
@@ -253,7 +242,7 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 	 * {@inheritDoc}
 	 */
 	public function get_args(): array {
-		$args = $this->args;
+		$args = $this->get_unfiltered_args();
 
 		if ( ! empty( $args['where'] ) ) {
 			// Ensure all IDs are converted to database IDs.
@@ -286,7 +275,6 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 		}
 
 		/**
-		 *
 		 * Filters the GraphQL args before they are used in get_query_args().
 		 *
 		 * @param array<string,mixed>                                     $args                The GraphQL args passed to the resolver.
@@ -295,7 +283,7 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 		 *
 		 * @since 1.11.0
 		 */
-		return apply_filters( 'graphql_term_object_connection_args', $args, $this, $this->args );
+		return apply_filters( 'graphql_term_object_connection_args', $args, $this, $this->get_unfiltered_args() );
 	}
 
 	/**
@@ -305,5 +293,14 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 	 */
 	public function is_valid_offset( $offset ) {
 		return get_term( absint( $offset ) ) instanceof \WP_Term;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * Default is true, meaning any time a TermObjectConnection resolver is asked for, it will execute.
+	 */
+	public function should_execute() {
+		return true;
 	}
 }

--- a/src/Data/Connection/ThemeConnectionResolver.php
+++ b/src/Data/Connection/ThemeConnectionResolver.php
@@ -42,9 +42,8 @@ class ThemeConnectionResolver extends AbstractConnectionResolver {
 		];
 	}
 
-
 	/**
-	 * Get the items from the source
+	 * {@inheritDoc}
 	 *
 	 * @return string[]
 	 */
@@ -57,7 +56,7 @@ class ThemeConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function get_loader_name() {
+	protected function loader_name(): string {
 		return 'theme';
 	}
 

--- a/src/Data/Connection/UserConnectionResolver.php
+++ b/src/Data/Connection/UserConnectionResolver.php
@@ -23,14 +23,7 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function should_execute() {
-		return true;
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function get_loader_name() {
+	protected function loader_name(): string {
 		return 'user';
 	}
 
@@ -185,7 +178,7 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * Return an instance of the WP_User_Query with the args for the connection being executed
+	 * {@inheritDoc}
 	 *
 	 * @return object|\WP_User_Query
 	 * @throws \Exception
@@ -283,11 +276,16 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @param int $offset The ID of the node used as the offset in the cursor
-	 *
-	 * @return bool
+	 * @param int $offset The ID of the node used as the offset in the cursor.
 	 */
 	public function is_valid_offset( $offset ) {
 		return (bool) get_user_by( 'ID', absint( $offset ) );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function should_execute() {
+		return true;
 	}
 }

--- a/src/Data/Connection/UserRoleConnectionResolver.php
+++ b/src/Data/Connection/UserRoleConnectionResolver.php
@@ -57,14 +57,14 @@ class UserRoleConnectionResolver extends AbstractConnectionResolver {
 	 */
 	public function get_query() {
 		$wp_roles = wp_roles();
-		
+
 		return ! empty( $wp_roles->get_names() ) ? array_keys( $wp_roles->get_names() ) : [];
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public function get_loader_name() {
+	protected function loader_name(): string {
 		return 'user_role';
 	}
 

--- a/src/Data/Loader/AbstractDataLoader.php
+++ b/src/Data/Loader/AbstractDataLoader.php
@@ -95,7 +95,7 @@ abstract class AbstractDataLoader {
 					static::class . '::buffer expects all keys to be scalars, but key ' .
 					'at position ' . esc_html( $index ) . ' is ' . esc_html(
 						Utils::printSafe( $keys ) . '. ' .
-						$this->get_scalar_key_hint( $key ) 
+						$this->get_scalar_key_hint( $key )
 					)
 				);
 			}
@@ -120,7 +120,7 @@ abstract class AbstractDataLoader {
 			throw new Exception(
 				static::class . '::load expects key to be scalar, but got ' . esc_html(
 					Utils::printSafe( $key ) .
-					$this->get_scalar_key_hint( $key ) 
+					$this->get_scalar_key_hint( $key )
 				)
 			);
 		}
@@ -150,7 +150,7 @@ abstract class AbstractDataLoader {
 			throw new Exception(
 				static::class . '::prime is expecting scalar $key, but got ' . esc_html(
 					Utils::printSafe( $key )
-					. $this->get_scalar_key_hint( $key ) 
+					. $this->get_scalar_key_hint( $key )
 				)
 			);
 		}

--- a/src/Data/Loader/TaxonomyLoader.php
+++ b/src/Data/Loader/TaxonomyLoader.php
@@ -12,7 +12,7 @@ class TaxonomyLoader extends AbstractDataLoader {
 
 	/**
 	 * {@inheritDoc}
-	 * 
+	 *
 	 * @param mixed|\WP_Taxonomy $entry The Taxonomy Object
 	 *
 	 * @return \WPGraphQL\Model\Taxonomy

--- a/src/Data/Loader/UserLoader.php
+++ b/src/Data/Loader/UserLoader.php
@@ -54,7 +54,7 @@ class UserLoader extends AbstractDataLoader {
 			'names',
 			[
 				'public' => true,
-			] 
+			]
 		);
 
 		/**

--- a/src/Data/MediaItemMutation.php
+++ b/src/Data/MediaItemMutation.php
@@ -26,7 +26,7 @@ class MediaItemMutation {
 	 */
 	public static function prepare_media_item( array $input, WP_Post_Type $post_type_object, string $mutation_name, $file ) {
 		$insert_post_args = [];
-		
+
 		/**
 		 * Set the post_type (attachment) for the insert
 		 */

--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -281,8 +281,6 @@ class NodeResolver {
 				return null;
 			}
 
-
-
 			return ! empty( $queried_object->name ) ? $this->context->get_loader( 'post_type' )->load_deferred( $queried_object->name ) : null;
 		}
 
@@ -389,7 +387,6 @@ class NodeResolver {
 		$this->wp->query_vars['uri'] = $uri;
 
 		// Process PATH_INFO, REQUEST_URI, and 404 for permalinks.
-
 
 		// Fetch the rewrite rules.
 		$rewrite = $wp_rewrite->wp_rewrite_rules();
@@ -593,7 +590,6 @@ class NodeResolver {
 		if ( isset( $error ) ) {
 			$this->wp->query_vars['error'] = $error;
 		}
-
 
 		// if the parsed url is ONLY a query, unset the pagename query var
 		if ( isset( $this->wp->query_vars['pagename'], $parsed_url['query'] ) && ( $parsed_url['query'] === $this->wp->query_vars['pagename'] ) ) {

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -1089,7 +1089,28 @@ class TypeRegistry {
 					return $fields;
 				}
 
+				// if a field has already been registered with the same name output a debug message
 				if ( isset( $fields[ $field_name ] ) ) {
+
+					// if the existing field is a connection type
+					// and the new field is also a connection type
+					// and the toType is the same for both
+					// then we can allow the duplicate field
+					if (
+						isset(
+							$fields[ $field_name ]['isConnectionField'],
+							$config['isConnectionField'],
+							$fields[ $field_name ]['toType'],
+							$config['toType'],
+							$fields[ $field_name ]['connectionTypeName'],
+							$config['connectionTypeName']
+						) &&
+						$fields[ $field_name ]['toType'] === $config['toType'] &&
+						$fields[ $field_name ]['connectionTypeName'] === $config['connectionTypeName']
+					) {
+						return $fields;
+					}
+
 					graphql_debug(
 						sprintf(
 							// translators: %1$s is the field name, %2$s is the type name.
@@ -1098,9 +1119,11 @@ class TypeRegistry {
 							$type_name
 						),
 						[
-							'type'       => 'DUPLICATE_FIELD',
-							'field_name' => $field_name,
-							'type_name'  => $type_name,
+							'type'            => 'DUPLICATE_FIELD',
+							'field_name'      => $field_name,
+							'type_name'       => $type_name,
+							'existing_field'  => $fields[ $field_name ],
+							'duplicate_field' => $config,
 						]
 					);
 					return $fields;

--- a/src/Router.php
+++ b/src/Router.php
@@ -323,7 +323,6 @@ class Router {
 			'X-GraphQL-URL'                => $host_and_path,
 		];
 
-
 		// If the Query Analyzer was instantiated
 		// Get the headers determined from its Analysis
 		if ( self::get_request() instanceof Request && self::get_request()->get_query_analyzer()->is_enabled_for_query() ) {

--- a/src/Type/Connection/TermObjects.php
+++ b/src/Type/Connection/TermObjects.php
@@ -38,7 +38,7 @@ class TermObjects {
 				'resolve'        => static function ( $source, $args, $context, $info ) {
 					$taxonomies = isset( $args['where']['taxonomies'] ) && is_array( $args['where']['taxonomies'] ) ? $args['where']['taxonomies'] : \WPGraphQL::get_allowed_taxonomies();
 					$resolver   = new TermObjectConnectionResolver( $source, $args, $context, $info, array_values( $taxonomies ) );
-					
+
 					return $resolver->get_connection();
 				},
 			]

--- a/src/Type/Connection/Users.php
+++ b/src/Type/Connection/Users.php
@@ -109,7 +109,7 @@ class Users {
 					$resolver->set_query_arg( 'include', [ absint( $post->authorDatabaseId ) ] );
 					return $resolver->one_to_one()->get_connection();
 				},
-			] 
+			]
 		);
 	}
 

--- a/src/Type/WPConnectionType.php
+++ b/src/Type/WPConnectionType.php
@@ -515,6 +515,7 @@ class WPConnectionType {
 				'type'                  => true === $this->one_to_one ? $this->connection_name . 'Edge' : $this->connection_name,
 				'args'                  => array_merge( $this->get_pagination_args(), $this->where_args ),
 				'auth'                  => $this->auth,
+				'isConnectionField'     => true,
 				'deprecationReason'     => ! empty( $this->config['deprecationReason'] ) ? $this->config['deprecationReason'] : null,
 				'description'           => ! empty( $this->config['description'] )
 					? $this->config['description']
@@ -561,7 +562,6 @@ class WPConnectionType {
 				]
 			);
 		}
-
 
 		if ( ! $this->type_registry->has_type( $connection_edge_type ) ) {
 			$this->type_registry->register_interface_type(

--- a/src/Type/WPInterfaceTrait.php
+++ b/src/Type/WPInterfaceTrait.php
@@ -2,6 +2,7 @@
 namespace WPGraphQL\Type;
 
 use GraphQL\Type\Definition\InterfaceType;
+use WPGraphQL\Registry\TypeRegistry;
 
 /**
  * Trait WPInterfaceTrait
@@ -101,5 +102,86 @@ trait WPInterfaceTrait {
 		}
 
 		return array_unique( $new_interfaces );
+	}
+
+	/**
+	 * Returns the fields for a Type, applying any missing fields defined on interfaces implemented on the type
+	 *
+	 * @param array<mixed>                     $config
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
+	 *
+	 * @return array<mixed>
+	 * @throws \Exception
+	 */
+	protected function get_fields( array $config, TypeRegistry $type_registry ): array {
+		$fields = $config['fields'];
+
+		$fields = array_filter( $fields );
+
+		/**
+		 * Get the fields of interfaces and ensure they exist as fields of this type.
+		 *
+		 * Types are still responsible for ensuring the fields resolve properly.
+		 */
+		$interface_fields = [];
+
+		if ( ! empty( $this->getInterfaces() ) && is_array( $this->getInterfaces() ) ) {
+			foreach ( $this->getInterfaces() as $interface_type ) {
+				if ( ! $interface_type instanceof InterfaceType ) {
+					$interface_type = $type_registry->get_type( $interface_type );
+				}
+
+				if ( ! $interface_type instanceof InterfaceType ) {
+					continue;
+				}
+
+				$interface_config_fields = $interface_type->getFields();
+
+				if ( empty( $interface_config_fields ) ) {
+					continue;
+				}
+
+				foreach ( $interface_config_fields as $interface_field_name => $interface_field ) {
+					$interface_fields[ $interface_field_name ] = $interface_field->config;
+				}
+			}
+		}
+
+		// diff the $interface_fields and the $fields
+		// if the field is not in $fields, add it
+		$diff = ! empty( $interface_fields ) ? array_diff_key( $interface_fields, $fields ) : [];
+
+		// If the Interface has fields defined that are not defined
+		// on the Object Type, add them to the Object Type
+		if ( ! empty( $diff ) ) {
+			$fields = array_merge( $fields, $diff );
+		}
+
+		foreach ( $fields as $field_name => $field ) {
+			$new_field = $field;
+
+			if ( empty( $new_field['description'] ) && ! empty( $interface_fields[ $field_name ]['description'] ) ) {
+				$new_field['description'] = $interface_fields[ $field_name ]['description'];
+			}
+
+			if ( ! isset( $new_field['type'] ) ) {
+				if ( isset( $interface_fields[ $field_name ]['type'] ) ) {
+					$new_field['type'] = $interface_fields[ $field_name ]['type'];
+				} else {
+					unset( $fields[ $field_name ] );
+				}
+			}
+
+			// If the field has not been unset, update the field
+			if ( isset( $fields[ $field_name ] ) ) {
+				$fields[ $field_name ] = $new_field;
+			}
+		}
+
+		$fields = $this->prepare_fields( $fields, $config['name'], $config );
+		$fields = $type_registry->prepare_fields( $fields, $config['name'] );
+
+		$this->fields = $fields;
+		return $this->fields;
 	}
 }

--- a/tests/wpunit/PostObjectConnectionQueriesTest.php
+++ b/tests/wpunit/PostObjectConnectionQueriesTest.php
@@ -153,7 +153,7 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 
 	public function testMaxQueryAmount() {
 		// Create some additional posts to test a large query.
-		$this->create_posts( 150 );
+		$post_ids = $this->create_posts( 150 );
 
 		$query = $this->getQuery();
 
@@ -186,16 +186,65 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		add_filter(
-			'graphql_connection_max_query_amount',
-			static function () {
-				return 100;
-			}
-		);
-
 		$this->assertCount( 20, $actual['data']['posts']['edges'] );
 		$this->assertTrue( $actual['data']['posts']['pageInfo']['hasNextPage'] );
 		$this->assertStringContainsString( 'The number of items requested by the connection (150) exceeds the max query amount.', $actual['extensions']['debug'][0]['message'] );
+
+		// Cleanup
+		remove_all_filters( 'graphql_connection_max_query_amount' );
+		foreach( $post_ids as $post_id ) {
+			wp_delete_post( $post_id, true );
+		}
+	}
+
+	public function testDefaultQueryAmount() {
+		// Create some additional posts to test a large query.
+		$post_ids = $this->create_posts( 25 );
+
+		$query = $this->getQuery();
+
+		$variables = [
+			'first' => null,
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+		$this->assertNotEmpty( $actual );
+
+		/**
+		 * The default that can be queried by default is 10 items
+		 */
+		$this->assertCount( 10, $actual['data']['posts']['edges'], '10 items should be returned by default' );
+
+		/**
+		 * Test the filter to make sure it's defaulting the results properly
+		 */
+		add_filter(
+			'graphql_connection_default_query_amount',
+			static function () {
+				return 20;
+			}
+		);
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertCount( 20, $actual['data']['posts']['edges'], '20 items should be returned by default' );
+
+		add_filter(
+			'graphql_connection_default_query_amount',
+			static function () {
+				return 5;
+			}
+		);
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertCount( 5, $actual['data']['posts']['edges'], '5 items should be returned by default' );
+
+		// Cleanup
+		remove_all_filters( 'graphql_connection_max_query_amount' );
+		foreach( $post_ids as $post_id ) {
+			wp_delete_post( $post_id, true );
+		}
 	}
 
 	/**

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.23.0
+ * Version: 1.24.0
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.23.0
+ * @version  1.24.0
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
## Release Notes

### Upgrade Notice

The AbstractConnectionResolver has undergone some refactoring. Some methods using `snakeCase` have been deprecated in favor of their `camel_case` equivalent. While we've preserved the deprecated methods to prevent breaking changes, you might begin seeing PHP notices about the deprecations. Any codebase that extends the `AbstractConnectionResolver` class should update the following methods:

- `getSource` -> `get_source`
- `getContext` -> `get_context`
- `getInfo` -> `get_info`
- `getShouldExecute` -> `get_should_execute`
- `getLoader` -> `getLoader`

### New Features

- [#3084](https://github.com/wp-graphql/wp-graphql/pull/3084): perf: refactor PluginConnectionResolver to only fetch plugins once. Thanks @justlevine!
- [#3088](https://github.com/wp-graphql/wp-graphql/pull/3088): refactor: improve loader handling in AbstractConnectionResolver. Thanks @justlevine!
- [#3087](https://github.com/wp-graphql/wp-graphql/pull/3087): feat: improve query amount handling in AbstractConnectionResolver. Thanks @justlevine!
- [#3086](https://github.com/wp-graphql/wp-graphql/pull/3086): refactor: add AbstractConnectionResolver::get_unfiltered_args() public getter. Thanks @justlevine!
- [#3085](https://github.com/wp-graphql/wp-graphql/pull/3085): refactor: add AbstractConnectionResolver::prepare_page_info()and only instantiate once. Thanks @justlevine!
- [#3083](https://github.com/wp-graphql/wp-graphql/pull/3083): refactor: deprecate camelCase methods in AbstractConnectionResolver for snake_case equivalents. Thanks @justlevine!


### Chores / Bugfixes

- [#3095](https://github.com/wp-graphql/wp-graphql/pull/3095): chore: lint for superfluous whitespace. Thanks @justlevine!
- [#3100](https://github.com/wp-graphql/wp-graphql/pull/3100): fix: recursion issues with interfaces
- [#3082](https://github.com/wp-graphql/wp-graphql/pull/3082): chore: prepare ConnectionResolver classes for v2 backport
