### PR TITLE
fix: Prevent bad string injection in plugin update message (#3318)

### DIFF
--- a/src/Admin/Updates/PluginsScreenLoader.php
+++ b/src/Admin/Updates/PluginsScreenLoader.php
@@ -54,12 +54,10 @@ class PluginsScreenLoader {
 			$update_message .= $this->update_checker->get_untested_plugins_modal( $untested_plugins );
 		}
 
-		// Handle dangling <p> tags from the default update message.
-		$update_message = sprintf( '</p>%s<p class="hidden">', $update_message );
-
 		// Output the JS for the modal.
 		add_action( 'admin_print_footer_scripts', [ $this, 'modal_js' ] );
 
+		// Output the update message directly, without forced paragraph wrapping, to avoid duplicate or broken HTML.
 		echo wp_kses_post( $update_message );
 	}
 


### PR DESCRIPTION
**This PR fixes issue #3318: Bad string injection of plugin update message.**

The update message for WPGraphQL in the WordPress admin was previously injected in a way that could cause duplicate or broken messages (e.g., the word "Updated" appearing multiple times).
The fix removes forced paragraph wrapping and ensures the update message is injected cleanly, without duplication or broken HTML.

**Does this close any currently open issues?**
Closes #3318

**Any other comments?**
I tested by lowering the plugin version in [wp-graphql.php] to simulate an update, copying the plugin to the WordPress plugins directory, and viewing the update message in the WordPress admin Plugins list.
The update message now displays correctly, with no duplication or broken formatting.

**Please see the attached screenshot for proof of the fix**

<img width="1119" height="163" alt="plugin fix" src="https://github.com/user-attachments/assets/99704a31-68d7-4d12-aadb-3bf5b71af888" />

