### PR TITLE
feat: introduce `$connection_resolver->override_query_arg` and `$connection_resolver->add_query_arg`

### DIFF
--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -824,22 +824,6 @@ abstract class AbstractConnectionResolver {
 	 */
 
 	/**
-	 * Given a key and value, this sets a query_arg which will modify the query_args used by ::get_query();
-	 *
-	 * @param string $key   The key of the query arg to set
-	 * @param mixed  $value The value of the query arg to set
-	 *
-	 * @deprecated Deprecated since v1.28.0 in favor of $this->get_args();
-	 *
-	 * @return static
-	 */
-	public function set_query_arg( string $key, $value ) {
-		_deprecated_function( __METHOD__, '1.28.0', static::class . '::override_query_arg()' );
-		$this->query_args[ $key ] = $value;
-		return $this;
-	}
-
-	/**
 	 * Given a key and value, this adds a query_arg which will modify the query_args used by ::get_query();
 	 *
 	 * Unlike ::override_query_arg(), this method will append the value to the query arg if the query arg is an array.
@@ -1599,6 +1583,23 @@ abstract class AbstractConnectionResolver {
 		_deprecated_function( __METHOD__, '0.3.0', static::class . '::set_query_arg()' );
 
 		return $this->set_query_arg( $key, $value );
+	}
+
+	/**
+	 * Given a key and value, this sets a query_arg which will modify the query_args used by ::get_query();
+	 *
+	 * @param string $key   The key of the query arg to set
+	 * @param mixed  $value The value of the query arg to set
+	 *
+	 * @deprecated 1.28.0
+	 *
+	 * @return static
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public function set_query_arg( string $key, $value ) {
+		_deprecated_function( __METHOD__, '1.28.0', static::class . '::override_query_arg()' );
+		return $this->override_query_arg( $key, $value );
 	}
 
 	/**

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -829,9 +829,27 @@ abstract class AbstractConnectionResolver {
 	 * @param string $key   The key of the query arg to set
 	 * @param mixed  $value The value of the query arg to set
 	 *
+	 * @deprecated Deprecated since v1.28.0 in favor of $this->get_args();
+	 *
 	 * @return static
 	 */
-	public function set_query_arg( $key, $value ) {
+	public function set_query_arg( string $key, $value ) {
+		_deprecated_function( __METHOD__, '1.28.0', static::class . '::override_query_arg()' );
+		$this->query_args[ $key ] = $value;
+		return $this;
+	}
+
+	/**
+	 * Given a key and value, this adds a query_arg which will modify the query_args used by ::get_query();
+	 *
+	 * Unlike ::override_query_arg(), this method will append the value to the query arg if the query arg is an array.
+	 *
+	 * @param string $key   The key of the query arg to set
+	 * @param mixed  $value The value of the query arg to set
+	 *
+	 * @return static
+	 */
+	public function add_query_arg( string $key, $value ) {
 		if ( ! empty( $this->query_args[ $key ] ) && is_array( $this->query_args[ $key ] ) ) {
 			if ( ! is_array( $value ) ) {
 				$value = [ $value ];
@@ -840,6 +858,23 @@ abstract class AbstractConnectionResolver {
 		} else {
 			$this->query_args[ $key ] = $value;
 		}
+		return $this;
+	}
+
+	/**
+	 * Given a key and value, this sets a query_arg which will modify the query_args used by ::get_query();
+	 *
+	 * This overrides any existing value for the query arg, including values filtered by plugins, rather than appending to it.
+	 *
+	 * This method can be used by resolvers to ensure the query args set by the resolver are used, rather than any filtered values or values input by the user as "$where" args.
+	 *
+	 * @param string $key   The key of the query arg to set
+	 * @param mixed  $value The value of the query arg to set
+	 *
+	 * @return static
+	 */
+	public function override_query_arg( string $key, $value ) {
+		$this->query_args[ $key ] = $value;
 		return $this;
 	}
 

--- a/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/src/Data/Connection/PostObjectConnectionResolver.php
@@ -430,6 +430,8 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		 */
 		$query_args = apply_filters( 'graphql_map_input_fields_to_wp_query', $query_args, $where_args, $this->source, $this->get_args(), $this->context, $this->info, $this->post_type );
 
+		codecept_debug( [ '$query_args' => $query_args ] );
+
 		/**
 		 * Return the Query Args
 		 */

--- a/src/Registry/Utils/PostObject.php
+++ b/src/Registry/Utils/PostObject.php
@@ -124,7 +124,7 @@ class PostObject {
 
 					$resolver = new CommentConnectionResolver( $post, $args, $context, $info );
 
-					return $resolver->set_query_arg( 'post_id', absint( $id ) )->get_connection();
+					return $resolver->override_query_arg( 'post_id', absint( $id ) )->get_connection();
 				},
 			];
 		}
@@ -151,7 +151,7 @@ class PostObject {
 					}
 
 					$resolver = new PostObjectConnectionResolver( $post, $args, $context, $info, 'revision' );
-					$resolver->set_query_arg( 'p', $post->previewRevisionDatabaseId );
+					$resolver->override_query_arg( 'p', $post->previewRevisionDatabaseId );
 
 					return $resolver->one_to_one()->get_connection();
 				},
@@ -167,7 +167,7 @@ class PostObject {
 				'connectionArgs'     => PostObjects::get_connection_args( [], $post_type_object ),
 				'resolve'            => static function ( Post $post, $args, $context, $info ) {
 					$resolver = new PostObjectConnectionResolver( $post, $args, $context, $info, 'revision' );
-					$resolver->set_query_arg( 'post_parent', $post->ID );
+					$resolver->override_query_arg( 'post_parent', $post->ID );
 
 					return $resolver->get_connection();
 				},
@@ -204,7 +204,7 @@ class PostObject {
 							return null;
 						}
 						$resolver = new TermObjectConnectionResolver( $post, $args, $context, $info, $taxonomies );
-						$resolver->set_query_arg( 'include', $terms );
+						$resolver->override_query_arg( 'include', $terms );
 
 						return $resolver->get_connection();
 					},
@@ -227,7 +227,7 @@ class PostObject {
 					}
 
 					$resolver = new TermObjectConnectionResolver( $post, $args, $context, $info, $tax_object->name );
-					$resolver->set_query_arg( 'object_ids', absint( $object_id ) );
+					$resolver->override_query_arg( 'object_ids', absint( $object_id ) );
 
 					return $resolver->get_connection();
 				},

