### PR TITLE
feat: add support for graphql_description on register_post_type and register_taxonomy

### DIFF
--- a/docs/custom-post-types.md
+++ b/docs/custom-post-types.md
@@ -7,27 +7,28 @@ title: "Custom Post Types"
 
 In order to use Custom Post Types with WPGraphQL, you must configure the Post Type to `show_in_graphql` using the following fields:
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `show_in_graphql` | boolean | Yes | If true, show the post type in the GraphQL Schema |
-| `graphql_single_name` | string | Yes | Camel case string with no punctuation or spaces. Needs to start with a letter (not a number) |
-| `graphql_plural_name` | string | No | Camel case string with no punctuation or spaces. Needs to start with a letter (not a number) |
-| `graphql_kind` | string | No | Allows the type representing the post type to be added to the graph as an object type, interface type or union type. Possible values are 'object', 'interface' or 'union'. Default is 'object' |
-| `graphql_resolve_type` | callable | No | The callback used to resolve the type. Only used if "graphql_kind" is set to "union" or "interface" |
-| `graphql_interfaces` | array&lt;string&gt; | No | List of Interface names the type should implement. These will be applied in addition to default interfaces such as "Node" |
-| `graphql_exclude_interfaces` | array&lt;string&gt; | No | List of Interface names the type *should not* implement. This is applied after default and custom interfaces are added |
-| `graphql_fields` | array&lt;$config&gt; | No | Array of fields to add to the Type. Applied if "graphql_kind" is "interface" or "object" |
-| `graphql_exclude_fields` | array&lt;string&gt; | No | Array of fields names to exclude from the type. Applies if "graphql_kind" is "interface" or "object" |
-| `graphql_connections` | array&lt;$config&gt; | No | Array of connection configs to register to the type. Only applies if the "graphql_kind" is "object" or "interface" |
-| `graphql_exclude_connections` | array&lt;string&gt; | No | Array of connection names to exclude from the type |
-| `graphql_union_types` | array&lt;string&gt; | No | Array of possible types the union can resolve to. Only used if "graphql_kind" is set to "union" |
-| `graphql_register_root_field` | boolean | No | Whether to register a field to the RootQuery to query a single node of this type. Default true |
-| `graphql_register_root_connection` | boolean | No | Whether to register a connection to the RootQuery to query multiple nodes of this type. Default true |
-| `graphql_exclude_mutations` | array&lt;string&gt; | No | Array of mutations to prevent from being registered. Possible values are "create", "update", "delete" |
+| Field                              | Type                 | Required | Description                                                                                                                                                                                    |
+| ---------------------------------- | -------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `show_in_graphql`                  | boolean              | Yes      | If true, show the post type in the GraphQL Schema                                                                                                                                              |
+| `graphql_single_name`              | string               | Yes      | Camel case string with no punctuation or spaces. Needs to start with a letter (not a number)                                                                                                   |
+| `graphql_plural_name`              | string               | No       | Camel case string with no punctuation or spaces. Needs to start with a letter (not a number)                                                                                                   |
+| `graphql_description`              | string               | No       | Custom description for the type in the GraphQL schema. If not set, will fallback to post type's description, then a default description                                                        |
+| `graphql_kind`                     | string               | No       | Allows the type representing the post type to be added to the graph as an object type, interface type or union type. Possible values are 'object', 'interface' or 'union'. Default is 'object' |
+| `graphql_resolve_type`             | callable             | No       | The callback used to resolve the type. Only used if "graphql_kind" is set to "union" or "interface"                                                                                            |
+| `graphql_interfaces`               | array&lt;string&gt;  | No       | List of Interface names the type should implement. These will be applied in addition to default interfaces such as "Node"                                                                      |
+| `graphql_exclude_interfaces`       | array&lt;string&gt;  | No       | List of Interface names the type _should not_ implement. This is applied after default and custom interfaces are added                                                                         |
+| `graphql_fields`                   | array&lt;$config&gt; | No       | Array of fields to add to the Type. Applied if "graphql_kind" is "interface" or "object"                                                                                                       |
+| `graphql_exclude_fields`           | array&lt;string&gt;  | No       | Array of fields names to exclude from the type. Applies if "graphql_kind" is "interface" or "object"                                                                                           |
+| `graphql_connections`              | array&lt;$config&gt; | No       | Array of connection configs to register to the type. Only applies if the "graphql_kind" is "object" or "interface"                                                                             |
+| `graphql_exclude_connections`      | array&lt;string&gt;  | No       | Array of connection names to exclude from the type                                                                                                                                             |
+| `graphql_union_types`              | array&lt;string&gt;  | No       | Array of possible types the union can resolve to. Only used if "graphql_kind" is set to "union"                                                                                                |
+| `graphql_register_root_field`      | boolean              | No       | Whether to register a field to the RootQuery to query a single node of this type. Default true                                                                                                 |
+| `graphql_register_root_connection` | boolean              | No       | Whether to register a connection to the RootQuery to query multiple nodes of this type. Default true                                                                                           |
+| `graphql_exclude_mutations`        | array&lt;string&gt;  | No       | Array of mutations to prevent from being registered. Possible values are "create", "update", "delete"                                                                                          |
 
 ## Registering a new Custom Post Type
 
