### PR TITLE
fix(ci): add WP version to child job name for better sidebar visibility

### DIFF
--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -44,9 +44,9 @@ on:
 jobs:
   # Job naming strategy:
   # The parent workflow sets name to "Integration: plugin / WP X.X / PHP X.X".
-  # The child job name shows theme + modifiers (no PHP to avoid duplication).
-  # Full header: "Integration: wp-graphql / WP 6.9 / PHP 8.4 / twentytwentyfive 📊"
-  # Note: GitHub's sidebar may not show all info, but header/branch protection will.
+  # The child job name includes WP version for sidebar visibility, then theme + modifiers.
+  # Full header: "Integration: wp-graphql / WP 6.9 / PHP 8.4 / WP 6.9 / twentytwentyfive 📊"
+  # Note: WP version appears twice but ensures it's visible in GitHub's sidebar.
   #
   # Runs integration tests for a WordPress plugin using Codeception.
   #
@@ -60,7 +60,7 @@ jobs:
   # - Runs Acceptance, Functional, and WPUnit tests.
   # - Uploads test failure artifacts and code coverage reports.
   test:
-    name: "${{ inputs.theme }}${{ inputs.multisite && ' (Multisite)' || '' }}${{ inputs.coverage && ' 📊' || '' }}${{ inputs.experimental && ' 🧪' || '' }}"
+    name: "WP ${{ inputs.wp }} / ${{ inputs.theme }}${{ inputs.multisite && ' (Multisite)' || '' }}${{ inputs.coverage && ' 📊' || '' }}${{ inputs.experimental && ' 🧪' || '' }}"
     runs-on: ubuntu-24.04
     continue-on-error: ${{ inputs.experimental }}
     permissions:


### PR DESCRIPTION
## Description

Follow-up to #3497. Adds WordPress version to the beginning of child job names so it's visible in GitHub's Actions sidebar.

## Problem

GitHub's sidebar for reusable workflows only shows the child job name, not the full parent job context. This meant the sidebar was showing just theme names like `twentytwentyfive 📊` without any version information.

## Solution

Add WP version to the start of the child job name:
- Before: `twentytwentyfive 📊`
- After: `WP 6.9 / twentytwentyfive 📊`

## Trade-off

The WP version will appear twice in the full job header (`Integration: wp-graphql / WP 6.9 / PHP 8.4 / WP 6.9 / twentytwentyfive 📊`), but this ensures version info is visible in the sidebar where it matters most for quick scanning.