### PR TITLE
release: v1.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 1.25.0
+
+### Upgrade Notice
+
+This release includes a fix to a regression in the v1.24.0. Users impacted by the regression in 1.24.0 included, but are not necessarily limited to, users of the WPGraphQL for WooCommerce extension.
+
+### New Features
+
+- [#3104](https://github.com/wp-graphql/wp-graphql/pull/3104): feat: add `AbsractConnectionResolver::pre_should_execute()`. Thanks @justlevine!
+
+### Chores / Bugfixes
+- [#3104](https://github.com/wp-graphql/wp-graphql/pull/3104): refactor: `AbstractConnectionResolver::should_execute()` Thanks @justlevine!
+- [#3112](https://github.com/wp-graphql/wp-graphql/pull/3104): fix: fixes a regression from v1.24.0 relating to field arguments defined on Interfaces not being properly merged onto Object Types that implement the interface. Thanks @kidunot89!
+- [#3114](https://github.com/wp-graphql/wp-graphql/pull/3114): fix: node IDs not showing in the Query Analyzer / X-GraphQL-Keys when using DataLoader->load_many()
+- [#3116](https://github.com/wp-graphql/wp-graphql/pull/3116): chore: Update WPGraphQLTestCase to v3. Thanks @kidunot89!
+
+
 ## 1.24.0
 
 ### Upgrade Notice
@@ -10,7 +27,7 @@ The AbstractConnectionResolver has undergone some refactoring. Some methods usin
 - `getContext` -> `get_context`
 - `getInfo` -> `get_info`
 - `getShouldExecute` -> `get_should_execute`
-- `getLoader` -> `getLoader`
+- `getLoader` -> `get_loader`
 
 ### New Features
 

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
 		"php-coveralls/php-coveralls": "^2.5",
 		"slevomat/coding-standard": "^8.9",
 		"szepeviktor/phpstan-wordpress": "~1.3.0",
-		"wp-graphql/wp-graphql-testcase": "~2.3",
+		"wp-graphql/wp-graphql-testcase": "^3.0",
 		"wp-cli/wp-cli-bundle": "^2.8"
 	},
 	"config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "41603756d279269a48144650f2d8e7a1",
+    "content-hash": "1a3f5842150c900c52f8026a66f17617",
     "packages": [
         {
             "name": "appsero/client",
@@ -1315,16 +1315,16 @@
         },
         {
             "name": "composer/composer",
-            "version": "2.7.2",
+            "version": "2.7.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "b826edb791571ab1eaf281eb1bd6e181a1192adc"
+                "reference": "a625e50598e12171d3f60b1149eb530690c43474"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/b826edb791571ab1eaf281eb1bd6e181a1192adc",
-                "reference": "b826edb791571ab1eaf281eb1bd6e181a1192adc",
+                "url": "https://api.github.com/repos/composer/composer/zipball/a625e50598e12171d3f60b1149eb530690c43474",
+                "reference": "a625e50598e12171d3f60b1149eb530690c43474",
                 "shasum": ""
             },
             "require": {
@@ -1409,7 +1409,7 @@
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/composer/issues",
                 "security": "https://github.com/composer/composer/security/policy",
-                "source": "https://github.com/composer/composer/tree/2.7.2"
+                "source": "https://github.com/composer/composer/tree/2.7.4"
             },
             "funding": [
                 {
@@ -1425,7 +1425,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-03-11T16:12:18+00:00"
+            "time": "2024-04-22T19:17:03+00:00"
         },
         {
             "name": "composer/metadata-minifier",
@@ -3690,17 +3690,74 @@
             "time": "2023-11-22T10:21:01+00:00"
         },
         {
-            "name": "php-stubs/wordpress-stubs",
-            "version": "v6.4.3",
+            "name": "php-extended/polyfill-php80-str-utils",
+            "version": "1.3.7",
             "source": {
                 "type": "git",
-                "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "6105bdab2f26c0204fe90ecc53d5684754550e8f"
+                "url": "https://gitlab.com/php-extended/polyfill-php80-str-utils.git",
+                "reference": "0749426252e3e27c526fda939e8d3ff050bf907b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/6105bdab2f26c0204fe90ecc53d5684754550e8f",
-                "reference": "6105bdab2f26c0204fe90ecc53d5684754550e8f",
+                "url": "https://gitlab.com/api/v4/projects/php-extended%2Fpolyfill-php80-str-utils/repository/archive.zip?sha=0749426252e3e27c526fda939e8d3ff050bf907b",
+                "reference": "0749426252e3e27c526fda939e8d3ff050bf907b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "php-extended/placeholder-phpunit": "^9"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "PhpExtended\\Polyfill\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Anastaszor",
+                    "homepage": "https://gitlab.com/Anastaszor",
+                    "role": "developer"
+                }
+            ],
+            "description": "A php implementation of string functions introduced in php8 and above",
+            "homepage": "https://gitlab.com/php-extended/polyfill-str-utils",
+            "keywords": [
+                "implementation",
+                "php",
+                "polyfill",
+                "str",
+                "string_ends_with",
+                "string_starts_with",
+                "utils"
+            ],
+            "support": {
+                "issues": "https://gitlab.com/php-extended/polyfill-str-utils/issues",
+                "source": "https://gitlab.com/php-extended/polyfill-str-utils"
+            },
+            "time": "2024-03-31T13:28:10+00:00"
+        },
+        {
+            "name": "php-stubs/wordpress-stubs",
+            "version": "v6.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-stubs/wordpress-stubs.git",
+                "reference": "379f17a90c01498d4c99a0d15aab6e7aa6a2c840"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/379f17a90c01498d4c99a0d15aab6e7aa6a2c840",
+                "reference": "379f17a90c01498d4c99a0d15aab6e7aa6a2c840",
                 "shasum": ""
             },
             "require-dev": {
@@ -3708,7 +3765,7 @@
                 "nikic/php-parser": "^4.13",
                 "php": "^7.4 || ~8.0.0",
                 "php-stubs/generator": "^0.8.3",
-                "phpdocumentor/reflection-docblock": "^5.3",
+                "phpdocumentor/reflection-docblock": "5.3",
                 "phpstan/phpstan": "^1.10.49",
                 "phpunit/phpunit": "^9.5",
                 "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^0.11"
@@ -3732,9 +3789,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.4.3"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.5.2"
             },
-            "time": "2024-02-11T18:56:19+00:00"
+            "time": "2024-04-14T17:30:14+00:00"
         },
         {
             "name": "php-webdriver/webdriver",
@@ -3808,12 +3865,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
-                "reference": "7cd518e4c67cac6299689e48f90f5b9cbe5ba770"
+                "reference": "96072c30924c80d20d74f1762cfd706754b17638"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/7cd518e4c67cac6299689e48f90f5b9cbe5ba770",
-                "reference": "7cd518e4c67cac6299689e48f90f5b9cbe5ba770",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/96072c30924c80d20d74f1762cfd706754b17638",
+                "reference": "96072c30924c80d20d74f1762cfd706754b17638",
                 "shasum": ""
             },
             "require": {
@@ -3890,32 +3947,32 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-04-07T00:09:28+00:00"
+            "time": "2024-04-30T23:24:59+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-paragonie",
-            "version": "1.3.2",
+            "version": "1.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
-                "reference": "bba5a9dfec7fcfbd679cfaf611d86b4d3759da26"
+                "reference": "293975b465e0e709b571cbf0c957c6c0a7b9a2ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/bba5a9dfec7fcfbd679cfaf611d86b4d3759da26",
-                "reference": "bba5a9dfec7fcfbd679cfaf611d86b4d3759da26",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/293975b465e0e709b571cbf0c957c6c0a7b9a2ac",
+                "reference": "293975b465e0e709b571cbf0c957c6c0a7b9a2ac",
                 "shasum": ""
             },
             "require": {
                 "phpcompatibility/php-compatibility": "^9.0"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
                 "paragonie/random_compat": "dev-master",
                 "paragonie/sodium_compat": "dev-master"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
                 "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
             "type": "phpcodesniffer-standard",
@@ -3945,22 +4002,37 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues",
+                "security": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/security/policy",
                 "source": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie"
             },
-            "time": "2022-10-25T01:46:02+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCompatibility",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-04-24T21:30:46+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-wp",
-            "version": "2.1.4",
+            "version": "2.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
-                "reference": "b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5"
+                "reference": "01c1ff2704a58e46f0cb1ca9d06aee07b3589082"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5",
-                "reference": "b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/01c1ff2704a58e46f0cb1ca9d06aee07b3589082",
+                "reference": "01c1ff2704a58e46f0cb1ca9d06aee07b3589082",
                 "shasum": ""
             },
             "require": {
@@ -3968,10 +4040,10 @@
                 "phpcompatibility/phpcompatibility-paragonie": "^1.0"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7"
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
                 "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
             "type": "phpcodesniffer-standard",
@@ -4000,9 +4072,24 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
+                "security": "https://github.com/PHPCompatibility/PHPCompatibilityWP/security/policy",
                 "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
             },
-            "time": "2022-10-24T09:00:36+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCompatibility",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-04-24T21:37:59+00:00"
         },
         {
             "name": "phpcsstandards/phpcsextra",
@@ -4084,16 +4171,16 @@
         },
         {
             "name": "phpcsstandards/phpcsutils",
-            "version": "1.0.10",
+            "version": "1.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "51609a5b89f928e0c463d6df80eb38eff1eaf544"
+                "reference": "c457da9dabb60eb7106dd5e3c05132b1a6539c6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/51609a5b89f928e0c463d6df80eb38eff1eaf544",
-                "reference": "51609a5b89f928e0c463d6df80eb38eff1eaf544",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/c457da9dabb60eb7106dd5e3c05132b1a6539c6a",
+                "reference": "c457da9dabb60eb7106dd5e3c05132b1a6539c6a",
                 "shasum": ""
             },
             "require": {
@@ -4168,7 +4255,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-03-17T23:44:50+00:00"
+            "time": "2024-04-24T11:47:18+00:00"
         },
         {
             "name": "phpstan/extension-installer",
@@ -4263,16 +4350,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.66",
+            "version": "1.10.67",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "94779c987e4ebd620025d9e5fdd23323903950bd"
+                "reference": "16ddbe776f10da6a95ebd25de7c1dbed397dc493"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/94779c987e4ebd620025d9e5fdd23323903950bd",
-                "reference": "94779c987e4ebd620025d9e5fdd23323903950bd",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/16ddbe776f10da6a95ebd25de7c1dbed397dc493",
+                "reference": "16ddbe776f10da6a95ebd25de7c1dbed397dc493",
                 "shasum": ""
             },
             "require": {
@@ -4315,13 +4402,9 @@
                 {
                     "url": "https://github.com/phpstan",
                     "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2024-03-28T16:17:31+00:00"
+            "time": "2024-04-16T07:22:02+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -6407,16 +6490,16 @@
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",
-            "version": "v2.11.17",
+            "version": "v2.11.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
-                "reference": "3b71162a6bf0cde2bff1752e40a1788d8273d049"
+                "reference": "ca242a0b7309e0f9d1f73b236e04ecf4ca3248d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/3b71162a6bf0cde2bff1752e40a1788d8273d049",
-                "reference": "3b71162a6bf0cde2bff1752e40a1788d8273d049",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/ca242a0b7309e0f9d1f73b236e04ecf4ca3248d0",
+                "reference": "ca242a0b7309e0f9d1f73b236e04ecf4ca3248d0",
                 "shasum": ""
             },
             "require": {
@@ -6461,7 +6544,7 @@
                 "source": "https://github.com/sirbrillig/phpcs-variable-analysis",
                 "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
             },
-            "time": "2023-08-05T23:46:11+00:00"
+            "time": "2024-04-13T16:42:46+00:00"
         },
         {
             "name": "slevomat/coding-standard",
@@ -6599,16 +6682,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.9.1",
+            "version": "3.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "267a4405fff1d9c847134db3a3c92f1ab7f77909"
+                "reference": "aac1f6f347a5c5ac6bc98ad395007df00990f480"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/267a4405fff1d9c847134db3a3c92f1ab7f77909",
-                "reference": "267a4405fff1d9c847134db3a3c92f1ab7f77909",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/aac1f6f347a5c5ac6bc98ad395007df00990f480",
+                "reference": "aac1f6f347a5c5ac6bc98ad395007df00990f480",
                 "shasum": ""
             },
             "require": {
@@ -6675,20 +6758,20 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-03-31T21:03:09+00:00"
+            "time": "2024-04-23T20:25:34+00:00"
         },
         {
             "name": "symfony/browser-kit",
-            "version": "v5.4.35",
+            "version": "v5.4.39",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/browser-kit.git",
-                "reference": "2f6f979b579ed1c051465c3c2fb81daf5bb4a002"
+                "reference": "4c5d1a88ceee2b1c5c0b400b0137989ec34f70fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/2f6f979b579ed1c051465c3c2fb81daf5bb4a002",
-                "reference": "2f6f979b579ed1c051465c3c2fb81daf5bb4a002",
+                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/4c5d1a88ceee2b1c5c0b400b0137989ec34f70fa",
+                "reference": "4c5d1a88ceee2b1c5c0b400b0137989ec34f70fa",
                 "shasum": ""
             },
             "require": {
@@ -6731,7 +6814,7 @@
             "description": "Simulates the behavior of a web browser, allowing you to make requests, click on links and submit forms programmatically",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/browser-kit/tree/v5.4.35"
+                "source": "https://github.com/symfony/browser-kit/tree/v5.4.39"
             },
             "funding": [
                 {
@@ -6747,20 +6830,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-23T13:51:25+00:00"
+            "time": "2024-04-18T08:26:06+00:00"
         },
         {
             "name": "symfony/config",
-            "version": "v5.4.38",
+            "version": "v5.4.39",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "3dcd47d4bbd9fea4d1210e7a7a0a5ca02d99df14"
+                "reference": "62cec4a067931552624a9962002c210c502d42fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/3dcd47d4bbd9fea4d1210e7a7a0a5ca02d99df14",
-                "reference": "3dcd47d4bbd9fea4d1210e7a7a0a5ca02d99df14",
+                "url": "https://api.github.com/repos/symfony/config/zipball/62cec4a067931552624a9962002c210c502d42fd",
+                "reference": "62cec4a067931552624a9962002c210c502d42fd",
                 "shasum": ""
             },
             "require": {
@@ -6810,7 +6893,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v5.4.38"
+                "source": "https://github.com/symfony/config/tree/v5.4.39"
             },
             "funding": [
                 {
@@ -6826,20 +6909,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-03-22T10:04:40+00:00"
+            "time": "2024-04-18T08:26:06+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v5.4.36",
+            "version": "v5.4.39",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "39f75d9d73d0c11952fdcecf4877b4d0f62a8f6e"
+                "reference": "f3e591c48688a0cfa1a3296205926c05e84b22b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/39f75d9d73d0c11952fdcecf4877b4d0f62a8f6e",
-                "reference": "39f75d9d73d0c11952fdcecf4877b4d0f62a8f6e",
+                "url": "https://api.github.com/repos/symfony/console/zipball/f3e591c48688a0cfa1a3296205926c05e84b22b1",
+                "reference": "f3e591c48688a0cfa1a3296205926c05e84b22b1",
                 "shasum": ""
             },
             "require": {
@@ -6909,7 +6992,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.36"
+                "source": "https://github.com/symfony/console/tree/v5.4.39"
             },
             "funding": [
                 {
@@ -6925,20 +7008,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-02-20T16:33:57+00:00"
+            "time": "2024-04-18T08:26:06+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v5.4.35",
+            "version": "v5.4.39",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "9e615d367e2bed41f633abb383948c96a2dbbfae"
+                "reference": "0934c9f1d433776f25c629bdc93f3e157d139e08"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/9e615d367e2bed41f633abb383948c96a2dbbfae",
-                "reference": "9e615d367e2bed41f633abb383948c96a2dbbfae",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/0934c9f1d433776f25c629bdc93f3e157d139e08",
+                "reference": "0934c9f1d433776f25c629bdc93f3e157d139e08",
                 "shasum": ""
             },
             "require": {
@@ -6975,7 +7058,7 @@
             "description": "Converts CSS selectors to XPath expressions",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/css-selector/tree/v5.4.35"
+                "source": "https://github.com/symfony/css-selector/tree/v5.4.39"
             },
             "funding": [
                 {
@@ -6991,7 +7074,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-23T13:51:25+00:00"
+            "time": "2024-04-18T08:26:06+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -7062,16 +7145,16 @@
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v5.4.35",
+            "version": "v5.4.39",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dom-crawler.git",
-                "reference": "e3b4806f88abf106a411847a78619a542e71de29"
+                "reference": "1dffb111b038412b028caba029240e379fda85b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/e3b4806f88abf106a411847a78619a542e71de29",
-                "reference": "e3b4806f88abf106a411847a78619a542e71de29",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/1dffb111b038412b028caba029240e379fda85b2",
+                "reference": "1dffb111b038412b028caba029240e379fda85b2",
                 "shasum": ""
             },
             "require": {
@@ -7117,7 +7200,7 @@
             "description": "Eases DOM navigation for HTML and XML documents",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dom-crawler/tree/v5.4.35"
+                "source": "https://github.com/symfony/dom-crawler/tree/v5.4.39"
             },
             "funding": [
                 {
@@ -7133,20 +7216,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-23T13:51:25+00:00"
+            "time": "2024-04-18T08:26:06+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v5.4.35",
+            "version": "v5.4.39",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "7a69a85c7ea5bdd1e875806a99c51a87d3a74b38"
+                "reference": "d40fae9fd85c762b6ba378152fdd1157a85d7e4f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/7a69a85c7ea5bdd1e875806a99c51a87d3a74b38",
-                "reference": "7a69a85c7ea5bdd1e875806a99c51a87d3a74b38",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/d40fae9fd85c762b6ba378152fdd1157a85d7e4f",
+                "reference": "d40fae9fd85c762b6ba378152fdd1157a85d7e4f",
                 "shasum": ""
             },
             "require": {
@@ -7202,7 +7285,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v5.4.35"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v5.4.39"
             },
             "funding": [
                 {
@@ -7218,7 +7301,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-23T13:51:25+00:00"
+            "time": "2024-04-18T08:26:06+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -7301,23 +7384,24 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.4.38",
+            "version": "v5.4.39",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "899330a01056077271e2f614c7b28b0379a671eb"
+                "reference": "e6edd875d5d39b03de51f3c3951148cfa79a4d12"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/899330a01056077271e2f614c7b28b0379a671eb",
-                "reference": "899330a01056077271e2f614c7b28b0379a671eb",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/e6edd875d5d39b03de51f3c3951148cfa79a4d12",
+                "reference": "e6edd875d5d39b03de51f3c3951148cfa79a4d12",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-mbstring": "~1.8",
-                "symfony/polyfill-php80": "^1.16"
+                "symfony/polyfill-php80": "^1.16",
+                "symfony/process": "^5.4|^6.4"
             },
             "type": "library",
             "autoload": {
@@ -7345,7 +7429,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.4.38"
+                "source": "https://github.com/symfony/filesystem/tree/v5.4.39"
             },
             "funding": [
                 {
@@ -7361,20 +7445,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-03-21T08:05:07+00:00"
+            "time": "2024-04-18T08:26:06+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v5.4.35",
+            "version": "v5.4.39",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "abe6d6f77d9465fed3cd2d029b29d03b56b56435"
+                "reference": "f6a96e4fcd468a25fede16ee665f50ced856bd0a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/abe6d6f77d9465fed3cd2d029b29d03b56b56435",
-                "reference": "abe6d6f77d9465fed3cd2d029b29d03b56b56435",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/f6a96e4fcd468a25fede16ee665f50ced856bd0a",
+                "reference": "f6a96e4fcd468a25fede16ee665f50ced856bd0a",
                 "shasum": ""
             },
             "require": {
@@ -7408,7 +7492,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v5.4.35"
+                "source": "https://github.com/symfony/finder/tree/v5.4.39"
             },
             "funding": [
                 {
@@ -7424,7 +7508,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-23T13:51:25+00:00"
+            "time": "2024-04-18T08:26:06+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -7978,16 +8062,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v5.4.36",
+            "version": "v5.4.39",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "4fdf34004f149cc20b2f51d7d119aa500caad975"
+                "reference": "85a554acd7c28522241faf2e97b9541247a0d3d5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/4fdf34004f149cc20b2f51d7d119aa500caad975",
-                "reference": "4fdf34004f149cc20b2f51d7d119aa500caad975",
+                "url": "https://api.github.com/repos/symfony/process/zipball/85a554acd7c28522241faf2e97b9541247a0d3d5",
+                "reference": "85a554acd7c28522241faf2e97b9541247a0d3d5",
                 "shasum": ""
             },
             "require": {
@@ -8020,7 +8104,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v5.4.36"
+                "source": "https://github.com/symfony/process/tree/v5.4.39"
             },
             "funding": [
                 {
@@ -8036,7 +8120,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-02-12T15:49:53+00:00"
+            "time": "2024-04-18T08:26:06+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -8123,16 +8207,16 @@
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v5.4.35",
+            "version": "v5.4.39",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "887762aa99ff16f65dc8b48aafead415f942d407"
+                "reference": "fb97497490bcec8a3c32c809cacfdd4c15dc8390"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/887762aa99ff16f65dc8b48aafead415f942d407",
-                "reference": "887762aa99ff16f65dc8b48aafead415f942d407",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/fb97497490bcec8a3c32c809cacfdd4c15dc8390",
+                "reference": "fb97497490bcec8a3c32c809cacfdd4c15dc8390",
                 "shasum": ""
             },
             "require": {
@@ -8165,7 +8249,7 @@
             "description": "Provides a way to profile code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/stopwatch/tree/v5.4.35"
+                "source": "https://github.com/symfony/stopwatch/tree/v5.4.39"
             },
             "funding": [
                 {
@@ -8181,20 +8265,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-23T13:51:25+00:00"
+            "time": "2024-04-18T08:26:06+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v5.4.36",
+            "version": "v5.4.39",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "4e232c83622bd8cd32b794216aa29d0d266d353b"
+                "reference": "495e71bae5862308051b9e63cc3e34078eed83ef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/4e232c83622bd8cd32b794216aa29d0d266d353b",
-                "reference": "4e232c83622bd8cd32b794216aa29d0d266d353b",
+                "url": "https://api.github.com/repos/symfony/string/zipball/495e71bae5862308051b9e63cc3e34078eed83ef",
+                "reference": "495e71bae5862308051b9e63cc3e34078eed83ef",
                 "shasum": ""
             },
             "require": {
@@ -8251,7 +8335,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.4.36"
+                "source": "https://github.com/symfony/string/tree/v5.4.39"
             },
             "funding": [
                 {
@@ -8267,20 +8351,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-02-01T08:49:30+00:00"
+            "time": "2024-04-18T08:26:06+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v5.4.35",
+            "version": "v5.4.39",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "77d7d1e46f52827585e65e6cd6f52a2542e59c72"
+                "reference": "0fabede35e3985c4f96089edeeefe8313e15ca3a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/77d7d1e46f52827585e65e6cd6f52a2542e59c72",
-                "reference": "77d7d1e46f52827585e65e6cd6f52a2542e59c72",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/0fabede35e3985c4f96089edeeefe8313e15ca3a",
+                "reference": "0fabede35e3985c4f96089edeeefe8313e15ca3a",
                 "shasum": ""
             },
             "require": {
@@ -8348,7 +8432,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v5.4.35"
+                "source": "https://github.com/symfony/translation/tree/v5.4.39"
             },
             "funding": [
                 {
@@ -8364,7 +8448,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-23T13:51:25+00:00"
+            "time": "2024-04-18T08:26:06+00:00"
         },
         {
             "name": "symfony/translation-contracts",
@@ -8446,16 +8530,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v5.4.35",
+            "version": "v5.4.39",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "e78db7f5c70a21f0417a31f414c4a95fe76c07e4"
+                "reference": "bc780e16879000f77a1022163c052f5323b5e640"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/e78db7f5c70a21f0417a31f414c4a95fe76c07e4",
-                "reference": "e78db7f5c70a21f0417a31f414c4a95fe76c07e4",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/bc780e16879000f77a1022163c052f5323b5e640",
+                "reference": "bc780e16879000f77a1022163c052f5323b5e640",
                 "shasum": ""
             },
             "require": {
@@ -8501,7 +8585,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v5.4.35"
+                "source": "https://github.com/symfony/yaml/tree/v5.4.39"
             },
             "funding": [
                 {
@@ -8517,7 +8601,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-23T13:51:25+00:00"
+            "time": "2024-04-23T11:57:27+00:00"
         },
         {
             "name": "szepeviktor/phpstan-wordpress",
@@ -9584,16 +9668,16 @@
         },
         {
             "name": "wp-cli/extension-command",
-            "version": "v2.1.19",
+            "version": "v2.1.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/extension-command.git",
-                "reference": "80713703e090fbc74926af6f75bf963619f76fdb"
+                "reference": "fa8bfd96a2c587a38e9e99d3cfb9fb5b35ee25d5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/extension-command/zipball/80713703e090fbc74926af6f75bf963619f76fdb",
-                "reference": "80713703e090fbc74926af6f75bf963619f76fdb",
+                "url": "https://api.github.com/repos/wp-cli/extension-command/zipball/fa8bfd96a2c587a38e9e99d3cfb9fb5b35ee25d5",
+                "reference": "fa8bfd96a2c587a38e9e99d3cfb9fb5b35ee25d5",
                 "shasum": ""
             },
             "require": {
@@ -9676,9 +9760,9 @@
             "homepage": "https://github.com/wp-cli/extension-command",
             "support": {
                 "issues": "https://github.com/wp-cli/extension-command/issues",
-                "source": "https://github.com/wp-cli/extension-command/tree/v2.1.19"
+                "source": "https://github.com/wp-cli/extension-command/tree/v2.1.20"
             },
-            "time": "2024-02-05T14:53:09+00:00"
+            "time": "2024-04-26T21:12:41+00:00"
         },
         {
             "name": "wp-cli/i18n-command",
@@ -10064,16 +10148,16 @@
         },
         {
             "name": "wp-cli/package-command",
-            "version": "v2.5.0",
+            "version": "v2.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/package-command.git",
-                "reference": "71683195f8c27ad97009628e2a72d2a4155503b2"
+                "reference": "afa90e92e6b2b1f9fe754963726909433facd9f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/package-command/zipball/71683195f8c27ad97009628e2a72d2a4155503b2",
-                "reference": "71683195f8c27ad97009628e2a72d2a4155503b2",
+                "url": "https://api.github.com/repos/wp-cli/package-command/zipball/afa90e92e6b2b1f9fe754963726909433facd9f5",
+                "reference": "afa90e92e6b2b1f9fe754963726909433facd9f5",
                 "shasum": ""
             },
             "require": {
@@ -10123,9 +10207,9 @@
             "homepage": "https://github.com/wp-cli/package-command",
             "support": {
                 "issues": "https://github.com/wp-cli/package-command/issues",
-                "source": "https://github.com/wp-cli/package-command/tree/v2.5.0"
+                "source": "https://github.com/wp-cli/package-command/tree/v2.5.1"
             },
-            "time": "2023-12-08T10:38:16+00:00"
+            "time": "2024-04-26T10:03:17+00:00"
         },
         {
             "name": "wp-cli/php-cli-tools",
@@ -10319,16 +10403,16 @@
         },
         {
             "name": "wp-cli/scaffold-command",
-            "version": "v2.2.0",
+            "version": "v2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/scaffold-command.git",
-                "reference": "8aa906c3ec6ae7d95f38c962fc2561714f9c7145"
+                "reference": "7a7d145c260ead64fa93a59498d60def970d5214"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/scaffold-command/zipball/8aa906c3ec6ae7d95f38c962fc2561714f9c7145",
-                "reference": "8aa906c3ec6ae7d95f38c962fc2561714f9c7145",
+                "url": "https://api.github.com/repos/wp-cli/scaffold-command/zipball/7a7d145c260ead64fa93a59498d60def970d5214",
+                "reference": "7a7d145c260ead64fa93a59498d60def970d5214",
                 "shasum": ""
             },
             "require": {
@@ -10379,9 +10463,9 @@
             "homepage": "https://github.com/wp-cli/scaffold-command",
             "support": {
                 "issues": "https://github.com/wp-cli/scaffold-command/issues",
-                "source": "https://github.com/wp-cli/scaffold-command/tree/v2.2.0"
+                "source": "https://github.com/wp-cli/scaffold-command/tree/v2.3.0"
             },
-            "time": "2023-11-16T15:25:33+00:00"
+            "time": "2024-04-26T21:05:48+00:00"
         },
         {
             "name": "wp-cli/search-replace-command",
@@ -10621,16 +10705,16 @@
         },
         {
             "name": "wp-cli/widget-command",
-            "version": "v2.1.9",
+            "version": "v2.1.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/widget-command.git",
-                "reference": "fa67eb62b3b0248014f48fb1280bfdea2eb96712"
+                "reference": "7062ed3fdfa17265320737f43efe5651d783f439"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/widget-command/zipball/fa67eb62b3b0248014f48fb1280bfdea2eb96712",
-                "reference": "fa67eb62b3b0248014f48fb1280bfdea2eb96712",
+                "url": "https://api.github.com/repos/wp-cli/widget-command/zipball/7062ed3fdfa17265320737f43efe5651d783f439",
+                "reference": "7062ed3fdfa17265320737f43efe5651d783f439",
                 "shasum": ""
             },
             "require": {
@@ -10682,9 +10766,9 @@
             "homepage": "https://github.com/wp-cli/widget-command",
             "support": {
                 "issues": "https://github.com/wp-cli/widget-command/issues",
-                "source": "https://github.com/wp-cli/widget-command/tree/v2.1.9"
+                "source": "https://github.com/wp-cli/widget-command/tree/v2.1.10"
             },
-            "time": "2023-08-30T15:52:58+00:00"
+            "time": "2024-04-19T13:21:01+00:00"
         },
         {
             "name": "wp-cli/wp-cli",
@@ -10941,27 +11025,27 @@
         },
         {
             "name": "wp-graphql/wp-graphql-testcase",
-            "version": "v2.3.0",
+            "version": "v3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-graphql/wp-graphql-testcase.git",
-                "reference": "d4c0bd7430efeca5a4982c1ed4d5a7935254abb7"
+                "reference": "c18eb271a4a1cf740e9ab8d9a13fecf150f04b5d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-graphql/wp-graphql-testcase/zipball/d4c0bd7430efeca5a4982c1ed4d5a7935254abb7",
-                "reference": "d4c0bd7430efeca5a4982c1ed4d5a7935254abb7",
+                "url": "https://api.github.com/repos/wp-graphql/wp-graphql-testcase/zipball/c18eb271a4a1cf740e9ab8d9a13fecf150f04b5d",
+                "reference": "c18eb271a4a1cf740e9ab8d9a13fecf150f04b5d",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0",
-                "phpunit/phpunit": "^7.5 || ^8.5.0 || ^9.5"
+                "php-extended/polyfill-php80-str-utils": "^1.3"
             },
             "require-dev": {
-                "automattic/vipwpcs": "^2.2",
+                "automattic/vipwpcs": "^2.3",
                 "composer/installers": "^1.9",
-                "johnpbloch/wordpress": "^5.4",
-                "simpod/php-coveralls-mirror": "^3.0",
+                "johnpbloch/wordpress": "^6.1",
+                "php-coveralls/php-coveralls": "2.4.3",
+                "squizlabs/php_codesniffer": "^3.5",
                 "wp-coding-standards/wpcs": "^2.3",
                 "wp-graphql/wp-graphql": "^1.1.8"
             },
@@ -10970,7 +11054,9 @@
                 "codeception/module-rest": "Needed for \\Tests\\WPGraphQL\\TestCase\\WPGraphQLTestcase to work.",
                 "codeception/util-universalframework": "Needed for \\Tests\\WPGraphQL\\TestCase\\WPGraphQLTestcase to work.",
                 "lucatume/wp-browser": "Needed for \\Tests\\WPGraphQL\\TestCase\\WPGraphQLTestcase to work.",
-                "wp-phpunit/wp-phpunit": "Needed for \\Tests\\WPGraphQL\\TestCase\\WPGraphQLUnitTestcase to work."
+                "phpunit/phpunit": "Needed for \\Tests\\WPGraphQL\\TestCase\\WPGraphQLUnitTestcase to work.",
+                "wp-phpunit/wp-phpunit": "Needed for \\Tests\\WPGraphQL\\TestCase\\WPGraphQLUnitTestcase to work.",
+                "yoast/phpunit-polyfills": "Needed for \\Tests\\WPGraphQL\\TestCase\\WPGraphQLUnitTestcase to work."
             },
             "type": "library",
             "extra": {
@@ -11002,9 +11088,9 @@
             "description": "Codeception module for WPGraphQL API testing",
             "support": {
                 "issues": "https://github.com/wp-graphql/wp-graphql-testcase/issues",
-                "source": "https://github.com/wp-graphql/wp-graphql-testcase/tree/v2.3.0"
+                "source": "https://github.com/wp-graphql/wp-graphql-testcase/tree/v3.0.0"
             },
-            "time": "2022-05-25T14:49:51+00:00"
+            "time": "2024-05-02T04:30:04+00:00"
         },
         {
             "name": "zordius/lightncandy",
@@ -11084,5 +11170,5 @@
     "platform-overrides": {
         "php": "7.3"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/constants.php
+++ b/constants.php
@@ -18,7 +18,7 @@ function graphql_setup_constants() {
 
 	// Plugin version.
 	if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-		define( 'WPGRAPHQL_VERSION', '1.24.0' );
+		define( 'WPGRAPHQL_VERSION', '1.25.0' );
 	}
 
 	// Plugin Folder Path.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, JSON, API, Gatsby, Faust, Headless, Decoupled, Svelte, React, Nex
 Requires at least: 5.0
 Tested up to: 6.5
 Requires PHP: 7.1
-Stable tag: 1.24.0
+Stable tag: 1.25.0
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -86,6 +86,10 @@ Integrating Appsero SDK **DOES NOT IMMEDIATELY** start gathering data, **without
 Learn more about how [Appsero collects and uses this data](https://appsero.com/privacy-policy/).
 
 == Upgrade Notice ==
+
+= 1.25.0 =
+
+This release includes a fix to a regression in the v1.24.0. Users impacted by the regression in 1.24.0 included, but are not necessarily limited to, users of the WPGraphQL for WooCommerce extension.
 
 = 1.24.0 =
 
@@ -261,6 +265,18 @@ The `uri` field was non-null on some Types in the Schema but has been changed to
 Composer dependencies are no longer versioned in Github. Recommended install source is WordPress.org or using Composer to get the code from Packagist.org or WPackagist.org.
 
 == Changelog ==
+
+= 1.25.0 =
+
+**New Features**
+
+- [#3104](https://github.com/wp-graphql/wp-graphql/pull/3104): feat: add `AbsractConnectionResolver::pre_should_execute()`. Thanks @justlevine!
+
+**Chores / Bugfixes**
+- [#3104](https://github.com/wp-graphql/wp-graphql/pull/3104): refactor: `AbstractConnectionResolver::should_execute()` Thanks @justlevine!
+- [#3112](https://github.com/wp-graphql/wp-graphql/pull/3104): fix: fixes a regression from v1.24.0 relating to field arguments defined on Interfaces not being properly merged onto Object Types that implement the interface. Thanks @kidunot89!
+- [#3114](https://github.com/wp-graphql/wp-graphql/pull/3114): fix: node IDs not showing in the Query Analyzer / X-GraphQL-Keys when using DataLoader->load_many()
+- [#3116](https://github.com/wp-graphql/wp-graphql/pull/3116): chore: Update WPGraphQLTestCase to v3. Thanks @kidunot89!
 
 = 1.24.0 =
 

--- a/src/Data/Connection/CommentConnectionResolver.php
+++ b/src/Data/Connection/CommentConnectionResolver.php
@@ -311,11 +311,4 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 	public function is_valid_offset( $offset ) {
 		return ! empty( get_comment( $offset ) );
 	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function should_execute() {
-		return true;
-	}
 }

--- a/src/Data/Connection/ContentTypeConnectionResolver.php
+++ b/src/Data/Connection/ContentTypeConnectionResolver.php
@@ -73,11 +73,4 @@ class ContentTypeConnectionResolver extends AbstractConnectionResolver {
 	public function is_valid_offset( $offset ) {
 		return (bool) get_post_type_object( $offset );
 	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function should_execute() {
-		return true;
-	}
 }

--- a/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
@@ -72,11 +72,4 @@ class EnqueuedScriptsConnectionResolver extends AbstractConnectionResolver {
 		global $wp_scripts;
 		return isset( $wp_scripts->registered[ $offset ] );
 	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function should_execute() {
-		return true;
-	}
 }

--- a/src/Data/Connection/EnqueuedStylesheetConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedStylesheetConnectionResolver.php
@@ -79,11 +79,4 @@ class EnqueuedStylesheetConnectionResolver extends AbstractConnectionResolver {
 		global $wp_styles;
 		return isset( $wp_styles->registered[ $offset ] );
 	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function should_execute() {
-		return true;
-	}
 }

--- a/src/Data/Connection/TaxonomyConnectionResolver.php
+++ b/src/Data/Connection/TaxonomyConnectionResolver.php
@@ -74,11 +74,4 @@ class TaxonomyConnectionResolver extends AbstractConnectionResolver {
 	public function is_valid_offset( $offset ) {
 		return (bool) get_taxonomy( $offset );
 	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function should_execute() {
-		return true;
-	}
 }

--- a/src/Data/Connection/TermObjectConnectionResolver.php
+++ b/src/Data/Connection/TermObjectConnectionResolver.php
@@ -294,13 +294,4 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 	public function is_valid_offset( $offset ) {
 		return get_term( absint( $offset ) ) instanceof \WP_Term;
 	}
-
-	/**
-	 * {@inheritDoc}
-	 *
-	 * Default is true, meaning any time a TermObjectConnection resolver is asked for, it will execute.
-	 */
-	public function should_execute() {
-		return true;
-	}
 }

--- a/src/Data/Connection/ThemeConnectionResolver.php
+++ b/src/Data/Connection/ThemeConnectionResolver.php
@@ -67,11 +67,4 @@ class ThemeConnectionResolver extends AbstractConnectionResolver {
 		$theme = wp_get_theme( $offset );
 		return $theme->exists();
 	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function should_execute() {
-		return true;
-	}
 }

--- a/src/Data/Connection/UserConnectionResolver.php
+++ b/src/Data/Connection/UserConnectionResolver.php
@@ -281,11 +281,4 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 	public function is_valid_offset( $offset ) {
 		return (bool) get_user_by( 'ID', absint( $offset ) );
 	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function should_execute() {
-		return true;
-	}
 }

--- a/src/Data/Loader/AbstractDataLoader.php
+++ b/src/Data/Loader/AbstractDataLoader.php
@@ -272,7 +272,7 @@ abstract class AbstractDataLoader {
 	private function generate_many( array $keys, array $result ) {
 		foreach ( $keys as $key ) {
 			$key = $this->key_to_scalar( $key );
-			yield isset( $result[ $key ] ) ? $this->get_model( $result[ $key ], $key ) : null;
+			yield isset( $result[ $key ] ) ? $this->normalize_entry( $result[ $key ], $key ) : null;
 		}
 	}
 

--- a/src/Type/WPInterfaceTrait.php
+++ b/src/Type/WPInterfaceTrait.php
@@ -105,6 +105,35 @@ trait WPInterfaceTrait {
 	}
 
 	/**
+	 * Given a type it will return a string representation of the type
+	 *
+	 * @param mixed $type  A GraphQL Type
+	 *
+	 * @return string
+	 */
+	private function field_arg_type_to_string( $type ) {
+		$output = '';
+		if ( empty( $type ) ) {
+			return $output;
+		} elseif ( is_string( $type ) ) {
+			$output = $type;
+		} elseif ( is_array( $type ) ) {
+			$modifier = array_keys( $type )[0];
+			$type     = $type[ $modifier ];
+			switch ( $modifier ) {
+				case 'list_of':
+					$output = '[' . $this->field_arg_type_to_string( $type ) . ']';
+					break;
+				case 'non_null':
+					$output = '!' . $this->field_arg_type_to_string( $type );
+					break;
+			}
+		}
+
+		return $output;
+	}
+
+	/**
 	 * Returns the fields for a Type, applying any missing fields defined on interfaces implemented on the type
 	 *
 	 * @param array<mixed>                     $config
@@ -162,6 +191,49 @@ trait WPInterfaceTrait {
 
 			if ( empty( $new_field['description'] ) && ! empty( $interface_fields[ $field_name ]['description'] ) ) {
 				$new_field['description'] = $interface_fields[ $field_name ]['description'];
+			}
+
+			if ( empty( $new_field['args'] ) && ! empty( $interface_fields[ $field_name ]['args'] ) ) {
+				$new_field['args'] = $interface_fields[ $field_name ]['args'];
+			} elseif ( ! empty( $new_field['args'] ) && ! empty( $interface_fields[ $field_name ]['args'] ) ) {
+				// Set field args to the interface fields to be overwrite with the new field args.
+				$field_args = $interface_fields[ $field_name ]['args'];
+
+				foreach ( $new_field['args'] as $arg_name => $arg_definition ) {
+					$new_field_arg_type = $this->field_arg_type_to_string( $arg_definition['type'] );
+					if ( empty( $field_args[ $arg_name ] ) ) {
+						$field_args[ $arg_name ] = $arg_definition;
+						continue;
+					}
+
+					$interface_arg_type = $field_args[ $arg_name ]['type']();
+					if ( ! empty( $new_field_arg_type ) && $interface_arg_type !== $new_field_arg_type ) {
+						graphql_debug(
+							sprintf(
+								/* translators: 1: Object type name, 2: Field name, 3: Argument name, 4: Expected argument type, 5: Actual argument type. */
+								__(
+									'Interface field argument "%1$s.%2$s(%3$s:)" expected to be of type "%4$s" but got "%5$s". Please ensure the field arguments match the interface field arguments or rename the argument.',
+									'wp-graphql'
+								),
+								$config['name'],
+								$field_name,
+								$arg_name,
+								$interface_arg_type,
+								$new_field_arg_type
+							)
+						);
+						continue;
+					}
+
+					// Set the field args to the new field args.
+					$field_args[ $arg_name ] = array_merge( $field_args[ $arg_name ], $arg_definition );
+				}
+
+				$new_field['args'] = array_merge( $interface_fields[ $field_name ]['args'], $new_field['args'] );
+			}
+
+			if ( empty( $new_field['resolve'] ) && ! empty( $interface_fields[ $field_name ]['resolve'] ) ) {
+				$new_field['resolve'] = $interface_fields[ $field_name ]['resolve'];
 			}
 
 			if ( ! isset( $new_field['type'] ) ) {

--- a/src/Type/WPInterfaceTrait.php
+++ b/src/Type/WPInterfaceTrait.php
@@ -105,29 +105,35 @@ trait WPInterfaceTrait {
 	}
 
 	/**
-	 * Given a type it will return a string representation of the type
+	 * Given a type it will return a string representation of the type.
 	 *
-	 * @param mixed $type  A GraphQL Type
+	 * This is used for optimistic comparison of the arg types.
 	 *
-	 * @return string
+	 * @param string|array<string,mixed>|mixed $type A GraphQL Type
 	 */
-	private function field_arg_type_to_string( $type ) {
-		$output = '';
+	private function field_arg_type_to_string( $type ): string {
+		// Bail if the type is empty.
 		if ( empty( $type ) ) {
-			return $output;
+			return '';
 		} elseif ( is_string( $type ) ) {
-			$output = $type;
-		} elseif ( is_array( $type ) ) {
-			$modifier = array_keys( $type )[0];
-			$type     = $type[ $modifier ];
-			switch ( $modifier ) {
-				case 'list_of':
-					$output = '[' . $this->field_arg_type_to_string( $type ) . ']';
-					break;
-				case 'non_null':
-					$output = '!' . $this->field_arg_type_to_string( $type );
-					break;
-			}
+			// If the type is already a string, return it as is.
+			return $type;
+		} elseif ( ! is_array( $type ) ) {
+			// If the type is not an array, we can't do anything with it.
+			return '';
+		}
+
+		// Arrays mean the type can be nested in modifiers.
+		$output   = '';
+		$modifier = array_keys( $type )[0];
+		$type     = $type[ $modifier ];
+		switch ( $modifier ) {
+			case 'list_of':
+				$output = '[' . $this->field_arg_type_to_string( $type ) . ']';
+				break;
+			case 'non_null':
+				$output = '!' . $this->field_arg_type_to_string( $type );
+				break;
 		}
 
 		return $output;
@@ -189,10 +195,29 @@ trait WPInterfaceTrait {
 		foreach ( $fields as $field_name => $field ) {
 			$new_field = $field;
 
+			// If the field does not have a type, attempt to inherit it from the interface.
+			if ( ! isset( $new_field['type'] ) ) {
+				// If the field doesn't exist in the interface, we have no way to determine (and later register) the type.
+				if ( ! isset( $interface_fields[ $field_name ] ) ) {
+					unset( $fields[ $field_name ] );
+					continue;
+				}
+
+				$new_field['type'] = $interface_fields[ $field_name ]['type'];
+			}
+
+			// Inherit the description from the interface if it's not set on the field.
 			if ( empty( $new_field['description'] ) && ! empty( $interface_fields[ $field_name ]['description'] ) ) {
 				$new_field['description'] = $interface_fields[ $field_name ]['description'];
 			}
 
+			// Inherit the resolver from the interface if it's not set on the field.
+			if ( empty( $new_field['resolve'] ) && ! empty( $interface_fields[ $field_name ]['resolve'] ) ) {
+				$new_field['resolve'] = $interface_fields[ $field_name ]['resolve'];
+			}
+
+			// If the args aren't explicitly defined, inherit them from the interface.
+			// If they're both set, we need to merge them.
 			if ( empty( $new_field['args'] ) && ! empty( $interface_fields[ $field_name ]['args'] ) ) {
 				$new_field['args'] = $interface_fields[ $field_name ]['args'];
 			} elseif ( ! empty( $new_field['args'] ) && ! empty( $interface_fields[ $field_name ]['args'] ) ) {
@@ -200,12 +225,14 @@ trait WPInterfaceTrait {
 				$field_args = $interface_fields[ $field_name ]['args'];
 
 				foreach ( $new_field['args'] as $arg_name => $arg_definition ) {
-					$new_field_arg_type = $this->field_arg_type_to_string( $arg_definition['type'] );
+					// If the arg is not defined in the interface, we can use the current arg definition.
 					if ( empty( $field_args[ $arg_name ] ) ) {
 						$field_args[ $arg_name ] = $arg_definition;
 						continue;
 					}
 
+					// Check if the interface arg type is different from the new field arg type.
+					$new_field_arg_type = $this->field_arg_type_to_string( $arg_definition['type'] );
 					$interface_arg_type = $field_args[ $arg_name ]['type']();
 					if ( ! empty( $new_field_arg_type ) && $interface_arg_type !== $new_field_arg_type ) {
 						graphql_debug(
@@ -232,22 +259,8 @@ trait WPInterfaceTrait {
 				$new_field['args'] = array_merge( $interface_fields[ $field_name ]['args'], $new_field['args'] );
 			}
 
-			if ( empty( $new_field['resolve'] ) && ! empty( $interface_fields[ $field_name ]['resolve'] ) ) {
-				$new_field['resolve'] = $interface_fields[ $field_name ]['resolve'];
-			}
-
-			if ( ! isset( $new_field['type'] ) ) {
-				if ( isset( $interface_fields[ $field_name ]['type'] ) ) {
-					$new_field['type'] = $interface_fields[ $field_name ]['type'];
-				} else {
-					unset( $fields[ $field_name ] );
-				}
-			}
-
-			// If the field has not been unset, update the field
-			if ( isset( $fields[ $field_name ] ) ) {
-				$fields[ $field_name ] = $new_field;
-			}
+			// Update the field.
+			$fields[ $field_name ] = $new_field;
 		}
 
 		$fields = $this->prepare_fields( $fields, $config['name'], $config );

--- a/tests/wpunit/AccessFunctionsTest.php
+++ b/tests/wpunit/AccessFunctionsTest.php
@@ -19,10 +19,10 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 	public function tearDown(): void {
 		// your tear down methods here
+		$this->clearSchema();
 
 		// then
 		parent::tearDown();
-		$this->clearSchema();
 	}
 
 	public function testGraphQLPhpVersion() {
@@ -1306,7 +1306,7 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$actual = graphql( compact( 'query' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 
 		// Ensure Post-related types have been removed.
@@ -1372,7 +1372,7 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$actual = $this->graphql( compact( 'query' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayHasKey( 'errors', $actual );
 
 		// Ensure Post is removed from interfaces.
@@ -1387,7 +1387,7 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		';
 		$actual = $this->graphql( compact( 'query' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertNotContains( 'Post', array_column( $actual['data']['__type']['possibleTypes'], 'name' ) );
 
@@ -1404,7 +1404,7 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$actual = $this->graphql( compact( 'query' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertNotContains( 'Post', array_column( $actual['data']['__type']['possibleTypes'], 'name' ) );
 
@@ -1435,7 +1435,7 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$actual = $this->graphql( compact( 'query' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayHasKey( 'errors', $actual );
 		$this->assertStringContainsString( 'GraphQL Interface Type `ContentNode` returned `null', $actual['errors'][0]['debugMessage'] );
 		$this->assertNull( $actual['data']['contentNodes'] );
@@ -1459,7 +1459,7 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$actual = $this->graphql( compact( 'query' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertNotContains( 'ContentTypeEnum', array_column( $actual['data']['__schema']['types'], 'name' ) );
 
@@ -1478,7 +1478,7 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$actual = graphql( compact( 'query' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertNotContains( 'contentType', array_column( $actual['data']['__type']['inputFields'], 'name' ) );
 
@@ -1502,7 +1502,7 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$actual = $this->graphql( compact( 'query' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertCount( 1, $actual['data']['contentNodes']['nodes'] );
 	}
@@ -1523,7 +1523,7 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$actual = graphql( compact( 'query' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertNotContains( 'DateQueryInput', array_column( $actual['data']['__schema']['types'], 'name' ) );
 
@@ -1539,7 +1539,7 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$actual = $this->graphql( compact( 'query' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertNotContains( 'dateQuery', array_column( $actual['data']['__type']['inputFields'], 'name' ) );
 
@@ -1563,7 +1563,7 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$actual = $this->graphql( compact( 'query' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertCount( 1, $actual['data']['posts']['nodes'] );
 	}
@@ -1584,7 +1584,7 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$actual = graphql( compact( 'query' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertNotContains( 'NodeWithTitle', array_column( $actual['data']['__schema']['types'], 'name' ) );
 
@@ -1600,7 +1600,7 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$actual = $this->graphql( compact( 'query' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertNotContains( 'NodeWithTitle', array_column( $actual['data']['__type']['interfaces'], 'name' ) );
 
@@ -1623,7 +1623,7 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$actual = $this->graphql( compact( 'query' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertCount( 1, $actual['data']['posts']['nodes'] );
 	}
@@ -1644,7 +1644,7 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$actual = graphql( compact( 'query' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertNotContains( 'MenuItemObjectUnion', array_column( $actual['data']['__schema']['types'], 'name' ) );
 
@@ -1660,7 +1660,7 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$actual = $this->graphql( compact( 'query' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertNotContains( 'connectedObject', array_column( $actual['data']['__type']['fields'], 'name' ) );
 	}
@@ -1681,7 +1681,7 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$actual = graphql( compact( 'query' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertNotContains( 'createPost', array_column( $actual['data']['__schema']['mutationType'], 'name' ) );
 
@@ -1702,7 +1702,7 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$actual = $this->graphql( compact( 'query' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertNotContains( 'createPost', array_column( $actual['data']['__type']['fields'], 'name' ) );
 		$this->assertNotContains( 'CreatePostInput', array_column( $actual['data']['__schema']['types'], 'name' ) );
@@ -2002,7 +2002,7 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->assertNotContains( 'UC_First', $field_names );
 	}
 
-	public function testRegisterGraphqlFieldWithAllowedUndercores() {
+	public function testRegisterGraphqlFieldWithAllowedUnderscores() {
 
 		$expected_value = uniqid( 'test value: ', true );
 
@@ -2036,7 +2036,7 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		);
 	}
 
-	public function testDeRegisterGraphqlFieldWithAllowedUndercores() {
+	public function testDeRegisterGraphqlFieldWithAllowedUnderscores() {
 
 		$expected_value = uniqid( 'test value: ', true );
 
@@ -2048,8 +2048,8 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 			'allowFieldUnderscores' => true,
 		];
 
-		deregister_graphql_field( 'RootQuery', 'underscore_test_field' );
 		register_graphql_field( 'RootQuery', 'underscore_test_field', $config, true );
+		deregister_graphql_field( 'RootQuery', 'underscore_test_field' );
 
 		$query = '
 		{
@@ -2063,7 +2063,7 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 			]
 		);
 
-		self::assertQueryError( $actual, [] );
+		self::assertQueryError( $actual );
 	}
 
 	public function testRegisterInputType(): void {
@@ -2118,7 +2118,7 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$actual = $this->graphql( compact( 'query' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 
 		$this->assertSame( 'TestInput', $actual['data']['__type']['name'] );
@@ -2232,8 +2232,7 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 	}
 
 	public function testDeRegisterConnectionWithUnderscores() {
-
-		deregister_graphql_connection( 'test_field_with_underscores' );
+		deregister_graphql_connection( 'Test_Connection_With_Underscores' );
 
 		register_graphql_connection(
 			[
@@ -2241,6 +2240,13 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 				'toType'                => 'Post',
 				'fromFieldName'         => 'test_field_with_underscores',
 				'allowFieldUnderscores' => true,
+				'connectionTypeName'    => 'Test_Connection_With_Underscores',
+				'resolve' 			 => static function () {
+					return [
+						'nodes' => [],
+						'edges' => [],
+					];
+				},
 			]
 		);
 

--- a/tests/wpunit/CommentConnectionQueriesTest.php
+++ b/tests/wpunit/CommentConnectionQueriesTest.php
@@ -355,7 +355,7 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 		$expected = $page_1['data']['comments']['nodes'][2];
 		$actual   = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertSame( $expected, $actual['data']['comments']['nodes'][0] );
 
@@ -374,7 +374,7 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 		// Get 5 items, but between the bounds of a before and after cursor.
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertSame( $expected, $actual['data']['comments']['nodes'][0] );
 	}
@@ -422,7 +422,7 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertCount( 1, $actual['data']['comments']['nodes'] );
 		$this->assertEquals( $comment_ids[0], $actual['data']['comments']['nodes'][0]['databaseId'] );
 
@@ -435,7 +435,7 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertCount( 1, $actual['data']['comments']['nodes'] );
 		$this->assertEquals( $comment_ids[1], $actual['data']['comments']['nodes'][0]['databaseId'] );
 
@@ -450,7 +450,7 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertCount( 2, $actual['data']['comments']['nodes'] );
 		$this->assertEquals( $comment_ids[1], $actual['data']['comments']['nodes'][0]['databaseId'] );
 		$this->assertEquals( $comment_ids[0], $actual['data']['comments']['nodes'][1]['databaseId'] );
@@ -465,7 +465,7 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertCount( 6, $actual['data']['comments']['nodes'] );
 		$this->assertNotEquals( $comment_ids[1], $actual['data']['comments']['nodes'][0]['databaseId'] );
 		$this->assertNotEquals( $comment_ids[0], $actual['data']['comments']['nodes'][0]['databaseId'] );
@@ -485,7 +485,7 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertCount( 2, $actual['data']['comments']['nodes'] );
 		$this->assertEquals( $this->created_comment_ids[1], $actual['data']['comments']['nodes'][1]['databaseId'] );
 		$this->assertEquals( $this->created_comment_ids[2], $actual['data']['comments']['nodes'][0]['databaseId'] );
@@ -500,7 +500,7 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertCount( 4, $actual['data']['comments']['nodes'] );
 		$this->assertNotEquals( $this->created_comment_ids[1], $actual['data']['comments']['nodes'][0]['databaseId'] );
 		$this->assertNotEquals( $this->created_comment_ids[2], $actual['data']['comments']['nodes'][0]['databaseId'] );
@@ -525,7 +525,7 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertCount( 1, $actual['data']['comments']['nodes'] );
 		$this->assertEquals( $comment_ids[0], $actual['data']['comments']['nodes'][0]['databaseId'] );
 
@@ -538,7 +538,7 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertCount( 2, $actual['data']['comments']['nodes'] );
 		$this->assertEquals( $comment_ids[1], $actual['data']['comments']['nodes'][0]['databaseId'] );
 		$this->assertEquals( $comment_ids[0], $actual['data']['comments']['nodes'][1]['databaseId'] );
@@ -552,7 +552,7 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertCount( 2, $actual['data']['comments']['nodes'] );
 		$this->assertEquals( $comment_ids[1], $actual['data']['comments']['nodes'][0]['databaseId'] );
 		$this->assertEquals( $comment_ids[0], $actual['data']['comments']['nodes'][1]['databaseId'] );
@@ -604,7 +604,7 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertCount( 2, $actual['data']['comments']['nodes'] );
 
@@ -617,7 +617,7 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 
 		$this->assertCount( 6, $actual['data']['comments']['nodes'] );
@@ -631,7 +631,7 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertCount( 1, $actual['data']['comments']['nodes'] );
 
@@ -649,7 +649,7 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertCount( 1, $actual['data']['comments']['nodes'] );
 		$this->assertEqualSets( $expected, $actual['data']['comments']['nodes'] );
@@ -663,7 +663,7 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertCount( 2, $actual['data']['comments']['nodes'] );
 
@@ -676,7 +676,7 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertCount( 6, $actual['data']['comments']['nodes'] );
 
@@ -690,7 +690,7 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 		
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertCount( 1, $actual['data']['comments']['nodes'] );
 
@@ -703,7 +703,7 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertCount( 1, $actual['data']['comments']['nodes'] );
 	}
@@ -734,7 +734,7 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertEmpty( $actual['data']['comments']['nodes'] );
 
@@ -742,7 +742,7 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 		wp_set_current_user( $this->admin );
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertCount( 1, $actual['data']['comments']['nodes'] );
 	}
@@ -793,7 +793,7 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertCount( 2, $actual['data']['comments']['nodes'] );
 	}
@@ -826,7 +826,7 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 		// Test unapproved comments are excluded by default.
 		$actual = $this->graphql( compact( 'query' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertCount( 6, $actual['data']['comments']['nodes'] );
 
 		// test includeUnapproved with global + db author ids.
@@ -843,7 +843,7 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertCount( 6, $actual['data']['comments']['nodes'] );
 
 		// test user with permissions
@@ -852,7 +852,7 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 		
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertCount( 8, $actual['data']['comments']['nodes'] );
 	}
 
@@ -868,7 +868,7 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 		];
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 
 		$this->assertCount( 6, $actual['data']['comments']['nodes'] );
 		$this->assertGreaterThan( $actual['data']['comments']['nodes'][0]['databaseId'], $actual['data']['comments']['nodes'][1]['databaseId'] );
@@ -878,7 +878,7 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 		$variables['where']['order'] = 'DESC';
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertEqualSets( $expected, $actual['data']['comments']['nodes'] );
 	}
 
@@ -910,7 +910,7 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 		
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertCount( 1, $actual['data']['comments']['nodes'] );
 		$this->assertEquals( $comment_one_id, $actual['data']['comments']['nodes'][0]['databaseId'] );
@@ -929,7 +929,7 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 		
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertCount( 2, $actual['data']['comments']['nodes'] );
 
@@ -945,7 +945,7 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertCount( 6, $actual['data']['comments']['nodes'] );
 	}
@@ -967,7 +967,7 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 		];
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertCount( 1, $actual['data']['comments']['nodes'] );
 		$this->assertEquals( $comment_one_id, $actual['data']['comments']['nodes'][0]['databaseId'] );
@@ -993,7 +993,7 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertCount( 1, $actual['data']['comments']['nodes'] );
 		$this->assertEquals( $comment_one_id, $actual['data']['comments']['nodes'][0]['databaseId'] );
@@ -1023,7 +1023,7 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 		];
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertCount( 1, $actual['data']['comments']['nodes'] );
 		$this->assertEquals( $comment_id, $actual['data']['comments']['nodes'][0]['databaseId'] );
@@ -1032,7 +1032,7 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 		$comment_global_id = Relay::toGlobalId( 'comment', $comment_id );
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertCount( 1, $actual['data']['comments']['nodes'] );
 		$this->assertEquals( $comment_id, $actual['data']['comments']['nodes'][0]['databaseId'] );
@@ -1045,7 +1045,7 @@ class CommentConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 	 * @param array $actual The GraphQL results.
 	 */
 	public function assertValidPagination( $expected, $actual ) {
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 
 		$this->assertEquals( 2, count( $actual['data']['comments']['edges'] ) );

--- a/tests/wpunit/ConnectionRegistrationTest.php
+++ b/tests/wpunit/ConnectionRegistrationTest.php
@@ -243,7 +243,7 @@ class ConnectionRegistrationTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTest
 						],
 						'fromFieldName' => 'failingAuthConnection',
 						'resolve'       => static function () {
-							return [ 'nodes' => [ null, false, 0 ] ];
+							return [ 'nodes' => [ 'test', false, 0 ] ];
 						},
 					]
 				);
@@ -264,9 +264,6 @@ class ConnectionRegistrationTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTest
 		 * Expect query to fail on type level due to missing "first" arg.
 		 */
 		$response = $this->graphql( compact( 'query' ) );
-
-		codecept_debug( $response );
-
 		$expected = [
 			$this->expectedErrorPath( 'secretConnection' ),
 			$this->expectedErrorMessage( 'Blocked on the type-level!!!', self::MESSAGE_EQUALS ),
@@ -280,8 +277,6 @@ class ConnectionRegistrationTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTest
 		 */
 		$variables = [ 'first' => 1 ];
 		$response  = $this->graphql( compact( 'query', 'variables' ) );
-
-		codecept_debug( $response );
 
 		$expected = [
 			$this->expectedNode( 'secretConnection.nodes', [ 'test' => 'Blah' ] ),
@@ -305,27 +300,27 @@ class ConnectionRegistrationTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTest
 		';
 
 		$response = $this->graphql( compact( 'query' ) );
-
-		codecept_debug( $response );
-
 		$expected = [
 			$this->expectedErrorPath( 'failingAuthConnection' ),
 			$this->expectedErrorMessage( 'Blocked on the field-level!!!', self::MESSAGE_EQUALS ),
 			$this->expectedField( 'failingAuthConnection', self::IS_NULL ),
 		];
-
 		$this->assertQueryError( $response, $expected );
 
+
+		/**
+		 * Expect adminstrator to bypass field-level auth due to caps but fail type-level auth for last to nodes because they have falsy root value.
+		 */
 		\wp_set_current_user( 1 );
+
 		$response = $this->graphql( compact( 'query' ) );
 		$expected = [
-			$this->expectedField( 'failingAuthConnection.nodes.0', self::NOT_NULL ),
-			$this->expectedErrorPath( 'failingAuthConnection.nodes.1.test' ),
-			$this->expectedErrorMessage( 'Blocked on the field-level!!!', self::MESSAGE_EQUALS ),
+			$this->expectedField( 'failingAuthConnection.nodes.0.test', 'test' ),
 			$this->expectedField( 'failingAuthConnection.nodes.1.test', self::IS_NULL ),
-			$this->expectedErrorPath( 'failingAuthConnection.nodes.2.test' ),
-			$this->expectedErrorMessage( 'Blocked on the field-level!!!', self::MESSAGE_EQUALS ),
 			$this->expectedField( 'failingAuthConnection.nodes.2.test', self::IS_NULL ),
+			$this->expectedErrorMessage( 'Blocked on the field-level!!!', self::MESSAGE_EQUALS ),
+			$this->expectedErrorPath( 'failingAuthConnection.nodes.1.test' ),
+			$this->expectedErrorPath( 'failingAuthConnection.nodes.2.test' ),
 		];
 
 		$this->assertQueryError( $response, $expected );

--- a/tests/wpunit/ContentTypeConnectionQueriesTest.php
+++ b/tests/wpunit/ContentTypeConnectionQueriesTest.php
@@ -278,7 +278,7 @@ class ContentTypeConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraph
 		$expected = $actual['data']['contentTypes']['nodes'][2];
 		$actual   = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertSame( $expected, $actual['data']['contentTypes']['nodes'][0] );
 
@@ -297,7 +297,7 @@ class ContentTypeConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraph
 		// Get 5 items, but between the bounds of a before and after cursor.
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertSame( $expected, $actual['data']['contentTypes']['nodes'][0] );
 	}
@@ -309,7 +309,7 @@ class ContentTypeConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraph
 	 * @param array $actual The GraphQL results.
 	 */
 	public function assertValidPagination( $expected, $actual ) {
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 
 		$this->assertEquals( 2, count( $actual['data']['contentTypes']['edges'] ) );

--- a/tests/wpunit/CustomPostTypeTest.php
+++ b/tests/wpunit/CustomPostTypeTest.php
@@ -721,7 +721,7 @@ class CustomPostTypeTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 			]
 		);
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertQuerySuccessful(
 			$actual,
 			[
@@ -857,7 +857,7 @@ class CustomPostTypeTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 			]
 		);
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayHasKey( 'errors', $actual );
 		$this->assertStringStartsWith( 'Cannot query field "authorDatabaseId"', $actual['errors'][0]['message'] );
 		$this->assertStringStartsWith( 'Cannot query field "title"', $actual['errors'][1]['message'] );
@@ -890,7 +890,7 @@ class CustomPostTypeTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 			]
 		);
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertNotContains(
 			$actual['data']['__type']['interfaces'],
 			[
@@ -916,7 +916,7 @@ class CustomPostTypeTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 			]
 		);
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertNotContains(
 			$actual['data']['__type']['possibleTypes'],
 			[
@@ -934,7 +934,7 @@ class CustomPostTypeTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 			]
 		);
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertNotContains(
 			$actual['data']['__type']['possibleTypes'],
 			[
@@ -988,7 +988,7 @@ class CustomPostTypeTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		);
 
 		// assert that the query is valid
-		$this->assertIsValidQueryResponse( $response );
+		$this->assertResponseIsValid( $response );
 		$this->assertArrayNotHasKey( 'errors', $response );
 
 		$query = '

--- a/tests/wpunit/CustomTaxonomyTest.php
+++ b/tests/wpunit/CustomTaxonomyTest.php
@@ -340,7 +340,7 @@ class CustomTaxonomyTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 			]
 		);
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertQuerySuccessful(
 			$actual,
 			[
@@ -476,7 +476,7 @@ class CustomTaxonomyTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 			]
 		);
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayHasKey( 'errors', $actual );
 		$this->assertStringStartsWith( 'Cannot query field "parentDatabaseId"', $actual['errors'][0]['message'] );
 
@@ -508,7 +508,7 @@ class CustomTaxonomyTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 			]
 		);
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertNotContains(
 			$actual['data']['__type']['interfaces'],
 			[
@@ -532,7 +532,7 @@ class CustomTaxonomyTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 			]
 		);
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertNotContains(
 			$actual['data']['__type']['possibleTypes'],
 			[
@@ -586,7 +586,7 @@ class CustomTaxonomyTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		);
 
 		// assert that the query is valid
-		$this->assertIsValidQueryResponse( $response );
+		$this->assertResponseIsValid( $response );
 		$this->assertArrayNotHasKey( 'errors', $response );
 
 		$query = '

--- a/tests/wpunit/InterfaceTest.php
+++ b/tests/wpunit/InterfaceTest.php
@@ -99,7 +99,7 @@ class InterfaceTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 				testInt
 				testString
 				interfaceOnlyField
-        	}
+			}
 		}';
 
 		$actual = $this->graphql( [ 'query' => $query ] );
@@ -530,12 +530,13 @@ class InterfaceTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 			interfaceArgsTest {
 				fieldWithArgs
 			}
-		  	interfaceArgsTest2 {
-		    	fieldWithArgs
-		  	}
+			interfaceArgsTest2 {
+				fieldWithArgs
+			}
 		}';
 
 		$actual = $this->graphql( [ 'query' => $query ] );
+		$this->assertEmpty( $actual['extensions']['debug'], 'The interface should be implemented with no debug messages.' );
 		$expected = [
 			$this->expectedField( 'interfaceArgsTest.fieldWithArgs', 'interfaceArg objectArg' ),
 			$this->expectedField( 'interfaceArgsTest2.fieldWithArgs', 'interfaceArg' ),
@@ -697,8 +698,11 @@ class InterfaceTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$actual = $this->graphql( [ 'query' => $query ] );
 
-		$this->assertQuerySuccessful( $actual, [
-			$this->expectedField( 'testField.fieldWithNonNullableArg', self::IS_NULL ),
-		], 'The query should be valid as the list of and non null arguments defined on the interface are valid when querying the field that returns the object type' );
+		$this->assertEmpty( $actual['extensions']['debug'], 'The interface should be implemented with no debug messages.' );
+		$this->assertQuerySuccessful(
+			$actual,
+			[ $this->expectedField( 'testField.fieldWithNonNullableArg',self::IS_NULL ) ],
+			'The query should be valid as the list of and non null arguments defined on the interface are valid when querying the field that returns the object type'
+		);
 	}
 }

--- a/tests/wpunit/InterfaceTest.php
+++ b/tests/wpunit/InterfaceTest.php
@@ -1,14 +1,14 @@
 <?php
 
-class InterfaceTest extends \Codeception\TestCase\WPTestCase {
+class InterfaceTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 	public function setUp(): void {
 		parent::setUp();
-		WPGraphQL::clear_schema();
+		$this->clearSchema();
 	}
 
 	public function tearDown(): void {
-		WPGraphQL::clear_schema();
+		$this->clearSchema();
 		parent::tearDown();
 	}
 
@@ -93,30 +93,24 @@ class InterfaceTest extends \Codeception\TestCase\WPTestCase {
 			]
 		);
 
-		$query = '
-		{
+		$query = 'query {
 			tester {
-            id
-            testInt
-            testString
-            interfaceOnlyField
-           }
-		}
-		';
+				id
+				testInt
+				testString
+				interfaceOnlyField
+        	}
+		}';
 
-		$actual = graphql(
-			[
-				'query' => $query,
-			]
-		);
+		$actual = $this->graphql( [ 'query' => $query ] );
+		$expected = [
+			$this->expectedField( 'tester.id', $test['id'] ),
+			$this->expectedField( 'tester.testInt', $test['testInt'] ),
+			$this->expectedField( 'tester.testString', $test['testString'] ),
+			$this->expectedField( 'tester.interfaceOnlyField', $test['interfaceOnlyField'] ),
+		];
 
-		codecept_debug( $actual );
-
-		$this->assertArrayNotHasKey( 'errors', $actual );
-		$this->assertEquals( $test['id'], $actual['data']['tester']['id'] );
-		$this->assertEquals( $test['testInt'], $actual['data']['tester']['testInt'] );
-		$this->assertEquals( $test['testString'], $actual['data']['tester']['testString'] );
-		$this->assertEquals( $test['interfaceOnlyField'], $actual['data']['tester']['interfaceOnlyField'] );
+		$this->assertQuerySuccessful( $actual, $expected );
 	}
 
 	// Validate schema.
@@ -205,17 +199,7 @@ class InterfaceTest extends \Codeception\TestCase\WPTestCase {
 		// the Interfaces registered to implement each other
 		$this->testSchemaIsValid();
 
-		$query = '
-		{
-			testTypeWithInterfaces {
-				...One
-				...Two
-				...Three
-				four
-			}
-		}
-		
-		fragment One on TestInterfaceOne {
+		$query = 'fragment One on TestInterfaceOne {
 			one
 		}
 		
@@ -229,30 +213,31 @@ class InterfaceTest extends \Codeception\TestCase\WPTestCase {
 			two
 			three
 		}
-		';
+		
+		query {
+			testTypeWithInterfaces {
+				...One
+				...Two
+				...Three
+				four
+			}
+		}';
 
-		$actual = graphql(
-			[
-				'query' => $query,
-			]
-		);
-
-		codecept_debug( $actual );
-
+		$actual = $this->graphql( [ 'query' => $query ] );
 		$expected = [
-			'testTypeWithInterfaces' => [
-				'one'   => 'one value',
-				'two'   => 'two value',
-				'three' => 'three value',
-				'four'  => 'four value',
-			],
+			$this->expectedObject(
+				'testTypeWithInterfaces',
+				[
+					$this->expectedField( 'one', 'one value' ),
+					$this->expectedField( 'two', 'two value' ),
+					$this->expectedField( 'three', 'three value' ),
+					$this->expectedField( 'four', 'four value' ),
+				]
+			),
 		];
+		$this->assertQuerySuccessful( $actual, $expected );
 
-		$this->assertArrayNotHasKey( 'errors', $actual );
-		$this->assertSame( $expected, $actual['data'] );
-
-		$query = '
-		query GetType($name:String!){
+		$query = 'query GetType($name:String!){
 			__type(name: $name) {
 				name
 				interfaces {
@@ -262,10 +247,9 @@ class InterfaceTest extends \Codeception\TestCase\WPTestCase {
 					name
 				}
 			}
-		}
-		';
+		}';
 
-		$actual = graphql(
+		$actual = $this->graphql(
 			[
 				'query'     => $query,
 				'variables' => [
@@ -274,18 +258,13 @@ class InterfaceTest extends \Codeception\TestCase\WPTestCase {
 			]
 		);
 
-		codecept_debug( $actual );
+		$expected = [
+			$this->expectedField( '__type.name', 'TestInterfaceTwo' ),
+			$this->expectedField( '__type.interfaces.#.name', 'TestInterfaceOne' ),
+		];
+		$this->assertQuerySuccessful( $actual, $expected );
 
-		$this->assertArrayNotHasKey( 'errors', $actual );
-		$this->assertSame( 'TestInterfaceTwo', $actual['data']['__type']['name'] );
-
-		$interfaces = wp_list_pluck( $actual['data']['__type']['interfaces'], 'name' );
-
-		codecept_debug( $interfaces );
-
-		$this->assertTrue( in_array( 'TestInterfaceOne', $interfaces ) );
-
-		$actual = graphql(
+		$actual = $this->graphql(
 			[
 				'query'     => $query,
 				'variables' => [
@@ -294,22 +273,14 @@ class InterfaceTest extends \Codeception\TestCase\WPTestCase {
 			]
 		);
 
-		$this->assertArrayNotHasKey( 'errors', $actual );
-		$this->assertSame( 'TestInterfaceThree', $actual['data']['__type']['name'] );
-
-		$interfaces = wp_list_pluck( $actual['data']['__type']['interfaces'], 'name' );
-
-		codecept_debug( $interfaces );
-
-		$this->assertTrue( in_array( 'TestInterfaceOne', $interfaces ) );
-		$this->assertTrue( in_array( 'TestInterfaceTwo', $interfaces ) );
-
-		$fields = wp_list_pluck( $actual['data']['__type']['fields'], 'name' );
-
-		codecept_debug( $fields );
-
-		$this->assertTrue( in_array( 'one', $fields ) );
-		$this->assertTrue( in_array( 'two', $fields ) );
+		$expected = [
+			$this->expectedField( '__type.name', 'TestInterfaceThree' ),
+			$this->expectedField( '__type.interfaces.#.name', 'TestInterfaceOne' ),
+			$this->expectedField( '__type.interfaces.#.name', 'TestInterfaceTwo' ),
+			$this->expectedField( '__type.fields.#.name', 'one' ),
+			$this->expectedField( '__type.fields.#.name', 'two' ),
+		];
+		$this->assertQuerySuccessful( $actual, $expected );
 	}
 
 	/**
@@ -358,8 +329,7 @@ class InterfaceTest extends \Codeception\TestCase\WPTestCase {
 			]
 		);
 
-		$query = '
-		query GetType($name:String!){
+		$query = 'query GetType($name:String!){
 			__type(name: $name) {
 				kind
 				name
@@ -370,10 +340,9 @@ class InterfaceTest extends \Codeception\TestCase\WPTestCase {
 					name
 				}
 			}
-		}
-		';
+		}';
 
-		$actual = graphql(
+		$actual = $this->graphql(
 			[
 				'query'     => $query,
 				'variables' => [
@@ -483,5 +452,253 @@ class InterfaceTest extends \Codeception\TestCase\WPTestCase {
 		);
 
 		$this->assertArrayNotHasKey( 'errors', $actual );
+	}
+
+	public function testArgsOnInterfaceFieldAreAppliedToObjectField() {
+
+		register_graphql_interface_type(
+			'InterfaceWithArgs',
+			[
+				'fields' => [
+					'fieldWithArgs' => [
+						'type'    => 'String',
+						'args'    => [
+							'interfaceArg' => [
+								'type'         => 'String',
+								'defaultValue' => 'parent'
+							],
+						],
+						'resolve' => function( $source, $args ) {
+							return implode( ' ', array_keys( $args ) );
+						}
+					],
+				]
+			]
+		);
+
+		register_graphql_object_type(
+			'ObjectTypeImplementingInterfaceWithArgs',
+			[
+				'interfaces' => [ 'InterfaceWithArgs' ],
+				'fields'     => [
+					'fieldWithArgs' => [
+						'args'    => [
+							'objectArg' => [
+								'type'         => 'String',
+								'defaultValue' => 'child'
+							],
+						],
+						'type'    => 'String',
+					],
+				],
+			]
+		);
+
+		register_graphql_object_type(
+			'AnotherObjectTypeImplementingInterfaceWithArgs',
+			[
+				'interfaces' => [ 'InterfaceWithArgs' ],
+				'fields'     => [
+					'fieldWithArgs' => [
+						'resolve' => function( $_, $args ) {
+							return implode( ',', array_keys( $args ) );
+						}
+					],
+				],
+			]
+		);
+
+		register_graphql_fields(
+			'RootQuery',
+			[
+				'interfaceArgsTest'      => [
+					'type'    => 'ObjectTypeImplementingInterfaceWithArgs',
+					'resolve' => function() {
+						return true;
+					},
+				],
+				'interfaceArgsTest2' => [
+					'type'    => 'AnotherObjectTypeImplementingInterfaceWithArgs',
+					'resolve' => function() {
+						return true;
+					},
+				]
+			]
+		);
+
+		$query = 'query {
+			interfaceArgsTest {
+				fieldWithArgs
+			}
+		  	interfaceArgsTest2 {
+		    	fieldWithArgs
+		  	}
+		}';
+
+		$actual = $this->graphql( [ 'query' => $query ] );
+		$expected = [
+			$this->expectedField( 'interfaceArgsTest.fieldWithArgs', 'interfaceArg objectArg' ),
+			$this->expectedField( 'interfaceArgsTest2.fieldWithArgs', 'interfaceArg' ),
+		];
+		$this->assertQuerySuccessful( $actual, $expected, 'The query should be valid as the Args from the Interface fields should be merged with the args from the object field' );
+	}
+
+	public function testInvalidArgsOnInheritedObjectFieldsAreCaptured() {
+		register_graphql_interface_type(
+			'InterfaceWithArgs',
+			[
+				'fields' => [
+					'fieldWithArgs' => [
+						'type'    => 'String',
+						'args'    => [
+							'interfaceArg' => [ 'type' => 'String' ],
+						],
+						'resolve' => function( $source, $args ) {
+							return $args['arg'];
+						}
+					],
+				]
+
+			] 
+
+		);
+
+		register_graphql_object_type(
+			'BadObjectTypeImplementingInterfaceWithArgs',
+			[
+				'interfaces' => [ 'InterfaceWithArgs' ],
+				'fields'     => [
+					'fieldWithArgs' => [
+						'args' => [
+							'interfaceArg' => [ 'type' => 'Number' ],
+						],
+						'type'    => 'String',
+						'resolve' => function() {
+							return 'object value';
+						}
+					],
+				],
+			]
+		);
+
+		register_graphql_object_type(
+			'BadObjectTypeImplementingInterfaceWithArgs2',
+			[
+				'interfaces' => [ 'InterfaceWithArgs' ],
+				'fields' => [
+					'fieldWithArgs' => [
+						'args' => [
+							'interfaceArg' => [
+								'type' => [ 'list_of' => 'Number' ],
+							],
+						],
+						'type' => 'String',
+						'resolve' => function() {
+							return 'object value';
+						}
+					],
+				],
+			]
+		);
+
+		register_graphql_fields(
+			'RootQuery',
+			[
+				'interfaceArgsTest'  => [
+					'type' => 'BadObjectTypeImplementingInterfaceWithArgs',
+					'resolve' => function() {
+						return true;
+					},
+				],
+				'interfaceArgsTest2' => [
+					'type' => 'BadObjectTypeImplementingInterfaceWithArgs2',
+					'resolve' => function() {
+						return true;
+					},
+				],
+			]
+		);
+
+		$query = 'query {
+			interfaceArgsTest {
+				fieldWithArgs(interfaceArg: 2)
+			}
+			interfaceArgsTest2 {
+				fieldWithArgs(interfaceArg: [2, 4, 5])
+			}
+		}';
+
+		$actual = $this->graphql( [ 'query' => $query ]);
+		$this->assertQuerySuccessful( $actual, [], 'Invalid field arguments should be flagged' );
+	}
+	
+	public function testInterfaceWithNonNullableArg() {
+		register_graphql_interface_type( 'InterfaceWithNonNullableArg', [
+			'fields' => [
+				'fieldWithNonNullableArg' => [
+					'type' => 'String',
+					'args' => [
+						'nonNullableArg' => [
+							'type' => [ 'non_null' => 'String' ],
+							'defaultValue' => 'nonNullableArg',
+						],
+						'listOfArg' => [
+							'type' => [ 'list_of' => 'String' ],
+							'defaultValue' => [ 'listOfArg', 'listOfArg 2' ],
+						],
+						'nonNullListOfString' => [
+							'type' => [ 'non_null' => [ 'list_of' => 'String' ] ],
+							'defaultValue' => [ 'nonNullListOfString', 'nonNullListOfString 2' ],
+						],
+						'listOfNonNullString' => [
+							'type' => [ 'list_of' => [ 'non_null' => 'String' ] ],
+							'defaultValue' => [ 'listOfNonNullString', 'listOfNonNullString 2' ],
+						],
+					],
+					'resolve' => function( $source, $args ) {
+						return null;
+					},
+				],
+			],
+		] );
+
+		register_graphql_object_type( 'TestTypeWithNonNullableArg', [
+			'interfaces' => [ 'InterfaceWithNonNullableArg' ],
+			'fields' => [
+				'testField' => [
+					'type' => 'String',
+					'resolve' => function() {
+						return 'object value';
+					},
+				],
+			],
+		] );
+
+		register_graphql_fields( 'RootQuery', [
+			'testField' => [
+				'type' => 'TestTypeWithNonNullableArg',
+				'resolve' => function() {
+					return true;
+				},
+			],
+		] );
+
+		$query = 'query {
+			testField {
+				fieldWithNonNullableArg(
+					nonNullableArg: "test" 
+					listOfArg: ["test"] 
+					nonNullListOfString: ["test"]
+					listOfNonNullString: ["test"]
+				)
+				testField
+			}
+		}';
+
+		$actual = $this->graphql( [ 'query' => $query ] );
+
+		$this->assertQuerySuccessful( $actual, [
+			$this->expectedField( 'testField.fieldWithNonNullableArg', self::IS_NULL ),
+		], 'The query should be valid as the list of and non null arguments defined on the interface are valid when querying the field that returns the object type' );
 	}
 }

--- a/tests/wpunit/MenuConnectionQueriesTest.php
+++ b/tests/wpunit/MenuConnectionQueriesTest.php
@@ -97,7 +97,7 @@ class MenuConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestC
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 
 		// a public request should get no menus if there are none associated with a location
 		$this->assertSame( [], $actual['data']['menus']['edges'] );
@@ -349,7 +349,7 @@ class MenuConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestC
 		$expected = $actual['data']['menus']['nodes'][2];
 		$actual   = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertSame( $expected, $actual['data']['menus']['nodes'][0] );
 
@@ -368,7 +368,7 @@ class MenuConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestC
 		// Get 5 items, but between the bounds of a before and after cursor.
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertSame( $expected, $actual['data']['menus']['nodes'][0] );
 	}
@@ -380,7 +380,7 @@ class MenuConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestC
 	 * @param array $actual The GraphQL results.
 	 */
 	public function assertValidPagination( $expected, $actual ) {
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 
 		$this->assertEquals( 2, count( $actual['data']['menus']['edges'] ) );

--- a/tests/wpunit/MenuItemConnectionQueriesTest.php
+++ b/tests/wpunit/MenuItemConnectionQueriesTest.php
@@ -378,7 +378,7 @@ class MenuItemConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 		$expected = $actual['data']['menuItems']['nodes'][2];
 		$actual   = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertSame( $expected, $actual['data']['menuItems']['nodes'][0] );
 
@@ -397,7 +397,7 @@ class MenuItemConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 		// Get 5 items, but between the bounds of a before and after cursor.
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertSame( $expected, $actual['data']['menuItems']['nodes'][0] );
 	}
@@ -416,7 +416,7 @@ class MenuItemConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 
 		$this->assertEquals( 1, count( $actual['data']['menuItems']['edges'] ) );
 		$this->compareResults( [ $menu_item_id ], [ $post_id ], $actual );
@@ -751,7 +751,7 @@ class MenuItemConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 		 * @param array $actual The GraphQL results.
 		 */
 	public function assertValidPagination( $expected, $actual ) {
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 
 		$this->assertEquals( 2, count( $actual['data']['menuItems']['edges'] ) );

--- a/tests/wpunit/PluginConnectionQueriesTest.php
+++ b/tests/wpunit/PluginConnectionQueriesTest.php
@@ -72,7 +72,7 @@ class PluginConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTes
 		);
 
 		// Confirm its valid.
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertNotEmpty( $actual['data']['plugins']['edges'][0]['node']['path'] );
 
 		// Store for use by $expected.
@@ -139,7 +139,7 @@ class PluginConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTes
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
 		// Theres only one item, so we cant assertValidPagination()
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 
 		$this->assertEquals( 1, count( $actual['data']['plugins']['edges'] ) );
@@ -183,7 +183,7 @@ class PluginConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTes
 		);
 
 		// Confirm its valid.
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertNotEmpty( $actual['data']['plugins']['edges'][0]['node']['path'] );
 
 		// Store for use by $expected.
@@ -255,7 +255,7 @@ class PluginConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTes
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
 		// Theres only one item, so we cant assertValidPagination()
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 
 		$this->assertEquals( 1, count( $actual['data']['plugins']['edges'] ) );
@@ -312,7 +312,7 @@ class PluginConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTes
 		$expected = $actual['data']['plugins']['nodes'][1];
 		$actual   = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertSame( $expected, $actual['data']['plugins']['nodes'][0] );
 
@@ -331,7 +331,7 @@ class PluginConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTes
 		// Get 5 items, but between the bounds of a before and after cursor.
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertSame( $expected, $actual['data']['plugins']['nodes'][0] );
 	}
@@ -359,7 +359,7 @@ class PluginConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTes
 		];
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 
 		$actual_plugins = array_column( $actual['data']['plugins']['nodes'], 'path' );
 		$this->assertContains( $active_plugin, $actual_plugins );
@@ -375,7 +375,7 @@ class PluginConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTes
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 
 		$actual_plugins = array_column( $actual['data']['plugins']['nodes'], 'path' );
 		$this->assertContains( $active_plugin, $actual_plugins );
@@ -385,7 +385,7 @@ class PluginConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTes
 		$variables['where']['status'] = 'INACTIVE';
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 
 		$actual_plugins = array_column( $actual['data']['plugins']['nodes'], 'path' );
 		$this->assertContains( $inactive_plugin, $actual_plugins );
@@ -399,7 +399,7 @@ class PluginConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTes
 		];
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 
 		$actual_plugins = array_column( $actual['data']['plugins']['nodes'], 'path' );
 		$this->assertContains( $inactive_plugin, $actual_plugins );
@@ -426,7 +426,7 @@ class PluginConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTes
 	 * @param array $actual The GraphQL results.
 	 */
 	public function assertValidPagination( $expected, $actual ) {
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 
 		$this->assertEquals( 2, count( $actual['data']['plugins']['edges'] ) );

--- a/tests/wpunit/PostConnectionPaginationTest.php
+++ b/tests/wpunit/PostConnectionPaginationTest.php
@@ -624,7 +624,7 @@ class PostConnectionPaginationTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 		$expected = $actual['data']['posts']['nodes'][2];
 		$actual   = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertSame( $expected, $actual['data']['posts']['nodes'][0] );
 
@@ -643,7 +643,7 @@ class PostConnectionPaginationTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 		// Get 5 items, but between the bounds of a before and after cursor.
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertSame( $expected, $actual['data']['posts']['nodes'][0] );
 	}
@@ -656,7 +656,7 @@ class PostConnectionPaginationTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 	 * @param array $actual The GraphQL results.
 	 */
 	public function assertValidPagination( $expected, $actual ) {
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 
 		$this->assertEquals( 2, count( $actual['data']['posts']['edges'] ) );

--- a/tests/wpunit/RegisteredScriptConnectionQueriesTest.php
+++ b/tests/wpunit/RegisteredScriptConnectionQueriesTest.php
@@ -66,7 +66,7 @@ class RegisteredScriptConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WP
 		);
 
 		// Confirm it's valid.
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertNotEmpty( $actual['data']['registeredScripts']['edges'][0]['node']['handle'] );
 
 		// Test fields for first asset.
@@ -147,7 +147,7 @@ class RegisteredScriptConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WP
 			]
 		);
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertNotEmpty( $actual['data']['registeredScripts']['edges'][0]['node']['handle'] );
 
 		$variables['after'] = $actual['data']['registeredScripts']['pageInfo']['startCursor'];
@@ -180,7 +180,7 @@ class RegisteredScriptConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WP
 		);
 
 		// Confirm it's valid.
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertNotEmpty( $actual['data']['registeredScripts']['edges'][0]['node']['handle'] );
 
 		// Store for use by $expected.
@@ -247,7 +247,7 @@ class RegisteredScriptConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WP
 			]
 		);
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertNotEmpty( $actual['data']['registeredScripts']['edges'][0]['node']['handle'] );
 
 		$variables['before'] = $actual['data']['registeredScripts']['pageInfo']['endCursor'];
@@ -292,7 +292,7 @@ class RegisteredScriptConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WP
 		$expected = $actual['data']['registeredScripts']['nodes'][1];
 		$actual   = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertSame( $expected, $actual['data']['registeredScripts']['nodes'][0] );
 
@@ -311,7 +311,7 @@ class RegisteredScriptConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WP
 		// Get 5 items, but between the bounds of a before and after cursor.
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertSame( $expected, $actual['data']['registeredScripts']['nodes'][0] );
 	}
@@ -323,7 +323,7 @@ class RegisteredScriptConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WP
 	 * @param array $actual The GraphQL results.
 	 */
 	public function assertValidPagination( $expected, $actual ) {
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 
 		$this->assertEquals( 2, count( $actual['data']['registeredScripts']['edges'] ) );

--- a/tests/wpunit/RegisteredStylesheetConnectionQueriesTest.php
+++ b/tests/wpunit/RegisteredStylesheetConnectionQueriesTest.php
@@ -66,7 +66,7 @@ class RegisteredStylesheetConnectionQueriesTest extends \Tests\WPGraphQL\TestCas
 		);
 
 		// Confirm it's valid.
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertNotEmpty( $actual['data']['registeredStylesheets']['edges'][0]['node']['handle'] );
 
 		// Test fields for first asset.
@@ -147,7 +147,7 @@ class RegisteredStylesheetConnectionQueriesTest extends \Tests\WPGraphQL\TestCas
 				],
 			]
 		);
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertNotEmpty( $actual['data']['registeredStylesheets']['edges'][0]['node']['handle'] );
 		$variables['after'] = $actual['data']['registeredStylesheets']['pageInfo']['startCursor'];
 
@@ -178,7 +178,7 @@ class RegisteredStylesheetConnectionQueriesTest extends \Tests\WPGraphQL\TestCas
 		);
 
 		// Confirm it's valid.
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertNotEmpty( $actual['data']['registeredStylesheets']['edges'][0]['node']['handle'] );
 
 		// Store for use by $expected.
@@ -246,7 +246,7 @@ class RegisteredStylesheetConnectionQueriesTest extends \Tests\WPGraphQL\TestCas
 			]
 		);
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertNotEmpty( $actual['data']['registeredStylesheets']['edges'][0]['node']['handle'] );
 
 		$variables['before'] = $actual['data']['registeredStylesheets']['pageInfo']['endCursor'];
@@ -291,7 +291,7 @@ class RegisteredStylesheetConnectionQueriesTest extends \Tests\WPGraphQL\TestCas
 		$expected = $actual['data']['registeredStylesheets']['nodes'][1];
 		$actual   = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 
 		$this->assertSame( $expected, $actual['data']['registeredStylesheets']['nodes'][0] );
@@ -311,7 +311,7 @@ class RegisteredStylesheetConnectionQueriesTest extends \Tests\WPGraphQL\TestCas
 		// Get 5 items, but between the bounds of a before and after cursor.
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertSame( $expected, $actual['data']['registeredStylesheets']['nodes'][0] );
 	}
@@ -323,7 +323,7 @@ class RegisteredStylesheetConnectionQueriesTest extends \Tests\WPGraphQL\TestCas
 	 * @param array $actual The GraphQL results.
 	 */
 	public function assertValidPagination( $expected, $actual ) {
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 
 		$this->assertEquals( 2, count( $actual['data']['registeredStylesheets']['edges'] ) );

--- a/tests/wpunit/TaxonomyConnectionQueriesTest.php
+++ b/tests/wpunit/TaxonomyConnectionQueriesTest.php
@@ -272,7 +272,7 @@ class TaxonomyConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 		$expected = $actual['data']['taxonomies']['nodes'][2];
 		$actual   = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertSame( $expected, $actual['data']['taxonomies']['nodes'][0] );
 
@@ -291,7 +291,7 @@ class TaxonomyConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 		// Get 5 items, but between the bounds of a before and after cursor.
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 
 		$this->assertSame( $expected, $actual['data']['taxonomies']['nodes'][0] );
@@ -304,7 +304,7 @@ class TaxonomyConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 		 * @param array $actual The GraphQL results.
 		 */
 	public function assertValidPagination( $expected, $actual ) {
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 
 		$this->assertEquals( 2, count( $actual['data']['taxonomies']['edges'] ) );

--- a/tests/wpunit/TermObjectConnectionQueriesTest.php
+++ b/tests/wpunit/TermObjectConnectionQueriesTest.php
@@ -319,7 +319,7 @@ class TermObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 		$expected = $actual['data']['categories']['nodes'][2];
 		$actual   = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertSame( $expected, $actual['data']['categories']['nodes'][0] );
 
@@ -338,7 +338,7 @@ class TermObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 		// Get 5 items, but between the bounds of a before and after cursor.
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertSame( $expected, $actual['data']['categories']['nodes'][0] );
 	}
@@ -671,7 +671,7 @@ class TermObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 	 * @param array $actual The GraphQL results.
 	 */
 	public function assertValidPagination( $expected, $actual ) {
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 
 		$expected_count = count( $expected ) ?? 2;

--- a/tests/wpunit/ThemeConnectionQueriesTest.php
+++ b/tests/wpunit/ThemeConnectionQueriesTest.php
@@ -129,7 +129,7 @@ class ThemeConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTest
 		);
 
 		// Confirm its valid.
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertNotEmpty( $actual['data']['themes']['edges'][0]['node']['slug'] );
 
 		// Store for use by $expected.
@@ -196,7 +196,7 @@ class ThemeConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTest
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
 		// Theres only one item, so we cant assertValidPagination()
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 
 		$this->assertEquals( 1, count( $actual['data']['themes']['edges'] ) );
@@ -243,7 +243,7 @@ class ThemeConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTest
 		);
 
 		// Confirm its valid.
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertNotEmpty( $actual['data']['themes']['edges'][0]['node']['slug'] );
 
 		$wp_query = $actual['data']['themes'];
@@ -314,7 +314,7 @@ class ThemeConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTest
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
 		// Theres only one item, so we cant assertValidPagination()
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 
 		$this->assertEquals( 1, count( $actual['data']['themes']['edges'] ) );
@@ -373,7 +373,7 @@ class ThemeConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTest
 		$expected = $actual['data']['themes']['nodes'][1];
 		$actual   = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 
 		$this->assertSame( $expected, $actual['data']['themes']['nodes'][0] );
@@ -393,7 +393,7 @@ class ThemeConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTest
 		// Get 5 items, but between the bounds of a before and after cursor.
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertSame( $expected, $actual['data']['themes']['nodes'][0] );
 	}
@@ -416,7 +416,7 @@ class ThemeConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTest
 	 * @param array $actual The GraphQL results.
 	 */
 	public function assertValidPagination( $expected, $actual ) {
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 
 		$this->assertEquals( 2, count( $actual['data']['themes']['edges'] ) );

--- a/tests/wpunit/TracingTest.php
+++ b/tests/wpunit/TracingTest.php
@@ -39,7 +39,7 @@ class TracingTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		codecept_debug( $response );
 
-		$this->assertIsValidQueryResponse( $response );
+		$this->assertResponseIsValid( $response );
 		$this->assertNotEmpty( $response['extensions']['tracing'] );
 	}
 
@@ -69,7 +69,7 @@ class TracingTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		codecept_debug( $response );
 
-		$this->assertIsValidQueryResponse( $response );
+		$this->assertResponseIsValid( $response );
 		$this->assertNotEmpty( $response['extensions']['tracing'] );
 	}
 }

--- a/tests/wpunit/UserConnectionPaginationTest.php
+++ b/tests/wpunit/UserConnectionPaginationTest.php
@@ -471,7 +471,7 @@ class UserConnectionPaginationTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 		$expected = $actual['data']['users']['nodes'][2];
 		$actual   = $this->usersQuery( $variables );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertSame( $expected, $actual['data']['users']['nodes'][0] );
 
@@ -490,7 +490,7 @@ class UserConnectionPaginationTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 		// Get 5 items, but between the bounds of a before and after cursor.
 		$actual = $this->usersQuery( $variables );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertSame( $expected, $actual['data']['users']['nodes'][0] );
 	}
@@ -503,7 +503,7 @@ class UserConnectionPaginationTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 	 * @param array $actual The GraphQL results.
 	 */
 	public function assertValidPagination( $expected, $actual ) {
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 
 		$this->assertEquals( 2, count( $actual['data']['users']['edges'] ) );

--- a/tests/wpunit/UserRoleConnectionQueriesTest.php
+++ b/tests/wpunit/UserRoleConnectionQueriesTest.php
@@ -176,7 +176,7 @@ class UserRoleConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 		);
 
 		// Confirm its valid.
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertNotEmpty( $actual['data']['userRoles']['edges'][0]['node']['name'] );
 
 		// Store for use by $expected.
@@ -273,7 +273,7 @@ class UserRoleConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 		);
 
 		// Confirm its valid.
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertNotEmpty( $actual['data']['userRoles']['edges'][0]['node']['name'] );
 
 		$wp_query = $actual['data']['userRoles'];
@@ -383,7 +383,7 @@ class UserRoleConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 		$expected = $actual['data']['userRoles']['nodes'][1];
 		$actual   = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 
 		$this->assertSame( $expected, $actual['data']['userRoles']['nodes'][0] );
@@ -403,7 +403,7 @@ class UserRoleConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 		// Get 5 items, but between the bounds of a before and after cursor.
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertSame( $expected, $actual['data']['userRoles']['nodes'][0] );
 	}
@@ -415,7 +415,7 @@ class UserRoleConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 	 * @param array $actual The GraphQL results.
 	 */
 	public function assertValidPagination( $expected, $actual ) {
-		$this->assertIsValidQueryResponse( $actual );
+		$this->assertResponseIsValid( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 
 		$this->assertEquals( 2, count( $actual['data']['userRoles']['edges'] ) );

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.24.0
+ * Version: 1.25.0
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.24.0
+ * @version  1.25.0
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
## Release Notes

### Upgrade Notice

This release includes a fix to a regression in the v1.24.0. Users impacted by the regression in 1.24.0 included, but are not necessarily limited to, users of the WPGraphQL for WooCommerce extension.

### New Features

- [#3104](https://github.com/wp-graphql/wp-graphql/pull/3104): feat: add `AbsractConnectionResolver::pre_should_execute()`. Thanks @justlevine!

### Chores / Bugfixes
- [#3104](https://github.com/wp-graphql/wp-graphql/pull/3104): refactor: `AbstractConnectionResolver::should_execute()` Thanks @justlevine!
- [#3112](https://github.com/wp-graphql/wp-graphql/pull/3104): fix: fixes a regression from v1.24.0 relating to field arguments defined on Interfaces not being properly merged onto Object Types that implement the interface. Thanks @kidunot89!
- [#3114](https://github.com/wp-graphql/wp-graphql/pull/3114): fix: node IDs not showing in the Query Analyzer / X-GraphQL-Keys when using DataLoader->load_many()
- [#3116](https://github.com/wp-graphql/wp-graphql/pull/3116): chore: Update WPGraphQLTestCase to v3. Thanks @kidunot89!