### PR TITLE
chore: cleanup AbstractConnectionResolver before release.

### DIFF
--- a/access-functions.php
+++ b/access-functions.php
@@ -82,7 +82,6 @@ function graphql_format_type_name( $type_name ) {
 	return str_replace( ' ', '', ucfirst( ucwords( $formatted_type_name ) ) );
 }
 
-
 /**
  * Provides a simple way to run a GraphQL query without posting a request to the endpoint.
  *
@@ -624,7 +623,6 @@ function deregister_graphql_field( string $type_name, string $field_name ) {
 		10
 	);
 }
-
 
 /**
  * Given a Connection Name, this removes the connection from the Schema

--- a/composer.lock
+++ b/composer.lock
@@ -1315,16 +1315,16 @@
         },
         {
             "name": "composer/composer",
-            "version": "2.7.4",
+            "version": "2.7.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "a625e50598e12171d3f60b1149eb530690c43474"
+                "reference": "fabd995783b633829fd4280e272284b39b6ae702"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/a625e50598e12171d3f60b1149eb530690c43474",
-                "reference": "a625e50598e12171d3f60b1149eb530690c43474",
+                "url": "https://api.github.com/repos/composer/composer/zipball/fabd995783b633829fd4280e272284b39b6ae702",
+                "reference": "fabd995783b633829fd4280e272284b39b6ae702",
                 "shasum": ""
             },
             "require": {
@@ -1409,7 +1409,7 @@
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/composer/issues",
                 "security": "https://github.com/composer/composer/security/policy",
-                "source": "https://github.com/composer/composer/tree/2.7.4"
+                "source": "https://github.com/composer/composer/tree/2.7.6"
             },
             "funding": [
                 {
@@ -1425,7 +1425,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-22T19:17:03+00:00"
+            "time": "2024-05-04T21:03:15+00:00"
         },
         {
             "name": "composer/metadata-minifier",
@@ -1730,16 +1730,16 @@
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "3.0.4",
+            "version": "3.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "4f988f8fdf580d53bdb2d1278fe93d1ed5462255"
+                "reference": "6c1925561632e83d60a44492e0b344cf48ab85ef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/4f988f8fdf580d53bdb2d1278fe93d1ed5462255",
-                "reference": "4f988f8fdf580d53bdb2d1278fe93d1ed5462255",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/6c1925561632e83d60a44492e0b344cf48ab85ef",
+                "reference": "6c1925561632e83d60a44492e0b344cf48ab85ef",
                 "shasum": ""
             },
             "require": {
@@ -1776,7 +1776,7 @@
             "support": {
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/xdebug-handler/issues",
-                "source": "https://github.com/composer/xdebug-handler/tree/3.0.4"
+                "source": "https://github.com/composer/xdebug-handler/tree/3.0.5"
             },
             "funding": [
                 {
@@ -1792,7 +1792,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-03-26T18:29:49+00:00"
+            "time": "2024-05-06T16:37:16+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -3748,16 +3748,16 @@
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v6.5.2",
+            "version": "v6.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "379f17a90c01498d4c99a0d15aab6e7aa6a2c840"
+                "reference": "e611a83292d02055a25f83291a98fadd0c21e092"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/379f17a90c01498d4c99a0d15aab6e7aa6a2c840",
-                "reference": "379f17a90c01498d4c99a0d15aab6e7aa6a2c840",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/e611a83292d02055a25f83291a98fadd0c21e092",
+                "reference": "e611a83292d02055a25f83291a98fadd0c21e092",
                 "shasum": ""
             },
             "require-dev": {
@@ -3789,9 +3789,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.5.2"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.5.3"
             },
-            "time": "2024-04-14T17:30:14+00:00"
+            "time": "2024-05-08T02:12:31+00:00"
         },
         {
             "name": "php-webdriver/webdriver",
@@ -4303,16 +4303,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.28.0",
+            "version": "1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "cd06d6b1a1b3c75b0b83f97577869fd85a3cd4fb"
+                "reference": "536889f2b340489d328f5ffb7b02bb6b183ddedc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/cd06d6b1a1b3c75b0b83f97577869fd85a3cd4fb",
-                "reference": "cd06d6b1a1b3c75b0b83f97577869fd85a3cd4fb",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/536889f2b340489d328f5ffb7b02bb6b183ddedc",
+                "reference": "536889f2b340489d328f5ffb7b02bb6b183ddedc",
                 "shasum": ""
             },
             "require": {
@@ -4344,9 +4344,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.28.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.29.0"
             },
-            "time": "2024-04-03T18:51:33+00:00"
+            "time": "2024-05-06T12:04:23+00:00"
         },
         {
             "name": "phpstan/phpstan",
@@ -8844,16 +8844,16 @@
         },
         {
             "name": "wp-cli/cache-command",
-            "version": "v2.1.2",
+            "version": "v2.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/cache-command.git",
-                "reference": "205c004ce6127c605e4a71840a6f0b5be72b0517"
+                "reference": "1dbb59e5ed126b9a2fa9d521d29910f3f4eb0f97"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/cache-command/zipball/205c004ce6127c605e4a71840a6f0b5be72b0517",
-                "reference": "205c004ce6127c605e4a71840a6f0b5be72b0517",
+                "url": "https://api.github.com/repos/wp-cli/cache-command/zipball/1dbb59e5ed126b9a2fa9d521d29910f3f4eb0f97",
+                "reference": "1dbb59e5ed126b9a2fa9d521d29910f3f4eb0f97",
                 "shasum": ""
             },
             "require": {
@@ -8913,9 +8913,9 @@
             "homepage": "https://github.com/wp-cli/cache-command",
             "support": {
                 "issues": "https://github.com/wp-cli/cache-command/issues",
-                "source": "https://github.com/wp-cli/cache-command/tree/v2.1.2"
+                "source": "https://github.com/wp-cli/cache-command/tree/v2.1.3"
             },
-            "time": "2024-01-11T14:00:20+00:00"
+            "time": "2024-04-26T14:54:22+00:00"
         },
         {
             "name": "wp-cli/checksum-command",
@@ -8978,16 +8978,16 @@
         },
         {
             "name": "wp-cli/config-command",
-            "version": "v2.3.3",
+            "version": "v2.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/config-command.git",
-                "reference": "890b6e3c8fd945dcad2bff4bf565ba6dfb33e35d"
+                "reference": "445dfd0276a8e717ed4d2dd6f9dd0b769097fba4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/config-command/zipball/890b6e3c8fd945dcad2bff4bf565ba6dfb33e35d",
-                "reference": "890b6e3c8fd945dcad2bff4bf565ba6dfb33e35d",
+                "url": "https://api.github.com/repos/wp-cli/config-command/zipball/445dfd0276a8e717ed4d2dd6f9dd0b769097fba4",
+                "reference": "445dfd0276a8e717ed4d2dd6f9dd0b769097fba4",
                 "shasum": ""
             },
             "require": {
@@ -9046,22 +9046,22 @@
             "homepage": "https://github.com/wp-cli/config-command",
             "support": {
                 "issues": "https://github.com/wp-cli/config-command/issues",
-                "source": "https://github.com/wp-cli/config-command/tree/v2.3.3"
+                "source": "https://github.com/wp-cli/config-command/tree/v2.3.4"
             },
-            "time": "2023-12-21T10:01:16+00:00"
+            "time": "2024-03-01T12:07:39+00:00"
         },
         {
             "name": "wp-cli/core-command",
-            "version": "v2.1.17",
+            "version": "v2.1.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/core-command.git",
-                "reference": "dcac4c36a3c596f1c81779bdbaa0c5f508f14075"
+                "reference": "f7580f93fe66a5584fa7b7c42bd2c0c1435c9d2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/core-command/zipball/dcac4c36a3c596f1c81779bdbaa0c5f508f14075",
-                "reference": "dcac4c36a3c596f1c81779bdbaa0c5f508f14075",
+                "url": "https://api.github.com/repos/wp-cli/core-command/zipball/f7580f93fe66a5584fa7b7c42bd2c0c1435c9d2e",
+                "reference": "f7580f93fe66a5584fa7b7c42bd2c0c1435c9d2e",
                 "shasum": ""
             },
             "require": {
@@ -9117,22 +9117,22 @@
             "homepage": "https://github.com/wp-cli/core-command",
             "support": {
                 "issues": "https://github.com/wp-cli/core-command/issues",
-                "source": "https://github.com/wp-cli/core-command/tree/v2.1.17"
+                "source": "https://github.com/wp-cli/core-command/tree/v2.1.18"
             },
-            "time": "2024-01-11T11:03:57+00:00"
+            "time": "2024-04-12T09:36:36+00:00"
         },
         {
             "name": "wp-cli/cron-command",
-            "version": "v2.2.3",
+            "version": "v2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/cron-command.git",
-                "reference": "bc7e4bd2f441a5bb3b311e1419be2b05ed53146d"
+                "reference": "2108295a2f30de77d3ee70b1a60d1b542c2dfd79"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/cron-command/zipball/bc7e4bd2f441a5bb3b311e1419be2b05ed53146d",
-                "reference": "bc7e4bd2f441a5bb3b311e1419be2b05ed53146d",
+                "url": "https://api.github.com/repos/wp-cli/cron-command/zipball/2108295a2f30de77d3ee70b1a60d1b542c2dfd79",
+                "reference": "2108295a2f30de77d3ee70b1a60d1b542c2dfd79",
                 "shasum": ""
             },
             "require": {
@@ -9186,22 +9186,22 @@
             "homepage": "https://github.com/wp-cli/cron-command",
             "support": {
                 "issues": "https://github.com/wp-cli/cron-command/issues",
-                "source": "https://github.com/wp-cli/cron-command/tree/v2.2.3"
+                "source": "https://github.com/wp-cli/cron-command/tree/v2.3.0"
             },
-            "time": "2023-08-30T13:31:32+00:00"
+            "time": "2024-02-15T10:23:39+00:00"
         },
         {
             "name": "wp-cli/db-command",
-            "version": "v2.0.27",
+            "version": "v2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/db-command.git",
-                "reference": "eea28dd115fb381c82641a2a3060856d3a67242d"
+                "reference": "bf741ebc532f7d4673f4552d1b3589265205cf32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/db-command/zipball/eea28dd115fb381c82641a2a3060856d3a67242d",
-                "reference": "eea28dd115fb381c82641a2a3060856d3a67242d",
+                "url": "https://api.github.com/repos/wp-cli/db-command/zipball/bf741ebc532f7d4673f4552d1b3589265205cf32",
+                "reference": "bf741ebc532f7d4673f4552d1b3589265205cf32",
                 "shasum": ""
             },
             "require": {
@@ -9260,22 +9260,22 @@
             "homepage": "https://github.com/wp-cli/db-command",
             "support": {
                 "issues": "https://github.com/wp-cli/db-command/issues",
-                "source": "https://github.com/wp-cli/db-command/tree/v2.0.27"
+                "source": "https://github.com/wp-cli/db-command/tree/v2.1.0"
             },
-            "time": "2023-11-13T12:34:44+00:00"
+            "time": "2024-04-27T03:11:44+00:00"
         },
         {
             "name": "wp-cli/embed-command",
-            "version": "v2.0.15",
+            "version": "v2.0.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/embed-command.git",
-                "reference": "3987e2051354eaad842c8612ea9255493534c589"
+                "reference": "edfa448396484770a419ac7a17b0ec194ae76654"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/embed-command/zipball/3987e2051354eaad842c8612ea9255493534c589",
-                "reference": "3987e2051354eaad842c8612ea9255493534c589",
+                "url": "https://api.github.com/repos/wp-cli/embed-command/zipball/edfa448396484770a419ac7a17b0ec194ae76654",
+                "reference": "edfa448396484770a419ac7a17b0ec194ae76654",
                 "shasum": ""
             },
             "require": {
@@ -9327,22 +9327,22 @@
             "homepage": "https://github.com/wp-cli/embed-command",
             "support": {
                 "issues": "https://github.com/wp-cli/embed-command/issues",
-                "source": "https://github.com/wp-cli/embed-command/tree/v2.0.15"
+                "source": "https://github.com/wp-cli/embed-command/tree/v2.0.16"
             },
-            "time": "2023-08-30T15:52:06+00:00"
+            "time": "2024-04-04T11:57:03+00:00"
         },
         {
             "name": "wp-cli/entity-command",
-            "version": "v2.6.2",
+            "version": "v2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/entity-command.git",
-                "reference": "2b5d5d54550edb7383ebaa77fb3a2d53871ba19a"
+                "reference": "8110a596db62eb423f7f8e49c99dbacacf01f6ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/entity-command/zipball/2b5d5d54550edb7383ebaa77fb3a2d53871ba19a",
-                "reference": "2b5d5d54550edb7383ebaa77fb3a2d53871ba19a",
+                "url": "https://api.github.com/repos/wp-cli/entity-command/zipball/8110a596db62eb423f7f8e49c99dbacacf01f6ed",
+                "reference": "8110a596db62eb423f7f8e49c99dbacacf01f6ed",
                 "shasum": ""
             },
             "require": {
@@ -9457,6 +9457,14 @@
                     "site empty",
                     "site list",
                     "site mature",
+                    "site meta",
+                    "site meta add",
+                    "site meta delete",
+                    "site meta get",
+                    "site meta list",
+                    "site meta patch",
+                    "site meta pluck",
+                    "site meta update",
                     "site option",
                     "site private",
                     "site public",
@@ -9486,8 +9494,17 @@
                     "user",
                     "user add-cap",
                     "user add-role",
+                    "user application-password",
+                    "user application-password create",
+                    "user application-password delete",
+                    "user application-password exists",
+                    "user application-password get",
+                    "user application-password list",
+                    "user application-password record-usage",
+                    "user application-password update",
                     "user create",
                     "user delete",
+                    "user exists",
                     "user generate",
                     "user get",
                     "user import-csv",
@@ -9541,9 +9558,9 @@
             "homepage": "https://github.com/wp-cli/entity-command",
             "support": {
                 "issues": "https://github.com/wp-cli/entity-command/issues",
-                "source": "https://github.com/wp-cli/entity-command/tree/v2.6.2"
+                "source": "https://github.com/wp-cli/entity-command/tree/v2.7.0"
             },
-            "time": "2024-02-06T13:38:03+00:00"
+            "time": "2024-04-29T07:34:56+00:00"
         },
         {
             "name": "wp-cli/eval-command",
@@ -9668,16 +9685,16 @@
         },
         {
             "name": "wp-cli/extension-command",
-            "version": "v2.1.20",
+            "version": "v2.1.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/extension-command.git",
-                "reference": "fa8bfd96a2c587a38e9e99d3cfb9fb5b35ee25d5"
+                "reference": "f9bc3fd2f2dabcbe9b3bc3dc9591535dd714fd3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/extension-command/zipball/fa8bfd96a2c587a38e9e99d3cfb9fb5b35ee25d5",
-                "reference": "fa8bfd96a2c587a38e9e99d3cfb9fb5b35ee25d5",
+                "url": "https://api.github.com/repos/wp-cli/extension-command/zipball/f9bc3fd2f2dabcbe9b3bc3dc9591535dd714fd3c",
+                "reference": "f9bc3fd2f2dabcbe9b3bc3dc9591535dd714fd3c",
                 "shasum": ""
             },
             "require": {
@@ -9760,9 +9777,9 @@
             "homepage": "https://github.com/wp-cli/extension-command",
             "support": {
                 "issues": "https://github.com/wp-cli/extension-command/issues",
-                "source": "https://github.com/wp-cli/extension-command/tree/v2.1.20"
+                "source": "https://github.com/wp-cli/extension-command/tree/v2.1.21"
             },
-            "time": "2024-04-26T21:12:41+00:00"
+            "time": "2024-05-02T13:35:09+00:00"
         },
         {
             "name": "wp-cli/i18n-command",
@@ -9895,16 +9912,16 @@
         },
         {
             "name": "wp-cli/language-command",
-            "version": "v2.0.19",
+            "version": "v2.0.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/language-command.git",
-                "reference": "4d0a2e58f8c48772e0a85a3b25f413ef240c212a"
+                "reference": "2e6edc65aff1828b79250b96ace93d77abcca481"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/language-command/zipball/4d0a2e58f8c48772e0a85a3b25f413ef240c212a",
-                "reference": "4d0a2e58f8c48772e0a85a3b25f413ef240c212a",
+                "url": "https://api.github.com/repos/wp-cli/language-command/zipball/2e6edc65aff1828b79250b96ace93d77abcca481",
+                "reference": "2e6edc65aff1828b79250b96ace93d77abcca481",
                 "shasum": ""
             },
             "require": {
@@ -9968,22 +9985,22 @@
             "homepage": "https://github.com/wp-cli/language-command",
             "support": {
                 "issues": "https://github.com/wp-cli/language-command/issues",
-                "source": "https://github.com/wp-cli/language-command/tree/v2.0.19"
+                "source": "https://github.com/wp-cli/language-command/tree/v2.0.20"
             },
-            "time": "2024-02-01T14:28:11+00:00"
+            "time": "2024-02-20T12:36:40+00:00"
         },
         {
             "name": "wp-cli/maintenance-mode-command",
-            "version": "v2.1.0",
+            "version": "v2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/maintenance-mode-command.git",
-                "reference": "2e9845a1cd1678b960dd8d0dd0c936648113788c"
+                "reference": "a329a536eb96890654b913b5499b300fcc3f8eab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/maintenance-mode-command/zipball/2e9845a1cd1678b960dd8d0dd0c936648113788c",
-                "reference": "2e9845a1cd1678b960dd8d0dd0c936648113788c",
+                "url": "https://api.github.com/repos/wp-cli/maintenance-mode-command/zipball/a329a536eb96890654b913b5499b300fcc3f8eab",
+                "reference": "a329a536eb96890654b913b5499b300fcc3f8eab",
                 "shasum": ""
             },
             "require": {
@@ -10029,22 +10046,22 @@
             "homepage": "https://github.com/wp-cli/maintenance-mode-command",
             "support": {
                 "issues": "https://github.com/wp-cli/maintenance-mode-command/issues",
-                "source": "https://github.com/wp-cli/maintenance-mode-command/tree/v2.1.0"
+                "source": "https://github.com/wp-cli/maintenance-mode-command/tree/v2.1.1"
             },
-            "time": "2023-11-06T14:04:13+00:00"
+            "time": "2024-04-04T11:28:11+00:00"
         },
         {
             "name": "wp-cli/media-command",
-            "version": "v2.0.21",
+            "version": "v2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/media-command.git",
-                "reference": "4950ed4ded35c52068d30fec080d545a33baa85c"
+                "reference": "210cccf80f4faa38c0c608768089edf7acf2b319"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/media-command/zipball/4950ed4ded35c52068d30fec080d545a33baa85c",
-                "reference": "4950ed4ded35c52068d30fec080d545a33baa85c",
+                "url": "https://api.github.com/repos/wp-cli/media-command/zipball/210cccf80f4faa38c0c608768089edf7acf2b319",
+                "reference": "210cccf80f4faa38c0c608768089edf7acf2b319",
                 "shasum": ""
             },
             "require": {
@@ -10091,9 +10108,9 @@
             "homepage": "https://github.com/wp-cli/media-command",
             "support": {
                 "issues": "https://github.com/wp-cli/media-command/issues",
-                "source": "https://github.com/wp-cli/media-command/tree/v2.0.21"
+                "source": "https://github.com/wp-cli/media-command/tree/v2.1.0"
             },
-            "time": "2023-11-10T21:56:52+00:00"
+            "time": "2024-03-14T09:04:20+00:00"
         },
         {
             "name": "wp-cli/mustangostang-spyc",
@@ -10469,16 +10486,16 @@
         },
         {
             "name": "wp-cli/search-replace-command",
-            "version": "v2.1.5",
+            "version": "v2.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/search-replace-command.git",
-                "reference": "f6c828abc6d5054d5bbf202b917d2a3b38abed84"
+                "reference": "d908c57ba744e14a32f3a577f9e45378d3fe1349"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/search-replace-command/zipball/f6c828abc6d5054d5bbf202b917d2a3b38abed84",
-                "reference": "f6c828abc6d5054d5bbf202b917d2a3b38abed84",
+                "url": "https://api.github.com/repos/wp-cli/search-replace-command/zipball/d908c57ba744e14a32f3a577f9e45378d3fe1349",
+                "reference": "d908c57ba744e14a32f3a577f9e45378d3fe1349",
                 "shasum": ""
             },
             "require": {
@@ -10523,9 +10540,9 @@
             "homepage": "https://github.com/wp-cli/search-replace-command",
             "support": {
                 "issues": "https://github.com/wp-cli/search-replace-command/issues",
-                "source": "https://github.com/wp-cli/search-replace-command/tree/v2.1.5"
+                "source": "https://github.com/wp-cli/search-replace-command/tree/v2.1.6"
             },
-            "time": "2024-01-09T00:29:39+00:00"
+            "time": "2024-05-07T09:27:51+00:00"
         },
         {
             "name": "wp-cli/server-command",
@@ -10644,16 +10661,16 @@
         },
         {
             "name": "wp-cli/super-admin-command",
-            "version": "v2.0.13",
+            "version": "v2.0.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/super-admin-command.git",
-                "reference": "9d91c131ad814f9bcec313c3877e8348622720d5"
+                "reference": "0fc8a6146d0450a8b522485e50886e976f5249b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/super-admin-command/zipball/9d91c131ad814f9bcec313c3877e8348622720d5",
-                "reference": "9d91c131ad814f9bcec313c3877e8348622720d5",
+                "url": "https://api.github.com/repos/wp-cli/super-admin-command/zipball/0fc8a6146d0450a8b522485e50886e976f5249b6",
+                "reference": "0fc8a6146d0450a8b522485e50886e976f5249b6",
                 "shasum": ""
             },
             "require": {
@@ -10699,9 +10716,9 @@
             "homepage": "https://github.com/wp-cli/super-admin-command",
             "support": {
                 "issues": "https://github.com/wp-cli/super-admin-command/issues",
-                "source": "https://github.com/wp-cli/super-admin-command/tree/v2.0.13"
+                "source": "https://github.com/wp-cli/super-admin-command/tree/v2.0.14"
             },
-            "time": "2024-01-08T12:21:39+00:00"
+            "time": "2024-02-26T12:17:45+00:00"
         },
         {
             "name": "wp-cli/widget-command",
@@ -11025,16 +11042,16 @@
         },
         {
             "name": "wp-graphql/wp-graphql-testcase",
-            "version": "v3.0.0",
+            "version": "v3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-graphql/wp-graphql-testcase.git",
-                "reference": "c18eb271a4a1cf740e9ab8d9a13fecf150f04b5d"
+                "reference": "743e920b23c370ef009c35456d03d956ea99886d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-graphql/wp-graphql-testcase/zipball/c18eb271a4a1cf740e9ab8d9a13fecf150f04b5d",
-                "reference": "c18eb271a4a1cf740e9ab8d9a13fecf150f04b5d",
+                "url": "https://api.github.com/repos/wp-graphql/wp-graphql-testcase/zipball/743e920b23c370ef009c35456d03d956ea99886d",
+                "reference": "743e920b23c370ef009c35456d03d956ea99886d",
                 "shasum": ""
             },
             "require": {
@@ -11088,9 +11105,9 @@
             "description": "Codeception module for WPGraphQL API testing",
             "support": {
                 "issues": "https://github.com/wp-graphql/wp-graphql-testcase/issues",
-                "source": "https://github.com/wp-graphql/wp-graphql-testcase/tree/v3.0.0"
+                "source": "https://github.com/wp-graphql/wp-graphql-testcase/tree/v3.0.1"
             },
-            "time": "2024-05-02T04:30:04+00:00"
+            "time": "2024-05-03T01:30:09+00:00"
         },
         {
             "name": "zordius/lightncandy",
@@ -11170,5 +11187,5 @@
     "platform-overrides": {
         "php": "7.3"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/src/Admin/Settings/SettingsRegistry.php
+++ b/src/Admin/Settings/SettingsRegistry.php
@@ -493,7 +493,6 @@ class SettingsRegistry {
 		echo wp_kses( $html, Utils::get_allowed_wp_kses_html() );
 	}
 
-
 	/**
 	 * Displays a select box for creating the pages select box
 	 *

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -244,7 +244,6 @@ abstract class AbstractConnectionResolver {
 		// The rest of the class properties are set when `$this->get_connection()` is called.
 	}
 
-
 	/**
 	 * ====================
 	 * Required/Abstract Methods

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -140,6 +140,10 @@ abstract class AbstractConnectionResolver {
 	/**
 	 * The IDs returned from the query.
 	 *
+	 * The IDs are sliced to confirm with the pagination args, and overfetched by one.
+	 *
+	 * Filterable by `graphql_connection_ids`.
+	 *
 	 * @var int[]|string[]|null
 	 */
 	protected $ids;