--- a/src/Registry/Utils/TermObject.php
+++ b/src/Registry/Utils/TermObject.php
@@ -201,17 +201,20 @@ class TermObject {
 						'toType'  => 'ContentNode',
 						'resolve' => static function ( Term $term, $args, $context, $info ) {
 
-						// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
-							$args['where']['tax_query'] = [
-								[
-									'taxonomy'         => $term->taxonomyName,
-									'terms'            => [ $term->term_id ],
-									'field'            => 'term_id',
-									'include_children' => false,
-								],
-							];
-
 							$resolver = new PostObjectConnectionResolver( $term, $args, $context, $info, 'any' );
+
+							// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+							$resolver->add_query_arg(
+								'tax_query',
+								[
+									[
+										'taxonomy'         => $term->taxonomyName,
+										'terms'            => [ $term->term_id ],
+										'field'            => 'term_id',
+										'include_children' => false,
+									],
+								]
+							);
 							return $resolver->get_connection();
 						},
 					]

--- a/src/Type/Connection/Comments.php
+++ b/src/Type/Connection/Comments.php
@@ -41,7 +41,7 @@ class Comments {
 					'resolve'  => static function ( User $user, $args, $context, $info ) {
 						$resolver = new CommentConnectionResolver( $user, $args, $context, $info );
 
-						return $resolver->set_query_arg( 'user_id', absint( $user->userId ) )->get_connection();
+						return $resolver->override_query_arg( 'user_id', absint( $user->userId ) )->get_connection();
 					},
 
 				]
@@ -59,7 +59,7 @@ class Comments {
 					'resolve'            => static function ( Comment $comment, $args, $context, $info ) {
 						$resolver = new CommentConnectionResolver( $comment, $args, $context, $info );
 
-						return ! empty( $comment->comment_parent_id ) ? $resolver->one_to_one()->set_query_arg( 'comment__in', [ $comment->comment_parent_id ] )->get_connection() : null;
+						return ! empty( $comment->comment_parent_id ) ? $resolver->one_to_one()->override_query_arg( 'comment__in', [ $comment->comment_parent_id ] )->get_connection() : null;
 					},
 				]
 			)
@@ -76,7 +76,7 @@ class Comments {
 					'resolve'       => static function ( Comment $comment, $args, $context, $info ) {
 						$resolver = new CommentConnectionResolver( $comment, $args, $context, $info );
 
-						return $resolver->set_query_arg( 'parent', absint( $comment->commentId ) )->get_connection();
+						return $resolver->override_query_arg( 'parent', absint( $comment->commentId ) )->get_connection();
 					},
 				]
 			)

