### PR TITLE
feat: expose `EnqueuedAsset.group` and `EnqueuedScript.location` to schema

### DIFF
--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -54,6 +54,7 @@ use WPGraphQL\Type\Enum\PostObjectsConnectionDateColumnEnum;
 use WPGraphQL\Type\Enum\PostObjectsConnectionOrderbyEnum;
 use WPGraphQL\Type\Enum\PostStatusEnum;
 use WPGraphQL\Type\Enum\RelationEnum;
+use WPGraphQL\Type\Enum\ScriptLoadingGroupEnum;
 use WPGraphQL\Type\Enum\ScriptLoadingStrategyEnum;
 use WPGraphQL\Type\Enum\TaxonomyEnum;
 use WPGraphQL\Type\Enum\TaxonomyIdTypeEnum;
@@ -356,6 +357,7 @@ class TypeRegistry {
 		PostStatusEnum::register_type();
 		RelationEnum::register_type();
 		ScriptLoadingStrategyEnum::register_type();
+		ScriptLoadingGroupEnum::register_type();
 		TaxonomyEnum::register_type();
 		TaxonomyIdTypeEnum::register_type();
 		TermNodeIdTypeEnum::register_type();

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -54,7 +54,7 @@ use WPGraphQL\Type\Enum\PostObjectsConnectionDateColumnEnum;
 use WPGraphQL\Type\Enum\PostObjectsConnectionOrderbyEnum;
 use WPGraphQL\Type\Enum\PostStatusEnum;
 use WPGraphQL\Type\Enum\RelationEnum;
-use WPGraphQL\Type\Enum\ScriptLoadingGroupEnum;
+use WPGraphQL\Type\Enum\ScriptLoadingGroupLocationEnum;
 use WPGraphQL\Type\Enum\ScriptLoadingStrategyEnum;
 use WPGraphQL\Type\Enum\TaxonomyEnum;
 use WPGraphQL\Type\Enum\TaxonomyIdTypeEnum;
@@ -357,7 +357,7 @@ class TypeRegistry {
 		PostStatusEnum::register_type();
 		RelationEnum::register_type();
 		ScriptLoadingStrategyEnum::register_type();
-		ScriptLoadingGroupEnum::register_type();
+		ScriptLoadingGroupLocationEnum::register_type();
 		TaxonomyEnum::register_type();
 		TaxonomyIdTypeEnum::register_type();
 		TermNodeIdTypeEnum::register_type();

--- a/src/Type/Enum/ScriptLoadingGroupEnum.php
+++ b/src/Type/Enum/ScriptLoadingGroupEnum.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Register the ScriptLoadingGroupEnum Type to the Schema
+ *
+ * @package WPGraphQL\Type\Enum
+ * @since TBD
+ */
+
+namespace WPGraphQL\Type\Enum;
+
+/**
+ * Class ScriptLoadingGroupEnum
+ */
+class ScriptLoadingGroupEnum {
+
+	/**
+	 * Register the ScriptLoadingStrategy Enum Type to the Schema
+	 *
+	 * @return void
+	 */
+	public static function register_type() {
+		register_graphql_enum_type(
+			'ScriptLoadingGroupEnum',
+			[
+				'description' => __( 'Locations for script to be loaded', 'wp-graphql' ),
+				'values'      => [
+					'HEADER' => [
+						'value'       => 0,
+						'description' => __( 'Script to be loaded in document `<head>` tags', 'wp-graphql' ),
+					],
+					'FOOTER' => [
+						'value'       => 1,
+						'description' => __( 'Script to be loaded in document at right before the closing `<body>` tag', 'wp-graphql' ),
+					],
+				],
+			]
+		);
+	}
+}

--- a/src/Type/Enum/ScriptLoadingGroupEnum.php
+++ b/src/Type/Enum/ScriptLoadingGroupEnum.php
@@ -22,15 +22,15 @@ class ScriptLoadingGroupEnum {
 		register_graphql_enum_type(
 			'ScriptLoadingGroupEnum',
 			[
-				'description' => __( 'Locations for script to be loaded', 'wp-graphql' ),
+				'description' => __( 'Location in the document where the script to be loaded', 'wp-graphql' ),
 				'values'      => [
 					'HEADER' => [
 						'value'       => 0,
-						'description' => __( 'Script to be loaded in document `<head>` tags', 'wp-graphql' ),
+						'description' => __( 'A script to be loaded in document `<head>` tag', 'wp-graphql' ),
 					],
 					'FOOTER' => [
 						'value'       => 1,
-						'description' => __( 'Script to be loaded in document at right before the closing `<body>` tag', 'wp-graphql' ),
+						'description' => __( 'A script to be loaded in document at right before the closing `<body>` tag', 'wp-graphql' ),
 					],
 				],
 			]

--- a/src/Type/Enum/ScriptLoadingGroupLocationEnum.php
+++ b/src/Type/Enum/ScriptLoadingGroupLocationEnum.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Register the ScriptLoadingGroupEnum Type to the Schema
+ * Register the ScriptLoadingGroupLocationEnum Type to the Schema
  *
  * @package WPGraphQL\Type\Enum
  * @since TBD
@@ -9,9 +9,9 @@
 namespace WPGraphQL\Type\Enum;
 
 /**
- * Class ScriptLoadingGroupEnum
+ * Class ScriptLoadingGroupLocationEnum
  */
-class ScriptLoadingGroupEnum {
+class ScriptLoadingGroupLocationEnum {
 
 	/**
 	 * Register the ScriptLoadingStrategy Enum Type to the Schema
@@ -20,7 +20,7 @@ class ScriptLoadingGroupEnum {
 	 */
 	public static function register_type() {
 		register_graphql_enum_type(
-			'ScriptLoadingGroupEnum',
+			'ScriptLoadingGroupLocationEnum',
 			[
 				'description' => __( 'Location in the document where the script to be loaded', 'wp-graphql' ),
 				'values'      => [

--- a/src/Type/InterfaceType/EnqueuedAsset.php
+++ b/src/Type/InterfaceType/EnqueuedAsset.php
@@ -125,14 +125,10 @@ class EnqueuedAsset {
 						},
 					],
 					'group'        => [
-						'type'        => 'Integer',
+						'type'        => 'Int',
 						'description' => __( 'The loading group to which this asset belongs.', 'wp-graphql' ),
 						'resolve'     => static function ( $asset ) {
-							if ( ! isset( $asset->extra['group'] ) ) {
-								return 0;
-							}
-
-							return absint( $asset->extra['group'] );
+							return isset( $asset->extra['group'] ) ? (int) $asset->extra['group'] : null;
 						},
 					],
 				],

--- a/src/Type/InterfaceType/EnqueuedAsset.php
+++ b/src/Type/InterfaceType/EnqueuedAsset.php
@@ -124,6 +124,17 @@ class EnqueuedAsset {
 							return isset( $asset->extra['data'] ) ? $asset->extra['data'] : null;
 						},
 					],
+					'group'        => [
+						'type'        => 'Integer',
+						'description' => __( 'The loading group to which this asset belongs.', 'wp-graphql' ),
+						'resolve'     => static function ( $asset ) {
+							if ( ! isset( $asset->extra['group'] ) ) {
+								return 0;
+							}
+
+							return absint( $asset->extra['group'] );
+						},
+					],
 				],
 			]
 		);

--- a/src/Type/ObjectType/EnqueuedScript.php
+++ b/src/Type/ObjectType/EnqueuedScript.php
@@ -56,6 +56,17 @@ class EnqueuedScript {
 							return $script->extra['strategy'];
 						},
 					],
+					'location'     => [
+						'type'        => 'ScriptLoadingGroupEnum',
+						'description' => __( 'The location where this script should be loaded', 'wp-graphql' ),
+						'resolve'     => static function ( \_WP_Dependency $script ) {
+							if ( ! isset( $script->extra['group'] ) ) {
+								return 0;
+							}
+
+							return absint( $script->extra['group'] );
+						},
+					],
 					'version'      => [
 						'description' => __( 'The version of the enqueued script', 'wp-graphql' ),
 						'resolve'     => static function ( \_WP_Dependency $script ) {

--- a/src/Type/ObjectType/EnqueuedScript.php
+++ b/src/Type/ObjectType/EnqueuedScript.php
@@ -57,7 +57,7 @@ class EnqueuedScript {
 						},
 					],
 					'groupLocation' => [
-						'type'        => 'ScriptLoadingGroupEnum',
+						'type'        => 'ScriptLoadingGroupLocationEnum',
 						'description' => __( 'The location where this script should be loaded', 'wp-graphql' ),
 						'resolve'     => static function ( \_WP_Dependency $script ) {
 							return isset( $script->extra['group'] ) ? (int) $script->extra['group'] : 0;

--- a/src/Type/ObjectType/EnqueuedScript.php
+++ b/src/Type/ObjectType/EnqueuedScript.php
@@ -23,18 +23,18 @@ class EnqueuedScript {
 				'description' => __( 'Script enqueued by the CMS', 'wp-graphql' ),
 				'interfaces'  => [ 'Node', 'EnqueuedAsset' ],
 				'fields'      => [
-					'id'           => [
+					'id'            => [
 						'type'        => [ 'non_null' => 'ID' ],
 						'description' => __( 'The global ID of the enqueued script', 'wp-graphql' ),
 						'resolve'     => static function ( $asset ) {
 							return isset( $asset->handle ) ? Relay::toGlobalId( 'enqueued_script', $asset->handle ) : null;
 						},
 					],
-					'dependencies' => [
+					'dependencies'  => [
 						'type'        => [ 'list_of' => 'EnqueuedScript' ],
 						'description' => __( 'Dependencies needed to use this asset', 'wp-graphql' ),
 					],
-					'extraData'    => [
+					'extraData'     => [
 						'type'        => 'String',
 						'description' => __( 'Extra data supplied to the enqueued script', 'wp-graphql' ),
 						'resolve'     => static function ( \_WP_Dependency $script ) {
@@ -45,7 +45,7 @@ class EnqueuedScript {
 							return $script->extra['data'];
 						},
 					],
-					'strategy'     => [
+					'strategy'      => [
 						'type'        => 'ScriptLoadingStrategyEnum',
 						'description' => __( 'The loading strategy to use on the script tag', 'wp-graphql' ),
 						'resolve'     => static function ( \_WP_Dependency $script ) {
@@ -56,18 +56,14 @@ class EnqueuedScript {
 							return $script->extra['strategy'];
 						},
 					],
-					'location'     => [
+					'groupLocation' => [
 						'type'        => 'ScriptLoadingGroupEnum',
 						'description' => __( 'The location where this script should be loaded', 'wp-graphql' ),
 						'resolve'     => static function ( \_WP_Dependency $script ) {
-							if ( ! isset( $script->extra['group'] ) ) {
-								return 0;
-							}
-
-							return absint( $script->extra['group'] );
+							return isset( $script->extra['group'] ) ? (int) $script->extra['group'] : 0;
 						},
 					],
-					'version'      => [
+					'version'       => [
 						'description' => __( 'The version of the enqueued script', 'wp-graphql' ),
 						'resolve'     => static function ( \_WP_Dependency $script ) {
 							/** @var \WP_Scripts $wp_scripts */

--- a/tests/wpunit/RegisteredScriptConnectionQueriesTest.php
+++ b/tests/wpunit/RegisteredScriptConnectionQueriesTest.php
@@ -40,6 +40,8 @@ class RegisteredScriptConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WP
 							handle
 						}
 						extraData
+						group
+						groupLocation
 						handle
 						id
 						src
@@ -52,6 +54,12 @@ class RegisteredScriptConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WP
 	}
 
 	public function testForwardPagination() {
+		// Mocks the values of the ScriptLoadingGroupEnum.
+		$location_enum_mock = [
+			0 => 'HEADER',
+			1 => 'FOOTER',
+		];
+
 		wp_set_current_user( $this->admin );
 		$query = $this->getQuery();
 
@@ -76,11 +84,14 @@ class RegisteredScriptConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WP
 		$expected_after  = ! empty( $expected->extra['after'] ) ? ( array_filter( $expected->extra['after'], 'is_string' ) ?: null ) : null;
 		$expected_before = ! empty( $expected->extra['before'] ) ? ( array_filter( $expected->extra['before'], 'is_string' ) ?: null ) : null;
 
+
 		$this->assertEquals( $expected_after, $actual['data']['registeredScripts']['nodes'][0]['after'] );
 		$this->assertEquals( $expected_before, $actual['data']['registeredScripts']['nodes'][0]['before'] );
 		$this->assertEquals( ! empty( $expected->extra['conditional'] ) ? $expected->extra['conditional'] : null, $actual['data']['registeredScripts']['nodes'][0]['conditional'] );
 		$this->assertEquals( $expected->handle, $actual['data']['registeredScripts']['nodes'][0]['handle'] );
 		$this->assertEquals( ! empty( $expected->extra['data'] ) ? $expected->extra['data'] : null, $actual['data']['registeredScripts']['nodes'][0]['extraData'] );
+		$this->assertEquals( isset( $expected->extra['group'] ) ? (int) $expected->extra['group'] : 0, $actual['data']['registeredScripts']['nodes'][0]['group'] );
+		$this->assertEquals( $location_enum_mock[ isset( $expected->extra['group'] ) ? (int) $expected->extra['group'] : 0 ], $actual['data']['registeredScripts']['nodes'][0]['groupLocation'] );
 		$this->assertEquals( $expected->src, $actual['data']['registeredScripts']['nodes'][0]['src'] );
 		$this->assertEquals( ! empty( $expected->extra['strategy'] ) ? WPEnumType::get_safe_name( $expected->extra['strategy'] ) : null, $actual['data']['registeredScripts']['nodes'][0]['strategy'] );
 		$this->assertEquals( $expected->ver ?: $wp_scripts->default_version, $actual['data']['registeredScripts']['nodes'][0]['version'] );

--- a/tests/wpunit/RegisteredScriptConnectionQueriesTest.php
+++ b/tests/wpunit/RegisteredScriptConnectionQueriesTest.php
@@ -54,7 +54,7 @@ class RegisteredScriptConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WP
 	}
 
 	public function testForwardPagination() {
-		// Mocks the values of the ScriptLoadingGroupEnum.
+		// Mocks the values of the ScriptLoadingGroupLocationEnum.
 		$location_enum_mock = [
 			0 => 'HEADER',
 			1 => 'FOOTER',

--- a/tests/wpunit/RegisteredStylesheetConnectionQueriesTest.php
+++ b/tests/wpunit/RegisteredStylesheetConnectionQueriesTest.php
@@ -36,6 +36,7 @@ class RegisteredStylesheetConnectionQueriesTest extends \Tests\WPGraphQL\TestCas
 						dependencies {
 							handle
 						}
+						group
 						handle
 						isRtl
 						media
@@ -76,6 +77,7 @@ class RegisteredStylesheetConnectionQueriesTest extends \Tests\WPGraphQL\TestCas
 		$expected = $wp_styles->registered[ $actual['data']['registeredStylesheets']['nodes'][0]['handle'] ];
 
 		$this->assertEquals( ! empty( $expected->extra['conditional'] ) ? $expected->extra['conditional'] : null, $actual['data']['registeredStylesheets']['nodes'][0]['conditional'] );
+		$this->assertEquals( isset( $expected->extra['group'] ) ? $expected->extra['group'] : null, $actual['data']['registeredStylesheets']['nodes'][0]['group'] );
 		$this->assertEquals( $expected->handle, $actual['data']['registeredStylesheets']['nodes'][0]['handle'] );
 		$this->assertEquals( ! empty( $expected->extra['rtl'] ), $actual['data']['registeredStylesheets']['nodes'][0]['isRtl'] );
 		$this->assertEquals( $expected->args ?: 'all', $actual['data']['registeredStylesheets']['nodes'][0]['media'] );


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR adds support for exposing the `WP_Dependency->extra['group']` field to the Schema. This field is useful for developers trying to imitate WordPress's frontend, and load their assets at the correct point in the rendered document.

Cherrypicked from #3169 (with some changes noted below - @kidunot89 see bd1627b9c51257b9c6610c7d9b3ec123eeca06e2)

### What's Included
- Exposes the `EnqueuedAsset.group` field, which returns the `Int` value of `$asset->extra['group']`
  - Change from #3169: If unset, this will return `null` for fidelity with WordPress, instead of cast to a default `0`
- Exposes the `EnqueuedScript.groupLocation` field, which returns a `ScriptLoadingGroupEnum` corresponding to header/footer scripts. This semantic meaning is _for DX simplicity only_ (WordPress internally uses `int`s).
  - Change from #3169: renamed from `location` to `groupLocation` to make it clearer that this is a derived value.

Tests (missing from #3169) have been added as well.

Does this close any currently open issues?
------------------------------------------
<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
<!-- (If it’s long, please paste to https://ghostbin.com/ and insert the link here.) -->


Any other comments?
-------------------
This is parceled off from #3169 so it can be reviewed/merged while more investigation continues on the best ways to fix missing assets/dependencies.


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (wsl2+ devilbox + PHP 8.1.14)

**WordPress Version:** 6.6.1
