### PR TITLE
perf: refactor `AppContext` to lazy-load dataloaders

### DIFF
--- a/docs/using-data-from-custom-database-tables.md
+++ b/docs/using-data-from-custom-database-tables.md
@@ -9,7 +9,7 @@ This is an advanced guide that will be most useful for developers with experienc
 
 WPGraphQL makes use of core WordPress registries, such as the Post Type and Taxonomy registry, to generate the GraphQL Schema for your WordPress instance. 
 
-Since WordPress doesn't have a formal "Custom Database Registry", WPGraphQL is unable to programatically expose data stored in custom databse tables to the WPGraphQL Schema. 
+Since WordPress doesn't have a formal "Custom Database Registry", WPGraphQL is unable to programmatically expose data stored in custom database tables to the WPGraphQL Schema. 
 
 In this guide, we will look into how to use data from Custom Database Tables with WPGraphQL.
 
@@ -51,21 +51,21 @@ The final result will allow us to make GraphQL queries to get data out of a cust
 
 ```graphql
 query GetAllNotifications {
-  notifications {
-    nodes {
-      __typename
-      id
-      message
-      date
-      user {
-        node {
-          __typename
-          id
-          name
-        }
-      }
-    }
-  }
+	notifications {
+		nodes {
+			__typename
+			id
+			message
+			date
+			user {
+				node {
+					__typename
+					id
+					name
+				}
+			}
+		}
+	}
 }
 ```
 
@@ -73,18 +73,18 @@ or:
 
 ```graphql
 query GetCurrentUserNotifications {
-  viewer {
-    id
-    name
-    notifications {
-      nodes {
-        __typename
-        id
-        message
-        date
-      }
-    }
-  }
+	viewer {
+		id
+		name
+		notifications {
+			nodes {
+				__typename
+				id
+				message
+				date
+			}
+		}
+	}
 }
 ```
 
@@ -92,15 +92,15 @@ or:
 
 ```graphql
 query GetNotificationNode {
-  node( id: "bm90aWZpY2F0aW9uOjE=" ) {
-    __typename
-    ...on Notification {
-      __typename
-      id
-      message
-      date
-    }
-  }
+	node( id: "bm90aWZpY2F0aW9uOjE=" ) {
+		__typename
+		...on Notification {
+			__typename
+			id
+			message
+			date
+		}
+	}
 }
 ```
 
@@ -123,7 +123,7 @@ Add a new file named `wp-graphql-notifications-example.php` and add the followin
 
 // Prevent direct access
 if (!defined('ABSPATH')) {
-    exit;
+	exit;
 }
 ```
 
@@ -141,12 +141,12 @@ Our goal is to be able to query a list of notifications, each with an ID, date, 
 
 Our database table will be structured as follows: 
 
-| Column   | Type            | Description                                 |
-|----------|-----------------|---------------------------------------------|
-| id       | mediumint(9)    | The primary key, auto-incremented           |
-| user_id  | mediumint(9)    | The ID of the user                          |
-| message  | text            | The notification message                    |
-| date     | datetime        | The date and time when the notification was created |
+| Column  | Type         | Description                                         |
+| ------- | ------------ | --------------------------------------------------- |
+| id      | mediumint(9) | The primary key, auto-incremented                   |
+| user_id | mediumint(9) | The ID of the user                                  |
+| message | text         | The notification message                            |
+| date    | datetime     | The date and time when the notification was created |
 
 We can add the following code to our PHP file to create this database table for us when our plugin is activated: 
 
@@ -158,21 +158,21 @@ The code below will execute when the plugin is activated, adding our custom data
 register_activation_hook( __FILE__, 'wpgraphql_notifications_example_create_notifications_table' );
 
 function wpgraphql_notifications_example_create_notifications_table() {
-    global $wpdb;
-    $table_name = $wpdb->prefix . 'notifications';
+		global $wpdb;
+		$table_name = $wpdb->prefix . 'notifications';
 
-    $charset_collate = $wpdb->get_charset_collate();
+		$charset_collate = $wpdb->get_charset_collate();
 
-    $sql = "CREATE TABLE $table_name (
-        id mediumint(9) NOT NULL AUTO_INCREMENT,
-        user_id mediumint(9) NOT NULL,
-        message text NOT NULL,
-        date datetime DEFAULT CURRENT_TIMESTAMP NOT NULL,
-        PRIMARY KEY  (id)
-    ) $charset_collate;";
+		$sql = "CREATE TABLE $table_name (
+				id mediumint(9) NOT NULL AUTO_INCREMENT,
+				user_id mediumint(9) NOT NULL,
+				message text NOT NULL,
+				date datetime DEFAULT CURRENT_TIMESTAMP NOT NULL,
+				PRIMARY KEY  (id)
+		) $charset_collate;"; // The space after primary key is important to avoid syntax errors
 
-    require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
-    dbDelta($sql);
+		require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
+		dbDelta($sql);
 }
 ```
 
