### PR TITLE
fix: update DisableIntrospection rule to pass the enabled/disabled state to class instead of being re-defined within the class

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -201,15 +201,8 @@ class Request {
 		$validation_rules = GraphQL::getStandardValidationRules();
 
 		$validation_rules['require_authentication'] = new RequireAuthentication();
-
-		// By default, introspection is disabled for non-logged-in users and when debug is off
-		$disable_introspection_rule_enabled = 0;
-		if ( ! get_current_user_id() && ! \WPGraphQL::debug() && 'off' === get_graphql_setting( 'public_introspection_enabled', 'off' ) ) {
-			$disable_introspection_rule_enabled = 1;
-		}
-
-		$validation_rules['disable_introspection'] = new DisableIntrospection( $disable_introspection_rule_enabled );
-		$validation_rules['query_depth']           = new QueryDepth();
+		$validation_rules['disable_introspection']  = new DisableIntrospection();
+		$validation_rules['query_depth']            = new QueryDepth();
 
 		/**
 		 * Return the validation rules to use in the request

--- a/src/Request.php
+++ b/src/Request.php
@@ -201,8 +201,15 @@ class Request {
 		$validation_rules = GraphQL::getStandardValidationRules();
 
 		$validation_rules['require_authentication'] = new RequireAuthentication();
-		$validation_rules['disable_introspection']  = new DisableIntrospection( 1 );
-		$validation_rules['query_depth']            = new QueryDepth();
+
+		// By default, introspection is disabled for non-logged-in users and when debug is off
+		$disable_introspection_rule_enabled = 0;
+		if ( ! get_current_user_id() && ! \WPGraphQL::debug() && 'off' === get_graphql_setting( 'public_introspection_enabled', 'off' ) ) {
+			$disable_introspection_rule_enabled = 1;
+		}
+
+		$validation_rules['disable_introspection'] = new DisableIntrospection( $disable_introspection_rule_enabled );
+		$validation_rules['query_depth']           = new QueryDepth();
 
 		/**
 		 * Return the validation rules to use in the request

--- a/src/Server/ValidationRules/DisableIntrospection.php
+++ b/src/Server/ValidationRules/DisableIntrospection.php
@@ -10,6 +10,26 @@ namespace WPGraphQL\Server\ValidationRules;
 class DisableIntrospection extends \GraphQL\Validator\Rules\DisableIntrospection {
 
 	/**
+	 * DisableIntrospection constructor.
+	 */
+	public function __construct() {
+		parent::__construct( $this->isEnabled() ? self::ENABLED : self::DISABLED );
+	}
+
+	/**
+	 * Whether the rule is enabled or not.
+	 */
+	public function isEnabled(): bool {
+		$enabled = false;
+
+		if ( ! get_current_user_id() && ! \WPGraphQL::debug() && 'off' === get_graphql_setting( 'public_introspection_enabled', 'off' ) ) {
+			$enabled = true;
+		}
+
+		return $enabled;
+	}
+
+	/**
 	 * Returns a helpful message when introspection is disabled and an introspection query is attempted.
 	 */
 	public static function introspectionDisabledMessage(): string {

--- a/src/Server/ValidationRules/DisableIntrospection.php
+++ b/src/Server/ValidationRules/DisableIntrospection.php
@@ -13,20 +13,18 @@ class DisableIntrospection extends \GraphQL\Validator\Rules\DisableIntrospection
 	 * DisableIntrospection constructor.
 	 */
 	public function __construct() {
-		parent::__construct( $this->isEnabled() ? self::ENABLED : self::DISABLED );
+		$should_be_enabled = $this->should_be_enabled();
+		parent::__construct( $should_be_enabled ? self::ENABLED : self::DISABLED );
 	}
 
 	/**
-	 * Whether the rule is enabled or not.
+	 * Determines whether the DisableIntrospection rule should be disabled.
 	 */
-	public function isEnabled(): bool {
-		$enabled = false;
-
+	public function should_be_enabled(): bool {
 		if ( ! get_current_user_id() && ! \WPGraphQL::debug() && 'off' === get_graphql_setting( 'public_introspection_enabled', 'off' ) ) {
-			$enabled = true;
+			return true;
 		}
-
-		return $enabled;
+		return false;
 	}
 
 	/**

--- a/src/Server/ValidationRules/DisableIntrospection.php
+++ b/src/Server/ValidationRules/DisableIntrospection.php
@@ -10,15 +10,9 @@ namespace WPGraphQL\Server\ValidationRules;
 class DisableIntrospection extends \GraphQL\Validator\Rules\DisableIntrospection {
 
 	/**
-	 * Whether the rule is enabled or not.
+	 * Returns a helpful message when introspection is disabled and an introspection query is attempted.
 	 */
-	public function isEnabled(): bool {
-		$enabled = false;
-
-		if ( ! get_current_user_id() && ! \WPGraphQL::debug() && 'off' === get_graphql_setting( 'public_introspection_enabled', 'off' ) ) {
-			$enabled = true;
-		}
-
-		return $enabled;
+	public static function introspectionDisabledMessage(): string {
+		return 'The query contained __schema or __type, however GraphQL introspection is not allowed for public requests by default. Public introspection can be enabled under the WPGraphQL Settings.';
 	}
 }

--- a/src/Server/ValidationRules/DisableIntrospection.php
+++ b/src/Server/ValidationRules/DisableIntrospection.php
@@ -33,6 +33,6 @@ class DisableIntrospection extends \GraphQL\Validator\Rules\DisableIntrospection
 	 * Returns a helpful message when introspection is disabled and an introspection query is attempted.
 	 */
 	public static function introspectionDisabledMessage(): string {
-		return 'The query contained __schema or __type, however GraphQL introspection is not allowed for public requests by default. Public introspection can be enabled under the WPGraphQL Settings.';
+		return __( 'The query contained __schema or __type, however GraphQL introspection is not allowed for public requests by default. Public introspection can be enabled under the WPGraphQL Settings.', 'wp-graphql' );
 	}
 }

--- a/tests/wpunit/AssertValidSchemaTest.php
+++ b/tests/wpunit/AssertValidSchemaTest.php
@@ -69,7 +69,7 @@ class AssertValidSchemaTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase 
 		);
 
 		$this->assertArrayHasKey( 'errors', $actual );
-		$this->assertSame( 'GraphQL introspection is not allowed, but the query contained __schema or __type', $actual['errors'][0]['message'] );
+		$this->assertSame( 'The query contained __schema or __type, however GraphQL introspection is not allowed for public requests by default. Public introspection can be enabled under the WPGraphQL Settings.', $actual['errors'][0]['message'] );
 	}
 
 	public function testIntrospectionQueriesByAdminWhenPublicIntrospectionIsDisabled() {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This determines whether the DisableIntrospection rule is enabled before instantiating the rule. 

Does this close any currently open issues?
------------------------------------------
related: https://github.com/wp-graphql/wp-graphql/pull/3247#discussion_r1941685001