--- a/src/Type/Connection/MenuItems.php
+++ b/src/Type/Connection/MenuItems.php
@@ -45,9 +45,9 @@ class MenuItems {
 						}
 
 						$resolver = new MenuItemConnectionResolver( $menu_item, $args, $context, $info );
-						$resolver->set_query_arg( 'nav_menu', $menu_item->menuId );
-						$resolver->set_query_arg( 'meta_key', '_menu_item_menu_item_parent' );
-						$resolver->set_query_arg( 'meta_value', (int) $menu_item->databaseId );
+						$resolver->override_query_arg( 'nav_menu', $menu_item->menuId );
+						$resolver->override_query_arg( 'meta_key', '_menu_item_menu_item_parent' );
+						$resolver->override_query_arg( 'meta_value', (int) $menu_item->databaseId );
 						return $resolver->get_connection();
 					},
 				]
@@ -64,7 +64,7 @@ class MenuItems {
 					'toType'   => 'MenuItem',
 					'resolve'  => static function ( Menu $menu, $args, AppContext $context, ResolveInfo $info ) {
 						$resolver = new MenuItemConnectionResolver( $menu, $args, $context, $info );
-						$resolver->set_query_arg(
+						$resolver->add_query_arg(
 							'tax_query',
 							[
 								[

--- a/src/Type/Connection/PostObjects.php
+++ b/src/Type/Connection/PostObjects.php
@@ -39,7 +39,7 @@ class PostObjects {
 				'queryClass'     => 'WP_Query',
 				'resolve'        => static function ( PostType $post_type, $args, AppContext $context, ResolveInfo $info ) {
 					$resolver = new PostObjectConnectionResolver( $post_type, $args, $context, $info );
-					$resolver->set_query_arg( 'post_type', $post_type->name );
+					$resolver->override_query_arg( 'post_type', $post_type->name );
 
 					return $resolver->get_connection();
 				},
@@ -60,7 +60,7 @@ class PostObjects {
 					$id       = absint( $comment->comment_post_ID );
 					$resolver = new PostObjectConnectionResolver( $comment, $args, $context, $info, 'any' );
 
-					return $resolver->one_to_one()->set_query_arg( 'p', $id )->set_query_arg( 'post_parent', null )->get_connection();
+					return $resolver->one_to_one()->override_query_arg( 'p', $id )->set_query_arg( 'post_parent', null )->get_connection();
 				},
 			]
 		);
@@ -78,7 +78,7 @@ class PostObjects {
 					}
 
 					$resolver = new PostObjectConnectionResolver( $post, $args, $context, $info );
-					$resolver->set_query_arg( 'p', $post->parentDatabaseId );
+					$resolver->override_query_arg( 'p', $post->parentDatabaseId );
 
 					return $resolver->one_to_one()->get_connection();
 				},
@@ -114,7 +114,7 @@ class PostObjects {
 					}
 
 					$resolver = new PostObjectConnectionResolver( $post, $args, $context, $info );
-					$resolver->set_query_arg( 'p', $post->parentDatabaseId );
+					$resolver->override_query_arg( 'p', $post->parentDatabaseId );
 
 					return $resolver->one_to_one()->get_connection();
 				},
@@ -137,7 +137,7 @@ class PostObjects {
 					}
 
 					$resolver = new PostObjectConnectionResolver( $post, $args, $context, $info, 'any' );
-					$resolver->set_query_arg( 'post_parent', $id );
+					$resolver->override_query_arg( 'post_parent', $id );
 
 					return $resolver->get_connection();
 				},
@@ -159,8 +159,8 @@ class PostObjects {
 						return null;
 					}
 					$resolver = new PostObjectConnectionResolver( $post, $args, $context, $info );
-					$resolver->set_query_arg( 'post__in', $ancestors );
-					$resolver->set_query_arg( 'orderby', 'post__in' );
+					$resolver->override_query_arg( 'post__in', $ancestors );
+					$resolver->override_query_arg( 'orderby', 'post__in' );
 
 					return $resolver->get_connection();
 				},
@@ -212,7 +212,7 @@ class PostObjects {
 							'fromType' => 'User',
 							'resolve'  => static function ( User $user, $args, AppContext $context, ResolveInfo $info ) use ( $post_type_object ) {
 								$resolver = new PostObjectConnectionResolver( $user, $args, $context, $info, $post_type_object->name );
-								$resolver->set_query_arg( 'author', $user->userId );
+								$resolver->override_query_arg( 'author', $user->userId );
 
 								return $resolver->get_connection();
 							},

--- a/src/Type/Connection/Taxonomies.php
+++ b/src/Type/Connection/Taxonomies.php
@@ -35,7 +35,7 @@ class Taxonomies {
 						return null;
 					}
 					$resolver = new TaxonomyConnectionResolver( $source, $args, $context, $info );
-					$resolver->set_query_arg( 'in', $source->taxonomies );
+					$resolver->add_query_arg( 'in', $source->taxonomies );
 					return $resolver->get_connection();
 				},
 			]