@@ -188,33 +188,32 @@ Or, you can use the following PHP snippet in your plugin file to insert some ent
 ```php
 add_action( 'init', function() { 
 
-  global $wpdb;
-  $table_name = $wpdb->prefix . 'notifications';
-  
-  // Sample data to be inserted
-  $notifications = [
-      ['user_id' => 1, 'message' => 'Lorem ipsum dolor sit amet'],
-      ['user_id' => 1, 'message' => 'Consectetur adipiscing elit'],
-      ['user_id' => 1, 'message' => 'Sed do eiusmod tempor incididunt']
-  ];
-  
-  // Inserting the data
-  foreach ($notifications as $notification) {
-      $wpdb->insert(
-          $table_name,
-          array(
-              'user_id' => $notification['user_id'],
-              'message' => $notification['message'],
-              'date'    => current_time('mysql') // WordPress function for current date-time
-          ),
-          array(
-              '%d', // user_id is an integer
-              '%s', // message is a string
-              '%s'  // date is a string (formatted date)
-          )
-      );
-  }
+	global $wpdb;
+	$table_name = $wpdb->prefix . 'notifications';
 
+	// Sample data to be inserted
+	$notifications = [
+			['user_id' => 1, 'message' => 'Lorem ipsum dolor sit amet'],
+			['user_id' => 1, 'message' => 'Consectetur adipiscing elit'],
+			['user_id' => 1, 'message' => 'Sed do eiusmod tempor incididunt']
+	];
+
+	// Inserting the data
+	foreach ($notifications as $notification) {
+			$wpdb->insert(
+					$table_name,
+					array(
+							'user_id' => $notification['user_id'],
+							'message' => $notification['message'],
+							'date'  => current_time('mysql') // WordPress function for current date-time
+					),
+					array(
+							'%d', // user_id is an integer
+							'%s', // message is a string
+							'%s' // date is a string (formatted date)
+					)
+			);
+	}
 } );
 ```
 
