### PR TITLE
devops: WPGraphQLTestCase constant usage updated for extendability

### DIFF
--- a/tests/wpunit/AccessFunctionsTest.php
+++ b/tests/wpunit/AccessFunctionsTest.php
@@ -943,7 +943,7 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->assertQuerySuccessful(
 			$actual,
 			[
-				$this->expectedField( 'graphqlInResolver', self::NOT_NULL ),
+				$this->expectedField( 'graphqlInResolver', static::NOT_NULL ),
 			]
 		);
 	}
@@ -1003,7 +1003,7 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 			$this->assertQuerySuccessful(
 				$response,
 				[
-					$this->expectedField( 'graphqlInResolver', self::NOT_NULL ),
+					$this->expectedField( 'graphqlInResolver', static::NOT_NULL ),
 				]
 			);
 		}
@@ -2226,7 +2226,7 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		self::assertQuerySuccessful(
 			$actual,
 			[
-				$this->expectedField( 'test_field_with_underscores', self::IS_FALSY ),
+				$this->expectedField( 'test_field_with_underscores', static::IS_FALSY ),
 			]
 		);
 	}
@@ -2365,7 +2365,7 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		]);
 
 		self::assertQuerySuccessful( $actual, [
-			$this->expectedField( 'posts', self::NOT_NULL ),
+			$this->expectedField( 'posts', static::NOT_NULL ),
 		] );
 
 		$actual_two = $this->graphql([
@@ -2373,7 +2373,7 @@ class AccessFunctionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		]);
 
 		self::assertQuerySuccessful( $actual_two, [
-			$this->expectedField( 'users', self::NOT_NULL ),
+			$this->expectedField( 'users', static::NOT_NULL ),
 		] );
 
 		$this->expectException( GraphQL\Error\Error::class );

--- a/tests/wpunit/CommentMutationsTest.php
+++ b/tests/wpunit/CommentMutationsTest.php
@@ -698,7 +698,7 @@ class CommentMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		self::assertQuerySuccessful(
 			$actual,
 			[
-				$this->expectedField( 'updateComment.success', self::IS_FALSY ),
+				$this->expectedField( 'updateComment.success', static::IS_FALSY ),
 				$this->expectedField( 'updateComment.comment.databaseId', (int) $comment['comment_ID'] ),
 				$this->expectedField( 'updateComment.comment.content', apply_filters( 'comment_text', $comment['comment_content'] ) ),
 			]

--- a/tests/wpunit/ConnectionRegistrationTest.php
+++ b/tests/wpunit/ConnectionRegistrationTest.php
@@ -125,7 +125,7 @@ class ConnectionRegistrationTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTest
 		$this->assertQuerySuccessful(
 			$actual,
 			[
-				$this->expectedField( 'testTypeConnection', self::IS_NULL ),
+				$this->expectedField( 'testTypeConnection', static::IS_NULL ),
 			]
 		);
 	}
@@ -190,7 +190,7 @@ class ConnectionRegistrationTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTest
 		$this->assertQuerySuccessful(
 			$actual,
 			[
-				$this->expectedField( 'test', self::IS_NULL ),
+				$this->expectedField( 'test', static::IS_NULL ),
 			]
 		);
 	}
@@ -270,7 +270,7 @@ class ConnectionRegistrationTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTest
 		$expected = [
 			$this->expectedErrorPath( 'secretConnection' ),
 			$this->expectedErrorMessage( 'Blocked on the type-level!!!', self::MESSAGE_EQUALS ),
-			$this->expectedField( 'secretConnection', self::IS_NULL ),
+			$this->expectedField( 'secretConnection', static::IS_NULL ),
 		];
 
 		$this->assertQueryError( $response, $expected );
@@ -306,7 +306,7 @@ class ConnectionRegistrationTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTest
 		$expected = [
 			$this->expectedErrorPath( 'failingAuthConnection' ),
 			$this->expectedErrorMessage( 'Blocked on the field-level!!!', self::MESSAGE_EQUALS ),
-			$this->expectedField( 'failingAuthConnection', self::IS_NULL ),
+			$this->expectedField( 'failingAuthConnection', static::IS_NULL ),
 		];
 		$this->assertQueryError( $response, $expected );
 
