### PR TITLE
fix: set_query_arg should not attempt to merge args

### DIFF
--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -832,14 +832,7 @@ abstract class AbstractConnectionResolver {
 	 * @return static
 	 */
 	public function set_query_arg( $key, $value ) {
-		if ( ! empty( $this->query_args[ $key ] ) && is_array( $this->query_args[ $key ] ) ) {
-			if ( ! is_array( $value ) ) {
-				$value = [ $value ];
-			}
-			$this->query_args[ $key ] = array_merge( $this->query_args[ $key ], $value );
-		} else {
-			$this->query_args[ $key ] = $value;
-		}
+		$this->query_args[ $key ] = $value;
 		return $this;
 	}
 

--- a/src/Registry/Utils/TermObject.php
+++ b/src/Registry/Utils/TermObject.php
@@ -230,17 +230,15 @@ class TermObject {
 					'queryClass' => 'WP_Query',
 					'resolve'    => static function ( Term $term, $args, AppContext $context, ResolveInfo $info ) use ( $post_type_object ) {
 						$resolver = new PostObjectConnectionResolver( $term, $args, $context, $info, $post_type_object->name );
-						$resolver->set_query_arg(
-							'tax_query',
-							[
-								[
-									'taxonomy'         => $term->taxonomyName,
-									'terms'            => [ $term->term_id ],
-									'field'            => 'term_id',
-									'include_children' => false,
-								],
-							]
-						);
+						$current_args = $resolver->get_query_args();
+						$tax_query = $current_args['tax_query'] ?? [];
+						$tax_query[] = [
+							'taxonomy'         => $term->taxonomyName,
+							'terms'            => [ $term->term_id ],
+							'field'            => 'term_id',
+							'include_children' => false,
+						];
+						$resolver->set_query_arg( 'tax_query', $tax_query );
 
 						return $resolver->get_connection();
 					},

--- a/src/Registry/Utils/TermObject.php
+++ b/src/Registry/Utils/TermObject.php
@@ -229,10 +229,10 @@ class TermObject {
 					'toType'     => $post_type_object->graphql_single_name,
 					'queryClass' => 'WP_Query',
 					'resolve'    => static function ( Term $term, $args, AppContext $context, ResolveInfo $info ) use ( $post_type_object ) {
-						$resolver = new PostObjectConnectionResolver( $term, $args, $context, $info, $post_type_object->name );
+						$resolver     = new PostObjectConnectionResolver( $term, $args, $context, $info, $post_type_object->name );
 						$current_args = $resolver->get_query_args();
-						$tax_query = $current_args['tax_query'] ?? [];
-						$tax_query[] = [
+						$tax_query    = $current_args['tax_query'] ?? [];
+						$tax_query[]  = [
 							'taxonomy'         => $term->taxonomyName,
 							'terms'            => [ $term->term_id ],
 							'field'            => 'term_id',

--- a/tests/wpunit/PostObjectConnectionQueriesTest.php
+++ b/tests/wpunit/PostObjectConnectionQueriesTest.php
@@ -1901,17 +1901,15 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 			],
 			'resolve' => function( \WPGraphQL\Model\Term $term, $args, $context, $info ) use ( &$query_args ) {
 				$resolver = new \WPGraphQL\Data\Connection\PostObjectConnectionResolver( $term, $args, $context, $info, 'post' );
-				$resolver->set_query_arg(
-					'tax_query',
-					[
-						[
-							'taxonomy'         => $term->taxonomyName,
-							'terms'            => [ $term->term_id ],
-							'field'            => 'term_id',
-							'include_children' => false,
-						],
-					]
-				);
+				$current_args = $resolver->get_query_args();
+				$tax_query = $current_args['tax_query'] ?? [];
+				$tax_query[] = [
+					'taxonomy'         => $term->taxonomyName,
+					'terms'            => [ $term->term_id ],
+					'field'            => 'term_id',
+					'include_children' => false,
+				];
+				$resolver->set_query_arg( 'tax_query', $tax_query );
 				$query_args = $resolver->get_query_args();
 				return $resolver->get_connection();
 			},


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This reverts a change introduced in #3066 that could be a breaking change, and instead handles it by merging args in the connection resolver and using set_query_arg with the merged args (instead of assuming set_query_arg will do the merging under the hood).

Does this close any currently open issues?
------------------------------------------
n/a

related: #3066
related: #3161 

Any other comments?
-------------------
More info here: https://github.com/wp-graphql/wp-graphql/pull/3161#issuecomment-2204937986
