### PR TITLE
fix: default cat should not be added when other categories are added

### DIFF
--- a/src/Data/PostObjectMutation.php
+++ b/src/Data/PostObjectMutation.php
@@ -355,9 +355,9 @@ class PostObjectMutation {
 						return;
 					}
 
-					if ( 'category' === $tax_object->name  ) {
+					if ( 'category' === $tax_object->name ) {
 						$default_category_id = absint( get_option( 'default_category' ) );
-						if ( ! in_array( $default_category_id, $terms_to_connect ) ) {
+						if ( ! in_array( $default_category_id, $terms_to_connect, true ) ) {
 							wp_remove_object_terms( $post_id, $default_category_id, 'category' );
 						}
 					}

--- a/src/Data/PostObjectMutation.php
+++ b/src/Data/PostObjectMutation.php
@@ -355,6 +355,13 @@ class PostObjectMutation {
 						return;
 					}
 
+					if ( 'category' === $tax_object->name  ) {
+						$default_category_id = absint( get_option( 'default_category' ) );
+						if ( ! in_array( $default_category_id, $terms_to_connect ) ) {
+							wp_remove_object_terms( $post_id, $default_category_id, 'category' );
+						}
+					}
+
 					wp_set_object_terms( $post_id, $terms_to_connect, $tax_object->name, $append );
 				}
 			}

--- a/src/Data/PostObjectMutation.php
+++ b/src/Data/PostObjectMutation.php
@@ -355,7 +355,7 @@ class PostObjectMutation {
 						return;
 					}
 
-					if ( 'category' === $tax_object->name ) {
+					if ( $append && 'category' === $tax_object->name ) {
 						$default_category_id = absint( get_option( 'default_category' ) );
 						if ( ! in_array( $default_category_id, $terms_to_connect, true ) ) {
 							wp_remove_object_terms( $post_id, $default_category_id, 'category' );

--- a/tests/wpunit/PostObjectMutationsTest.php
+++ b/tests/wpunit/PostObjectMutationsTest.php
@@ -1298,4 +1298,57 @@ class PostObjectMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCas
 		$actual = graphql( compact( 'query', 'variables' ) );
 		$this->assertEquals( \GraphQLRelay\Relay::toGlobalId( 'post', $post_id ), $actual['data']['deletePost']['post']['id'] );
 	}
+
+	public function testCreatePostMutationDoesNotAppendDefaultCategoryIfOtherCategoriesAreInput() {
+
+		// Create a category
+		$category_id = $this->factory()->category->create( [ 'name' => 'Test Category' ] );
+
+		// Create a post with the category
+		$query = '
+		mutation createPost($input:CreatePostInput!){
+			createPost(input:$input){
+				post{
+					id
+					title
+					categories {
+						nodes {
+							id
+							databaseId
+							name
+						}
+					}
+				}
+			}
+		}
+		';
+
+		// get category slug
+		$category = get_category( $category_id );
+		$category_slug = $category->slug;
+
+		$variables = [
+			'input' => [
+				'title'      => 'Test Post',
+				'categories' => [
+					'nodes' => [
+						[ 'slug' => $category_slug ]
+					]
+				],
+			],
+		];
+
+		wp_set_current_user( $this->admin );
+		codecept_debug( [
+			'variables' => $variables,
+		]);
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEquals( $category_id, $actual['data']['createPost']['post']['categories']['nodes'][0]['databaseId'] );
+
+		// there should only be 1 category (the one we added, not the default one)
+		$this->assertCount( 1, $actual['data']['createPost']['post']['categories']['nodes'] );
+
+	}
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This fixes a bug where the `createPost` mutation would assign the "default category" to newly created posts even when other categories were explicitly assigned during the mutation. 

The default category should only be assigned if other categories are not assigned during the creation.

- [x] **FAILING TEST:** https://github.com/wp-graphql/wp-graphql/actions/runs/12798916700/job/35683922462?pr=3271
- [x] **PASSING TEST:** https://github.com/wp-graphql/wp-graphql/actions/runs/12798966725

Does this close any currently open issues?
------------------------------------------
closes #3269 

Any other comments?
-------------------

## Before

Submitting the `createPost` mutation with categories would create the post with the submitted categories, but _also_ include the default category. 

![CleanShot 2025-01-15 at 16 32 04](https://github.com/user-attachments/assets/4b7a182d-87ae-4369-a781-8774251c9d79)

## After

Submitting the `createPost` mutation with categories would create the post with the submitted categories, and **not include** the default category. 

![CleanShot 2025-01-15 at 16 32 30](https://github.com/user-attachments/assets/340cd725-2ce7-40b8-b8e3-c8ab634395f0)
