### PR TITLE
release: v1.29.0

### DIFF
--- a/.github/LABELS.md
+++ b/.github/LABELS.md
@@ -1,0 +1,102 @@
+# Labels
+
+This document describes the labels we use for the main WPGraphQL repository and can be used as a reference for other repositories.
+
+## Global Labels
+
+- `#ffffff` wontfix - *This will not be worked on*
+- `#fcbfe3` good first issue - *Issue that doesn't require previous experience with codebase*
+- `#e03590` close candidate - *Needs confirmation before closing*
+- `#adb5bd` duplicate - *This issue or pull request already exists* (Changed from gray to a lighter gray for better visibility)
+- `#6c757d` invalid? - *Something is not right here* (Changed to a darker gray to distinguish from other grays)
+- `#ced4da` stale? - *May need to be revalidated due to prolonged inactivity* (Changed to an even lighter gray to differentiate within grays)
+- `#d93f0b` regression - *Bug that causes a regression to a previously working feature*
+- `#0e8a16` help wanted - *Issue with a clear description that the community can help with*
+
+## Has
+
+- `#adb5bd` has: workaround - *A temporary workaround has been provided* (Changed to a uniform gray to match other informational labels)
+
+## Compatibility
+
+- `#c82333` compat: breaking change - *This is a breaking change to existing functionality* (Brightened red for urgency)
+- `#e0a800` compat: possible break - *There is a possibility that this might lead to breaking changes, but not confirmed yet* (Changed from a muted red to a clear yellow for caution)
+
+## Level of Effort
+
+- `#dc3545` effort: high - *More than a week* (Brightened to a more urgent red)
+- `#ffc107` effort: med - *Less than a week* (Changed to a standard yellow for moderate effort)
+- `#28a745` effort: low - *Around a day or less* (Standard green for low effort)
+
+## Level of Impact
+
+- `#28a745` impact: high - *Unblocks new use cases, substantial improvement to existing feature, fixes a major bug* (Uniform green for positive impact)
+- `#ffc107` impact: med - *Minor performance improvements, fix broad user base issues* (Yellow for moderate impact)
+- `#f8d7da` impact: low - *Fixes a minor issue for some people, slight DX improvement* (Soft pink for less critical improvements)
+
+# Language
+
+- `#45229e` lang: php - *Pull requests that update PHP code*
+- `#168799` lang: javascript - *Pull requests that update JavaScript code*
+
+## Needs Something
+
+- `#6c757d` needs: discussion - *Requires a discussion to proceed* (Changed to a darker gray for visibility and importance)
+- `#adb5bd` needs: info - *More information is needed to resolve this issue* (Uniform gray for informational needs)
+- `#ced4da` needs: reproduction - *This issue needs to be reproduced independently* (Lighter gray to distinguish from more urgent needs)
+- `#f2994a` needs: reviewer response - *This needs the attention of a codeowner or maintainer*
+- `#56ccf2` needs: author response - *Pending information from the author*
+- `#adb5bd` needs: tests - *Tests should be added to be sure this works as expected* (Uniform gray for consistency)
+
+## Issue Scope
+
+- `#b0c8d9` scope: build scripts - *Automating task runners and compilation processes*
+- `#b8a8d6` scope: code quality - *Refactoring, linting, and enforcing coding standards*
+- `#a8d2a0` scope: dependencies - *Managing, updating, or removing dependencies*
+- `#ded6b0` scope: docs - *Updating, correcting, and improving documentation*
+- `#a8d6d4` scope: extensions - *Integrating plugins, add-ons, or other extensions*
+- `#ded3a0` scope: i18n - *Internationalizing, translating, and localizing*
+- `#a8dbd4` scope: performance - *Enhancing speed and efficiency*
+- `#deb5a0` scope: security - *Securing against vulnerabilities and threats*
+- `#d3b8d6` scope: tests - *Developing unit tests, integration tests, and ensuring coverage*
+- `#5ac5c5` scope: accessibility - *Enhancing accessibility and ensuring compliance with WCAG/ADA standards*
+- `#b8a6d9` scope: graphiql - *Issues related to the GraphiQL interface enhancements or issues.*
+
+## Statuses
+
+- `#28a745` status: actionable - *Ready for work to begin* (Reverted to green for intuitive 'go' signaling)
+- `#dc3545` status: blocked - *Progress halted due to dependencies or issues* (Bright red for critical blockage)
+- `#fd7e14` status: in progress - *Currently being worked on* (Changed to a vibrant orange for visibility)
+- `#17a2b8` status: in review - *Awaiting review before merging or closing* (Changed to a soothing blue to indicate ongoing review)
+
+## Issue Type
+
+- `#d73a4a` type: bug - *Issue that causes incorrect or unexpected behavior*
+- `#fff1bc` type: chore - *Maintenance tasks, refactoring, and other non-functional changes*
+- `#84b6eb` type: enhancement - *Improvements to existing functionality*
+- `#f9ab45` type: feature - *New functionality being added*
+- `#cc317c` type: question - *An issue that involve inquiries, clarifications, or requests for guidance*
+- `#bfdadc` type: spike - *An issue that needs more research before becoming actionable*
+- `#e88bdd` type: release - *Pull request intended for a release*
+- `#005d5d` type: epic - *Large-scale feature or initiative that spans multiple issues and pull requests.*
+
+## Dependencies
+
+These should use the associated branding color
+
+- `#7f54b3` dep: woocommerce - *Integration or compatibility with WooCommerce*
+- `#c9471f` dep: wpml - *Related to WPML for multilingual support*
+- `#b2fe80` dep: acf - *Involving Advanced Custom Fields functionality*
+- `#a8c0d6` dep: polylang - *Integrating Polylang for multilingual support*
+
+## Components
+
+Specific components of the application
+
+- `#fce6c4` component: ________ - *Relating to ________*
+
+## Repo Specific (for now)
+
+### wp-graphql
+
+- `#59f7ad` not stale - *Short circuit stalebot. USE SPARINGLY.*

