### PR TITLE
release: v1.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.31.0
+
+### New Features
+
+- [#3278](https://github.com/wp-graphql/wp-graphql/pull/3278): feat: add option to provide custom file path for static schemas when using the `wp graphql generate-static-schema` command
+
+### Chores / Bugfixes
+
+- [#3284](https://github.com/wp-graphql/wp-graphql/pull/3284): fix: fix: Updated docs link for example of hierarchical data
+- [#3283](https://github.com/wp-graphql/wp-graphql/pull/3283): fix: Error in update checker when WPGraphQL is active as an mu-plugin
+
 ## 1.30.0
 
 ### Chores / Bugfixes

--- a/cli/wp-cli.php
+++ b/cli/wp-cli.php
@@ -12,22 +12,36 @@ class WPGraphQL_CLI_Command extends WP_CLI_Command {
 	 * Defaults to creating a schema.graphql file in the IDL format at the root
 	 * of the plugin.
 	 *
-	 * @todo: Provide alternative formats (AST? INTROSPECTION JSON?) and options for output location/file-type?
+	 * [--output=<output>]
+	 * : The file path to save the schema to.
+	 *
+	 * @todo: Provide alternative formats (AST? INTROSPECTION JSON?) and options for output file-type?
 	 * @todo: Add Unit Tests
 	 *
 	 * ## EXAMPLE
 	 *
+	 *     # Generate a static schema
 	 *     $ wp graphql generate-static-schema
+	 *
+	 *     # Generate a static schema and save it to a specific file
+	 *     $ wp graphql generate-static-schema --output=/path/to/file.graphql
 	 *
 	 * @alias generate
 	 * @subcommand generate-static-schema
 	 */
 	public function generate_static_schema( $args, $assoc_args ) {
 
-		/**
-		 * Set the file path for where to save the static schema
-		 */
-		$file_path = get_temp_dir() . 'schema.graphql';
+		// Check if the output flag is set
+		if ( isset( $assoc_args['output'] ) ) {
+			// Check if the output file path is writable and its parent directory exists
+			if ( ! is_writable( dirname( $assoc_args['output'] ) ) ) {
+			WP_CLI::error( 'The output file path is not writable or its parent directory does not exist.' );
+				return;
+			}
+			$file_path = $assoc_args['output'];
+		} else {
+			$file_path = get_temp_dir() . 'schema.graphql';
+		}
 
 		if ( ! defined( 'GRAPHQL_REQUEST' ) ) {
 			define( 'GRAPHQL_REQUEST', true );

--- a/constants.php
+++ b/constants.php
@@ -18,7 +18,7 @@ function graphql_setup_constants() {
 
 	// Plugin version.
 	if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-		define( 'WPGRAPHQL_VERSION', '1.30.0' );
+		define( 'WPGRAPHQL_VERSION', '1.31.0' );
 	}
 
 	// Plugin Folder Path.

--- a/docs/menus.md
+++ b/docs/menus.md
@@ -134,7 +134,7 @@ One thing you may have noticed is that Menu Items will be returned in a flat-lis
 
 There's a good chance you might need to convert a flat list into a hierarchical list in the consumer application to be used in a component such as a Checkbox Tree or Dropdown Menu, for example.
 
-> You can see this technique in action in the codebase for the website you're reading [here](https://github.com/wp-graphql/wpgraphql.com/blob/master/src/components/DocsSidebar.js#L8-L26).
+> You can see this technique in action in the codebase for the website you're reading [here](https://github.com/wp-graphql/wpgraphql.com/blob/master/src/components/Docs/DocsNav.js#L8-L39).
 
 Given the query above, we might have a payload of data like so:
 

--- a/readme.txt
+++ b/readme.txt
@@ -271,6 +271,18 @@ Composer dependencies are no longer versioned in Github. Recommended install sou
 
 == Changelog ==
 
+= 1.31.0 =
+
+**New Features**
+
+- [#3278](https://github.com/wp-graphql/wp-graphql/pull/3278): feat: add option to provide custom file path for static schemas when using the `wp graphql generate-static-schema` command
+
+**Chores / Bugfixes**
+
+- [#3284](https://github.com/wp-graphql/wp-graphql/pull/3284): fix: fix: Updated docs link for example of hierarchical data
+- [#3283](https://github.com/wp-graphql/wp-graphql/pull/3283): fix: Error in update checker when WPGraphQL is active as an mu-plugin
+
+
 = 1.30.0 =
 
 **Chores / Bugfixes**

--- a/src/Admin/Updates/Updates.php
+++ b/src/Admin/Updates/Updates.php
@@ -136,8 +136,12 @@ final class Updates {
 	 * Disables plugins that don't meet the minimum `Requires WPGraphQL` version.
 	 */
 	public function disable_incompatible_plugins(): void {
+
+		// Get the plugin data.
+		$plugin_data = get_plugin_data( WPGRAPHQL_PLUGIN_DIR . '/wp-graphql.php' );
+
 		// Initialize the Update Checker.
-		$update_checker = new UpdateChecker( (object) get_plugins()['wp-graphql/wp-graphql.php'] );
+		$update_checker = new UpdateChecker( (object) $plugin_data );
 
 		// Get the incompatible plugins.
 		$incompatible_plugins = $update_checker->get_incompatible_plugins( WPGRAPHQL_VERSION, true );

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.30.0
+ * Version: 1.31.0
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.9
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.30.0
+ * @version  1.31.0
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
## Release Notes

### New Features

- [#3278](https://github.com/wp-graphql/wp-graphql/pull/3278): feat: add option to provide custom file path for static schemas when using the `wp graphql generate-static-schema` command

### Chores / Bugfixes

- [#3284](https://github.com/wp-graphql/wp-graphql/pull/3284): fix: fix: Updated docs link for example of hierarchical data
- [#3283](https://github.com/wp-graphql/wp-graphql/pull/3283): fix: Error in update checker when WPGraphQL is active as an mu-plugin
