### PR TITLE
feat: add the WPGraphQL Yoast SEO addon to the extensions page

### DIFF
--- a/src/Admin/Extensions/Registry.php
+++ b/src/Admin/Extensions/Registry.php
@@ -71,6 +71,17 @@ final class Registry {
 					'homepage' => 'https://wpgraphql.com',
 				],
 			],
+			'ashhitch/wp-graphql-yoast-seo'          => [
+				'name'              => 'WPGraphQL Yoast SEO Addon',
+				'description'       => 'This plugin enables Yoast SEO Support for WPGraphQL',
+				'documentation_url' => 'https://github.com/ashhitch/wp-graphql-yoast-seo',
+				'plugin_url'        => 'https://wordpress.org/plugins/add-wpgraphql-seo/',
+				'support_url'       => 'https://github.com/wp-graphql/wpgraphql-acf/issues/new/choose',
+				'author'            => [
+					'name'     => 'Ash Hitchcock',
+					'homepage' => 'https://www.ashleyhitchcock.com/',
+				],
+			],
 		];
 	}
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This adds the WPGraphQL for Yoast SEO to the extensions page registry. 


## Smoke Tests

I've verified basic functionality with the plugin. 

With the following environment:

WordPress 6.7.1
PHP: 8.2.23
WPGraphQL v1.29.3
WPGraphQL Yoast SEO Addon v4.23.2
Yoast SEO v24.2

I was able to create a post with some SEO data: 

![CleanShot 2025-01-16 at 12 40 47](https://github.com/user-attachments/assets/df8b03ee-b7cb-4bf0-b99a-73367e7f5224)

And I was able to query the SEO data for the post: 

![CleanShot 2025-01-16 at 12 41 38](https://github.com/user-attachments/assets/db20aafc-e724-46f2-a64c-3b8618f8fca0)

Here's the full query I used:

```graphql
query GetPostWithSEOFields {
  post(id:83 idType:DATABASE_ID) {
    id
    databaseId
    seo {
      ...PostTypeSEO
    }
  }
}

fragment PostTypeSEO on PostTypeSEO {
  canonical
  metaKeywords
  metaDesc
  title
}
```

And the payload I received: 

```json
{
  "data": {
    "post": {
      "id": "cG9zdDo4Mw==",
      "databaseId": 83,
      "seo": {
        "canonical": "http://wpgraphql.local/test-slug/",
        "metaKeywords": "",
        "metaDesc": "Test meta description",
        "title": "SEO Post Test - wpgraphql"
      }
    }
  }
}
```

## Conclusion

The plugin appears to work as advertised, provides [documentation](https://github.com/ashhitch/wp-graphql-yoast-seo?tab=readme-ov-file#wpgraphql-yoast-seo-plugin), has [regular maintenance](https://github.com/ashhitch/wp-graphql-yoast-seo/pulls?q=is%3Apr+is%3Aclosed) and offers support via [WordPress.org](https://wordpress.org/support/plugin/add-wpgraphql-seo/) and [Github](https://github.com/ashhitch/wp-graphql-yoast-seo/issues)  