### PR TITLE
Introducing WPGraphQL Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Below are some links to help you get started with WPGraphQL
 [![License](https://poser.pugx.org/wp-graphql/wp-graphql/license)](https://packagist.org/packages/wp-graphql/wp-graphql)
 [![Actions Status](https://github.com/wp-graphql/wp-graphql/workflows/Testing%20Integration/badge.svg)](https://github.com/wp-graphql/wp-graphql/actions?query=workflow%3A%22Testing+Integration%22) [![Actions Status](https://github.com/wp-graphql/wp-graphql/workflows/WordPress%20Coding%20Standards/badge.svg)](https://github.com/wp-graphql/wp-graphql/actions?query=workflow%3A%22WordPress+Coding+Standards%22)
 [![Coverage Status](https://coveralls.io/repos/github/wp-graphql/wp-graphql/badge.svg)](https://coveralls.io/github/wp-graphql/wp-graphql)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20WPGraphQL%20Guru-006BFF)](https://gurubase.io/g/wpgraphql)
 -----
 
 ## Install


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [WPGraphQL Guru](https://gurubase.io/g/wpgraphql) to Gurubase. WPGraphQL Guru uses the data from this repo and data from the [docs](https://www.wpgraphql.com) to answer questions by leveraging the LLM.

In this PR, I showcased the "WPGraphQL Guru", which highlights that WPGraphQL now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable WPGraphQL Guru in Gurubase, just let me know that's totally fine.
