### PR TITLE
Update term connection resolver in PostObject.php

### DIFF
--- a/src/Registry/Utils/PostObject.php
+++ b/src/Registry/Utils/PostObject.php
@@ -198,14 +198,15 @@ class PostObject {
 					),
 					'resolve'        => static function ( Post $post, $args, AppContext $context, ResolveInfo $info ) {
 						$taxonomies = \WPGraphQL::get_allowed_taxonomies();
-						$terms      = wp_get_post_terms( $post->ID, $taxonomies, [ 'fields' => 'ids' ] );
+						$object_id = true === $post->isPreview && ! empty( $post->parentDatabaseId ) ? $post->parentDatabaseId : $post->ID;
 
-						if ( empty( $terms ) || is_wp_error( $terms ) ) {
+						if ( empty( $object_id ) || ! absint( $object_id ) ) {
 							return null;
 						}
-						$resolver = new TermObjectConnectionResolver( $post, $args, $context, $info, $taxonomies );
-						$resolver->set_query_arg( 'include', $terms );
 
+						$resolver = new TermObjectConnectionResolver( $post, $args, $context, $info, $taxonomies );
+						$resolver->set_query_arg( 'object_ids', absint( $object_id ) );
+						$resolver->set_query_arg( 'taxonomies', $taxonomies );
 						return $resolver->get_connection();
 					},
 				];


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

This updates the resolver to use the parentDatabaseId if the connection is coming from a preview post.

NOTE: This might require an update to TermObjectConnectionResolver.php to allow `$taxonomy` to be an array instead of just a string, to satisfy phpstan. Unconfirmed yet, but highly likely going to see some phpstan errors I believe. (I just made these changes directly in Github to get a quick PR together).


Does this close any currently open issues?
------------------------------------------
closes #3238 


Any other comments?
-------------------

## Before

Querying a preview post returns `null` for terms instead of returning the parent (published post) terms

![CleanShot 2024-12-13 at 09 35 00](https://github.com/user-attachments/assets/5e609115-266b-4e90-a411-785a12007808)


## After

Querying a preview post returns the parent (published post) terms

![CleanShot 2024-12-13 at 09 34 10](https://github.com/user-attachments/assets/e6504a9a-5493-4ab9-b267-e1e3b3a5124b)
