### PR TITLE
fix: Deprecated null value warning in `titleRendered` callback

### DIFF
--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -484,7 +484,7 @@ class Post extends Model {
 					$id    = ! empty( $this->data->ID ) ? $this->data->ID : null;
 					$title = ! empty( $this->data->post_title ) ? $this->data->post_title : '';
 
-					$processedTitle = !empty($title) ? $this->html_entity_decode( apply_filters( 'the_title', $title, $id ), 'titleRendered', true ) : '';
+					$processedTitle = ! empty( $title ) ? $this->html_entity_decode( apply_filters( 'the_title', $title, $id ), 'titleRendered', true ) : '';
 
 					return $processedTitle === '' ? null : $processedTitle;
 				},

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -486,7 +486,7 @@ class Post extends Model {
 
 					$processedTitle = ! empty( $title ) ? $this->html_entity_decode( apply_filters( 'the_title', $title, $id ), 'titleRendered', true ) : '';
 
-					return $processedTitle === '' ? null : $processedTitle;
+					return empty( $processedTitle ) ? null : $processedTitle;
 				},
 				'titleRaw'                  => [
 					'callback'   => function () {

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -482,7 +482,7 @@ class Post extends Model {
 				],
 				'titleRendered'             => function () {
 					$id    = ! empty( $this->data->ID ) ? $this->data->ID : null;
-					$title = ! empty( $this->data->post_title ) ? $this->data->post_title : null;
+					$title = ! empty( $this->data->post_title ) ? $this->data->post_title : '';
 
 					return $this->html_entity_decode( apply_filters( 'the_title', $title, $id ), 'titleRendered', true );
 				},

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -484,7 +484,9 @@ class Post extends Model {
 					$id    = ! empty( $this->data->ID ) ? $this->data->ID : null;
 					$title = ! empty( $this->data->post_title ) ? $this->data->post_title : '';
 
-					return $this->html_entity_decode( apply_filters( 'the_title', $title, $id ), 'titleRendered', true );
+					$processedTitle = !empty($title) ? $this->html_entity_decode( apply_filters( 'the_title', $title, $id ), 'titleRendered', true ) : '';
+
+					return $processedTitle === '' ? null : $processedTitle;
 				},
 				'titleRaw'                  => [
 					'callback'   => function () {


### PR DESCRIPTION

![screencapture-sentry-oustatic-organizations-orthodox-union-issues-109053-2024-11-12-14_43_19](https://github.com/user-attachments/assets/1a4f00f8-5764-49e1-a33e-73d7610c5b8f)

**This PR addresses a deprecation warning in PHP 8+ caused by passing a null value to the trim() function within the titleRendered method. Previously, if $this->data->post_title was null, it would be passed to apply_filters, potentially resulting in a null value for trim(). This caused a warning in environments using PHP 8+.**

**Changes Made:** 
- Added a default empty string '' as a fallback for $title if $this->data->post_title is null.
- This ensures $title is always a string, preventing trim() from encountering a null value.

**Reason for Change:**
- This change prevents deprecation warnings when using PHP 8+, improving compatibility and removing unnecessary noise in logs related to deprecated behavior.
- 

**Testing Notes:**

- Verified that titleRendered returns the post title if available, or an empty string if not, without causing warnings.
- Checked that the HTML entity decoding and filter application still work as expected.