### PR TITLE
fix: update deploy-to-wordpress.yml

### DIFF
--- a/.github/workflows/deploy-to-wordpress.yml
+++ b/.github/workflows/deploy-to-wordpress.yml
@@ -18,7 +18,10 @@ jobs:
           php-version: 8.2
           extensions: mbstring, intl
           tools: composer
-
+      
+      - name: Install Subversion
+        run: sudo apt-get update && sudo apt-get install -y subversion
+      
       - name: Install PHP dependencies
         run: |
           composer install --no-dev --optimize-autoloader


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Add step to install subversion. 

see: https://github.com/10up/action-wordpress-plugin-deploy/issues/158#issuecomment-2565445055



Does this close any currently open issues?
------------------------------------------
closes #3275
