### PR TITLE
chore: add cursor files

### DIFF
--- a/.cursor/prd.md
+++ b/.cursor/prd.md
@@ -1,0 +1,211 @@
+# WPGraphQL Product Requirements Document
+
+## Product Overview
+WPGraphQL is a free, open-source WordPress plugin that provides an extendable GraphQL API for WordPress websites. 
+
+It provides a modern, performant GraphQL API that directly interfaces with WordPress internal data structures and registries, allowing developers to build headless WordPress applications.
+
+### Core Value Proposition
+- Enable headless WordPress architecture with a modern GraphQL API
+- Improve performance through selective data fetching
+- Provide a modern developer experience for WordPress
+- Enable better integrations with modern frontend frameworks
+- Maintain WordPress security model and permissions
+
+## Target Users
+
+### Primary Users
+
+1. WordPress Developers
+   - Building headless WordPress applications
+   - Integrating WordPress with modern frontend frameworks
+   - Creating custom plugins that extend WPGraphQL
+
+2. Frontend Developers
+   - Consuming WordPress data in React, Vue, or other frontend applications
+   - Building JAMstack websites with WordPress as a backend
+   - Developing mobile applications that use WordPress data
+
+3. Agency Developers
+   - Building enterprise WordPress solutions
+   - Creating scalable multi-site implementations
+   - Developing custom client solutions
+
+### Secondary Users
+1. WordPress Site Administrators
+   - Managing GraphQL API access
+   - Configuring API permissions
+   - Monitoring API usage
+
+2. Plugin Developers
+   - Extending WPGraphQL with custom types and fields
+   - Adding GraphQL support to existing WordPress plugins
+   - Creating WPGraphQL extension plugins
+
+## Core Features
+
+### GraphQL API Endpoint
+- Single endpoint at /graphql 
+  - endpoint can be changed via code or WPGraphQL settings
+- Handles GraphQL Queries and Mutations
+- Supports HTTP POST and GET requests
+- Implements GraphQL specification
+- Provides schema introspection
+
+### Schema Generation
+- Automatically generates GraphQL schema for WordPress data
+- Support for Post Types (built-in and custom)
+- Support for Taxonomies (built-in and custom)
+- Support for Users
+- Support for Comments
+- Support for WordPress settings
+
+### Security & Authentication
+- Can integrate with WordPress authentication
+- Respects WordPress capabilities
+- Supports JWT authentication
+- Provides options for field-level access control
+- Maintains WordPress access-control model
+
+### Performance Features
+- Selective data fetching
+- Connection/pagination support
+- Query batching
+- Caching integration
+- N+1 query prevention
+
+### Developer Tools
+- GraphiQL IDE integration
+- Debug mode
+- Query logging
+- Performance metrics
+- Schema exploration tools
+
+### Extension System
+- Hook and filter system for schema and data modification
+- Custom Type registration API
+- Field registration API
+- Custom resolver support
+
+## Technical Requirements
+
+### WordPress Compatibility
+- WordPress (6.0+ preferred)
+- PHP (7.4+ preferred)
+- MySQL (8+ preferred) or MariaDB (10.0+ preferred)
+- Standard WordPress plugin installation. Can be installed via composer as well.
+
+### Security Requirements
+- Input sanitization
+- Output escaping
+- Follow WordPress Access Control standards
+
+### API Standards
+- GraphQL Specification compliance
+- Relay specification support
+- REST API coexistence
+- Proper error handling
+- Clear error messages
+
+## Integration Requirements
+
+### Frontend Framework Support
+- React compatibility
+- Vue.js compatibility
+- Next.js compatibility
+- Svelte compatibility
+- Astro compatibility
+- Gatsby compatibility
+- Apollo Client support
+
+### Plugin Ecosystem
+- WooCommerce integration
+- ACF integration
+- Yoast SEO integration
+- Gravity Forms integration
+- Custom plugin extensibility
+- Multi-plugin compatibility
+
+### Development Tools
+- WP-CLI support (limited)
+- Composer integration
+- npm package management
+- Docker development environment
+- CI/CD pipeline support
+
+## Success Metrics
+
+### Performance Metrics (ideals)
+- Query response times
+- Server resource usage
+- Cache hit rates
+- Error rates
+- Concurrent user handling
+
+### Developer Metrics
+- GitHub stars and forks
+- Active installations
+- Community contributions
+- Documentation usage
+- Support forum activity
+
+### User Success Metrics
+- Successful installations
+- API uptime
+- Query success rates
+- Extension adoption
+- User satisfaction
+- Query response times
+
+## Future Considerations
+
+### Planned Features
+- Real-time subscriptions
+- Enhanced caching system (see WPGraphQL Smart Cache)
+- Improved debugging tools (see WPGraphQL IDE)
+- Better error reporting
+- Performance optimizations
+- Custom Scalars
+- Support for additional directives
+
+### Scalability Goals
+- Increased Support for high-traffic sites
+- Enterprise-level performance
+- Multi-site network support (tbd)
+
+### Community Growth
+- Documentation expansion
+- Tutorial development
+- Example project creation
+- Community event participation
+- Contributor program development
+
+## Implementation Guidelines
+
+### Code Standards
+- WordPress Coding Standards
+- PHPStan Level 10 compliance
+- 85+% unit test coverage
+- Integration test suite
+- E2E test coverage
+
+### Documentation Requirements
+- Inline code documentation
+- API documentation
+- Usage examples
+- Integration guides
+- Troubleshooting guides
+
+### Release Process
+- Semantic versioning
+- Change log maintenance
+- Beta testing process
+- Release candidates
+- Backward compatibility (breaking changes communicated with semver)
+
+### Support Requirements
+- GitHub issue tracking
+- WordPress.org support
+- Documentation updates
+- Security advisories
+- Version compatibility

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,104 @@
+# WPGraphQL is a WordPress plugin that adds a /graphql endpoint to the WordPress site and defines a GraphQL Schema based on internal WordPress registries such as the post type, taxonomy and settings registries. It includes the Schema, resolvers and a model layer for determining access to objects before resolving them. It is extendable by using WordPress hooks and filters via the add_action and add_filter functions. It follows phpcs standards defined in .phpcs.xml.dist. It uses composer to manage external dependencies such as graphql-php. It includes user interfaces in the WordPress admin dashboard for plugin settings and the GraphiQL IDE for interacting with the GraphQL Schema and testing queries and mutations.
+
+## Frameworks and Technologies
+- framework: wordpress
+- language: php
+- package-manager: composer
+- testing-framework: phpunit (codeception, wp-graphql-testcase)
+- coding-standards: phpcs
+- api: graphql
+
+## Key Concepts
+- concept: "GraphQL Schema": "The structure that defines the types, queries, and mutations available in the WPGraphQL API"
+- concept: "WordPress Registries": "Internal WordPress systems that store information about post types, taxonomies, and settings"
+- concept: "Resolvers": "Functions that determine how to fetch and return data for specific GraphQL fields"
+- concept: "Model Layer": "Classes that handle access control and data preparation before resolution"
+- concept: "GraphiQL IDE": "An interactive development environment for testing GraphQL queries"
+
+## File Patterns
+- pattern: "src/Admin/*.php": "WordPress admin interface implementations"
+- pattern: "src/Connection/*.php": "Classes handling GraphQL connections and pagination"
+- pattern: "src/Data/*.php": "Data manipulation and transformation classes"
+- pattern: "src/Model/*.php": "Model classes that handle data access and authorization"
+- pattern: "src/Mutation/*.php": "Classes defining GraphQL mutations"
+- pattern: "src/Registry/*.php": "Classes for registering types and fields"
+- pattern: "src/Server/*.php": "Validation Rules and other configuration for the GraphQL Server"
+- pattern: "src/Type/*.php": "GraphQL type definitions"
+- pattern: "src/Utils/*.php": "Utility classes and helper functions"
+- pattern: "tests/**/*.php": "PHPUnit test files"
+- pattern: "access-functions.php": "Global access functions"
+- pattern: "docs/*.md": "User documentation for the plugin"
+- pattern: "cli/*.php": "WP-CLI commands for interacting with WPGraphQL using WP-CLI"
+- pattern: "phpstan/*.php": "Stubs for use with phpstan for static analysis"
+- pattern: "packages/**/*.js": "JavaScript packages that make up the GraphiQL IDE"
+- pattern: ".wordpress-org/": "Files used for building and deploying the plugin to WordPress.org"
+
+## Dependencies
+- dependency: "webonyx/graphql-php": "Core GraphQL PHP implementation"
+- dependency: "ivome/graphql-relay-php": "Relay specification implementation"
+- dependency: "phpunit/phpunit": "Testing framework"
+- dependency: "squizlabs/php_codesniffer": "Code style checking"
+- dependency: "phpstan/phpstan": "Static analysis tool"
+- dependency: "wp-coding-standards/wpcs": "WordPress Coding Standards"
+
+## Common Code Patterns
+```php
+// Registering a GraphQL Type
+add_action( 'graphql_register_types', function( $type_registry ) {
+
+    register_graphql_object_type( 'TypeName', [
+        'fields' => [
+            'fieldName' => [
+                'type' => 'String',
+                'resolve' => function($source, $args, $context, $info) {
+                    // Resolution logic
+                }
+            ]
+        ]
+    ]);
+
+});
+
+// Registering a GraphQL Field
+add_action( 'graphql_register_types', function( $type_registry ) {
+
+    register_graphql_field( 'TypeName', 'FieldName', [
+        'description' => __( 'Description of the field', 'your-textdomain' ),
+        'type' => 'String',
+        'resolve' => function() {
+            // interact with the WordPress database, or even an external API or whatever.
+            return 'value retrieved from WordPress, or elsewhere';
+        }
+    ]);
+
+});
+```
+
+## Key Directories
+- directory: "src/": "Core plugin source code"
+- directory: "includes/": "Plugin includes and utilities"
+- directory: "tests/": "Test files"
+- directory: "docs/": "Documentation"
+- directory: "languages/": "Translation files"
+- directory: ".github/": "Files used for interacting with GitHub"
+- directory ".wordpress-org/": "Files used for building and deploying the plugin to WordPress.org"
+- directory "build/": "Contains the built assets for the GraphiQL IDE"
+- directory "bin/": "Contains scripts used in CI"
+- directory "docker/": "Contains configuration for running WPGraphQL in Docker"
+- directory "img": "Contains images used in documentation"
+- directory: "phpstan/": "PHPStan configuration and stubs"
+
+## Important Files
+- file: "wp-graphql.php": "Main plugin file"
+- file: "composer.json": "Dependency management"
+- file: ".phpcs.xml.dist": "PHP CodeSniffer configuration"
+- file: "phpunit.xml.dist": "PHPUnit configuration"
+- file: "access-functions.php": "Global access functions"
+- file: "phpstan.neon.dist": "PHPStan configuration"
+- file: "docker-compose.yml": "Docker environment configuration"
+- file: ".wordpress-org/blueprints/blueprint.json": "Blueprint for running WPGraphQL in WordPress Playground, a WASM environment that runs WordPress fully in the browser"
+
+## Debug Tools
+- concept: "GraphQL Debug Mode": "Enable via WPGraphQL Settings or define('GRAPHQL_DEBUG', true)"
+- concept: "Query Logs": "Logs the SQL queries to fulfil a graphql request. Requires Query Monitor to be active. Enabled via WPGraphQL Settings and available in GraphiQL when debug mode is enabled"
+- concept: "Query Tracing": "Shows trace data for resolvers (i.e. timing for execution). Enabled via WPGraphQL Settings and available in GraphiQL when debug mode is enabled"

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,14 @@
 # Hidden files for users using VSCode as their IDE.
 .vscode
 
+# Cursor files for users using the Cursor IDE
+
+# Ignore all files under the .cursor directory as users will use this directory for personal IDE configuration
+.cursor/*
+
+# Do not ignore the prd.md file as this helps cursor understand the project and requirements and the community can help maintain it
+!.cursor/prd.md
+
 # Composer dependencies. These should be installed on the users machine
 vendor
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

Adds initial support for contributors that want to use the Cursor IDE. 

- updates the .gitignore to ignore the .cursor directory other than the pr…d.md file (as users can use the .cursor directory for their own personal configurations)
- add .cursor/prd.md file (Product Requirements Document) to help the cursor IDE understand the project structure, dependencies, who the audience is, etc
- add a .cursrrules file to help Cursor understand the project. Should work hand-in-hand with the PRD document helping Cursor users have a better experience

Does this close any currently open issues?
------------------------------------------
no

Any other comments?
-------------------
I'm experimenting with Cursor and wanted to share my configurations for anyone else interested in using Cursor while working on WPGraphQL. 

WIP. Expect this to evolve over time.
