### PR TITLE
feat: introduce GraphQL event registry system and event registration hook

### DIFF
--- a/access-functions.php
+++ b/access-functions.php
@@ -7,6 +7,7 @@
  */
 
 use GraphQL\Type\Definition\Type;
+use WPGraphQL\Registry\EventRegistry;
 use WPGraphQL\Registry\TypeRegistry;
 use WPGraphQL\Request;
 use WPGraphQL\Router;
@@ -942,4 +943,26 @@ function register_graphql_admin_notice( string $slug, array $config ): void {
 function get_graphql_admin_notices(): array {
 	$admin_notices = \WPGraphQL\Admin\AdminNotices::get_instance();
 	return $admin_notices->get_admin_notices();
+}
+/**
+ * Registers a GraphQL event configuration to be attached to a WordPress action.
+ *
+ * This function schedules an event registration callback to be executed when
+ * the `graphql_register_events` action is fired (during `EventRegistry::init()`).
+ *
+ * The registered event will listen to a specified WordPress action (e.g. 'publish_post'),
+ * and execute a qualifying callback to potentially dispatch notifications or other side effects.
+ *
+ */
+function register_graphql_event( ...$args ) {
+	if ( did_action ( 'graphql_register_events' ) ) {
+		_doing_it_wrong( 'register_graphql_event', esc_html__( 'Call this before EventRegistry::init', 'wp-graphql' ), '2.4.0' );
+	}
+
+	add_action(
+		'graphql_register_events', 
+		static function (EventRegistry $event_registry) use ($args) {
+			$event_registry->register_event( ...$args );
+		}
+	);
 }

--- a/src/Registry/EventRegistry.php
+++ b/src/Registry/EventRegistry.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace WPGraphQL\Registry;
+
+use WPGraphQL\Utils\EventMonitor;
+
+/**
+ * Class EventRegistry
+ *
+ * @package WPGraphQL\Registry
+ */
+class EventRegistry {
+
+    /**
+     * Array of registered events.
+     *
+     * @var array
+     */
+    protected static $registered_events = [];
+
+    /**
+     * EventRegistry constructor.
+     *
+     * @param array $default_events Optional. Array of event configurations to initialize with.
+     */
+    public function __construct( array $default_events = [] ) {
+        $this->registered_events = $default_events;
+    }
+
+    /**
+     * Initialize the Event Registry.
+     *
+     * @return void
+     */
+    public function init(): void {
+        do_action( 'graphql_register_events', $this );
+        $this->registered_events = apply_filters( 'graphql_registered_events', $this->registered_events, $this );
+        $this->attach_events();
+    }
+
+    /**
+     * Register a new event.
+     *
+     * Adds an event configuration to the static list of registered events.
+     *
+     * @param string   $name      Unique identifier for the event.
+     * @param string   $hook_name The WordPress action hook to attach the event to.
+     * @param callable $callback  Callback function to execute when the action fires.
+     * @param int      $priority  Optional. Priority for the callback. Default 10.
+     * @param int      $arg_count Optional. Number of arguments accepted by the callback. Default 1.
+     *
+     * @return void
+     */
+    public static function register_event( $name, $hook_name, $callback, $priority = 10, $arg_count = 1 ) {
+        self::$registered_events[] = [
+            'name'      => $name,
+            'hook_name' => $hook_name,
+            'callback'  => $callback,
+            'priority'  => $priority,
+            'arg_count' => $arg_count,
+        ];
+    }
+
+    /**
+     * Attach all registered events to their corresponding WordPress actions.
+     *
+     * @return void
+     */
+    public static function attach_events() {
+        foreach ( self::$registered_events as $config ) {
+            add_action( $config['hook_name'], function ( ...$hook_args ) use ( $config ) {
+                // Skip event escape hatch.
+                $maybe_skip = apply_filters( "graphql_event_should_handle_{$config['name']}", null, ...$hook_args );
+                if ( null !== $maybe_skip && false === $maybe_skip ) {
+                    return;
+                }
+
+                // Execute event callback.
+                $payload = call_user_func( $config['callback'], ...$hook_args );
+
+                // Handle errors.
+                if ( is_wp_error( $payload ) ) {
+                    do_action( "graphql_event_error_{$config['name']}", $payload, $hook_args );
+                    return;
+                }
+
+                // Filter the payload before tracking.
+                $payload = apply_filters( "graphql_event_payload_{$config['name']}", $payload, $hook_args );
+
+                // Track event in a custom event monitor or DB table.
+                EventMonitor::track( $config['name'], $payload );
+
+            }, $config['priority'], $config['arg_count'] );
+        }
+    }
+}

--- a/src/Utils/EventMonitor.php
+++ b/src/Utils/EventMonitor.php
@@ -1,0 +1,22 @@
+<?php
+namespace WPGraphQL\Utils;
+
+/**
+ * Class EventMonitor
+ *
+ * @package WPGraphQL\Utils
+ */
+class EventMonitor {
+	/**
+	 * Tracks an event by firing a corresponding WordPress action.
+	 *
+	 * @param string $event_name The unique name of the event being tracked.
+	 * @param mixed  $payload    The data payload associated with the event. Can be any type of data relevant to the event.
+	 *
+	 * @return void
+	 */
+	public static function track( $event_name, $payload ) {
+		do_action( "wpgraphql_event_tracked_{$event_name}", $payload );
+	}
+
+}

--- a/src/WPGraphQL.php
+++ b/src/WPGraphQL.php
@@ -195,6 +195,20 @@ final class WPGraphQL {
 				do_action( 'graphql_init', $instance );
 			}
 		);
+		// Initialize Event Registry and fire off filters
+		$eventRegistryTracking = new \WPGraphQL\Registry\EventRegistry( [] );
+		$hook = apply_filters(
+			'graphql_tracking_hook',
+			is_plugin_active_for_network( 'wp-graphql/wp-graphql.php' )
+				? 'muplugins_loaded'
+				: 'plugins_loaded'
+		);
+		add_action(
+			$hook,
+			static function () use ( $eventRegistryTracking ) {
+				$eventRegistryTracking->init();
+			}
+		);
 
 		// Initialize the plugin url constant
 		// see: https://developer.wordpress.org/reference/functions/plugins_url/#more-information


### PR DESCRIPTION

<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!


-->

## What does this implement/fix? Explain your changes.

This PR introduces a new event registry system for WPGraphQL to centralize the registration and handling of WordPress hooks as GraphQL events. It includes:

- A `EventRegistry` class to manage event configurations and attach them to WordPress actions.
- A `register_graphql_event()` helper function for external plugins or themes to declaratively register events.
- An `EventMonitor` utility to track dispatched events via hooks like `wpgraphql_event_tracked_{event}`.



## Does this close any currently open issues?

Draft PR for https://github.com/wp-graphql/wp-graphql/issues/2517

<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Any other comments?

<!-- Please add any additional context that would be helpful. Feel free to include screenshots of the GraphiQL IDE or other relevant screenshotes, logs, error output, etc -->

Looking forward to feedback on the pattern and implementation approach and other suggestions around testing and documentation