### PR TITLE
fix: error in Github Workflow

### DIFF
--- a/.github/workflows/generate-changeset.yml
+++ b/.github/workflows/generate-changeset.yml
@@ -80,9 +80,9 @@ jobs:
             - [ ] @since tags are identified for update
 
             ### Files with @since Tags to Update
-            ${{ fromJson(steps.since_tags.outputs.tags).sinceFiles || 'No files with @since tags found.' }}
+            ${{ steps.since_tags.outputs.tags != '' && fromJson(steps.since_tags.outputs.tags).sinceFiles || 'No files with @since tags found.' }}
 
-            Total tags to update: ${{ fromJson(steps.since_tags.outputs.tags).totalTags || 0 }}
+            Total tags to update: ${{ steps.since_tags.outputs.tags != '' && fromJson(steps.since_tags.outputs.tags).totalTags || 0 }}
           labels: |
             automated pr
             changeset


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

Fixes a bug in the Github workflow that generates changesets.

Only use fromJson if there's a payload for the tags