### PR TITLE
chore: implement array shapes for `AdminNotices`

### DIFF
--- a/access-functions.php
+++ b/access-functions.php
@@ -956,8 +956,15 @@ if ( ! function_exists( 'str_ends_with' ) ) {
 }
 
 /**
- * @param string       $slug A unique slug to identify the admin notice by
- * @param array<mixed> $config The config for the admin notice. Determines visibility, context, etc.
+ * @param string              $slug A unique slug to identify the admin notice by
+ * @param array<string,mixed> $config The config for the admin notice. Determines visibility, context, etc.
+ *
+ * @phpstan-param array{
+ *  message: string,
+ *  type?: 'error'|'warning'|'success'|'info',
+ *  is_dismissable?: bool,
+ *  conditions?: callable():bool
+ * } $config
  */
 function register_graphql_admin_notice( string $slug, array $config ): void {
 	add_action(
@@ -971,7 +978,12 @@ function register_graphql_admin_notice( string $slug, array $config ): void {
 /**
  * Get the admin notices registered for the WPGraphQL plugin screens
  *
- * @return array|mixed[][] An array of admin notices
+ * @return array<string,array{
+ *  message: string,
+ *  type?: 'error'|'warning'|'success'|'info',
+ *  is_dismissable?: bool,
+ *  conditions?: callable():bool,
+ * }>
  */
 function get_graphql_admin_notices() {
 	$admin_notices = \WPGraphQL\Admin\AdminNotices::get_instance();

--- a/src/Admin/AdminNotices.php
+++ b/src/Admin/AdminNotices.php
@@ -11,6 +11,13 @@ namespace WPGraphQL\Admin;
  * Breaking changes to this class will not be considered a semver breaking change as there's no
  * expectation that users will be calling these functions directly or extending this class.
  *
+ * @phpstan-type AdminNoticeConfig array{
+ *   message: string,
+ *   type?: 'error'|'warning'|'success'|'info',
+ *   is_dismissable?: bool,
+ *   conditions?: callable():bool,
+ * }
+ *
  * @internal
  */
 class AdminNotices {
@@ -25,7 +32,7 @@ class AdminNotices {
 	/**
 	 * Stores the admin notices to display
 	 *
-	 * @var array<string,array<string,mixed>>
+	 * @var array<string,AdminNoticeConfig>
 	 */
 	protected $admin_notices = [];
 
@@ -132,24 +139,24 @@ class AdminNotices {
 	/**
 	 * Return all admin notices
 	 *
-	 * @return array<string,array<string,mixed>>
+	 * @return array<string,AdminNoticeConfig>
 	 */
 	public function get_admin_notices(): array {
 		return $this->admin_notices;
 	}
 
 	/**
-	 * @param string              $slug The slug identifying the admin notice
-	 * @param array<string,mixed> $config The config of the admin notice
+	 * @param string            $slug   The slug identifying the admin notice
+	 * @param AdminNoticeConfig $config The config of the admin notice
 	 *
-	 * @return array<string,mixed>
+	 * @return AdminNoticeConfig|array{}
 	 */
 	public function add_admin_notice( string $slug, array $config ): array {
 		/**
 		 * Pass the notice through a filter before registering it
 		 *
 		 * @param array<string,mixed> $config The config of the admin notice
-		 * @param string              $slug   The slug identifying the admin notice
+		 * @param string            $slug   The slug identifying the admin notice
 		 */
 		$filtered_notice = apply_filters( 'graphql_add_admin_notice', $config, $slug );
 
@@ -168,6 +175,13 @@ class AdminNotices {
 	 * @since v1.21.0
 	 *
 	 * @param array<string,mixed> $config The config of the admin notice
+	 *
+	 * @phpstan-assert-if-true array{
+	 *  message: string,
+	 *  type?: 'error'|'warning'|'success'|'info',
+	 *  is_dismissable?: bool,
+	 *  conditions?: callable,
+	 * } $config
 	 */
 	public function is_valid_config( array $config ): bool {
 		if ( empty( $config['message'] ) ) {
@@ -198,7 +212,7 @@ class AdminNotices {
 	 *
 	 * @param string $slug The slug identifying the admin notice to remove
 	 *
-	 * @return array<mixed>
+	 * @return array<string,AdminNoticeConfig>
 	 */
 	public function remove_admin_notice( string $slug ): array {
 		unset( $this->admin_notices[ $slug ] );
@@ -208,7 +222,7 @@ class AdminNotices {
 	/**
 	 * Determine whether a notice is dismissable or not
 	 *
-	 * @param array<mixed> $notice The notice to check whether its dismissable or not
+	 * @param AdminNoticeConfig|array{} $notice The notice to check whether its dismissable or not
 	 */
 	public function is_notice_dismissable( array $notice = [] ): bool {
 		return ( ! isset( $notice['is_dismissable'] ) || false !== (bool) $notice['is_dismissable'] );
@@ -288,7 +302,7 @@ class AdminNotices {
 		/**
 		 * Fires before the admin notices are rendered.
 		 *
-		 * @param array<string,mixed> $notices The notices to be rendered
+		 * @param array<string,AdminNoticeConfig> $notices The notices to be rendered
 		 *
 		 * @since v1.23.0
 		 */
@@ -325,7 +339,7 @@ class AdminNotices {
 			 * Fires for each admin notice that is rendered.
 			 *
 			 * @param string $notice_slug The slug of the notice
-			 * @param array<mixed> $notice The notice to be rendered
+			 * @param AdminNoticeConfig $notice The notice to be rendered
 			 * @param bool $is_dismissable Whether the notice is dismissable or not
 			 * @param int $count The count of the notice
 			 *

--- a/src/Admin/AdminNotices.php
+++ b/src/Admin/AdminNotices.php
@@ -161,7 +161,7 @@ class AdminNotices {
 		$filtered_notice = apply_filters( 'graphql_add_admin_notice', $config, $slug );
 
 		// If not a valid config, bail early.
-		if ( ! $this->is_valid_config( $config ) ) {
+		if ( ! $this->is_valid_config( $filtered_notice ) ) {
 			return [];
 		}
 


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

## What does this implement/fix? Explain your changes.

This PR implements a reusable PHPStan array shape for the `AdminNotices` class, removing all unintentional uses for `mixed`. (`mixed` is still used for the filter, so it can be validated).

As a result of this change, PHPStan caught (and this fixes) the incorrect validation of the filtered notice.

_There are no breaking changes in this PR_.


## Does this close any currently open issues?

<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Any other comments?

<!-- Please add any additional context that would be helpful. Feel free to include screenshots of the GraphiQL IDE or other relevant screenshotes, logs, error output, etc -->

LLMs + IDEs + Extenders all really like shaped arrays. This is the first PR of hopefully many getting rid of the `mixed` type however possible.
