### PR TITLE
fix: handle regression when implementing interface with identical args.

### DIFF
--- a/src/Registry/Utils/PostObject.php
+++ b/src/Registry/Utils/PostObject.php
@@ -411,8 +411,20 @@ class PostObject {
 				],
 				true
 			) ) {
-			$fields['ancestors']['deprecationReason'] = __( 'This content type is not hierarchical and typically will not have ancestors', 'wp-graphql' );
-			$fields['parent']['deprecationReason']    = __( 'This content type is not hierarchical and typically will not have a parent', 'wp-graphql' );
+			$fields['ancestors']                   = [
+				'type'              => [ 'list_of' => 'PostObject' ],
+				'deprecationReason' => __( 'This content type is not hierarchical and typically will not have ancestors', 'wp-graphql' ),
+				'resolve'           => static function () {
+					return [];
+				},
+			];
+			$fields['parent']                      = [
+				'type'              => 'PostObject',
+				'deprecationReason' => __( 'This content type is not hierarchical and typically will not have a parent', 'wp-graphql' ),
+				'resolve'           => static function () {
+					return null;
+				},
+			];
 		}
 
 		// Merge with fields set in register_post_type.

--- a/src/Registry/Utils/PostObject.php
+++ b/src/Registry/Utils/PostObject.php
@@ -234,6 +234,35 @@ class PostObject {
 			];
 		}
 
