### PR TITLE
release: v1.32.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.32.1
+
+### Chores / Bugfixes
+
+- [#3308](https://github.com/wp-graphql/wp-graphql/pull/3308): fix: update term mutation was preventing terms from removing the parentId
+
 ## 1.32.0
 
 ### Upgrade Notice

--- a/constants.php
+++ b/constants.php
@@ -18,7 +18,7 @@ function graphql_setup_constants() {
 
 	// Plugin version.
 	if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-		define( 'WPGRAPHQL_VERSION', '1.32.0' );
+		define( 'WPGRAPHQL_VERSION', '1.32.1' );
 	}
 
 	// Plugin Folder Path.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wp-graphql",
   "private": true,
-  "version": "1.22.0",
+  "version": "1.32.1",
   "description": "GraphQL API for WordPress",
   "homepage": "https://github.com/wp-graphql/wp-graphql#readme",
   "author": "WPGraphQL <info@wpgraphql.com> (https://www.wpgraphql.com)",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, Headless, REST API, Decoupled, React
 Requires at least: 5.0
 Tested up to: 6.7.1
 Requires PHP: 7.1
-Stable tag: 1.32.0
+Stable tag: 1.32.1
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -272,6 +272,13 @@ The `uri` field was non-null on some Types in the Schema but has been changed to
 Composer dependencies are no longer versioned in Github. Recommended install source is WordPress.org or using Composer to get the code from Packagist.org or WPackagist.org.
 
 == Changelog ==
+
+= 1.32.1 =
+
+**Chores / Bugfixes**
+
+- [#3308](https://github.com/wp-graphql/wp-graphql/pull/3308): fix: update term mutation was preventing terms from removing the parentId
+
 
 = 1.32.0 =
 

--- a/src/Data/TermObjectMutation.php
+++ b/src/Data/TermObjectMutation.php
@@ -48,17 +48,22 @@ class TermObjectMutation {
 		}
 
 		/**
-		 * If the parentId argument was entered, we need to validate that it's actually a legit term that can
-		 * be set as a parent
+		 * If both parentId and parentDatabaseId are provided, throw an error
 		 */
-		if ( ! empty( $input['parentId'] ) ) {
+		if ( isset( $input['parentId'] ) && isset( $input['parentDatabaseId'] ) ) {
+			throw new UserError( esc_html__( 'Please provide only one of parentId or parentDatabaseId', 'wp-graphql' ) );
+		}
 
+		/**
+		 * Handle parentId input
+		 */
+		if ( isset( $input['parentId'] ) ) {
 			/**
 			 * Convert parent ID to WordPress ID
 			 */
 			$parent_id = Utils::get_database_id_from_id( $input['parentId'] );
 
-			if ( empty( $parent_id ) ) {
+			if ( false === $parent_id ) {
 				throw new UserError( esc_html__( 'The parent ID is not a valid ID', 'wp-graphql' ) );
 			}
 
@@ -67,11 +72,29 @@ class TermObjectMutation {
 			 */
 			$parent_term = get_term( absint( $parent_id ), $taxonomy->name );
 
-			if ( ! $parent_term instanceof \WP_Term ) {
+			if ( 0 !== $parent_id && ! $parent_term instanceof \WP_Term ) {
 				throw new UserError( esc_html__( 'The parent does not exist', 'wp-graphql' ) );
 			}
 
-			$insert_args['parent'] = $parent_term->term_id;
+			$insert_args['parent'] = 0 !== $parent_id ? $parent_term->term_id : 0;
+		}
+
+		/**
+		 * Handle parentDatabaseId input
+		 */
+		if ( isset( $input['parentDatabaseId'] ) ) {
+			$parent_id = absint( $input['parentDatabaseId'] );
+
+			// If parent_id is not 0, verify the term exists
+			if ( 0 !== $parent_id ) {
+				$parent_term = get_term( $parent_id, $taxonomy->name );
+
+				if ( ! $parent_term instanceof \WP_Term ) {
+					throw new UserError( esc_html__( 'The parent does not exist', 'wp-graphql' ) );
+				}
+			}
+
+			$insert_args['parent'] = $parent_id;
 		}
 
 		/**

--- a/src/Mutation/TermObjectCreate.php
+++ b/src/Mutation/TermObjectCreate.php
@@ -69,10 +69,15 @@ class TermObjectCreate {
 		 * Add a parentId field to hierarchical taxonomies to allow parents to be set
 		 */
 		if ( true === $taxonomy->hierarchical ) {
-			$fields['parentId'] = [
+			$fields['parentId']         = [
 				'type'        => 'ID',
 				// translators: The placeholder is the name of the taxonomy for the object being mutated
-				'description' => sprintf( __( 'The ID of the %1$s that should be set as the parent', 'wp-graphql' ), $taxonomy->name ),
+				'description' => sprintf( __( 'The ID of the %1$s that should be set as the parent. This field cannot be used in conjunction with parentDatabaseId', 'wp-graphql' ), $taxonomy->name ),
+			];
+			$fields['parentDatabaseId'] = [
+				'type'        => 'Int',
+				// translators: The placeholder is the name of the taxonomy for the object being mutated
+				'description' => sprintf( __( 'The database ID of the %1$s that should be set as the parent. This field cannot be used in conjunction with parentId', 'wp-graphql' ), $taxonomy->name ),
 			];
 		}
 

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -344,7 +344,7 @@ class Utils {
 
 		$id_parts = Relay::fromGlobalId( $id );
 
-		return ! empty( $id_parts['id'] ) && is_numeric( $id_parts['id'] ) ? absint( $id_parts['id'] ) : false;
+		return isset( $id_parts['id'] ) && is_numeric( $id_parts['id'] ) ? absint( $id_parts['id'] ) : false;
 	}
 
 	/**

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 1.32.0
+ * Version: 1.32.1
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 5.9
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  1.32.0
+ * @version  1.32.1
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
# Release Notes

## Chores / Bugfixes

- [#3308](https://github.com/wp-graphql/wp-graphql/pull/3308): fix: update term mutation was preventing terms from removing the parentId
