### PR TITLE
Disable SSL requirement for mariadb when running tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       MYSQL_DATABASE:      wordpress
       MYSQL_USER:          wordpress
       MYSQL_PASSWORD:      wordpress
+    command: --ssl=0 --require-secure-transport=OFF
     ports:
       - '3306'
     networks:


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

Some tests are failing (https://github.com/wp-graphql/wp-graphql/actions/runs/17052839494) and from what I can tell it has to do with MariaDB requiring SSL which might not be available/configured in the test environment. 

Trying to add this command to prevent MariaDB from requiring SSL when it might not be available in the env.