@@ -237,34 +236,34 @@ add_action( 'graphql_register_types', 'wpgraphql_notifications_example_register_
 
 function wpgraphql_notifications_example_register_types() {
 
-  // Register the GraphQL Object Type to the Schema
-  register_graphql_object_type( 'Notification', [
-    // Be sure to replace your-text-domain for i18n of your plugin
-    'description' => __( 'Notification messages for a user', 'your-text-domain' ),
-    // By implementing the "Node" interface the Notification Object Type will automaticaly have an "id" field.
-    // By implementing the "DatabaseIdentifier" interface, the Notification Object Type will automatically have a "databaseId" field
-    'interfaces' => [ 'Node', 'DatabaseIdentifier' ],
-    // The fields that can be queried for on the Notification type
-    'fields' => [
-       'id' => [
-         'resolve' => function( $source ) {
-            return base64_encode( 'notification', $source->id );
-         }
-       ],
-       'userDatabaseId' => [
-         'type' => 'Int',
-         'description' => __( 'The databaseId of the user the message belongs to', 'your-text-domain' ),
-       ],
-       'message' => [
-         'type' => 'String',
-         'description' => __( 'The notification message', 'your-text-domain' ),
-       ],
-       'date' => [
-         'type' => 'String',
-         'description' => __( 'The date the message was created', 'your-text-domain' ),
-       ],
-    ]
-  ] );
+	// Register the GraphQL Object Type to the Schema
+	register_graphql_object_type( 'Notification', [
+		// Be sure to replace your-text-domain for i18n of your plugin
+		'description' => __( 'Notification messages for a user', 'your-text-domain' ),
+		// By implementing the "Node" interface the Notification Object Type will automatically have an "id" field.
+		// By implementing the "DatabaseIdentifier" interface, the Notification Object Type will automatically have a "databaseId" field
+		'interfaces' => [ 'Node', 'DatabaseIdentifier' ],
+		// The fields that can be queried for on the Notification type
+		'fields' => [
+			 'id' => [
+				 'resolve' => function( $source ) {
+						return base64_encode( 'notification', $source->id );
+				 }
+			 ],
+			 'userDatabaseId' => [
+				 'type' => 'Int',
+				 'description' => __( 'The databaseId of the user the message belongs to', 'your-text-domain' ),
+			 ],
+			 'message' => [
+				 'type' => 'String',
+				 'description' => __( 'The notification message', 'your-text-domain' ),
+			 ],
+			 'date' => [
+				 'type' => 'String',
+				 'description' => __( 'The date the message was created', 'your-text-domain' ),
+			 ],
+		]
+	] );
 
 }
 ```
@@ -287,17 +286,17 @@ Within the `wpgraphql_notifications_example_register_types` function, add the fo
 
 ```php
 register_graphql_connection([
-  // The GraphQL Type that will have a field added to it to query a connection from
-  'fromType' => 'RootQuery',
-  // The GraphQL Type the connection will return Nodes of. This type MUST implement the "Node" interface
-  'toType' => 'Notification',
-  // The field name to represent the connection on the "from" Type
-  'fromFieldName' => 'notifications',
-  // How to resolve the connection. For now we will return null, but will visit this below.
-  'resolve' => function( $root, $args, $context, $info ) {
-    // we will revisit this shortly
-    return null;
-  } 
+	// The GraphQL Type that will have a field added to it to query a connection from
+	'fromType' => 'RootQuery',
+	// The GraphQL Type the connection will return Nodes of. This type MUST implement the "Node" interface
+	'toType' => 'Notification',
+	// The field name to represent the connection on the "from" Type
+	'fromFieldName' => 'notifications',
+	// How to resolve the connection. For now we will return null, but will visit this below.
+	'resolve' => function( $root, $args, $context, $info ) {
+		// we will revisit this shortly
+		return null;
+	} 
 ]);
 ```
 
@@ -307,14 +306,14 @@ You should now be able to execute the following query and it would be a valid, w
 
 ```graphql
 query GetAllNotifications {
-  notifications {
-    nodes {
-      __typename
-      id
-      message
-      date
-    }
-  }
+	notifications {
+		nodes {
+			__typename
+			id
+			message
+			date
+		}
+	}
 }
 ```
 
@@ -358,9 +357,9 @@ add_action( 'graphql_init', function() {
 
 			// Prepare a SQL query to select rows that match the given IDs
 			$table_name = $wpdb->prefix . 'notifications';
-			$ids        = implode( ', ', $keys );
-			$query      = $wpdb->prepare( "SELECT * FROM $table_name WHERE id IN ($ids) ORDER BY id ASC", $ids );
-			$results    = $wpdb->get_results($query);
+			$ids				= implode( ', ', $keys );
+			$query			= $wpdb->prepare( "SELECT * FROM $table_name WHERE id IN ($ids) ORDER BY id ASC", $ids );
+			$results		= $wpdb->get_results($query);
 
 			if ( empty( $results ) ) {
 				return [];
@@ -387,13 +386,13 @@ add_action( 'graphql_init', function() {
 		}
 	}
 
-  // Add the notifications loader to be used under the hood by WPGraphQL when loading nodes
-	add_filter( 'graphql_data_loaders', function( $loaders, $context ) {
-		$loaders['notification'] = new NotificationLoader( $context );
+	// Add the notifications loader to be used under the hood by WPGraphQL when loading nodes
+	add_filter( 'graphql_data_loader_classes', function( $loaders ) {
+		$loaders['notification'] = NotificationLoader::class;
 		return $loaders;
-	}, 10, 2 );
+	}, 10, 1 );
 
-  // Filter so nodes that have a __typename will return that typename
+	// Filter so nodes that have a __typename will return that typename
 	add_filter( 'graphql_resolve_node_type', function( $type, $node ) {
 		return $node->__typename ?? $type;
 	}, 10, 2 );
@@ -405,7 +404,7 @@ This adds a `NotificationLoader` class, extending the WPGraphQL `AbstractDataLoa
 
 This tells WPGraphQL how to resolve data of the `Notification` Type when it's being asked for given 1 or more IDs.
 
-Then, using the `graphql_data_loaders` filter, we let WPGraphQL know about our new custom `NotificationLoader` so that it can be used when resolving data.
+Then, using the `graphql_data_loader_classes` filter, we let WPGraphQL know about our new custom `NotificationLoader` so that it can be used when resolving data.
 
 And last, using the `graphql_resolve_node_type` filter, we allow the notifications `__typename` property to determine which type of node to return. 
 
@@ -413,15 +412,15 @@ Now, as long as you have a notification in the database with id `1`, you should 
 
 ```graphql
 query GetNotificationNode {
-  node( id: "bm90aWZpY2F0aW9uOjE=" ) {
-    __typename
-    ...on Notification {
-      __typename
-      id
-      message
-      date
-    }
-  }
+	node( id: "bm90aWZpY2F0aW9uOjE=" ) {
+		__typename
+		...on Notification {
+			__typename
+			id
+			message
+			date
+		}
+	}
 }
 ```
 
@@ -444,22 +443,22 @@ add_action( 'graphql_init', function() {
 
 	class NotificationConnectionResolver extends \WPGraphQL\Data\Connection\AbstractConnectionResolver {
 
-    // Tell WPGraphQL which Loader to use. We define the `notification` loader that we registered already.
+		// Tell WPGraphQL which Loader to use. We define the `notification` loader that we registered already.
 		public function get_loader_name(): string {
 			return 'notification';
 		}
 
-    // Get the arguments to pass to the query.
-    // We're defaulting to an empty array as we're not supporting pagination/filtering/sorting in this example
+		// Get the arguments to pass to the query.
+		// We're defaulting to an empty array as we're not supporting pagination/filtering/sorting in this example
 		public function get_query_args(): array {
 			return [];
 		}
 
-    // Determine the query to run. Since we're interacting with a custom database Table, we
-    // use $wpdb to execute a query against the table.
-    // This is where logic needs to be mapped to account for any arguments the user inputs, such as pagination, filtering, sorting, etc.
-    // For this example, we are only executing the most basic query without support for pagination, etc.
-    // You could use an ORM to access data or whatever else you like here.
+		// Determine the query to run. Since we're interacting with a custom database Table, we
+		// use $wpdb to execute a query against the table.
+		// This is where logic needs to be mapped to account for any arguments the user inputs, such as pagination, filtering, sorting, etc.
+		// For this example, we are only executing the most basic query without support for pagination, etc.
+		// You could use an ORM to access data or whatever else you like here.
 		public function get_query(): array|bool|null {
 			global $wpdb;
 			$current_user_id = get_current_user_id();
@@ -479,26 +478,26 @@ add_action( 'graphql_init', function() {
 			return ! empty( $ids_array ) ? array_values( array_column( $ids_array, 'id' ) ) : [];
 		}
 
-    // This determines how to get IDs. In our case, the query itself returns IDs
-    // But sometimes queries, such as WP_Query might return an object with IDs as a property (i.e. $wp_query->posts )
+		// This determines how to get IDs. In our case, the query itself returns IDs
+		// But sometimes queries, such as WP_Query might return an object with IDs as a property (i.e. $wp_query->posts )
 		public function get_ids(): array|bool|null {
 			return $this->get_query();
 		}
 
-    // This allows for validation on the offset. If your data set needs specific data to determine the offset, you can validate that here.
+		// This allows for validation on the offset. If your data set needs specific data to determine the offset, you can validate that here.
 		public function is_valid_offset( $offset ): bool {
 			return true;
 		}
 
-    // This gives a chance to validate that the Model being resolved is valid.
-    // We're skipping this and always saying the data is valid, but this is a good
-    // place to add some validation before returning data
+		// This gives a chance to validate that the Model being resolved is valid.
+		// We're skipping this and always saying the data is valid, but this is a good
+		// place to add some validation before returning data
 		public function is_valid_model( $model ): bool {
 			return true;
 		}
 
-    // You can implement logic here to determine whether or not to execute.
-    // for example, if the data is private you could set to false if the user is not logged in, etc
+		// You can implement logic here to determine whether or not to execute.
+		// for example, if the data is private you could set to false if the user is not logged in, etc
 		public function should_execute(): bool {
 			return true;
 		}
@@ -518,9 +517,9 @@ In our `register_graphql_connection()` that we already added, let's replace the 
 
 ```php
 'resolve' => function( $root, $args, $context, $info ) {
-	  // we will revisit this shortly
-	  $resolver = new NotificationConnectionResolver( $root, $args, $context, $info );
-    return $resolver->get_connection();
+		// we will revisit this shortly
+		$resolver = new NotificationConnectionResolver( $root, $args, $context, $info );
+		return $resolver->get_connection();
 }
 ```
 
@@ -530,14 +529,14 @@ We can now query the following, and we should see results:
 
 ```graphql
 query GetAllNotifications {
-  notifications {
-    nodes {
-      __typename
-      id
-      message
-      date
-    }
-  }
+	notifications {
+		nodes {
+			__typename
+			id
+			message
+			date
+		}
+	}
 }
 ```
 
@@ -555,11 +554,11 @@ register_graphql_connection([
 	'toType' => 'User',
 	'fromFieldName' => 'user',
 	'oneToOne' => true,
-  'resolve' => function( $root, $args, $context, $info ) {
+	'resolve' => function( $root, $args, $context, $info ) {
 		$resolver = new \WPGraphQL\Data\Connection\UserConnectionResolver( $root, $args, $context, $info );
 		$resolver->set_query_arg( 'include', $root->user_id );
-	  return $resolver->one_to_one()->get_connection();
-  }
+		return $resolver->one_to_one()->get_connection();
+	}
 ]);
 ```
 
@@ -568,14 +567,14 @@ Let's also add a Connection from the User to the Notification:
 ```php
 register_graphql_connection([
 	'fromType' => 'User',
-	'toType' => 'Noticication',
+	'toType' => 'Notification',
 	'fromFieldName' => 'notifications',
 	'oneToOne' => true,
-  'resolve' => function( $root, $args, $context, $info ) {
+	'resolve' => function( $root, $args, $context, $info ) {
 		$resolver = new NotificationConnectionResolver( $root, $args, $context, $info );
 		$resolver->set_query_arg( 'user_id', $root->ID );
-	  return $resolver->one_to_one()->get_connection();
-  }
+		return $resolver->one_to_one()->get_connection();
+	}
 ]);
 ```
 
@@ -583,21 +582,21 @@ Now, all 3 of the queries we set out to have work are working with data from our
 
 ```graphql
 query GetAllNotifications {
-  notifications {
-    nodes {
-      __typename
-      id
-      message
-      date
-      user {
-        node {
-          __typename
-          id
-          name
-        }
-      }
-    }
-  }
+	notifications {
+		nodes {
+			__typename
+			id
+			message
+			date
+			user {
+				node {
+					__typename
+					id
+					name
+				}
+			}
+		}
+	}
 }
 ```
 
@@ -605,18 +604,18 @@ or:
 
 ```graphql
 query GetCurrentUserNotifications {
-  viewer {
-    id
-    name
-    notifications {
-      nodes {
-        __typename
-        id
-        message
-        date
-      }
-    }
-  }
+	viewer {
+		id
+		name
+		notifications {
+			nodes {
+				__typename
+				id
+				message
+				date
+			}
+		}
+	}
 }
 ```
 
@@ -624,14 +623,14 @@ or:
 
 ```graphql
 query GetNotificationNode {
-  node( id: "bm90aWZpY2F0aW9uOjE=" ) {
-    __typename
-    ...on Notification {
-      __typename
-      id
-      message
-      date
-    }
-  }
+	node( id: "bm90aWZpY2F0aW9uOjE=" ) {
+		__typename
+		...on Notification {
+			__typename
+			id
+			message
+			date
+		}
+	}
 }
 ```

--- a/src/AppContext.php
+++ b/src/AppContext.php
@@ -186,8 +186,8 @@ class AppContext {
 		 * @todo Remove this when the loaders are instantiated on demand.
 		 */
 		$loaders = array_map(
-			static function ( $loader_class ) {
-				return new $loader_class();
+			function ( $loader_class ) {
+				return new $loader_class( $this );
 			},
 			$this->loader_classes
 		);

--- a/src/AppContext.php
+++ b/src/AppContext.php
@@ -30,6 +30,24 @@ use WPGraphQL\Data\NodeResolver;
  */
 #[\AllowDynamicProperties]
 class AppContext {
+	/**
+	 * The default loaders for the AppContext.
+	 */
+	public const DEFAULT_LOADERS = [
+		'comment_author'      => CommentAuthorLoader::class,
+		'comment'             => CommentLoader::class,
+		'enqueued_script'     => EnqueuedScriptLoader::class,
+		'enqueued_stylesheet' => EnqueuedStylesheetLoader::class,
+		'plugin'              => PluginLoader::class,
+		'nav_menu_item'       => PostObjectLoader::class,
+		'post'                => PostObjectLoader::class,
+		'post_type'           => PostTypeLoader::class,
+		'taxonomy'            => TaxonomyLoader::class,
+		'term'                => TermObjectLoader::class,
+		'theme'               => ThemeLoader::class,
+		'user'                => UserLoader::class,
+		'user_role'           => UserRoleLoader::class,
+	];
 
 	/**
 	 * Stores the class to use for the connection query.
@@ -74,12 +92,16 @@ class AppContext {
 	/**
 	 * Passes context about the current connection being resolved
 	 *
+	 * @todo These properties and methods are unused. We should consider deprecating/removing them.
+	 *
 	 * @var mixed|string|null
 	 */
 	public $currentConnection = null;
 
 	/**
 	 * Passes context about the current connection
+	 *
+	 * @todo These properties and methods are unused. We should consider deprecating/removing them.
 	 *
 	 * @var array<string,mixed>
 	 */
@@ -89,6 +111,14 @@ class AppContext {
 	 * Stores the loaders for the class
 	 *
 	 * @var array<string,\WPGraphQL\Data\Loader\AbstractDataLoader>
+	 *
+	 * phpcs:disable SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameInAnnotation, -- For phpstan type hinting
+	 *
+	 * @template T of key-of<self::DEFAULT_LOADERS>
+	 *
+	 * @phpstan-var array<T, new<self::DEFAULT_LOADERS[T]>>|array<string,\WPGraphQL\Data\Loader\AbstractDataLoader>
+	 *
+	 * phpcs:enable
 	 */
 	public $loaders = [];
 
@@ -100,38 +130,19 @@ class AppContext {
 	public $node_resolver;
 
 	/**
+	 * The loader classes, before they are instantiated.
+	 *
+	 * @var array<string,class-string<\WPGraphQL\Data\Loader\AbstractDataLoader>>
+	 */
+	private $loader_classes = self::DEFAULT_LOADERS;
+
+	/**
 	 * AppContext constructor.
 	 */
 	public function __construct() {
 
-		/**
-		 * Create a list of loaders to be available in AppContext
-		 */
-		$loaders = [
-			'comment_author'      => new CommentAuthorLoader( $this ),
-			'comment'             => new CommentLoader( $this ),
-			'enqueued_script'     => new EnqueuedScriptLoader( $this ),
-			'enqueued_stylesheet' => new EnqueuedStylesheetLoader( $this ),
-			'plugin'              => new PluginLoader( $this ),
-			'nav_menu_item'       => new PostObjectLoader( $this ),
-			'post'                => new PostObjectLoader( $this ),
-			'post_type'           => new PostTypeLoader( $this ),
-			'taxonomy'            => new TaxonomyLoader( $this ),
-			'term'                => new TermObjectLoader( $this ),
-			'theme'               => new ThemeLoader( $this ),
-			'user'                => new UserLoader( $this ),
-			'user_role'           => new UserRoleLoader( $this ),
-		];
-
-		/**
-		 * This filters the data loaders, allowing for additional loaders to be
-		 * added to the AppContext or for existing loaders to be replaced if
-		 * needed.
-		 *
-		 * @param array<string,\WPGraphQL\Data\Loader\AbstractDataLoader> $loaders The loaders accessible in the AppContext
-		 * @param \WPGraphQL\AppContext                                   $context The AppContext
-		 */
-		$this->loaders = apply_filters( 'graphql_data_loaders', $loaders, $this );
+		// Prime the loader classes (and their instances) for the AppContext.
+		$this->prepare_data_loaders();
 
 		/**
 		 * This sets up the NodeResolver to allow nodes to be resolved by URI
@@ -147,6 +158,54 @@ class AppContext {
 		 * @param mixed[] $config The config array of the AppContext object
 		 */
 		$this->config = apply_filters( 'graphql_app_context_config', $this->config );
+	}
+
+	/**
+	 * Prepares the data loaders for the AppContext.
+	 *
+	 * This method instantiates the loader classes and prepares them for use in the AppContext.
+	 * It also applies filters to allow customization of the loader classes.
+	 *
+	 * @uses graphql_data_loader_classes filter.
+	 * @uses graphql_data_loaders filter (deprecated).
+	 */
+	private function prepare_data_loaders(): void {
+		/**
+		 * Filter to change the data loader classes.
+		 *
+		 * This allows for additional loaders to be added to the AppContext or replaced as needed.
+		 *
+		 * @param array<string,class-string<\WPGraphQL\Data\Loader\AbstractDataLoader>> $loader_classes The loader classes accessible in the AppContext
+		 * @param \WPGraphQL\AppContext                                                $context        The AppContext
+		 */
+		$this->loader_classes = apply_filters( 'graphql_data_loader_classes', $this->loader_classes, $this );
+
+		/**
+		 * Prime the loaders.
+		 *
+		 * @todo Remove this when the loaders are instantiated on demand.
+		 */
+		$loaders = array_map(
+			static function ( $loader_class ) {
+				return new $loader_class();
+			},
+			$this->loader_classes
+		);
+
+		/**
+		 * @deprecated next-version in favor of graphql_data_loader_classes.
+		 * @todo Remove in a future version.
+		 *
+		 * @param array<string,\WPGraphQL\Data\Loader\AbstractDataLoader> $loaders The loaders accessible in the AppContext
+		 * @param \WPGraphQL\AppContext                                   $context The AppContext
+		 */
+		$this->loaders = apply_filters_deprecated(
+			'graphql_data_loaders',
+			[ $loaders, $this ],
+			'@next-version',
+			'graphql_data_loader_classes',
+			esc_html__( 'The graphql_data_loaders filter is deprecated and will be removed in a future version. Instead, use the graphql_data_loader_classes filter to add/change data loader classes before they are instantiated.', 'wp-graphql' ),
+		);
 	}
 
 	/**
@@ -166,10 +225,14 @@ class AppContext {
 	/**
 	 * Retrieves loader assigned to $key
 	 *
-	 * @param string $key The name of the loader to get
+	 * @template T of key-of<self::DEFAULT_LOADERS>
+	 *
+	 * @param T|string $key The name of the loader to get.
 	 *
 	 * @return \WPGraphQL\Data\Loader\AbstractDataLoader
 	 * @throws \GraphQL\Error\UserError If the loader is not found.
+	 *
+	 * @phpstan-return ( $key is T ? new<self::DEFAULT_LOADERS[T]> : \WPGraphQL\Data\Loader\AbstractDataLoader )
 	 */
 	public function get_loader( $key ) {
 		if ( ! array_key_exists( $key, $this->loaders ) ) {
@@ -194,6 +257,8 @@ class AppContext {
 	/**
 	 * Returns the $args for the connection the field is a part of
 	 *
+	 * @todo These properties and methods are unused. We should consider deprecating/removing them.
+	 *
 	 * @return mixed[]|mixed
 	 */
 	public function get_connection_args() {
@@ -202,6 +267,8 @@ class AppContext {
 
 	/**
 	 * Returns the current connection
+	 *
+	 * @todo These properties and methods are unused. We should consider deprecating/removing them.
 	 *
 	 * @return mixed|string|null
 	 */

--- a/src/AppContext.php
+++ b/src/AppContext.php
@@ -276,7 +276,8 @@ class AppContext {
 			'@next-version' // phpcs:ignore PHPCS.Functions.VersionParameter.OldVersionPlaceholder -- @todo Fix this smell.
 		);
 
-		return $this->get_loader( $key );
+		// Return the actual loaders array.
+		return $this->loaders;
 	}
 
 	/**

--- a/src/AppContext.php
+++ b/src/AppContext.php
@@ -33,7 +33,7 @@ class AppContext {
 	/**
 	 * The default loaders for the AppContext.
 	 */
-	public const DEFAULT_LOADERS = [
+	private const DEFAULT_LOADERS = [
 		'comment_author'      => CommentAuthorLoader::class,
 		'comment'             => CommentLoader::class,
 		'enqueued_script'     => EnqueuedScriptLoader::class,

--- a/src/Data/Cursor/AbstractCursor.php
+++ b/src/Data/Cursor/AbstractCursor.php
@@ -149,7 +149,7 @@ abstract class AbstractCursor {
 	 * Validates cursor compare field configuration. Validation failure results in a fatal
 	 * error because query execution is guaranteed to fail.
 	 *
-	 * @param array<string,mixed>|mixed $field  Threshold configuration.
+	 * @param array<string,mixed> $field Threshold configuration.
 	 *
 	 * @throws \GraphQL\Error\InvariantViolation Invalid configuration format.
 	 */


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

## What does this implement/fix? Explain your changes.

This PR refactors `AppContext` in the following ways:

1. Only instantiate DataLoaders when they're used instead of instantiating _all_ of them):
  - Deprecates the `graphql_data_loaders` filter in favor of the new `graphql_data_loader_classes` filter. (so you can replace the loader _before_ it's instantiated
  - Accessing `AppContext::$loaders` has been deprecated, in lieu of changing the property's visibility to `protected`/`private` in a future breaking release.
 
2. Updates the PHPStan typehinting for `::get_loader()` to correctly type-hint the loader instance for the given key.
   E.g. Previously, this would have thrown a PHPStan error that `::get_public_users()` doesn't exist on `AbstractDataLoader`
   ```php
     $users = $context->get_loader( 'user' )->get_public_users( [ ] );
     ````
     
This is a _nonbreaking_ change. Users still relying on `graphql_data_loaders` will have all their `AppContext::$loaders` pre-instantiated as before.

## Does this close any currently open issues?

<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Any other comments?

- This PR should open the way for type hinting/inference for Connection Resolvers, deferred Models, etc.

<!-- Please add any additional context that would be helpful. Feel free to include screenshots of the GraphiQL IDE or other relevant screenshotes, logs, error output, etc -->
