### PR TITLE
ci: don't group NPM production deps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,7 +40,8 @@ updates:
     groups:
       npm-minor-patch:
         update-types: [minor, patch]
-      npm-major:
+      npm-dev-major:
+        dependency-type: 'development'
         update-types: [major]
 
   # GitHub Actions: 1x weekly.


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/main/docs/CONTRIBUTING.md

- [x] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [x] Make sure you are making a pull request against the **main branch** (left side). Also you should start *your branch* off *our main*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your main!

-->

## What does this implement/fix? Explain your changes.

This PR fixes dependabot.yml so major npm production dependencies aren't grouped, only  dev dependencies.


## Does this close any currently open issues?

<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Invalidates https://github.com/wp-graphql/wp-graphql/pull/3490

## Any other comments?

<!-- Please add any additional context that would be helpful. Feel free to include screenshots of the GraphiQL IDE or other relevant screenshotes, logs, error output, etc -->
