### PR TITLE
chore: relocate `AbstractConnectionResolver::is_valid_offset()` with other abstract methods.

### DIFF
--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -261,6 +261,17 @@ abstract class AbstractConnectionResolver {
 	abstract public function get_query();
 
 	/**
+	 * Determine whether or not the the offset is valid, i.e the item corresponding to the offset exists.
+	 *
+	 * Offset is equivalent to WordPress ID (e.g post_id, term_id). So this is equivalent to checking if the WordPress object exists for the given ID.
+	 *
+	 * @param mixed $offset The offset to validate. Typically a WordPress Database ID
+	 *
+	 * @return bool
+	 */
+	abstract public function is_valid_offset( $offset );
+
+	/**
 	 * Used to determine whether the connection query should be executed. This is useful for short-circuiting the connection resolver before executing the query.
 	 *
 	 * When `pre_should_excecute()` returns false, that's a sign the Resolver shouldn't execute the query. Otherwise, the more expensive logic logic in `should_execute()` will run later in the lifecycle.
@@ -293,19 +304,6 @@ abstract class AbstractConnectionResolver {
 	protected function max_query_amount(): int {
 		return 100;
 	}
-
-	/**
-	 * Is_valid_offset
-	 *
-	 * Determine whether or not the the offset is valid, i.e the item corresponding to the offset
-	 * exists. Offset is equivalent to WordPress ID (e.g post_id, term_id). So this function is
-	 * equivalent to checking if the WordPress object exists for the given ID.
-	 *
-	 * @param mixed $offset The offset to validate. Typically a WordPress Database ID
-	 *
-	 * @return bool
-	 */
-	abstract public function is_valid_offset( $offset );
 
 	/**
 	 * Return an array of ids from the query


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR moves the abstract `AbstractConnectionResolver::is_valid_offset()` method to be alongside the other abstract methods in the class.

**No actual code changes were made in this PR**


Does this close any currently open issues?
------------------------------------------
<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
<!-- (If it’s long, please paste to https://ghostbin.com/ and insert the link here.) -->


Any other comments?
-------------------
Part of #2749 


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php 8.1.15)

**WordPress Version:** 6.5.2
