### PR TITLE
refactor: cleanup `Model` class to reduce complexity and improve type safety

### DIFF
--- a/src/Data/Loader/AbstractDataLoader.php
+++ b/src/Data/Loader/AbstractDataLoader.php
@@ -12,6 +12,9 @@ use WPGraphQL\Model\Model;
  * Class AbstractDataLoader
  *
  * @package WPGraphQL\Data\Loader
+ *
+ * @todo Replace this type with a generic.
+ * @phpstan-type TModel \WPGraphQL\Model\Model<mixed>
  */
 abstract class AbstractDataLoader {
 
@@ -113,7 +116,7 @@ abstract class AbstractDataLoader {
 	 *
 	 * @param int|string|mixed $key
 	 *
-	 * @return ?\WPGraphQL\Model\Model
+	 * @return ?TModel
 	 * @throws \Exception
 	 */
 	public function load( $key ) {
@@ -371,7 +374,7 @@ abstract class AbstractDataLoader {
 	 * @param mixed $entry The entry loaded from the dataloader to be used to generate a Model
 	 * @param mixed $key   The Key used to identify the loaded entry
 	 *
-	 * @return \WPGraphQL\Model\Model|null
+	 * @return TModel|null
 	 */
 	protected function normalize_entry( $entry, $key ) {
 
@@ -484,7 +487,7 @@ abstract class AbstractDataLoader {
 	 * @param mixed $entry The entry data to be used to generate a Model.
 	 * @param mixed $key   The Key to identify the entry by.
 	 *
-	 * @return ?\WPGraphQL\Model\Model
+	 * @return ?TModel
 	 */
 	protected function get_model( $entry, $key ) {
 		return $entry;

--- a/src/Model/Avatar.php
+++ b/src/Model/Avatar.php
@@ -17,16 +17,10 @@ namespace WPGraphQL\Model;
  * @property ?int    $width
  *
  * @package WPGraphQL\Model
+ *
+ * @extends \WPGraphQL\Model\Model<array<string,mixed>>
  */
 class Avatar extends Model {
-
-	/**
-	 * Stores the incoming avatar to be modeled
-	 *
-	 * @var array<string,mixed>
-	 */
-	protected $data;
-
 	/**
 	 * Avatar constructor.
 	 *

--- a/src/Model/Comment.php
+++ b/src/Model/Comment.php
@@ -35,16 +35,10 @@ use WP_Comment;
  * @property int     $comment_parent_id
  *
  * @package WPGraphQL\Model
+ *
+ * @extends \WPGraphQL\Model\Model<\WP_Comment>
  */
 class Comment extends Model {
-
-	/**
-	 * Stores the incoming WP_Comment object to be modeled
-	 *
-	 * @var \WP_Comment $data
-	 */
-	protected $data;
-
 	/**
 	 * Comment constructor.
 	 *

--- a/src/Model/CommentAuthor.php
+++ b/src/Model/CommentAuthor.php
@@ -15,16 +15,10 @@ use WP_Comment;
  * @property ?string $url
  *
  * @package WPGraphQL\Model
+ *
+ * @extends \WPGraphQL\Model\Model<\WP_Comment>
  */
 class CommentAuthor extends Model {
-
-	/**
-	 * Stores the comment author to be modeled
-	 *
-	 * @var \WP_Comment $data The raw data passed to he model
-	 */
-	protected $data;
-
 	/**
 	 * CommentAuthor constructor.
 	 *

--- a/src/Model/Menu.php
+++ b/src/Model/Menu.php
@@ -15,16 +15,10 @@ use GraphQLRelay\Relay;
  * @property ?string       $slug
  *
  * @package WPGraphQL\Model
+ *
+ * @extends \WPGraphQL\Model\Model<\WP_Term>
  */
 class Menu extends Model {
-
-	/**
-	 * Stores the incoming WP_Term object
-	 *
-	 * @var \WP_Term $data
-	 */
-	protected $data;
-
 	/**
 	 * Menu constructor.
 	 *

--- a/src/Model/MenuItem.php
+++ b/src/Model/MenuItem.php
@@ -28,16 +28,10 @@ use WP_Post;
  * @property ?string       $url
  *
  * @package WPGraphQL\Model
+ *
+ * @extends \WPGraphQL\Model\Model<object|mixed>
  */
 class MenuItem extends Model {
-
-	/**
-	 * Stores the incoming post data
-	 *
-	 * @var mixed|object $data
-	 */
-	protected $data;
-
 	/**
 	 * MenuItem constructor.
 	 *

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -177,9 +177,9 @@ abstract class Model {
 	 * @return string
 	 */
 	protected function get_model_name() {
-		$name = static::class;
-
 		if ( empty( $this->model_name ) ) {
+			$name = static::class;
+
 			if ( false !== strpos( static::class, '\\' ) ) {
 				$starting_character = strrchr( static::class, '\\' );
 				if ( ! empty( $starting_character ) ) {
@@ -189,7 +189,7 @@ abstract class Model {
 			$this->model_name = $name . 'Object';
 		}
 
-		return ! empty( $this->model_name ) ? $this->model_name : $name;
+		return $this->model_name;
 	}
 
 	/**

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -11,7 +11,7 @@ use Exception;
  * @property bool $isPublic
  * @property bool $isRestricted
  *
- * @package WPGraphQL\Model
+ * @template TData
  */
 abstract class Model {
 
@@ -25,7 +25,7 @@ abstract class Model {
 	/**
 	 * Stores the raw data passed to the child class when it's instantiated before it's transformed
 	 *
-	 * @var mixed[]|object|mixed
+	 * @var TData
 	 */
 	protected $data;
 
@@ -161,7 +161,7 @@ abstract class Model {
 	}
 
 	/**
-	 * Setup the global data for the model to have proper context when resolving.
+	 * Setup the global state before each field is resolved so the Model has the necessary context.
 	 *
 	 * @return void
 	 */
@@ -169,8 +169,9 @@ abstract class Model {
 	}
 
 	/**
-	 * Generic model tear down after the fields are setup. This can be used
-	 * to reset state to where it was before the model was setup.
+	 * Tear-down call that runs after each field is resolved.
+	 *
+	 * This can be used to reset state to where it was before the model was setup.
 	 *
 	 * @return void
 	 */
@@ -211,7 +212,7 @@ abstract class Model {
 			 *
 			 * @param string      $restricted_cap The capability to check against
 			 * @param string      $model_name     Name of the model the filter is currently being executed in
-			 * @param mixed       $data           The un-modeled incoming data
+			 * @param TData       $data           The un-modeled incoming data
 			 * @param string|null $visibility     The visibility that has currently been set for the data at this point
 			 * @param int|null    $owner          The user ID for the owner of this piece of data
 			 * @param \WP_User $current_user The current user for the session
@@ -226,7 +227,7 @@ abstract class Model {
 			 *
 			 * @param ?bool       $is_private   Whether the model data is private. Defaults to null.
 			 * @param string      $model_name   Name of the model the filter is currently being executed in
-			 * @param mixed       $data         The un-modeled incoming data
+			 * @param TData       $data         The un-modeled incoming data
 			 * @param string|null $visibility   The visibility that has currently been set for the data at this point
 			 * @param int|null    $owner        The user ID for the owner of this piece of data
 			 * @param \WP_User $current_user The current user for the session
@@ -246,12 +247,12 @@ abstract class Model {
 			/**
 			 * Filter to determine if the data should be considered private or not
 			 *
-			 * @param bool     $is_private   Whether the model is private
+			 * @param bool        $is_private   Whether the model is private
 			 * @param string      $model_name   Name of the model the filter is currently being executed in
-			 * @param mixed       $data         The un-modeled incoming data
+			 * @param TData       $data         The un-modeled incoming data
 			 * @param string|null $visibility   The visibility that has currently been set for the data at this point
 			 * @param int|null    $owner        The user ID for the owner of this piece of data
-			 * @param \WP_User $current_user The current user for the session
+			 * @param \WP_User    $current_user The current user for the session
 			 *
 			 * @return bool
 			 */
@@ -273,9 +274,9 @@ abstract class Model {
 		 *
 		 * @param string|null $visibility   The visibility that has currently been set for the data at this point
 		 * @param string      $model_name   Name of the model the filter is currently being executed in
-		 * @param mixed       $data         The un-modeled incoming data
+		 * @param TData       $data         The un-modeled incoming data
 		 * @param int|null    $owner        The user ID for the owner of this piece of data
-		 * @param \WP_User $current_user The current user for the session
+		 * @param \WP_User    $current_user The current user for the session
 		 *
 		 * @return string
 		 */
@@ -319,10 +320,10 @@ abstract class Model {
 			 *
 			 * @param string[]    $allowed_restricted_fields The fields to allow when the data is designated as restricted to the current user
 			 * @param string      $model_name                Name of the model the filter is currently being executed in
-			 * @param mixed       $data                      The un-modeled incoming data
+			 * @param TData       $data                      The un-modeled incoming data
 			 * @param string|null $visibility                The visibility that has currently been set for the data at this point
 			 * @param int|null    $owner                     The user ID for the owner of this piece of data
-			 * @param \WP_User $current_user The current user for the session
+			 * @param \WP_User    $current_user The current user for the session
 			 */
 				apply_filters( 'graphql_allowed_fields_on_restricted_type', $this->allowed_restricted_fields, $this->get_model_name(), $this->data, $this->visibility, $this->owner, $this->current_user )
 			)
@@ -351,7 +352,7 @@ abstract class Model {
 				 * @param mixed    $result       The data returned from the callback. Null by default.
 				 * @param string   $key          The name of the field on the type
 				 * @param string   $model_name   Name of the model the filter is currently being executed in
-				 * @param mixed    $data         The un-modeled incoming data
+				 * @param TData    $data         The un-modeled incoming data
 				 * @param string   $visibility   The visibility setting for this piece of data
 				 * @param int|null $owner        The user ID for the owner of this piece of data
 				 * @param \WP_User $current_user The current user for the session
@@ -362,7 +363,7 @@ abstract class Model {
 					// If the pre filter returns a value, we use that instead of the callback.
 					$result = $pre;
 				} else {
-					$result = $this->prepare_field( $key );
+					$result = $this->prepare_field( $key, $this->fields[ $key ] );
 				}
 
 				/**
@@ -371,7 +372,7 @@ abstract class Model {
 				 * @param mixed    $result       The returned data for the field
 				 * @param string   $key          The name of the field on the type
 				 * @param string   $model_name   Name of the model the filter is currently being executed in
-				 * @param mixed    $data         The un-modeled incoming data
+				 * @param TData    $data         The un-modeled incoming data
 				 * @param string   $visibility   The visibility setting for this piece of data
 				 * @param int|null $owner        The user ID for the owner of this piece of data
 				 * @param \WP_User $current_user The current user for the session
@@ -412,7 +413,7 @@ abstract class Model {
 		 * @param mixed    $field        The data returned from the callback
 		 * @param string   $field_name   The name of the field on the type
 		 * @param string   $model_name   Name of the model the filter is currently being executed in
-		 * @param mixed    $data         The un-modeled incoming data
+		 * @param TData    $data         The un-modeled incoming data
 		 * @param string   $visibility   The visibility setting for this piece of data
 		 * @param int|null $owner        The user ID for the owner of this piece of data
 		 * @param \WP_User $current_user The current user for the session
@@ -439,7 +440,7 @@ abstract class Model {
 		 * @param string   $capability   The capability to check against to return the field
 		 * @param string   $field_name   The name of the field on the type
 		 * @param string   $model_name   Name of the model the filter is currently being executed in
-		 * @param mixed    $data         The un-modeled incoming data
+		 * @param TData    $data         The un-modeled incoming data
 		 * @param string   $visibility   The visibility setting for this piece of data
 		 * @param int|null $owner        The user ID for the owner of this piece of data
 		 * @param \WP_User $current_user The current user for the session
@@ -501,7 +502,7 @@ abstract class Model {
 		 *
 		 * @param array<string,mixed>    $fields       The array of fields for the model
 		 * @param string                 $model_name   Name of the model the filter is currently being executed in
-		 * @param mixed                  $data         The un-modeled incoming data
+		 * @param TData                  $data         The un-modeled incoming data
 		 * @param string                 $visibility   The visibility setting for this piece of data
 		 * @param ?int                   $owner        The user ID for the owner of this piece of data
 		 * @param \WP_User               $current_user The current user for the session

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -138,26 +138,19 @@ abstract class Model {
 	 * @return mixed|null
 	 */
 	public function __get( $key ) {
-		if ( isset( $this->fields[ $key ] ) ) {
-			/**
-			 * If the property has already been processed and cached to the model
-			 * return the processed value.
-			 *
-			 * Otherwise, if it's a callable, process it and cache the value.
-			 */
-			if ( is_scalar( $this->fields[ $key ] ) || ( is_object( $this->fields[ $key ] ) && ! is_callable( $this->fields[ $key ] ) ) || is_array( $this->fields[ $key ] ) ) {
-				return $this->fields[ $key ];
-			} elseif ( is_callable( $this->fields[ $key ] ) ) {
-				$data       = call_user_func( $this->fields[ $key ] );
-				$this->$key = $data;
-
-				return $data;
-			} else {
-				return $this->fields[ $key ];
-			}
-		} else {
+		if ( ! array_key_exists( $key, $this->fields ) ) {
 			return null;
 		}
+
+		// If the property is a callable, we need to process it.
+		if ( is_callable( $this->fields[ $key ] ) ) {
+			$data       = call_user_func( $this->fields[ $key ] );
+			$this->$key = $data;
+
+			return $data;
+		}
+
+		return $this->fields[ $key ];
 	}
 
 	/**

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -389,15 +389,15 @@ abstract class Model {
 	 * Prepares an individual field for the model.
 	 *
 	 * @param string $field_name The name of the field on the type
+	 * @param mixed  $field      The field data to prepare.
 	 *
 	 * @return mixed
 	 */
-	private function prepare_field( string $field_name ) {
-		$field = null;
+	private function prepare_field( string $field_name, $field ) {
 
 		// If the user doesn't have access to the field, sanitize it to null.
-		if ( $this->current_user_can_access_field( $field_name ) ) {
-			$field = $this->fields[ $field_name ];
+		if ( ! $this->current_user_can_access_field( $field_name ) ) {
+			$field = null;
 		}
 
 		if ( is_callable( $field ) ) {
@@ -416,8 +416,6 @@ abstract class Model {
 		 * @param string   $visibility   The visibility setting for this piece of data
 		 * @param int|null $owner        The user ID for the owner of this piece of data
 		 * @param \WP_User $current_user The current user for the session
-		 *
-		 * @phpstan-param T $field
 		 */
 		return apply_filters( 'graphql_return_field_from_model', $field, $field_name, $this->get_model_name(), $this->data, $this->visibility, $this->owner, $this->current_user );
 	}

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -383,9 +383,9 @@ abstract class Model {
 	 * Prepares an individual field for the model.
 	 *
 	 * @param string $field_name The name of the field on the type
-	 * @param mixed  $field      The field data to prepare.
+	 * @param TData  $field      The field data to prepare.
 	 *
-	 * @return mixed
+	 * @return TData
 	 */
 	private function prepare_field( string $field_name, $field ) {
 		$can_access_field = $this->current_user_can_access_field( $field_name, $field );

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -395,7 +395,10 @@ abstract class Model {
 	 * @return mixed
 	 */
 	private function prepare_field( string $field_name, $field ) {
-
+		// If the field is an array with a 'callback', use that as the callback.
+		if ( is_array( $field ) && ! empty( $field['callback'] ) ) {
+			$field = $field['callback'];
+		}
 		// If the user doesn't have access to the field, sanitize it to null.
 		if ( ! $this->current_user_can_access_field( $field_name ) ) {
 			$field = null;

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -342,7 +342,7 @@ abstract class Model {
 
 		$clean_array = [];
 		foreach ( $this->fields as $key => $data ) {
-			$clean_array[ $key ] = function () use ( $key ) {
+			$clean_array[ $key ] = function () use ( $key, $data ) {
 				/**
 				 * Filter to short circuit the callback for any field on a type.
 				 *
@@ -363,7 +363,7 @@ abstract class Model {
 					// If the pre filter returns a value, we use that instead of the callback.
 					$result = $pre;
 				} else {
-					$result = $this->prepare_field( $key, $this->fields[ $key ] );
+					$result = $this->prepare_field( $key, $data );
 				}
 
 				/**

--- a/src/Model/Plugin.php
+++ b/src/Model/Plugin.php
@@ -17,16 +17,10 @@ use GraphQLRelay\Relay;
  * @property ?string $version
  *
  * @package WPGraphQL\Model
+ *
+ * @extends \WPGraphQL\Model\Model<array<string,mixed>>
  */
 class Plugin extends Model {
-
-	/**
-	 * Stores the incoming plugin data to be modeled
-	 *
-	 * @var array<string,mixed> $data
-	 */
-	protected $data;
-
 	/**
 	 * Plugin constructor.
 	 *

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -78,16 +78,10 @@ use WP_Post;
  * @property ?int    $ID
  * @property ?int    $post_author
  * @property ?string $post_status
+ *
+ * @extends \WPGraphQL\Model\Model<\WP_Post>
  */
 class Post extends Model {
-
-	/**
-	 * Stores the incoming post data
-	 *
-	 * @var \WP_Post $data
-	 */
-	protected $data;
-
 	/**
 	 * Store the global post to reset during model tear down
 	 *

--- a/src/Model/PostType.php
+++ b/src/Model/PostType.php
@@ -37,16 +37,10 @@ use GraphQLRelay\Relay;
  * @property ?string       $graphql_single_name
  *
  * @package WPGraphQL\Model
+ *
+ * @extends \WPGraphQL\Model\Model<\WP_Post_Type>
  */
 class PostType extends Model {
-
-	/**
-	 * Stores the incoming WP_Post_Type to be modeled
-	 *
-	 * @var \WP_Post_Type $data
-	 */
-	protected $data;
-
 	/**
 	 * PostType constructor.
 	 *

--- a/src/Model/Taxonomy.php
+++ b/src/Model/Taxonomy.php
@@ -32,16 +32,10 @@ use GraphQLRelay\Relay;
  * @property ?string       $graphql_single_name
  *
  * @package WPGraphQL\Model
+ *
+ * @extends \WPGraphQL\Model\Model<\WP_Taxonomy>
  */
 class Taxonomy extends Model {
-
-	/**
-	 * Stores the incoming WP_Taxonomy object to be modeled
-	 *
-	 * @var \WP_Taxonomy $data
-	 */
-	protected $data;
-
 	/**
 	 * Taxonomy constructor.
 	 *

--- a/src/Model/Term.php
+++ b/src/Model/Term.php
@@ -26,16 +26,10 @@ use WP_Term;
  * @property ?int     $term_id
  *
  * @package WPGraphQL\Model
+ *
+ * @extends \WPGraphQL\Model\Model<\WP_Term>
  */
 class Term extends Model {
-
-	/**
-	 * Stores the incoming WP_Term object
-	 *
-	 * @var \WP_Term $data
-	 */
-	protected $data;
-
 	/**
 	 * Stores the taxonomy object for the term being modeled
 	 *

--- a/src/Model/Theme.php
+++ b/src/Model/Theme.php
@@ -19,16 +19,10 @@ use GraphQLRelay\Relay;
  * @property ?string       $version
  *
  * @package WPGraphQL\Model
+ *
+ * @extends \WPGraphQL\Model\Model<\WP_Theme>
  */
 class Theme extends Model {
-
-	/**
-	 * Stores the incoming WP_Theme to be modeled
-	 *
-	 * @var \WP_Theme $data
-	 */
-	protected $data;
-
 	/**
 	 * Theme constructor.
 	 *

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -31,16 +31,10 @@ use WP_User;
  * @property ?string       $username
  *
  * @package WPGraphQL\Model
+ *
+ * @extends \WPGraphQL\Model\Model<\WP_User>
  */
 class User extends Model {
-
-	/**
-	 * Stores the WP_User object for the incoming data
-	 *
-	 * @var \WP_User $data
-	 */
-	protected $data;
-
 	/**
 	 * The Global Post at time of Model generation
 	 *

--- a/src/Model/UserRole.php
+++ b/src/Model/UserRole.php
@@ -13,16 +13,10 @@ use GraphQLRelay\Relay;
  * @property ?string   $name
  *
  * @package WPGraphQL\Model
+ *
+ * @extends \WPGraphQL\Model\Model<array<string,mixed>>
  */
 class UserRole extends Model {
-
-	/**
-	 * Stores the incoming user role to be modeled
-	 *
-	 * @var array<string,mixed> $data
-	 */
-	protected $data;
-
 	/**
 	 * UserRole constructor.
 	 *


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our master*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

-->

## What does this implement/fix? Explain your changes.

This PR refactors the `Model` class to reduce code complexity and improve maintainability and DX. More specifically:

- `Model::$data` is now typed via a Generic type, instead of needlessly type-hinting in child classes.
   As a result, many doc types have been updated to use that generic instead of `mixed` or a lower-fidelity type.

- Splits the `wrap_fields()` method into several smaller functions (Single Responsibilities principle)

- **Fixes** the `graphql_model_field_capability` filter, so it runs on _all_ fields, not just those that are registered with a `capability` property. 
   This allows the filter to be used to add capability checks to existing fields, and not just to modify preset capabilities.

- Clarifies usage of various functions, specifically that `setup()` and `tear_down()` functions apply _per field_.

Files that rely on the `Model` class have been cleaned up accordingly.

### Developers Note

To correctly type the `TData` generic used by the `Model`, you can use the `@extends` syntax on the class doc-block:

For example if you are modeling data sourced from a custom `WP_Post` object:
```php
{...}

use \WPGraphQL\Model\Model;

/**
 * {other class-docblock meta}
 *
 * @extends \WPGraphQL\Model\Model<\WP_Post>
 */
class EventCptModel extends Model { ... }
```

## Does this close any currently open issues?

<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Any other comments?

<!-- Please add any additional context that would be helpful. Feel free to include screenshots of the GraphiQL IDE or other relevant screenshotes, logs, error output, etc -->
- `AbstractDataLoader` is using a `@phpstan-type` to centrally suppress the generic warning. In the future we can just swap that out with a `@template` or `@extends` without disrupting the rest of the file again.