### PR TITLE
fix(ci): improve integration test job naming for branch protection

### DIFF
--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -44,10 +44,9 @@ on:
 jobs:
   # Job naming strategy:
   # The parent workflow sets name to "Integration: plugin / WP X.X / PHP X.X".
-  # However, GitHub's sidebar only shows partial names for reusable workflow groups.
-  # So we include PHP in the child job name too for visibility when expanded.
-  # Full header: "Integration: wp-graphql / WP 6.9 / PHP 8.4 / PHP 8.4 - twentytwentyfive 📊"
-  # Yes, PHP is duplicated, but this ensures it's visible somewhere in the UI.
+  # The child job name shows theme + modifiers (no PHP to avoid duplication).
+  # Full header: "Integration: wp-graphql / WP 6.9 / PHP 8.4 / twentytwentyfive 📊"
+  # Note: GitHub's sidebar may not show all info, but header/branch protection will.
   #
   # Runs integration tests for a WordPress plugin using Codeception.
   #
@@ -61,7 +60,7 @@ jobs:
   # - Runs Acceptance, Functional, and WPUnit tests.
   # - Uploads test failure artifacts and code coverage reports.
   test:
-    name: "PHP ${{ inputs.php }} - ${{ inputs.theme }}${{ inputs.multisite && ' (Multisite)' || '' }}${{ inputs.coverage && ' 📊' || '' }}${{ inputs.experimental && ' 🧪' || '' }}"
+    name: "${{ inputs.theme }}${{ inputs.multisite && ' (Multisite)' || '' }}${{ inputs.coverage && ' 📊' || '' }}${{ inputs.experimental && ' 🧪' || '' }}"
     runs-on: ubuntu-24.04
     continue-on-error: ${{ inputs.experimental }}
     permissions:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -104,9 +104,8 @@ jobs:
 
   # Job naming strategy:
   # - Parent job name: "Integration: plugin / WP X.X / PHP X.X"
-  # - Child job name: "PHP X.X - theme (modifiers)" (from reusable workflow)
-  # - Full name in branch protection: "Integration: wp-graphql / WP 6.9 / PHP 8.4 / PHP 8.4 - twentytwentyfive 📊"
-  # Note: PHP is duplicated due to GitHub UI limitations with reusable workflow sidebar display.
+  # - Child job name: "theme (modifiers)" (from reusable workflow)
+  # - Full name in branch protection: "Integration: wp-graphql / WP 6.9 / PHP 8.4 / twentytwentyfive 📊"
   wp-graphql:
     name: "Integration: ${{ matrix.name }}"
     needs: detect-changes


### PR DESCRIPTION
## Description

Improves job naming in the integration tests workflow for better clarity in the branch protection UI.

## Changes

- Prefix job names with `Integration:` to clearly identify them as integration tests
- Include plugin name (`wp-graphql`) in the matrix name for multi-plugin support
- Update comments documenting the naming strategy

## Before

Job names like:
- `wp-graphql: WP 6.9 / PHP 8.4 / PHP 8.4 - twentytwentyfive 📊`

## After

Job names like:
- `Integration: wp-graphql / WP 6.9 / PHP 8.4 / PHP 8.4 - twentytwentyfive 📊`

This makes it much clearer which checks are integration tests when configuring branch protection rules.