### PR TITLE
feat: expose commenter edge fields

### DIFF
--- a/access-functions.php
+++ b/access-functions.php
@@ -974,11 +974,6 @@ function register_graphql_admin_notice( string $slug, array $config ): void {
  * @return array|mixed[][] An array of admin notices
  */
 function get_graphql_admin_notices() {
-
-	if ( ! is_admin() ) {
-		return [];
-	}
-
 	$admin_notices = \WPGraphQL\Admin\AdminNotices::get_instance();
 	return $admin_notices->get_admin_notices();
 }

--- a/access-functions.php
+++ b/access-functions.php
@@ -967,3 +967,18 @@ function register_graphql_admin_notice( string $slug, array $config ): void {
 		}
 	);
 }
+
+/**
+ * Get the admin notices registered for the WPGraphQL plugin screens
+ *
+ * @return array|mixed[][] An array of admin notices
+ */
+function get_graphql_admin_notices() {
+
+	if ( ! is_admin() ) {
+		return [];
+	}
+
+	$admin_notices = \WPGraphQL\Admin\AdminNotices::get_instance();
+	return $admin_notices->get_admin_notices();
+}

--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -43,8 +43,7 @@ class Admin {
 		$this->admin_enabled    = apply_filters( 'graphql_show_admin', true );
 		$this->graphiql_enabled = apply_filters( 'graphql_enable_graphiql', get_graphql_setting( 'graphiql_enabled', true ) );
 
-		$admin_notices = new AdminNotices();
-		$admin_notices->init();
+		AdminNotices::get_instance();
 
 		// This removes the menu page for WPGraphiQL as it's now built into WPGraphQL
 		if ( $this->graphiql_enabled ) {

--- a/src/Admin/AdminNotices.php
+++ b/src/Admin/AdminNotices.php
@@ -44,12 +44,12 @@ class AdminNotices {
 	/**
 	 * Prevent cloning the instance
 	 */
-	private function __clone() {}
+	public function __clone() {}
 
 	/**
 	 * Prevent unserializing the instance
 	 */
-	private function __wakeup() {}
+	public function __wakeup() {}
 
 	/**
 	 * Get the singleton instance of the class

--- a/src/Admin/AdminNotices.php
+++ b/src/Admin/AdminNotices.php
@@ -16,6 +16,13 @@ namespace WPGraphQL\Admin;
 class AdminNotices {
 
 	/**
+	 * Stores the singleton instance of the class
+	 *
+	 * @var self|null
+	 */
+	private static $instance = null;
+
+	/**
 	 * Stores the admin notices to display
 	 *
 	 * @var array<string,array<string,mixed>>
@@ -26,6 +33,34 @@ class AdminNotices {
 	 * @var array<string>
 	 */
 	protected $dismissed_notices = [];
+
+	/**
+	 * Private constructor to prevent direct instantiation
+	 */
+	private function __construct() {
+		// Initialize the class (can move code from init() here if desired)
+	}
+
+	/**
+	 * Prevent cloning the instance
+	 */
+	private function __clone() {}
+
+	/**
+	 * Prevent unserializing the instance
+	 */
+	private function __wakeup() {}
+
+	/**
+	 * Get the singleton instance of the class
+	 */
+	public static function get_instance(): self {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+			self::$instance->init();
+		}
+		return self::$instance;
+	}
 
 	/**
 	 * Initialize the Admin Notices class
@@ -206,8 +241,8 @@ class AdminNotices {
 
 		foreach ( $menu as $key => $item ) {
 			if ( 'graphiql-ide' === $item[2] ) {
-				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-				$menu[ $key ][0] .= ' <span class="update-plugins count-' . absint( $notice_count ) . '>"><span class="plugin-count">' . absint( $notice_count ) . '</span></span>';
+                // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+				$menu[ $key ][0] .= ' <span class="update-plugins count-' . absint( $notice_count ) . '"><span class="plugin-count">' . absint( $notice_count ) . '</span></span>';
 				break;
 			}
 		}

--- a/src/Model/Comment.php
+++ b/src/Model/Comment.php
@@ -17,6 +17,8 @@ use WP_Comment;
  * @property string $authorIp
  * @property string $comment_author
  * @property string $comment_author_url
+ * @property string $commentAuthor
+ * @property string $commentAuthorUrl
  * @property string $commentAuthorEmail
  * @property string $contentRaw
  * @property string $contentRendered
@@ -60,6 +62,9 @@ class Comment extends Model {
 			'type',
 			'commentedOnId',
 			'comment_post_ID',
+			'commentAuthorUrl',
+			'commentAuthorEmail',
+			'commentAuthor',
 			'approved',
 			'status',
 			'comment_parent_id',
@@ -122,7 +127,7 @@ class Comment extends Model {
 					return ! empty( $this->data->comment_ID ) ? $this->data->comment_ID : 0;
 				},
 				'commentAuthorEmail' => function () {
-					return ! empty( $this->data->comment_author_email ) ? $this->data->comment_author_email : 0;
+					return current_user_can( 'moderate_comments' ) && ! empty( $this->data->comment_author_email ) ? $this->data->comment_author_email : null;
 				},
 				'comment_ID'         => function () {
 					return ! empty( $this->data->comment_ID ) ? absint( $this->data->comment_ID ) : 0;
@@ -140,10 +145,16 @@ class Comment extends Model {
 					return ! empty( $this->comment_parent_id ) ? Relay::toGlobalId( 'comment', $this->data->comment_parent ) : null;
 				},
 				'comment_author'     => function () {
-					return ! empty( $this->data->comment_author ) ? absint( $this->data->comment_author ) : null;
+					return ! empty( $this->data->comment_author ) ? $this->data->comment_author : null;
 				},
 				'comment_author_url' => function () {
-					return ! empty( $this->data->comment_author_url ) ? absint( $this->data->comment_author_url ) : null;
+					return ! empty( $this->data->comment_author_url ) ? $this->data->comment_author_url : null;
+				},
+				'commentAuthor'      => function () {
+					return ! empty( $this->data->comment_author ) ? $this->data->comment_author : null;
+				},
+				'commentAuthorUrl'   => function () {
+					return ! empty( $this->data->comment_author_url ) ? $this->data->comment_author_url : null;
 				},
 				'authorIp'           => function () {
 					return ! empty( $this->data->comment_author_IP ) ? $this->data->comment_author_IP : null;

--- a/src/Type/ObjectType/Comment.php
+++ b/src/Type/ObjectType/Comment.php
@@ -30,21 +30,28 @@ class Comment {
 						'description' => __( 'The author of the comment', 'wp-graphql' ),
 						'oneToOne'    => true,
 						'edgeFields'  => [
-							'name'  => [
-								'type'        => 'String',
-								'description' => __( 'The display name of the comment author for this particular comment', 'wp-graphql' ),
-								'resolve'     => static function ( $edge ) {
-									return $edge['source']->commentAuthor;
-								},
-							],
-							'email' => [
+							'email'     => [
 								'type'        => 'String',
 								'description' => __( 'The email address representing the author for this particular comment', 'wp-graphql' ),
 								'resolve'     => static function ( $edge ) {
 									return $edge['source']->commentAuthorEmail ?: null;
 								},
 							],
-							'url'   => [
+							'ipAddress' => [
+								'type'        => 'String',
+								'description' => __( 'IP address of the author at the time of making this comment. This field is equivalent to WP_Comment->comment_author_IP and the value matching the "comment_author_IP" column in SQL.', 'wp-graphql' ),
+								'resolve'     => static function ( $edge ) {
+									return $edge['source']->authorIp ?: null;
+								},
+							],
+							'name'      => [
+								'type'        => 'String',
+								'description' => __( 'The display name of the comment author for this particular comment', 'wp-graphql' ),
+								'resolve'     => static function ( $edge ) {
+									return $edge['source']->commentAuthor;
+								},
+							],
+							'url'       => [
 								'type'        => 'String',
 								'description' => __( 'The url entered for the comment author on this particular comment', 'wp-graphql' ),
 								'resolve'     => static function ( $edge ) {
@@ -87,8 +94,9 @@ class Comment {
 						},
 					],
 					'authorIp'         => [
-						'type'        => 'String',
-						'description' => __( 'IP address for the author. This field is equivalent to WP_Comment->comment_author_IP and the value matching the "comment_author_IP" column in SQL.', 'wp-graphql' ),
+						'type'              => 'String',
+						'deprecationReason' => __( 'Use the ipAddress field on the edge between the comment and author', 'wp-graphql' ),
+						'description'       => __( 'IP address for the author at the time of commenting. This field is equivalent to WP_Comment->comment_author_IP and the value matching the "comment_author_IP" column in SQL.', 'wp-graphql' ),
 					],
 					'commentId'        => [
 						'type'              => 'Int',

--- a/src/Type/ObjectType/Comment.php
+++ b/src/Type/ObjectType/Comment.php
@@ -29,6 +29,29 @@ class Comment {
 						'toType'      => 'Commenter',
 						'description' => __( 'The author of the comment', 'wp-graphql' ),
 						'oneToOne'    => true,
+						'edgeFields'  => [
+							'name'  => [
+								'type'        => 'String',
+								'description' => __( 'The display name of the comment author for this particular comment', 'wp-graphql' ),
+								'resolve'     => static function ( $edge ) {
+									return $edge['source']->commentAuthor;
+								},
+							],
+							'email' => [
+								'type'        => 'String',
+								'description' => __( 'The email address representing the author for this particular comment', 'wp-graphql' ),
+								'resolve'     => static function ( $edge ) {
+									return $edge['source']->commentAuthorEmail ?: null;
+								},
+							],
+							'url'   => [
+								'type'        => 'String',
+								'description' => __( 'The url entered for the comment author on this particular comment', 'wp-graphql' ),
+								'resolve'     => static function ( $edge ) {
+									return $edge['source']->commentAuthorUrl ?: null;
+								},
+							],
+						],
 						'resolve'     => static function ( $comment, $_args, AppContext $context ) {
 							$node = null;
 

--- a/tests/wpunit/AdminNoticesTest.php
+++ b/tests/wpunit/AdminNoticesTest.php
@@ -48,6 +48,30 @@ class AdminNoticesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->assertSame($config, $notices[$slug]);
 	}
 
+    /**
+     * Test adding and retrieving admin notices.
+     */
+    public function testGetAdminNotices(): void {
+        $adminNotices = AdminNotices::get_instance();
+
+        $slug = 'test-notice';
+        $config = [
+            'message' => 'Test Notice Message',
+            'type' => 'warning',
+            'is_dismissable' => true
+        ];
+
+        $adminNotices->add_admin_notice($slug, $config);
+
+        $notices = $adminNotices->get_admin_notices();
+        $this->assertArrayHasKey($slug, $notices);
+        $this->assertSame($config, $notices[$slug]);
+
+        $get_admin_notices = get_graphql_admin_notices();
+
+        $this->assertSame($get_admin_notices, $notices);
+    }
+
 	/**
 	 * Test removing admin notices.
 	 */

--- a/tests/wpunit/AdminNoticesTest.php
+++ b/tests/wpunit/AdminNoticesTest.php
@@ -21,8 +21,7 @@ class AdminNoticesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 	 * Test initialization of admin notices.
 	 */
 	public function testInit(): void {
-		$adminNotices = new AdminNotices();
-		$adminNotices->init();
+		AdminNotices::get_instance();
 
 		// Assertions to ensure actions are hooked correctly
 		// This might require functional testing or integration testing setup
@@ -33,7 +32,7 @@ class AdminNoticesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 	 * Test adding and retrieving admin notices.
 	 */
 	public function testAddAndGetAdminNotices(): void {
-		$adminNotices = new AdminNotices();
+		$adminNotices = AdminNotices::get_instance();
 
 		$slug = 'test-notice';
 		$config = [
@@ -53,7 +52,7 @@ class AdminNoticesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 	 * Test removing admin notices.
 	 */
 	public function testRemoveAdminNotices(): void {
-		$adminNotices = new AdminNotices();
+        $adminNotices = AdminNotices::get_instance();
 
 		$slug = 'test-notice';
 		$config = ['message' => 'Test Notice Message'];

--- a/tests/wpunit/CommentObjectQueriesTest.php
+++ b/tests/wpunit/CommentObjectQueriesTest.php
@@ -465,16 +465,21 @@ class CommentObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 			'comment_post_ID'      => $post_id,
 			'comment_content'      => 'Admin Comment',
 			'comment_author_email' => 'admin@test.com',
+            'comment_author_url'   => 'https://example.com',
 			'comment_author_IP'    => '127.0.0.1',
 			'comment_agent'        => 'Admin Agent',
+            'comment_author'       => 'Admin Name',
+
 		];
 		$admin_comment      = $this->createCommentObject( $admin_args );
 		$subscriber_args    = [
 			'comment_post_ID'      => $post_id,
 			'comment_content'      => 'Subscriber Comment',
-			'comment_author_email' => 'subscriber@test.com',
+			'comment_author_email' => 'subscriber@example.com',
+            'comment_author_url'   => 'https://example.com',
 			'comment_author_IP'    => '127.0.0.1',
 			'comment_agent'        => 'Subscriber Agent',
+            'comment_author'       => 'Subscriber Name',
 		];
 		$subscriber_comment = $this->createCommentObject( $subscriber_args );
 
@@ -497,6 +502,14 @@ class CommentObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 						}
 					}
 				}
+				author {
+				  name
+				  email
+				  url
+				  node {
+				    __typename
+				  }
+				}
 			}
 		}
 		';
