### PR TITLE
fix: bump `GRAPHQL_MIN_PHP_VERSION` and remove 7.3 references

### DIFF
--- a/.github/workflows/deploy-docker-image.yml
+++ b/.github/workflows/deploy-docker-image.yml
@@ -13,7 +13,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        php: [ '8.1', '8.0', '7.4', '7.3' ]
+        php: [ '8.1', '8.0', '7.4' ]
         wordpress: [ '6.7', '6.6', '6.5', '6.4', '6.3', '6.2', '6.1', '6.0' ]
         include:
           # WordPress versions above the PHP testing matrix.
@@ -43,36 +43,20 @@ jobs:
             php: '8.0'
           - wordpress: '6.7'
             php: '7.4'
-          - wordpress: '6.7'
-            php: '7.3'
           - wordpress: '6.6'
             php: '8.0'
           - wordpress: '6.6'
             php: '7.4'
-          - wordpress: '6.6'
-            php: '7.3'
           - wordpress: '6.5'
             php: '8.0'
           - wordpress: '6.5'
             php: '7.4'
-          - wordpress: '6.5'
-            php: '7.3'
           - wordpress: '6.4'
             php: '7.4'
-          - wordpress: '6.4'
-            php: '7.3'
           - wordpress: '6.3'
             php: '7.4'
-          - wordpress: '6.3'
-            php: '7.3'
           - wordpress: '6.2'
             php: '7.4'
-          - wordpress: '6.2'
-            php: '7.3'
-          - wordpress: '6.1'
-            php: '7.3'
-          - wordpress: '6.0'
-            php: '7.3'
 
       fail-fast: false
     name: WordPress ${{ matrix.wordpress }} on PHP ${{ matrix.php }}

--- a/access-functions.php
+++ b/access-functions.php
@@ -875,49 +875,6 @@ function graphql_get_endpoint_url() {
 }
 
 /**
- * Polyfill for PHP versions below 7.3
- *
- * @return int|string|null
- *
- * @since 0.10.0
- */
-if ( ! function_exists( 'array_key_first' ) ) {
-
-	/**
-	 * @param mixed[] $arr
-	 *
-	 * @return int|string|null
-	 */
-	function array_key_first( array $arr ) {
-		foreach ( $arr as $key => $value ) {
-			return $key;
-		}
-		return null;
-	}
-}
-
-/**
- * Polyfill for PHP versions below 7.3
- *
- * @return mixed|string|int
- *
- * @since 0.10.0
- */
-if ( ! function_exists( 'array_key_last' ) ) {
-
-	/**
-	 * @param mixed[] $arr
-	 *
-	 * @return int|string|null
-	 */
-	function array_key_last( array $arr ) {
-		end( $arr );
-
-		return key( $arr );
-	}
-}
-
-/**
  * Polyfill for PHP versions below 8.0
  */
 if ( ! function_exists( 'str_starts_with' ) ) {

--- a/constants.php
+++ b/constants.php
@@ -33,6 +33,6 @@ function graphql_setup_constants() {
 
 	// The minimum version of PHP this plugin requires to work properly
 	if ( ! defined( 'GRAPHQL_MIN_PHP_VERSION' ) ) {
-		define( 'GRAPHQL_MIN_PHP_VERSION', '7.1' );
+		define( 'GRAPHQL_MIN_PHP_VERSION', '7.4' );
 	}
 }

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -14,7 +14,7 @@ Running tests locally with Codeception is the fastest way to run tests, but it r
 ### Pre-requisites
 
 - Command line access
-- PHP 7.3+ installed and running on your machine
+- PHP 7.4+ installed and running on your machine
 - MySQL installed and running on your machine
 - Composer
 


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

## What does this implement/fix? Explain your changes.

This PR fixes the `GRAPHQL_MIN_PHP_VERSION` constant to correctly be `7.4`.

Additionally, code, workflow matrices, and doc references to v7.3 have been updated/removed.

## Does this close any currently open issues?

<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Any other comments?

<!-- Please add any additional context that would be helpful. Feel free to include screenshots of the GraphiQL IDE or other relevant screenshotes, logs, error output, etc -->
