### PR TITLE
fix: use `version_compare` to simplify incompatible dependent check

### DIFF
--- a/src/Admin/Updates/UpdateChecker.php
+++ b/src/Admin/Updates/UpdateChecker.php
@@ -450,12 +450,6 @@ class UpdateChecker {
 	 * @param string $version     The current version to check against.
 	 */
 	private function is_incompatible_dependent( string $plugin_path, string $version = WPGRAPHQL_VERSION ): bool {
-		$current_version = SemVer::parse( $version );
-
-		if ( null === $current_version ) {
-			return false;
-		}
-
 		$all_plugins = $this->get_all_plugins();
 		$plugin_data = $all_plugins[ $plugin_path ] ?? null;
 
@@ -464,28 +458,8 @@ class UpdateChecker {
 			return false;
 		}
 
-		// Parse the version.
-		$minimum_version = SemVer::parse( $plugin_data[ self::VERSION_HEADER ] );
-
-		if ( null === $minimum_version ) {
-			return false;
-		}
-
-		// Check if the plugin is incompatible.
-		if ( $minimum_version['major'] > $current_version['major'] ) {
-			return true;
-		}
-
-		if ( $minimum_version['minor'] > $current_version['minor'] ) {
-			return true;
-		}
-
-		if ( $minimum_version['patch'] > $current_version['patch'] ) {
-			return true;
-		}
-
-		// The plugin is compatible.
-		return false;
+		// The version is incompatible if the current version is less than the required version.
+		return version_compare( $version, $plugin_data[ self::VERSION_HEADER ], '<' );
 	}
 
 	/**


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR fixes edge cases in UpdateChecker::is_incompatible_plugin() by replacing the SemVer parser in that function with a basic `version_compare()`.


Does this close any currently open issues?
------------------------------------------
<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
<!-- (If it’s long, please paste to https://ghostbin.com/ and insert the link here.) -->

Before:
![image](https://github.com/user-attachments/assets/af5d33df-26fc-48eb-9b8a-4fe5e3933f99)

After:

![image](https://github.com/user-attachments/assets/8df17838-dac3-4750-96d1-51cce49aabfc)




Any other comments?
-------------------



Where has this been tested?
---------------------------
**Operating System:** Ubuntu 24.04 (wsl2 + ddev + php 8.2.26)

**WordPress Version:** 6.7.1