@@ -319,8 +319,8 @@ class ConnectionRegistrationTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTest
 		$response = $this->graphql( compact( 'query' ) );
 		$expected = [
 			$this->expectedField( 'failingAuthConnection.nodes.0.test', 'test' ),
-			$this->expectedField( 'failingAuthConnection.nodes.1.test', self::IS_NULL ),
-			$this->expectedField( 'failingAuthConnection.nodes.2.test', self::IS_NULL ),
+			$this->expectedField( 'failingAuthConnection.nodes.1.test', static::IS_NULL ),
+			$this->expectedField( 'failingAuthConnection.nodes.2.test', static::IS_NULL ),
 			$this->expectedErrorMessage( 'Blocked on the field-level!!!', self::MESSAGE_EQUALS ),
 			$this->expectedErrorPath( 'failingAuthConnection.nodes.1.test' ),
 			$this->expectedErrorPath( 'failingAuthConnection.nodes.2.test' ),
@@ -765,7 +765,7 @@ class ConnectionRegistrationTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTest
 			[
 				$this->expectedErrorPath( 'connectionWithConfig' ),
 				$this->expectedErrorMessage( $expected, self::MESSAGE_EQUALS ),
-				$this->expectedField( 'connectionWithConfig', self::IS_NULL ),
+				$this->expectedField( 'connectionWithConfig', static::IS_NULL ),
 			]
 		);
 	}

--- a/tests/wpunit/CustomPostTypeTest.php
+++ b/tests/wpunit/CustomPostTypeTest.php
@@ -1741,7 +1741,7 @@ class CustomPostTypeTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		self::assertQuerySuccessful(
 			$actual,
 			[
-				$this->expectedField( 'allNoPlural.nodes', self::IS_FALSY ),
+				$this->expectedField( 'allNoPlural.nodes', static::IS_FALSY ),
 			]
 		);
 

--- a/tests/wpunit/CustomTaxonomyTest.php
+++ b/tests/wpunit/CustomTaxonomyTest.php
@@ -1270,7 +1270,7 @@ class CustomTaxonomyTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		self::assertQuerySuccessful(
 			$actual,
 			[
-				$this->expectedField( 'allTaxNoPlural.nodes', self::IS_FALSY ),
+				$this->expectedField( 'allTaxNoPlural.nodes', static::IS_FALSY ),
 			]
 		);
 

--- a/tests/wpunit/FiltersTest.php
+++ b/tests/wpunit/FiltersTest.php
@@ -141,7 +141,7 @@ class FiltersTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->assertQuerySuccessful(
 			$actual,
 			[
-				$this->expectedField( 'users.nodes', self::NOT_NULL ),
+				$this->expectedField( 'users.nodes', static::NOT_NULL ),
 			]
 		);
 	}
@@ -183,7 +183,7 @@ class FiltersTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->assertQuerySuccessful(
 			$actual,
 			[
-				$this->expectedField( 'posts.nodes', self::NOT_NULL ),
+				$this->expectedField( 'posts.nodes', static::NOT_NULL ),
 			]
 		);
 	}

--- a/tests/wpunit/InterfaceTest.php
+++ b/tests/wpunit/InterfaceTest.php
@@ -760,7 +760,7 @@ class InterfaceTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->assertEmpty( $actual['extensions']['debug'], 'The interface should be implemented with no debug messages.' );
 		$this->assertQuerySuccessful(
 			$actual,
-			[ $this->expectedField( 'testField.fieldWithNonNullableArg',self::IS_NULL ) ],
+			[ $this->expectedField( 'testField.fieldWithNonNullableArg',static::IS_NULL ) ],
 			'The query should be valid as the list of and non null arguments defined on the interface are valid when querying the field that returns the object type'
 		);
 	}