@@ -513,6 +526,10 @@ class CommentObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 		];
 		$subscriber_actual = $this->graphql( compact( 'query', 'variables' ) );
 
+        codecept_debug( [
+            '$subscriber_actual' => $subscriber_actual,
+        ]);
+
 		$this->assertArrayNotHasKey( 'errors', $admin_actual );
 		$this->assertArrayNotHasKey( 'errors', $subscriber_actual );
 
@@ -526,12 +543,17 @@ class CommentObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 		$this->assertEquals( $expected_link, $admin_actual['data']['comment']['link'] );
 		$this->assertEquals( str_ireplace( home_url(), '', $expected_link ), $admin_actual['data']['comment']['uri'] );
 
+        $this->assertEquals( $subscriber_args['comment_author'], $subscriber_actual['data']['comment']['author']['name'] );
+        $this->assertEquals( $subscriber_args['comment_author_url'], $subscriber_actual['data']['comment']['author']['url'] );
+
 		if ( true === $should_display ) {
 			$this->assertNotNull( $admin_actual['data']['comment']['authorIp'] );
 			$this->assertNotNull( $admin_actual['data']['comment']['agent'] );
+            $this->assertSame( $subscriber_args['comment_author_email'], $subscriber_actual['data']['comment']['author']['email'] );
 		} else {
 			$this->assertNull( $admin_actual['data']['comment']['authorIp'] );
 			$this->assertNull( $admin_actual['data']['comment']['agent'] );
+            $this->assertNull( $subscriber_actual['data']['comment']['author']['email'] );
 		}
 	}
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

