### PR TITLE
feat: add option to get filesize externally

### DIFF
--- a/src/Registry/Utils/PostObject.php
+++ b/src/Registry/Utils/PostObject.php
@@ -613,6 +613,11 @@ class PostObject {
 						if ( empty( $source_url ) ) {
 							return null;
 						}
+						// allow to get filesize from other sources, like database or offloaded file
+						$filesize = apply_filter('graphql_get_filesize', $image->databaseId);
+						if(!empty($filesize)) {
+							return $filesize;
+						}
 
 						$path_parts    = pathinfo( $source_url );
 						$original_file = get_attached_file( absint( $image->databaseId ) );


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [ ] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This allows the developer to get the filesize of an attachment that can be offloaded or the size be already in the DB, that way, it will not return 0 if the file is not local


Does this close any currently open issues?
------------------------------------------
<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
No

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
<!-- (If it’s long, please paste to https://ghostbin.com/ and insert the link here.) -->


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …
Linux 5.15.167.4-microsoft-standard-WSL2
**WordPress Version:** …
6.6.2