### PR TITLE
fix: Error in update checker when WPGraphQL is active as an mu-plugin

### DIFF
--- a/src/Admin/Updates/Updates.php
+++ b/src/Admin/Updates/Updates.php
@@ -136,8 +136,12 @@ final class Updates {
 	 * Disables plugins that don't meet the minimum `Requires WPGraphQL` version.
 	 */
 	public function disable_incompatible_plugins(): void {
+
+		// Get the plugin data.
+		$plugin_data = get_plugin_data( WPGRAPHQL_PLUGIN_DIR . '/wp-graphql.php' );
+
 		// Initialize the Update Checker.
-		$update_checker = new UpdateChecker( (object) get_plugins()['wp-graphql/wp-graphql.php'] );
+		$update_checker = new UpdateChecker( (object) $plugin_data );
 
 		// Get the incompatible plugins.
 		$incompatible_plugins = $update_checker->get_incompatible_plugins( WPGRAPHQL_VERSION, true );


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This fixes a bug where wp-graphql can't be found in the array of plugins when WPGraphQL is active as an mu-plugin.

Does this close any currently open issues?
------------------------------------------
Closes #3282 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

## BEFORE

Error shown when WPGraphQL is active as an MU plugin

![CleanShot 2025-01-27 at 15 51 28](https://github.com/user-attachments/assets/01352c52-1d80-42ef-982d-f90de01d0098)


## AFTER

No error:

![CleanShot 2025-01-27 at 15 53 05](https://github.com/user-attachments/assets/1342c998-8b5d-43a0-ad33-169b7929276a)



Any other comments?
-------------------

I haven't done thorough testing yet to ensure this change doesn't accidentally cause unpredicted side-effects. The get_plugins function that we were using does use get_plugin_data under the hood, so I think this more direct call to get_plugin_data should do what we need with the added flexibility of working when WPGraphQL is a "regular" or "mu" plugin. 

Would love @justlevine to confirm this change doesn't cause any unintended side effects. 
