### PR TITLE
chore: inline (non-breaking) native return types

### DIFF
--- a/access-functions.php
+++ b/access-functions.php
@@ -39,7 +39,7 @@ function graphql_format_name( string $name, string $replacement = '_', string $r
  *
  * @todo refactor to use Utils::format_field_name()
  */
-function graphql_format_field_name( $field_name ) {
+function graphql_format_field_name( $field_name ): string {
 	// Bail if empty.
 	if ( empty( $field_name ) ) {
 		return '';
@@ -65,7 +65,7 @@ function graphql_format_field_name( $field_name ) {
  * @return string Name of the field
  * @since  0.0.2
  */
-function graphql_format_type_name( $type_name ) {
+function graphql_format_type_name( $type_name ): string {
 	// Bail if empty.
 	if ( empty( $type_name ) ) {
 		return '';
@@ -130,10 +130,8 @@ function do_graphql_request( $query, $operation_name = '', $variables = [], $ret
 
 /**
  * Determine when to register types
- *
- * @return string
  */
-function get_graphql_register_action() {
+function get_graphql_register_action(): string {
 	$action = 'graphql_register_types_late';
 	if ( ! did_action( 'graphql_register_initial_types' ) ) {
 		$action = 'graphql_register_initial_types';
@@ -157,10 +155,8 @@ function get_graphql_register_action() {
  * Schema.
  *
  * register_graphql_interfaces_to_types( [ 'MyNewInterface' ], [ 'Post', 'Page' ] );
- *
- * @return void
  */
-function register_graphql_interfaces_to_types( $interface_names, $type_names ) {
+function register_graphql_interfaces_to_types( $interface_names, $type_names ): void {
 	if ( is_string( $type_names ) ) {
 		$type_names = [ $type_names ];
 	}
@@ -198,12 +194,11 @@ function register_graphql_interfaces_to_types( $interface_names, $type_names ) {
  * @param array<string,mixed> $config    The Type config
  *
  * @throws \Exception
- * @return void
  */
-function register_graphql_type( string $type_name, array $config ) {
+function register_graphql_type( string $type_name, array $config ): void {
 	add_action(
 		get_graphql_register_action(),
-		static function ( TypeRegistry $type_registry ) use ( $type_name, $config ) {
+		static function ( TypeRegistry $type_registry ) use ( $type_name, $config ): void {
 			$type_registry->register_type( $type_name, $config );
 		},
 		10
@@ -217,12 +212,11 @@ function register_graphql_type( string $type_name, array $config ) {
  * @param mixed|array<string,mixed>|\GraphQL\Type\Definition\Type $config    The Type config
  *
  * @throws \Exception
- * @return void
  */
-function register_graphql_interface_type( string $type_name, $config ) {
+function register_graphql_interface_type( string $type_name, $config ): void {
 	add_action(
 		get_graphql_register_action(),
-		static function ( TypeRegistry $type_registry ) use ( $type_name, $config ) {
+		static function ( TypeRegistry $type_registry ) use ( $type_name, $config ): void {
 			$type_registry->register_interface_type( $type_name, $config );
 		},
 		10
@@ -234,10 +228,8 @@ function register_graphql_interface_type( string $type_name, $config ) {
  *
  * @param string              $type_name The name of the Type to register
  * @param array<string,mixed> $config    The Type config
- *
- * @return void
  */
-function register_graphql_object_type( string $type_name, array $config ) {
+function register_graphql_object_type( string $type_name, array $config ): void {
 	$config['kind'] = 'object';
 	register_graphql_type( $type_name, $config );
 }
@@ -247,10 +239,8 @@ function register_graphql_object_type( string $type_name, array $config ) {
  *
  * @param string              $type_name The name of the Type to register
  * @param array<string,mixed> $config    The Type config
- *
- * @return void
  */
-function register_graphql_input_type( string $type_name, array $config ) {
+function register_graphql_input_type( string $type_name, array $config ): void {
 	$config['kind'] = 'input';
 	register_graphql_type( $type_name, $config );
 }
@@ -262,13 +252,11 @@ function register_graphql_input_type( string $type_name, array $config ) {
  * @param array<string,mixed> $config    The Type config
  *
  * @throws \Exception
- *
- * @return void
  */
-function register_graphql_union_type( string $type_name, array $config ) {
+function register_graphql_union_type( string $type_name, array $config ): void {
 	add_action(
 		get_graphql_register_action(),
-		static function ( TypeRegistry $type_registry ) use ( $type_name, $config ) {
+		static function ( TypeRegistry $type_registry ) use ( $type_name, $config ): void {
 			$config['kind'] = 'union';
 			$type_registry->register_type( $type_name, $config );
 		},
@@ -281,10 +269,8 @@ function register_graphql_union_type( string $type_name, array $config ) {
  *
  * @param string              $type_name The name of the Type to register
  * @param array<string,mixed> $config    The Type config
- *
- * @return void
  */
-function register_graphql_enum_type( string $type_name, array $config ) {
+function register_graphql_enum_type( string $type_name, array $config ): void {
 	$config['kind'] = 'enum';
 	register_graphql_type( $type_name, $config );
 }
@@ -297,14 +283,13 @@ function register_graphql_enum_type( string $type_name, array $config ) {
  * @param string              $field_name The name of the Field to add to the Type
  * @param array<string,mixed> $config     The Type config
  *
- * @return void
  * @throws \Exception
  * @since 0.1.0
  */
-function register_graphql_field( string $type_name, string $field_name, array $config ) {
+function register_graphql_field( string $type_name, string $field_name, array $config ): void {
 	add_action(
 		get_graphql_register_action(),
-		static function ( TypeRegistry $type_registry ) use ( $type_name, $field_name, $config ) {
+		static function ( TypeRegistry $type_registry ) use ( $type_name, $field_name, $config ): void {
 			$type_registry->register_field( $type_name, $field_name, $config );
 		},
 		10
@@ -318,14 +303,13 @@ function register_graphql_field( string $type_name, string $field_name, array $c
  * @param string                            $type_name The name of the Type to add the fields to
  * @param array<string,array<string,mixed>> $fields    An array of field configs
  *
- * @return void
  * @throws \Exception
  * @since 0.1.0
  */
-function register_graphql_fields( string $type_name, array $fields ) {
+function register_graphql_fields( string $type_name, array $fields ): void {
 	add_action(
 		get_graphql_register_action(),
-		static function ( TypeRegistry $type_registry ) use ( $type_name, $fields ) {
+		static function ( TypeRegistry $type_registry ) use ( $type_name, $fields ): void {
 			$type_registry->register_fields( $type_name, $fields );
 		},
 		10
@@ -347,7 +331,7 @@ function register_graphql_edge_field( string $from_type, string $to_type, string
 
 	add_action(
 		get_graphql_register_action(),
-		static function ( TypeRegistry $type_registry ) use ( $connection_name, $field_name, $config ) {
+		static function ( TypeRegistry $type_registry ) use ( $connection_name, $field_name, $config ): void {
 			$type_registry->register_field( $connection_name, $field_name, $config );
 		},
 		10
@@ -368,7 +352,7 @@ function register_graphql_edge_fields( string $from_type, string $to_type, array
 
 	add_action(
 		get_graphql_register_action(),
-		static function ( TypeRegistry $type_registry ) use ( $connection_name, $fields ) {
+		static function ( TypeRegistry $type_registry ) use ( $connection_name, $fields ): void {
 			$type_registry->register_fields( $connection_name, $fields );
 		},
 		10
@@ -390,7 +374,7 @@ function register_graphql_connection_where_arg( string $from_type, string $to_ty
 
 	add_action(
 		get_graphql_register_action(),
-		static function ( TypeRegistry $type_registry ) use ( $connection_name, $field_name, $config ) {
+		static function ( TypeRegistry $type_registry ) use ( $connection_name, $field_name, $config ): void {
 			$type_registry->register_field( $connection_name, $field_name, $config );
 		},
 		10
@@ -411,7 +395,7 @@ function register_graphql_connection_where_args( string $from_type, string $to_t
 
 	add_action(
 		get_graphql_register_action(),
-		static function ( TypeRegistry $type_registry ) use ( $connection_name, $fields ) {
+		static function ( TypeRegistry $type_registry ) use ( $connection_name, $fields ): void {
 			$type_registry->register_fields( $connection_name, $fields );
 		},
 		10
@@ -425,10 +409,9 @@ function register_graphql_connection_where_args( string $from_type, string $to_t
  * @param string $field_name      Field name to be renamed.
  * @param string $new_field_name  New field name.
  *
- * @return void
  * @since 1.3.4
  */
-function rename_graphql_field( string $type_name, string $field_name, string $new_field_name ) {
+function rename_graphql_field( string $type_name, string $field_name, string $new_field_name ): void {
 	// Rename fields on the type.
 	add_filter(
 		"graphql_{$type_name}_fields",
@@ -465,12 +448,11 @@ function rename_graphql_field( string $type_name, string $field_name, string $ne
  * @param string $type_name The name of the Type in the Schema to rename.
  * @param string $new_type_name  The new name to give the Type.
  *
- * @return void
  * @throws \Exception
  *
  * @since 1.3.4
  */
-function rename_graphql_type( string $type_name, string $new_type_name ) {
+function rename_graphql_type( string $type_name, string $new_type_name ): void {
 	add_filter(
 		'graphql_type_name',
 		static function ( $name ) use ( $type_name, $new_type_name ) {
@@ -486,7 +468,7 @@ function rename_graphql_type( string $type_name, string $new_type_name ) {
 	// referenced as the type when registering fields.
 	add_action(
 		'graphql_register_types_late',
-		static function ( TypeRegistry $type_registry ) use ( $type_name, $new_type_name ) {
+		static function ( TypeRegistry $type_registry ) use ( $type_name, $new_type_name ): void {
 			$type = $type_registry->get_type( $type_name );
 			if ( ! $type instanceof Type ) {
 				return;
@@ -503,14 +485,13 @@ function rename_graphql_type( string $type_name, string $new_type_name ) {
  * @param array<string,mixed> $config Array to configure the connection
  *
  * @throws \Exception
- * @return void
  *
  * @since 0.1.0
  */
-function register_graphql_connection( array $config ) {
+function register_graphql_connection( array $config ): void {
 	add_action(
 		get_graphql_register_action(),
-		static function ( TypeRegistry $type_registry ) use ( $config ) {
+		static function ( TypeRegistry $type_registry ) use ( $config ): void {
 			$type_registry->register_connection( $config );
 		},
 		20
@@ -525,13 +506,12 @@ function register_graphql_connection( array $config ) {
  *
  * @throws \Exception
  *
- * @return void
  * @since 0.1.0
  */
-function register_graphql_mutation( string $mutation_name, array $config ) {
+function register_graphql_mutation( string $mutation_name, array $config ): void {
 	add_action(
 		get_graphql_register_action(),
-		static function ( TypeRegistry $type_registry ) use ( $mutation_name, $config ) {
+		static function ( TypeRegistry $type_registry ) use ( $mutation_name, $config ): void {
 			$type_registry->register_mutation( $mutation_name, $config );
 		},
 		10
@@ -545,14 +525,13 @@ function register_graphql_mutation( string $mutation_name, array $config ) {
  * @param array<string,mixed> $config    The config for the scalar type to register
  *
  * @throws \Exception
- * @return void
  *
  * @since 0.8.4
  */
-function register_graphql_scalar( string $type_name, array $config ) {
+function register_graphql_scalar( string $type_name, array $config ): void {
 	add_action(
 		get_graphql_register_action(),
-		static function ( TypeRegistry $type_registry ) use ( $type_name, $config ) {
+		static function ( TypeRegistry $type_registry ) use ( $type_name, $config ): void {
 			$type_registry->register_scalar( $type_name, $config );
 		},
 		10
@@ -610,14 +589,12 @@ function deregister_graphql_type( string $type_name ): void {
  * @param string $type_name  The name of the Type to remove the field from
  * @param string $field_name The name of the field to remove
  *
- * @return void
- *
  * @since 0.1.0
  */
-function deregister_graphql_field( string $type_name, string $field_name ) {
+function deregister_graphql_field( string $type_name, string $field_name ): void {
 	add_action(
 		get_graphql_register_action(),
-		static function ( TypeRegistry $type_registry ) use ( $type_name, $field_name ) {
+		static function ( TypeRegistry $type_registry ) use ( $type_name, $field_name ): void {
 			$type_registry->deregister_field( $type_name, $field_name );
 		},
 		10
@@ -634,7 +611,7 @@ function deregister_graphql_field( string $type_name, string $field_name ) {
 function deregister_graphql_connection( string $connection_name ): void {
 	add_action(
 		get_graphql_register_action(),
-		static function ( TypeRegistry $type_registry ) use ( $connection_name ) {
+		static function ( TypeRegistry $type_registry ) use ( $connection_name ): void {
 			$type_registry->deregister_connection( $connection_name );
 		},
 		10
@@ -651,7 +628,7 @@ function deregister_graphql_connection( string $connection_name ): void {
 function deregister_graphql_mutation( string $mutation_name ): void {
 	add_action(
 		get_graphql_register_action(),
-		static function ( TypeRegistry $type_registry ) use ( $mutation_name ) {
+		static function ( TypeRegistry $type_registry ) use ( $mutation_name ): void {
 			$type_registry->deregister_mutation( $mutation_name );
 		},
 		10
@@ -667,10 +644,9 @@ function deregister_graphql_mutation( string $mutation_name ): void {
  *
  * Default false.
  *
- * @return bool
  * @since 0.4.1
  */
-function is_graphql_request() {
+function is_graphql_request(): bool {
 	return WPGraphQL::is_graphql_request();
 }
 
@@ -685,10 +661,9 @@ function is_graphql_request() {
  *
  * Default false.
  *
- * @return bool
  * @since 0.4.1
  */
-function is_graphql_http_request() {
+function is_graphql_http_request(): bool {
 	return Router::is_graphql_http_request();
 }
 
@@ -698,13 +673,12 @@ function is_graphql_http_request() {
  * @param string              $slug   The slug of the group being registered
  * @param array<string,mixed> $config Array configuring the section. Should include: title
  *
- * @return void
  * @since 0.13.0
  */
-function register_graphql_settings_section( string $slug, array $config ) {
+function register_graphql_settings_section( string $slug, array $config ): void {
 	add_action(
 		'graphql_init_settings',
-		static function ( \WPGraphQL\Admin\Settings\SettingsRegistry $registry ) use ( $slug, $config ) {
+		static function ( \WPGraphQL\Admin\Settings\SettingsRegistry $registry ) use ( $slug, $config ): void {
 			$registry->register_section( $slug, $config );
 		}
 	);
@@ -716,13 +690,12 @@ function register_graphql_settings_section( string $slug, array $config ) {
  * @param string              $group  The name of the group to register a setting field to
  * @param array<string,mixed> $config The config for the settings field being registered
  *
- * @return void
  * @since 0.13.0
  */
-function register_graphql_settings_field( string $group, array $config ) {
+function register_graphql_settings_field( string $group, array $config ): void {
 	add_action(
 		'graphql_init_settings',
-		static function ( \WPGraphQL\Admin\Settings\SettingsRegistry $registry ) use ( $group, $config ) {
+		static function ( \WPGraphQL\Admin\Settings\SettingsRegistry $registry ) use ( $group, $config ): void {
 			$registry->register_field( $group, $config );
 		}
 	);
@@ -736,10 +709,9 @@ function register_graphql_settings_field( string $group, array $config ) {
  *                                      $config['type'] will set the "type" of the log, default type is GRAPHQL_DEBUG.
  *                                      Other fields added to $config will be merged into the debug entry.
  *
- * @return void
  * @since 0.14.0
  */
-function graphql_debug( $message, $config = [] ) {
+function graphql_debug( $message, $config = [] ): void {
 	$debug_backtrace     = debug_backtrace(); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
 	$config['backtrace'] = ! empty( $debug_backtrace )
 		?
@@ -762,7 +734,7 @@ function graphql_debug( $message, $config = [] ) {
 
 	add_action(
 		'graphql_get_debug_log',
-		static function ( \WPGraphQL\Utils\DebugLog $debug_log ) use ( $message, $config ) {
+		static function ( \WPGraphQL\Utils\DebugLog $debug_log ) use ( $message, $config ): void {
 			$debug_log->add_log_entry( $message, $config );
 		}
 	);
@@ -773,10 +745,9 @@ function graphql_debug( $message, $config = [] ) {
  *
  * @param string $type_name The name of the type to validate
  *
- * @return bool
  * @since 0.14.0
  */
-function is_valid_graphql_name( string $type_name ) {
+function is_valid_graphql_name( string $type_name ): bool {
 	if ( preg_match( '/^\d/', $type_name ) ) {
 		return false;
 	}
@@ -790,13 +761,12 @@ function is_valid_graphql_name( string $type_name ) {
  * @param string                $group  The name of the settings group to register fields to
  * @param array<string,mixed>[] $fields Array of field configs to register to the group
  *
- * @return void
  * @since 0.13.0
  */
-function register_graphql_settings_fields( string $group, array $fields ) {
+function register_graphql_settings_fields( string $group, array $fields ): void {
 	add_action(
 		'graphql_init_settings',
-		static function ( \WPGraphQL\Admin\Settings\SettingsRegistry $registry ) use ( $group, $fields ) {
+		static function ( \WPGraphQL\Admin\Settings\SettingsRegistry $registry ) use ( $group, $fields ): void {
 			$registry->register_fields( $group, $fields );
 		}
 	);
@@ -847,10 +817,9 @@ function get_graphql_setting( string $option_name, $default_value = '', $section
 /**
  * Get the endpoint route for the WPGraphQL API
  *
- * @return string
  * @since 1.12.0
  */
-function graphql_get_endpoint() {
+function graphql_get_endpoint(): string {
 
 	// get the endpoint from the settings. default to 'graphql'
 	$endpoint = get_graphql_setting( 'graphql_endpoint', 'graphql' );
@@ -861,17 +830,16 @@ function graphql_get_endpoint() {
 	$filtered_endpoint = apply_filters( 'graphql_endpoint', $endpoint );
 
 	// If the filtered endpoint has a value (not filtered to a falsy value), use it. else return the default endpoint
-	return ! empty( $filtered_endpoint ) ? $filtered_endpoint : $endpoint;
+	return is_string( $filtered_endpoint ) && ! empty( $filtered_endpoint ) ? $filtered_endpoint : $endpoint;
 }
 
 /**
  * Return the full url for the GraphQL Endpoint.
  *
- * @return string
  * @since 1.12.0
  */
-function graphql_get_endpoint_url() {
-	return site_url( graphql_get_endpoint() );
+function graphql_get_endpoint_url(): string {
+	return (string) site_url( graphql_get_endpoint() );
 }
 
 /**
@@ -962,7 +930,7 @@ if ( ! function_exists( 'str_ends_with' ) ) {
 function register_graphql_admin_notice( string $slug, array $config ): void {
 	add_action(
 		'graphql_admin_notices_init',
-		static function ( \WPGraphQL\Admin\AdminNotices $admin_notices ) use ( $slug, $config ) {
+		static function ( \WPGraphQL\Admin\AdminNotices $admin_notices ) use ( $slug, $config ): void {
 			$admin_notices->add_admin_notice( $slug, $config );
 		}
 	);
@@ -973,7 +941,7 @@ function register_graphql_admin_notice( string $slug, array $config ): void {
  *
  * @return array|mixed[][] An array of admin notices
  */
-function get_graphql_admin_notices() {
+function get_graphql_admin_notices(): array {
 	$admin_notices = \WPGraphQL\Admin\AdminNotices::get_instance();
 	return $admin_notices->get_admin_notices();
 }

--- a/activation.php
+++ b/activation.php
@@ -1,9 +1,7 @@
 <?php
 /**
  * Runs when WPGraphQL is activated
- *
- * @return void
  */
-function graphql_activation_callback() {
+function graphql_activation_callback(): void {
 	do_action( 'graphql_activate' );
 }

--- a/deactivation.php
+++ b/deactivation.php
@@ -21,10 +21,8 @@ function graphql_deactivation_callback() {
 
 /**
  * Delete data on deactivation
- *
- * @return void
  */
-function delete_graphql_data() {
+function delete_graphql_data(): void {
 
 	if ( ! class_exists( 'WPGraphQL' ) ) {
 		return;

--- a/src/Admin/Extensions/Extensions.php
+++ b/src/Admin/Extensions/Extensions.php
@@ -180,7 +180,7 @@ final class Extensions {
 	 *
 	 * @return array<string, array<string, mixed>> List of installed plugins.
 	 */
-	private function get_installed_plugins() {
+	private function get_installed_plugins(): array {
 		if ( ! function_exists( 'get_plugins' ) ) {
 			// @phpstan-ignore requireOnce.fileNotFound
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
@@ -210,7 +210,7 @@ final class Extensions {
 	 * @param array<string,mixed> $extension The extension to sanitize.
 	 * @return array<string,mixed> The sanitized extension.
 	 */
-	private function sanitize_extension( array $extension ) {
+	private function sanitize_extension( array $extension ): array {
 		return [
 			'name'              => ! empty( $extension['name'] ) ? sanitize_text_field( $extension['name'] ) : null,
 			'description'       => ! empty( $extension['description'] ) ? sanitize_text_field( $extension['description'] ) : null,
@@ -280,7 +280,7 @@ final class Extensions {
 	 *
 	 * @return PopulatedExtension[] The populated extensions.
 	 */
-	private function populate_installation_data( $extensions ) {
+	private function populate_installation_data( $extensions ): array {
 		$installed_plugins = $this->get_installed_plugins();
 
 		$populated_extensions = [];

--- a/src/Data/Cursor/PostObjectCursor.php
+++ b/src/Data/Cursor/PostObjectCursor.php
@@ -173,10 +173,8 @@ class PostObjectCursor extends AbstractCursor {
 	 *
 	 * @param string $by    The order by key
 	 * @param string $order The order direction ASC or DESC
-	 *
-	 * @return void
 	 */
-	private function compare_with( $by, $order ) {
+	private function compare_with( $by, $order ): void {
 		// Bail early, if "key" and "value" provided in query_vars.
 		$key   = $this->get_query_var( "graphql_cursor_compare_by_{$by}_key" );
 		$value = $this->get_query_var( "graphql_cursor_compare_by_{$by}_value" );
@@ -223,10 +221,8 @@ class PostObjectCursor extends AbstractCursor {
 	 *
 	 * @param string $meta_key post meta key
 	 * @param string $order    The comparison string
-	 *
-	 * @return void
 	 */
-	private function compare_with_meta_field( string $meta_key, string $order ) {
+	private function compare_with_meta_field( string $meta_key, string $order ): void {
 		$meta_type  = $this->get_query_var( 'meta_type' );
 		$meta_value = get_post_meta( $this->cursor_offset, $meta_key, true );
 

--- a/src/Data/Cursor/TermObjectCursor.php
+++ b/src/Data/Cursor/TermObjectCursor.php
@@ -144,10 +144,8 @@ class TermObjectCursor extends AbstractCursor {
 	 *
 	 * @param string $by    The order by key
 	 * @param string $order The order direction ASC or DESC
-	 *
-	 * @return void
 	 */
-	private function compare_with( string $by, string $order ) {
+	private function compare_with( string $by, string $order ): void {
 
 		// Bail early, if "key" and "value" provided in query_vars.
 		$key   = $this->get_query_var( "graphql_cursor_compare_by_{$by}_key" );
@@ -180,10 +178,8 @@ class TermObjectCursor extends AbstractCursor {
 	 *
 	 * @param string $meta_key meta key
 	 * @param string $order    The comparison string
-	 *
-	 * @return void
 	 */
-	private function compare_with_meta_field( string $meta_key, string $order ) {
+	private function compare_with_meta_field( string $meta_key, string $order ): void {
 		$meta_type  = $this->get_query_var( 'meta_type' );
 		$meta_value = get_term_meta( $this->cursor_offset, $meta_key, true );
 

--- a/src/Data/Cursor/UserCursor.php
+++ b/src/Data/Cursor/UserCursor.php
@@ -159,10 +159,8 @@ class UserCursor extends AbstractCursor {
 	 *
 	 * @param string $by    The order by key
 	 * @param string $order The order direction ASC or DESC
-	 *
-	 * @return void
 	 */
-	private function compare_with( $by, $order ) {
+	private function compare_with( $by, $order ): void {
 		// Bail early, if "key" and "value" provided in query_vars.
 		$key   = $this->get_query_var( "graphql_cursor_compare_by_{$by}_key" );
 		$value = $this->get_query_var( "graphql_cursor_compare_by_{$by}_value" );
@@ -206,10 +204,8 @@ class UserCursor extends AbstractCursor {
 	 *
 	 * @param string $meta_key user meta key
 	 * @param string $order    The comparison string
-	 *
-	 * @return void
 	 */
-	private function compare_with_meta_field( string $meta_key, string $order ) {
+	private function compare_with_meta_field( string $meta_key, string $order ): void {
 		$meta_type  = $this->get_query_var( 'meta_type' );
 		$meta_value = get_user_meta( $this->cursor_offset, $meta_key, true );
 

--- a/src/Data/Loader/AbstractDataLoader.php
+++ b/src/Data/Loader/AbstractDataLoader.php
@@ -284,7 +284,7 @@ abstract class AbstractDataLoader {
 	 * @return array<int|string,mixed>
 	 * @throws \Exception
 	 */
-	private function load_buffered() {
+	private function load_buffered(): array {
 		// Do not load previously-cached entries:
 		$keysToLoad = [];
 		foreach ( $this->buffer as $key => $unused ) {
@@ -331,10 +331,8 @@ abstract class AbstractDataLoader {
 	 * This helps to ensure null values aren't being loaded by accident.
 	 *
 	 * @param mixed $key
-	 *
-	 * @return string
 	 */
-	private function get_scalar_key_hint( $key ) {
+	private function get_scalar_key_hint( $key ): string {
 		if ( null === $key ) {
 			return ' Make sure to add additional checks for null values.';
 		} else {

--- a/src/Data/UserMutation.php
+++ b/src/Data/UserMutation.php
@@ -239,10 +239,9 @@ class UserMutation {
 	 * @param int      $user_id The ID of the user
 	 * @param string[] $roles   List of roles that need to get added to the user
 	 *
-	 * @return void
 	 * @throws \Exception
 	 */
-	private static function add_user_roles( $user_id, $roles ) {
+	private static function add_user_roles( $user_id, $roles ): void {
 		if ( empty( $roles ) || ! is_array( $roles ) || ! current_user_can( 'edit_user', $user_id ) ) {
 			return;
 		}
@@ -272,7 +271,7 @@ class UserMutation {
 	 * @param string $role    Name of the role trying to get added to a user object
 	 * @param int    $user_id The ID of the user being mutated
 	 *
-	 * @return bool|\WP_Error
+	 * @return true|\WP_Error
 	 */
 	private static function verify_user_role( $role, $user_id ) {
 		global $wp_roles;
@@ -309,8 +308,8 @@ class UserMutation {
 		if ( empty( $editable_roles[ $role ] ) ) {
 			// Translators: %s is the name of the role that can't be added to the user.
 			return new \WP_Error( 'wpgraphql_user_invalid_role', sprintf( __( 'Sorry, you are not allowed to give this the following role: %s.', 'wp-graphql' ), $role ) );
-		} else {
-			return true;
 		}
+
+		return true;
 	}
 }

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -430,10 +430,8 @@ abstract class Model {
 
 	/**
 	 * Adds the model visibility fields to the data
-	 *
-	 * @return void
 	 */
-	private function add_model_visibility() {
+	private function add_model_visibility(): void {
 
 		/**
 		 * @todo: potentially abstract this out into a more central spot

--- a/src/Mutation/SendPasswordResetEmail.php
+++ b/src/Mutation/SendPasswordResetEmail.php
@@ -127,10 +127,8 @@ class SendPasswordResetEmail {
 	 * Was a username or email address provided?
 	 *
 	 * @param array<string,mixed> $input The input args.
-	 *
-	 * @return bool
 	 */
-	private static function was_username_provided( $input ) {
+	private static function was_username_provided( $input ): bool {
 		return ! empty( $input['username'] ) && is_string( $input['username'] );
 	}
 
@@ -159,10 +157,8 @@ class SendPasswordResetEmail {
 	 * Get the error message indicating why the user wasn't found
 	 *
 	 * @param string $username The user's username or email address.
-	 *
-	 * @return string
 	 */
-	private static function get_user_not_found_error_message( string $username ) {
+	private static function get_user_not_found_error_message( string $username ): string {
 		if ( self::is_email_address( $username ) ) {
 			return __( 'There is no user registered with that email address.', 'wp-graphql' );
 		}
@@ -174,10 +170,8 @@ class SendPasswordResetEmail {
 	 * Is the provided username arg an email address?
 	 *
 	 * @param string $username The user's username or email address.
-	 *
-	 * @return bool
 	 */
-	private static function is_email_address( string $username ) {
+	private static function is_email_address( string $username ): bool {
 		return (bool) strpos( $username, '@' );
 	}
 
@@ -185,10 +179,8 @@ class SendPasswordResetEmail {
 	 * Get the subject of the password reset email
 	 *
 	 * @param \WP_User $user_data User data
-	 *
-	 * @return string
 	 */
-	private static function get_email_subject( $user_data ) {
+	private static function get_email_subject( $user_data ): string {
 		/* translators: Password reset email subject. %s: Site name */
 		$title = sprintf( __( '[%s] Password Reset', 'wp-graphql' ), self::get_site_name() );
 
@@ -199,15 +191,13 @@ class SendPasswordResetEmail {
 		 * @param string   $user_login The username for the user.
 		 * @param \WP_User $user_data WP_User object.
 		 */
-		return apply_filters( 'retrieve_password_title', $title, $user_data->user_login, $user_data );
+		return (string) apply_filters( 'retrieve_password_title', $title, $user_data->user_login, $user_data );
 	}
 
 	/**
 	 * Get the site name.
-	 *
-	 * @return string
 	 */
-	private static function get_site_name() {
+	private static function get_site_name(): string {
 		if ( is_multisite() ) {
 			$network = get_network();
 			if ( isset( $network->site_name ) ) {
@@ -220,7 +210,7 @@ class SendPasswordResetEmail {
 		* in sanitize_option we want to reverse this for the plain text arena of emails.
 		*/
 
-		return wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
+		return wp_specialchars_decode( (string) get_option( 'blogname' ), ENT_QUOTES );
 	}
 
 	/**
@@ -228,10 +218,8 @@ class SendPasswordResetEmail {
 	 *
 	 * @param \WP_User $user_data User data
 	 * @param string   $key       Password reset key
-	 *
-	 * @return string
 	 */
-	private static function get_email_message( $user_data, $key ) {
+	private static function get_email_message( $user_data, $key ): string {
 		$message = __( 'Someone has requested a password reset for the following account:', 'wp-graphql' ) . "\r\n\r\n";
 		/* translators: %s: site name */
 		$message .= sprintf( __( 'Site Name: %s', 'wp-graphql' ), self::get_site_name() ) . "\r\n\r\n";
@@ -251,6 +239,6 @@ class SendPasswordResetEmail {
 		 * @param string   $user_login The username for the user.
 		 * @param \WP_User $user_data WP_User object.
 		 */
-		return apply_filters( 'retrieve_password_message', $message, $key, $user_data->user_login, $user_data );
+		return (string) apply_filters( 'retrieve_password_message', $message, $key, $user_data->user_login, $user_data );
 	}
 }

--- a/src/Registry/Utils/PostObject.php
+++ b/src/Registry/Utils/PostObject.php
@@ -455,10 +455,8 @@ class PostObject {
 	 * Register fields to the Type used for attachments (MediaItem).
 	 *
 	 * @param \WP_Post_Type $post_type_object Post type.
-	 *
-	 * @return void
 	 */
-	private static function register_attachment_fields( WP_Post_Type $post_type_object ) {
+	private static function register_attachment_fields( WP_Post_Type $post_type_object ): void {
 		/**
 		 * Register fields custom to the MediaItem Type
 		 */

--- a/src/Request.php
+++ b/src/Request.php
@@ -575,10 +575,8 @@ class Request {
 	 * Run action for a request.
 	 *
 	 * @param \GraphQL\Server\OperationParams $params OperationParams for the request.
-	 *
-	 * @return void
 	 */
-	private function do_action( OperationParams $params ) {
+	private function do_action( OperationParams $params ): void {
 
 		/**
 		 * Run an action for each request.
@@ -810,10 +808,8 @@ class Request {
 	 * Determines if batch queries are enabled for the server.
 	 *
 	 * Default is to have batch queries enabled.
-	 *
-	 * @return bool
 	 */
-	private function is_batch_queries_enabled() {
+	private function is_batch_queries_enabled(): bool {
 		$batch_queries_enabled = true;
 
 		$batch_queries_setting = get_graphql_setting( 'batch_queries_enabled', 'on' );
@@ -827,15 +823,13 @@ class Request {
 		 * @param bool         $batch_queries_enabled Whether Batch Queries should be enabled
 		 * @param \GraphQL\Server\OperationParams $params Request operation params
 		 */
-		return apply_filters( 'graphql_is_batch_queries_enabled', $batch_queries_enabled, $this->params );
+		return (bool) apply_filters( 'graphql_is_batch_queries_enabled', $batch_queries_enabled, $this->params );
 	}
 
 	/**
 	 * Create the GraphQL server that will process the request.
-	 *
-	 * @return \GraphQL\Server\StandardServer
 	 */
-	private function get_server() {
+	private function get_server(): StandardServer {
 		$debug_flag = $this->get_debug_flag();
 
 		$config = new ServerConfig();

--- a/src/Server/WPHelper.php
+++ b/src/Server/WPHelper.php
@@ -67,7 +67,7 @@ class WPHelper extends Helper {
 	 * @param array<string,mixed>|array<string,mixed>[] $params Request parameters.
 	 * @return array<string,mixed>|array<string,mixed>[]
 	 */
-	private function parse_params( $params ) {
+	private function parse_params( $params ): array {
 		if ( isset( $params[0] ) ) {
 			return array_map( [ $this, 'parse_extensions' ], $params );
 		}
@@ -81,7 +81,7 @@ class WPHelper extends Helper {
 	 * @param  array<string,mixed> $params Request parameters.
 	 * @return array<string,mixed>
 	 */
-	private function parse_extensions( $params ) {
+	private function parse_extensions( $params ): array {
 		if ( isset( $params['extensions'] ) && is_string( $params['extensions'] ) ) {
 			$tmp = json_decode( $params['extensions'], true );
 			if ( ! json_last_error() ) {

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -138,10 +138,8 @@ final class WPGraphQL {
 	 * Set whether the request is a GraphQL request or not
 	 *
 	 * @param bool $is_graphql_request
-	 *
-	 * @return void
 	 */
-	public static function set_is_graphql_request( $is_graphql_request = false ) {
+	public static function set_is_graphql_request( $is_graphql_request = false ): void {
 		self::$is_graphql_request = $is_graphql_request;
 	}
 

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -157,11 +157,9 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 }
 
 /**
- * Initialize the plugin tracker
- *
- * @return void
+ * Initialize the plugin tracker.
  */
-function graphql_init_appsero_telemetry() {
+function graphql_init_appsero_telemetry(): void {
 	// If the class doesn't exist, or code is being scanned by PHPSTAN, move on.
 	if ( ! class_exists( 'Appsero\Client' ) || defined( 'PHPSTAN' ) ) {
 		return;


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

## What does this implement/fix? Explain your changes.

This PHP inlines return types for number functions where this change has been confirmed to be nonbreaking i.e.:
 - cant cause an error
 - wont cause an error
 - would already cause an error
 - are private and cant affect extenders/users

Native return types provide:
- better IDE support (dont need an extra doc-block parser)
- better LLM support (less likely to get confused or lose context)
- better DX (since the error happens where it's caused and not where the correct type is expected ).
- better refactorability (since we know what parts of the codebase are "safe".


## Does this close any currently open issues?

<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

No but I Should make more for all the 3.0 breaking type changes I wanna make 🧑‍🍳

## Any other comments?

<!-- Please add any additional context that would be helpful. Feel free to include screenshots of the GraphiQL IDE or other relevant screenshotes, logs, error output, etc -->
