### PR TITLE
refactor: wrap `AbstractConnectionResolver::is_valid_model()` in `::get_is_valid_model()`

### DIFF
--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -382,7 +382,7 @@ abstract class AbstractConnectionResolver {
 	 * If model isn't a class with a `fields` member, this function with have be overridden in
 	 * the Connection class.
 	 *
-	 * @param \WPGraphQL\Model\Model|mixed $model The model being validated
+	 * @param \WPGraphQL\Model\Model|mixed $model The model being validated.
 	 *
 	 * @return bool
 	 */
@@ -565,7 +565,7 @@ abstract class AbstractConnectionResolver {
 
 		foreach ( $ids as $id ) {
 			$model = $this->get_node_by_id( $id );
-			if ( true === $this->is_valid_model( $model ) ) {
+			if ( true === $this->get_is_valid_model( $model ) ) {
 				$nodes[ $id ] = $model;
 			}
 		}
@@ -1014,6 +1014,27 @@ abstract class AbstractConnectionResolver {
 	}
 
 	/**
+	 * Gets whether or not the model is valid.
+	 *
+	 * @param mixed $model The model being validated.
+	 */
+	protected function get_is_valid_model( $model ): bool {
+		$is_valid = $this->is_valid_model( $model );
+
+		/**
+		 * Filters whether or not the model is valid.
+		 *
+		 * This is useful when the dataloader is overridden and uses a different model than expected by default.
+		 *
+		 * @param bool  $is_valid Whether or not the model is valid.
+		 * @param mixed $model    The model being validated
+		 * @param self  $resolver The connection resolver instance
+		 */
+		return apply_filters( 'graphql_connection_is_valid_model', $is_valid, $model, $this );
+	}
+
+
+	/**
 	 * Given an ID, a cursor is returned.
 	 *
 	 * @param int|string $id The ID to get the cursor for.
@@ -1091,8 +1112,7 @@ abstract class AbstractConnectionResolver {
 	/**
 	 * Whether there is a next page in the connection.
 	 *
-	 * If there are more "items" than were asked for in the "first" argument
-	 * ore if there are more "items" after the "before" argument, has_next_page() will be set to true.
+	 * If there are more "items" than were asked for in the "first" argument or if there are more "items" after the "before" argument, has_next_page() will be set to true.
 	 *
 	 * @return bool
 	 */
@@ -1113,8 +1133,7 @@ abstract class AbstractConnectionResolver {
 	/**
 	 * Whether there is a previous page in the connection.
 	 *
-	 * If there are more "items" than were asked for in the "last" argument
-	 * or if there are more "items" before the "after" argument, has_previous_page() will be set to true.
+	 * If there are more "items" than were asked for in the "last" argument or if there are more "items" before the "after" argument, has_previous_page() will be set to true.
 	 *
 	 * @return bool
 	 */

--- a/tests/wpunit/PostObjectConnectionQueriesTest.php
+++ b/tests/wpunit/PostObjectConnectionQueriesTest.php
@@ -1864,5 +1864,8 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertArrayHasKey( 'data', $actual );
 		$this->assertEmpty( $actual['data']['posts']['nodes'], 'The filtered connection should not return posts' );
+
+		// Reset the filter
+		remove_filter( 'graphql_connection_is_valid_model', '__return_false' );
 	}
 }

--- a/tests/wpunit/PostObjectConnectionQueriesTest.php
+++ b/tests/wpunit/PostObjectConnectionQueriesTest.php
@@ -1839,4 +1839,30 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 		wp_delete_post( $child );
 		wp_delete_post( $grandchild );
 	}
+
+	public function testIsValidModelFilter(): void {
+		$query = '
+		query {
+			posts {
+				nodes {
+					__typename
+				}
+			}
+		}
+		';
+
+		$actual = $this->graphql( compact( 'query' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertArrayHasKey( 'data', $actual );
+		$this->assertNotEmpty( $actual['data']['posts']['nodes'], 'The unfiltered connection should return posts' );
+
+		add_filter( 'graphql_connection_is_valid_model', '__return_false' );
+
+		$actual = $this->graphql( compact( 'query' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertArrayHasKey( 'data', $actual );
+		$this->assertEmpty( $actual['data']['posts']['nodes'], 'The filtered connection should not return posts' );
+	}
 }


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR adds the new `AbstractConnectionResolver::get_is_valid_model()` method, which wraps the `::is_valid_model()` logic in the new `graphql_connection_is_valid_model` filter.

This filter is useful for developers who wish to override a Connection Resolver's `is_valid_model()` check. The separation of concerns helps those extending a Connection Resolver by minimizing the about of boilerplate they need to copy when overloading `is_valid_model()` in their child classes.

This is a *non-breaking* change.

Additionally, the spacing in some docblocks was cleaned up.

Does this close any currently open issues?
------------------------------------------
<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

There are _no breaking changes_ in this PR.


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
<!-- (If it’s long, please paste to https://ghostbin.com/ and insert the link here.) -->


Any other comments?
-------------------
Part of https://github.com/wp-graphql/wp-graphql/pull/2749


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php 8.1.15)

**WordPress Version:** 6.5.2