-This is an example of registering a new "docs" post\_type and enabling GraphQL Support.
+This is an example of registering a new "docs" post_type and enabling GraphQL Support.
 
 ```php
 add_action( 'init', function() {
@@ -39,7 +40,7 @@ add_action( 'init', function() {
       ],
       'hierarchical' => true, # set to false if you don't want parent/child relationships for the entries
       'show_in_graphql' => true, # Set to false if you want to exclude this type from the GraphQL Schema
-      'graphql_single_name' => 'document', 
+      'graphql_single_name' => 'document',
       'graphql_plural_name' => 'documents', # If set to the same name as graphql_single_name, the field name will default to `all${graphql_single_name}`, i.e. `allDocument`.
       'public' => true, # set to false if entries of the post_type should not have public URIs per entry
       'publicly_queryable' => true, # Set to false if entries should only be queryable in WPGraphQL by authenticated requests
@@ -96,7 +97,7 @@ And if your `graphql_single_name` were `Doc`, you would be able to query a singl
 
 ```graphql
 {
-  doc( id: "validIdGoesHere" ) {
+  doc(id: "validIdGoesHere") {
     id
     title
   }
@@ -107,7 +108,7 @@ And if your `graphql_single_name` were `Doc`, you would be able to query a singl
 
 All post types have the `ContentNode` Interface applied to their GraphQL Type.
 
-WPGraphQL exposes fields that a post type has registered support for using the [post\_type\_supports](https://developer.wordpress.org/reference/functions/post_type_supports/), and leaves out fields that a post type does not support.
+WPGraphQL exposes fields that a post type has registered support for using the [post_type_supports](https://developer.wordpress.org/reference/functions/post_type_supports/), and leaves out fields that a post type does not support.
 
 Supported fields are applied to the GraphQL Type using [Interfaces](/docs/interfaces/).
 

--- a/docs/custom-taxonomies.md
+++ b/docs/custom-taxonomies.md
@@ -7,23 +7,24 @@ title: "Custom Taxonomies"
 
 In order to use Custom Taxonomies with WPGraphQL, you must configure the Taxonomy to `show_in_graphql` using the following fields:
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `show_in_graphql` | boolean | Yes | If true, show the taxonomy in the GraphQL Schema |
-| `graphql_single_name` | string | Yes | Camel case string with no punctuation or spaces. Needs to start with a letter (not a number) |
-| `graphql_plural_name` | string | No | Camel case string with no punctuation or spaces. Needs to start with a letter (not a number) |
-| `graphql_kind` | string | No | Allows the type representing the taxonomy to be added to the graph as an object type, interface type or union type. Possible values are 'object', 'interface' or 'union'. Default is 'object' |
-| `graphql_resolve_type` | callable | No | The callback used to resolve the type. Only used if "graphql_kind" is set to "union" or "interface" |
-| `graphql_interfaces` | array&lt;string&gt; | No | List of Interface names the type should implement. These will be applied in addition to default interfaces such as "Node" |
-| `graphql_exclude_interfaces` | array&lt;string&gt; | No | List of Interface names the type *should not* implement. This is applied after default and custom interfaces are added |
-| `graphql_fields` | array&lt;$config&gt; | No | Array of fields to add to the Type. Applies if "graphql_kind" is "interface" or "object" |
-| `graphql_exclude_fields` | array&lt;string&gt; | No | Array of fields names to exclude from the type. Applies if "graphql_kind" is "interface" or "object" |
-| `graphql_connections` | array&lt;$config&gt; | No | Array of connection configs to register to the type. Only applies if the "graphql_kind" is "object" or "interface" |
-| `graphql_exclude_connections` | array&lt;string&gt; | No | Array of connection names to exclude from the type |
-| `graphql_union_types` | array&lt;string&gt; | No | Array of possible types the union can resolve to. Only used if "graphql_kind" is set to "union" |
-| `graphql_register_root_field` | boolean | No | Whether to register a field to the RootQuery to query a single node of this type. Default true |
-| `graphql_register_root_connection` | boolean | No | Whether to register a connection to the RootQuery to query multiple nodes of this type. Default true |
-| `graphql_exclude_mutations` | array&lt;string&gt; | No | Array of mutations to prevent from being registered. Possible values are "create", "update", "delete" |
+| Field                              | Type                 | Required | Description                                                                                                                                                                                   |
+| ---------------------------------- | -------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `show_in_graphql`                  | boolean              | Yes      | If true, show the taxonomy in the GraphQL Schema                                                                                                                                              |
+| `graphql_single_name`              | string               | Yes      | Camel case string with no punctuation or spaces. Needs to start with a letter (not a number)                                                                                                  |
+| `graphql_plural_name`              | string               | No       | Camel case string with no punctuation or spaces. Needs to start with a letter (not a number)                                                                                                  |
+| `graphql_description`              | string               | No       | Custom description for the type in the GraphQL schema. If not set, will fallback to taxonomy's description, then a default description                                                        |
+| `graphql_kind`                     | string               | No       | Allows the type representing the taxonomy to be added to the graph as an object type, interface type or union type. Possible values are 'object', 'interface' or 'union'. Default is 'object' |
+| `graphql_resolve_type`             | callable             | No       | The callback used to resolve the type. Only used if "graphql_kind" is set to "union" or "interface"                                                                                           |
+| `graphql_interfaces`               | array&lt;string&gt;  | No       | List of Interface names the type should implement. These will be applied in addition to default interfaces such as "Node"                                                                     |
+| `graphql_exclude_interfaces`       | array&lt;string&gt;  | No       | List of Interface names the type _should not_ implement. This is applied after default and custom interfaces are added                                                                        |
+| `graphql_fields`                   | array&lt;$config&gt; | No       | Array of fields to add to the Type. Applies if "graphql_kind" is "interface" or "object"                                                                                                      |
+| `graphql_exclude_fields`           | array&lt;string&gt;  | No       | Array of fields names to exclude from the type. Applies if "graphql_kind" is "interface" or "object"                                                                                          |
+| `graphql_connections`              | array&lt;$config&gt; | No       | Array of connection configs to register to the type. Only applies if the "graphql_kind" is "object" or "interface"                                                                            |
+| `graphql_exclude_connections`      | array&lt;string&gt;  | No       | Array of connection names to exclude from the type                                                                                                                                            |
+| `graphql_union_types`              | array&lt;string&gt;  | No       | Array of possible types the union can resolve to. Only used if "graphql_kind" is set to "union"                                                                                               |
+| `graphql_register_root_field`      | boolean              | No       | Whether to register a field to the RootQuery to query a single node of this type. Default true                                                                                                |
+| `graphql_register_root_connection` | boolean              | No       | Whether to register a connection to the RootQuery to query multiple nodes of this type. Default true                                                                                          |
+| `graphql_exclude_mutations`        | array&lt;string&gt;  | No       | Array of mutations to prevent from being registered. Possible values are "create", "update", "delete"                                                                                         |
 
 ### Registering a new Custom Taxonomy
 
@@ -100,7 +101,7 @@ And you'd be able to query a single `documentTag` like so:
 
 ```graphql
 {
-  documentTag( id: "validIdGoesHere" ) {
+  documentTag(id: "validIdGoesHere") {
     id
     name
   }

--- a/src/Registry/Utils/PostObject.php
+++ b/src/Registry/Utils/PostObject.php
@@ -34,8 +34,13 @@ class PostObject {
 		$single_name = $post_type_object->graphql_single_name;
 
 		$config = [
-			/* translators: post object singular name w/ description */
-			'description' => sprintf( __( 'The %s type', 'wp-graphql' ), $single_name ),
+			'description' => ! empty( $post_type_object->graphql_description )
+				? $post_type_object->graphql_description
+				: ( ! empty( $post_type_object->description )
+					? $post_type_object->description
+					/* translators: post object singular name w/ description */
+					: sprintf( __( 'The %s type', 'wp-graphql' ), $single_name )
+				),
 			'connections' => static::get_connections( $post_type_object ),
 			'interfaces'  => static::get_interfaces( $post_type_object ),
 			'fields'      => static::get_fields( $post_type_object ),

--- a/src/Registry/Utils/TermObject.php
+++ b/src/Registry/Utils/TermObject.php
@@ -33,11 +33,13 @@ class TermObject {
 		$single_name = $tax_object->graphql_single_name;
 
 		$config = [
-			'description' => sprintf(
-				// translators: %s is the term object singular name.
-				__( 'The %s type', 'wp-graphql' ),
-				$single_name
-			),
+			'description' => ! empty( $tax_object->graphql_description )
+				? $tax_object->graphql_description
+				: ( ! empty( $tax_object->description )
+					? $tax_object->description
+					/* translators: taxonomy object singular name w/ description */
+					: sprintf( __( 'The %s type', 'wp-graphql' ), $single_name )
+				),
 			'connections' => static::get_connections( $tax_object ),
 			'interfaces'  => static::get_interfaces( $tax_object ),
 			'fields'      => static::get_fields( $tax_object ),

--- a/src/Type/ObjectType/Comment.php
+++ b/src/Type/ObjectType/Comment.php
@@ -21,7 +21,7 @@ class Comment {
 		register_graphql_object_type(
 			'Comment',
 			[
-				'description' => __( 'A Comment object', 'wp-graphql' ),
+				'description' => __( 'A response or reaction to content submitted by users. Comments are typically associated with a specific content entry.', 'wp-graphql' ),
 				'model'       => CommentModel::class,
 				'interfaces'  => [ 'Node', 'DatabaseIdentifier', 'UniformResourceIdentifiable' ],
 				'connections' => [

--- a/src/Type/ObjectType/Menu.php
+++ b/src/Type/ObjectType/Menu.php
@@ -15,7 +15,7 @@ class Menu {
 		register_graphql_object_type(
 			'Menu',
 			[
-				'description' => __( 'Menus are the containers for navigation items. Menus can be assigned to menu locations, which are typically registered by the active theme.', 'wp-graphql' ),
+				'description' => __( 'Collections of navigation links. Menus can be assigned to designated locations and used to build site navigation structures.', 'wp-graphql' ),
 				'interfaces'  => [ 'Node', 'DatabaseIdentifier' ],
 				'model'       => MenuModel::class,
 				'fields'      => [

--- a/src/Type/ObjectType/User.php
+++ b/src/Type/ObjectType/User.php
@@ -26,7 +26,7 @@ class User {
 		register_graphql_object_type(
 			'User',
 			[
-				'description' => __( 'A User object', 'wp-graphql' ),
+				'description' => __( 'A registered user account. Users can be assigned roles, author content, and have various capabilities within the site.', 'wp-graphql' ),
 				'model'       => UserModel::class,
 				'interfaces'  => [ 'Node', 'UniformResourceIdentifiable', 'Commenter', 'DatabaseIdentifier' ],
 				'connections' => [

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -531,14 +531,17 @@ final class WPGraphQL {
 			$args['show_in_graphql']     = true;
 			$args['graphql_single_name'] = 'mediaItem';
 			$args['graphql_plural_name'] = 'mediaItems';
+			$args['graphql_description'] = __( 'Represents uploaded media, including images, videos, documents, and audio files.', 'wp-graphql' );
 		} elseif ( 'page' === $post_type ) { // Adds GraphQL support for pages.
 			$args['show_in_graphql']     = true;
 			$args['graphql_single_name'] = 'page';
 			$args['graphql_plural_name'] = 'pages';
+			$args['graphql_description'] = __( 'A standalone content entry generally used for static, non-chronological content such as "About Us" or "Contact" pages.', 'wp-graphql' );
 		} elseif ( 'post' === $post_type ) { // Adds GraphQL support for posts.
 			$args['show_in_graphql']     = true;
 			$args['graphql_single_name'] = 'post';
 			$args['graphql_plural_name'] = 'posts';
+			$args['graphql_description'] = __( 'A chronological content entry typically used for blog posts, news articles, or similar date-based content.', 'wp-graphql' );
 		}
 
 		return $args;
@@ -559,14 +562,17 @@ final class WPGraphQL {
 			$args['show_in_graphql']     = true;
 			$args['graphql_single_name'] = 'category';
 			$args['graphql_plural_name'] = 'categories';
+			$args['graphql_description'] = __( 'A taxonomy term that classifies content. Categories support hierarchy and can be used to create a nested structure.', 'wp-graphql' );
 		} elseif ( 'post_tag' === $taxonomy ) { // Adds GraphQL support for tags.
 			$args['show_in_graphql']     = true;
 			$args['graphql_single_name'] = 'tag';
 			$args['graphql_plural_name'] = 'tags';
+			$args['graphql_description'] = __( 'A taxonomy term used to organize and classify content. Unlike categories, tags do not support hierarchy and are generally used for more specific classifications.', 'wp-graphql' );
 		} elseif ( 'post_format' === $taxonomy ) { // Adds GraphQL support for post formats.
 			$args['show_in_graphql']     = true;
 			$args['graphql_single_name'] = 'postFormat';
 			$args['graphql_plural_name'] = 'postFormats';
+			$args['graphql_description'] = __( 'A formatting template that defines how content is styled and presented. Examples include "standard", "gallery", "video", etc.', 'wp-graphql' );
 		}
 
 		return $args;

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -567,12 +567,12 @@ final class WPGraphQL {
 			$args['show_in_graphql']     = true;
 			$args['graphql_single_name'] = 'tag';
 			$args['graphql_plural_name'] = 'tags';
-			$args['graphql_description'] = __( 'A taxonomy term used to organize and classify content. Unlike categories, tags do not support hierarchy and are generally used for more specific classifications.', 'wp-graphql' );
+			$args['graphql_description'] = __( 'A taxonomy term used to organize and classify content. Tags do not have a hierarchy and are generally used for more specific classifications.', 'wp-graphql' );
 		} elseif ( 'post_format' === $taxonomy ) { // Adds GraphQL support for post formats.
 			$args['show_in_graphql']     = true;
 			$args['graphql_single_name'] = 'postFormat';
 			$args['graphql_plural_name'] = 'postFormats';
-			$args['graphql_description'] = __( 'A formatting template that defines how content is styled and presented. Examples include "standard", "gallery", "video", etc.', 'wp-graphql' );
+			$args['graphql_description'] = __( 'A standardized classification system for content presentation styles. These formats can be used to display content differently based on type, such as "standard", "gallery", "video", etc.', 'wp-graphql' );
 		}
 
 		return $args;


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

This adds support for passing `graphql_description` when registering a Post Type or Taxonomy. This field will be used as the description in the Schema for the Type representing the Post Type or Taxonomy. 

In addition to adding support for the `graphql_description` arg, this also updates the descriptions for the built in post types and taxonomies, as well as the User, Menu and Comment types. 

|GraphQL Type | Current Description | Improved Description |
|---------------|---------------------|----------------------|
| Category | "The category type" | "A taxonomy term that classifies content. Categories support hierarchy and can be used to create a nested structure." |
| Post | "The post type" | "A chronological content entry typically used for blog posts, news articles, or similar date-based content." |
| Page | "The page type" | "A standalone content entry generally used for static, non-chronological content such as 'About Us' or 'Contact' pages." |
| MediaItem | "The mediaItem type" | "Represents uploaded media, including images, videos, documents, and audio files." |
| User | "A User object" | "A registered user account. Users can be assigned roles, author content, and have various capabilities within the site." |
| Comment | "A Comment object" | "A response or reaction to content submitted by users. Comments are typically associated with a specific content entry." |
| Tag | "The tag type" | "A taxonomy term used to organize and classify content. Tags do not have a hierarchy and are generally used for more specific classifications." |
| PostFormat | "The postFormat type" | "A standardized classification system for content presentation styles. These formats can be used to display content differently based on type, such as "standard", "gallery", "video", etc." |
| Menu | "Menus are the containers for navigation items. Menus can be assigned to menu locations, which are typically registered by the active theme." | "Collections of navigation links. Menus can be assigned to designated locations and used to build site navigation structures." |