+		// Deprecated connections.
+		if ( ! $post_type_object->hierarchical &&
+			! in_array(
+				$post_type_object->name,
+				[
+					'attachment',
+					'revision',
+				],
+				true
+			) ) {
+			$connections['ancestors'] = [
+				'toType'            => $post_type_object->graphql_single_name,
+				'description'       => __( 'The ancestors of the content node.', 'wp-graphql' ),
+				'deprecationReason' => __( 'This content type is not hierarchical and typically will not have ancestors', 'wp-graphql' ),
+				'resolve'           => static function () {
+					return null;
+				},
+			];
+			$connections['parent']    = [
+				'toType'            => $post_type_object->graphql_single_name,
+				'oneToOne'          => true,
+				'description'       => __( 'The parent of the content node.', 'wp-graphql' ),
+				'deprecationReason' => __( 'This content type is not hierarchical and typically will not have a parent', 'wp-graphql' ),
+				'resolve'           => static function () {
+					return null;
+				},
+			];
+		}
+
 		// Merge with connections set in register_post_type.
 		if ( ! empty( $post_type_object->graphql_connections ) ) {
 			$connections = array_merge( $connections, $post_type_object->graphql_connections );
@@ -399,31 +428,6 @@ class PostObject {
 			$fields['isSticky'] = [
 				'type'        => [ 'non_null' => 'Bool' ],
 				'description' => __( 'Whether this page is sticky', 'wp-graphql' ),
-			];
-		}
-
-		if ( ! $post_type_object->hierarchical &&
-			! in_array(
-				$post_type_object->name,
-				[
-					'attachment',
-					'revision',
-				],
-				true
-			) ) {
-			$fields['ancestors']                   = [
-				'type'              => [ 'list_of' => 'PostObject' ],
-				'deprecationReason' => __( 'This content type is not hierarchical and typically will not have ancestors', 'wp-graphql' ),
-				'resolve'           => static function () {
-					return [];
-				},
-			];
-			$fields['parent']                      = [
-				'type'              => 'PostObject',
-				'deprecationReason' => __( 'This content type is not hierarchical and typically will not have a parent', 'wp-graphql' ),
-				'resolve'           => static function () {
-					return null;
-				},
 			];
 		}
 

--- a/src/Type/WPInterfaceTrait.php
+++ b/src/Type/WPInterfaceTrait.php
@@ -201,16 +201,16 @@ trait WPInterfaceTrait {
 			graphql_debug(
 				sprintf(
 					// translators: %1$s is the field name, %2$s is the type name.
-					__( 'Invalid Interface field registered to the "%s" Type. Fields must be registered a valid GraphQL `type`.', 'wp-graphql' ),
+					__( 'Invalid Interface field %1$s registered to the "%2$s" Type. Fields must be registered a valid GraphQL `type`.', 'wp-graphql' ),
 					$field_name,
-					$this->name
+					$this->config['name']
 				)
 			);
 
 			return null;
 		}
 
-		// Inherit the field type from the interface if it's not set on the field.
+		// Inherit the field config from the interface if it's not set on the field.
 		foreach ( $interface_field as $key => $config ) {
 			// Inherit the field config from the interface if it's not set on the field.
 			if ( empty( $field[ $key ] ) ) {

--- a/src/Type/WPInterfaceTrait.php
+++ b/src/Type/WPInterfaceTrait.php
@@ -42,7 +42,7 @@ trait WPInterfaceTrait {
 		$new_interfaces = [];
 
 		foreach ( $interfaces as $interface ) {
-			if ( $interface instanceof InterfaceType && $interface->name !== $this->name ) {
+			if ( $interface instanceof InterfaceType && $interface->name !== $this->config['name'] ) {
 				$new_interfaces[ $interface->name ] = $interface;
 				continue;
 			}
@@ -53,7 +53,7 @@ trait WPInterfaceTrait {
 					sprintf(
 						// translators: %s is the name of the GraphQL type.
 						__( 'Invalid Interface registered to the "%s" Type. Interfaces can only be registered with an interface name or a valid instance of an InterfaceType', 'wp-graphql' ),
-						$this->name
+						$this->config['name']
 					),
 					[ 'invalid_interface' => $interface ]
 				);
@@ -79,7 +79,7 @@ trait WPInterfaceTrait {
 						// translators: %1$s is the name of the interface, %2$s is the name of the type.
 						__( '"%1$s" is not a valid Interface Type and cannot be implemented as an Interface on the "%2$s" Type', 'wp-graphql' ),
 						$interface,
-						$this->name
+						$this->config['name']
 					)
 				);
 				continue;
@@ -102,6 +102,178 @@ trait WPInterfaceTrait {
 		}
 
 		return array_unique( $new_interfaces );
+	}
+
+
+	/**
+	 * Returns the fields for a Type, applying any missing fields defined on interfaces implemented on the type
+	 *
+	 * @param array<mixed>                     $config
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
+	 *
+	 * @return array<mixed>
+	 * @throws \Exception
+	 */
+	protected function get_fields( array $config, TypeRegistry $type_registry ): array {
+		$fields = array_filter( $config['fields'] );
+
+		/**
+		 * Get the fields of interfaces and ensure they exist as fields of this type.
+		 *
+		 * Types are still responsible for ensuring the fields resolve properly.
+		 */
+		$interface_fields = $this->get_fields_from_implemented_interfaces( $type_registry );
+
+		// Merge fields with interface fields that are not already in fields
+		$fields = array_merge( $fields, array_diff_key( $interface_fields, $fields ) );
+
+		foreach ( $fields as $field_name => $field ) {
+			$merged_field_config = $this->inherit_field_config_from_interface( $field_name, $field, $interface_fields );
+
+			if ( null === $merged_field_config ) {
+				unset( $fields[ $field_name ] );
+				continue;
+			}
+
+			// Update the field.
+			$fields[ $field_name ] = $merged_field_config;
+		}
+
+		$fields = $this->prepare_fields( $fields, $config['name'], $config );
+		$fields = $type_registry->prepare_fields( $fields, $config['name'] );
+
+		$this->fields = $fields;
+		return $this->fields;
+	}
+
+	/**
+	 * Get the fields from the implemented interfaces.
+	 *
+	 * @param \WPGraphQL\Registry\TypeRegistry $registry The TypeRegistry instance.
+	 *
+	 * @return array<string,array<string,mixed>>
+	 */
+	private function get_fields_from_implemented_interfaces( TypeRegistry $registry ): array {
+		$interface_fields = [];
+
+		$interfaces = $this->getInterfaces();
+
+		// Get the fields for each interface.
+		foreach ( $interfaces as $interface_type ) {
+			// Get the resolved InterfaceType instance, if it's not already an instance of InterfaceType.
+			if ( ! $interface_type instanceof InterfaceType ) {
+				$interface_type = $registry->get_type( $interface_type );
+			}
+
+			if ( ! $interface_type instanceof InterfaceType ) {
+				continue;
+			}
+
+			$interface_config_fields = $interface_type->getFields();
+
+			if ( empty( $interface_config_fields ) ) {
+				continue;
+			}
+
+			foreach ( $interface_config_fields as $interface_field_name => $interface_field ) {
+				$interface_fields[ $interface_field_name ] = $interface_field->config;
+			}
+		}
+
+		return $interface_fields;
+	}
+
+	/**
+	 * Inherit missing field configs from the interface.
+	 *
+	 * @param string                            $field_name The field name.
+	 * @param array<string,mixed>               $field The field config.
+	 * @param array<string,array<string,mixed>> $interface_fields The fields from the interface. This is passed by reference.
+	 *
+	 * @return ?array<string,mixed> The field config with inherited values. Null if the field type cannot be determined.
+	 */
+	private function inherit_field_config_from_interface( string $field_name, array $field, array $interface_fields ): ?array {
+
+		$interface_field = $interface_fields[ $field_name ] ?? [];
+
+		// Bail early, if there is no field type or an interface to inherit it from since we won't be able to register it.
+		if ( empty( $field['type'] ) && empty( $interface_field['type'] ) ) {
+			graphql_debug(
+				sprintf(
+					// translators: %1$s is the field name, %2$s is the type name.
+					__( 'Invalid Interface field registered to the "%s" Type. Fields must be registered a valid GraphQL `type`.', 'wp-graphql' ),
+					$field_name,
+					$this->name
+				)
+			);
+
+			return null;
+		}
+
+		// Inherit the field type from the interface if it's not set on the field.
+		foreach ( $interface_field as $key => $config ) {
+			// Inherit the field config from the interface if it's not set on the field.
+			if ( empty( $field[ $key ] ) ) {
+				$field[ $key ] = $config;
+				continue;
+			}
+
+			// If the args on both the field and the interface are set, we need to merge them.
+			if ( 'args' === $key ) {
+				$field[ $key ] = $this->merge_field_args( $field_name, $field[ $key ], $interface_field[ $key ] );
+			}
+		}
+
+		return $field;
+	}
+
+	/**
+	 * Merge the field args from the field and the interface.
+	 *
+	 * @param string                            $field_name The field name.
+	 * @param array<string,array<string,mixed>> $field_args The field args.
+	 * @param array<string,array<string,mixed>> $interface_args The interface args.
+	 *
+	 * @return array<string,array<string,mixed>> The merged field args.
+	 */
+	private function merge_field_args( string $field_name, array $field_args, array $interface_args ): array {
+		// We use the interface args as the base and overwrite them with the field args.
+		$merged_args = $interface_args;
+
+		foreach ( $field_args as $arg_name => $config ) {
+			// If the arg is not defined on the interface, we can use the field arg config.
+			if ( empty( $merged_args[ $arg_name ] ) ) {
+				$merged_args[ $arg_name ] = $config;
+				continue;
+			}
+
+			// Check if the interface arg type is different from the new field arg type.
+			$field_arg_type     = $this->field_arg_type_to_string( $config['type'] );
+			$interface_arg_type = $merged_args[ $arg_name ]['type']();
+
+			if ( ! empty( $field_arg_type ) && $interface_arg_type !== $field_arg_type ) {
+				graphql_debug(
+					sprintf(
+						/* translators: 1: Object type name, 2: Field name, 3: Argument name, 4: Expected argument type, 5: Actual argument type. */
+						__(
+							'Interface field argument "%1$s.%2$s(%3$s:)" expected to be of type "%4$s" but got "%5$s". Please ensure the field arguments match the interface field arguments or rename the argument.',
+							'wp-graphql'
+						),
+						$this->config['name'],
+						$field_name,
+						$arg_name,
+						$interface_arg_type,
+						$field_arg_type
+					)
+				);
+				continue;
+			}
+
+			// Merge the field arg config with the interface arg config.
+			$merged_args[ $arg_name ] = array_merge( $merged_args[ $arg_name ], $config );
+		}
+
+		return $merged_args;
 	}
 
 	/**
@@ -137,136 +309,5 @@ trait WPInterfaceTrait {
 		}
 
 		return $output;
-	}
-
-	/**
-	 * Returns the fields for a Type, applying any missing fields defined on interfaces implemented on the type
-	 *
-	 * @param array<mixed>                     $config
-	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
-	 *
-	 * @return array<mixed>
-	 * @throws \Exception
-	 */
-	protected function get_fields( array $config, TypeRegistry $type_registry ): array {
-		$fields = $config['fields'];
-
-		$fields = array_filter( $fields );
-
-		/**
-		 * Get the fields of interfaces and ensure they exist as fields of this type.
-		 *
-		 * Types are still responsible for ensuring the fields resolve properly.
-		 */
-		$interface_fields = [];
-
-		if ( ! empty( $this->getInterfaces() ) && is_array( $this->getInterfaces() ) ) {
-			foreach ( $this->getInterfaces() as $interface_type ) {
-				if ( ! $interface_type instanceof InterfaceType ) {
-					$interface_type = $type_registry->get_type( $interface_type );
-				}
-
-				if ( ! $interface_type instanceof InterfaceType ) {
-					continue;
-				}
-
-				$interface_config_fields = $interface_type->getFields();
-
-				if ( empty( $interface_config_fields ) ) {
-					continue;
-				}
-
-				foreach ( $interface_config_fields as $interface_field_name => $interface_field ) {
-					$interface_fields[ $interface_field_name ] = $interface_field->config;
-				}
-			}
-		}
-
-		// diff the $interface_fields and the $fields
-		// if the field is not in $fields, add it
-		$diff = ! empty( $interface_fields ) ? array_diff_key( $interface_fields, $fields ) : [];
-
-		// If the Interface has fields defined that are not defined
-		// on the Object Type, add them to the Object Type
-		if ( ! empty( $diff ) ) {
-			$fields = array_merge( $fields, $diff );
-		}
-
-		foreach ( $fields as $field_name => $field ) {
-			$new_field = $field;
-
-			// If the field does not have a type, attempt to inherit it from the interface.
-			if ( ! isset( $new_field['type'] ) ) {
-				// If the field doesn't exist in the interface, we have no way to determine (and later register) the type.
-				if ( ! isset( $interface_fields[ $field_name ] ) ) {
-					unset( $fields[ $field_name ] );
-					continue;
-				}
-
-				$new_field['type'] = $interface_fields[ $field_name ]['type'];
-			}
-
-			// Inherit the description from the interface if it's not set on the field.
-			if ( empty( $new_field['description'] ) && ! empty( $interface_fields[ $field_name ]['description'] ) ) {
-				$new_field['description'] = $interface_fields[ $field_name ]['description'];
-			}
-
-			// Inherit the resolver from the interface if it's not set on the field.
-			if ( empty( $new_field['resolve'] ) && ! empty( $interface_fields[ $field_name ]['resolve'] ) ) {
-				$new_field['resolve'] = $interface_fields[ $field_name ]['resolve'];
-			}
-
-			// If the args aren't explicitly defined, inherit them from the interface.
-			// If they're both set, we need to merge them.
-			if ( empty( $new_field['args'] ) && ! empty( $interface_fields[ $field_name ]['args'] ) ) {
-				$new_field['args'] = $interface_fields[ $field_name ]['args'];
-			} elseif ( ! empty( $new_field['args'] ) && ! empty( $interface_fields[ $field_name ]['args'] ) ) {
-				// Set field args to the interface fields to be overwrite with the new field args.
-				$field_args = $interface_fields[ $field_name ]['args'];
-
-				foreach ( $new_field['args'] as $arg_name => $arg_definition ) {
-					// If the arg is not defined in the interface, we can use the current arg definition.
-					if ( empty( $field_args[ $arg_name ] ) ) {
-						$field_args[ $arg_name ] = $arg_definition;
-						continue;
-					}
-
-					// Check if the interface arg type is different from the new field arg type.
-					$new_field_arg_type = $this->field_arg_type_to_string( $arg_definition['type'] );
-					$interface_arg_type = $field_args[ $arg_name ]['type']();
-					if ( ! empty( $new_field_arg_type ) && $interface_arg_type !== $new_field_arg_type ) {
-						graphql_debug(
-							sprintf(
-								/* translators: 1: Object type name, 2: Field name, 3: Argument name, 4: Expected argument type, 5: Actual argument type. */
-								__(
-									'Interface field argument "%1$s.%2$s(%3$s:)" expected to be of type "%4$s" but got "%5$s". Please ensure the field arguments match the interface field arguments or rename the argument.',
-									'wp-graphql'
-								),
-								$config['name'],
-								$field_name,
-								$arg_name,
-								$interface_arg_type,
-								$new_field_arg_type
-							)
-						);
-						continue;
-					}
-
-					// Set the field args to the new field args.
-					$field_args[ $arg_name ] = array_merge( $field_args[ $arg_name ], $arg_definition );
-				}
-
-				$new_field['args'] = array_merge( $interface_fields[ $field_name ]['args'], $new_field['args'] );
-			}
-
-			// Update the field.
-			$fields[ $field_name ] = $new_field;
-		}
-
-		$fields = $this->prepare_fields( $fields, $config['name'], $config );
-		$fields = $type_registry->prepare_fields( $fields, $config['name'] );
-
-		$this->fields = $fields;
-		return $this->fields;
 	}
 }

--- a/tests/wpunit/InterfaceTest.php
+++ b/tests/wpunit/InterfaceTest.php
@@ -584,7 +584,9 @@ class InterfaceTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		}';
 
 		$actual = $this->graphql( [ 'query' => $query ] );
+
 		$this->assertEmpty( $actual['extensions']['debug'], 'The interface should be implemented with no debug messages.' );
+
 		$expected = [
 			$this->expectedField( 'interfaceArgsTest.fieldWithArgs', 'interfaceArg objectArg' ),
 			$this->expectedField( 'interfaceArgsTest2.fieldWithArgs', 'interfaceArg' ),
@@ -679,7 +681,14 @@ class InterfaceTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		}';
 
 		$actual = $this->graphql( [ 'query' => $query ]);
-		$this->assertQuerySuccessful( $actual, [], 'Invalid field arguments should be flagged' );
+		$this->assertResponseIsValid( $actual, 'The query should be valid as the Args from the Interface fields should be merged with the args from the object field' );
+		$this->assertNotEmpty( $actual['errors'], 'Invalid field arguments should be flagged' );
+		$this->assertEquals( 'Field "fieldWithArgs" argument "interfaceArg" requires type String, found 2.', $actual['errors'][0]['message'] );
+		$this->assertEquals( 'Field "fieldWithArgs" argument "interfaceArg" requires type String, found [2, 4, 5].', $actual['errors'][1]['message'] );
+
+		$this->assertNotEmpty( $actual['extensions']['debug'], 'The interface should be implemented with debug messages.' );
+		$this->assertStringStartsWith( 'Interface field argument "BadObjectTypeImplementingInterfaceWithArgs.fieldWithArgs(interfaceArg:)" expected to be of type "String" but got "Number".', $actual['extensions']['debug'][0]['message'] );
+		$this->assertStringStartsWith( 'Interface field argument "BadObjectTypeImplementingInterfaceWithArgs2.fieldWithArgs(interfaceArg:)" expected to be of type "String" but got "[Number]".', $actual['extensions']['debug'][1]['message'] );
 	}
 	
 	public function testInterfaceWithNonNullableArg() {

--- a/tests/wpunit/InterfaceTest.php
+++ b/tests/wpunit/InterfaceTest.php
@@ -476,6 +476,27 @@ class InterfaceTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 			]
 		);
 
