### PR TITLE
fix: refactor SVG handling to `Utils::get_image_asset_contents()`

### DIFF
--- a/src/Admin/GraphiQL/GraphiQL.php
+++ b/src/Admin/GraphiQL/GraphiQL.php
@@ -2,6 +2,7 @@
 
 namespace WPGraphQL\Admin\GraphiQL;
 
+use WPGraphQL\Utils\Utils;
 use WP_Admin_Bar;
 
 /**
@@ -96,13 +97,10 @@ class GraphiQL {
 	 * @return void
 	 */
 	public function register_admin_page() {
-		$svg_file = file_get_contents( WPGRAPHQL_PLUGIN_DIR . '/img/wpgraphql-elephant.svg' );
 
-		if ( false === $svg_file ) {
-			return;
-		}
+		$svg_file = Utils::get_image_asset_contents( WPGRAPHQL_PLUGIN_DIR . '/img/wpgraphql-elephant.svg' );
 
-		$svg_base64 = base64_encode( $svg_file );
+		$svg_base64 = ! empty( $svg_file ) ? base64_encode( $svg_file ) : '';
 
 		// Top level menu page should be labeled GraphQL
 		add_menu_page(

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -387,4 +387,40 @@ class Utils {
 
 		return is_object( $post_id ) ? (int) $post_id->ID : (int) $post_id;
 	}
+
+	/**
+	 * Get the file contents of an image asset in the plugin.
+	 *
+	 * This is most commonly used to get the contents of an SVG file, like the WPGraphQL logo.
+	 *
+	 * @param string $filename The filename of the image asset, relative to the plugin directory.
+	 *
+	 * @return string The contents of the image asset. Empty string if the asset doesn't exist.
+	 */
+	public static function get_image_asset_contents( string $filename ): string {
+		// Try to get the asset from the cache.
+		$cached_asset = wp_cache_get( $filename, 'wp-graphql-image-assets' );
+
+		if ( false !== $cached_asset ) {
+			return (string) $cached_asset;
+		}
+
+		$asset_path = WPGRAPHQL_PLUGIN_DIR . '/img/' . $filename;
+
+		if ( ! file_exists( $asset_path ) ) {
+			return '';
+		}
+
+		$asset_contents = file_get_contents( $asset_path ); // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
+
+		// Set the asset contents to an empty string if it's false so we can cache it.
+		if ( false === $asset_contents ) {
+			$asset_contents = '';
+		}
+
+		// Cache the asset contents.
+		wp_cache_set( $filename, $asset_contents, 'wp-graphql-image-assets' );
+
+		return $asset_contents;
+	}
 }


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR
- Relocates the `get_file_contents()` logic used to read our SVG logo to the new `Utils::get_image_asset_contents()`. This is because we also use a svg in `WPGraphQL\Admin\Settings\Settings` which we might want to move to a static file as well.
- Fixes the `GraphiQL::register_admin_page()` to register the menu even if the image file cannot be read.

### Todo
- [ ] Unit tests
- [ ] Maybe use a fallback logo instead of an empty string?


Does this close any currently open issues?
------------------------------------------
<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #3164


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
<!-- (If it’s long, please paste to https://ghostbin.com/ and insert the link here.) -->


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2 + devilbox + php 8.1.15)

**WordPress Version:** 6.5.5
