### PR TITLE
chore: update `@since next-version` placeholder that didn't properly get replaced during release

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -730,7 +730,7 @@ class Request {
 		 * @param bool $is_valid Whether the content type is valid
 		 * @param string $content_type The content type header value that was received
 		 *
-		 * @since next-version
+		 * @since 2.1.0
 		 */
 		return (bool) apply_filters( 'graphql_is_valid_http_content_type', $is_valid, $content_type );
 	}


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

This updates a `@since next-version` placeholder that didn't properly get replaced during the v2.1.0 release