### PR TITLE
chore: improve type-safety for `WPGraphQL` class

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -77,6 +77,8 @@
 		<exclude name="Squiz.Commenting.FunctionComment.IncorrectTypeHint" />
 		<!-- Conflicts with b/c in AbstractConnectionResolver -->
 		<exclude name="Squiz.Commenting.FunctionComment.InvalidNoReturn" />
+		<!-- Better handled by SlevomatCodingStandard.TypeHints.PropertyTypeHint -->
+		<exclude name="Squiz.Commenting.VariableComment.MissingVar" />
 
 		<!-- Should probably be added back -->
 		<exclude name="Generic.Commenting.DocComment.MissingShort"/>

--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -182,9 +182,7 @@ class DataSource {
 	public static function resolve_taxonomy( $taxonomy ) {
 
 		/**
-		 * Get the allowed_taxonomies
-		 *
-		 * @var string[] $allowed_taxonomies
+		 * Get the allowed_taxonomies.
 		 */
 		$allowed_taxonomies = \WPGraphQL::get_allowed_taxonomies();
 

--- a/src/Data/Loader/PostTypeLoader.php
+++ b/src/Data/Loader/PostTypeLoader.php
@@ -25,19 +25,22 @@ class PostTypeLoader extends AbstractDataLoader {
 	 * {@inheritDoc}
 	 *
 	 * @param string[] $keys
-	 * @return array<string,\WP_Post|null>
+	 * @return array<string,\WP_Post_Type|null>
 	 */
 	public function loadKeys( array $keys ) {
 		$post_types = \WPGraphQL::get_allowed_post_types( 'objects' );
 
+		if ( empty( $post_types ) ) {
+			return [];
+		}
+
 		$loaded = [];
-		if ( ! empty( $post_types ) && is_array( $post_types ) ) {
-			foreach ( $keys as $key ) {
-				if ( isset( $post_types[ $key ] ) ) {
-					$loaded[ $key ] = $post_types[ $key ];
-				} else {
-					$loaded[ $key ] = null;
-				}
+
+		foreach ( $keys as $key ) {
+			if ( isset( $post_types[ $key ] ) ) {
+				$loaded[ $key ] = $post_types[ $key ];
+			} else {
+				$loaded[ $key ] = null;
 			}
 		}
 

--- a/src/Data/Loader/TaxonomyLoader.php
+++ b/src/Data/Loader/TaxonomyLoader.php
@@ -31,14 +31,16 @@ class TaxonomyLoader extends AbstractDataLoader {
 	public function loadKeys( array $keys ) {
 		$taxonomies = \WPGraphQL::get_allowed_taxonomies( 'objects' );
 
+		if ( empty( $taxonomies ) ) {
+			return [];
+		}
+
 		$loaded = [];
-		if ( ! empty( $taxonomies ) && is_array( $taxonomies ) ) {
-			foreach ( $keys as $key ) {
-				if ( isset( $taxonomies[ $key ] ) ) {
-					$loaded[ $key ] = $taxonomies[ $key ];
-				} else {
-					$loaded[ $key ] = null;
-				}
+		foreach ( $keys as $key ) {
+			if ( isset( $taxonomies[ $key ] ) ) {
+				$loaded[ $key ] = $taxonomies[ $key ];
+			} else {
+				$loaded[ $key ] = null;
 			}
 		}
 

--- a/src/Data/PostObjectMutation.php
+++ b/src/Data/PostObjectMutation.php
@@ -241,9 +241,7 @@ class PostObjectMutation {
 		do_action( 'graphql_post_object_mutation_set_object_terms', $post_id, $input, $post_type_object, $mutation_name );
 
 		/**
-		 * Get the allowed taxonomies and iterate through them to find the term inputs to use for setting relationships
-		 *
-		 * @var \WP_Taxonomy[] $allowed_taxonomies
+		 * Get the allowed taxonomies and iterate through them to find the term inputs to use for setting relationships.
 		 */
 		$allowed_taxonomies = \WPGraphQL::get_allowed_taxonomies( 'objects' );
 

--- a/src/Mutation/PostObjectCreate.php
+++ b/src/Mutation/PostObjectCreate.php
@@ -143,7 +143,6 @@ class PostObjectCreate {
 			];
 		}
 
-		/** @var \WP_Taxonomy[] $allowed_taxonomies */
 		$allowed_taxonomies = \WPGraphQL::get_allowed_taxonomies( 'objects' );
 
 		foreach ( $allowed_taxonomies as $tax_object ) {

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -411,13 +411,9 @@ class TypeRegistry {
 		UpdateSettings::register_mutation( $this );
 
 		/**
-		 * Register PostObject types based on post_types configured to show_in_graphql
-		 *
-		 * @var \WP_Post_Type[] $allowed_post_types
+		 * Register PostObject types based on post_types configured to show_in_graphql.
 		 */
 		$allowed_post_types = WPGraphQL::get_allowed_post_types( 'objects' );
-
-		/** @var \WP_Taxonomy[] $allowed_taxonomies */
 		$allowed_taxonomies = WPGraphQL::get_allowed_taxonomies( 'objects' );
 
 		foreach ( $allowed_post_types as $post_type_object ) {

--- a/src/Type/Connection/PostObjects.php
+++ b/src/Type/Connection/PostObjects.php
@@ -168,9 +168,7 @@ class PostObjects {
 		);
 
 		/**
-		 * Register Connections to PostObjects
-		 *
-		 * @var \WP_Post_Type[] $allowed_post_types
+		 * Register Connections to PostObjects.
 		 */
 		$allowed_post_types = \WPGraphQL::get_allowed_post_types( 'objects' );
 

--- a/src/Type/Connection/TermObjects.php
+++ b/src/Type/Connection/TermObjects.php
@@ -44,7 +44,6 @@ class TermObjects {
 			]
 		);
 
-		/** @var \WP_Taxonomy[] $allowed_taxonomies */
 		$allowed_taxonomies = \WPGraphQL::get_allowed_taxonomies( 'objects' );
 
 		/**

--- a/src/Type/Enum/ContentNodeIdTypeEnum.php
+++ b/src/Type/Enum/ContentNodeIdTypeEnum.php
@@ -20,7 +20,6 @@ class ContentNodeIdTypeEnum {
 			]
 		);
 
-		/** @var \WP_Post_Type[] */
 		$allowed_post_types = \WPGraphQL::get_allowed_post_types( 'objects' );
 
 		foreach ( $allowed_post_types as $post_type_object ) {

--- a/src/Type/Enum/ContentTypeEnum.php
+++ b/src/Type/Enum/ContentTypeEnum.php
@@ -15,11 +15,7 @@ class ContentTypeEnum {
 	public static function register_type() {
 		$values = [];
 
-		/**
-		 * Get the allowed post types
-		 *
-		 * @var string[] $allowed_post_types
-		 */
+		// Get the allowed post types.
 		$allowed_post_types = \WPGraphQL::get_allowed_post_types();
 
 		/**
@@ -42,9 +38,7 @@ class ContentTypeEnum {
 		);
 
 		/**
-		 * Register a ContentTypesOf${taxonomyName}Enum for each taxonomy
-		 *
-		 * @var \WP_Taxonomy[] $allowed_taxonomies
+		 * Register a ContentTypesOf${taxonomyName}Enum for each taxonomy.
 		 */
 		$allowed_taxonomies = \WPGraphQL::get_allowed_taxonomies( 'objects' );
 		foreach ( $allowed_taxonomies as $tax_object ) {

--- a/src/Type/Enum/TaxonomyEnum.php
+++ b/src/Type/Enum/TaxonomyEnum.php
@@ -12,7 +12,6 @@ class TaxonomyEnum {
 	 * @return void
 	 */
 	public static function register_type() {
-		/** @var \WP_Taxonomy[] $allowed_taxonomies */
 		$allowed_taxonomies = \WPGraphQL::get_allowed_taxonomies( 'objects' );
 
 		$values = [];

--- a/src/Type/ObjectType/RootQuery.php
+++ b/src/Type/ObjectType/RootQuery.php
@@ -654,7 +654,6 @@ class RootQuery {
 	 * @return void
 	 */
 	public static function register_post_object_fields() {
-		/** @var \WP_Post_Type[] */
 		$allowed_post_types = \WPGraphQL::get_allowed_post_types( 'objects', [ 'graphql_register_root_field' => true ] );
 
 		foreach ( $allowed_post_types as $post_type_object ) {
@@ -884,7 +883,6 @@ class RootQuery {
 	 * @return void
 	 */
 	public static function register_term_object_fields() {
-		/** @var \WP_Taxonomy[] $allowed_taxonomies */
 		$allowed_taxonomies = \WPGraphQL::get_allowed_taxonomies( 'objects', [ 'graphql_register_root_field' => true ] );
 
 		foreach ( $allowed_taxonomies as $tax_object ) {

--- a/src/Type/Union/MenuItemObjectUnion.php
+++ b/src/Type/Union/MenuItemObjectUnion.php
@@ -72,8 +72,6 @@ class MenuItemObjectUnion {
 
 		/**
 		 * Add post types that are allowed in WPGraphQL.
-		 *
-		 * @var \WP_Post_Type $post_type_object
 		 */
 		foreach ( \WPGraphQL::get_allowed_post_types( 'objects', $args ) as $post_type_object ) {
 			if ( isset( $post_type_object->graphql_single_name ) ) {

--- a/src/Type/Union/PostObjectUnion.php
+++ b/src/Type/Union/PostObjectUnion.php
@@ -49,8 +49,7 @@ class PostObjectUnion {
 	 * @return string[]
 	 */
 	public static function get_possible_types() {
-		$possible_types = [];
-		/** @var \WP_Post_Type[] */
+		$possible_types     = [];
 		$allowed_post_types = \WPGraphQL::get_allowed_post_types( 'objects', [ 'graphql_kind' => 'object' ] );
 
 		foreach ( $allowed_post_types as $post_type_object ) {

--- a/src/Type/Union/TermObjectUnion.php
+++ b/src/Type/Union/TermObjectUnion.php
@@ -48,8 +48,7 @@ class TermObjectUnion {
 	 * @return array<string,string>
 	 */
 	public static function get_possible_types() {
-		$possible_types = [];
-		/** @var \WP_Taxonomy[] $allowed_taxonomies */
+		$possible_types     = [];
 		$allowed_taxonomies = \WPGraphQL::get_allowed_taxonomies( 'objects', [ 'graphql_kind' => 'object' ] );
 
 		foreach ( $allowed_taxonomies as $tax_object ) {

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -648,17 +648,20 @@ final class WPGraphQL {
 
 	/**
 	 * Get the post types that are allowed to be used in GraphQL.
+	 *
 	 * This gets all post_types that are set to show_in_graphql, but allows for external code
 	 * (plugins/theme) to filter the list of allowed_post_types to add/remove additional post_types
 	 *
-	 * @param string|mixed[]      $output Optional. The type of output to return. Accepts post type 'names' or 'objects'. Default 'names'.
+	 * @param 'names'|'objects'   $output Optional. The type of output to return. Accepts post type 'names' or 'objects'. Default 'names'.
 	 * @param array<string,mixed> $args   Optional. Arguments to filter allowed post types
 	 *
-	 * @return array<string,mixed>
+	 * @return string[]|\WP_Post_Type[]
+	 * @phpstan-return ( $output is 'objects' ? \WP_Post_Type[] : string[] )
+	 *
 	 * @since  0.0.4
 	 * @since  1.8.1 adds $output as first param, and stores post type objects in class property.
 	 */
-	public static function get_allowed_post_types( $output = 'names', $args = [] ) {
+	public static function get_allowed_post_types( $output = 'names', $args = [] ): array {
 		// Support deprecated param order.
 		if ( is_array( $output ) ) {
 			_deprecated_argument( __METHOD__, '1.8.1', '$args should be passed as the second parameter.' );
@@ -742,10 +745,11 @@ final class WPGraphQL {
 	 * (plugins/themes) to filter the list of allowed_taxonomies to add/remove additional
 	 * taxonomies
 	 *
-	 * @param string              $output Optional. The type of output to return. Accepts taxonomy 'names' or 'objects'. Default 'names'.
+	 * @param 'names'|'objects'   $output Optional. The type of output to return. Accepts taxonomy 'names' or 'objects'. Default 'names'.
 	 * @param array<string,mixed> $args   Optional. Arguments to filter allowed taxonomies.
 	 *
-	 * @return array<string,mixed>
+	 * @return string[]|\WP_Taxonomy[]
+	 * @phpstan-return ( $output is 'objects' ? \WP_Taxonomy[] : string[] )
 	 * @since  0.0.4
 	 */
 	public static function get_allowed_taxonomies( $output = 'names', $args = [] ): array {

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -24,10 +24,10 @@ final class WPGraphQL {
 	/**
 	 * Stores the instance of the WPGraphQL class
 	 *
-	 * @var ?\WPGraphQL The one true WPGraphQL
+	 * @var \WPGraphQL The one true WPGraphQL
 	 * @since  0.0.1
 	 */
-	private static $instance;
+	private static self $instance;
 
 	/**
 	 * Holds the Schema def
@@ -49,7 +49,7 @@ final class WPGraphQL {
 	 * @var ?\WP_Post_Type[] allowed_post_types
 	 * @since  0.0.5
 	 */
-	protected static $allowed_post_types;
+	protected static ?array $allowed_post_types;
 
 	/**
 	 * Stores an array of allowed taxonomies
@@ -57,17 +57,17 @@ final class WPGraphQL {
 	 * @var ?\WP_Taxonomy[] allowed_taxonomies
 	 * @since  0.0.5
 	 */
-	protected static $allowed_taxonomies;
+	protected static ?array $allowed_taxonomies;
 
 	/**
-	 * @var bool
+	 * Whether a GraphQL request is currently being processed.
 	 */
-	protected static $is_graphql_request = false;
+	protected static bool $is_graphql_request = false;
 
 	/**
-	 * @var bool
+	 * Whether an Introspection query is currently being processed.
 	 */
-	protected static $is_introspection_query = false;
+	protected static bool $is_introspection_query = false;
 
 	/**
 	 * The instance of the WPGraphQL object
@@ -75,8 +75,8 @@ final class WPGraphQL {
 	 * @return \WPGraphQL - The one true WPGraphQL
 	 * @since  0.0.1
 	 */
-	public static function instance() {
-		if ( ! isset( self::$instance ) || ! ( self::$instance instanceof self ) ) {
+	public static function instance(): self {
+		if ( ! isset( self::$instance ) ) {
 			self::$instance = new self();
 			self::$instance->setup_constants();
 			self::$instance->includes();
@@ -96,10 +96,9 @@ final class WPGraphQL {
 	 * The whole idea of the singleton design pattern is that there is a single object
 	 * therefore, we don't want the object to be cloned.
 	 *
-	 * @return void
 	 * @since  0.0.1
 	 */
-	public function __clone() {
+	public function __clone(): void {
 		// Cloning instances of the class is forbidden.
 		_doing_it_wrong( __FUNCTION__, esc_html__( 'The WPGraphQL class should not be cloned.', 'wp-graphql' ), '0.0.1' );
 	}
@@ -107,10 +106,9 @@ final class WPGraphQL {
 	/**
 	 * Disable unserializing of the class.
 	 *
-	 * @return void
 	 * @since  0.0.1
 	 */
-	public function __wakeup() {
+	public function __wakeup(): void {
 		// De-serializing instances of the class is forbidden.
 		_doing_it_wrong( __FUNCTION__, esc_html__( 'De-serializing instances of the WPGraphQL class is not allowed', 'wp-graphql' ), '0.0.1' );
 	}
@@ -118,10 +116,9 @@ final class WPGraphQL {
 	/**
 	 * Setup plugin constants.
 	 *
-	 * @return void
 	 * @since  0.0.1
 	 */
-	private function setup_constants() {
+	private function setup_constants(): void {
 		graphql_setup_constants();
 	}
 
@@ -288,10 +285,9 @@ final class WPGraphQL {
 	 * If the server is running a lower version than required, throw an exception and prevent
 	 * further execution.
 	 *
-	 * @return void
 	 * @throws \Exception
 	 */
-	public function min_php_version_check() {
+	public function min_php_version_check(): void {
 		if ( defined( 'GRAPHQL_MIN_PHP_VERSION' ) && version_compare( PHP_VERSION, GRAPHQL_MIN_PHP_VERSION, '<' ) ) {
 			throw new \Exception(
 				esc_html(
@@ -308,10 +304,8 @@ final class WPGraphQL {
 
 	/**
 	 * Sets up the plugin url
-	 *
-	 * @return void
 	 */
-	public function setup_plugin_url() {
+	public function setup_plugin_url(): void {
 		// Plugin Folder URL.
 		if ( ! defined( 'WPGRAPHQL_PLUGIN_URL' ) ) {
 			define( 'WPGRAPHQL_PLUGIN_URL', plugin_dir_url( dirname( __DIR__ ) . '/wp-graphql.php' ) );
@@ -319,11 +313,9 @@ final class WPGraphQL {
 	}
 
 	/**
-	 * Determine the post_types and taxonomies, etc that should show in GraphQL
-	 *
-	 * @return void
+	 * Determine the post_types and taxonomies, etc that should show in GraphQL.
 	 */
-	public function setup_types() {
+	public function setup_types(): void {
 		/**
 		 * Set up the settings, post_types and taxonomies to show_in_graphql
 		 */
@@ -331,11 +323,9 @@ final class WPGraphQL {
 	}
 
 	/**
-	 * Flush permalinks if the GraphQL Endpoint route isn't yet registered
-	 *
-	 * @return void
+	 * Flush permalinks if the GraphQL Endpoint route isn't yet registered.
 	 */
-	public function maybe_flush_permalinks() {
+	public function maybe_flush_permalinks(): void {
 		$rules = get_option( 'rewrite_rules' );
 		if ( ! isset( $rules[ graphql_get_endpoint() . '/?$' ] ) ) {
 			flush_rewrite_rules(); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.flush_rewrite_rules_flush_rewrite_rules
@@ -419,11 +409,9 @@ final class WPGraphQL {
 	}
 
 	/**
-	 * Upgrade routine
-	 *
-	 * @return void
+	 * Upgrade routine.
 	 */
-	public function upgrade() {
+	public function upgrade(): void {
 		$version = get_option( 'wp_graphql_version', null );
 
 		// If the version is not set, this is a fresh install, not an update.
@@ -477,10 +465,8 @@ final class WPGraphQL {
 
 	/**
 	 * Clear all caches in the "wpgraphql_extensions" cache group.
-	 *
-	 * @return void
 	 */
-	public function clear_extensions_cache() {
+	public function clear_extensions_cache(): void {
 		global $wp_object_cache;
 
 		if ( isset( $wp_object_cache->cache['wpgraphql_extensions'] ) ) {
@@ -491,22 +477,19 @@ final class WPGraphQL {
 	}
 
 	/**
-	 * Initialize admin functionality
-	 *
-	 * @return void
+	 * Initialize admin functionality.
 	 */
-	public function init_admin() {
+	public function init_admin(): void {
 		$admin = new Admin();
 		$admin->init();
 	}
 
 	/**
-	 * This sets up built-in post_types and taxonomies to show in the GraphQL Schema
+	 * This sets up built-in post_types and taxonomies to show in the GraphQL Schema.
 	 *
-	 * @return void
 	 * @since  0.0.2
 	 */
-	public static function show_in_graphql() {
+	public static function show_in_graphql(): void {
 		add_filter( 'register_post_type_args', [ self::class, 'setup_default_post_types' ], 10, 2 );
 		add_filter( 'register_taxonomy_args', [ self::class, 'setup_default_taxonomies' ], 10, 2 );
 
@@ -586,7 +569,7 @@ final class WPGraphQL {
 	 * @throws \Exception
 	 * @since 1.12.0
 	 */
-	public static function register_graphql_post_type_args( array $args, string $post_type_name ) {
+	public static function register_graphql_post_type_args( array $args, string $post_type_name ): array {
 		// Bail early if the post type is hidden from the WPGraphQL schema.
 		if ( empty( $args['show_in_graphql'] ) ) {
 			return $args;
@@ -615,7 +598,7 @@ final class WPGraphQL {
 	 * @throws \Exception
 	 * @since 1.12.0
 	 */
-	public static function register_graphql_taxonomy_args( array $args, string $taxonomy_name ) {
+	public static function register_graphql_taxonomy_args( array $args, string $taxonomy_name ): array {
 		// Bail early if the taxonomy  is hidden from the WPGraphQL schema.
 		if ( empty( $args['show_in_graphql'] ) ) {
 			return $args;
@@ -765,7 +748,7 @@ final class WPGraphQL {
 	 * @return array<string,mixed>
 	 * @since  0.0.4
 	 */
-	public static function get_allowed_taxonomies( $output = 'names', $args = [] ) {
+	public static function get_allowed_taxonomies( $output = 'names', $args = [] ): array {
 
 		// Initialize array of allowed post type objects.
 		if ( empty( self::$allowed_taxonomies ) ) {
@@ -838,11 +821,9 @@ final class WPGraphQL {
 	}
 
 	/**
-	 * Allow Schema to be cleared
-	 *
-	 * @return void
+	 * Allow Schema to be cleared.
 	 */
-	public static function clear_schema() {
+	public static function clear_schema(): void {
 		self::$type_registry      = null;
 		self::$schema             = null;
 		self::$allowed_post_types = null;
@@ -938,11 +919,9 @@ final class WPGraphQL {
 	}
 
 	/**
-	 * Return the static schema if there is one
-	 *
-	 * @return ?string
+	 * Return the static schema if there is one.
 	 */
-	public static function get_static_schema() {
+	public static function get_static_schema(): ?string {
 		$schema_file = WPGRAPHQL_PLUGIN_DIR . 'schema.graphql';
 
 		if ( ! file_exists( $schema_file ) ) {
@@ -956,10 +935,8 @@ final class WPGraphQL {
 
 	/**
 	 * Get the AppContext for use in passing down the Resolve Tree
-	 *
-	 * @return \WPGraphQL\AppContext
 	 */
-	public static function get_app_context() {
+	public static function get_app_context(): AppContext {
 		/**
 		 * Configure the app_context which gets passed down to all the resolvers.
 		 *

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -32,14 +32,14 @@ final class WPGraphQL {
 	/**
 	 * Holds the Schema def
 	 *
-	 * @var mixed|\WPGraphQL\WPSchema|null $schema The Schema used for the GraphQL API
+	 * @var ?\WPGraphQL\WPSchema $schema The Schema used for the GraphQL API
 	 */
 	protected static $schema;
 
 	/**
 	 * Holds the TypeRegistry instance
 	 *
-	 * @var mixed|\WPGraphQL\Registry\TypeRegistry|null $type_registry The registry that holds all GraphQL Types
+	 * @var ?\WPGraphQL\Registry\TypeRegistry $type_registry The registry that holds all GraphQL Types
 	 */
 	protected static $type_registry;
 
@@ -376,9 +376,9 @@ final class WPGraphQL {
 					/**
 					 * Filters the interfaces applied to an object type
 					 *
-					 * @param string[]                                                           $interfaces List of interfaces applied to the Object Type
-					 * @param array<string,mixed>                                                $config     The config for the Object Type
-					 * @param mixed|\WPGraphQL\Type\WPInterfaceType|\WPGraphQL\Type\WPObjectType $type       The Type instance
+					 * @param string[]                                                     $interfaces List of interfaces applied to the Object Type
+					 * @param array<string,mixed>                                          $config     The config for the Object Type
+					 * @param \WPGraphQL\Type\WPInterfaceType|\WPGraphQL\Type\WPObjectType $type       The Type instance
 					 */
 					return apply_filters_deprecated( 'graphql_object_type_interfaces', [ $interfaces, $config, $type ], '1.4.1', 'graphql_type_interfaces' );
 				}
@@ -622,7 +622,15 @@ final class WPGraphQL {
 	 *
 	 * @since 1.12.0
 	 *
-	 * @return array<string,mixed>
+	 * @return array{
+	 *   graphql_kind: 'interface'|'object'|'union',
+	 *   graphql_resolve_type: ?callable,
+	 *   graphql_interfaces: string[],
+	 *   graphql_connections: string[],
+	 *   graphql_union_types: string[],
+	 *   graphql_register_root_field: bool,
+	 *   graphql_register_root_connection: bool,
+	 * }
 	 */
 	public static function get_default_graphql_type_args(): array {
 		return [
@@ -793,7 +801,7 @@ final class WPGraphQL {
 					if ( empty( $obj->graphql_single_name ) || empty( $obj->graphql_plural_name ) ) {
 						graphql_debug(
 							sprintf(
-							/* translators: %s will replaced with the registered taxonomty */
+							/* translators: %s will replaced with the registered taxonomy */
 								__( 'The "%s" taxonomy isn\'t configured properly to show in GraphQL. It needs a "graphql_single_name" and a "graphql_plural_name"', 'wp-graphql' ),
 								$obj->name
 							),
@@ -843,7 +851,7 @@ final class WPGraphQL {
 	 * @throws \Exception
 	 */
 	public static function get_schema() {
-		if ( null === self::$schema ) {
+		if ( ! isset( self::$schema ) ) {
 			$schema_registry = new SchemaRegistry();
 			$schema          = $schema_registry->get_schema();
 
@@ -867,7 +875,7 @@ final class WPGraphQL {
 		/**
 		 * Return the Schema after applying filters
 		 */
-		return ! empty( self::$schema ) ? self::$schema : null;
+		return self::$schema;
 	}
 
 	/**
@@ -888,15 +896,14 @@ final class WPGraphQL {
 	}
 
 	/**
-	 * Returns the Schema as defined by static registrations throughout
-	 * the WP Load.
+	 * Returns the type registry, instantiating it if it doesn't exist.
 	 *
 	 * @return \WPGraphQL\Registry\TypeRegistry
 	 *
 	 * @throws \Exception
 	 */
 	public static function get_type_registry() {
-		if ( null === self::$type_registry ) {
+		if ( ! isset( self::$type_registry ) ) {
 			$type_registry = new TypeRegistry();
 
 			/**
@@ -919,7 +926,7 @@ final class WPGraphQL {
 		/**
 		 * Return the Schema after applying filters
 		 */
-		return ! empty( self::$type_registry ) ? self::$type_registry : null;
+		return self::$type_registry;
 	}
 
 	/**

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -96,9 +96,10 @@ final class WPGraphQL {
 	 * The whole idea of the singleton design pattern is that there is a single object
 	 * therefore, we don't want the object to be cloned.
 	 *
+	 * @return void
 	 * @since  0.0.1
 	 */
-	public function __clone(): void {
+	public function __clone() {
 		// Cloning instances of the class is forbidden.
 		_doing_it_wrong( __FUNCTION__, esc_html__( 'The WPGraphQL class should not be cloned.', 'wp-graphql' ), '0.0.1' );
 	}
@@ -106,9 +107,10 @@ final class WPGraphQL {
 	/**
 	 * Disable unserializing of the class.
 	 *
+	 * @return void
 	 * @since  0.0.1
 	 */
-	public function __wakeup(): void {
+	public function __wakeup() {
 		// De-serializing instances of the class is forbidden.
 		_doing_it_wrong( __FUNCTION__, esc_html__( 'De-serializing instances of the WPGraphQL class is not allowed', 'wp-graphql' ), '0.0.1' );
 	}


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

## What does this implement/fix? Explain your changes.

This PR:

- Inlines all (backwards-compatible) PHPDoc types into their native PHP types
- Replaces the use of `mixed` with the specific array shape (_where possible_)
- Adds type-narrowing to `WPGraphQL::get_allowed_post_types()` and `::get_allowed_taxonomies()`, so the correct traversable type of the array is hinted correctly.

References to these functions have been cleaned up accordingly (usually just by removing a `/** @var {...} */` typehint.

There are _no_ breaking changes in this PR.


## Does this close any currently open issues?

<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Any other comments?

<!-- Please add any additional context that would be helpful. Feel free to include screenshots of the GraphiQL IDE or other relevant screenshotes, logs, error output, etc -->