--- a/.github/workflows/graphiql-e2e-tests.yml
+++ b/.github/workflows/graphiql-e2e-tests.yml
@@ -10,6 +10,9 @@ on:
       - develop
       - master
     paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - 'packages/**'
       - '**.js'
       - '.github/workflows/*.yml'
       - '!docs/**'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 1.29.0
+
+### New Features
+
+- [#3208](https://github.com/wp-graphql/wp-graphql/pull/3208): feat: expose commenter edge fields
+- [#3207](https://github.com/wp-graphql/wp-graphql/pull/3207): feat: introduce get_graphql_admin_notices and convert AdminNotices class to a singleton
+
+### Chores / Bugfixes
+
+- [#3213](https://github.com/wp-graphql/wp-graphql/pull/3213): chore(deps): bump the npm_and_yarn group across 1 directory with 4 updates
+- [#3212](https://github.com/wp-graphql/wp-graphql/pull/3212): chore(deps): bump dset from 3.1.3 to 3.1.4 in the npm_and_yarn group across 1 directory
+- [#3211](https://github.com/wp-graphql/wp-graphql/pull/3211): chore: add LABELS.md
+- [#3201](https://github.com/wp-graphql/wp-graphql/pull/3201): fix: ensure connectedTerms returns terms for the specified taxonomy only
+- [#3199](https://github.com/wp-graphql/wp-graphql/pull/3199): chore(deps-dev): bump the npm_and_yarn group across 1 directory with 2 updates
+
 ## 1.28.1
 
 ### Chores / Bugfixes

--- a/access-functions.php
+++ b/access-functions.php
@@ -967,3 +967,13 @@ function register_graphql_admin_notice( string $slug, array $config ): void {
 		}
 	);
 }
+
+/**
+ * Get the admin notices registered for the WPGraphQL plugin screens
+ *
+ * @return array|mixed[][] An array of admin notices
+ */
+function get_graphql_admin_notices() {
+	$admin_notices = \WPGraphQL\Admin\AdminNotices::get_instance();
+	return $admin_notices->get_admin_notices();
+}

--- a/constants.php
+++ b/constants.php
@@ -18,7 +18,7 @@ function graphql_setup_constants() {
 
 	// Plugin version.
 	if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-		define( 'WPGRAPHQL_VERSION', '1.28.1' );
+		define( 'WPGRAPHQL_VERSION', '1.29.0' );
 	}
 
 	// Plugin Folder Path.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4395,19 +4395,11 @@
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.6.tgz",
       "integrity": "sha512-ymwc+qb1XkjT/gfoQwxIeHZ6ixH23A+tCT2ADSA/DPVKzAjwYkTXBMCQ/f6fe4wEa85Lhp26VPeUxI7wMhAi7A==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
-      }
-    },
-    "node_modules/@types/eslint-scope": {
-      "version": "3.7.7",
-      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
-      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
-      "dev": true,
-      "dependencies": {
-        "@types/eslint": "*",
-        "@types/estree": "*"
       }
     },
     "node_modules/@types/estree": {
@@ -6142,10 +6134,10 @@
         "acorn-walk": "^8.0.2"
       }
     },
-    "node_modules/acorn-import-assertions": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
-      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
       "dev": true,
       "peerDependencies": {
         "acorn": "^8"
@@ -6735,9 +6727,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
-      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.6.tgz",
+      "integrity": "sha512-Ekur6XDwhnJ5RgOCaxFnXyqlPALI3rVeukZMwOdfghW7/wGz784BYKiQq+QD8NPcr91KRo30KfHOchyijwWw7g==",
       "dev": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -7107,9 +7099,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
-      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
       "dev": true,
       "dependencies": {
         "bytes": "3.1.2",
@@ -7120,7 +7112,7 @@
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
-        "qs": "6.11.0",
+        "qs": "6.13.0",
         "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
@@ -9682,9 +9674,9 @@
       }
     },
     "node_modules/dset": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.3.tgz",
-      "integrity": "sha512-20TuZZHCEZ2O71q9/+8BwKwZ0QtD9D8ObhrihJPr+vLLYlSuAU3/zL4cSlgbfeoGHTjCSJBa7NGcrF9/Bx/WJQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
+      "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
       "engines": {
         "node": ">=4"
       }
@@ -9734,9 +9726,9 @@
       }
     },
     "node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "dev": true,
       "engines": {
         "node": ">= 0.8"
@@ -9760,9 +9752,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.16.0.tgz",
-      "integrity": "sha512-O+QWCviPNSSLAD9Ucn8Awv+poAkqn3T1XY5/N7kR7rQO9yfSGWkYZDwpJ+iKF7B8rxaQKWngSqACpgzeapSyoA==",
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
+      "integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
       "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -11152,37 +11144,37 @@
       "dev": true
     },
     "node_modules/express": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