+		register_graphql_interface_type(
+			'AnotherInterfaceWithArgs',
+			[
+				'interfaces' => [ 'InterfaceWithArgs' ],
+				'fields' => [
+					'fieldWithArgs' => [
+						'type'    => 'String',
+						'args'    => [
+							'interfaceArg' => [
+								'type'         => 'String',
+								'defaultValue' => 'another parent'
+							],
+						],
+						'resolve' => function( $source, $args ) {
+							return implode( ' ', array_keys( $args ) );
+						}
+					],
+				]
+			]
+		);
+
 		register_graphql_object_type(
 			'ObjectTypeImplementingInterfaceWithArgs',
 			[
@@ -508,6 +529,24 @@ class InterfaceTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 			]
 		);
 
+		register_graphql_object_type(
+			'ObjectTypeImplementingAnotherInterfaceWithArgs',
+			[
+				'interfaces' => [ 'InterfaceWithArgs' , 'AnotherInterfaceWithArgs' ],
+				'fields'     => [
+					'fieldWithArgs' => [
+						'args'    => [
+							'objectArg' => [
+								'type'         => 'String',
+								'defaultValue' => 'child'
+							],
+						],
+						'type'    => 'String',
+					],
+				],
+			]
+		);
+
 		register_graphql_fields(
 			'RootQuery',
 			[
@@ -522,7 +561,13 @@ class InterfaceTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 					'resolve' => function() {
 						return true;
 					},
-				]
+				],
+				'interfaceArgsTest3' => [
+					'type'    => 'ObjectTypeImplementingAnotherInterfaceWithArgs',
+					'resolve' => function() {
+						return true;
+					},
+				],
 			]
 		);
 
