### PR TITLE
chore: remove Git Updater headers

### DIFF
--- a/plugins/wp-graphql/wp-graphql.php
+++ b/plugins/wp-graphql/wp-graphql.php
@@ -2,8 +2,6 @@
 /**
  * Plugin Name: WPGraphQL
  * Plugin URI: https://github.com/wp-graphql/wp-graphql
- * GitHub Plugin URI: https://github.com/wp-graphql/wp-graphql
- * Release Asset: true
  * Description: GraphQL API for WordPress
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com


### PR DESCRIPTION
## Summary

Removes the `GitHub Plugin URI` and `Release Asset` headers from `wp-graphql.php`.

## Why?

Git Updater does not support monorepo structures with multiple independently-released plugins. After consulting with the Git Updater maintainer, we've confirmed this limitation.

**Reference:** https://github.com/afragen/git-updater/issues/1131

## Impact

Users who relied on Git Updater for WPGraphQL updates will need to migrate to:
- **WordPress.org** (recommended for most users)
- **Composer via wpackagist**: `composer require wpackagist-plugin/wp-graphql`
- **Manual download** from GitHub Releases

Standard WordPress.org, Composer, and zip file installations are unaffected.