### PR TITLE
fix: correct the resolver for the MediaDetails.file field to return the file name

### DIFF
--- a/src/Type/ObjectType/MediaDetails.php
+++ b/src/Type/ObjectType/MediaDetails.php
@@ -26,6 +26,9 @@ class MediaDetails {
 					'file'   => [
 						'type'        => 'String',
 						'description' => __( 'The filename of the mediaItem', 'wp-graphql' ),
+						'resolve'     => static function ( $media_details ) {
+							return ! empty( $media_details['file'] ) ? basename( $media_details['file'] ) : null;
+						},
 					],
 					'sizes'  => [
 						'type'        => [

--- a/tests/wpunit/MediaItemMutationsTest.php
+++ b/tests/wpunit/MediaItemMutationsTest.php
@@ -494,7 +494,7 @@ class MediaItemMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 					'mediaType'     => 'image',
 					'sourceUrl'     => $attachment_url,
 					'mediaDetails'  => [
-						'file'   => $attachment_details['file'],
+						'file'   => basename( $attachment_details['file'] ),
 						'height' => $attachment_details['height'],
 						'meta'   => [
 							'aperture'         => 0.0,
@@ -682,7 +682,7 @@ class MediaItemMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 					'parent'       => null,
 					'sourceUrl'    => $attachment_url,
 					'mediaDetails' => [
-						'file'   => $attachment_details['file'],
+						'file'   => basename( $attachment_details['file'] ),
 						'height' => $attachment_details['height'],
 						'meta'   => [
 							'aperture'         => 0.0,
@@ -761,7 +761,7 @@ class MediaItemMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 					'mediaType'     => 'image',
 					'sourceUrl'     => $attachment_url,
 					'mediaDetails'  => [
-						'file'   => $attachment_details['file'],
+						'file'   => basename( $attachment_details['file'] ),
 						'height' => $attachment_details['height'],
 						'meta'   => [
 							'aperture'         => 0.0,

--- a/tests/wpunit/MediaItemQueriesTest.php
+++ b/tests/wpunit/MediaItemQueriesTest.php
@@ -762,4 +762,44 @@ class MediaItemQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		wp_delete_attachment( $attachment_id, true );
 	}
+
+	/**
+	 * Test that MediaDetails.file returns just the filename without the path
+	 */
+	public function testMediaDetailsFile() {
+		// Upload a test image
+		$filename = ( WPGRAPHQL_PLUGIN_DIR . 'tests/_data/images/test.png' );
+		$attachment_id = $this->factory()->attachment->create_upload_object( $filename );
+
+		$query = '
+		query GetMediaDetailsFile($id: ID!) {
+			mediaItem(id: $id, idType: DATABASE_ID) {
+				mediaDetails {
+					file
+				}
+			}
+		}
+		';
+
+		$variables = [
+			'id' => $attachment_id,
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+		
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		
+		// Get the metadata to verify filename
+		$metadata = wp_get_attachment_metadata( $attachment_id );
+		$this->assertNotEmpty( $metadata['file'], 'Attachment metadata file should not be empty' );
+		
+		// Test that MediaDetails.file returns just the filename
+		$this->assertEquals( 
+			basename( $metadata['file'] ),
+			$actual['data']['mediaItem']['mediaDetails']['file'],
+			'MediaDetails.file should return just the filename without the path'
+		);
+
+		wp_delete_attachment( $attachment_id, true );
+	}
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

This fixes a bug where the `MediaDetails.file` field was returning a path to the file instead of the filename. 

The description of the field is: `The filename of the mediaItem`, however values such as `2025/02/test-4.png` were being returned, which is unexpected behavior.

- [x] failing test: https://github.com/wp-graphql/wp-graphql/actions/runs/13205103635/job/36866295120?pr=3293#step:7:916
- [x] passing test: https://github.com/wp-graphql/wp-graphql/actions/runs/13205434357


Does this close any currently open issues?
------------------------------------------
closes: #2982 

Any other comments?
-------------------

Running a query like so:

```graphql
query GetMediaItemFilePath($id: ID!) {
  mediaItem(id: $id, idType: DATABASE_ID) {
    mediaDetails {
      file
    }
  }
}
```

## Before

the file field returns a path: 

![CleanShot 2025-02-07 at 10 39 21](https://github.com/user-attachments/assets/6cbd8fc8-5f21-442d-a872-e5f2ed8bd00d)


## After

the file field returns just the filename as the field description states it will: 

![CleanShot 2025-02-07 at 10 39 32](https://github.com/user-attachments/assets/fe9102d9-b45f-480d-bd58-0c121ca0b4b2)

Breaking Change?
-------------------

This is not considered a breaking change as the actual behavior was not matching the documented intent of the field. 

However, some users may have been relying on the output with the path, using the bug as a feature, so for those users this might come across as a breaking change. 

Should a user need the field to resolve how it was previously, the following filter can be used, which will resolve the field as it was before this bugfix: 

```php
add_filter( 'graphql_resolve_field', function( $result, $source, $args, $context, $info, $type_name, $field_key ) {

  if ( 'MediaDetails' !== $type_name && 'file' !== $field_key ) {
    return $result;
  }
  
  return $source['file'];

}, 10, 7 );
```

