### PR TITLE
refactor: improve `should_execute()` handling in AbstractConnectionResolver [WIP]

### DIFF
--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -64,9 +64,13 @@ abstract class AbstractConnectionResolver {
 	/**
 	 * Whether the connection resolver should execute.
 	 *
-	 * @var bool
+	 * If `false`, the connection resolve will short-circuit and return an empty array.
+	 *
+	 * Filterable by `graphql_connection_pre_should_execute` and `graphql_connection_should_execute`.
+	 *
+	 * @var ?bool
 	 */
-	protected $should_execute = true;
+	protected $should_execute;
 
 	/**
 	 * The loader name.
@@ -172,8 +176,8 @@ abstract class AbstractConnectionResolver {
 		 */
 		$this->args = $args;
 
-		// Bail if the Post->ID is empty, as that indicates a private post.
-		if ( $source instanceof Post && empty( $source->ID ) ) {
+		// Pre-check if the connection should execute so we can skip expensive logic if we already know it shouldn't execute.
+		if ( ! $this->get_pre_should_execute( $this->source, $this->unfiltered_args, $this->context, $this->info ) ) {
 			$this->should_execute = false;
 		}
 
@@ -257,22 +261,29 @@ abstract class AbstractConnectionResolver {
 	abstract public function get_query();
 
 	/**
-	 * Should_execute
+	 * Used to determine whether the connection query should be executed. This is useful for short-circuiting the connection resolver before executing the query.
 	 *
-	 * Determine whether or not the query should execute.
+	 * When `pre_should_excecute()` returns false, that's a sign the Resolver shouldn't execute the query. Otherwise, the more expensive logic logic in `should_execute()` will run later in the lifecycle.
 	 *
-	 * Return true to execute, return false to prevent execution.
-	 *
-	 * Various criteria can be used to determine whether a Connection Query should
-	 * be executed.
-	 *
-	 * For example, if a user is requesting revisions of a Post, and the user doesn't have
-	 * permission to edit the post, they don't have permission to view the revisions, and therefore
-	 * we can prevent the query to fetch revisions from executing in the first place.
-	 *
-	 * @return bool
+	 * @param mixed                                $source  Source passed down from the resolve tree
+	 * @param array<string,mixed>                  $args    Array of arguments input in the field as part of the GraphQL query.
+	 * @param \WPGraphQL\AppContext                $context The app context that gets passed down the resolve tree.
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info    Info about fields passed down the resolve tree.
 	 */
-	abstract public function should_execute();
+	protected function pre_should_execute( $source, array $args, AppContext $context, ResolveInfo $info ): bool {
+		$should_execute = true;
+
+		/**
+		 * If the source is a Post and the ID is empty, we should not execute the query.
+		 *
+		 * @todo this can probably be moved to the PostObjectConnectionResolver when we don't care about b/c.
+		 */
+		if ( $source instanceof Post && empty( $source->ID ) ) {
+			$should_execute = false;
+		}
+
+		return $should_execute;
+	}
 
 	/**
 	 * The maximum number of items that should be returned by the query.
@@ -320,6 +331,25 @@ abstract class AbstractConnectionResolver {
 				static::class
 			)
 		);
+	}
+
+	/**
+	 * Determine whether or not the query should execute.
+	 *
+	 * Return true to exeucte, return false to prevent execution.
+	 *
+	 * Various criteria can be used to determine whether a Connection Query should be executed.
+	 *
+	 * For example, if a user is requesting revisions of a Post, and the user doesn't have permission to edit the post, they don't have permission to view the revisions, and therefore we can prevent the query to fetch revisions from executing in the first place.
+	 *
+	 * Runs only if `pre_should_execute()` returns true.
+	 *
+	 * @todo This is public for b/c but it should be protected.
+	 *
+	 * @return bool
+	 */
+	public function should_execute() {
+		return true;
 	}
 
 	/**
@@ -429,13 +459,6 @@ abstract class AbstractConnectionResolver {
 	}
 
 	/**
-	 * Returns whether the connection should execute.
-	 */
-	public function get_should_execute(): bool {
-		return $this->should_execute;
-	}
-
-	/**
 	 * Returns the $args passed to the connection, before any modifications.
 	 *
 	 * @return array<string,mixed>
@@ -496,6 +519,26 @@ abstract class AbstractConnectionResolver {
 		return $this->query_amount;
 	}
 
+	/**
+	 * Returns whether the connection should execute.
+	 *
+	 * If conditions are met that should prevent the execution, we can bail from resolving early, before the query is executed.
+	 */
+	public function get_should_execute(): bool {
+		if ( ! isset( $this->should_execute ) ) {
+			$should_execute = $this->should_execute();
+
+			/**
+			 * Filter whether the connection should execute.
+			 *
+			 * @param bool $should_execute Whether the connection should execute
+			 * @param self $resolver       Instance of the Connection Resolver
+			 */
+			$this->should_execute = apply_filters( 'graphql_connection_should_execute', $should_execute, $this );
+		}
+
+		return $this->should_execute;
+	}
 
 	/**
 	 * Returns an array of IDs for the connection.
@@ -650,6 +693,33 @@ abstract class AbstractConnectionResolver {
 	}
 
 	/**
+	 * Gets whether or not the query should execute, BEFORE any data is fetched or altered, filtered by 'graphql_connection_pre_should_execute'.
+	 *
+	 * @param mixed                                $source  The source that's passed down the GraphQL queries.
+	 * @param array<string,mixed>                  $args    The inputArgs on the field.
+	 * @param \WPGraphQL\AppContext                $context The AppContext passed down the GraphQL tree.
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info    The ResolveInfo passed down the GraphQL tree.
+	 */
+	protected function get_pre_should_execute( $source, array $args, AppContext $context, ResolveInfo $info ): bool {
+		$should_execute = $this->pre_should_execute( $source, $args, $context, $info );
+
+		/**
+		 * Filters whether or not the query should execute, BEFORE any data is fetched or altered.
+		 *
+		 * This is evaluated based solely on the values passed to the constructor, before any data is fetched or altered, and is useful for shortcircuiting the Connection Resolver before any heavy logic is executed.
+		 *
+		 * For more in-depth checks, use the `graphql_connection_should_execute` filter instead.
+		 *
+		 * @param bool                                 $should_execute Whether or not the query should execute.
+		 * @param mixed                                $source         The source that's passed down the GraphQL queries.
+		 * @param array                                $args           The inputArgs on the field.
+		 * @param \WPGraphQL\AppContext                $context        The AppContext passed down the GraphQL tree.
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info           The ResolveInfo passed down the GraphQL tree.
+		 */
+		return apply_filters( 'graphql_connection_pre_should_execute', $should_execute, $source, $args, $context, $info );
+	}
+
+	/**
 	 * Returns the loader.
 	 *
 	 * If $loader is not initialized, this method will initialize it.
@@ -792,25 +862,12 @@ abstract class AbstractConnectionResolver {
 	 * @throws \Exception
 	 */
 	public function execute_and_get_ids() {
-
 		/**
-		 * If should_execute is explicitly set to false already, we can
-		 * prevent execution quickly. If it's not, we need to
-		 * call the should_execute() method to execute any situational logic
-		 * to determine if the connection query should execute or not
+		 * If should_execute is explicitly set to false already, we can prevent execution quickly.
+		 * If it's not, we need to call the get_should_execute() method to execute any situational logic to determine if the connection query should execute.
 		 */
-		$should_execute = false === $this->should_execute ? false : $this->should_execute();
+		$this->should_execute = false === $this->should_execute ? false : $this->get_should_execute();
 
-		/**
-		 * Check if the connection should execute. If conditions are met that should prevent
-		 * the execution, we can bail from resolving early, before the query is executed.
-		 *
-		 * Filter whether the connection should execute.
-		 *
-		 * @param bool                       $should_execute      Whether the connection should execute
-		 * @param \WPGraphQL\Data\Connection\AbstractConnectionResolver $connection_resolver Instance of the Connection Resolver
-		 */
-		$this->should_execute = apply_filters( 'graphql_connection_should_execute', $should_execute, $this );
 		if ( false === $this->should_execute ) {
 			return [];
 		}

--- a/src/Data/Connection/CommentConnectionResolver.php
+++ b/src/Data/Connection/CommentConnectionResolver.php
@@ -311,11 +311,4 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 	public function is_valid_offset( $offset ) {
 		return ! empty( get_comment( $offset ) );
 	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function should_execute() {
-		return true;
-	}
 }

--- a/src/Data/Connection/ContentTypeConnectionResolver.php
+++ b/src/Data/Connection/ContentTypeConnectionResolver.php
@@ -73,11 +73,4 @@ class ContentTypeConnectionResolver extends AbstractConnectionResolver {
 	public function is_valid_offset( $offset ) {
 		return (bool) get_post_type_object( $offset );
 	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function should_execute() {
-		return true;
-	}
 }

--- a/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
@@ -72,11 +72,4 @@ class EnqueuedScriptsConnectionResolver extends AbstractConnectionResolver {
 		global $wp_scripts;
 		return isset( $wp_scripts->registered[ $offset ] );
 	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function should_execute() {
-		return true;
-	}
 }

--- a/src/Data/Connection/EnqueuedStylesheetConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedStylesheetConnectionResolver.php
@@ -79,11 +79,4 @@ class EnqueuedStylesheetConnectionResolver extends AbstractConnectionResolver {
 		global $wp_styles;
 		return isset( $wp_styles->registered[ $offset ] );
 	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function should_execute() {
-		return true;
-	}
 }

--- a/src/Data/Connection/TaxonomyConnectionResolver.php
+++ b/src/Data/Connection/TaxonomyConnectionResolver.php
@@ -74,11 +74,4 @@ class TaxonomyConnectionResolver extends AbstractConnectionResolver {
 	public function is_valid_offset( $offset ) {
 		return (bool) get_taxonomy( $offset );
 	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function should_execute() {
-		return true;
-	}
 }

--- a/src/Data/Connection/TermObjectConnectionResolver.php
+++ b/src/Data/Connection/TermObjectConnectionResolver.php
@@ -294,13 +294,4 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 	public function is_valid_offset( $offset ) {
 		return get_term( absint( $offset ) ) instanceof \WP_Term;
 	}
-
-	/**
-	 * {@inheritDoc}
-	 *
-	 * Default is true, meaning any time a TermObjectConnection resolver is asked for, it will execute.
-	 */
-	public function should_execute() {
-		return true;
-	}
 }

--- a/src/Data/Connection/ThemeConnectionResolver.php
+++ b/src/Data/Connection/ThemeConnectionResolver.php
@@ -67,11 +67,4 @@ class ThemeConnectionResolver extends AbstractConnectionResolver {
 		$theme = wp_get_theme( $offset );
 		return $theme->exists();
 	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function should_execute() {
-		return true;
-	}
 }

--- a/src/Data/Connection/UserConnectionResolver.php
+++ b/src/Data/Connection/UserConnectionResolver.php
@@ -281,11 +281,4 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 	public function is_valid_offset( $offset ) {
 		return (bool) get_user_by( 'ID', absint( $offset ) );
 	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function should_execute() {
-		return true;
-	}
 }


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR improves the DX around how Connection Resolvers determine whether they `should_execute`.

More specifically:

- `AbstractConnectionResolver` is no longer initialized as true by default, instead the `should_execute()` method is no longer abstract, and defaults to `true`.
- The `should_execute` pre-check in the constructor has moved into the new `pre_should_execute()` method, which is passed through the new `graphql_connection_pre_should_execute` filter in the new `get_pre_should_execute()` method. (The check itself remains unchanged for b/c).
- The `get_should_execute()` method has been refactored to check whether `AbstractConnectionResolver::$should_execute`  is already set, and _only if not_ to run the `should_execute()` logic.

Does this close any currently open issues?
------------------------------------------
<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
<!-- (If it’s long, please paste to https://ghostbin.com/ and insert the link here.) -->


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
