### PR TITLE
fix: don't reinitialize Request::$app_context in constructor

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -158,17 +158,8 @@ class Request {
 		$this->validation_rules = $this->get_validation_rules();
 		$this->field_resolver   = $this->get_field_resolver();
 
-		/**
-		 * Configure the app_context which gets passed down to all the resolvers.
-		 *
-		 * @since 0.0.4
-		 */
-		$app_context                = new AppContext();
-		$app_context->viewer        = wp_get_current_user();
-		$app_context->root_url      = get_bloginfo( 'url' );
-		$app_context->request       = ! empty( $_REQUEST ) ? $_REQUEST : null; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$app_context->type_registry = $this->type_registry;
-		$this->app_context          = $app_context;
+		// Inject the type registry into the app context.
+		$this->app_context->type_registry = $this->type_registry;
 
 		$this->query_analyzer = new QueryAnalyzer( $this );
 


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

## What does this implement/fix? Explain your changes.

This PR fixes a bug in the `Request::__construct()` method, where the `->app_context` was previously initialized twice.

Now it's only initialized once, while the `$type_registry` continues to be injected onto the AppContext class at the same point of the lifecycle.


## Does this close any currently open issues?

<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Any other comments?

<!-- Please add any additional context that would be helpful. Feel free to include screenshots of the GraphiQL IDE or other relevant screenshotes, logs, error output, etc -->