--- a/src/Type/Connection/Users.php
+++ b/src/Type/Connection/Users.php
@@ -67,7 +67,7 @@ class Users {
 					}
 
 					$resolver = new UserConnectionResolver( $source, $args, $context, $info );
-					$resolver->one_to_one()->set_query_arg( 'include', [ absint( $source->editLock[1] ) ] );
+					$resolver->one_to_one()->override_query_arg( 'include', [ absint( $source->editLock[1] ) ] );
 
 					return $resolver->get_connection();
 				},
@@ -88,7 +88,7 @@ class Users {
 					}
 
 					$resolver = new UserConnectionResolver( $source, $args, $context, $info );
-					$resolver->set_query_arg( 'include', [ absint( $source->editLastId ) ] );
+					$resolver->override_query_arg( 'include', [ absint( $source->editLastId ) ] );
 					return $resolver->one_to_one()->get_connection();
 				},
 			]
@@ -106,7 +106,7 @@ class Users {
 					}
 
 					$resolver = new UserConnectionResolver( $post, $args, $context, $info );
-					$resolver->set_query_arg( 'include', [ absint( $post->authorDatabaseId ) ] );
+					$resolver->override_query_arg( 'include', [ absint( $post->authorDatabaseId ) ] );
 					return $resolver->one_to_one()->get_connection();
 				},
 			]

--- a/src/Type/InterfaceType/ContentNode.php
+++ b/src/Type/InterfaceType/ContentNode.php
@@ -45,7 +45,7 @@ class ContentNode {
 
 							$resolver = new ContentTypeConnectionResolver( $source, $args, $context, $info );
 
-							return $resolver->one_to_one()->set_query_arg( 'name', $post_type )->get_connection();
+							return $resolver->one_to_one()->override_query_arg( 'name', $post_type )->get_connection();
 						},
 						'oneToOne' => true,
 					],

--- a/src/Type/InterfaceType/NodeWithFeaturedImage.php
+++ b/src/Type/InterfaceType/NodeWithFeaturedImage.php
@@ -33,7 +33,7 @@ class NodeWithFeaturedImage {
 							}
 
 							$resolver = new PostObjectConnectionResolver( $post, $args, $context, $info, 'attachment' );
-							$resolver->set_query_arg( 'p', absint( $post->featuredImageDatabaseId ) );
+							$resolver->override_query_arg( 'p', absint( $post->featuredImageDatabaseId ) );
 
 							return $resolver->one_to_one()->get_connection();
 						},

