### PR TITLE
feat: Enhance tab state management with query arguments and localStorage fallback

### DIFF
--- a/src/Admin/Settings/SettingsRegistry.php
+++ b/src/Admin/Settings/SettingsRegistry.php
@@ -678,7 +678,7 @@ class SettingsRegistry {
 	/**
 	 * Tabbable JavaScript codes & Initiate Color Picker
 	 *
-	 * This code uses localstorage for displaying active tabs
+	 * This code uses query arguments and localstorage for displaying active tabs
 	 *
 	 * @return void
 	 */
@@ -686,22 +686,22 @@ class SettingsRegistry {
 		?>
 		<script>
 			jQuery(document).ready(function ($) {
-				//Initiate Color Picker
+				// Initiate Color Picker
 				$('.wp-color-picker-field').wpColorPicker();
 
 				// Switches option sections
 				$('.group').hide();
 				var activetab = '';
-				if (typeof (localStorage) != 'undefined') {
-					activetab = localStorage.getItem("activetab");
-				}
+				var urlParams = new URLSearchParams(window.location.search);
+				var queryTab = urlParams.get('tab');
 
-				//if url has section id as hash then set it as active or override the current local storage value
-				if (window.location.hash) {
-					activetab = window.location.hash;
+				if (queryTab) {
+					activetab = '#' + queryTab;
 					if (typeof (localStorage) != 'undefined') {
 						localStorage.setItem("activetab", activetab);
 					}
+				} else if (typeof (localStorage) != 'undefined') {
+					activetab = localStorage.getItem("activetab");
 				}
 
 				if (activetab != '' && $(activetab).length) {
@@ -709,6 +709,7 @@ class SettingsRegistry {
 				} else {
 					$('.group:first').fadeIn();
 				}
+
 				$('.group .collapsed').each(function () {
 					$(this).find('input:checked').parent().parent().parent().nextAll().each(
 						function () {
@@ -725,13 +726,16 @@ class SettingsRegistry {
 				} else {
 					$('.nav-tab-wrapper a:first').addClass('nav-tab-active');
 				}
+
 				$('.nav-tab-wrapper a').click(function (evt) {
 					$('.nav-tab-wrapper a').removeClass('nav-tab-active');
 					$(this).addClass('nav-tab-active').blur();
 					var clicked_group = $(this).attr('href');
 					if (typeof (localStorage) != 'undefined') {
-						localStorage.setItem("activetab", $(this).attr('href'));
+						localStorage.setItem("activetab", clicked_group);
 					}
+					urlParams.set('tab', clicked_group.substring(1));
+					history.replaceState(null, '', '?' + urlParams.toString());
 					$('.group').hide();
 					$(clicked_group).fadeIn();
 					evt.preventDefault();

--- a/src/Admin/Settings/SettingsRegistry.php
+++ b/src/Admin/Settings/SettingsRegistry.php
@@ -678,7 +678,7 @@ class SettingsRegistry {
 	/**
 	 * Tabbable JavaScript codes & Initiate Color Picker
 	 *
-	 * This code uses query arguments and localstorage for displaying active tabs
+	 * This code uses URL hash fragments and localStorage for displaying active tabs
 	 *
 	 * @return void
 	 */
@@ -692,11 +692,10 @@ class SettingsRegistry {
 				// Switches option sections
 				$('.group').hide();
 				var activetab = '';
-				var urlParams = new URLSearchParams(window.location.search);
-				var queryTab = urlParams.get('tab');
+				var urlHash = window.location.hash;
 
-				if (queryTab) {
-					activetab = '#' + queryTab;
+				if (urlHash) {
+					activetab = urlHash;
 					if (typeof (localStorage) != 'undefined') {
 						localStorage.setItem("activetab", activetab);
 					}
@@ -734,8 +733,7 @@ class SettingsRegistry {
 					if (typeof (localStorage) != 'undefined') {
 						localStorage.setItem("activetab", clicked_group);
 					}
-					urlParams.set('tab', clicked_group.substring(1));
-					history.replaceState(null, '', '?' + urlParams.toString());
+					history.replaceState(null, '', clicked_group);
 					$('.group').hide();
 					$(clicked_group).fadeIn();
 					evt.preventDefault();


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This pull request enhances the tab state management for the WPGraphQL settings page by integrating query arguments with a fallback to localStorage. This ensures that tab states are sharable via URLs while maintaining backward compatibility with users' existing localStorage preferences.

Does this close any currently open issues?
------------------------------------------
closes #3142


Testing
------------------------------------------
1. Navigate to a tab using a URL with the tab query argument and verify the correct tab opens.
2. Clear the query argument, navigate to different tabs, and ensure the last active tab is remembered across page loads.
3. Click on different tabs and verify that both the URL and localStorage are updated correctly.

[2024-05-29 at 17.09.37 - Yellow Finch.webm](https://github.com/wp-graphql/wp-graphql/assets/6676674/5ab35e61-054c-4b82-8018-67a1b23c51d8)
