### PR TITLE
 chore: add blueprint.json so WPGraphQL can be demo'd with a live preview on WordPress.org

### DIFF
--- a/assets/blueprints/blueprint.json
+++ b/assets/blueprints/blueprint.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://playground.wordpress.net/blueprint-schema.json",
+  "meta": {
+    "title": "Use WPGraphQL to query WordPress",
+    "description": "Example that loads WordPress with WPGraphQL active and defaults to the WPGraphQL IDE page to allow users to test GraphQL queries and explore the GraphQL Schema.",
+    "author": "jasonbahl",
+    "categories": ["API", "wpgraphql"]
+  },
+  "landingPage": "/wp-admin/admin.php?page=graphiql-ide&query=I4VwpgTgngBA4mALgBQPYGdHpgbwFAwwAOGWuBhMAdqgCZjb6WUCWtFziLiANmB5VoBDRP2YBfCpPFA",
+  "plugins": [
+    "wp-graphql"
+  ],
+  "steps": [
+    {
+      "step": "login",
+      "username": "admin"
+    }
+  ]
+}


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This adds a blueprint for WordPress Playground so the plugin can be tested by users with a live preview button on WordPress.org


Does this close any currently open issues?
------------------------------------------
n/a

Any other comments?
-------------------
related: https://github.com/WordPress/blueprints/pull/74

