### PR TITLE
chore: add array shapes to `Admin\Extensions` and `Admin\AdminNotices`

### DIFF
--- a/src/Admin/AdminNotices.php
+++ b/src/Admin/AdminNotices.php
@@ -155,7 +155,7 @@ class AdminNotices {
 		/**
 		 * Pass the notice through a filter before registering it
 		 *
-		 * @param array<string,mixed> $config The config of the admin notice
+		 * @param AdminNoticeConfig $config The config of the admin notice
 		 * @param string            $slug   The slug identifying the admin notice
 		 */
 		$filtered_notice = apply_filters( 'graphql_add_admin_notice', $config, $slug );

--- a/src/Admin/Extensions/Extensions.php
+++ b/src/Admin/Extensions/Extensions.php
@@ -35,16 +35,14 @@ final class Extensions {
 	 *
 	 * Filtered by `graphql_get_extensions`.
 	 *
-	 * @var ?PopulatedExtension[]
+	 * @var PopulatedExtension[]
 	 */
-	private $extensions;
+	private array $extensions;
 
 	/**
 	 * Initialize Extensions functionality for WPGraphQL.
-	 *
-	 * @return void
 	 */
-	public function init() {
+	public function init(): void {
 		add_action( 'admin_menu', [ $this, 'register_admin_page' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
 		add_action( 'rest_api_init', [ $this, 'register_rest_routes' ] );
@@ -52,10 +50,8 @@ final class Extensions {
 
 	/**
 	 * Register the admin page for extensions.
-	 *
-	 * @return void
 	 */
-	public function register_admin_page() {
+	public function register_admin_page(): void {
 		add_submenu_page(
 			'graphiql-ide',
 			__( 'WPGraphQL Extensions', 'wp-graphql' ),
@@ -68,10 +64,8 @@ final class Extensions {
 
 	/**
 	 * Render the admin page content.
-	 *
-	 * @return void
 	 */
-	public function render_admin_page() {
+	public function render_admin_page(): void {
 		echo '<div class="wrap">';
 		echo '<h1>' . esc_html( get_admin_page_title() ) . '</h1>';
 		echo '<div style="margin-top: 20px;" id="wpgraphql-extensions"></div>';
@@ -82,10 +76,8 @@ final class Extensions {
 	 * Enqueue the necessary scripts and styles for the extensions page.
 	 *
 	 * @param string $hook_suffix The current admin page.
-	 *
-	 * @return void
 	 */
-	public function enqueue_scripts( $hook_suffix ) {
+	public function enqueue_scripts( $hook_suffix ): void {
 		if ( 'graphql_page_wpgraphql-extensions' !== $hook_suffix ) {
 			return;
 		}
@@ -121,10 +113,8 @@ final class Extensions {
 
 	/**
 	 * Register custom REST API routes.
-	 *
-	 * @return void
 	 */
-	public function register_rest_routes() {
+	public function register_rest_routes(): void {
 		register_rest_route(
 			'wp/v2',
 			'/plugins/(?P<plugin>.+)',

--- a/src/Admin/Extensions/Registry.php
+++ b/src/Admin/Extensions/Registry.php
@@ -13,6 +13,11 @@ namespace WPGraphQL\Admin\Extensions;
 /**
  * Class Registry
  *
+ * phpcs:disable -- For phpstan type hinting
+ * @phpstan-type ExtensionAuthor array{
+ *  name: string,
+ *  homepage?: string,
+ * }
  * @phpstan-type Extension array{
  *  name: non-empty-string,
  *  description: non-empty-string,
@@ -20,11 +25,9 @@ namespace WPGraphQL\Admin\Extensions;
  *  support_url: non-empty-string,
  *  documentation_url: non-empty-string,
  *  repo_url?: string,
- *  author: array{
- *   name: non-empty-string,
- *   homepage?: string,
- *  },
+ *  author: ExtensionAuthor,
  * }
+ * phpcs:enable
  */
 final class Registry {
 	/**


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

## What does this implement/fix? Explain your changes.

This PR fixes the use of `mixed` in iterable types inside the `Admin\Extensions` and `Admin\AdminNotices` class. The only remaining uses of mixed in that class are intentional: i.e. when we're trying to validate if a filtered list of extensions has the necessary data.

Additionally, native types have been implemented in all places in those classes where to do so would not cause any breakings.

There are _no_ breaking or user-facing changes in this PR. 

## Does this close any currently open issues?

<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Any other comments?

<!-- Please add any additional context that would be helpful. Feel free to include screenshots of the GraphiQL IDE or other relevant screenshotes, logs, error output, etc -->
