### PR TITLE
feat: introduce new fields for getting mediaItem files and filePaths

### DIFF
--- a/src/Registry/Utils/PostObject.php
+++ b/src/Registry/Utils/PostObject.php
@@ -585,6 +585,70 @@ class PostObject {
 						return $image->get_source_url_by_size( $size );
 					},
 				],
+				'file' => [
+                    'type' => 'String',
+                    'description' => __( 'The filename of the mediaItem for the specified size (default size is full)', 'wp-graphql' ),
+                    'args' => [
+                        'size' => [
+                            'type' => 'MediaItemSizeEnum',
+                            'description' => __( 'Size of the MediaItem to return', 'wp-graphql' ),
+                        ],
+                    ],
+                    'resolve' => static function ( $source, $args ) {
+                        // If a size is specified, get the size-specific filename
+                        if ( ! empty( $args['size'] ) ) {
+                            $size = 'full' === $args['size'] ? 'large' : $args['size'];
+                            
+                            // Get the metadata which contains size information
+                            $metadata = wp_get_attachment_metadata( $source->databaseId );
+                            
+                            if ( ! empty( $metadata['sizes'][ $size ]['file'] ) ) {
+                                return $metadata['sizes'][ $size ]['file'];
+                            }
+                        }
+
+                        // Default to original file
+                        $attached_file = get_post_meta( $source->databaseId, '_wp_attached_file', true );
+                        return ! empty( $attached_file ) ? basename( $attached_file ) : null;
+                    }
+                ],
+				'filePath' => [
+					'type' => 'String',
+					'description' => __( 'The path to the original file relative to the uploads directory', 'wp-graphql' ),
+					'args' => [
+						'size' => [
+							'type' => 'MediaItemSizeEnum',
+							'description' => __( 'Size of the MediaItem to return', 'wp-graphql' ),
+						],
+					],
+					'resolve' => static function ( $source, $args ) {
+						// Get the upload directory info
+						$upload_dir = wp_upload_dir();
+						$relative_upload_path = wp_make_link_relative( $upload_dir['baseurl'] );
+
+						// If a size is specified, get the size-specific path
+						if ( ! empty( $args['size'] ) ) {
+							$size = 'full' === $args['size'] ? 'large' : $args['size'];
+							
+							// Get the metadata which contains size information
+							$metadata = wp_get_attachment_metadata( $source->databaseId );
+							
+							if ( ! empty( $metadata['sizes'][ $size ]['file'] ) ) {
+								$file_path = $metadata['file'];
+								return path_join( $relative_upload_path, dirname( $file_path ) . '/' . $metadata['sizes'][ $size ]['file'] );
+							}
+						}
+
+						// Default to original file path
+						$attached_file = get_post_meta( $source->databaseId, '_wp_attached_file', true );
+						
+						if ( empty( $attached_file ) ) {
+							return null;
+						}
+
+						return path_join( $relative_upload_path, $attached_file );
+					}
+				],
 				'fileSize'     => [
 					'type'        => 'Int',
 					'description' => __( 'The filesize in bytes of the resource', 'wp-graphql' ),

--- a/src/Registry/Utils/PostObject.php
+++ b/src/Registry/Utils/PostObject.php
@@ -585,54 +585,54 @@ class PostObject {
 						return $image->get_source_url_by_size( $size );
 					},
 				],
