### PR TITLE
feat: Ability to Sort Variation Terms by Menu order

### DIFF
--- a/src/Type/Enum/TermObjectsConnectionOrderbyEnum.php
+++ b/src/Type/Enum/TermObjectsConnectionOrderbyEnum.php
@@ -38,6 +38,10 @@ class TermObjectsConnectionOrderbyEnum {
 						'value'       => 'description',
 						'description' => __( 'Order the connection by description.', 'wp-graphql' ),
 					],
+					'MENU_ORDER'    => [
+						'value'       => 'menu_order',
+						'description' => __( 'Order by the menu order value', 'wp-graphql' ),
+					],
 					'COUNT'       => [
 						'value'       => 'count',
 						'description' => __( 'Order the connection by item count.', 'wp-graphql' ),


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

This PR updates the TermObjectsConnectionOrderbyEnum.php file to include the MENU_ORDER option. This change enables GraphQL queries to sort terms by menu order (MENU_ORDER) when fetching data related to attributes. It enhances the flexibility of sorting options available to users, improving how terms associated with attributes are organized and presented.

```
  terms(where: {orderby: MENU_ORDER, order: ASC}) {
    nodes {
      name
      slug
      taxonomyName
      databaseId
    }
 }
```



Does this close any currently open issues?
------------------------------------------
https://github.com/wp-graphql/wp-graphql-woocommerce/issues/475
https://github.com/wp-graphql/wp-graphql-woocommerce/issues/389

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

Any other comments?
-------------------
...

Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