This introduces new fields on the "Edge" on the `CommentToCommenter` connection:

- name: The display name of the comment author for this particular comment
- url: The url entered for the comment author on this particular comment
- email: The email address representing the author for this particular comment
- ipAddress: IP address of the author at the time of making this comment. 

This allows for the relational data between a Commenter and the Comment to be queried for, in addition to the Commenter node itself. 

### Why?

Comment Authors can be represented by both their User object data _and_ conditional data related to a specific comment.

By exposing this edge data, the client application can combine data from the `User` node and the `Comment.author` edge fields to provide a UI matching similar UIs as the WordPress Dashboard. 

For example:

In the WordPress Dashboard, when moderating comments, the Author is represented as a mix of a User _and_ comment-specific data. 

With these edge fields, we can now query the User that authored the comment as well as the conditional fields specific to the comment:

![CleanShot 2024-09-10 at 13 20 53](https://github.com/user-attachments/assets/0788e3ae-358c-4eb0-9d18-aa24f02f6f2a)


With this data queried at the edge between the Comment and the Author, we could create a UI similar to what is displayed in the WP Admin, where we see some information (avatar, etc) from the User node, and some information (commenter's name) in place of the User's information:


![CleanShot 2024-09-10 at 13 19 25](https://github.com/user-attachments/assets/76ef2f05-9502-4b09-a98c-e5408500d550)

Does this close any currently open issues?
------------------------------------------
closes #3197 