@@ -834,7 +834,7 @@ class InterfaceTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->assertEmpty( $actual['extensions']['debug'], 'The interface should be implemented with no debug messages.' );
 		$this->assertQuerySuccessful(
 			$actual,
-			[ $this->expectedField( 'testField.fieldWithNoArgs', self::IS_NULL ) ],
+			[ $this->expectedField( 'testField.fieldWithNoArgs', static::IS_NULL ) ],
 			'The query should be valid as the interface field has no arguments'
 		);
 	}

--- a/tests/wpunit/MediaItemMutationsTest.php
+++ b/tests/wpunit/MediaItemMutationsTest.php
@@ -1266,7 +1266,7 @@ class MediaItemMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		$expected = [
 			$this->expectedErrorPath( 'createMediaItem' ),
 			$this->expectedErrorMessage( 'Invalid filePath', self::MESSAGE_STARTS_WITH ),
-			$this->expectedField( 'createMediaItem', self::IS_NULL ),
+			$this->expectedField( 'createMediaItem', static::IS_NULL ),
 		];
 
 		$this->assertQueryError( $actual, $expected );
@@ -1307,7 +1307,7 @@ class MediaItemMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		$expected = [
 			$this->expectedErrorPath( 'createMediaItem' ),
 			$this->expectedErrorMessage( 'Invalid filePath', self::MESSAGE_STARTS_WITH ),
-			$this->expectedField( 'createMediaItem', self::IS_NULL ),
+			$this->expectedField( 'createMediaItem', static::IS_NULL ),
 		];
 
 		$this->assertQueryError( $actual, $expected );

--- a/tests/wpunit/NodeByUriTest.php
+++ b/tests/wpunit/NodeByUriTest.php
@@ -2243,7 +2243,7 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 			[
 				// the query should return a null value as the uri
 				// cannot be found
-				$this->expectedField( 'nodeByUri', self::IS_NULL ),
+				$this->expectedField( 'nodeByUri', static::IS_NULL ),
 			]
 		);
 	}
@@ -2289,7 +2289,7 @@ class NodeByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 			[
 				// the query should return a null value as the uri
 				// cannot be found
-				$this->expectedField( 'nodeByUri', self::IS_NULL ),
+				$this->expectedField( 'nodeByUri', static::IS_NULL ),
 			]
 		);
 

--- a/tests/wpunit/PageByUriTest.php
+++ b/tests/wpunit/PageByUriTest.php
@@ -68,7 +68,7 @@ class PageByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		self::assertQuerySuccessful(
 			$actual,
 			[
-				$this->expectedField( 'page', self::IS_NULL ),
+				$this->expectedField( 'page', static::IS_NULL ),
 			]
 		);
 
@@ -137,7 +137,7 @@ class PageByUriTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->assertQuerySuccessful(
 			$actual,
 			[
-				$this->expectedField( 'page', self::IS_NULL ),
+				$this->expectedField( 'page', static::IS_NULL ),
 			]
 		);
 	}

--- a/tests/wpunit/PreviewTest.php
+++ b/tests/wpunit/PreviewTest.php
@@ -156,21 +156,21 @@ class PreviewTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		self::assertQuerySuccessful(
 			$actual_by_database_id,
 			[
-				$this->expectedField( 'post.preview', self::IS_NULL ),
+				$this->expectedField( 'post.preview', static::IS_NULL ),
 			]
 		);
 
 		self::assertQuerySuccessful(
 			$actual_by_uri,
 			[
-				$this->expectedField( 'post.preview', self::IS_NULL ),
+				$this->expectedField( 'post.preview', static::IS_NULL ),
 			]
 		);
 
 		self::assertQuerySuccessful(
 			$actual_by_slug,
 			[
-				$this->expectedField( 'post.preview', self::IS_NULL ),
+				$this->expectedField( 'post.preview', static::IS_NULL ),
 			]
 		);
 	}