--- a/src/Type/ObjectType/MenuItem.php
+++ b/src/Type/ObjectType/MenuItem.php
@@ -61,16 +61,16 @@ class MenuItem {
 								// Post object
 								case 'post_type':
 									$resolver = new PostObjectConnectionResolver( $menu_item, $args, $context, $info, 'any' );
-									$resolver->set_query_arg( 'p', $object_id );
+									$resolver->override_query_arg( 'p', $object_id );
 
 									// connected objects to menu items can be any post status
-									$resolver->set_query_arg( 'post_status', 'any' );
+									$resolver->add_query_arg( 'post_status', 'any' );
 									break;
 
 								// Taxonomy term
 								case 'taxonomy':
 									$resolver = new TermObjectConnectionResolver( $menu_item, $args, $context, $info );
-									$resolver->set_query_arg( 'include', $object_id );
+									$resolver->override_query_arg( 'include', $object_id );
 									break;
 								default:
 									$resolver = null;
@@ -86,7 +86,7 @@ class MenuItem {
 						'oneToOne'    => true,
 						'resolve'     => static function ( MenuItemModel $menu_item, $args, $context, $info ) {
 							$resolver = new MenuConnectionResolver( $menu_item, $args, $context, $info );
-							$resolver->set_query_arg( 'include', $menu_item->menuDatabaseId );
+							$resolver->override_query_arg( 'include', $menu_item->menuDatabaseId );
 
 							return $resolver->one_to_one()->get_connection();
 						},

--- a/src/Type/ObjectType/Taxonomy.php
+++ b/src/Type/ObjectType/Taxonomy.php
@@ -29,7 +29,7 @@ class Taxonomy {
 						'resolve'     => static function ( TaxonomyModel $taxonomy, $args, AppContext $context, ResolveInfo $info ) {
 							$connected_post_types = ! empty( $taxonomy->object_type ) ? $taxonomy->object_type : [];
 							$resolver             = new ContentTypeConnectionResolver( $taxonomy, $args, $context, $info );
-							$resolver->set_query_arg( 'contentTypeNames', $connected_post_types );
+							$resolver->add_query_arg( 'contentTypeNames', $connected_post_types );
 							return $resolver->get_connection();
 						},
 					],

--- a/src/Type/ObjectType/User.php
+++ b/src/Type/ObjectType/User.php
@@ -70,7 +70,7 @@ class User {
 							}
 
 							// Only get roles matching the slugs of the roles belonging to the user
-							$resolver->set_query_arg( 'slugIn', $user->roles );
+							$resolver->override_query_arg( 'slugIn', $user->roles );
 							return $resolver->get_connection();
 						},
 					],

--- a/tests/wpunit/CommentObjectCursorTest.php
+++ b/tests/wpunit/CommentObjectCursorTest.php
@@ -57,7 +57,7 @@ class CommentObjectCursorTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCas
 
 					$resolver = new CommentConnectionResolver( $source, $args, $context, $info );
 
-					$resolver->set_query_arg( 'post_id', absint( $id ) );
+					$resolver->override_query_arg( 'post_id', absint( $id ) );
 
 					// Get cursor node
 					$cursor     = $args['after'] ?? null;
@@ -68,7 +68,7 @@ class CommentObjectCursorTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCas
 					// Get order.
 					$order = ! empty( $args['last'] ) ? 'ASC' : 'DESC';
 
-					$resolver->set_query_arg(
+					$resolver->add_query_arg(
 						'graphql_cursor_threshold_fields',
 						[
 							[
@@ -82,11 +82,11 @@ class CommentObjectCursorTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCas
 
 					// Set default ordering.
 					if ( empty( $args['where']['orderby'] ) ) {
-						$resolver->set_query_arg( 'orderby', 'comment_author_email' );
+						$resolver->add_query_arg( 'orderby', 'comment_author_email' );
 					}
 
 					if ( empty( $args['where']['order'] ) ) {
-						$resolver->set_query_arg( 'order', $order );
+						$resolver->add_query_arg( 'order', $order );
 					}
 
 					return $resolver->get_connection();

--- a/tests/wpunit/MenuItemQueriesTest.php
+++ b/tests/wpunit/MenuItemQueriesTest.php
@@ -185,7 +185,7 @@ class MenuItemQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		// Filter the resolver.
 		add_filter( 'graphql_pre_resolve_menu_item_connected_node', static function ( $deferred_connection, $source, $args, $context, $info ) use ( $post_id ) {
 			$resolver = new \WPGraphQL\Data\Connection\PostObjectConnectionResolver( $source, [], $context, $info, 'any' );
-			$resolver->set_query_arg( 'p', $post_id );
+			$resolver->override_query_arg( 'p', $post_id );
 
 			return $resolver->one_to_one()->get_connection();
 		}, 10, 7 );


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Deprecates `$connection_resolver->set_query_arg` in favor of newly introduced: 

- `$connection_resolver->override_query_arg`: used to override query args at the resolver level. Good for resolvers that want to enforce a final argument without impact of internal filters or user input. 
- `$connection_resolver->add_query_arg` used to add a query arg which appends / merges with existing query args. Good for args that have arrays, like tax_query. 


Does this close any currently open issues?
------------------------------------------
n/a

- related to: #3066 

Any other comments?
-------------------
The changes merged in #3066 could have caused a regression, especially for plugin authors that used `$connection_resolver->set_query_arg()` intentionally to override other arguments. 

This now separates the method into 2 methods with (hopefully) better naming: 

- override_query_arg (overrides existing args)
- add_query_arg (appends/merges args when possible)