### PR TITLE
chore: add WPGraphQL IDE to the extensions page

### DIFF
--- a/src/Admin/Extensions/Registry.php
+++ b/src/Admin/Extensions/Registry.php
@@ -49,7 +49,7 @@ final class Registry {
 	 */
 	public static function get_extensions(): array {
 		return [
-			'wp-graphql/wpgraphql-ide'  => [
+			'wp-graphql/wpgraphql-ide'           => [
 				'name'              => 'WPGraphQL IDE',
 				'description'       => 'GraphQL IDE for WPGraphQL',
 				'documentation_url' => 'https://github.com/wp-graphql/wpgraphql-ide',

--- a/src/Admin/Extensions/Registry.php
+++ b/src/Admin/Extensions/Registry.php
@@ -49,6 +49,17 @@ final class Registry {
 	 */
 	public static function get_extensions(): array {
 		return [
+			'wp-graphql/wpgraphql-ide'  => [
+				'name'              => 'WPGraphQL IDE',
+				'description'       => 'GraphQL IDE for WPGraphQL',
+				'documentation_url' => 'https://github.com/wp-graphql/wpgraphql-ide',
+				'plugin_url'        => 'https://wordpress.org/plugins/wpgraphql-ide/',
+				'support_url'       => 'https://github.com/wp-graphql/wpgraphql-ide/issues/new/choose',
+				'author'            => [
+					'name'     => 'WPGraphQL',
+					'homepage' => 'https://wpgraphql.com',
+				],
+			],
 			'wp-graphql/wp-graphql-smart-cache'  => [
 				'name'              => 'WPGraphQL Smart Cache',
 				'description'       => 'A smart cache for WPGraphQL that caches only the data you need.',


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

This adds the WPGraphQL IDE plugin to the "Extensions" page

## WPGraphQL IDE

The WPGraphQL IDE is a new version of GraphiQL that ships with the core WPGraphQL plugin.

It provides users with the ability to open the IDE from any page in WordPress via the Admin Bar, leading to increased productivity when testing queries and mutations.

The new IDE allows for users to test queries as authenticated or public users, open queries in tabs, and more. 

I've been using the new IDE daily for quite some time and I think users will enjoy it. 

It has a pluggable architecture, allowing for plugins to add new panels and interact with the IDE. 

The plugin is maintained as an external plugin to WPGraphQL as it will have it's own release cycles that may include breaking changes independent from the core WPGraphQL Schema. 

![CleanShot 2025-03-06 at 11 01 17](https://github.com/user-attachments/assets/e9e32704-ad69-4221-8f0c-a1251191fcd6)