@@ -213,21 +213,21 @@ class PreviewTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		self::assertQuerySuccessful(
 			$actual_by_database_id,
 			[
-				$this->expectedField( 'post.preview', self::NOT_NULL ),
+				$this->expectedField( 'post.preview', static::NOT_NULL ),
 			]
 		);
 
 		self::assertQuerySuccessful(
 			$actual_by_uri,
 			[
-				$this->expectedField( 'post.preview', self::NOT_NULL ),
+				$this->expectedField( 'post.preview', static::NOT_NULL ),
 			]
 		);
 
 		self::assertQuerySuccessful(
 			$actual_by_slug,
 			[
-				$this->expectedField( 'post.preview', self::NOT_NULL ),
+				$this->expectedField( 'post.preview', static::NOT_NULL ),
 			]
 		);
 
@@ -278,21 +278,21 @@ class PreviewTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		self::assertQuerySuccessful(
 			$actual_by_database_id,
 			[
-				$this->expectedField( 'post.preview', self::NOT_NULL ),
+				$this->expectedField( 'post.preview', static::NOT_NULL ),
 			]
 		);
 
 		self::assertQuerySuccessful(
 			$actual_by_uri,
 			[
-				$this->expectedField( 'post.preview', self::NOT_NULL ),
+				$this->expectedField( 'post.preview', static::NOT_NULL ),
 			]
 		);
 
 		self::assertQuerySuccessful(
 			$actual_by_slug,
 			[
-				$this->expectedField( 'post.preview', self::NOT_NULL ),
+				$this->expectedField( 'post.preview', static::NOT_NULL ),
 			]
 		);
 	}
@@ -334,21 +334,21 @@ class PreviewTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		self::assertQuerySuccessful(
 			$actual_by_database_id,
 			[
-				$this->expectedField( 'post.preview', self::NOT_NULL ),
+				$this->expectedField( 'post.preview', static::NOT_NULL ),
 			]
 		);
 
 		self::assertQuerySuccessful(
 			$actual_by_uri,
 			[
-				$this->expectedField( 'post.preview', self::NOT_NULL ),
+				$this->expectedField( 'post.preview', static::NOT_NULL ),
 			]
 		);
 
 		self::assertQuerySuccessful(
 			$actual_by_slug,
 			[
-				$this->expectedField( 'post.preview', self::NOT_NULL ),
+				$this->expectedField( 'post.preview', static::NOT_NULL ),
 			]
 		);
 
@@ -404,21 +404,21 @@ class PreviewTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		self::assertQuerySuccessful(
 			$actual_by_database_id,
 			[
-				$this->expectedField( 'post.preview', self::NOT_NULL ),
+				$this->expectedField( 'post.preview', static::NOT_NULL ),
 			]
 		);
 
 		self::assertQuerySuccessful(
 			$actual_by_uri,
 			[
-				$this->expectedField( 'post.preview', self::NOT_NULL ),
+				$this->expectedField( 'post.preview', static::NOT_NULL ),
 			]
 		);
 
 		self::assertQuerySuccessful(
 			$actual_by_slug,
 			[
-				$this->expectedField( 'post.preview', self::NOT_NULL ),
+				$this->expectedField( 'post.preview', static::NOT_NULL ),
 			]
 		);
 	}
@@ -460,21 +460,21 @@ class PreviewTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		self::assertQuerySuccessful(
 			$actual_by_database_id,
 			[
-				$this->expectedField( 'post.preview', self::NOT_NULL ),
+				$this->expectedField( 'post.preview', static::NOT_NULL ),
 			]
 		);
 
 		self::assertQuerySuccessful(
 			$actual_by_uri,
 			[
-				$this->expectedField( 'post.preview', self::NOT_NULL ),
+				$this->expectedField( 'post.preview', static::NOT_NULL ),
 			]
 		);
 
 		self::assertQuerySuccessful(
 			$actual_by_slug,
 			[
-				$this->expectedField( 'post.preview', self::NOT_NULL ),
+				$this->expectedField( 'post.preview', static::NOT_NULL ),
 			]
 		);
 
