### PR TITLE
fix: only `eagerlyLoadType` on introspection requests

### DIFF
--- a/cli/wp-cli.php
+++ b/cli/wp-cli.php
@@ -39,7 +39,15 @@ class WPGraphQL_CLI_Command extends WP_CLI_Command {
 		 * Generate the Schema
 		 */
 		WP_CLI::line( 'Getting the Schema...' );
+
+		// Set the introspection query flag
+		WPGraphQL::set_is_introspection_query( true );
+
+		// Get the schema
 		$schema = WPGraphQL::get_schema();
+
+		// Reset the introspection query flag
+		WPGraphQL::set_is_introspection_query( false );
 
 		/**
 		 * Format the Schema

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -714,7 +714,7 @@ class TypeRegistry {
 			return $this->prepare_type( $type_name, $config );
 		};
 
-		if ( is_array( $config ) && isset( $config['eagerlyLoadType'] ) && true === $config['eagerlyLoadType'] && ! isset( $this->eager_type_map[ $this->format_key( $type_name ) ] ) ) {
+		if ( \WPGraphQL::is_introspection_query() && is_array( $config ) && isset( $config['eagerlyLoadType'] ) && true === $config['eagerlyLoadType'] && ! isset( $this->eager_type_map[ $this->format_key( $type_name ) ] ) ) {
 			$this->eager_type_map[ $this->format_key( $type_name ) ] = $this->format_key( $type_name );
 		}
 	}

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -4,6 +4,7 @@ namespace WPGraphQL\Registry;
 
 use GraphQL\Error\Error;
 use GraphQL\Type\Definition\Type;
+use WPGraphQL;
 use WPGraphQL\Data\DataSource;
 use WPGraphQL\Mutation\CommentCreate;
 use WPGraphQL\Mutation\CommentDelete;
@@ -407,10 +408,10 @@ class TypeRegistry {
 		 *
 		 * @var \WP_Post_Type[] $allowed_post_types
 		 */
-		$allowed_post_types = \WPGraphQL::get_allowed_post_types( 'objects' );
+		$allowed_post_types = WPGraphQL::get_allowed_post_types( 'objects' );
 
 		/** @var \WP_Taxonomy[] $allowed_taxonomies */
-		$allowed_taxonomies = \WPGraphQL::get_allowed_taxonomies( 'objects' );
+		$allowed_taxonomies = WPGraphQL::get_allowed_taxonomies( 'objects' );
 
 		foreach ( $allowed_post_types as $post_type_object ) {
 			PostObject::register_types( $post_type_object );
@@ -714,7 +715,7 @@ class TypeRegistry {
 			return $this->prepare_type( $type_name, $config );
 		};
 
-		if ( \WPGraphQL::is_introspection_query() && is_array( $config ) && isset( $config['eagerlyLoadType'] ) && true === $config['eagerlyLoadType'] && ! isset( $this->eager_type_map[ $this->format_key( $type_name ) ] ) ) {
+		if ( WPGraphQL::is_introspection_query() && is_array( $config ) && isset( $config['eagerlyLoadType'] ) && true === $config['eagerlyLoadType'] && ! isset( $this->eager_type_map[ $this->format_key( $type_name ) ] ) ) {
 			$this->eager_type_map[ $this->format_key( $type_name ) ] = $this->format_key( $type_name );
 		}
 	}

--- a/src/Request.php
+++ b/src/Request.php
@@ -151,9 +151,6 @@ class Request {
 		// Get the Type Registry
 		$this->type_registry = \WPGraphQL::get_type_registry();
 
-		// Get the Schema
-		$this->schema = \WPGraphQL::get_schema();
-
 		// Get the App Context
 		$this->app_context = \WPGraphQL::get_app_context();
 
@@ -179,6 +176,7 @@ class Request {
 		// to return in headers and debug messages to help developers understand
 		// what was resolved, how to cache it, etc.
 		$this->query_analyzer->init();
+
 	}
 
 	/**
@@ -291,6 +289,9 @@ class Request {
 		} else {
 			$this->do_action( $this->params );
 		}
+
+		// Get the Schema
+		$this->schema = \WPGraphQL::get_schema();
 
 		/**
 		 * This action runs before execution of a GraphQL request (regardless if it's a single or batch request)

--- a/src/Request.php
+++ b/src/Request.php
@@ -176,7 +176,6 @@ class Request {
 		// to return in headers and debug messages to help developers understand
 		// what was resolved, how to cache it, etc.
 		$this->query_analyzer->init();
-
 	}
 
 	/**

--- a/src/Utils/QueryAnalyzer.php
+++ b/src/Utils/QueryAnalyzer.php
@@ -137,7 +137,6 @@ class QueryAnalyzer {
 	 */
 	public function __construct( Request $request ) {
 		$this->request       = $request;
-		$this->schema        = $request->schema;
 		$this->runtime_nodes = [];
 		$this->models        = [];
 		$this->list_types    = [];

--- a/src/Utils/QueryAnalyzer.php
+++ b/src/Utils/QueryAnalyzer.php
@@ -147,7 +147,7 @@ class QueryAnalyzer {
 	 * Get the GraphQL Schema.
 	 * If the schema is not set, it will be set.
 	 *
-	 * @return Schema|WPSchema|null
+	 * @return \GraphQL\Type\Schema|\WPGraphQL\WPSchema|null
 	 * @throws \Exception
 	 */
 	public function get_schema() {

--- a/src/Utils/QueryAnalyzer.php
+++ b/src/Utils/QueryAnalyzer.php
@@ -32,7 +32,7 @@ use WPGraphQL\WPSchema;
 class QueryAnalyzer {
 
 	/**
-	 * @var \GraphQL\Type\Schema
+	 * @var \WPGraphQL\WPSchema|null
 	 */
 	protected $schema;
 
@@ -147,10 +147,9 @@ class QueryAnalyzer {
 	 * Get the GraphQL Schema.
 	 * If the schema is not set, it will be set.
 	 *
-	 * @return \GraphQL\Type\Schema|\WPGraphQL\WPSchema|null
 	 * @throws \Exception
 	 */
-	public function get_schema() {
+	public function get_schema(): ?WPSchema {
 		if ( ! $this->schema ) {
 			$this->schema = WPGraphQL::get_schema();
 		}

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -62,7 +62,12 @@ final class WPGraphQL {
 	/**
 	 * @var bool
 	 */
-	protected static $is_graphql_request;
+	protected static $is_graphql_request = false;
+
+	/**
+	 * @var bool
+	 */
+	protected static $is_introspection_query = false;
 
 	/**
 	 * The instance of the WPGraphQL object
@@ -140,10 +145,28 @@ final class WPGraphQL {
 	}
 
 	/**
-	 * @return bool
+	 * Whether the request is a graphql request or not
 	 */
-	public static function is_graphql_request() {
+	public static function is_graphql_request(): bool {
 		return self::$is_graphql_request;
+	}
+
+	/**
+	 * Set whether the request is an introspection query or not
+	 *
+	 * @param bool $is_introspection_query
+	 *
+	 * @return void
+	 */
+	public static function set_is_introspection_query( bool $is_introspection_query = false ) {
+		self::$is_introspection_query = $is_introspection_query;
+	}
+
+	/**
+	 * Whether the request is an introspection query or not (query for __type or __schema)
+	 */
+	public static function is_introspection_query(): bool {
+		return self::$is_introspection_query;
 	}
 
 	/**
@@ -203,6 +226,7 @@ final class WPGraphQL {
 
 		// Throw an exception
 		add_action( 'do_graphql_request', [ $this, 'min_php_version_check' ] );
+		add_action( 'do_graphql_request', [ $this, 'introspection_check' ], 10, 4 );
 
 		// Initialize Admin functionality
 		add_action( 'after_setup_theme', [ $this, 'init_admin' ] );
@@ -220,6 +244,41 @@ final class WPGraphQL {
 	}
 
 	/**
+	 * @param ?string                         $query     The GraphQL query
+	 * @param ?string                         $operation The name of the operation
+	 * @param ?array<mixed>                   $variables Variables to be passed to your GraphQL
+	 *                                                   request
+	 * @param \GraphQL\Server\OperationParams $params    The Operation Params. This includes any
+	 *                                                   extra params,
+	 *
+	 * @throws \GraphQL\Error\SyntaxError
+	 * @throws \Exception
+	 */
+	public function introspection_check( ?string $query, ?string $operation, ?array $variables, \GraphQL\Server\OperationParams $params ): void {
+
+		if ( empty( $query ) ) {
+			return;
+		}
+
+		$ast              = \GraphQL\Language\Parser::parse( $query );
+		$is_introspection = false;
+
+		\GraphQL\Language\Visitor::visit(
+			$ast,
+			[
+				'Field' => static function ( \GraphQL\Language\AST\FieldNode $node ) use ( &$is_introspection ) {
+					if ( '__schema' === $node->name->value || '__type' === $node->name->value ) {
+						$is_introspection = true;
+						return \GraphQL\Language\Visitor::stop();
+					}
+				},
+			]
+		);
+
+		self::set_is_introspection_query( $is_introspection );
+	}
+
+	/**
 	 * Check if the minimum PHP version requirement is met before execution begins.
 	 *
 	 * If the server is running a lower version than required, throw an exception and prevent
@@ -233,7 +292,7 @@ final class WPGraphQL {
 			throw new \Exception(
 				esc_html(
 					sprintf(
-						// translators: %1$s is the current PHP version, %2$s is the minimum required PHP version.
+					// translators: %1$s is the current PHP version, %2$s is the minimum required PHP version.
 						__( 'The server\'s current PHP version %1$s is lower than the WPGraphQL minimum required version: %2$s', 'wp-graphql' ),
 						PHP_VERSION,
 						GRAPHQL_MIN_PHP_VERSION

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -156,14 +156,16 @@ final class WPGraphQL {
 	 *
 	 * @param bool $is_introspection_query
 	 *
-	 * @return void
+	 * @since todo
 	 */
-	public static function set_is_introspection_query( bool $is_introspection_query = false ) {
+	public static function set_is_introspection_query( bool $is_introspection_query = false ): void {
 		self::$is_introspection_query = $is_introspection_query;
 	}
 
 	/**
 	 * Whether the request is an introspection query or not (query for __type or __schema)
+	 *
+	 * @since todo
 	 */
 	public static function is_introspection_query(): bool {
 		return self::$is_introspection_query;

--- a/tests/wpunit/AccessFunctionsTest.php
+++ b/tests/wpunit/AccessFunctionsTest.php
@@ -2376,17 +2376,11 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 			$this->expectedField( 'users', self::NOT_NULL ),
 		] );
 
+		$this->expectException( GraphQL\Error\Error::class );
+		$this->expectExceptionMessageMatches( "/non-existent/" );
 
 		$actual_three = $this->graphql([
 			'query' => $query_three
-		]);
-
-		self::assertQueryError( $actual_three, [
-			$this->expectedErrorMessage( 'non-existent', self::MESSAGE_CONTAINS ),
-		] );
-
-		codecept_debug( [
-			'$actual_three' => $actual_three,
 		]);
 	}
 }

--- a/tests/wpunit/AccessFunctionsTest.php
+++ b/tests/wpunit/AccessFunctionsTest.php
@@ -2376,13 +2376,17 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 			$this->expectedField( 'users', self::NOT_NULL ),
 		] );
 
-		// The third query should throw a GraphQL\Error calling out the fact that the field is referencing a non-existent type
-		$this->expectException( GraphQL\Error\Error::class );
-		$this->expectExceptionMessageMatches( "/non-existent/" );
 
 		$actual_three = $this->graphql([
 			'query' => $query_three
 		]);
 
+		self::assertQueryError( $actual_three, [
+			$this->expectedErrorMessage( 'non-existent', self::MESSAGE_CONTAINS ),
+		] );
+
+		codecept_debug( [
+			'$actual_three' => $actual_three,
+		]);
 	}
 }

--- a/tests/wpunit/AssertValidSchemaTest.php
+++ b/tests/wpunit/AssertValidSchemaTest.php
@@ -27,7 +27,9 @@ class AssertValidSchemaTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase 
 	public function testSchema() {
 		try {
 			$request = new \WPGraphQL\Request();
-			$request->schema->assertValid();
+
+			$schema = WPGraphQL::get_schema();
+			$schema->assertValid();
 
 			// Assert true upon success.
 			$this->assertTrue( true );

--- a/tests/wpunit/CustomPostTypeTest.php
+++ b/tests/wpunit/CustomPostTypeTest.php
@@ -1769,12 +1769,12 @@ class CustomPostTypeTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$map = array_keys( $schema->getTypeMap() );
 
-		$this->assertTrue( ! in_array( 'BootstrapPost', $map, true ) );
+		$this->assertTrue( in_array( 'BootstrapPost', $map, true ) );
 		$this->assertTrue( ! in_array( 'CptNoSinglePlural', $map, true ) );
 
 		// Cleanup
 		unregister_post_type( 'cpt_no_single_plural' );
-		$this->clearSchema();
+
 	}
 
 	public function testRegisterPostTypeWithUnderscoresAsGraphqlSingleName() {

--- a/tests/wpunit/CustomPostTypeTest.php
+++ b/tests/wpunit/CustomPostTypeTest.php
@@ -1694,13 +1694,15 @@ class CustomPostTypeTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 			$schema = WPGraphQL::get_schema();
 
-			// clean up
-			unregister_post_type( 'with_underscore' );
+			$this->assertTrue( $schema->hasType( 'With_underscore' ) );
 
 			$schema->assertValid();
 
 			// Assert true upon success.
 			$this->assertTrue( true );
+
+			// clean up
+			unregister_post_type( 'with_underscore' );
 	}
 
 	public function testRegisterPostTypeWithoutGraphqlPluralNameIsValid() {

--- a/tests/wpunit/CustomPostTypeTest.php
+++ b/tests/wpunit/CustomPostTypeTest.php
@@ -1690,12 +1690,14 @@ class CustomPostTypeTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 			// register the post type with underscore in the graphql_single_name / graphql_plural_name
 			register_post_type( 'with_underscore', $args );
 
-			$request = new \WPGraphQL\Request();
+			new \WPGraphQL\Request();
+
+			$schema = WPGraphQL::get_schema();
 
 			// clean up
 			unregister_post_type( 'with_underscore' );
 
-			$request->schema->assertValid();
+			$schema->assertValid();
 
 			// Assert true upon success.
 			$this->assertTrue( true );
@@ -1730,7 +1732,8 @@ class CustomPostTypeTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		);
 
 		$request = new \WPGraphQL\Request();
-		$request->schema->assertValid();
+		$schema  = WPGraphQL::get_schema();
+		$schema->assertValid();
 
 		self::assertQuerySuccessful(
 			$actual,
@@ -1758,7 +1761,8 @@ class CustomPostTypeTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		// assert that the schema is still valid, even though the tax
 		// didn't provide the single/plural name (it will be left out of the schema)
 		$request = new \WPGraphQL\Request();
-		$request->schema->assertValid();
+		$schema = WPGraphQL::get_schema();
+		$schema->assertValid();
 
 		// Cleanup
 		unregister_post_type( 'cpt_no_single_plural' );

--- a/tests/wpunit/CustomPostTypeTest.php
+++ b/tests/wpunit/CustomPostTypeTest.php
@@ -1736,6 +1736,7 @@ class CustomPostTypeTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$request = new \WPGraphQL\Request();
 		$schema  = WPGraphQL::get_schema();
 		$schema->assertValid();
+		$this->assertTrue( $schema->hasType( 'NoPlural' ) );
 
 		self::assertQuerySuccessful(
 			$actual,
@@ -1762,9 +1763,14 @@ class CustomPostTypeTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		// assert that the schema is still valid, even though the tax
 		// didn't provide the single/plural name (it will be left out of the schema)
-		$request = new \WPGraphQL\Request();
+		new \WPGraphQL\Request();
 		$schema = WPGraphQL::get_schema();
 		$schema->assertValid();
+
+		$map = array_keys( $schema->getTypeMap() );
+
+		$this->assertTrue( ! in_array( 'BootstrapPost', $map, true ) );
+		$this->assertTrue( ! in_array( 'CptNoSinglePlural', $map, true ) );
 
 		// Cleanup
 		unregister_post_type( 'cpt_no_single_plural' );

--- a/tests/wpunit/CustomTaxonomyTest.php
+++ b/tests/wpunit/CustomTaxonomyTest.php
@@ -1229,7 +1229,8 @@ class CustomTaxonomyTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		unregister_taxonomy( 'with_underscore' );
 
-		$request->schema->assertValid();
+		$schema = WPGraphQL::get_schema();
+		$schema->assertValid();
 
 		// Assert true upon success.
 		$this->assertTrue( true );
@@ -1247,7 +1248,8 @@ class CustomTaxonomyTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		);
 
 		$request = new \WPGraphQL\Request();
-		$request->schema->assertValid();
+		$schema = WPGraphQL::get_schema();
+		$schema->assertValid();
 
 		$query = '
 		{
@@ -1290,7 +1292,8 @@ class CustomTaxonomyTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		// assert that the schema is still valid, even though the tax
 		// didn't provide the single/plural name (it will be left out of the schema)
 		$request = new \WPGraphQL\Request();
-		$request->schema->assertValid();
+		$schema = WPGraphQL::get_schema();
+		$schema->assertValid();
 
 		unregister_taxonomy( 'tax_no_single_plural' );
 	}

--- a/tests/wpunit/InterfaceTest.php
+++ b/tests/wpunit/InterfaceTest.php
@@ -117,7 +117,8 @@ class InterfaceTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 	public function testSchemaIsValid() {
 		try {
 			$request = new \WPGraphQL\Request();
-			$request->schema->assertValid();
+			$schema  = WPGraphQL::get_schema();
+			$schema->assertValid();
 
 			// Assert true upon success.
 			$this->assertTrue( true );

--- a/tests/wpunit/PostObjectMutationsTest.php
+++ b/tests/wpunit/PostObjectMutationsTest.php
@@ -787,12 +787,12 @@ class PostObjectMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCas
 		$page_id = $this->factory()->post->create( $args );
 
 		$query = '
-		mutation deletePostWithPageIdShouldFail{
-			deletePost( $id:ID! ){
-				post{
-					id
-				}
-			}
+		mutation deletePostWithPageIdShouldFail($id: ID!) {
+		  deletePost(input: {id: $id}) {
+		    post {
+		      id
+		    }
+		  }
 		}
 		';
 

--- a/tests/wpunit/RequestTest.php
+++ b/tests/wpunit/RequestTest.php
@@ -94,11 +94,9 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 		$this->factory->post->create();
 
 		$request = new Request( [ 'query' => 'query {}' ] );
+		$this->expectException( Exception::class );
 		$results = $request->execute();
 
-		$this->assertArrayHasKey( 'errors', $results );
-		$this->assertArrayNotHasKey( 'data', $results );
-		$this->assertEquals( 1, count( $results['errors'] ) );
 	}
 
 	/**


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Any type that is registered to `eagerlyLoadType` will now only be eagerly loaded for Introspection requests (typically used for tooling such as GraphiQL IDE, Codegen, etc)

For standard execution of queries the eagerly loaded types will not be eagerly loaded which dramatically reduces the number of Object Types that are required to be generated per request.

This introduces: 

- WPGraphQL::set_is_introspection_query
- WPGraphQL::is_introspection_query

Does this close any currently open issues?
------------------------------------------
Closes #3159 


Any other comments?
-------------------
This _might_ be a breaking change if shipped as-is, as the Schema is now generated later in the lifecycle. 

### Performance Tests

I ran some (super basic) performance tests using k6. 

<details>
  <summary>(performance-test.js)</summary>
    
    ```js
    import http from 'k6/http'
    import { check, sleep } from 'k6'
    
    export const options = {
        vus: 10,
        duration: '10s',
    };
    
    export default function() {
        const url = 'http://uri-debugging.local/graphql'
        const query = `
        query {
            posts(first: 10) {
                nodes {
                    __typename
                    title
                    date
                }
            }
        }
        `;
    
    
        // format the query as a query param and append to the url
        // const res = http.get(`${url}?query=${encodeURIComponent(query)}`)
    
        const headers = { 'Content-Type': 'application/json' }
        const res = http.post(url, JSON.stringify({ query: query }), { headers: headers })
        sleep(1)
    
        check(res, {
            'status was 200': r => r.status === 200,
            'transaction time OK (less than 200ms)': r => r.timings.duration < 200
        });
    
    }
    ```
</details>

The test simulates 10 concurrent users executing the following query as a POST request and continues to execute as many times as it can for 10 seconds.

```graphql
    query {
        posts(first: 10) {
            nodes {
                __typename
                title
                date
            }
        }
    }
```

#### BEFORE 

```bash
http_req_duration..............: avg=156.21ms min=52.89ms med=109.72ms max=585.73ms p(90)=331.21ms p(95)=371.64ms
```

#### AFTER

```bash
http_req_duration..............: avg=67.21ms  min=44.3ms  med=56.27ms max=279.04ms p(90)=70.38ms p(95)=164.29ms
```