### PR TITLE
fix: typo in `Extensions\Registry\get_extensions()` method name

### DIFF
--- a/docs/submit-extension.md
+++ b/docs/submit-extension.md
@@ -46,7 +46,7 @@ We are exploring additional submission methods:
 
 ```php
 // ./src/Admin/Extensions/Registry.php
-public static function get_extenions(): array {
+public static function get_extensions(): array {
 	return [
 		// ... other extensions
 		'my-unique-prefix/my-new-extension' => [ // Unique identifier for the extension, this should be placed alphabetically in the list.

--- a/src/Admin/Extensions/Extensions.php
+++ b/src/Admin/Extensions/Extensions.php
@@ -341,7 +341,7 @@ final class Extensions {
 	public function get_extensions(): array {
 		if ( ! isset( $this->extensions ) ) {
 			// @todo Replace with a call to the WPGraphQL server.
-			$extensions = Registry::get_extenions();
+			$extensions = Registry::get_extensions();
 
 			/**
 			 * Filter the list of extensions, allowing other plugins to add or remove extensions.

--- a/src/Admin/Extensions/Registry.php
+++ b/src/Admin/Extensions/Registry.php
@@ -47,7 +47,7 @@ final class Registry {
 	 *
 	 * @return array<string,Extension>
 	 */
-	public static function get_extenions(): array {
+	public static function get_extensions(): array {
 		return [
 			'wp-graphql/wp-graphql-smart-cache' => [
 				'name'              => 'WPGraphQL Smart Cache',

--- a/src/Request.php
+++ b/src/Request.php
@@ -587,7 +587,7 @@ class Request {
 		 * @param ?string          $operation The name of the operation
 		 * @param ?array          $variables Variables to be passed to your GraphQL request
 		 * @param \GraphQL\Server\OperationParams $params The Operation Params. This includes any extra params,
-		 * such as extenions or any other modifications to the request body
+		 * such as extensions or any other modifications to the request body
 		 */
 		do_action( 'do_graphql_request', $params->query, $params->operation, $params->variables, $params );
 	}


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Somehow, I shipped the `get_extensions()` function as `get_extenions()` (missing `s`). This fixes that super awkward mistake.

Considering this a regression.


Does this close any currently open issues?
------------------------------------------
<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
<!-- (If it’s long, please paste to https://ghostbin.com/ and insert the link here.) -->


Any other comments?
-------------------
🤦


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 24.04 (wsl2 + ddev + php 8.2.26)

**WordPress Version:** 6.7.1
