### PR TITLE
ci: trigger Codeception workflow more often

### DIFF
--- a/.github/workflows/testing-integration.yml
+++ b/.github/workflows/testing-integration.yml
@@ -12,8 +12,13 @@ on:
       - master
       - release/*
     paths:
+      - '.github/workflows/testing-integration.yml'
       - '**.php'
-      - '.github/workflows/*.yml'
+      - 'composer.json'
+      - 'composer.lock'
+      - 'tests/**'
+      - 'codeception.dist.yml'
+      - 'docker-compose.yml'
       - '!docs/**'
 
 # Cancel previous workflow run groups that have not completed.


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

## What does this implement/fix? Explain your changes.

This PR updates our Codeception workflow to trigger more often.

More specifically it now:
- Triggers on changes to Composer dependencies.
- Triggers on changes to any test files
- _Only_ triggers on changes to `'.github/workflows/testing-integration.yml'` and not on all workflow changes.

## Does this close any currently open issues?

<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Any other comments?

<!-- Please add any additional context that would be helpful. Feel free to include screenshots of the GraphiQL IDE or other relevant screenshotes, logs, error output, etc -->

To be pedantic, you could merge this to ensure #3358 is tested