@@ -147,12 +151,16 @@ abstract class AbstractConnectionResolver {
 	/**
 	 * The nodes (usually GraphQL models) returned from the query.
 	 *
+	 * Filterable by `graphql_connection_nodes`.
+	 *
 	 * @var \WPGraphQL\Model\Model[]|mixed[]|null
 	 */
 	protected $nodes;
 
 	/**
 	 * The edges for the connection.
+	 *
+	 * Filterable by `graphql_connection_edges`.
 	 *
 	 * @var ?array<string,mixed>[]
 	 */
@@ -236,6 +244,17 @@ abstract class AbstractConnectionResolver {
 		// The rest of the class properties are set when `$this->get_connection()` is called.
 	}
 
+
+	/**
+	 * ====================
+	 * Required/Abstract Methods
+	 *
+	 * These methods must be implemented or overloaded in the extending class.
+	 *
+	 * The reason not all methods are abstract is to prevent backwards compatibility issues.
+	 * ====================
+	 */
+
 	/**
 	 * The name of the loader to use for this connection.
 	 *
@@ -274,6 +293,31 @@ abstract class AbstractConnectionResolver {
 	}
 
 	/**
+	 * Return an array of ids from the query
+	 *
+	 * Each Query class in WP and potential datasource handles this differently,
+	 * so each connection resolver should handle getting the items into a uniform array of items.
+	 *
+	 * @todo: This is not an abstract function to prevent backwards compatibility issues, so it instead throws an exception.
+	 *
+	 * Classes that extend AbstractConnectionResolver should
+	 * override this method instead of ::get_ids().
+	 *
+	 * @since 1.9.0
+	 *
+	 * @throws \GraphQL\Error\InvariantViolation If child class forgot to implement this.
+	 * @return int[]|string[] the array of IDs.
+	 */
+	public function get_ids_from_query() {
+		throw new InvariantViolation(
+			sprintf(
+				// translators: %s is the name of the connection resolver class.
+				esc_html__( 'Class %s does not implement a valid method `get_ids_from_query()`.', 'wp-graphql' ),
+				static::class
+			)
+		);
+	}
+	/**
 	 * Determine whether or not the the offset is valid, i.e the item corresponding to the offset exists.
 	 *
 	 * Offset is equivalent to WordPress ID (e.g post_id, term_id). So this is equivalent to checking if the WordPress object exists for the given ID.
@@ -283,6 +327,14 @@ abstract class AbstractConnectionResolver {
 	 * @return bool
 	 */
 	abstract public function is_valid_offset( $offset );
+
+	/**
+	 * ====================
+	 * The following methods handle the underlying behavior of the connection, and are intended to be overloaded by the child class.
+	 *
+	 * These methods are wrapped in getters which apply the filters and set the properties of the class instance.
+	 * ====================
+	 */
 
 	/**
 	 * Used to determine whether the connection query should be executed. This is useful for short-circuiting the connection resolver before executing the query.
@@ -384,32 +436,6 @@ abstract class AbstractConnectionResolver {
 	}
 
 	/**
-	 * Return an array of ids from the query
-	 *
-	 * Each Query class in WP and potential datasource handles this differently, so each connection
-	 * resolver should handle getting the items into a uniform array of items.
-	 *
-	 * @todo: This is not an abstract function to prevent backwards compatibility issues, so it
-	 * instead throws an exception. Classes that extend AbstractConnectionResolver should
-	 * override this method, instead of AbstractConnectionResolver::get_ids().
-	 *
-	 * @since 1.9.0
-	 *
-	 * @throws \GraphQL\Error\InvariantViolation If child class forgot to implement this.
-	 *
-	 * @return int[]|string[] the array of IDs.
-	 */
-	public function get_ids_from_query() {
-		throw new InvariantViolation(
-			sprintf(
-				// translators: %s is the name of the connection resolver class.
-				esc_html__( 'Class %s does not implement a valid method `get_ids_from_query()`.', 'wp-graphql' ),
-				static::class
-			)
-		);
-	}
-
-	/**
 	 * Determine whether or not the query should execute.
 	 *
 	 * Return true to exeucte, return false to prevent execution.
@@ -465,6 +491,16 @@ abstract class AbstractConnectionResolver {
 	protected function is_valid_model( $model ) {
 		return isset( $model->fields ) && ! empty( $model->fields );
 	}
+
+	/**
+	 * ====================
+	 * Public Getters
+	 *
+	 * These methods are used to get the properties of the class instance.
+	 *
+	 * You shouldn't need to overload these, but if you do, take care to ensure that the overloaded method applies the same filters and sets the same properties as the methods here.
+	 * ====================
+	 */
 
 	/**
 	 * Returns the source of the connection
@@ -887,10 +923,13 @@ abstract class AbstractConnectionResolver {
 		 */
 		$amount_requested = apply_filters( 'graphql_connection_default_query_amount', 10, $this );
 
+		// @todo This should use  ::get_args() when b/c is not a concern.
+		$args = $this->args;
+
 		/**
 		 * If both first & last are used in the input args, throw an exception.
 		 */
-		if ( ! empty( $this->args['first'] ) && ! empty( $this->args['last'] ) ) {
+		if ( ! empty( $args['first'] ) && ! empty( $args['last'] ) ) {
 			throw new UserError( esc_html__( 'The `first` and `last` connection args cannot be used together. For forward pagination, use `first` & `after`. For backward pagination, use `last` & `before`.', 'wp-graphql' ) );
 		}
 
@@ -898,17 +937,17 @@ abstract class AbstractConnectionResolver {
 		 * Get the key to use for the query amount.
 		 * We avoid a ternary here for unit testing.
 		 */
-		$args_key = ! empty( $this->args['first'] ) && is_int( $this->args['first'] ) ? 'first' : null;
+		$args_key = ! empty( $args['first'] ) && is_int( $args['first'] ) ? 'first' : null;
 		if ( null === $args_key ) {
-			$args_key = ! empty( $this->args['last'] ) && is_int( $this->args['last'] ) ? 'last' : null;
+			$args_key = ! empty( $args['last'] ) && is_int( $args['last'] ) ? 'last' : null;
 		}
 
 		/**
 		 * If the key is set, and is a positive integer, use it for the $amount_requested
 		 * but if it's set to anything that isn't a positive integer, throw an exception
 		 */
-		if ( null !== $args_key && isset( $this->args[ $args_key ] ) ) {
-			if ( 0 > $this->args[ $args_key ] ) {
+		if ( null !== $args_key && isset( $args[ $args_key ] ) ) {
+			if ( 0 > $args[ $args_key ] ) {
 				throw new UserError(
 					sprintf(
 						// translators: %s: The name of the arg that was invalid
@@ -918,7 +957,7 @@ abstract class AbstractConnectionResolver {
 				);
 			}
 
-			$amount_requested = $this->args[ $args_key ];
+			$amount_requested = $args[ $args_key ];
 		}
 
 		return (int) $amount_requested;
@@ -946,9 +985,12 @@ abstract class AbstractConnectionResolver {
 		 */
 		return new Deferred(
 			function () {
-				if ( ! empty( $this->ids ) ) {
+				// @todo This should use ::get_ids() when b/c is not a concern.
+				$ids = $this->ids;
+
+				if ( ! empty( $ids ) ) {
 					// Load the ids.
-					$this->get_loader()->load_many( $this->ids );
+					$this->get_loader()->load_many( $ids );
 				}
 
 				/**
@@ -1023,6 +1065,7 @@ abstract class AbstractConnectionResolver {
 		 * @param \WPGraphQL\Data\Connection\AbstractConnectionResolver $connection_resolver Instance of the Connection Resolver
 		 */
 		$this->should_execute = apply_filters( 'graphql_connection_should_execute', $should_execute, $this );
+
 		if ( false === $this->should_execute ) {
 			return [];
 		}
@@ -1153,9 +1196,12 @@ abstract class AbstractConnectionResolver {
 			return [];
 		}
 
+		// @todo This should use ::get_args() when b/c is not a concern.
+		$args = $this->args;
+
 		// First we slice the array from the front.
-		if ( ! empty( $this->args['after'] ) ) {
-			$offset = $this->get_offset_for_cursor( $this->args['after'] );
+		if ( ! empty( $args['after'] ) ) {
+			$offset = $this->get_offset_for_cursor( $args['after'] );
 			$index  = $this->get_array_index_for_offset( $offset, $ids );
 
 			if ( false !== $index ) {
@@ -1165,8 +1211,8 @@ abstract class AbstractConnectionResolver {
 		}
 
 		// Then we slice the array from the back.
-		if ( ! empty( $this->args['before'] ) ) {
-			$offset = $this->get_offset_for_cursor( $this->args['before'] );
+		if ( ! empty( $args['before'] ) ) {
+			$offset = $this->get_offset_for_cursor( $args['before'] );
 			$index  = $this->get_array_index_for_offset( $offset, $ids );
 
 			if ( false !== $index ) {
@@ -1241,17 +1287,22 @@ abstract class AbstractConnectionResolver {
 	 * @return int[]|string[]
 	 */
 	public function get_ids_for_nodes() {
-		if ( empty( $this->ids ) ) {
+		// @todo This should use ::get_ids() and get_args() when b/c is not a concern.
+		$ids = $this->ids;
+
+		if ( empty( $ids ) ) {
 			return [];
 		}
 
+		$args = $this->args;
+
 		// If we're going backwards then our overfetched ID is at the front.
-		if ( ! empty( $this->args['last'] ) && count( $this->ids ) > absint( $this->args['last'] ) ) {
-			return array_slice( $this->ids, count( $this->ids ) - absint( $this->args['last'] ), $this->get_query_amount(), true );
+		if ( ! empty( $args['last'] ) && count( $ids ) > absint( $args['last'] ) ) {
+			return array_slice( $ids, count( $ids ) - absint( $args['last'] ), $this->get_query_amount(), true );
 		}
 
 		// If we're going forwards, our overfetched ID is at the back.
-		return array_slice( $this->ids, 0, $this->get_query_amount(), true );
+		return array_slice( $ids, 0, $this->get_query_amount(), true );
 	}
 
 	/**
@@ -1397,8 +1448,11 @@ abstract class AbstractConnectionResolver {
 	 * @return int|string|null
 	 */
 	public function get_after_offset() {
-		if ( ! empty( $this->args['after'] ) ) {
-			return $this->get_offset_for_cursor( $this->args['after'] );
+		// @todo This should use ::get_args() when b/c is not a concern.
+		$args = $this->args;
+
+		if ( ! empty( $args['after'] ) ) {
+			return $this->get_offset_for_cursor( $args['after'] );
 		}
 
 		return null;
@@ -1410,8 +1464,11 @@ abstract class AbstractConnectionResolver {
 	 * @return int|string|null
 	 */
 	public function get_before_offset() {
-		if ( ! empty( $this->args['before'] ) ) {
-			return $this->get_offset_for_cursor( $this->args['before'] );
+		// @todo This should use ::get_args() when b/c is not a concern.
+		$args = $this->args;
+
+		if ( ! empty( $args['before'] ) ) {
+			return $this->get_offset_for_cursor( $args['before'] );
 		}
 
 		return null;
@@ -1425,8 +1482,13 @@ abstract class AbstractConnectionResolver {
 	 * @return bool
 	 */
 	public function has_next_page() {
-		if ( ! empty( $this->args['first'] ) ) {
-			return ! empty( $this->ids ) && count( $this->ids ) > $this->get_query_amount();
+		// @todo This should use ::get_ids() and ::get_args() when b/c is not a concern.
+		$args = $this->args;
+
+		if ( ! empty( $args['first'] ) ) {
+			$ids = $this->ids;
+
+			return ! empty( $ids ) && count( $ids ) > $this->get_query_amount();
 		}
 
 		$before_offset = $this->get_before_offset();
@@ -1446,8 +1508,13 @@ abstract class AbstractConnectionResolver {
 	 * @return bool
 	 */
 	public function has_previous_page() {
-		if ( ! empty( $this->args['last'] ) ) {
-			return ! empty( $this->ids ) && count( $this->ids ) > $this->get_query_amount();
+		// @todo This should use ::get_ids() and ::get_args() when b/c is not a concern.
+		$args = $this->args;
+
+		if ( ! empty( $args['last'] ) ) {
+			$ids = $this->ids;
+
+			return ! empty( $ids ) && count( $ids ) > $this->get_query_amount();
 		}
 
 		$after_offset = $this->get_after_offset();

--- a/src/Data/Cursor/CursorBuilder.php
+++ b/src/Data/Cursor/CursorBuilder.php
@@ -146,7 +146,6 @@ class CursorBuilder {
 		return sprintf( $sql, $key, $compare, $value, $nest );
 	}
 
-
 	/**
 	 * Copied from
 	 * https://github.com/WordPress/WordPress/blob/c4f8bc468db56baa2a3bf917c99cdfd17c3391ce/wp-includes/class-wp-meta-query.php#L272-L296

--- a/src/Mutation/PostObjectDelete.php
+++ b/src/Mutation/PostObjectDelete.php
@@ -9,7 +9,6 @@ use WPGraphQL\Model\Post;
 use WPGraphQL\Utils\Utils;
 use WP_Post_Type;
 
-
 class PostObjectDelete {
 	/**
 	 * Registers the PostObjectDelete mutation.

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -144,7 +144,6 @@ class TypeRegistry {
 	 */
 	protected $types;
 
-
 	/**
 	 * The loaders needed to register types
 	 *
@@ -170,7 +169,6 @@ class TypeRegistry {
 	 * @var string[]
 	 */
 	protected $excluded_types = null;
-
 
 	/**
 	 * Stores a list of mutation names that should be excluded from the schema, along with their generated input and payload types.

--- a/src/Registry/Utils/PostObject.php
+++ b/src/Registry/Utils/PostObject.php
@@ -430,7 +430,6 @@ class PostObject {
 		return $fields;
 	}
 
-
 	/**
 	 * Register fields to the Type used for attachments (MediaItem).
 	 *

--- a/src/Registry/Utils/TermObject.php
+++ b/src/Registry/Utils/TermObject.php
@@ -21,7 +21,6 @@ use WP_Taxonomy;
  */
 class TermObject {
 
-
 	/**
 	 * Registers a taxonomy type to the schema as either a GraphQL object, interface, or union.
 	 *

--- a/src/Request.php
+++ b/src/Request.php
@@ -26,7 +26,6 @@ use WPGraphQL\Utils\QueryAnalyzer;
  */
 class Request {
 
-
 	/**
 	 * App context for this request.
 	 *

--- a/src/Type/ObjectType/PostObject.php
+++ b/src/Type/ObjectType/PostObject.php
@@ -29,7 +29,6 @@ class PostObject {
 		\WPGraphQL\Registry\Utils\PostObject::register_types( $post_type_object );
 	}
 
-
 	/**
 	 * Registers common post type fields on schema type corresponding to provided post type object.
 	 *

--- a/src/Utils/QueryAnalyzer.php
+++ b/src/Utils/QueryAnalyzer.php
@@ -338,7 +338,6 @@ class QueryAnalyzer {
 		return $this->query_id;
 	}
 
-
 	/**
 	 * @param \GraphQL\Type\Definition\Type            $type The Type of field
 	 * @param \GraphQL\Type\Definition\FieldDefinition $field_def The field definition the type is for
@@ -779,7 +778,6 @@ class QueryAnalyzer {
 
 		return $this->graphql_keys;
 	}
-
 
 	/**
 	 * Return headers

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -21,7 +21,6 @@ use WPGraphQL\Utils\Preview;
  */
 final class WPGraphQL {
 
-
 	/**
 	 * Stores the instance of the WPGraphQL class
 	 *

--- a/tests/_data/classes/WP_Query_Custom.php
+++ b/tests/_data/classes/WP_Query_Custom.php
@@ -62,7 +62,6 @@ class WP_Query_Custom {
 		return $this->query->$name;
 	}
 
-
 		/**
 	 * Forwards function calls to WP_Query instance.
 	 *

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -53,7 +53,6 @@ function graphql_require_bootstrap_files(): void {
 	}
 }
 
-
 /**
  * Determines if the plugin can load.
  *


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR:
- Updates `wp-graphql-test-case` to 3.0.1 (just in case)
- Cleans up `AbstractConnectionResolver` with doc-blocks, formatting, and rearranging where some of the methods are in the class.
- Removes multiple repeat newlines from the source files.

**No code logic has been changed in this PR**

Does this close any currently open issues?
------------------------------------------
<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
<!-- (If it’s long, please paste to https://ghostbin.com/ and insert the link here.) -->


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php 8.1.15)

**WordPress Version:** 6.5.2
