### PR TITLE
fix: node ids not showing in query analyzer when using DataLoader->load_many()

### DIFF
--- a/src/Data/Loader/AbstractDataLoader.php
+++ b/src/Data/Loader/AbstractDataLoader.php
@@ -272,7 +272,7 @@ abstract class AbstractDataLoader {
 	private function generate_many( array $keys, array $result ) {
 		foreach ( $keys as $key ) {
 			$key = $this->key_to_scalar( $key );
-			yield isset( $result[ $key ] ) ? $this->get_model( $result[ $key ], $key ) : null;
+			yield isset( $result[ $key ] ) ? $this->normalize_entry( $result[ $key ], $key ) : null;
 		}
 	}
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

This fixes a bug where Node IDs are not being output by the QueryAnalyzer when a resolver uses the `load_many()` method of the DataLoader.

This bug can lead to issues with tag-based caching / tag-based cache invalidation as some nodes might not be getting tagged as expected.

- [x] failing test: https://github.com/wp-graphql/wp-graphql/actions/runs/8905311933
- [x] passing test: https://github.com/wp-graphql/wp-graphql/actions/runs/8905321473

Does this close any currently open issues?
------------------------------------------
closes #3101 

Any other comments?
-------------------
Given the scenario outlined in #3113:

### Before

The Node IDs are not present in the Query Analyzer output

![CleanShot 2024-04-30 at 22 18 06@2x](https://github.com/wp-graphql/wp-graphql/assets/1260765/55f4d5fe-5caf-4c58-b5f4-672c9fb7d326)

### After

The Node IDs _are_ present in the Query Analyzer output

![CleanShot 2024-04-30 at 22 16 48@2x](https://github.com/wp-graphql/wp-graphql/assets/1260765/dea8f74f-503c-4331-b975-2cf38f3cf09d)