-      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
+      "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
       "dev": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.2",
+        "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
         "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.2.0",
+        "finalhandler": "1.3.1",
         "fresh": "0.5.2",
         "http-errors": "2.0.0",
-        "merge-descriptors": "1.0.1",
+        "merge-descriptors": "1.0.3",
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.7",
+        "path-to-regexp": "0.1.10",
         "proxy-addr": "~2.0.7",
-        "qs": "6.11.0",
+        "qs": "6.13.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.18.0",
-        "serve-static": "1.15.0",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
         "setprototypeof": "1.2.0",
         "statuses": "2.0.1",
         "type-is": "~1.6.18",
@@ -11462,13 +11454,13 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
-      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
       "dev": true,
       "dependencies": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
@@ -16857,10 +16849,13 @@
       }
     },
     "node_modules/merge-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
-      "dev": true
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -18323,9 +18318,9 @@
       "dev": true
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
+      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
       "dev": true
     },
     "node_modules/path-type": {
@@ -19520,12 +19515,12 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
       "dev": true,
       "dependencies": {
-        "side-channel": "^1.0.4"
+        "side-channel": "^1.0.6"
       },
       "engines": {
         "node": ">=0.6"
@@ -21016,9 +21011,9 @@
       }
     },
     "node_modules/send": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
       "dev": true,
       "dependencies": {
         "debug": "2.6.9",
@@ -21053,6 +21048,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
+    },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/send/node_modules/mime": {
       "version": "1.6.0",
@@ -21178,15 +21182,15 @@
       }
     },
     "node_modules/serve-static": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
