### PR TITLE
fix: receiving post for Incorrect uri

### DIFF
--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -213,7 +213,6 @@ class NodeResolver {
 		// Resolve Post Objects.
 		if ( $queried_object instanceof WP_Post ) {
 
-
 			// If Page for Posts is set, we need to return the Page archive, not the page.
 			if ( $query->is_posts_page ) {
 				// If were intentionally querying for a something other than a ContentType, we need to return null instead of the archive.
@@ -501,7 +500,6 @@ class NodeResolver {
 			}
 		}
 
-
 		/**
 		 * Filters the query variables allowed before processing.
 		 *
@@ -604,8 +602,6 @@ class NodeResolver {
 
 		// We don't need the GraphQL args anymore.
 		unset( $this->wp->query_vars['graphql'] );
-
-
 
 		do_action_ref_array( 'parse_request', [ &$this->wp ] );
 

--- a/src/Data/NodeResolver.php
+++ b/src/Data/NodeResolver.php
@@ -22,6 +22,11 @@ class NodeResolver {
 	protected $context;
 
 	/**
+	 * @var string
+	 */
+	protected $route;
+
+	/**
 	 * NodeResolver constructor.
 	 *
 	 * @param \WPGraphQL\AppContext $context
@@ -31,7 +36,8 @@ class NodeResolver {
 	public function __construct( AppContext $context ) {
 		global $wp;
 		$this->wp               = $wp;
-		$this->wp->matched_rule = Router::$route . '/?$';
+		$this->route            = Router::$route . '/?$';
+		$this->wp->matched_rule = $this->route;
 		$this->context          = $context;
 	}
 
@@ -50,22 +56,6 @@ class NodeResolver {
 		if ( ! $this->is_valid_node_type( 'ContentNode' ) ) {
 			return null;
 		}
-
-		/**
-		 * Disabling the following code for now, since add_rewrite_uri() would cause a request to direct to a different valid permalink.
-		 */
-		/* phpcs:disable
-		if ( ! isset( $this->wp->query_vars['uri'] ) ) {
-			return $post;
-		}
-		$permalink    = get_permalink( $post );
-		$parsed_path  = $permalink ? wp_parse_url( $permalink, PHP_URL_PATH ) : null;
-		$trimmed_path = $parsed_path ? rtrim( ltrim( $parsed_path, '/' ), '/' ) : null;
-		$uri_path     = rtrim( ltrim( $this->wp->query_vars['uri'], '/' ), '/' );
-		if ( $trimmed_path !== $uri_path ) {
-			return null;
-		}
-		phpcs:enable */
 
 		if ( empty( $this->wp->query_vars['uri'] ) ) {
 			return $post;
@@ -222,6 +212,8 @@ class NodeResolver {
 
 		// Resolve Post Objects.
 		if ( $queried_object instanceof WP_Post ) {
+
+
 			// If Page for Posts is set, we need to return the Page archive, not the page.
 			if ( $query->is_posts_page ) {
 				// If were intentionally querying for a something other than a ContentType, we need to return null instead of the archive.
@@ -240,6 +232,10 @@ class NodeResolver {
 
 			// Validate the post before returning it.
 			if ( ! $this->validate_post( $queried_object ) ) {
+				return null;
+			}
+
+			if ( empty( $extra_query_vars ) && isset( $this->wp->query_vars['error'] ) && '404' === $this->wp->query_vars['error'] ) {
 				return null;
 			}
 
@@ -485,7 +481,7 @@ class NodeResolver {
 				}
 			}
 
-			if ( ! empty( $this->wp->matched_rule ) ) {
+			if ( ! empty( $this->wp->matched_rule ) && $this->wp->matched_rule !== $this->route ) {
 				// Trim the query of everything up to the '?'.
 				$query = preg_replace( '!^.+\?!', '', $query );
 
@@ -504,6 +500,7 @@ class NodeResolver {
 				}
 			}
 		}
+
 
 		/**
 		 * Filters the query variables allowed before processing.
@@ -607,6 +604,8 @@ class NodeResolver {
 
 		// We don't need the GraphQL args anymore.
 		unset( $this->wp->query_vars['graphql'] );
+
+
 
 		do_action_ref_array( 'parse_request', [ &$this->wp ] );
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This fixes a bug where entering a uri for an invalid node might return a node with a different uri. 

- [x] failing test: (didn't run in Github properly, but you can confirm locally with this commit: https://github.com/wp-graphql/wp-graphql/pull/3250/commits/b5e25aaddd1c10e1302665679ff129ee1a284ab8)
- [x] passing test: https://github.com/wp-graphql/wp-graphql/actions/runs/12190547800


Does this close any currently open issues?
------------------------------------------

Closes #3240 

With this PR in place, following the same steps to reproduce (as documented in #3240):

## Before

Querying for a node by uri might return a node that has a _different_ uri. 

![CleanShot 2024-12-05 at 16 43 44](https://github.com/user-attachments/assets/8c644306-2d47-452e-9db6-7e962724eede)


## After

Now, querying for a node using a uri that would 404 in traditional WP will return a `null` instead of returning a node that doesn't match the uri input. 

![CleanShot 2024-12-05 at 16 42 24](https://github.com/user-attachments/assets/44d5cc76-21bf-49c1-9e2e-83e13ed8f735)

And querying with the correct uri continues to return the expected node: 

![CleanShot 2024-12-05 at 16 47 42](https://github.com/user-attachments/assets/5237a6e3-e904-4142-8918-1cb5842865b1)
