### PR TITLE
fix: return 415 status code for missing or invalid content type header

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -722,7 +722,7 @@ class Request {
 			return false;
 		}
 
-		return 'application/json' === trim( strtolower( $content_type ) );
+		return 0 === stripos( $content_type, 'application/json' );
 	}
 
 	/**

--- a/src/Request.php
+++ b/src/Request.php
@@ -678,7 +678,7 @@ class Request {
 	 * @throws \Exception
 	 */
 	public function execute_http() {
-		if ( ! $this->validate_http_content_type() ) {
+		if ( ! $this->is_valid_http_content_type() ) {
 			return $this->get_invalid_content_type_response();
 		}
 
@@ -712,13 +712,17 @@ class Request {
 	/**
 	 * Validates the content type for HTTP POST requests
 	 */
-	private function validate_http_content_type(): bool {
+	private function is_valid_http_content_type(): bool {
 		if ( ! isset( $_SERVER['REQUEST_METHOD'] ) || 'POST' !== $_SERVER['REQUEST_METHOD'] ) {
 			return true;
 		}
 
 		$content_type = $this->get_content_type();
-		return ! empty( $content_type ) && 0 === strpos( $content_type, 'application/json' );
+		if ( empty( $content_type ) ) {
+			return false;
+		}
+
+		return 'application/json' === trim( strtolower( $content_type ) );
 	}
 
 	/**

--- a/src/Request.php
+++ b/src/Request.php
@@ -694,6 +694,7 @@ class Request {
 				return [
 					'errors' => [
 						[
+							// translators: %s is the content type header value that was received 
 							'message' => sprintf( esc_html__( 'HTTP POST requests must have Content-Type: application/json header. Received: %s', 'wp-graphql' ), $content_type ),
 						],
 					],

--- a/src/Request.php
+++ b/src/Request.php
@@ -678,42 +678,8 @@ class Request {
 	 * @throws \Exception
 	 */
 	public function execute_http() {
-		// Validate content-type header for POST requests
-		if ( isset( $_SERVER['REQUEST_METHOD'] ) && 'POST' === $_SERVER['REQUEST_METHOD'] ) {
-			// Check both possible content-type header locations
-			$content_type = '';
-			if ( isset( $_SERVER['CONTENT_TYPE'] ) ) {
-				$content_type = sanitize_text_field( $_SERVER['CONTENT_TYPE'] );
-			} elseif ( isset( $_SERVER['HTTP_CONTENT_TYPE'] ) ) {
-				$content_type = sanitize_text_field( $_SERVER['HTTP_CONTENT_TYPE'] );
-			}
-
-			if ( empty( $content_type ) || 0 !== strpos( $content_type, 'application/json' ) ) {
-
-
-				/**
-				 * Filter the status code to return when the content type is invalid
-				 *
-				 * @param int    $status_code The status code to return
-				 * @param string $content_type The content type header value that was received
-				 */
-				$filtered_status_code = apply_filters( 'graphql_invalid_content_type_status_code', 415, $content_type );
-
-				// validate that the status code is in valid http status code ranges (100-599)
-				if ( is_numeric( $filtered_status_code ) && ( $filtered_status_code > 100 && $filtered_status_code < 599 ) ) {
-					// Set status code to 415 (Unsupported Media Type)
-					Router::$http_status_code = $filtered_status_code;
-				}
-
-				return [
-					'errors' => [
-						[
-							// translators: %s is the content type header value that was received
-							'message' => sprintf( esc_html__( 'HTTP POST requests must have Content-Type: application/json header. Received: %s', 'wp-graphql' ), $content_type ),
-						],
-					],
-				];
-			}
+		if ( ! $this->validate_http_content_type() ) {
+			return $this->get_invalid_content_type_response();
 		}
 
 		/**
@@ -741,6 +707,65 @@ class Request {
 		}
 
 		return $this->after_execute( $response );
+	}
+
+	/**
+	 * Validates the content type for HTTP POST requests
+	 */
+	private function validate_http_content_type(): bool {
+		if ( ! isset( $_SERVER['REQUEST_METHOD'] ) || 'POST' !== $_SERVER['REQUEST_METHOD'] ) {
+			return true;
+		}
+
+		$content_type = $this->get_content_type();
+		return ! empty( $content_type ) && 0 === strpos( $content_type, 'application/json' );
+	}
+
+	/**
+	 * Gets the content type from the request headers
+	 */
+	private function get_content_type(): string {
+		if ( isset( $_SERVER['CONTENT_TYPE'] ) ) {
+			return sanitize_text_field( $_SERVER['CONTENT_TYPE'] );
+		}
+
+		if ( isset( $_SERVER['HTTP_CONTENT_TYPE'] ) ) {
+			return sanitize_text_field( $_SERVER['HTTP_CONTENT_TYPE'] );
+		}
+
+		return '';
+	}
+
+	/**
+	 * Returns the error response for invalid content type
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function get_invalid_content_type_response(): array {
+		$content_type = $this->get_content_type();
+
+		/**
+		 * Filter the status code to return when the content type is invalid
+		 *
+		 * @param int    $status_code The status code to return
+		 * @param string $content_type The content type header value that was received
+		 */
+		$filtered_status_code = apply_filters( 'graphql_invalid_content_type_status_code', 415, $content_type );
+
+		// validate that the status code is in valid http status code ranges (100-599)
+		if ( is_numeric( $filtered_status_code ) && ( $filtered_status_code > 100 && $filtered_status_code < 599 ) ) {
+			// Set status code to 415 (Unsupported Media Type)
+			Router::$http_status_code = $filtered_status_code;
+		}
+
+		return [
+			'errors' => [
+				[
+					// translators: %s is the content type header value that was received
+					'message' => sprintf( esc_html__( 'HTTP POST requests must have Content-Type: application/json header. Received: %s', 'wp-graphql' ), $content_type ),
+				],
+			],
+		];
 	}
 
 	/**

--- a/src/Request.php
+++ b/src/Request.php
@@ -678,6 +678,24 @@ class Request {
 	 * @throws \Exception
 	 */
 	public function execute_http() {
+		// Validate content-type header for POST requests
+		if ( isset( $_SERVER['REQUEST_METHOD'] ) && 'POST' === $_SERVER['REQUEST_METHOD'] ) {
+			$content_type = isset( $_SERVER['HTTP_CONTENT_TYPE'] ) ? sanitize_text_field( $_SERVER['HTTP_CONTENT_TYPE'] ) : '';
+			if ( empty( $content_type ) || 'application/json' !== $content_type ) {
+				// Send a 415 error (unsupported media type) with a JSON response and error message
+				wp_send_json(
+					[
+						'errors' => [
+							[
+								'message' => __( 'HTTP POST requests must have Content-Type: application/json header', 'wp-graphql' ),
+							],
+						],
+					],
+					415
+				);
+			}
+		}
+
 		/**
 		 * Parse HTTP request.
 		 */

--- a/src/Request.php
+++ b/src/Request.php
@@ -689,8 +689,22 @@ class Request {
 			}
 
 			if ( empty( $content_type ) || 0 !== strpos( $content_type, 'application/json' ) ) {
-				// Set status code to 415 (Unsupported Media Type)
-				Router::$http_status_code = 415;
+
+
+				/**
+				 * Filter the status code to return when the content type is invalid
+				 *
+				 * @param int    $status_code The status code to return
+				 * @param string $content_type The content type header value that was received
+				 */
+				$filtered_status_code = apply_filters( 'graphql_invalid_content_type_status_code', 415, $content_type );
+
+				// validate that the status code is in valid http status code ranges (100-599)
+				if ( is_numeric( $filtered_status_code ) && ( $filtered_status_code > 100 && $filtered_status_code < 599 ) ) {
+					// Set status code to 415 (Unsupported Media Type)
+					Router::$http_status_code = $filtered_status_code;
+				}
+
 				return [
 					'errors' => [
 						[

--- a/src/Request.php
+++ b/src/Request.php
@@ -694,7 +694,7 @@ class Request {
 				return [
 					'errors' => [
 						[
-							// translators: %s is the content type header value that was received 
+							// translators: %s is the content type header value that was received
 							'message' => sprintf( esc_html__( 'HTTP POST requests must have Content-Type: application/json header. Received: %s', 'wp-graphql' ), $content_type ),
 						],
 					],

--- a/src/Router.php
+++ b/src/Router.php
@@ -286,7 +286,7 @@ class Router {
 	 *
 	 * @return void
 	 */
-	protected static function set_status( $status_code = null ) {
+	protected static function set_status( ?int $status_code = null ) {
 		$status_code = null === $status_code ? self::$http_status_code : $status_code;
 
 		// validate that the status code is a valid http status code

--- a/src/Router.php
+++ b/src/Router.php
@@ -282,10 +282,19 @@ class Router {
 	/**
 	 * Sends an HTTP status code.
 	 *
+	 * @param int|null $status_code The status code to send.
+	 *
 	 * @return void
 	 */
-	protected static function set_status() {
-		status_header( self::$http_status_code );
+	protected static function set_status( $status_code = null ) {
+		$status_code = null === $status_code ? self::$http_status_code : $status_code;
+
+		// validate that the status code is a valid http status code
+		if ( ! is_numeric( $status_code ) || $status_code < 100 || $status_code > 599 ) {
+			$status_code = 500;
+		}
+
+		status_header( $status_code );
 	}
 
 	/**
@@ -365,7 +374,7 @@ class Router {
 			/**
 			 * Set the HTTP response status
 			 */
-			self::set_status();
+			self::set_status( self::$http_status_code );
 
 			/**
 			 * Get the response headers

--- a/tests/functional/ContentTypeHeaderCept.php
+++ b/tests/functional/ContentTypeHeaderCept.php
@@ -12,7 +12,7 @@ $I->seeResponseCodeIs(415);
 $I->seeResponseContainsJson([
     'errors' => [
         [
-            'message' => 'HTTP POST requests must have Content-Type: application/json header. Received: application/x-www-form-urlencoded'
+            'message' => 'HTTP POST requests must have Content-Type: application/json header. Received: '
         ]
     ]
 ]);

--- a/tests/functional/ContentTypeHeaderCept.php
+++ b/tests/functional/ContentTypeHeaderCept.php
@@ -40,8 +40,8 @@ $I->seeResponseCodeIs(200);
 
 // Verify that application/json with charset works
 $I->haveHttpHeader('Content-Type', 'application/json; charset=utf-8');
-$I->sendPOST('http://localhost/graphql', [
+$I->sendPOST('http://localhost/graphql', json_encode([
     'query' => '{posts{nodes{id}}}'
-]);
+]));
 $I->seeResponseCodeIs(200);
 

--- a/tests/functional/ContentTypeHeaderCept.php
+++ b/tests/functional/ContentTypeHeaderCept.php
@@ -7,7 +7,7 @@ $I->wantTo('Ensure 415 status code is returned when content-type header is missi
 // Test with no content-type header
 $I->sendPOST('http://localhost/graphql', json_encode([
     'query' => '{posts{nodes{id}}}'
-]);
+]));
 $I->seeResponseCodeIs(415);
 $I->seeResponseContainsJson([
     'errors' => [
@@ -21,7 +21,7 @@ $I->seeResponseContainsJson([
 $I->haveHttpHeader('Content-Type', 'text/plain');
 $I->sendPOST('http://localhost/graphql', json_encode([
     'query' => '{posts{nodes{id}}}'
-]);
+]));
 $I->seeResponseCodeIs(415);
 $I->seeResponseContainsJson([
     'errors' => [

--- a/tests/functional/ContentTypeHeaderCept.php
+++ b/tests/functional/ContentTypeHeaderCept.php
@@ -5,7 +5,7 @@ $I = new FunctionalTester($scenario);
 $I->wantTo('Ensure 415 status code is returned when content-type header is missing or incorrect');
 
 // Test with no content-type header
-$I->sendPOST('http://localhost/graphql', [
+$I->sendPOST('http://localhost/graphql', json_encode([
     'query' => '{posts{nodes{id}}}'
 ]);
 $I->seeResponseCodeIs(415);
@@ -19,7 +19,7 @@ $I->seeResponseContainsJson([
 
 // Test with incorrect content-type header
 $I->haveHttpHeader('Content-Type', 'text/plain');
-$I->sendPOST('http://localhost/graphql', [
+$I->sendPOST('http://localhost/graphql', json_encode([
     'query' => '{posts{nodes{id}}}'
 ]);
 $I->seeResponseCodeIs(415);
@@ -33,9 +33,9 @@ $I->seeResponseContainsJson([
 
 // Verify that application/json content-type works correctly
 $I->haveHttpHeader('Content-Type', 'application/json');
-$I->sendPOST('http://localhost/graphql', [
+$I->sendPOST('http://localhost/graphql', json_encode([
     'query' => '{posts{nodes{id}}}'
-]);
+]));
 $I->seeResponseCodeIs(200);
 
 // Verify that application/json with charset works

--- a/tests/functional/HttpStatusCodeCept.php
+++ b/tests/functional/HttpStatusCodeCept.php
@@ -9,6 +9,13 @@ $I->sendPOST('http://localhost/graphql', [
     'query' => '{posts{nodes{id}}}'
 ]);
 $I->seeResponseCodeIs(415);
+$I->seeResponseContainsJson([
+    'errors' => [
+        [
+            'message' => 'HTTP POST requests must have Content-Type: application/json header'
+        ]
+    ]
+]);
 
 // Test with incorrect content-type header
 $I->haveHttpHeader('Content-Type', 'text/plain');
@@ -16,6 +23,13 @@ $I->sendPOST('http://localhost/graphql', [
     'query' => '{posts{nodes{id}}}'
 ]);
 $I->seeResponseCodeIs(415);
+$I->seeResponseContainsJson([
+    'errors' => [
+        [
+            'message' => 'HTTP POST requests must have Content-Type: application/json header'
+        ]
+    ]
+]);
 
 // Verify that application/json content-type works correctly
 $I->haveHttpHeader('Content-Type', 'application/json');

--- a/tests/functional/HttpStatusCodeCept.php
+++ b/tests/functional/HttpStatusCodeCept.php
@@ -38,3 +38,10 @@ $I->sendPOST('http://localhost/graphql', [
 ]);
 $I->seeResponseCodeIs(200);
 
+// Verify that application/json with charset works
+$I->haveHttpHeader('Content-Type', 'application/json; charset=utf-8');
+$I->sendPOST('http://localhost/graphql', [
+    'query' => '{posts{nodes{id}}}'
+]);
+$I->seeResponseCodeIs(200);
+

--- a/tests/functional/HttpStatusCodeCept.php
+++ b/tests/functional/HttpStatusCodeCept.php
@@ -12,7 +12,7 @@ $I->seeResponseCodeIs(415);
 $I->seeResponseContainsJson([
     'errors' => [
         [
-            'message' => 'HTTP POST requests must have Content-Type: application/json header'
+            'message' => 'HTTP POST requests must have Content-Type: application/json header. Received: application/x-www-form-urlencoded'
         ]
     ]
 ]);
@@ -26,7 +26,7 @@ $I->seeResponseCodeIs(415);
 $I->seeResponseContainsJson([
     'errors' => [
         [
-            'message' => 'HTTP POST requests must have Content-Type: application/json header'
+            'message' => 'HTTP POST requests must have Content-Type: application/json header. Received: text/plain'
         ]
     ]
 ]);

--- a/tests/functional/HttpStatusCodeCept.php
+++ b/tests/functional/HttpStatusCodeCept.php
@@ -1,0 +1,26 @@
+<?php
+
+$I = new FunctionalTester($scenario);
+
+$I->wantTo('Ensure 415 status code is returned when content-type header is missing or incorrect');
+
+// Test with no content-type header
+$I->sendPOST('http://localhost/graphql', [
+    'query' => '{posts{nodes{id}}}'
+]);
+$I->seeResponseCodeIs(415);
+
+// Test with incorrect content-type header
+$I->haveHttpHeader('Content-Type', 'text/plain');
+$I->sendPOST('http://localhost/graphql', [
+    'query' => '{posts{nodes{id}}}'
+]);
+$I->seeResponseCodeIs(415);
+
+// Verify that application/json content-type works correctly
+$I->haveHttpHeader('Content-Type', 'application/json');
+$I->sendPOST('http://localhost/graphql', [
+    'query' => '{posts{nodes{id}}}'
+]);
+$I->seeResponseCodeIs(200);
+


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This updates the response to return a 415 status code if the POST request to the endpoint is missing a "content-type" header or has an invalid value (something other than `application/json`)

- [x] Failing Test: https://github.com/wp-graphql/wp-graphql/actions/runs/13168466543/job/36753997929#step:6:592
- [x] Passing Test: https://github.com/wp-graphql/wp-graphql/actions/runs/13187533719/job/36813105163?pr=3291


Does this close any currently open issues?
------------------------------------------
This closes #1692 


Any other comments?
-------------------
**This is considered a breaking change** as clients will now have different behavior. 

While it's already documented that the content-type needs to be application/json and that errors were returned, this changes the status code from 500 to 415, which might require some clients to make adjustments. 

We've introduced the `graphql_invalid_content_type_status_code` filter, which would allow for the status code to be set back to `500` (or any other status code) should users want to maintain backward compatibility with v1.* where the status code was 500 when the content type was invalid. 

This PR is to the v2.0 release branch and should be documented in the v2.0 release notes.