-      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
       "dev": true,
       "dependencies": {
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
-        "send": "0.18.0"
+        "send": "0.19.0"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -23516,21 +23520,20 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.91.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.91.0.tgz",
-      "integrity": "sha512-rzVwlLeBWHJbmgTC/8TvAcu5vpJNII+MelQpylD4jNERPwpBJOE2lEcko1zJX3QJeLjTTAnQxn/OJ8bjDzVQaw==",
+      "version": "5.94.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
+      "integrity": "sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==",
       "dev": true,
       "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.5",
         "@webassemblyjs/ast": "^1.12.1",
         "@webassemblyjs/wasm-edit": "^1.12.1",
         "@webassemblyjs/wasm-parser": "^1.12.1",
         "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.9.0",
+        "acorn-import-attributes": "^1.9.5",
         "browserslist": "^4.21.10",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.16.0",
+        "enhanced-resolve": "^5.17.1",
         "es-module-lexer": "^1.2.1",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -282,6 +282,22 @@ Composer dependencies are no longer versioned in Github. Recommended install sou
 
 == Changelog ==
 
+= 1.29.0 =
+
+**New Features**
+
+- [#3208](https://github.com/wp-graphql/wp-graphql/pull/3208): feat: expose commenter edge fields
+- [#3207](https://github.com/wp-graphql/wp-graphql/pull/3207): feat: introduce get_graphql_admin_notices and convert AdminNotices class to a singleton
+
+**Chores / Bugfixes**
+
+- [#3213](https://github.com/wp-graphql/wp-graphql/pull/3213): chore(deps): bump the npm_and_yarn group across 1 directory with 4 updates
+- [#3212](https://github.com/wp-graphql/wp-graphql/pull/3212): chore(deps): bump dset from 3.1.3 to 3.1.4 in the npm_and_yarn group across 1 directory
+- [#3211](https://github.com/wp-graphql/wp-graphql/pull/3211): chore: add LABELS.md
+- [#3201](https://github.com/wp-graphql/wp-graphql/pull/3201): fix: ensure connectedTerms returns terms for the specified taxonomy only
+- [#3199](https://github.com/wp-graphql/wp-graphql/pull/3199): chore(deps-dev): bump the npm_and_yarn group across 1 directory with 2 updates
+
+
 = 1.28.1 =
 
 **Chores / Bugfixes**

--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -43,8 +43,7 @@ class Admin {
 		$this->admin_enabled    = apply_filters( 'graphql_show_admin', true );
 		$this->graphiql_enabled = apply_filters( 'graphql_enable_graphiql', get_graphql_setting( 'graphiql_enabled', true ) );
 
-		$admin_notices = new AdminNotices();
-		$admin_notices->init();
+		AdminNotices::get_instance();
 
 		// This removes the menu page for WPGraphiQL as it's now built into WPGraphQL
 		if ( $this->graphiql_enabled ) {

--- a/src/Admin/AdminNotices.php
+++ b/src/Admin/AdminNotices.php
@@ -16,6 +16,13 @@ namespace WPGraphQL\Admin;
 class AdminNotices {
 
 	/**
+	 * Stores the singleton instance of the class
+	 *
+	 * @var self|null
+	 */
+	private static $instance = null;
+
+	/**
 	 * Stores the admin notices to display
 	 *
 	 * @var array<string,array<string,mixed>>
@@ -26,6 +33,34 @@ class AdminNotices {
 	 * @var array<string>
 	 */
 	protected $dismissed_notices = [];
+
+	/**
+	 * Private constructor to prevent direct instantiation
+	 */
+	private function __construct() {
+		// Initialize the class (can move code from init() here if desired)
+	}
+
+	/**
+	 * Prevent cloning the instance
+	 */
+	public function __clone() {}
+
+	/**
+	 * Prevent unserializing the instance
+	 */
+	public function __wakeup() {}
+
+	/**
+	 * Get the singleton instance of the class
+	 */
+	public static function get_instance(): self {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+			self::$instance->init();
+		}
+		return self::$instance;
+	}
 
 	/**
 	 * Initialize the Admin Notices class
@@ -206,8 +241,8 @@ class AdminNotices {
 
 		foreach ( $menu as $key => $item ) {
 			if ( 'graphiql-ide' === $item[2] ) {
-				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-				$menu[ $key ][0] .= ' <span class="update-plugins count-' . absint( $notice_count ) . '>"><span class="plugin-count">' . absint( $notice_count ) . '</span></span>';
+                // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+				$menu[ $key ][0] .= ' <span class="update-plugins count-' . absint( $notice_count ) . '"><span class="plugin-count">' . absint( $notice_count ) . '</span></span>';
 				break;
 			}
 		}

--- a/src/Data/Connection/TermObjectConnectionResolver.php
+++ b/src/Data/Connection/TermObjectConnectionResolver.php
@@ -35,7 +35,12 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 	 */
 	protected function prepare_query_args( array $args ): array {
 		$all_taxonomies = \WPGraphQL::get_allowed_taxonomies();
-		$taxonomy       = ! empty( $this->taxonomy ) && in_array( $this->taxonomy, $all_taxonomies, true ) ? [ $this->taxonomy ] : $all_taxonomies;
+
+		if ( ! is_array( $this->taxonomy ) ) {
+			$taxonomy = ! empty( $this->taxonomy ) && in_array( $this->taxonomy, $all_taxonomies, true ) ? [ $this->taxonomy ] : $all_taxonomies;
+		} else {
+			$taxonomy = $this->taxonomy;
+		}
 
 		if ( ! empty( $args['where']['taxonomies'] ) ) {
 			/**

--- a/src/Model/Comment.php
+++ b/src/Model/Comment.php
@@ -17,6 +17,8 @@ use WP_Comment;
  * @property string $authorIp
  * @property string $comment_author
  * @property string $comment_author_url
+ * @property string $commentAuthor
+ * @property string $commentAuthorUrl
  * @property string $commentAuthorEmail
  * @property string $contentRaw
  * @property string $contentRendered
@@ -60,6 +62,9 @@ class Comment extends Model {
 			'type',
 			'commentedOnId',
 			'comment_post_ID',
+			'commentAuthorUrl',
+			'commentAuthorEmail',
+			'commentAuthor',
 			'approved',
 			'status',
 			'comment_parent_id',
@@ -122,7 +127,7 @@ class Comment extends Model {
 					return ! empty( $this->data->comment_ID ) ? $this->data->comment_ID : 0;
 				},
 				'commentAuthorEmail' => function () {
-					return ! empty( $this->data->comment_author_email ) ? $this->data->comment_author_email : 0;
+					return current_user_can( 'moderate_comments' ) && ! empty( $this->data->comment_author_email ) ? $this->data->comment_author_email : null;
 				},
 				'comment_ID'         => function () {
 					return ! empty( $this->data->comment_ID ) ? absint( $this->data->comment_ID ) : 0;
@@ -140,10 +145,16 @@ class Comment extends Model {
 					return ! empty( $this->comment_parent_id ) ? Relay::toGlobalId( 'comment', $this->data->comment_parent ) : null;
 				},
 				'comment_author'     => function () {
-					return ! empty( $this->data->comment_author ) ? absint( $this->data->comment_author ) : null;
+					return ! empty( $this->data->comment_author ) ? $this->data->comment_author : null;
 				},
 				'comment_author_url' => function () {
-					return ! empty( $this->data->comment_author_url ) ? absint( $this->data->comment_author_url ) : null;
+					return ! empty( $this->data->comment_author_url ) ? $this->data->comment_author_url : null;
+				},
+				'commentAuthor'      => function () {
+					return ! empty( $this->data->comment_author ) ? $this->data->comment_author : null;
+				},
+				'commentAuthorUrl'   => function () {
+					return ! empty( $this->data->comment_author_url ) ? $this->data->comment_author_url : null;
 				},
 				'authorIp'           => function () {
 					return ! empty( $this->data->comment_author_IP ) ? $this->data->comment_author_IP : null;

--- a/src/Type/ObjectType/Comment.php
+++ b/src/Type/ObjectType/Comment.php
@@ -29,6 +29,36 @@ class Comment {
 						'toType'      => 'Commenter',
 						'description' => __( 'The author of the comment', 'wp-graphql' ),
 						'oneToOne'    => true,
+						'edgeFields'  => [
+							'email'     => [
+								'type'        => 'String',
+								'description' => __( 'The email address representing the author for this particular comment', 'wp-graphql' ),
+								'resolve'     => static function ( $edge ) {
+									return $edge['source']->commentAuthorEmail ?: null;
+								},
+							],
+							'ipAddress' => [
+								'type'        => 'String',
+								'description' => __( 'IP address of the author at the time of making this comment. This field is equivalent to WP_Comment->comment_author_IP and the value matching the "comment_author_IP" column in SQL.', 'wp-graphql' ),
+								'resolve'     => static function ( $edge ) {
+									return $edge['source']->authorIp ?: null;
+								},
+							],
+							'name'      => [
+								'type'        => 'String',
+								'description' => __( 'The display name of the comment author for this particular comment', 'wp-graphql' ),
+								'resolve'     => static function ( $edge ) {
+									return $edge['source']->commentAuthor;
+								},
+							],
+							'url'       => [
+								'type'        => 'String',
+								'description' => __( 'The url entered for the comment author on this particular comment', 'wp-graphql' ),
+								'resolve'     => static function ( $edge ) {
+									return $edge['source']->commentAuthorUrl ?: null;
+								},
+							],
+						],
 						'resolve'     => static function ( $comment, $_args, AppContext $context ) {
 							$node = null;
 
@@ -64,8 +94,9 @@ class Comment {
 						},
 					],
 					'authorIp'         => [
-						'type'        => 'String',
-						'description' => __( 'IP address for the author. This field is equivalent to WP_Comment->comment_author_IP and the value matching the "comment_author_IP" column in SQL.', 'wp-graphql' ),
+						'type'              => 'String',
+						'deprecationReason' => __( 'Use the ipAddress field on the edge between the comment and author', 'wp-graphql' ),
+						'description'       => __( 'IP address for the author at the time of commenting. This field is equivalent to WP_Comment->comment_author_IP and the value matching the "comment_author_IP" column in SQL.', 'wp-graphql' ),
 					],
 					'commentId'        => [
 						'type'              => 'Int',

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -401,7 +401,7 @@ final class WPGraphQL {
 		 * Prevent WPML from redirecting within WPGraphQL requests
 		 *
 		 * @see https://github.com/wp-graphql/wp-graphql/issues/1626#issue-769089073
-		 * @since @todo
+		 * @since 1.27.0
 		 */
 		add_filter(
 			'wpml_is_redirected',

--- a/tests/wpunit/AdminNoticesTest.php
+++ b/tests/wpunit/AdminNoticesTest.php
@@ -21,8 +21,7 @@ class AdminNoticesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 	 * Test initialization of admin notices.
 	 */
 	public function testInit(): void {
-		$adminNotices = new AdminNotices();
-		$adminNotices->init();
+		AdminNotices::get_instance();
 
 		// Assertions to ensure actions are hooked correctly
 		// This might require functional testing or integration testing setup
@@ -33,7 +32,7 @@ class AdminNoticesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 	 * Test adding and retrieving admin notices.
 	 */
 	public function testAddAndGetAdminNotices(): void {
-		$adminNotices = new AdminNotices();
+		$adminNotices = AdminNotices::get_instance();
 
 		$slug = 'test-notice';
 		$config = [
@@ -49,11 +48,35 @@ class AdminNoticesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->assertSame($config, $notices[$slug]);
 	}
 
+    /**
+     * Test adding and retrieving admin notices.
+     */
+    public function testGetAdminNotices(): void {
+        $adminNotices = AdminNotices::get_instance();
+
+        $slug = 'test-notice';
+        $config = [
+            'message' => 'Test Notice Message',
+            'type' => 'warning',
+            'is_dismissable' => true
+        ];
+
+        $adminNotices->add_admin_notice($slug, $config);
+
+        $notices = $adminNotices->get_admin_notices();
+        $this->assertArrayHasKey($slug, $notices);
+        $this->assertSame($config, $notices[$slug]);
+
+        $get_admin_notices = get_graphql_admin_notices();
+
+        $this->assertSame($get_admin_notices, $notices);
+    }
+
 	/**
 	 * Test removing admin notices.
 	 */
 	public function testRemoveAdminNotices(): void {
-		$adminNotices = new AdminNotices();
+        $adminNotices = AdminNotices::get_instance();
 
 		$slug = 'test-notice';
 		$config = ['message' => 'Test Notice Message'];

--- a/tests/wpunit/CommentObjectQueriesTest.php
+++ b/tests/wpunit/CommentObjectQueriesTest.php
@@ -465,16 +465,21 @@ class CommentObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 			'comment_post_ID'      => $post_id,
 			'comment_content'      => 'Admin Comment',
 			'comment_author_email' => 'admin@test.com',
+            'comment_author_url'   => 'https://example.com',
 			'comment_author_IP'    => '127.0.0.1',
 			'comment_agent'        => 'Admin Agent',
+            'comment_author'       => 'Admin Name',
+
 		];
 		$admin_comment      = $this->createCommentObject( $admin_args );
 		$subscriber_args    = [
 			'comment_post_ID'      => $post_id,
 			'comment_content'      => 'Subscriber Comment',
-			'comment_author_email' => 'subscriber@test.com',
+			'comment_author_email' => 'subscriber@example.com',
+            'comment_author_url'   => 'https://example.com',
 			'comment_author_IP'    => '127.0.0.1',
 			'comment_agent'        => 'Subscriber Agent',
+            'comment_author'       => 'Subscriber Name',
 		];
 		$subscriber_comment = $this->createCommentObject( $subscriber_args );
 
@@ -497,6 +502,14 @@ class CommentObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 						}
 					}
 				}
+				author {
+				  name
+				  email
+				  url
+				  node {
+				    __typename
+				  }
+				}
 			}
 		}
 		';
@@ -513,6 +526,10 @@ class CommentObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 		];
 		$subscriber_actual = $this->graphql( compact( 'query', 'variables' ) );
 
+        codecept_debug( [
+            '$subscriber_actual' => $subscriber_actual,
+        ]);
+
 		$this->assertArrayNotHasKey( 'errors', $admin_actual );
 		$this->assertArrayNotHasKey( 'errors', $subscriber_actual );
 
@@ -526,12 +543,17 @@ class CommentObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 		$this->assertEquals( $expected_link, $admin_actual['data']['comment']['link'] );
 		$this->assertEquals( str_ireplace( home_url(), '', $expected_link ), $admin_actual['data']['comment']['uri'] );
 
+        $this->assertEquals( $subscriber_args['comment_author'], $subscriber_actual['data']['comment']['author']['name'] );
+        $this->assertEquals( $subscriber_args['comment_author_url'], $subscriber_actual['data']['comment']['author']['url'] );
+
 		if ( true === $should_display ) {
 			$this->assertNotNull( $admin_actual['data']['comment']['authorIp'] );
 			$this->assertNotNull( $admin_actual['data']['comment']['agent'] );
+            $this->assertSame( $subscriber_args['comment_author_email'], $subscriber_actual['data']['comment']['author']['email'] );
 		} else {
 			$this->assertNull( $admin_actual['data']['comment']['authorIp'] );
 			$this->assertNull( $admin_actual['data']['comment']['agent'] );
+            $this->assertNull( $subscriber_actual['data']['comment']['author']['email'] );
 		}
 	}
 

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.28.1
+ * Version: 1.29.0
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.9
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.28.1
+ * @version  1.29.0
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
# Release Notes

### New Features

- [#3208](https://github.com/wp-graphql/wp-graphql/pull/3208): feat: expose commenter edge fields
- [#3207](https://github.com/wp-graphql/wp-graphql/pull/3207): feat: introduce get_graphql_admin_notices and convert AdminNotices class to a singleton

### Chores / Bugfixes

- [#3213](https://github.com/wp-graphql/wp-graphql/pull/3213): chore(deps): bump the npm_and_yarn group across 1 directory with 4 updates
- [#3212](https://github.com/wp-graphql/wp-graphql/pull/3212): chore(deps): bump dset from 3.1.3 to 3.1.4 in the npm_and_yarn group across 1 directory
- [#3211](https://github.com/wp-graphql/wp-graphql/pull/3211): chore: add LABELS.md
- [#3201](https://github.com/wp-graphql/wp-graphql/pull/3201): fix: ensure connectedTerms returns terms for the specified taxonomy only
- [#3199](https://github.com/wp-graphql/wp-graphql/pull/3199): chore(deps-dev): bump the npm_and_yarn group across 1 directory with 2 updates