@@ -530,21 +530,21 @@ class PreviewTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		self::assertQuerySuccessful(
 			$actual_by_database_id,
 			[
-				$this->expectedField( 'post.preview', self::NOT_NULL ),
+				$this->expectedField( 'post.preview', static::NOT_NULL ),
 			]
 		);
 
 		self::assertQuerySuccessful(
 			$actual_by_uri,
 			[
-				$this->expectedField( 'post.preview', self::NOT_NULL ),
+				$this->expectedField( 'post.preview', static::NOT_NULL ),
 			]
 		);
 
 		self::assertQuerySuccessful(
 			$actual_by_slug,
 			[
-				$this->expectedField( 'post.preview', self::NOT_NULL ),
+				$this->expectedField( 'post.preview', static::NOT_NULL ),
 			]
 		);
 	}
@@ -586,7 +586,7 @@ class PreviewTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		self::assertQuerySuccessful(
 			$actual_by_database_id,
 			[
-				$this->expectedField( 'post.preview', self::NOT_NULL ),
+				$this->expectedField( 'post.preview', static::NOT_NULL ),
 				$this->expectedField( 'post.preview.node.author.node.databaseId', $this->admin ),
 				$this->expectedField( 'post.author.node.databaseId', $this->admin ),
 			]
@@ -595,7 +595,7 @@ class PreviewTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		self::assertQuerySuccessful(
 			$actual_by_uri,
 			[
-				$this->expectedField( 'post.preview', self::NOT_NULL ),
+				$this->expectedField( 'post.preview', static::NOT_NULL ),
 				$this->expectedField( 'post.preview.node.author.node.databaseId', $this->admin ),
 				$this->expectedField( 'post.author.node.databaseId', $this->admin ),
 			]
@@ -604,7 +604,7 @@ class PreviewTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		self::assertQuerySuccessful(
 			$actual_by_slug,
 			[
-				$this->expectedField( 'post.preview', self::NOT_NULL ),
+				$this->expectedField( 'post.preview', static::NOT_NULL ),
 				$this->expectedField( 'post.preview.node.author.node.databaseId', $this->admin ),
 				$this->expectedField( 'post.author.node.databaseId', $this->admin ),
 			]
@@ -648,7 +648,7 @@ class PreviewTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		self::assertQuerySuccessful(
 			$actual_by_database_id,
 			[
-				$this->expectedField( 'post.preview', self::NOT_NULL ),
+				$this->expectedField( 'post.preview', static::NOT_NULL ),
 				$this->expectedNode(
 					'post.preview.node.categories.nodes',
 					[
@@ -667,7 +667,7 @@ class PreviewTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		self::assertQuerySuccessful(
 			$actual_by_uri,
 			[
-				$this->expectedField( 'post.preview', self::NOT_NULL ),
+				$this->expectedField( 'post.preview', static::NOT_NULL ),
 				$this->expectedNode(
 					'post.preview.node.categories.nodes',
 					[
@@ -686,7 +686,7 @@ class PreviewTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		self::assertQuerySuccessful(
 			$actual_by_slug,
 			[
-				$this->expectedField( 'post.preview', self::NOT_NULL ),
+				$this->expectedField( 'post.preview', static::NOT_NULL ),
 				$this->expectedNode(
 					'post.preview.node.categories.nodes',
 					[
@@ -740,7 +740,7 @@ class PreviewTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		self::assertQuerySuccessful(
 			$actual_by_database_id,
 			[
-				$this->expectedField( 'post.preview', self::NOT_NULL ),
+				$this->expectedField( 'post.preview', static::NOT_NULL ),
 				$this->expectedNode(
 					'post.preview.node.featuredImage.node',
 					[
@@ -759,7 +759,7 @@ class PreviewTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		self::assertQuerySuccessful(
 			$actual_by_uri,
 			[
-				$this->expectedField( 'post.preview', self::NOT_NULL ),
+				$this->expectedField( 'post.preview', static::NOT_NULL ),
 				$this->expectedNode(
 					'post.preview.node.featuredImage.node',
 					[
@@ -778,7 +778,7 @@ class PreviewTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		self::assertQuerySuccessful(
 			$actual_by_slug,
 			[
-				$this->expectedField( 'post.preview', self::NOT_NULL ),
+				$this->expectedField( 'post.preview', static::NOT_NULL ),
 				$this->expectedNode(
 					'post.preview.node.featuredImage.node',
 					[

--- a/tests/wpunit/RootQueryConnectionsTest.php
+++ b/tests/wpunit/RootQueryConnectionsTest.php
@@ -95,7 +95,7 @@ class RootQueryConnectionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 				/**
 				 * @todo 'nodes' should return null.
 				 */
-				$this->expectedField( 'plugins.nodes', self::IS_FALSY ),
+				$this->expectedField( 'plugins.nodes', static::IS_FALSY ),
 			]
 		);
 	}
@@ -203,7 +203,7 @@ class RootQueryConnectionsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 				/**
 				 * @todo 'nodes' should return null.
 				 */
-				$this->expectedField( 'userRoles.nodes', self::IS_FALSY ),
+				$this->expectedField( 'userRoles.nodes', static::IS_FALSY ),
 			]
 		);
 	}

--- a/tests/wpunit/TypesTest.php
+++ b/tests/wpunit/TypesTest.php
@@ -67,7 +67,7 @@ class TypesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->assertQuerySuccessful(
 			$response,
 			[
-				$this->expectedField( 'example.example', self::IS_NULL ),
+				$this->expectedField( 'example.example', static::IS_NULL ),
 			]
 		);
 		$this->assertNotEmpty( $this->lodashGet( $response, 'extensions.debug' ) );
@@ -105,7 +105,7 @@ class TypesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->assertQuerySuccessful(
 			$response,
 			[
-				$this->expectedField( 'posts.nodes', self::NOT_NULL ),
+				$this->expectedField( 'posts.nodes', static::NOT_NULL ),
 			]
 		);
 
@@ -383,7 +383,7 @@ class TypesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->assertQuerySuccessful(
 			$response,
 			[
-				$this->expectedField( 'customTestConnection.nodes', self::IS_NULL ),
+				$this->expectedField( 'customTestConnection.nodes', static::IS_NULL ),
 			]
 		);
 	}

--- a/tests/wpunit/UserObjectCursorTest.php
+++ b/tests/wpunit/UserObjectCursorTest.php
@@ -939,8 +939,8 @@ class UserObjectCursorTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 				[
 					$this->expectedField( 'id', $this->toRelayId( 'user', $this->admin ) ),
 					$this->expectedField( 'databaseId', $this->admin ),
-					$this->expectedField( 'email', self::NOT_NULL ),
-					$this->expectedField( 'username', self::NOT_NULL ),
+					$this->expectedField( 'email', static::NOT_NULL ),
+					$this->expectedField( 'username', static::NOT_NULL ),
 				],
 				0
 			),
@@ -1099,7 +1099,7 @@ class UserObjectCursorTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 				[
 					$this->expectedField( 'id', $this->toRelayId( 'user', 1 ) ),
 					$this->expectedField( 'databaseId', 1 ),
-					$this->expectedField( 'email', self::NOT_NULL ),
+					$this->expectedField( 'email', static::NOT_NULL ),
 					$this->expectedField( 'username', 'admin' ),
 				],
 				4

--- a/tests/wpunit/UserRoleConnectionQueriesTest.php
+++ b/tests/wpunit/UserRoleConnectionQueriesTest.php
@@ -102,7 +102,7 @@ class UserRoleConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 		self::assertQuerySuccessful(
 			$actual,
 			[
-				$this->expectedField( 'user.roles', self::IS_NULL ),
+				$this->expectedField( 'user.roles', static::IS_NULL ),
 			]
 		);
 


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Replaces all calls to `WPGraphQLTestcase` using `self` to use `static`. e.g. `self::IS_NULL` became `static::IS_NULL`.


Does this close any currently open issues?
------------------------------------------
<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
<!-- (If it’s long, please paste to https://ghostbin.com/ and insert the link here.) -->


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
