### PR TITLE
release: v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.1.0
+
+### New Features
+
+- [#3325](https://github.com/wp-graphql/wp-graphql/pull/3325): feat: add filter to Request::is_valid_http_content_type to allow for custom content types with POST method requests
+
+### Chores / Bugfixes
+
+- [#3314](https://github.com/wp-graphql/wp-graphql/pull/3314): fix: use version_compare to simplify incompatible dependent check
+- [#3316](https://github.com/wp-graphql/wp-graphql/pull/3316): docs: update changelog and upgrade notice
+- [#3325](https://github.com/wp-graphql/wp-graphql/pull/3325): docs: update quick-start.md
+
 ## 2.0.0
 
 ### BREAKING CHANGE UPDATE
@@ -61,7 +73,7 @@ In [#3293](https://github.com/wp-graphql/wp-graphql/pull/3293) a bug was fixed i
 ### Chores / Bugfixes
 
 - [#3250](https://github.com/wp-graphql/wp-graphql/pull/3250): fix: receiving post for Incorrect uri
-- [#3268](https://github.com/wp-graphql/wp-graphql/pull/3268): ci: trigger PR workflows on release/* branches
+- [#3268](https://github.com/wp-graphql/wp-graphql/pull/3268): ci: trigger PR workflows on release/\* branches
 - [#3267](https://github.com/wp-graphql/wp-graphql/pull/3267): chore: fix bleeding edge/deprecated PHPStan smells [first pass]
 - [#3270](https://github.com/wp-graphql/wp-graphql/pull/3270): build(deps): bump the npm_and_yarn group across 1 directory with 3 updates
 - [#3271](https://github.com/wp-graphql/wp-graphql/pull/3271): fix: default cat should not be added when other categories are added
@@ -174,12 +186,12 @@ While there are no intentional breaking changes, because this change impacts eve
 ### New Features
 
 - [#3125](https://github.com/wp-graphql/wp-graphql/pull/3125): refactor: improve query handling in AbstractConnectionResolver
-    - new: `graphql_connection_pre_get_query` filter
-    - new: `AbstractConnectionResolver::is_valid_query_class()`
-    - new: `AbstractConnectionResolver::get_query()`
-    - new: `AbstractConnectionResolver::get_query_class()`
-    - new: `AsbtractConnectionResolver::query_class()`
-    - new: `AbstractConnectionResolver::$query_class`
+  - new: `graphql_connection_pre_get_query` filter
+  - new: `AbstractConnectionResolver::is_valid_query_class()`
+  - new: `AbstractConnectionResolver::get_query()`
+  - new: `AbstractConnectionResolver::get_query_class()`
+  - new: `AsbtractConnectionResolver::query_class()`
+  - new: `AbstractConnectionResolver::$query_class`
 - [#3124](https://github.com/wp-graphql/wp-graphql/pull/3124): refactor: split `AbstractConnectionResolver::get_args()` and `::get_query_args()` into `::prepare_*()` methods
 - [#3123](https://github.com/wp-graphql/wp-graphql/pull/3123): refactor: split `AbstractConnectionResolver::get_ids()` into `::prepare_ids()`
 - [#3121](https://github.com/wp-graphql/wp-graphql/pull/3121): refactor: split `AbstractConnectionResolver::get_nodes()` and `get_edges()` into `prepare_*()` methods
@@ -188,11 +200,12 @@ While there are no intentional breaking changes, because this change impacts eve
 ### Chores / Bugfixes
 
 - [#3125](https://github.com/wp-graphql/wp-graphql/pull/3125): refactor: improve query handling in AbstractConnectionResolver
-    - Implement PHPStan Generic Type
-    - Update generic Exceptions to InvariantViolation
+  - Implement PHPStan Generic Type
+  - Update generic Exceptions to InvariantViolation
 - [#3127](https://github.com/wp-graphql/wp-graphql/pull/3127): chore: update references to the WPGraphQL Slack Community to point to the new WPGraphQL Discord community instead.
 - [#3122](https://github.com/wp-graphql/wp-graphql/pull/3122): chore: relocate `AbstractConnectionResolver::is_valid_offset()` with other abstract methods.
 -
+
 ## 1.25.0
 
 ### Upgrade Notice
@@ -204,11 +217,11 @@ This release includes a fix to a regression in the v1.24.0. Users impacted by th
 - [#3104](https://github.com/wp-graphql/wp-graphql/pull/3104): feat: add `AbsractConnectionResolver::pre_should_execute()`. Thanks @justlevine!
 
 ### Chores / Bugfixes
+
 - [#3104](https://github.com/wp-graphql/wp-graphql/pull/3104): refactor: `AbstractConnectionResolver::should_execute()` Thanks @justlevine!
 - [#3112](https://github.com/wp-graphql/wp-graphql/pull/3104): fix: fixes a regression from v1.24.0 relating to field arguments defined on Interfaces not being properly merged onto Object Types that implement the interface. Thanks @kidunot89!
 - [#3114](https://github.com/wp-graphql/wp-graphql/pull/3114): fix: node IDs not showing in the Query Analyzer / X-GraphQL-Keys when using DataLoader->load_many()
 - [#3116](https://github.com/wp-graphql/wp-graphql/pull/3116): chore: Update WPGraphQLTestCase to v3. Thanks @kidunot89!
-
 
 ## 1.24.0
 
@@ -230,7 +243,6 @@ The AbstractConnectionResolver has undergone some refactoring. Some methods usin
 - [#3086](https://github.com/wp-graphql/wp-graphql/pull/3086): refactor: add AbstractConnectionResolver::get_unfiltered_args() public getter. Thanks @justlevine!
 - [#3085](https://github.com/wp-graphql/wp-graphql/pull/3085): refactor: add AbstractConnectionResolver::prepare_page_info()and only instantiate once. Thanks @justlevine!
 - [#3083](https://github.com/wp-graphql/wp-graphql/pull/3083): refactor: deprecate camelCase methods in AbstractConnectionResolver for snake_case equivalents. Thanks @justlevine!
-
 
 ### Chores / Bugfixes
 
@@ -328,7 +340,6 @@ The AbstractConnectionResolver has undergone some refactoring. Some methods usin
 
 - ci: update tests to run against WordPress 6.4.1. Update Docker Deploy to include WP 6.4.1. Update README, plugin file's "tested up to" to reflect.
 
-
 ## 1.18.1
 
 ### Chores / Bugfixes
@@ -350,7 +361,6 @@ The AbstractConnectionResolver has undergone some refactoring. Some methods usin
 - [#2975](https://github.com/wp-graphql/wp-graphql/pull/2975): chore: lint and remove useless variables [phpcs]
 - [#2977](https://github.com/wp-graphql/wp-graphql/pull/2977): chore: sort use statements alphabetically with SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses (autofix)
 - [#2978](https://github.com/wp-graphql/wp-graphql/pull/2978]): chore: implement stricter type hinting with SlevomatCodingStandard.TypeHints [phpcs]
-
 
 ## 1.17.0
 
@@ -496,7 +506,6 @@ queries you have using pagination arguments (`first`, `last`, `after`, `before`)
 - [#2799](https://github.com/wp-graphql/wp-graphql/pull/2794): fix: querying posts by slug fails when custom permalinks are set
 - [#2794](https://github.com/wp-graphql/wp-graphql/pull/2794): chore(deps): bump guzzlehttp/psr7 from 1.9.0 to 1.9.1
 
-
 ## 1.14.2
 
 ### Chores / Bugfixes
@@ -519,7 +528,7 @@ queries you have using pagination arguments (`first`, `last`, `after`, `before`)
 - [#2777](https://github.com/wp-graphql/wp-graphql/pull/2777): chore: update composer dev-deps (not PHPStan). Thanks @justlevine!
 - [#2778](https://github.com/wp-graphql/wp-graphql/pull/2778): fix: Update PHPStan and fix smells. Thanks @justlevine!
 - [#2779](https://github.com/wp-graphql/wp-graphql/pull/2779): ci: test against WordPress 6.2. Thanks @justlevine!
-- [#2781](https://github.com/wp-graphql/wp-graphql/pull/2781): chore: call _doing_it_wrong() when using deprecated PostObjectUnion and TermObjectUnion. Thanks @justlevine!
+- [#2781](https://github.com/wp-graphql/wp-graphql/pull/2781): chore: call \_doing_it_wrong() when using deprecated PostObjectUnion and TermObjectUnion. Thanks @justlevine!
 - [#2782](https://github.com/wp-graphql/wp-graphql/pull/2782): ci: fix deprecation warnings in Github workflows. Thanks @justlevine!
 - [#2786](https://github.com/wp-graphql/wp-graphql/pull/2786): fix: early return for HTTP OPTIONS requests.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2.0.0
+
+### BREAKING CHANGE UPDATE
+
+This is a major update that drops support for PHP versions below 7.4 and WordPress versions below 6.0.
+
+We've written more about the update here:
+
+- https://www.wpgraphql.com/2024/12/16/wpgraphql-v2-0-is-coming-heres-what-you-need-to-know
+- https://www.wpgraphql.com/2024/12/16/wpgraphql-v2-0-technical-update-breaking-changes
+
 ## 1.32.1
 
 ### Chores / Bugfixes
@@ -113,7 +124,7 @@ In [#3293](https://github.com/wp-graphql/wp-graphql/pull/3293) a bug was fixed i
 
 ### Upgrade Notice
 
-This release contains an internal refactor for how the Type Registry is generated which should lead to significant performance improvements for most users. 
+This release contains an internal refactor for how the Type Registry is generated which should lead to significant performance improvements for most users.
 
 While there are no intentional breaking changes, because this change impacts every user we highly recommend testing this release thoroughly on staging servers to ensure the changes don't negatively impact your projects.
 
@@ -138,7 +149,7 @@ While there are no intentional breaking changes, because this change impacts eve
 ### Chores / Bugfixes
 
 - [#3066](https://github.com/wp-graphql/wp-graphql/pull/3066): fix: merge query arg arrays instead of overriding.
-- [#3151](https://github.com/wp-graphql/wp-graphql/pull/3151): fix: update dev-deps and fix `WPGraphQL::get_static_schema()` 
+- [#3151](https://github.com/wp-graphql/wp-graphql/pull/3151): fix: update dev-deps and fix `WPGraphQL::get_static_schema()`
 - [#3152](https://github.com/wp-graphql/wp-graphql/pull/3152): fix: handle regression when implementing interface with identical args.
 - [#3153](https://github.com/wp-graphql/wp-graphql/pull/3153): chore(deps-dev): bump composer/composer from 2.7.6 to 2.7.7 in the composer group across 1 directory
 - [#3155](https://github.com/wp-graphql/wp-graphql/pull/3155): chore(deps-dev): bump the npm_and_yarn group across 1 directory with 2 updates
@@ -181,7 +192,7 @@ While there are no intentional breaking changes, because this change impacts eve
     - Update generic Exceptions to InvariantViolation
 - [#3127](https://github.com/wp-graphql/wp-graphql/pull/3127): chore: update references to the WPGraphQL Slack Community to point to the new WPGraphQL Discord community instead.
 - [#3122](https://github.com/wp-graphql/wp-graphql/pull/3122): chore: relocate `AbstractConnectionResolver::is_valid_offset()` with other abstract methods.
-- 
+-
 ## 1.25.0
 
 ### Upgrade Notice
@@ -260,7 +271,7 @@ The AbstractConnectionResolver has undergone some refactoring. Some methods usin
 
 ### Chores / Bugfixes
 
-- [#3062](https://github.com/wp-graphql/wp-graphql/pull/3062): ci: pin wp-browser to "<3.5" to allow automated tests to run properly 
+- [#3062](https://github.com/wp-graphql/wp-graphql/pull/3062): ci: pin wp-browser to "<3.5" to allow automated tests to run properly
 - [#3057](https://github.com/wp-graphql/wp-graphql/pull/3057): fix: `admin_enqueue_scripts` callback should expect a possible `null` value passed to it
 - [#3048](https://github.com/wp-graphql/wp-graphql/pull/3048): fix: `isPostsPage` on content type
 - [#3043](https://github.com/wp-graphql/wp-graphql/pull/3043): fix: return empty when filtering `menuItems` by a location with no assigned items
@@ -289,7 +300,7 @@ The AbstractConnectionResolver has undergone some refactoring. Some methods usin
 ### Chores / Bugfixes
 
 - [#3022](https://github.com/wp-graphql/wp-graphql/pull/3022): chore: add @justlevine to list of contributors! 🙌 🥳
-- [#3011](https://github.com/wp-graphql/wp-graphql/pull/3011): chore: update composer dev-dependencies and use php-compatibility:develop branch to 8.0+ lints. Thanks @justlevine! 
+- [#3011](https://github.com/wp-graphql/wp-graphql/pull/3011): chore: update composer dev-dependencies and use php-compatibility:develop branch to 8.0+ lints. Thanks @justlevine!
 - [#3010](https://github.com/wp-graphql/wp-graphql/pull/3010): chore: implement stricter PHPDoc types. Thanks @justlevine!
 - [#3009](https://github.com/wp-graphql/wp-graphql/pull/3009): chore: implement stricter PHPStan config and clean up unnecessary type-guards. Thanks @justlevine!
 - [#3007](https://github.com/wp-graphql/wp-graphql/pull/3007): fix: call html_entity_decode() with explicit flags and decode single-quotes. Thanks @justlevine!
@@ -309,7 +320,7 @@ The AbstractConnectionResolver has undergone some refactoring. Some methods usin
 
 - [#2989](https://github.com/wp-graphql/wp-graphql/pull/2989): fix: make User.url public
 - [#2990](https://github.com/wp-graphql/wp-graphql/pull/2990): chore: autolint tests with phpcbf
-- [#2992](https://github.com/wp-graphql/wp-graphql/pull/2992): fix: add polyfills for `str_starts_with()` and `str_ends_with()` to prevent fatal errors in `PHP < 8.0` 
+- [#2992](https://github.com/wp-graphql/wp-graphql/pull/2992): fix: add polyfills for `str_starts_with()` and `str_ends_with()` to prevent fatal errors in `PHP < 8.0`
 
 ## 1.18.2
 
@@ -381,18 +392,18 @@ The AbstractConnectionResolver has undergone some refactoring. Some methods usin
 ### Upgrade Notice
 
 **WPGraphQL Smart Cache**
-For WPGraphQL Smart Cache users, you should update WPGraphQL Smart Cache to v1.2.0 when updating 
+For WPGraphQL Smart Cache users, you should update WPGraphQL Smart Cache to v1.2.0 when updating
 WPGraphQL to v1.16.0 to ensure caches continue to purge as expected.
 
 **Cursor Pagination Updates**
 This version fixes some behaviors of Cursor Pagination which _may_ lead to behavior changes in your application.
 
-As with any release, we recommend you test in staging environments. For this release, specifically any 
-queries you have using pagination arguments (`first`, `last`, `after`, `before`). 
+As with any release, we recommend you test in staging environments. For this release, specifically any
+queries you have using pagination arguments (`first`, `last`, `after`, `before`).
 
 ### New Features
 
-- [#2918](https://github.com/wp-graphql/wp-graphql/pull/2918): feat: Use graphql endpoint without scheme in url header. 
+- [#2918](https://github.com/wp-graphql/wp-graphql/pull/2918): feat: Use graphql endpoint without scheme in url header.
 - [#2882](https://github.com/wp-graphql/wp-graphql/pull/2882): feat: Config and Cursor Classes refactor
 
 ## 1.15.0
@@ -510,7 +521,7 @@ queries you have using pagination arguments (`first`, `last`, `after`, `before`)
 - [#2779](https://github.com/wp-graphql/wp-graphql/pull/2779): ci: test against WordPress 6.2. Thanks @justlevine!
 - [#2781](https://github.com/wp-graphql/wp-graphql/pull/2781): chore: call _doing_it_wrong() when using deprecated PostObjectUnion and TermObjectUnion. Thanks @justlevine!
 - [#2782](https://github.com/wp-graphql/wp-graphql/pull/2782): ci: fix deprecation warnings in Github workflows. Thanks @justlevine!
-- [#2786](https://github.com/wp-graphql/wp-graphql/pull/2786): fix: early return for HTTP OPTIONS requests. 
+- [#2786](https://github.com/wp-graphql/wp-graphql/pull/2786): fix: early return for HTTP OPTIONS requests.
 
 ## 1.14.0
 

--- a/constants.php
+++ b/constants.php
@@ -18,7 +18,7 @@ function graphql_setup_constants() {
 
 	// Plugin version.
 	if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-		define( 'WPGRAPHQL_VERSION', '2.0.0' );
+		define( 'WPGRAPHQL_VERSION', '2.0.1' );
 	}
 
 	// Plugin Folder Path.

--- a/constants.php
+++ b/constants.php
@@ -18,7 +18,7 @@ function graphql_setup_constants() {
 
 	// Plugin version.
 	if ( ! defined( 'WPGRAPHQL_VERSION' ) ) {
-		define( 'WPGRAPHQL_VERSION', '2.0.1' );
+		define( 'WPGRAPHQL_VERSION', '2.1.0' );
 	}
 
 	// Plugin Folder Path.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -31,12 +31,12 @@ If you prefer not to install WPGraphQL from the WordPress.org repository, you ca
 
 Installing plugins with [Composer](https://getcomposer.org/), a PHP dependency manager, allows you to avoid committing plugin code into your project's version control.
 
-WPGraphQL is available for installing with Composer from [packagist.org](https://packagist.org/packages/wp-graphql/wp-graphql) and [wpackagist.org](https://wpackagist.org/search?q=wp-graphql\&type=any\&search=).
+WPGraphQL is available for installing with Composer from [wpackagist.org](https://wpackagist.org/search?q=wp-graphql\&type=any\&search=).
 
 You can add WPGraphQL as a dependency to your project with the following command: 
 
 ```bash
-composer require wp-graphql/wp-graphql
+composer require wpackagist-plugin/wp-graphql
 ```
 
 Below is an example of a composer.json file with WPGraphQL added as as a plugin dependency:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wp-graphql",
   "private": true,
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "GraphQL API for WordPress",
   "homepage": "https://github.com/wp-graphql/wp-graphql#readme",
   "author": "WPGraphQL <info@wpgraphql.com> (https://www.wpgraphql.com)",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wp-graphql",
   "private": true,
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "GraphQL API for WordPress",
   "homepage": "https://github.com/wp-graphql/wp-graphql#readme",
   "author": "WPGraphQL <info@wpgraphql.com> (https://www.wpgraphql.com)",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -64,6 +64,9 @@
 		<exclude name="WordPress.NamingConventions.ValidVariableName"/>
 		<exclude name="WordPress.WP.Capabilities.Undetermined" />
 
+		<!-- Include only once we support PHP 8.3 and above -->
+		<exclude name="SlevomatCodingStandard.TypeHints.ClassConstantTypeHint" />
+
 		<!-- This would be a breaking change to fix-->
 		<exclude name="Generic.CodeAnalysis.UnusedFunctionParameter" />
 	</rule>

--- a/readme.txt
+++ b/readme.txt
@@ -72,6 +72,21 @@ Learn more about how [Appsero collects and uses this data](https://appsero.com/p
 
 == Upgrade Notice ==
 
+= 2.0.0 =
+
+**BREAKING CHANGE UPDATE**
+
+This is a major update that drops support for PHP versions below 7.4 and WordPress versions below 6.0.
+
+We've written more about the update here:
+
+- https://www.wpgraphql.com/2024/12/16/wpgraphql-v2-0-is-coming-heres-what-you-need-to-know
+- https://www.wpgraphql.com/2024/12/16/wpgraphql-v2-0-technical-update-breaking-changes
+
+= 1.32.0 =
+
+In <a href="https://github.com/wp-graphql/wp-graphql/pull/3293">#3293</a> a bug was fixed in how the `MediaDetails.file` field resolves. The previous behavior was a bug, but might have been used as a feature. If you need the field to behave the same as it did prior to this bugfix, you can [follow the instructions here](https://github.com/wp-graphql/wp-graphql/pull/3293) to override the field's resolver to how it worked before.
+
 = 1.30.0 =
 
 This release includes a new feature to implement a SemVer-compliant update checker, which will prevent auto-updates for major releases that include breaking changes.
@@ -84,7 +99,7 @@ There are no known breaking changes in this release, however, we recommend testi
 
 This release contains an internal refactor for how the Type Registry is generated which should lead to significant performance improvements for most users.
 
-While there are no intentional breaking changes, because this change impacts every suser we highly recommend testing this release thoroughly on staging servers to ensure the changes don't negatively impact your projects.
+While there are no intentional breaking changes, because this change impacts every user we highly recommend testing this release thoroughly on staging servers to ensure the changes don't negatively impact your projects.
 
 = 1.26.0 =
 
@@ -269,6 +284,17 @@ Composer dependencies are no longer versioned in Github. Recommended install sou
 
 == Changelog ==
 
+= 2.0.0 =
+
+**BREAKING CHANGE UPDATE**
+
+This is a major update that drops support for PHP versions below 7.4 and WordPress versions below 6.0.
+
+We've written more about the update here:
+
+- https://www.wpgraphql.com/2024/12/16/wpgraphql-v2-0-is-coming-heres-what-you-need-to-know
+- https://www.wpgraphql.com/2024/12/16/wpgraphql-v2-0-technical-update-breaking-changes
+
 = 1.32.1 =
 
 **Chores / Bugfixes**
@@ -296,7 +322,15 @@ Composer dependencies are no longer versioned in Github. Recommended install sou
 
 - [#3284](https://github.com/wp-graphql/wp-graphql/pull/3284): fix: fix: Updated docs link for example of hierarchical data
 - [#3283](https://github.com/wp-graphql/wp-graphql/pull/3283): fix: Error in update checker when WPGraphQL is active as an mu-plugin
-
+- [#3293](https://github.com/wp-graphql/wp-graphql/pull/3293): fix: correct the resolver for the MediaDetails.file field to return the file name
+- [#3299](https://github.com/wp-graphql/wp-graphql/pull/3299): chore: restore excluded PHPCS rules
+- [#3301](https://github.com/wp-graphql/wp-graphql/pull/3301): fix: React backwards-compatibility with WP < 6.6
+- [#3302](https://github.com/wp-graphql/wp-graphql/pull/3302): chore: update NPM dependencies
+- [#3297](https://github.com/wp-graphql/wp-graphql/pull/3297): fix: typo in `Extensions\Registry\get_extensions()` method name
+- [#3303](https://github.com/wp-graphql/wp-graphql/pull/3303): chore: cleanup git cache
+- [#3298](https://github.com/wp-graphql/wp-graphql/pull/3298): chore: submit GF, Rank Math, and Headless Login plugins
+- [#3287](https://github.com/wp-graphql/wp-graphql/pull/3287): chore: fixes the syntax of the readme.txt so that the short description is shown on WordPress.org
+- [#3284](https://github.com/wp-graphql/wp-graphql/pull/3284): fix: Updated docs link for example of hierarchical data
 
 = 1.30.0 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, Headless, REST API, Decoupled, React
 Requires at least: 6.0
 Tested up to: 6.7.1
 Requires PHP: 7.4
-Stable tag: 2.0.1
+Stable tag: 2.1.0
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -283,6 +283,19 @@ The `uri` field was non-null on some Types in the Schema but has been changed to
 Composer dependencies are no longer versioned in Github. Recommended install source is WordPress.org or using Composer to get the code from Packagist.org or WPackagist.org.
 
 == Changelog ==
+
+= 2.1.0 =
+
+**New Features**
+
+- [#3325](https://github.com/wp-graphql/wp-graphql/pull/3325): feat: add filter to Request::is_valid_http_content_type to allow for custom content types with POST method requests
+
+**Chores / Bugfixes**
+
+- [#3314](https://github.com/wp-graphql/wp-graphql/pull/3314): fix: use version_compare to simplify incompatible dependent check
+- [#3316](https://github.com/wp-graphql/wp-graphql/pull/3316): docs: update changelog and upgrade notice
+- [#3325](https://github.com/wp-graphql/wp-graphql/pull/3325): docs: update quick-start.md
+
 
 = 2.0.0 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, Headless, REST API, Decoupled, React
 Requires at least: 6.0
 Tested up to: 6.7.1
 Requires PHP: 7.4
-Stable tag: 2.0.0
+Stable tag: 2.0.1
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/src/Admin/Updates/UpdateChecker.php
+++ b/src/Admin/Updates/UpdateChecker.php
@@ -450,12 +450,6 @@ class UpdateChecker {
 	 * @param string $version     The current version to check against.
 	 */
 	private function is_incompatible_dependent( string $plugin_path, string $version = WPGRAPHQL_VERSION ): bool {
-		$current_version = SemVer::parse( $version );
-
-		if ( null === $current_version ) {
-			return false;
-		}
-
 		$all_plugins = $this->get_all_plugins();
 		$plugin_data = $all_plugins[ $plugin_path ] ?? null;
 
@@ -464,28 +458,8 @@ class UpdateChecker {
 			return false;
 		}
 
-		// Parse the version.
-		$minimum_version = SemVer::parse( $plugin_data[ self::VERSION_HEADER ] );
-
-		if ( null === $minimum_version ) {
-			return false;
-		}
-
-		// Check if the plugin is incompatible.
-		if ( $minimum_version['major'] > $current_version['major'] ) {
-			return true;
-		}
-
-		if ( $minimum_version['minor'] > $current_version['minor'] ) {
-			return true;
-		}
-
-		if ( $minimum_version['patch'] > $current_version['patch'] ) {
-			return true;
-		}
-
-		// The plugin is compatible.
-		return false;
+		// The version is incompatible if the current version is less than the required version.
+		return version_compare( $version, $plugin_data[ self::VERSION_HEADER ], '<' );
 	}
 
 	/**

--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -214,7 +214,7 @@ abstract class AbstractConnectionResolver {
 		/**
 		 * Filters the GraphQL args before they are used in get_query_args().
 		 *
-		 * @todo We reinstantate this here for b/c. Once that is not a concern, we should relocate this filter to ::get_args().
+		 * @todo We reinstantiate this here for b/c. Once that is not a concern, we should relocate this filter to ::get_args().
 		 *
 		 * @param array<string,mixed>                                   $args                The GraphQL args passed to the resolver.
 		 * @param \WPGraphQL\Data\Connection\AbstractConnectionResolver $connection_resolver Instance of the ConnectionResolver.
@@ -230,7 +230,7 @@ abstract class AbstractConnectionResolver {
 		/**
 		 * Filters the query args before they are used in the query.
 		 *
-		 *  @todo We reinstantate this here for b/c. Once that is not a concern, we should relocate this filter to ::get_query_args().
+		 *  @todo We reinstantiate this here for b/c. Once that is not a concern, we should relocate this filter to ::get_query_args().
 		 *
 		 * @param array<string,mixed>                                   $query_args          The query args to be used with the executable query to get data.
 		 * @param \WPGraphQL\Data\Connection\AbstractConnectionResolver $connection_resolver Instance of the ConnectionResolver
@@ -338,7 +338,7 @@ abstract class AbstractConnectionResolver {
 	/**
 	 * Used to determine whether the connection query should be executed. This is useful for short-circuiting the connection resolver before executing the query.
 	 *
-	 * When `pre_should_excecute()` returns false, that's a sign the Resolver shouldn't execute the query. Otherwise, the more expensive logic logic in `should_execute()` will run later in the lifecycle.
+	 * When `pre_should_execute()` returns false, that's a sign the Resolver shouldn't execute the query. Otherwise, the more expensive logic logic in `should_execute()` will run later in the lifecycle.
 	 *
 	 * @param mixed                                $source  Source passed down from the resolve tree
 	 * @param array<string,mixed>                  $args    Array of arguments input in the field as part of the GraphQL query.
@@ -437,7 +437,7 @@ abstract class AbstractConnectionResolver {
 	/**
 	 * Determine whether or not the query should execute.
 	 *
-	 * Return true to exeucte, return false to prevent execution.
+	 * Return true to execute, return false to prevent execution.
 	 *
 	 * Various criteria can be used to determine whether a Connection Query should be executed.
 	 *
@@ -787,7 +787,7 @@ abstract class AbstractConnectionResolver {
 			 *
 			 * This filter allows for additional fields to be filtered into the pageInfo
 			 * of a connection, such as "totalCount", etc, because the filter has enough
-			 * context of the query, args, request, etc to be able to calcuate and return
+			 * context of the query, args, request, etc to be able to calculate and return
 			 * that information.
 			 *
 			 * example:
@@ -874,7 +874,7 @@ abstract class AbstractConnectionResolver {
 		/**
 		 * Filters whether or not the query should execute, BEFORE any data is fetched or altered.
 		 *
-		 * This is evaluated based solely on the values passed to the constructor, before any data is fetched or altered, and is useful for shortcircuiting the Connection Resolver before any heavy logic is executed.
+		 * This is evaluated based solely on the values passed to the constructor, before any data is fetched or altered, and is useful for short-circuiting the Connection Resolver before any heavy logic is executed.
 		 *
 		 * For more in-depth checks, use the `graphql_connection_should_execute` filter instead.
 		 *
@@ -996,7 +996,7 @@ abstract class AbstractConnectionResolver {
 				 *
 				 * Filters the nodes in the connection
 				 *
-				 * @todo We reinstantate this here for b/c. Once that is not a concern, we should relocate this filter to ::get_nodes().
+				 * @todo We reinstantiate this here for b/c. Once that is not a concern, we should relocate this filter to ::get_nodes().
 				 *
 				 * @param \WPGraphQL\Model\Model[]|mixed[]|null $nodes   The nodes in the connection
 				 * @param self                                 $resolver Instance of the Connection Resolver
@@ -1006,14 +1006,14 @@ abstract class AbstractConnectionResolver {
 				/**
 				 * Filters the edges in the connection.
 				 *
-				 * @todo We reinstantate this here for b/c. Once that is not a concern, we should relocate this filter to ::get_edges().
+				 * @todo We reinstantiate this here for b/c. Once that is not a concern, we should relocate this filter to ::get_edges().
 				 *
 				 * @param array<string,mixed> $edges    The edges in the connection
 				 * @param self                $resolver Instance of the Connection Resolver
 				 */
 				$this->edges = apply_filters( 'graphql_connection_edges', $this->get_edges(), $this );
 
-				// @todo: we should also shortcircuit fetching/populating the actual nodes/edges if we only need one result.
+				// @todo: we should also short-circuit fetching/populating the actual nodes/edges if we only need one result.
 				if ( true === $this->one_to_one ) {
 					// For one to one connections, return the first edge.
 					$first_edge_key = array_key_first( $this->edges );
@@ -1084,7 +1084,7 @@ abstract class AbstractConnectionResolver {
 		 * the query to that instead of a native WP_Query class. You could override this with a
 		 * query to that datasource instead.
 		 *
-		 *  @todo We reinstantate this here for b/c. Once that is not a concern, we should relocate this filter to ::get_query_args().
+		 *  @todo We reinstantiate this here for b/c. Once that is not a concern, we should relocate this filter to ::get_query_args().
 		 *
 		 * @param mixed                      $query               Instance of the Query for the resolver
 		 * @param \WPGraphQL\Data\Connection\AbstractConnectionResolver $connection_resolver Instance of the Connection Resolver
@@ -1360,11 +1360,7 @@ abstract class AbstractConnectionResolver {
 			 * @param array<string,mixed> $edge     The edge within the connection
 			 * @param self                $resolver Instance of the connection resolver class
 			 */
-			$edge = apply_filters(
-				'graphql_connection_edge',
-				$edge,
-				$this
-			);
+			$edge = apply_filters( 'graphql_connection_edge', $edge, $this );
 
 			$edges[] = $edge;
 		}

--- a/src/Data/Connection/README.md
+++ b/src/Data/Connection/README.md
@@ -1,0 +1,389 @@
+# Developer Docs: AbstractConnectionResolver
+
+A Connection Resolver is responsible for resolving a ([Relay spec](https://relay.dev/graphql/connections.htm)-compliant) connection for a given GraphQL field.
+
+The connection resolver:
+1. maps the GraphQL arguments to the underlying database query,
+2. executes the database query,
+3. instantiates the GraphQL model for each result and caches it in the DataLoader,
+4. populates the connection edges and page info,
+5. and finally returns the connection data to populate the connected GraphQL type.
+
+As WordPress stores and fetches object types differently for each type, a separate connection resolver is used for each type. Developers can create their own connection resolvers by extending the `WPGraphQL\Data\Connection\AbstractConnectionResolver` class, or one of the existing child classes (e.g. extending `WPGraphQL\Data\Connection\PostObjectConnectionResolver` for Custom Post Type-specific resolver).
+
+Before we get into the details of how to create your own connection resolver, let's take a look at the lifecycle of a connection resolver in more detail.
+
+## Lifecycle
+
+As follows is an example action of registering a custom WPGraphQL connection:
+
+```php
+add_action( 'graphql_register_types', function() {
+	// Register your custom connection.
+	register_graphql_connection( [
+		'fromType'      => $my_from_type,
+		'fromFieldName' => $my_field_name,
+		// other supported args...
+
+		// The `resolve` callback is where the lifecycle magic happens 👇
+		'resolve'       => function( $source, array $args, \WPGraphQL\AppContext $context, \GraphQL\Type\Definition\ResolveInfo $info ) {
+			// Create a new instance of the connection resolver.
+			$resolver = new \WPGraphQL\Data\Connection\MyCustomConnectionResolver( $source, $args, $context, $info );
+
+			// Modify the resolver properties before the connection is executed.
+			$resolver->set_query_arg( 'post_type', 'post' );
+			$resolver->one_to_one();
+
+			// If the connection uses a query class (e.g. `WP_Query`) we can overload that.
+			$resolver->set_query_class( 'WP_Meta_Query' );
+
+			// Return the connection data.
+			return $resolver->get_connection();
+		},
+	] );
+} );
+
+```
+
+### 1. Class instantiation
+The first step to using a Connection Resolver is to instantiate it. The connection resolver is instantiated in the `resolve` callback of the `register_graphql_connection` function. The `resolve` callback is passed the `$source` node, an `array` of GraphQL `$args`, the `$context`, and `$info` arguments, which are then passed to the connection resolver constructor.
+
+```php
+// Create a new instance of the connection resolver.
+$resolver = new \WPGraphQL\Data\Connection\MyCustomConnectionResolver( $source, $args, $context, $info );
+```
+
+The constructor then sets and prepares the following instance properties (in order):
+
+1. `$this->source` - The source object that the connection is coming from. This can be retrieved from the resolver instance using `$resolver->get_source()`.
+2. `$this->unfiltered_args` - The GraphQL args passed to the connection resolver, before they've been filtered by the `graphql_connection_args` filter. This can be retrieved from the resolver instance using `$resolver->get_unfiltered_args()`.
+3. `$this->context` - The context object that the connection is coming from. This can be retrieved from the resolver instance using `$resolver->get_context()`.
+4. `$this->info` - The info object that the connection is coming from. This can be retrieved from the resolver instance using `$resolver->get_info()`.
+5. `$this->should_execute` - This is set to `false` _only if_ the `get_pre_should_execute( $source, $args, $context, $info )` method returns `false`, and is used to short circuit the connection resolver. If it returns `true`, then the `should_execute()` method will be run later in the lifecycle.
+6. `$this->loader` - The DataLoader instance used by the connection resolver. This can be retrieved from the resolver instance using `$resolver->get_loader()`.
+7. `$this->args` - The GraphQL args passed to the connection resolver, after they've been filtered by the `graphql_connection_args` filter. This can be retrieved from the resolver instance using `$resolver->get_args()`.
+8. `$this->query_amount` - The number of items to query for the connection. This can be retrieved from the resolver instance using `$resolver->get_query_amount()`.
+9. `$this->query_args` - The query args that will be used to query the database, after they've been filtered by the `graphql_connection_query_args` filter. This can be retrieved from the resolver instance using `$resolver->get_query_args()`.
+10. `$this->query_class` - The query class (e.g. `WP_Query`) that will be used to query the database, after it has been filtered by the `graphql_connection_query_class` filter. This can be retrieved from the resolver instance using `$resolver->get_query_class()`. **Note:** This should return `null` if the connection resolver does not use a query class.
+
+### 2. (Optional) Modify the resolver properties
+In some cases, you may want to modify the resolver properties before the connection is executed. This allows you to reuse the same connection resolver for multiple fields, and modify the query args or connection type based on the field that is being resolved.
+
+> [!NOTE]
+> Whenever possible, it's better to use the `$args` passed to the connection resolver constructor to modify the query args, rather than modifying the query args directly using the setter methods.
+> This ensures that the connection resolver has a more predictable lifecycle reduces the likelihood of unexpected behavior and conflicts.
+
+```php
+// Modify the resolver properties before the connection is executed.
+$resolver->set_query_arg( 'post_type', 'post' );
+$resolver->set_query_class( 'WP_Meta_Query' );
+$resolver->one_to_one();
+```
+
+The `AbstractConnectionResolver` class provides three methods for modifying the resolver properties:
+
+- `public function set_query_arg( $key, $value )`
+  This method allows you to set a query arg for the connection resolver. This is useful for setting a custom query arg or modifying an existing one that isn't handled by the AbstractConnectionResolver's `prepare_query_args()` method.
+
+- `public function set_query_class( $class )`
+  This method allows you to overload the query class (e.g. `WP_Query`) that the connection resolver uses to query the database in the `$resolver->query()` method. This is useful if the data your connection is querying requires a specialized query class (e.g. `WP_Meta_Query`, `WP_Term_Query`, WooCommerce's `WC_Query`, etc ). **Note:** Not all connection resolvers use a query class, and using this method on a connection resolver that doesn't use a query class will throw an error.
+
+- `public function one_to_one()`
+  This method allows you to set the connection type to `one-to-one`. If set then the connection resolver will only return the first item in the connection.
+
+### 3. Execute the connection
+Once the Connection Resolver has been instantiated and the properties have been set, the connection is executed by calling the `get_connection()` method.
+
+```php
+// Return the connection data.
+return $resolver->get_connection();
+```
+
+When `get_connection()` is called, the connection resolver will first execute the query and get the IDs of the results, and then return a `Deferred` function to populate the connection data, such as the `nodes`, `edges`, and `pageInfo`.
+
+Lets drill down even further into the `get_connection()` method to see what happens when it's called.
+
+#### 3A. - Executing the Query.
+
+The first thing that happens in `get_connection()` is that the `execute_and_get_ids()` method is called. This method:
+
+1. Checks if the pre-execution hook (`get_pre_should_execute( $source, $args, $context, $info )`) returns false. If it does, then the connection resolver will short circuit and return an empty array. If it returns true, then the `should_execute()` method will be called.
+
+2. If `should_execute()` returns true, then the connection will:
+
+	1. Execute the `query()` method, which uses the `$query_args` to query the database and fetch the results.
+
+		Note that we overfetch our query results by 1, to determine if there are more pages in the connection.
+
+		If the query requires the use of a `$query_class`, then `is_valid_query_class()` will be called to ensure that the query class is compatible with this method.
+
+	2. Get the IDs of the query results (and sorts them for pagination if necessary) from the executed query, using the `get_ids_from_query()` method.
+
+	3. Apply the Relay-spec pagination args, to slice the results to the correct page, using the `apply_cursors_to_ids()` method.
+
+	4. Buffer the results in the DataLoader for deferred resolution.
+
+#### 3B. - (Defer) loading the connection data.
+Once the query has been executed and the IDs have been buffered in the DataLoader, the connection resolver will return a `Deferred` function to populate the connection data.
+
+Inside the `Deferred` callback, the connection resolver will:
+
+1. Fetch the full object data for the query results from the DataLoader.
+
+2. Generate the nodes:
+
+	1. First, we trim our overfetched results to the correct `query_amount`, using the `get_ids_for_nodes()` method.
+
+	2. Then we loop through the IDs, using `get_node_by_id()` to get the full GraphQL Model for the object.
+
+3. Use the nodes to generate the edge data, such as the `cursor`, `node`, `source`, and `connection`.
+
+4. Generate the connection data.
+
+   If the connection is a 'one-to-one' connection, only the `edge` data for the first node will be returned. Otherwise, the connection will include the `nodes`, `edges`, and the `pageInfo` used for paginating results will be generated and returned.
+
+## Interacting with the Connection Resolver instance.
+
+The `AbstractConnectionResolver` class provides a number of setter and getter methods that can be used to interact with the instance properties.
+
+These methods are often essential to extending the resolver within a WordPress filter callback. As such, care must be taken to ensure that the getter methods are called in the correct order (ideally _after_ the requested parameters have been set on the Resolver instance), to ensure the lifecycle of the resolver isn't altered in a way that would break expected behavior.
+
+The following "getter" methods are available on the `AbstractConnectionResolver` class:
+
+- `$instance->get_source() : mixed`
+
+   Gets the source object passed to the connection.
+
+- `$instance->get_context() : \WPGraphQL\AppContext`
+
+   Gets the AppContext instance passed to the connection.
+
+- `$instance->get_info() : \GraphQL\Type\Definition\ResolveInfo`
+
+   Gets the ResolveInfo instance passed to the connection.
+
+- `$instance->get_unfiltered_args() : array`
+
+   Gets the GraphQL args passed to the connection, _before_ the resolver applies any filters or modifications.
+
+   All the above methods are available and can be called safely at _any point_ in the resolver's lifecycle.
+
+- `$instance->get_loader() : \WPGraphQL\Data\Loader`
+   Gets the DataLoader instance used to cache and resolve the connection node data.
+
+   Can be called any time _after_ the `graphql_connection_loader_name` filter has been applied.
+
+- `$instance->get_args() : array`
+
+   Gets the GraphQL args passed to the connection, _after_ the resolver applies any filters or modifications.
+
+   Can be called any time _after_ the `graphql_connection_args` filter has been applied.
+
+- `$instance->get_query_amount() : int`
+
+   Gets the number of items to query for the connection.
+
+   Can be called any time _after_ the `graphql_connection_amount_requested` filter has been applied.
+
+- `$instance->get_query_args() : array`
+
+   Gets the query args used to query the database for the connection.
+
+   Can be called any time _after_ the `graphql_connection_query_args` filter has been applied.
+
+- `$instance->get_query_class() : ?string`
+
+   Gets the query class used by the `$instance->query()` method to query the database for the connection. Should return null if no query class is used.
+
+   Can be called any time _after_ the `graphql_connection_query_class` filter has been applied.
+
+- `$instance->get_should_execute() : bool`
+
+   Gets whether or not the connection should execute.
+
+   Can be called any time _after_ the `graphql_connection_should_execute` filter has been applied.
+
+- `$instance->get_query() : mixed` Gets the executed query for the connection.
+
+   Can be called any time _after_ the `graphql_connection_query` filter has been applied.
+
+- `$instance->get_ids() : array`
+
+   Gets the IDs of the query results for the connection.
+
+   Can be called any time _after_ the `graphql_connection_ids` filter has been applied.
+
+- `$instance->get_nodes() : array`
+
+   Gets the nodes (GraphQL models) for the connection results.
+
+   Can be called any time _after_ the `graphql_connection_nodes` filter has been applied.
+
+- `$instance->get_edges() : array`
+
+   Gets the array of edge data for the connection results.
+
+   Can be called any time _after_ the `graphql_connection_edges` filter has been applied.
+
+- `$instance->get_page_info() : array`
+
+   Gets the pageInfo data for the connection results.
+
+   Can be called any time _after_ the `graphql_connection_page_info` filter has been applied.
+
+## Extending a connection resolver with WordPress Filters.
+
+The `AbstractConnectionResolver` class provides a number of filters that can be used to modify the behavior of an existing Connection Resolver. They are listed below in the order that they are executed.
+
+> [!NOTE]
+> For advanced use cases, you will likely want to access properties already set on the `AbstractConnectionResolver` instance, such as the `$query_args` or `$args`. As such, it is recommended to pay attention to the order in which the filters are executed, as some filters may be executed before the properties are set, leading to unexpected behavior.
+
+- `apply_filters( 'graphql_connection_pre_should_execute', bool $should_execute, $source, array $args, \WPGraphQL\AppContext $context, \GraphQL\Type\Definition\ResolveInfo $info )`
+
+   Filters whether or not the query should execute, BEFORE any data is fetched or altered. This is evaluated based solely on the values passed to the constructor, before any data is fetched or altered, and is useful for short-circuiting the Connection Resolver before any heavy logic is executed.
+
+   For more in-depth checks, use the `graphql_connection_should_execute` filter instead.
+
+- `apply_filters( 'graphql_connection_loader_name', string $loader_name, \WPGraphQL\Data\Connection\AbstractConnectionResolver $resolver )`
+
+   Filters the `name` (array key) of the registered DataLoader to use for the connection. This is useful if you want to use a custom DataLoader for a connection (e.g. for a custom post type using `PostObjectConnectionResolver`).
+
+- `apply_filters( 'graphql_connection_args', array $args, \WPGraphQL\Data\Connection\AbstractConnectionResolver $resolver )`
+
+   Filters the `$args` passed to the connection resolver, before they are mapped to the `$query_args` that will be used to execute the query.
+
+- `apply_filters( 'graphql_connection_max_query_amount', int $max_query_amount, $source, array $args, \WPGraphQL\AppContext $context, \GraphQL\Type\Definition\ResolveInfo $info )`
+
+   Filters the maximum number of items that should be queried. Defaults to 100.
+
+- `apply_filters( 'graphql_connection_amount_requested', int $amount_requested, \WPGraphQL\Data\Connection\AbstractConnectionResolver $resolver )`
+
+   Filters the number of items requested by the connection, e.g. the `first` or `last` argument. Defaults to 10.
+
+- `apply_filters( 'graphql_connection_query_args', array $query_args, \WPGraphQL\Data\Connection\AbstractConnectionResolver $resolver )`
+
+   Filters the `$query_args` that will be used to execute the query. This is useful for modifying the query args before they are executed, or for handling custom connection args that aren’t mapped by the AbstractConnectionResolver's `prepare_query_args()` method.
+
+- `apply_filters( 'graphql_connection_query_class', ?string $query_class, \WPGraphQL\Data\Connection\AbstractConnectionResolver $resolver )`
+
+   Filters the `$query_class` that will be used to execute the query. This is useful for replacing the default query class (e.g. `WP_Query`) with a custom one (e.g. `WP_Term_Query` or WooCommerce's `WC_Query`).
+
+- `apply_filters( 'graphql_connection_should_execute', bool $should_execute, \WPGraphQL\Data\Connection\AbstractConnectionResolver $resolver )`
+
+   Filters whether or not the resolver should return any data, _after_ the `$query_args` have been mapped, but before the query is executed.
+
+   You can short-circuit the connection resolver earlier in the lifecycle by using the `graphql_connection_pre_should_execute` filter instead.
+
+- `apply_filters( 'graphql_connection_pre_get_query', \WP_Query $query, \WPGraphQL\Data\Connection\AbstractConnectionResolver $resolver )`
+
+   When this filter returns anything but false, it will be used as the resolved query, and the default query execution will be skipped.
+
+   Useful for replacing the default query (e.g. `WP_Query()`) with a custom one (e.g. `WP_Term_Query()` or even a query to an external datasource such as a REST API.)
+
+- `apply_filters( 'graphql_connection_query', \WP_Query $query, \WPGraphQL\Data\Connection\AbstractConnectionResolver $resolver )`
+
+   Filters the `$query` after it has been executed (either by the `graphql_connection_pre_get_query` filter or the default `$this->query()` method).
+
+-  `apply_filters( 'graphql_connection_ids', array $ids, \WPGraphQL\Data\Connection\AbstractConnectionResolver $resolver )`
+
+   Filters the IDs of the results returned from the query. This is useful for modifying the IDs before they are buffered in the DataLoader, or for modifying the IDs before they are used to generate the nodes.
+
+   The resulting array of IDs should be sorted in the order expected from the GraphQL connection, and sliced to the correct amount of items to return plus 1 (we overfetch to determine if there are more pages in the connection).
+
+- `apply_filters( 'graphql_connection_nodes', array $nodes, \WPGraphQL\Data\Connection\AbstractConnectionResolver $resolver )`
+
+   Filters the nodes returned by the connection resolver.
+
+   This is useful for modifying the nodes before they are used to generate the edges and connection data.
+
+- `apply_filters( 'graphql_connection_edge', array $edges, \WPGraphQL\Data\Connection\AbstractConnectionResolver $resolver )`
+
+   Filters the data returned by the connection resolver for the individual edge.
+
+   This is useful for modifying the edge data, or passing custom data that can be used to resolve edge fields.
+
+- `apply_filters( 'graphql_connection_edges', array $edges, \WPGraphQL\Data\Connection\AbstractConnectionResolver $resolver )`
+
+   Filters the edges returned by the connection resolver.
+
+   This is useful for modifying the edges before they are used to generate the connection data.
+
+- `apply_filters( 'graphql_connection_page_info', array $page_info, \WPGraphQL\Data\Connection\AbstractConnectionResolver $resolver )`
+
+   Filters the pageInfo that is returned by the connection resolver.
+
+   This filter is useful for modifying the pageInfo data, or resolving custom pageInfo fields.
+
+- `apply_filters( 'graphql_connection', array $connection, \WPGraphQL\Data\Connection\AbstractConnectionResolver $resolver )`
+
+   Filters the connection data returned by the connection resolver.
+
+   This is useful for providing additional data other than the `edges`, `nodes`, and `pageInfo` that can be used by the connection.
+
+## Creating a Custom Connection Resolver
+
+You can create a custom connection resolver by extending the `AbstractConnectionResolver` (or one of the existing child classes) class and overloading the methods you need to customize.
+
+Below is a list of some of the more common `AbstractConnectionResolver` methods that you may need to implement in your child class.
+
+(For real-world examples, see the [other connection resolvers included with WPGraphQL](./)).
+
+- `protected function loader_name() : string` (Required)
+
+   Sets the name (array key) of the DataLoader to use for the connection. E.g. `post`, `comment`, `user`, etc.
+
+- `protected function prepare_query_args( array $args ) : array` (Required)
+
+   Maps the `$args` passed to the connection to the `$query_args` used to execute the query.
+
+- `public function get_ids_from_query() : array` (Required)
+
+   Returns an array of IDs from the processed query. Each Query class in WordPress and potential datasource handles this differently, so this handles getting the items into a uniform array of items.
+
+- `public function is_valid_offset( $offset ) : bool` (Required)
+
+   Determines whether a provided offset (i.e. the item it corresponds to) exists. This is equivalent to checking if the WordPress object for a given ID exists.
+
+- `protected function prepare_args( array $args ) : array`
+
+   Prepares the `$args` passed to the connection, before they are mapped to the `$query_args` used to execute the query.
+
+- `protected function query_class() : ?string`
+
+   Sets the class used by the `query()` method to execute the query. Should return `null` if the `query()` method does not rely on a `$query_class`.
+
+- `protected function is_valid_query_class( string $query_class ) : bool`
+
+   Determines whether the `$query_class` set in the Connection Resolver is compatible with the `query()` method. This is ignored if the `query()` method does not rely on a `$query_class`.
+
+- `protected function query( array $query_args ) : mixed`
+
+   Executes the query. Usually this will return an instance of the `$query_class`, but it can return anything that can be used to generate the nodes for the connection. This **must** be overridden if the Resolver does not use a `$query_class`.
+
+- `protected function get_pre_should_execute( $source, array $args, \WPGraphQL\AppContext $context, \GraphQL\Type\Definition\ResolveInfo $info ) : bool`
+
+   Determines whether the connection query should be executed before any heavy logic runs. Use this hook to short-circuit execution when appropriate.
+
+- `protected function should_execute() : bool`
+
+   Used to determine whether or not the connection query should be executed (after mapping `$query_args`). This method is only run if the pre-execution hook passes.
+
+- `public function get_offset_for_cursor( string $cursor = null )`
+
+   Returns the array offset for a given connection item cursor. This is used to convert the list of items from the query so that it follows the `first` or `last` argument correctly.
+
+   Connections that use a string-based offset should override this method.
+
+- `protected function is_valid_model( $model ) : bool`
+
+   Validates the GraphQL model returned from the DataLoader. By default, this ensures that the model’s fields are set appropriately, but your GraphQL implementation might have different requirements.
+
+## Implementation Tips
+
+- **Avoid overloading `::get_*()`** methods in your child class. Instead, use the methods they wrap (e.g. use `loader_name()` instead of `get_loader_name()`, `prepare_args()` instead of `get_args()`, etc).
+
+- **Call `::get_*()`** methods on the instance rather than accessing properties directly.
+
+- Before creating a new connection resolver, check if there is an existing connection resolver that can be **extended via a filter** to meet your needs.
+
+- When resolving a connection, it’s best to **modify the GraphQL `$args`** before they are passed to the connection resolver constructor rather than modifying the underlying WordPress query args directly using the setter methods.

--- a/src/Request.php
+++ b/src/Request.php
@@ -722,7 +722,17 @@ class Request {
 			return false;
 		}
 
-		return 0 === stripos( $content_type, 'application/json' );
+		$is_valid = 0 === stripos( $content_type, 'application/json' );
+
+		/**
+		 * Allow graphql to validate custom content types for HTTP POST requests
+		 *
+		 * @param bool $is_valid Whether the content type is valid
+		 * @param string $content_type The content type header value that was received
+		 *
+		 * @since todo
+		 */
+		return (bool) apply_filters( 'graphql_is_valid_http_content_type', $is_valid, $content_type );
 	}
 
 	/**

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 2.0.0
+ * Version: 2.0.1
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 6.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  2.0.0
+ * @version  2.0.1
  */
 
 // Exit if accessed directly.

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -6,7 +6,7 @@
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
- * Version: 2.0.1
+ * Version: 2.1.0
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 6.0
@@ -18,7 +18,7 @@
  * @package  WPGraphQL
  * @category Core
  * @author   WPGraphQL
- * @version  2.0.1
+ * @version  2.1.0
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
## Release Notes

### New Features

- [#3325](https://github.com/wp-graphql/wp-graphql/pull/3325): feat: add filter to Request::is_valid_http_content_type to allow for custom content types with POST method requests

### Chores / Bugfixes

- [#3314](https://github.com/wp-graphql/wp-graphql/pull/3314): fix: use version_compare to simplify incompatible dependent check
- [#3316](https://github.com/wp-graphql/wp-graphql/pull/3316): docs: update changelog and upgrade notice
- [#3325](https://github.com/wp-graphql/wp-graphql/pull/3325): docs: update quick-start.md