### PR TITLE
Feat/make admin notices a singleton

### DIFF
--- a/access-functions.php
+++ b/access-functions.php
@@ -974,11 +974,6 @@ function register_graphql_admin_notice( string $slug, array $config ): void {
  * @return array|mixed[][] An array of admin notices
  */
 function get_graphql_admin_notices() {
-
-	if ( ! is_admin() ) {
-		return [];
-	}
-
 	$admin_notices = \WPGraphQL\Admin\AdminNotices::get_instance();
 	return $admin_notices->get_admin_notices();
 }

--- a/access-functions.php
+++ b/access-functions.php
@@ -967,3 +967,18 @@ function register_graphql_admin_notice( string $slug, array $config ): void {
 		}
 	);
 }
+
+/**
+ * Get the admin notices registered for the WPGraphQL plugin screens
+ *
+ * @return array|mixed[][] An array of admin notices
+ */
+function get_graphql_admin_notices() {
+
+	if ( ! is_admin() ) {
+		return [];
+	}
+
+	$admin_notices = \WPGraphQL\Admin\AdminNotices::get_instance();
+	return $admin_notices->get_admin_notices();
+}

--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -43,8 +43,7 @@ class Admin {
 		$this->admin_enabled    = apply_filters( 'graphql_show_admin', true );
 		$this->graphiql_enabled = apply_filters( 'graphql_enable_graphiql', get_graphql_setting( 'graphiql_enabled', true ) );
 
-		$admin_notices = new AdminNotices();
-		$admin_notices->init();
+		AdminNotices::get_instance();
 
 		// This removes the menu page for WPGraphiQL as it's now built into WPGraphQL
 		if ( $this->graphiql_enabled ) {

--- a/src/Admin/AdminNotices.php
+++ b/src/Admin/AdminNotices.php
@@ -44,12 +44,12 @@ class AdminNotices {
 	/**
 	 * Prevent cloning the instance
 	 */
-	private function __clone() {}
+	public function __clone() {}
 
 	/**
 	 * Prevent unserializing the instance
 	 */
-	private function __wakeup() {}
+	public function __wakeup() {}
 
 	/**
 	 * Get the singleton instance of the class

--- a/src/Admin/AdminNotices.php
+++ b/src/Admin/AdminNotices.php
@@ -16,6 +16,13 @@ namespace WPGraphQL\Admin;
 class AdminNotices {
 
 	/**
+	 * Stores the singleton instance of the class
+	 *
+	 * @var self|null
+	 */
+	private static $instance = null;
+
+	/**
 	 * Stores the admin notices to display
 	 *
 	 * @var array<string,array<string,mixed>>
@@ -26,6 +33,34 @@ class AdminNotices {
 	 * @var array<string>
 	 */
 	protected $dismissed_notices = [];
+
+	/**
+	 * Private constructor to prevent direct instantiation
+	 */
+	private function __construct() {
+		// Initialize the class (can move code from init() here if desired)
+	}
+
+	/**
+	 * Prevent cloning the instance
+	 */
+	private function __clone() {}
+
+	/**
+	 * Prevent unserializing the instance
+	 */
+	private function __wakeup() {}
+
+	/**
+	 * Get the singleton instance of the class
+	 */
+	public static function get_instance(): self {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+			self::$instance->init();
+		}
+		return self::$instance;
+	}
 
 	/**
 	 * Initialize the Admin Notices class
@@ -206,8 +241,8 @@ class AdminNotices {
 
 		foreach ( $menu as $key => $item ) {
 			if ( 'graphiql-ide' === $item[2] ) {
-				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-				$menu[ $key ][0] .= ' <span class="update-plugins count-' . absint( $notice_count ) . '>"><span class="plugin-count">' . absint( $notice_count ) . '</span></span>';
+                // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+				$menu[ $key ][0] .= ' <span class="update-plugins count-' . absint( $notice_count ) . '"><span class="plugin-count">' . absint( $notice_count ) . '</span></span>';
 				break;
 			}
 		}

--- a/tests/wpunit/AdminNoticesTest.php
+++ b/tests/wpunit/AdminNoticesTest.php
@@ -48,6 +48,30 @@ class AdminNoticesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->assertSame($config, $notices[$slug]);
 	}
 
+    /**
+     * Test adding and retrieving admin notices.
+     */
+    public function testGetAdminNotices(): void {
+        $adminNotices = AdminNotices::get_instance();
+
+        $slug = 'test-notice';
+        $config = [
+            'message' => 'Test Notice Message',
+            'type' => 'warning',
+            'is_dismissable' => true
+        ];
+
+        $adminNotices->add_admin_notice($slug, $config);
+
+        $notices = $adminNotices->get_admin_notices();
+        $this->assertArrayHasKey($slug, $notices);
+        $this->assertSame($config, $notices[$slug]);
+
+        $get_admin_notices = get_graphql_admin_notices();
+
+        $this->assertSame($get_admin_notices, $notices);
+    }
+
 	/**
 	 * Test removing admin notices.
 	 */

--- a/tests/wpunit/AdminNoticesTest.php
+++ b/tests/wpunit/AdminNoticesTest.php
@@ -21,8 +21,7 @@ class AdminNoticesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 	 * Test initialization of admin notices.
 	 */
 	public function testInit(): void {
-		$adminNotices = new AdminNotices();
-		$adminNotices->init();
+		AdminNotices::get_instance();
 
 		// Assertions to ensure actions are hooked correctly
 		// This might require functional testing or integration testing setup
@@ -33,7 +32,7 @@ class AdminNoticesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 	 * Test adding and retrieving admin notices.
 	 */
 	public function testAddAndGetAdminNotices(): void {
-		$adminNotices = new AdminNotices();
+		$adminNotices = AdminNotices::get_instance();
 
 		$slug = 'test-notice';
 		$config = [
@@ -53,7 +52,7 @@ class AdminNoticesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 	 * Test removing admin notices.
 	 */
 	public function testRemoveAdminNotices(): void {
-		$adminNotices = new AdminNotices();
+        $adminNotices = AdminNotices::get_instance();
 
 		$slug = 'test-notice';
 		$config = ['message' => 'Test Notice Message'];


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This updates the WPGraphQL/Admin/AdminNotice to be a Singleton, and introduces the `get_graphql_admin_notices()` function.


Does this close any currently open issues?
------------------------------------------
no

