### PR TITLE
chore: rename default branch from master to main

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -21,7 +21,7 @@ When contributing please ensure you follow the guidelines below so that we can k
   * Ensure you stick to the [WordPress Coding Standards](https://codex.wordpress.org/WordPress_Coding_Standards)
 * When committing, reference your issue (if present) and include a note about the fix
 * If possible, and if applicable, please also add/update unit tests for your changes
-* Push the changes to your fork and submit a pull request to the 'develop' branch of this repository
+* Push the changes to your fork and submit a pull request to the `main` branch of this repository
 
 ## Code Documentation
 
@@ -63,4 +63,4 @@ There are 4 Github Project Boards for the WPGraphQL organization:
     - If an issue couldn't be completed for whatever, but still needs to be, it should be moved out of the "In Progress" column and back into the top of "Prioritized" column.
 
   
-> **NOTE:** This CONTRIBUTING.md file was forked from [Easy Digital Downloads](https://github.com/easydigitaldownloads/easy-digital-downloads/blob/master/CONTRIBUTING.md)
+> **NOTE:** This CONTRIBUTING.md file was forked from [Easy Digital Downloads](https://github.com/easydigitaldownloads/easy-digital-downloads/blob/main/CONTRIBUTING.md)

--- a/.github/ISSUE_TEMPLATE/experiment_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/experiment_proposal.yml
@@ -6,7 +6,7 @@ body:
       value: >-
         Thank you for proposing an experiment for WPGraphQL core!
 
-        Before submitting your proposal, please review the [Contributing Experiments Guide](https://github.com/wp-graphql/wp-graphql/blob/master/plugins/wp-graphql/docs/experiments-contributing.md) to understand the process and requirements.
+        Before submitting your proposal, please review the [Contributing Experiments Guide](https://github.com/wp-graphql/wp-graphql/blob/main/plugins/wp-graphql/docs/experiments-contributing.md) to understand the process and requirements.
 
         **Important**: Experiments are for proposed core features that need real-world validation. They are not suitable for plugin-specific features, bug fixes, or minor enhancements.
 

--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -1,10 +1,10 @@
 <!--
-🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/master/docs/CONTRIBUTING.md
+🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/main/docs/CONTRIBUTING.md
 
 ### Your checklist for this bugfix pull request
 - [ ] Make sure your PR title follows Conventional Commit standards (use `fix:` prefix). See: https://www.conventionalcommits.org/en/v1.0.0/#specification
-- [ ] Make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
-- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!
+- [ ] Make sure you are making a pull request against the **main branch** (left side). Also you should start *your branch* off *our main*.
+- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your main!
 - [ ] Include a failing test that reproduces the bug (if possible)
 - [ ] Include the fix that makes the test pass
 - [ ] All existing tests should still pass

--- a/.github/PULL_REQUEST_TEMPLATE/chore.md
+++ b/.github/PULL_REQUEST_TEMPLATE/chore.md
@@ -1,10 +1,10 @@
 <!--
-🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/master/docs/CONTRIBUTING.md
+🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/main/docs/CONTRIBUTING.md
 
 ### Your checklist for this maintenance pull request
 - [ ] Make sure your PR title follows Conventional Commit standards (use `chore:` prefix). See: https://www.conventionalcommits.org/en/v1.0.0/#specification
-- [ ] Make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
-- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!
+- [ ] Make sure you are making a pull request against the **main branch** (left side). Also you should start *your branch* off *our main*.
+- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your main!
 - [ ] Changes improve project maintenance or development workflow
 - [ ] No functional changes to WPGraphQL core
 - [ ] All existing tests pass

--- a/.github/PULL_REQUEST_TEMPLATE/dependency-update.md
+++ b/.github/PULL_REQUEST_TEMPLATE/dependency-update.md
@@ -1,10 +1,10 @@
 <!--
-🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/master/docs/CONTRIBUTING.md
+🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/main/docs/CONTRIBUTING.md
 
 ### Your checklist for this dependency update pull request
 - [ ] Make sure your PR title follows Conventional Commit standards (use `chore:` or `fix:` prefix). See: https://www.conventionalcommits.org/en/v1.0.0/#specification
-- [ ] Make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
-- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!
+- [ ] Make sure you are making a pull request against the **main branch** (left side). Also you should start *your branch* off *our main*.
+- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your main!
 - [ ] All tests pass after dependency updates
 - [ ] No breaking changes introduced by dependency updates
 - [ ] Security vulnerabilities addressed (if applicable)

--- a/.github/PULL_REQUEST_TEMPLATE/documentation.md
+++ b/.github/PULL_REQUEST_TEMPLATE/documentation.md
@@ -1,10 +1,10 @@
 <!--
-🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/master/docs/CONTRIBUTING.md
+🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/main/docs/CONTRIBUTING.md
 
 ### Your checklist for this documentation pull request
 - [ ] Make sure your PR title follows Conventional Commit standards (use `docs:` prefix). See: https://www.conventionalcommits.org/en/v1.0.0/#specification
-- [ ] Make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
-- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!
+- [ ] Make sure you are making a pull request against the **main branch** (left side). Also you should start *your branch* off *our main*.
+- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your main!
 - [ ] Documentation is accurate and up-to-date
 - [ ] Grammar and spelling have been checked
 - [ ] Links are working and point to correct resources

--- a/.github/PULL_REQUEST_TEMPLATE/experiment-update.md
+++ b/.github/PULL_REQUEST_TEMPLATE/experiment-update.md
@@ -1,10 +1,10 @@
 <!--
-🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/master/docs/CONTRIBUTING.md
+🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/main/docs/CONTRIBUTING.md
 
 ### Your checklist for this experiment update pull request
 - [ ] Make sure your PR title follows Conventional Commit standards (use `feat(experiments):` or `fix(experiments):` prefix). See: https://www.conventionalcommits.org/en/v1.0.0/#specification
-- [ ] Make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
-- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!
+- [ ] Make sure you are making a pull request against the **main branch** (left side). Also you should start *your branch* off *our main*.
+- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your main!
 - [ ] Changes are backwards compatible with existing experiment usage
 - [ ] All new functionality is covered by tests
 - [ ] Existing tests still pass

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -1,10 +1,10 @@
 <!--
-🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/master/docs/CONTRIBUTING.md
+🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/main/docs/CONTRIBUTING.md
 
 ### Your checklist for this feature pull request
 - [ ] Make sure your PR title follows Conventional Commit standards (use `feat:` prefix). See: https://www.conventionalcommits.org/en/v1.0.0/#specification
-- [ ] Make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
-- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!
+- [ ] Make sure you are making a pull request against the **main branch** (left side). Also you should start *your branch* off *our main*.
+- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your main!
 - [ ] Feature has been discussed and approved (link to issue/discussion)
 - [ ] All new functionality is covered by tests
 - [ ] Documentation has been updated (if applicable)

--- a/.github/PULL_REQUEST_TEMPLATE/general.md
+++ b/.github/PULL_REQUEST_TEMPLATE/general.md
@@ -3,11 +3,11 @@
 ### Your checklist for this pull request
 Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
 
-🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/master/docs/CONTRIBUTING.md
+🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/main/docs/CONTRIBUTING.md
 
 - [ ] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
-- [ ] Make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
-- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!
+- [ ] Make sure you are making a pull request against the **main branch** (left side). Also you should start *your branch* off *our main*.
+- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your main!
 
 -->
 

--- a/.github/PULL_REQUEST_TEMPLATE/new-experiment.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new-experiment.md
@@ -1,10 +1,10 @@
 <!--
-🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/master/docs/CONTRIBUTING.md
+🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/main/docs/CONTRIBUTING.md
 
 ### Your checklist for this new experiment pull request
 - [ ] Make sure your PR title follows Conventional Commit standards (use `feat(experiments):` prefix). See: https://www.conventionalcommits.org/en/v1.0.0/#specification
-- [ ] Make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
-- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!
+- [ ] Make sure you are making a pull request against the **main branch** (left side). Also you should start *your branch* off *our main*.
+- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your main!
 - [ ] Experiment has been approved via GitHub issue (link to proposal)
 - [ ] Experiment class extends AbstractExperiment
 - [ ] Experiment is registered in ExperimentRegistry

--- a/.github/PULL_REQUEST_TEMPLATE/refactor.md
+++ b/.github/PULL_REQUEST_TEMPLATE/refactor.md
@@ -1,10 +1,10 @@
 <!--
-🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/master/docs/CONTRIBUTING.md
+🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/main/docs/CONTRIBUTING.md
 
 ### Your checklist for this refactoring pull request
 - [ ] Make sure your PR title follows Conventional Commit standards (use `refactor:` prefix). See: https://www.conventionalcommits.org/en/v1.0.0/#specification
-- [ ] Make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
-- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!
+- [ ] Make sure you are making a pull request against the **main branch** (left side). Also you should start *your branch* off *our main*.
+- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your main!
 - [ ] No functional changes (behavior remains the same)
 - [ ] All existing tests pass
 - [ ] Performance is maintained or improved

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -63,7 +63,7 @@ This directory contains GitHub Actions workflows that automate our development, 
 
 We use [release-please](https://github.com/googleapis/release-please) for automated releases:
 
-1. **On Push to Master**: release-please analyzes commits and creates/updates a Release PR
+1. **On Push to Main**: release-please analyzes commits and creates/updates a Release PR
 2. **Release PR Contents**:
    - Version bump based on commit types (`feat:` → minor, `fix:` → patch, `!` → major)
    - Auto-generated changelog from commit messages
@@ -108,8 +108,8 @@ flowchart TD
     Tests --> E2E[GraphiQL E2E]
 
     %% Merge and Release
-    PR --> |Squash Merged| MASTER[master branch]
-    MASTER --> RP[release-please]
+    PR --> |Squash Merged| MAIN[main branch]
+    MAIN --> RP[release-please]
     RP --> |Creates/Updates| RPR[Release PR]
     RPR --> |Merged| REL[Create Release]
     REL --> WO[Deploy to WordPress.org]

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -4,11 +4,11 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - master
+      - main
       - release/*
   pull_request:
     branches:
-      - master
+      - main
       - release/*
 
 # Cancels all previous workflow runs for pull requests that have not completed.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ develop, master ]
+    branches: [ main ]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ develop ]
+    branches: [ main ]
   schedule:
     - cron: '15 21 * * 1'
 

--- a/.github/workflows/graphiql-e2e-tests.yml
+++ b/.github/workflows/graphiql-e2e-tests.yml
@@ -3,11 +3,11 @@ name: GraphiQL E2E Tests
 on:
   push:
     branches:
-      - master
+      - main
       - release/*
   pull_request:
     branches:
-      - master
+      - main
       - release/*
     paths:
       - 'plugins/wp-graphql/packages/**'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,7 +3,7 @@
 # ===========================================
 #
 # This workflow uses Google's release-please to automate releases:
-# 1. On push to master, release-please analyzes commits since last release
+# 1. On push to main, release-please analyzes commits since last release
 # 2. It creates/updates a Release PR with version bump and changelog
 # 3. When the Release PR is merged, it creates a GitHub release and tag
 # 4. The deploy job then publishes to WordPress.org
@@ -26,7 +26,7 @@ name: Release Please
 on:
   push:
     branches:
-      - master
+      - main
   workflow_dispatch:
     inputs:
       debug:
@@ -104,7 +104,7 @@ jobs:
           if [[ -n "$(git status --porcelain)" ]]; then
             git add -A
             git commit -m "chore: update @since tags for v${{ needs.release-please.outputs['wp-graphql--version'] }}"
-            git push origin HEAD:master
+            git push origin HEAD:main
           else
             echo "No @since tag updates needed"
           fi
@@ -118,7 +118,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: master
+          ref: main
           fetch-depth: 0
 
       - name: Setup PHP

--- a/.github/workflows/schema-linter.yml
+++ b/.github/workflows/schema-linter.yml
@@ -3,11 +3,11 @@ name: Schema Linter
 on:
   push:
     branches:
-      - master
+      - main
       - release/*
   pull_request:
     branches:
-      - master
+      - main
       - release/*
 
 # Cancel previous workflow run groups that have not completed.

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -29,11 +29,11 @@ name: Smoke Test
 on:
   push:
     branches:
-      - master
+      - main
       - release/*
   pull_request:
     branches:
-      - master
+      - main
       - release/*
     paths:
       - '.github/workflows/smoke-test.yml'

--- a/.github/workflows/testing-integration.yml
+++ b/.github/workflows/testing-integration.yml
@@ -11,7 +11,7 @@
 #
 # TWO MATRIX MODES:
 # - MINIMAL (regular PRs): ~8 jobs for quick feedback
-# - FULL (merges to master + release PRs): ~18 jobs for thorough pre-release testing
+# - FULL (merges to main + release PRs): ~18 jobs for thorough pre-release testing
 #
 # COVERAGE STRATEGY:
 # Code coverage is collected from 4 configurations on the latest WP/PHP:
@@ -39,11 +39,11 @@ name: Testing Integration
 on:
   push:
     branches:
-      - master
+      - main
       - release/*
   pull_request:
     branches:
-      - master
+      - main
       - release/*
     paths:
       - '.github/workflows/testing-integration.yml'
@@ -80,10 +80,10 @@ jobs:
         id: set-matrix
         run: |
           # Use full matrix for:
-          # - Push events (merges to master)
+          # - Push events (merges to main)
           # - Release PRs (PRs from release-please with title starting with "chore: release")
           # Use minimal matrix for:
-          # - Regular PRs targeting master
+          # - Regular PRs targeting main
           
           # Check if this is a release-please PR (full matrix needed for release validation)
           IS_RELEASE_PR="false"
@@ -117,7 +117,7 @@ jobs:
           else
             # ===========================================
             # FULL MATRIX (~18 jobs)
-            # For merges to master and release-please PRs
+            # For merges to main and release-please PRs
             # Provides thorough testing before releases
             # ===========================================
             # - 4 coverage jobs: Latest WP/PHP with all theme × multisite combos

--- a/.github/workflows/wordpress-coding-standards.yml
+++ b/.github/workflows/wordpress-coding-standards.yml
@@ -4,11 +4,11 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - master
+      - main
       - release/*
   pull_request:
     branches:
-      - master
+      - main
       - release/*
 
 # Cancel previous workflow run groups that have not completed.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Schema Linter](https://github.com/wp-graphql/wp-graphql/workflows/Schema%20Linter/badge.svg)](https://github.com/wp-graphql/wp-graphql/actions?query=workflow%3A%22Schema+Linter%22)
 [![GraphiQL E2E Tests](https://github.com/wp-graphql/wp-graphql/workflows/GraphiQL%20E2E%20Tests/badge.svg)](https://github.com/wp-graphql/wp-graphql/actions?query=workflow%3A%22GraphiQL+E2E+Tests%22)
 [![Code Quality](https://github.com/wp-graphql/wp-graphql/workflows/Code%20Quality/badge.svg)](https://github.com/wp-graphql/wp-graphql/actions?query=workflow%3A%22Code+Quality%22)
-[![codecov](https://codecov.io/gh/wp-graphql/wp-graphql/branch/master/graph/badge.svg)](https://codecov.io/gh/wp-graphql/wp-graphql)
+[![codecov](https://codecov.io/gh/wp-graphql/wp-graphql/branch/main/graph/badge.svg)](https://codecov.io/gh/wp-graphql/wp-graphql)
 
 **Unlock the power of WordPress data with GraphQL**
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -170,7 +170,7 @@ register_graphql_connection([
 | `code-quality.yml` | PR, Push | PHPStan analysis |
 | `wordpress-coding-standards.yml` | PR, Push | PHPCS linting |
 | `schema-linter.yml` | PR, Push | GraphQL schema validation |
-| `release.yml` | Merge to master | Version bump, release |
+| `release-please.yml` | Push to main | Automated releases via release-please |
 
 ### Testing Strategy
 
@@ -182,11 +182,12 @@ Tests run across a matrix of configurations:
 
 ### Release Process
 
-1. PRs merged to `develop` generate changesets
-2. Changesets accumulate until release
-3. PR from `develop` to `master` triggers release
-4. Version bumped, changelog generated
-5. Tag created, deployed to WordPress.org
+We use [release-please](https://github.com/googleapis/release-please) for automated releases:
+
+1. PRs are merged to `main` with conventional commit titles
+2. release-please creates/updates a Release PR with changelog and version bump
+3. When the Release PR is merged, a GitHub release is created
+4. The release triggers deployment to WordPress.org
 
 ## Future Plugins
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -277,8 +277,8 @@ This catches issues that unit tests might miss:
 ## CI/CD Testing
 
 Tests run automatically on:
-- Pull requests to `develop` or `master`
-- Pushes to `develop` or `master`
+- Pull requests to `main`
+- Pushes to `main`
 
 ### Test Matrix
 

--- a/plugins/wp-graphql/docs/compatibility-guide.md
+++ b/plugins/wp-graphql/docs/compatibility-guide.md
@@ -9,7 +9,7 @@ This guide outlines compatibility requirements and considerations when using WPG
 
 ## WordPress Compatibility
 
-WPGraphQL requires WordPress 6.0 or higher. We [actively test](https://github.com/wp-graphql/wp-graphql/blob/master/.github/workflows/testing-integration.yml) and support against newer versions of WordPress. For the best experience and support, we strongly recommend keeping WordPress updated to the latest stable version.
+WPGraphQL requires WordPress 6.0 or higher. We [actively test](https://github.com/wp-graphql/wp-graphql/blob/main/.github/workflows/testing-integration.yml) and support against newer versions of WordPress. For the best experience and support, we strongly recommend keeping WordPress updated to the latest stable version.
 
 ### Version Requirements
 

--- a/plugins/wp-graphql/docs/contributing.md
+++ b/plugins/wp-graphql/docs/contributing.md
@@ -5,7 +5,7 @@ title: "Contributing"
 
 This document will be most useful for developers that want to contribute to WPGraphQL and want to run the docker container locally as well as utilize xdebug for debugging and tracing.
 
-> **Note**: WPGraphQL is now a monorepo. For detailed setup instructions, see the [Development Setup Guide](https://github.com/wp-graphql/wp-graphql/blob/develop/docs/DEVELOPMENT.md) in the repository root.
+> **Note**: WPGraphQL is now a monorepo. For detailed setup instructions, see the [Development Setup Guide](https://github.com/wp-graphql/wp-graphql/blob/main/docs/DEVELOPMENT.md) in the repository root.
 
 ## Development Workflow
 
@@ -17,11 +17,11 @@ WPGraphQL uses several automated processes to maintain consistency and quality:
    - Breaking changes use `!` suffix (e.g., `feat!:`)
    - See [Conventional Commits](https://www.conventionalcommits.org/) for more details
 
-2. **Automated Changesets**
+2. **Automated Releases**
 
-   - Generated automatically when PRs are merged
-   - Based on PR title and description
-   - Includes breaking changes and upgrade notes
+   - release-please creates Release PRs automatically
+   - Changelog generated from PR titles
+   - Version bumps determined by commit types
 
 3. **Version Management**
 
@@ -142,15 +142,16 @@ Create or add the following configuration to your `.vscode/launch.json` in the r
 }
 ```
 
-## Changesets and Releases
+## Releases
 
-WPGraphQL uses [changesets](../.changeset/README.md) to manage versioning and changelogs. When contributing:
+WPGraphQL uses [release-please](https://github.com/googleapis/release-please) for automated versioning and releases. When contributing:
 
 1. Your PR title must follow [conventional commits](https://www.conventionalcommits.org/) format:
 
    - `feat:` for new features (minor version bump)
    - `fix:` for bug fixes (patch version bump)
    - Add `!` suffix for breaking changes: `feat!:` or `fix!:`
+   - Non-release types: `docs:`, `chore:`, `ci:`, `test:`, `refactor:` (no version bump)
 
 2. **Use the appropriate PR template**:
 
@@ -176,12 +177,8 @@ WPGraphQL uses [changesets](../.changeset/README.md) to manage versioning and ch
 
    - These will be automatically updated during the release process.
 
-5. **Changeset Generation Process**:
-   - When your PR is ready for review, a maintainer will review it
-   - After approval, the maintainer will merge the PR
-   - This triggers an automated workflow that:
-     - Creates a changeset based on your PR title and description
-     - Adds the changeset to the develop branch
-     - Creates/updates a PR from the develop branch to master
-   - When one or more changesets are collected, they'll be released together
-   - Merging the PR containing multiple changesets will trigger a release workflow that will publish and deploy the plugin
+5. **Release Process**:
+   - PRs are merged to `main` via squash merge (PR title becomes commit message)
+   - release-please analyzes commits and creates/updates a Release PR
+   - The Release PR accumulates changes and shows the upcoming version bump
+   - When the Release PR is merged, a GitHub release is created and the plugin is deployed to WordPress.org

--- a/plugins/wp-graphql/docs/customizing-wpgraphiql.md
+++ b/plugins/wp-graphql/docs/customizing-wpgraphiql.md
@@ -60,7 +60,7 @@ WPGraphQL ships with 3 features (Auth Switch, Fullscreen Toggle, and Query Compo
 using the extension architecture. The code can serve as an example for how you might approach building
 an extension.
 
-You can find the code for these extensions [here](https://github.com/wp-graphql/wp-graphql/tree/develop/packages/).
+You can find the code for these extensions [here](https://github.com/wp-graphql/wp-graphql/tree/main/plugins/wp-graphql/packages/).
 
 Below, is documentation on the hooks and filters provided by the codebase:
 

--- a/plugins/wp-graphql/docs/experiments-contributing.md
+++ b/plugins/wp-graphql/docs/experiments-contributing.md
@@ -466,7 +466,7 @@ Stuck or have questions?
 - [Using Experiments Guide](/docs/experiments-using)
 - [Contributing Guide](/docs/contributing)
 - [Testing Guide](/docs/testing)
-- [Code Standards](https://github.com/wp-graphql/wp-graphql/blob/develop/phpcs.xml.dist)
+- [Code Standards](https://github.com/wp-graphql/wp-graphql/blob/main/plugins/wp-graphql/phpcs.xml.dist)
 
 ---
 

--- a/plugins/wp-graphql/docs/experiments.md
+++ b/plugins/wp-graphql/docs/experiments.md
@@ -78,7 +78,7 @@ Proposed → Active → Feedback → Decision
 To see which experiments are currently available:
 
 1. Navigate to **GraphQL > Settings > Experiments** in your WordPress admin
-2. Review the [Experiments README](https://github.com/wp-graphql/wp-graphql/tree/develop/src/Experimental) on GitHub
+2. Review the [Experiments README](https://github.com/wp-graphql/wp-graphql/tree/main/plugins/wp-graphql/src/Experimental) on GitHub
 3. Check release notes for the `Experimental` badge
 
 ### Example Experiments (For Developers)

--- a/plugins/wp-graphql/docs/menus.md
+++ b/plugins/wp-graphql/docs/menus.md
@@ -134,7 +134,7 @@ One thing you may have noticed is that Menu Items will be returned in a flat-lis
 
 There's a good chance you might need to convert a flat list into a hierarchical list in the consumer application to be used in a component such as a Checkbox Tree or Dropdown Menu, for example.
 
-> You can see this technique in action in the codebase for the website you're reading [here](https://github.com/wp-graphql/wpgraphql.com/blob/master/src/components/DocsSidebar.js#L8-L26).
+> You can see this technique in action in the codebase for the website you're reading [here](https://github.com/wp-graphql/wpgraphql.com/blob/main/src/components/DocsSidebar.js#L8-L26).
 
 Given the query above, we might have a payload of data like so:
 

--- a/plugins/wp-graphql/docs/security.md
+++ b/plugins/wp-graphql/docs/security.md
@@ -67,7 +67,7 @@ For example, in WordPress core, users that have not published posts are only vis
 
 To help facilitate what data is publicly exposed and what data is considered private, WPGraphQL has a "Model Layer". Each type of object (Posts, Terms, Users, Comments, etc) have a WPGraphQL Model that is responsible for permission checks. Anytime an object is asked for from the Graph, the Model determines if the object is allowed to be returned to the requesting user, and if so, what specific fields can be returned. The Model Layer takes into consideration many things when determining if the object should be considered public or private.
 
-Some things the [Model Layer](https://github.com/wp-graphql/wp-graphql/tree/develop/src/Model) will consider before returning an object:
+Some things the [Model Layer](https://github.com/wp-graphql/wp-graphql/tree/main/plugins/wp-graphql/src/Model) will consider before returning an object:
 
 - Is the Request for data authenticated or public?
 - What is the state of the object being requested (is it published, draft, etc)?
@@ -103,7 +103,7 @@ For remote HTTP requests to the `/graphql` endpoint, existing authentication plu
 - https://github.com/WP-API/Basic-Auth (even though it’s labeled for the REST API, it works well with WPGraphQL – but not recommended for non-SSL connections)
 - https://github.com/WP-API/OAuth1 (labeled for use with the WP REST API, but works well with WPGraphQL)
 
-If the remote request is within the WordPress admin, such as the WPGraphiQL plugin, you can use the existing Auth nonce as seen in action [here](https://github.com/wp-graphql/wp-graphiql/blob/master/packages/graphiql-auth-switch).
+If the remote request is within the WordPress admin, such as the WPGraphiQL plugin, you can use the existing Auth nonce as seen in action [here](https://github.com/wp-graphql/wp-graphiql/blob/main/packages/graphiql-auth-switch).
 
 For non-remote requests (PHP function calls), if the context of the request is already authenticated, such as an Admin page in the WordPress dashboard, existing WordPress authentication can be used, taking advantage of the existing session. For example, if you wanted to use a GraphQL query to populate a dashboard page, you could send your query to the `do_graphql_request( $query )` function, and since the request is already authenticated, GraphQL will execute with the current user set, and will resolve fields that the users has permission to resolve.
 

--- a/plugins/wp-graphql/docs/testing.md
+++ b/plugins/wp-graphql/docs/testing.md
@@ -7,7 +7,7 @@ This document will be most useful for developers that want to contribute to WPGr
 
 In order to run tests, you must [clone the plugin from GitHub](https://github.com/wp-graphql/wp-graphql). Downloading from Composer or Packagist will not include the dev dependencies needed to run tests.
 
-> **Note**: WPGraphQL is now a monorepo. For detailed testing instructions, see the [Testing Guide](https://github.com/wp-graphql/wp-graphql/blob/develop/docs/TESTING.md) in the repository root.
+> **Note**: WPGraphQL is now a monorepo. For detailed testing instructions, see the [Testing Guide](https://github.com/wp-graphql/wp-graphql/blob/main/docs/TESTING.md) in the repository root.
 
 ## Testing with `wp-env`
 
@@ -126,7 +126,7 @@ Smoke tests verify:
 
 ### Testing the Production Zip
 
-To test the actual production zip artifact (mimicking CI), you need to install the plugin via WP-CLI rather than mounting it via wp-env. See the [Testing Guide](https://github.com/wp-graphql/wp-graphql/blob/develop/docs/TESTING.md#testing-the-production-zip-artifact) for detailed instructions.
+To test the actual production zip artifact (mimicking CI), you need to install the plugin via WP-CLI rather than mounting it via wp-env. See the [Testing Guide](https://github.com/wp-graphql/wp-graphql/blob/main/docs/TESTING.md#testing-the-production-zip-artifact) for detailed instructions.
 
 ## Testing Locally with Codeception
 

--- a/plugins/wp-graphql/docs/using-data-from-custom-database-tables.md
+++ b/plugins/wp-graphql/docs/using-data-from-custom-database-tables.md
@@ -432,7 +432,7 @@ We need to have the connection resolver return something other than null.
 
 WPGraphQL has an AbstractConnectionResolver that helps facilitate resolving connections. 
 
-You can see all the ConnectionResolvers in core WPGraphQL here: https://github.com/wp-graphql/wp-graphql/tree/develop/src/Data/Connection
+You can see all the ConnectionResolvers in core WPGraphQL here: https://github.com/wp-graphql/wp-graphql/tree/main/plugins/wp-graphql/src/Data/Connection
 
 Let's define a `NotificationConnectionResolver` class to help resolve connection queries for Notifications.
 

--- a/plugins/wp-graphql/docs/wpgraphql-request-lifecycle.md
+++ b/plugins/wp-graphql/docs/wpgraphql-request-lifecycle.md
@@ -18,7 +18,7 @@ An over-simplified summary of the WPGraphQL lifecycle looks something like the f
 
 Most users of WPGraphQL will be interacting with it from the site's `/graphql` endpoint.
 
-The endpoint is created by the [WPGraphQL Router Class](https://github.com/wp-graphql/wp-graphql/blob/develop/src/Router.php). The default Route is `/graphql` but can be changed via filter or the WPGraphQL Settings page. Additionally, for sites that do not have pretty permalinks enabled, the endpoint can be queried at `/index.php?graphql`.
+The endpoint is created by the [WPGraphQL Router Class](https://github.com/wp-graphql/wp-graphql/blob/main/plugins/wp-graphql/src/Router.php). The default Route is `/graphql` but can be changed via filter or the WPGraphQL Settings page. Additionally, for sites that do not have pretty permalinks enabled, the endpoint can be queried at `/index.php?graphql`.
 
 The Router determines whether the request is a GraphQL HTTP Request.
 

--- a/plugins/wp-graphql/tests/wpunit/InterfaceTest.php
+++ b/plugins/wp-graphql/tests/wpunit/InterfaceTest.php
@@ -1154,7 +1154,7 @@ class InterfaceTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$actual = $this->graphql([ 'query' => $query ]);
 
-		// On master branch, this would pass without debug messages
+		// Before PR #3383, this would pass without debug messages
 		// With PR #3383, this should have debug messages about type conflicts
 		$this->assertNotEmpty($actual['extensions']['debug'], 'The interface should have debug messages about type conflicts');
 		$this->assertStringContainsString('expected to be of type "String"', $actual['extensions']['debug'][0]['message']);
@@ -1300,7 +1300,7 @@ class InterfaceTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		$actual = $this->graphql([ 'query' => $query ]);
 
-		// On master branch, this would pass without debug messages
+		// Before PR #3383, this would pass without debug messages
 		// With PR #3383, this should have debug messages about type conflicts
 		$this->assertNotEmpty($actual['extensions']['debug'], 'The interface should have debug messages about nested type conflicts');
 		$this->assertStringContainsString('expected to be of type', $actual['extensions']['debug'][0]['message']);
@@ -1443,8 +1443,8 @@ class InterfaceTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		codecept_debug('Found inheritedField:');
 		codecept_debug($inheritedField);
 
-		// On master branch, this might not have all arguments
-		// On PR branch, it should have all arguments from the inheritance chain
+		// Before this PR, this might not have all arguments
+		// After this PR, it should have all arguments from the inheritance chain
 		$argNames = array_map(function($arg) {
 			return $arg['name'];
 		}, $inheritedField['args']);
@@ -1521,8 +1521,8 @@ class InterfaceTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		codecept_debug('Field query response:');
 		codecept_debug($actual);
 
-		// On master branch, this might fail if arguments aren't properly merged
-		// On PR branch, it should succeed
+		// Before this fix, this might fail if arguments aren't properly merged
+		// After this fix, it should succeed
 		$this->assertQuerySuccessful($actual, [
 			$this->expectedField('testInheritance.inheritedField', 'parent: parent value, child: child value, object: object value')
 		], 'The query should be valid with all arguments from the inheritance chain');

--- a/plugins/wp-graphql/tests/wpunit/MediaItemMutationsTest.php
+++ b/plugins/wp-graphql/tests/wpunit/MediaItemMutationsTest.php
@@ -82,7 +82,7 @@ class MediaItemMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		$this->date          = '2017-08-01T15:00:00';
 		$this->dateGmt       = '2017-08-01T21:00:00';
 		$this->description   = 'This is a magic description.';
-		$this->filePath      = 'https://raw.githubusercontent.com/wp-graphql/wp-graphql/refs/heads/master/tests/_data/images/test-mgc.gif';
+		$this->filePath      = 'https://raw.githubusercontent.com/wp-graphql/wp-graphql/refs/heads/main/plugins/wp-graphql/tests/_data/images/test-mgc.gif';
 		$this->fileType      = 'IMAGE_GIF';
 		$this->slug          = 'magic-shia';
 		$this->status        = 'INHERIT';


### PR DESCRIPTION
## Summary

Renames all references to the default branch from `master` to `main`, aligning with modern Git conventions and GitHub's default branch naming.

## Changes

- **GitHub Workflows**: Updated all CI triggers to use `main` instead of `master`
- **PR Templates**: Updated target branch references
- **Issue Templates**: Updated branch links
- **Documentation**: Updated all contributing guides and docs
- **Source Code Links**: Updated GitHub URLs in documentation to point to `main` branch and new monorepo paths
- **Test Files**: Updated comments and URLs

## Why?

- `main` is the modern convention (GitHub's default since 2020)
- Good time to make this change as part of the monorepo transition
- Signals a fresh start with the new structure

## GitHub Settings Required

After merging this PR and `feat/monorepo` to the current default branch, the repo admin should:

1. Go to **Settings → General → Default branch**
2. Change the default branch from `master` to `main`
3. Update branch protection rules to apply to `main`