### PR TITLE
fix: error in Github Workflow 

### DIFF
--- a/.github/workflows/generate-changeset.yml
+++ b/.github/workflows/generate-changeset.yml
@@ -12,6 +12,9 @@ jobs:
     name: Generate Changeset
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write # Grant write access to the repository contents
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -48,7 +51,7 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT }}
         run: |
           # Run with error handling
           if ! node scripts/generate-changeset.js; then
@@ -58,8 +61,9 @@ jobs:
 
       # Create PR with changeset
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ secrets.PAT }}
           commit-message: "chore: add changeset for PR #${{ github.event.pull_request.number }}"
           branch: changeset-pr-${{ github.event.pull_request.number }}
           title: "chore: add changeset for PR #${{ github.event.pull_request.number }}"


### PR DESCRIPTION
Fixes a bug in the Github workflow that generates changesets.

Use Personal Access Token instead of GITHUB_TOKEN for the `peter-evans/create-pull-request@v7` action