### PR TITLE
fix: arguments on Interface Fields were not properly applied to interfaces and object types implementing the Interface

### DIFF
--- a/src/Type/WPInterfaceTrait.php
+++ b/src/Type/WPInterfaceTrait.php
@@ -160,10 +160,6 @@ trait WPInterfaceTrait {
 		foreach ( $fields as $field_name => $field ) {
 			$new_field = $field;
 
-			if ( empty( $new_field['description'] ) && ! empty( $interface_fields[ $field_name ]['description'] ) ) {
-				$new_field['description'] = $interface_fields[ $field_name ]['description'];
-			}
-
 			if ( ! isset( $new_field['type'] ) ) {
 				if ( isset( $interface_fields[ $field_name ]['type'] ) ) {
 					$new_field['type'] = $interface_fields[ $field_name ]['type'];
@@ -174,7 +170,17 @@ trait WPInterfaceTrait {
 
 			// If the field has not been unset, update the field
 			if ( isset( $fields[ $field_name ] ) ) {
+
+				if ( empty( $new_field['description'] ) && ! empty( $interface_fields[ $field_name ]['description'] ) ) {
+					$new_field['description'] = $interface_fields[ $field_name ]['description'];
+				}
+
+				if ( ! empty( $interface_fields[ $field_name ]['args'] ) && is_array( $interface_fields[ $field_name ]['args'] ) ) {
+					$new_field['args'] = ! empty( $new_field['args'] ) && is_array( $new_field['args'] ) ? array_merge( $interface_fields[ $field_name ]['args'], $new_field['args'] ) : $interface_fields[ $field_name ]['args'];
+				}
+
 				$fields[ $field_name ] = $new_field;
+
 			}
 		}
 

--- a/src/Type/WPInterfaceTrait.php
+++ b/src/Type/WPInterfaceTrait.php
@@ -170,7 +170,6 @@ trait WPInterfaceTrait {
 
 			// If the field has not been unset, update the field
 			if ( isset( $fields[ $field_name ] ) ) {
-
 				if ( empty( $new_field['description'] ) && ! empty( $interface_fields[ $field_name ]['description'] ) ) {
 					$new_field['description'] = $interface_fields[ $field_name ]['description'];
 				}
@@ -180,7 +179,6 @@ trait WPInterfaceTrait {
 				}
 
 				$fields[ $field_name ] = $new_field;
-
 			}
 		}
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This fixes a regression to #3102 / #3100 

- [x] Failing Test: https://github.com/wp-graphql/wp-graphql/actions/runs/8852128733
- [x] Passing Test: https://github.com/wp-graphql/wp-graphql/actions/runs/8852138235

Does this close any currently open issues?
------------------------------------------
closes: #3108 


Any other comments?
-------------------

Given the following code: 

```php
add_action( 'graphql_register_types', function() {

	register_graphql_interface_type( 'InterfaceWithArgs', [
		'fields' => [
			'fieldWithArgs' => [
				'type' => 'String',
				'args' => [
					'interfaceArg' => [
						'type' => 'String',
					],
				],
				'resolve' => function( $source, $args ) {
					return $args['arg'];
				}
			],
		]
	] );

	register_graphql_object_type( 'ObjectTypeImplementingInterfaceWithArgs', [
		'interfaces' => [ 'InterfaceWithArgs' ],
		'fields' => [
			'fieldWithArgs' => [
				'type' => 'String',
				'resolve' => function() {
					return 'object value';
				}
			],
		],
	] );

	register_graphql_field( 'RootQuery', 'interfaceArgsTest', [
		'type' => 'ObjectTypeImplementingInterfaceWithArgs',
		'resolve' => function() {
			return true;
		},
	]);

});
```

### Before

The schema would be invalid:

![CleanShot 2024-04-26 at 11 33 56](https://github.com/wp-graphql/wp-graphql/assets/1260765/82606964-7fd6-4b82-8f8d-4803d68e3f28)

And this query would be invalid:


![CleanShot 2024-04-26 at 11 35 38](https://github.com/wp-graphql/wp-graphql/assets/1260765/8e579c5e-4912-446e-897c-5e1d61ed6539)


### After

The schema loads as valid and the test field can be queried

![CleanShot 2024-04-26 at 11 35 05](https://github.com/wp-graphql/wp-graphql/assets/1260765/f7c7f290-6d8d-4502-b5ab-2cb193116c59)

Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
