### PR TITLE
fix: update term mutation was preventing terms from removing the parentId 

### DIFF
--- a/src/Data/TermObjectMutation.php
+++ b/src/Data/TermObjectMutation.php
@@ -77,7 +77,6 @@ class TermObjectMutation {
 			}
 
 			$insert_args['parent'] = 0 !== $parent_id ? $parent_term->term_id : 0;
-
 		}
 
 		/**

--- a/src/Data/TermObjectMutation.php
+++ b/src/Data/TermObjectMutation.php
@@ -48,17 +48,22 @@ class TermObjectMutation {
 		}
 
 		/**
-		 * If the parentId argument was entered, we need to validate that it's actually a legit term that can
-		 * be set as a parent
+		 * If both parentId and parentDatabaseId are provided, throw an error
 		 */
-		if ( ! empty( $input['parentId'] ) ) {
+		if ( isset( $input['parentId'] ) && isset( $input['parentDatabaseId'] ) ) {
+			throw new UserError( esc_html__( 'Please provide only one of parentId or parentDatabaseId', 'wp-graphql' ) );
+		}
 
+		/**
+		 * Handle parentId input
+		 */
+		if ( isset( $input['parentId'] ) ) {
 			/**
 			 * Convert parent ID to WordPress ID
 			 */
 			$parent_id = Utils::get_database_id_from_id( $input['parentId'] );
 
-			if ( empty( $parent_id ) ) {
+			if ( false === $parent_id ) {
 				throw new UserError( esc_html__( 'The parent ID is not a valid ID', 'wp-graphql' ) );
 			}
 
@@ -67,11 +72,30 @@ class TermObjectMutation {
 			 */
 			$parent_term = get_term( absint( $parent_id ), $taxonomy->name );
 
-			if ( ! $parent_term instanceof \WP_Term ) {
+			if ( 0 !== $parent_id && ! $parent_term instanceof \WP_Term ) {
 				throw new UserError( esc_html__( 'The parent does not exist', 'wp-graphql' ) );
 			}
 
-			$insert_args['parent'] = $parent_term->term_id;
+			$insert_args['parent'] = 0 !== $parent_id ? $parent_term->term_id : 0;
+
+		}
+
+		/**
+		 * Handle parentDatabaseId input
+		 */
+		if ( isset( $input['parentDatabaseId'] ) ) {
+			$parent_id = absint( $input['parentDatabaseId'] );
+
+			// If parent_id is not 0, verify the term exists
+			if ( 0 !== $parent_id ) {
+				$parent_term = get_term( $parent_id, $taxonomy->name );
+
+				if ( ! $parent_term instanceof \WP_Term ) {
+					throw new UserError( esc_html__( 'The parent does not exist', 'wp-graphql' ) );
+				}
+			}
+
+			$insert_args['parent'] = $parent_id;
 		}
 
 		/**

--- a/src/Mutation/TermObjectCreate.php
+++ b/src/Mutation/TermObjectCreate.php
@@ -72,7 +72,12 @@ class TermObjectCreate {
 			$fields['parentId'] = [
 				'type'        => 'ID',
 				// translators: The placeholder is the name of the taxonomy for the object being mutated
-				'description' => sprintf( __( 'The ID of the %1$s that should be set as the parent', 'wp-graphql' ), $taxonomy->name ),
+				'description' => sprintf( __( 'The ID of the %1$s that should be set as the parent. This field cannot be used in conjunction with parentDatabaseId', 'wp-graphql' ), $taxonomy->name ),
+			];
+			$fields['parentDatabaseId'] = [
+				'type'        => 'Int',
+				// translators: The placeholder is the name of the taxonomy for the object being mutated
+				'description' => sprintf( __( 'The database ID of the %1$s that should be set as the parent. This field cannot be used in conjunction with parentId', 'wp-graphql' ), $taxonomy->name ),
 			];
 		}
 

--- a/src/Mutation/TermObjectCreate.php
+++ b/src/Mutation/TermObjectCreate.php
@@ -69,7 +69,7 @@ class TermObjectCreate {
 		 * Add a parentId field to hierarchical taxonomies to allow parents to be set
 		 */
 		if ( true === $taxonomy->hierarchical ) {
-			$fields['parentId'] = [
+			$fields['parentId']         = [
 				'type'        => 'ID',
 				// translators: The placeholder is the name of the taxonomy for the object being mutated
 				'description' => sprintf( __( 'The ID of the %1$s that should be set as the parent. This field cannot be used in conjunction with parentDatabaseId', 'wp-graphql' ), $taxonomy->name ),

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -344,7 +344,8 @@ class Utils {
 
 		$id_parts = Relay::fromGlobalId( $id );
 
-		return ! empty( $id_parts['id'] ) && is_numeric( $id_parts['id'] ) ? absint( $id_parts['id'] ) : false;
+		return isset( $id_parts['id'] ) && is_numeric( $id_parts['id'] ) ? absint( $id_parts['id'] ) : false;
+
 	}
 
 	/**

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -345,7 +345,6 @@ class Utils {
 		$id_parts = Relay::fromGlobalId( $id );
 
 		return isset( $id_parts['id'] ) && is_numeric( $id_parts['id'] ) ? absint( $id_parts['id'] ) : false;
-
 	}
 
 	/**

--- a/tests/wpunit/TermObjectMutationsTest.php
+++ b/tests/wpunit/TermObjectMutationsTest.php
@@ -798,4 +798,69 @@ class TermObjectMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCas
 		$this->assertSame( $expected_slug, get_term( $actual['data']['createTag']['tag']['databaseId'], 'post_tag' )->slug );
 		$this->assertSame( $expected_description, get_term( $actual['data']['createTag']['tag']['databaseId'], 'post_tag' )->description );
 	}
+
+	/**
+	 * Tests that a child category can be updated to have no parent
+	 */
+	public function testChildCategoryCanBeUpdatedWithNoParent() {
+		wp_set_current_user( $this->admin );
+
+		// First create a parent category
+		$parent_term_id = $this->factory()->term->create([
+			'taxonomy' => 'category',
+			'name'     => 'Parent Category',
+		]);
+
+		// Then create a child category
+		$child_term_id = $this->factory()->term->create([
+			'taxonomy' => 'category',
+			'name'     => 'Child Category',
+			'parent'   => $parent_term_id,
+		]);
+
+		$query = '
+		mutation updateChildCategory($input: UpdateCategoryInput!) {
+			updateCategory(input: $input) {
+				category {
+					id
+					databaseId
+					parentDatabaseId
+				}
+			}
+		}
+		';
+
+		// Test updating with parentId: "0"
+		$variables = [
+			'input' => [
+				'id'       => $child_term_id,
+				'parentId' => "0",
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertNull( $actual['data']['updateCategory']['category']['parentDatabaseId'] );
+
+		// Reset the parent
+		wp_update_term( $child_term_id, 'category', [ 'parent' => $parent_term_id ] );
+
+		// Verify the parent was actually set
+		$term = get_term( $child_term_id, 'category' );
+		$this->assertEquals( $parent_term_id, $term->parent, 'Parent was not properly reset between tests' );
+
+		// Test updating with encoded ID "term:0"
+		$variables = [
+			'input' => [
+				'id'       => $child_term_id,
+				'parentId' => 'dGVybTow', // base64 encoded "term:0"
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertNull( $actual['data']['updateCategory']['category']['parentDatabaseId'] );
+	}
 }

--- a/tests/wpunit/TermObjectMutationsTest.php
+++ b/tests/wpunit/TermObjectMutationsTest.php
@@ -863,4 +863,93 @@ class TermObjectMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCas
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertNull( $actual['data']['updateCategory']['category']['parentDatabaseId'] );
 	}
+
+	/**
+	 * Tests that a child category can be updated to have no parent using parentDatabaseId
+	 */
+	public function testChildCategoryCanBeUpdatedWithNoParentUsingDatabaseId() {
+		wp_set_current_user( $this->admin );
+
+		// First create a parent category
+		$parent_term_id = $this->factory()->term->create([
+			'taxonomy' => 'category',
+			'name'     => 'Parent Category',
+		]);
+
+		// Then create a child category
+		$child_term_id = $this->factory()->term->create([
+			'taxonomy' => 'category',
+			'name'     => 'Child Category',
+			'parent'   => $parent_term_id,
+		]);
+
+		$query = '
+		mutation updateChildCategory($input: UpdateCategoryInput!) {
+			updateCategory(input: $input) {
+				category {
+					id
+					databaseId
+					parentDatabaseId
+				}
+			}
+		}
+		';
+
+		// Test updating with parentDatabaseId: 0
+		$variables = [
+			'input' => [
+				'id'              => $child_term_id,
+				'parentDatabaseId' => 0,
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertNull( $actual['data']['updateCategory']['category']['parentDatabaseId'] );
+
+		// Reset the parent
+		wp_update_term( $child_term_id, 'category', [ 'parent' => $parent_term_id ] );
+
+		// Verify the parent was actually set
+		$term = get_term( $child_term_id, 'category' );
+		$this->assertEquals( $parent_term_id, $term->parent, 'Parent was not properly reset between tests' );
+	}
+
+	/**
+	 * Tests that an error is thrown when both parentId and parentDatabaseId are provided
+	 */
+	public function testErrorWhenBothParentIdAndParentDatabaseIdProvided() {
+		wp_set_current_user( $this->admin );
+
+		$child_term_id = $this->factory()->term->create([
+			'taxonomy' => 'category',
+			'name'     => 'Test Category',
+		]);
+
+		$query = '
+		mutation updateChildCategory($input: UpdateCategoryInput!) {
+			updateCategory(input: $input) {
+				category {
+					id
+					databaseId
+					parentDatabaseId
+				}
+			}
+		}
+		';
+
+		$variables = [
+			'input' => [
+				'id'              => $child_term_id,
+				'parentId'        => '0',
+				'parentDatabaseId' => 0,
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayHasKey( 'errors', $actual );
+		$this->assertStringContainsString( 'Please provide only one of parentId or parentDatabaseId', $actual['errors'][0]['message'] );
+	}
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This fixes a bug where updating child terms to have no parent was being prevented. 

The bug was that we were using some `if ( empty() ) ` checks vs `if ( ! isset() )` checks.

So, when the ID `0` was passed for the parentId, it was bailing because it was "empty", even though it was set intentionally as 0 and 0 is a valid ID to set as the parent of a term.

- [x] failing tests: https://github.com/wp-graphql/wp-graphql/actions/runs/13274749264/job/37062012106?pr=3308
- [x] passing tests: https://github.com/wp-graphql/wp-graphql/actions/runs/13274806513/job/37062179962?pr=3308

Does this close any currently open issues?
------------------------------------------
closes: #3296 

Any other comments?
-------------------

### Before:

Executing the updateCategory mutation on a child term, setting the parentId to `"0"` would not properly set the term's parent to `0`, leaving the child category a child category instead of a top level category. 

![CleanShot 2025-02-11 at 20 24 53](https://github.com/user-attachments/assets/000abb64-0a18-42db-94f0-956b1ed5a761)

Also, if we use an encoded id of `term:0` (`dGVybTow`) that also does not work:

![CleanShot 2025-02-11 at 20 26 24](https://github.com/user-attachments/assets/49fb7a7e-d761-46e5-8d17-a53192275e71)

### After

Now, setting the `parentId` to `"0"` (or the encoded id for `term:0` (`dGVybTow`)) properly updates the term to be a top-level term with no parent.

![CleanShot 2025-02-11 at 20 28 23](https://github.com/user-attachments/assets/529e70dd-d64c-480f-a282-6ba9a0efcd68)

![CleanShot 2025-02-11 at 20 28 14](https://github.com/user-attachments/assets/80448961-e06c-4c6b-aa67-432b068d4bf5)

Additionally, we've also added the `parentDatabaseId` input as an option. So mutations can accept encoded Ids for `parentId` _or_ the `parentDatabaseId` using the integer value. The docs for each field have been updated to indicate one or the other should be used but not both, and an error is returned if both are used. 

