### PR TITLE
fix: git updater compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -547,11 +547,23 @@ jobs:
         run: |
           composer run-script zip
 
+      - name: Create GitHub Updater compatible artifact
+        run: |
+          # Create a copy of the zip file with GitHub Updater naming convention ($repo-$tag.zip)
+          cp plugin-build/wp-graphql.zip plugin-build/wp-graphql-${{ steps.get_version_info.outputs.tag_name }}.zip
+          echo "Created GitHub Updater compatible artifact: wp-graphql-${{ steps.get_version_info.outputs.tag_name }}.zip"
+
       - name: Upload artifact to workflow
         uses: actions/upload-artifact@v4
         with:
           name: wp-graphql
           path: plugin-build/wp-graphql.zip
+
+      - name: Upload GitHub Updater artifact to workflow
+        uses: actions/upload-artifact@v4
+        with:
+          name: wp-graphql-github-updater-${{ steps.get_version_info.outputs.tag_name }}
+          path: plugin-build/wp-graphql-${{ steps.get_version_info.outputs.tag_name }}.zip
 
       - name: Upload artifact to release
         # Only upload to release if we're not doing a manual deploy
@@ -560,6 +572,8 @@ jobs:
         with:
           # Use the correct tag name (e.g., v2.3.0)
           tag_name: ${{ steps.get_version_info.outputs.tag_name }}
-          files: plugin-build/wp-graphql.zip
+          files: |
+            plugin-build/wp-graphql.zip
+            plugin-build/wp-graphql-${{ steps.get_version_info.outputs.tag_name }}.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/wp-graphql.php
+++ b/wp-graphql.php
@@ -3,6 +3,7 @@
  * Plugin Name: WPGraphQL
  * Plugin URI: https://github.com/wp-graphql/wp-graphql
  * GitHub Plugin URI: https://github.com/wp-graphql/wp-graphql
+ * Release Asset: true
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

This updates the plugin to be compatible with Git Updater by setting `Release Asset: true` header and updating the release workflow to upload an asset named `$repo-$tag.zip` following the docs here: https://git-updater.com/knowledge-base/required-headers/

## Does this close any currently open issues?

closes #3418 