-				'file' => [
-                    'type' => 'String',
-                    'description' => __( 'The filename of the mediaItem for the specified size (default size is full)', 'wp-graphql' ),
-                    'args' => [
-                        'size' => [
-                            'type' => 'MediaItemSizeEnum',
-                            'description' => __( 'Size of the MediaItem to return', 'wp-graphql' ),
-                        ],
-                    ],
-                    'resolve' => static function ( $source, $args ) {
-                        // If a size is specified, get the size-specific filename
-                        if ( ! empty( $args['size'] ) ) {
-                            $size = 'full' === $args['size'] ? 'large' : $args['size'];
-                            
-                            // Get the metadata which contains size information
-                            $metadata = wp_get_attachment_metadata( $source->databaseId );
-                            
-                            if ( ! empty( $metadata['sizes'][ $size ]['file'] ) ) {
-                                return $metadata['sizes'][ $size ]['file'];
-                            }
-                        }
-
-                        // Default to original file
-                        $attached_file = get_post_meta( $source->databaseId, '_wp_attached_file', true );
-                        return ! empty( $attached_file ) ? basename( $attached_file ) : null;
-                    }
-                ],
-				'filePath' => [
-					'type' => 'String',
-					'description' => __( 'The path to the original file relative to the uploads directory', 'wp-graphql' ),
-					'args' => [
+				'file'         => [
+					'type'        => 'String',
+					'description' => __( 'The filename of the mediaItem for the specified size (default size is full)', 'wp-graphql' ),
+					'args'        => [
 						'size' => [
-							'type' => 'MediaItemSizeEnum',
+							'type'        => 'MediaItemSizeEnum',
 							'description' => __( 'Size of the MediaItem to return', 'wp-graphql' ),
 						],
 					],
-					'resolve' => static function ( $source, $args ) {
+					'resolve'     => static function ( $source, $args ) {
+						// If a size is specified, get the size-specific filename
+						if ( ! empty( $args['size'] ) ) {
+							$size = 'full' === $args['size'] ? 'large' : $args['size'];
+
+							// Get the metadata which contains size information
+							$metadata = wp_get_attachment_metadata( $source->databaseId );
+
+							if ( ! empty( $metadata['sizes'][ $size ]['file'] ) ) {
+								return $metadata['sizes'][ $size ]['file'];
+							}
+						}
+
+						// Default to original file
+						$attached_file = get_post_meta( $source->databaseId, '_wp_attached_file', true );
+						return ! empty( $attached_file ) ? basename( $attached_file ) : null;
+					},
+				],
+				'filePath'     => [
+					'type'        => 'String',
+					'description' => __( 'The path to the original file relative to the uploads directory', 'wp-graphql' ),
+					'args'        => [
+						'size' => [
+							'type'        => 'MediaItemSizeEnum',
+							'description' => __( 'Size of the MediaItem to return', 'wp-graphql' ),
+						],
+					],
+					'resolve'     => static function ( $source, $args ) {
 						// Get the upload directory info
-						$upload_dir = wp_upload_dir();
+						$upload_dir           = wp_upload_dir();
 						$relative_upload_path = wp_make_link_relative( $upload_dir['baseurl'] );
 
 						// If a size is specified, get the size-specific path
 						if ( ! empty( $args['size'] ) ) {
 							$size = 'full' === $args['size'] ? 'large' : $args['size'];
-							
+
 							// Get the metadata which contains size information
 							$metadata = wp_get_attachment_metadata( $source->databaseId );
-							
+
 							if ( ! empty( $metadata['sizes'][ $size ]['file'] ) ) {
 								$file_path = $metadata['file'];
 								return path_join( $relative_upload_path, dirname( $file_path ) . '/' . $metadata['sizes'][ $size ]['file'] );
@@ -641,13 +641,13 @@ class PostObject {
 
 						// Default to original file path
 						$attached_file = get_post_meta( $source->databaseId, '_wp_attached_file', true );
-						
+
 						if ( empty( $attached_file ) ) {
 							return null;
 						}
 
 						return path_join( $relative_upload_path, $attached_file );
-					}
+					},
 				],
 				'fileSize'     => [
 					'type'        => 'Int',

--- a/src/Type/ObjectType/MediaDetails.php
+++ b/src/Type/ObjectType/MediaDetails.php
@@ -15,15 +15,15 @@ class MediaDetails {
 			[
 				'description' => __( 'File details for a Media Item', 'wp-graphql' ),
 				'fields'      => [
-					'width'  => [
+					'width'    => [
 						'type'        => 'Int',
 						'description' => __( 'The width of the mediaItem', 'wp-graphql' ),
 					],
-					'height' => [
+					'height'   => [
 						'type'        => 'Int',
 						'description' => __( 'The height of the mediaItem', 'wp-graphql' ),
 					],
-					'file'   => [
+					'file'     => [
 						'type'        => 'String',
 						'description' => __( 'The filename of the mediaItem', 'wp-graphql' ),
 						'resolve'     => static function ( $media_details ) {
@@ -35,17 +35,17 @@ class MediaDetails {
 						'description' => __( 'The path to the mediaItem relative to the uploads directory', 'wp-graphql' ),
 						'resolve'     => static function ( $media_details ) {
 							// Get the upload directory info
-							$upload_dir = wp_upload_dir();
+							$upload_dir           = wp_upload_dir();
 							$relative_upload_path = wp_make_link_relative( $upload_dir['baseurl'] );
-							
+
 							if ( ! empty( $media_details['file'] ) ) {
 								return path_join( $relative_upload_path, $media_details['file'] );
 							}
-							
+
 							return null;
 						},
 					],
-					'sizes'  => [
+					'sizes'    => [
 						'type'        => [
 							'list_of' => 'MediaSize',
 						],
@@ -87,7 +87,7 @@ class MediaDetails {
 							return ! empty( $sizes ) ? $sizes : null;
 						},
 					],
-					'meta'   => [
+					'meta'     => [
 						'type'        => 'MediaItemMeta',
 						'description' => __( 'Meta information associated with the mediaItem', 'wp-graphql' ),
 						'resolve'     => static function ( $media_details ) {

--- a/src/Type/ObjectType/MediaDetails.php
+++ b/src/Type/ObjectType/MediaDetails.php
@@ -26,6 +26,9 @@ class MediaDetails {
 					'file'   => [
 						'type'        => 'String',
 						'description' => __( 'The filename of the mediaItem', 'wp-graphql' ),
+						'resolve'     => static function ( $media_details ) {
+							return ! empty( $media_details['file'] ) ? basename( $media_details['file'] ) : null;
+						},
 					],
 					'sizes'  => [
 						'type'        => [

--- a/src/Type/ObjectType/MediaDetails.php
+++ b/src/Type/ObjectType/MediaDetails.php
@@ -30,6 +30,21 @@ class MediaDetails {
 							return ! empty( $media_details['file'] ) ? basename( $media_details['file'] ) : null;
 						},
 					],
+					'filePath' => [
+						'type'        => 'String',
+						'description' => __( 'The path to the mediaItem relative to the uploads directory', 'wp-graphql' ),
+						'resolve'     => static function ( $media_details ) {
+							// Get the upload directory info
+							$upload_dir = wp_upload_dir();
+							$relative_upload_path = wp_make_link_relative( $upload_dir['baseurl'] );
+							
+							if ( ! empty( $media_details['file'] ) ) {
+								return path_join( $relative_upload_path, $media_details['file'] );
+							}
+							
+							return null;
+						},
+					],
 					'sizes'  => [
 						'type'        => [
 							'list_of' => 'MediaSize',

--- a/src/Type/ObjectType/MediaSize.php
+++ b/src/Type/ObjectType/MediaSize.php
@@ -23,6 +23,23 @@ class MediaSize {
 						'type'        => 'String',
 						'description' => __( 'The filename of the referenced size', 'wp-graphql' ),
 					],
+					'filePath' => [
+						'type' => 'String',
+						'description' => __( 'The path of the file for the referenced size (default size is full)', 'wp-graphql' ),
+						'resolve' => static function ( $image ) {
+							if ( ! empty( $image['ID'] ) ) {
+								$original_file = get_attached_file( absint( $image['ID'] ) );
+								if ( ! empty( $original_file ) && ! empty( $image['file'] ) ) {
+									// Return the relative path for the specific size
+									return path_join( dirname( wp_make_link_relative( wp_get_attachment_url( $image['ID'] ) ) ), $image['file'] );
+								}
+							} elseif ( ! empty( $image['file'] ) ) {
+								return wp_make_link_relative( $image['file'] );
+							}
+
+							return null;
+						}
+					],
 					'width'     => [
 						'type'        => 'String',
 						'description' => __( 'The width of the referenced size', 'wp-graphql' ),

--- a/src/Type/ObjectType/MediaSize.php
+++ b/src/Type/ObjectType/MediaSize.php
@@ -23,10 +23,10 @@ class MediaSize {
 						'type'        => 'String',
 						'description' => __( 'The filename of the referenced size', 'wp-graphql' ),
 					],
-					'filePath' => [
-						'type' => 'String',
+					'filePath'  => [
+						'type'        => 'String',
 						'description' => __( 'The path of the file for the referenced size (default size is full)', 'wp-graphql' ),
-						'resolve' => static function ( $image ) {
+						'resolve'     => static function ( $image ) {
 							if ( ! empty( $image['ID'] ) ) {
 								$original_file = get_attached_file( absint( $image['ID'] ) );
 								if ( ! empty( $original_file ) && ! empty( $image['file'] ) ) {
@@ -38,7 +38,7 @@ class MediaSize {
 							}
 
 							return null;
-						}
+						},
 					],
 					'width'     => [
 						'type'        => 'String',

--- a/src/Type/ObjectType/MediaSize.php
+++ b/src/Type/ObjectType/MediaSize.php
@@ -28,10 +28,12 @@ class MediaSize {
 						'description' => __( 'The path of the file for the referenced size (default size is full)', 'wp-graphql' ),
 						'resolve'     => static function ( $image ) {
 							if ( ! empty( $image['ID'] ) ) {
-								$original_file = get_attached_file( absint( $image['ID'] ) );
-								if ( ! empty( $original_file ) && ! empty( $image['file'] ) ) {
+								$original_file  = get_attached_file( absint( $image['ID'] ) );
+								$attachment_url = wp_get_attachment_url( $image['ID'] );
+
+								if ( ! empty( $original_file ) && ! empty( $image['file'] ) && ! empty( $attachment_url ) ) {
 									// Return the relative path for the specific size
-									return path_join( dirname( wp_make_link_relative( wp_get_attachment_url( $image['ID'] ) ) ), $image['file'] );
+									return path_join( dirname( wp_make_link_relative( $attachment_url ) ), $image['file'] );
 								}
 							} elseif ( ! empty( $image['file'] ) ) {
 								return wp_make_link_relative( $image['file'] );


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This introduces some new fields for retrieving MediaItem file values: 

- `MediaDetails.filePath`: The path to the mediaItem relative to the uploads directory
- `MediaItem.file`: The filename of the mediaItem for the specified size (default size is full)
- `MediaItem.filePath`: The path to the original file relative to the uploads directory
- `MediaSize.filePath` The path of the file for the referenced size (default size is full)


Does this close any currently open issues?
------------------------------------------
related: #2982 


Any other comments?
-------------------

In #3293 we fixed a bug in how the MediaDetails.file field resolved. This introduces some new fields to access both the filename and filePath to accommodate various use cases.

ex:

```graphql
query GetMediaItemFilePath($id: ID!) {
  mediaItem(id: $id, idType: DATABASE_ID) {
    file
    filePath
    mediaDetails {
      file
      filePath
      sizes {
        file
        filePath
      }
    }
  }
}
```

**Standard site with standard uploads directory**

![CleanShot 2025-02-07 at 12 01 14](https://github.com/user-attachments/assets/5c75bd52-68b2-4eab-b6d2-959c5d1cfd03)


**Bedrock site with a different uploads directory**


![CleanShot 2025-02-07 at 12 00 58](https://github.com/user-attachments/assets/e1e74505-012d-4dcf-9504-0f3a44cc712a)