@@ -533,6 +578,9 @@ class InterfaceTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 			interfaceArgsTest2 {
 				fieldWithArgs
 			}
+			interfaceArgsTest3 {
+				fieldWithArgs
+			}
 		}';
 
 		$actual = $this->graphql( [ 'query' => $query ] );
@@ -540,6 +588,7 @@ class InterfaceTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$expected = [
 			$this->expectedField( 'interfaceArgsTest.fieldWithArgs', 'interfaceArg objectArg' ),
 			$this->expectedField( 'interfaceArgsTest2.fieldWithArgs', 'interfaceArg' ),
+			$this->expectedField( 'interfaceArgsTest3.fieldWithArgs', 'interfaceArg objectArg' ),
 		];
 		$this->assertQuerySuccessful( $actual, $expected, 'The query should be valid as the Args from the Interface fields should be merged with the args from the object field' );
 	}

--- a/tests/wpunit/InterfaceTest.php
+++ b/tests/wpunit/InterfaceTest.php
@@ -771,8 +771,7 @@ class InterfaceTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 					'type' => 'String',
 					'args' => [
 						'interfaceArg' => [
-							'type' => 'String',
-							'defaultValue' => 'interfaceArg',
+							'type' => 'Boolean',
 						],
 					],
 					'resolve' => function() {
@@ -794,12 +793,6 @@ class InterfaceTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 				// so it should inherit the arguments from the interface
 				'fieldWithArgs' => [
 					'type' => 'String',
-					'args' => [
-						'anotherInterfaceArg' => [
-							'type' => 'String',
-							'defaultValue' => 'anotherInterfaceArg',
-						],
-					],
 					'resolve' => function() {
 						return null;
 					},
@@ -831,13 +824,11 @@ class InterfaceTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$query = 'query {
 			testField {
-				fieldWithArgs(interfaceArg: "test")
+				fieldWithArgs(interfaceArg: true )
 			}
 		}';
 
 		$actual = $this->graphql( [ 'query' => $query ] );
-
-
 
 		$this->assertEmpty( $actual['extensions']['debug'], 'The interface should be implemented with no debug messages.' );
 		$this->assertQuerySuccessful(


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [ ] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
The PR cleans up the `InterfaceTrait` class and addresses regressions in #3100 and #3112 in the following ways:

- chore: Reduce code complexity by breaking up nested conditionals into smaller methods with simpler logic. Similarly, variables were renamed and additional annotations added to improve readability.
- dev: Add new `graphql_debug()` message when a field has _no_ associated type. The faux `PostObject.ancestors` and `PostObject.parent` have been fixed to be registered as deprecated Connections (that resolve null) to prevent schema breaks for people using those deprecated fields in the same query as a `HierarchicalContentNode.ancestors/parent`.
- fix: the use of `$this->name` to `$this->config['name']` for getting the Interface name in the trait.
- fix: the config "inheritence loop", so _all_ interface properties are inherited when they are not set on the implementing type.
- tests: fix `InterfaceTest:testInvalidArgsOnInheritedObjectFieldsAreCaptured` whose errors should be explicitly caught.
- tests: Added a (failing) test case for "arg type" != "same arg type" (https://github.com/wp-graphql/wp-graphql/issues/3106#issuecomment-2105981045)
- Rename `field_arg_type_to_string()` to `normalize_type_name()` and change the usage to handle callables/resolved types.

Does this close any currently open issues?
------------------------------------------
<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

closes #3106 
closes https://github.com/wpengine/wp-graphql-content-blocks/issues/240

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
<!-- (If it’s long, please paste to https://ghostbin.com/ and insert the link here.) -->


Any other comments?
-------------------



Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php8.1.15)

**WordPress Version:** 6.5.3
