### PR TITLE
fix: ensure connectedTerms returns terms for the specified taxonomy only

### DIFF
--- a/src/Data/Connection/TermObjectConnectionResolver.php
+++ b/src/Data/Connection/TermObjectConnectionResolver.php
@@ -35,7 +35,12 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 	 */
 	protected function prepare_query_args( array $args ): array {
 		$all_taxonomies = \WPGraphQL::get_allowed_taxonomies();
-		$taxonomy       = ! empty( $this->taxonomy ) && in_array( $this->taxonomy, $all_taxonomies, true ) ? [ $this->taxonomy ] : $all_taxonomies;
+
+		if ( ! is_array( $this->taxonomy ) ) {
+			$taxonomy = ! empty( $this->taxonomy ) && in_array( $this->taxonomy, $all_taxonomies, true ) ? [ $this->taxonomy ] : $all_taxonomies;
+		} else {
+			$taxonomy = $this->taxonomy;
+		}
 
 		if ( ! empty( $args['where']['taxonomies'] ) ) {
 			/**


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This fixes a bug where the connectedTerms connection was returning terms of any taxonomy instead of a specific relevant taxonomy.

- [Failing Test](https://github.com/wp-graphql/wp-graphql/actions/runs/10688931102/job/29630077623#step:7:882)
- [Passing Test](https://github.com/wp-graphql/wp-graphql/actions/runs/10688938581/job/29630508452)

Does this close any currently open issues?
------------------------------------------
closes #3200 

Any other comments?
-------------------

### Before

Querying for connected terms from a category was returning both category and tag nodes:

![CleanShot 2024-09-03 at 14 54 20@2x](https://github.com/user-attachments/assets/6287f959-bf60-4dc2-8c6c-96afcc877dce)

### After

Querying for connected terms from a category returns just category nodes:

![CleanShot 2024-09-03 at 14 52 49@2x](https://github.com/user-attachments/assets/bd60d0f4-dd8e-40a9-84d4-9938ce785cfe)
