### PR TITLE
chore: Update references to Slack, pointing folks to Discord instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Below are some links to help you get started with WPGraphQL
 - <a href="https://wpgraphql.com/docs/quick-start" target="_blank">Quick Start Guide</a>
 - <a href="https://wpgraphql.com/docs/intro-to-graphql" target="_blank">Intro to GraphQL</a>
 - <a href="https://wpgraphql.com/docs/intro-to-wordpress" target="_blank">Intro to WordPress</a>
-- <a href="https://join.slack.com/t/wp-graphql/shared_invite/zt-3vloo60z-PpJV2PFIwEathWDOxCTTLA" target="_blank">Join the WPGraphQL community on Slack</a>
+- <a href="https://discord.gg/AGVBqqyaUY" target="_blank">Join the WPGraphQL community on Discord</a>
 
 -----
 

--- a/packages/wpgraphiql/screens/Help/Help.js
+++ b/packages/wpgraphiql/screens/Help/Help.js
@@ -227,19 +227,18 @@ const Help = () => {
         <Col xs={24} sm={24} md={24} lg={8} xl={8}>
           <Card
             style={{ height: "100%" }}
-            title="Join us in Slack"
+            title="Join us in Discord"
             actions={[
               <a
-                href="https://join.slack.com/t/wp-graphql/shared_invite/zt-3vloo60z-PpJV2PFIwEathWDOxCTTLA"
+                href="https://discord.gg/AGVBqqyaUY"
                 target="_blank"
               >
-                <Button type="primary">Join us in Slack</Button>
+                <Button type="primary">Join us in Discord</Button>
               </a>,
             ]}
           >
             <p>
-              There are more than 2,000 people in the WPGraphQL Slack community
-              asking questions and helping each other. Join us today!
+              Join the WPGraphQL Community in Discord where you can ask questions, show off projects and help other WPGraphQL users. Join us today!
             </p>
           </Card>
         </Col>

--- a/readme.txt
+++ b/readme.txt
@@ -18,7 +18,7 @@ Below are some links to help you get started with WPGraphQL
 - <a href="https://wpgraphql.com/docs/quick-start" target="_blank">Quick Start Guide</a>
 - <a href="https://wpgraphql.com/docs/intro-to-graphql" target="_blank">Intro to GraphQL</a>
 - <a href="https://wpgraphql.com/docs/intro-to-wordpress" target="_blank">Intro to WordPress</a>
-- <a href="https://join.slack.com/t/wp-graphql/shared_invite/zt-3vloo60z-PpJV2PFIwEathWDOxCTTLA" target="_blank">Join the WPGraphQL community on Slack</a>
+- <a href="https://discord.gg/AGVBqqyaUY" target="_blank">Join the WPGraphQL community on Discord</a>
 
 = Build rich JavaScript applications with WordPress and GraphQL =
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Update references in the WPGraphQL codebase that link to Slack to link to Discord instead
