### PR TITLE
fix: use clean build directory for WordPress.org deployment

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -107,6 +107,32 @@ jobs:
           npm ci
           npm run -w @wpgraphql/wp-graphql build
 
+      - name: Create clean build directory for deployment
+        working-directory: plugins/wp-graphql
+        run: |
+          echo "📦 Creating clean build directory using .distignore..."
+          echo "This ensures only production files are included (respects .distignore)"
+          
+          # Create the build directory (same as zip script does)
+          mkdir -p ../../plugin-build/wp-graphql
+          
+          # Use rsync with .distignore to create a clean copy (same as zip script)
+          # This respects .distignore and excludes node_modules, packages, etc.
+          rsync -rc --exclude-from=.distignore --exclude=plugin-build . ../../plugin-build/wp-graphql/ --delete --delete-excluded -v
+          
+          echo "✅ Clean build directory created at plugin-build/wp-graphql"
+          echo "📋 Verifying no node_modules in build directory..."
+          if find ../../plugin-build/wp-graphql -type d -name "node_modules" 2>/dev/null | grep -q .; then
+            echo "⚠️  Warning: node_modules found in build directory!"
+            find ../../plugin-build/wp-graphql -type d -name "node_modules" 2>/dev/null | head -5
+            exit 1
+          else
+            echo "✅ No node_modules found in build directory"
+          fi
+          
+          echo "📦 Files in build directory:"
+          ls -la ../../plugin-build/wp-graphql | head -20
+
       - name: WordPress Plugin Deploy
         uses: 10up/action-wordpress-plugin-deploy@stable
         env:
@@ -114,15 +140,13 @@ jobs:
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
           SLUG: wp-graphql
-          BUILD_DIR: plugins/wp-graphql
+          BUILD_DIR: plugin-build/wp-graphql
           VERSION: ${{ needs.release-please.outputs['wp-graphql--version'] }}
 
-      - name: Create artifact directory
-        run: mkdir -p plugin-build
-
-      - name: Create plugin artifact
-        working-directory: plugins/wp-graphql
-        run: composer run-script zip
+      - name: Create plugin zip artifact
+        run: |
+          cd plugin-build
+          zip -r wp-graphql.zip wp-graphql
 
       - name: Upload artifact to workflow
         uses: actions/upload-artifact@v6

--- a/plugins/wp-graphql/.distignore
+++ b/plugins/wp-graphql/.distignore
@@ -3,7 +3,7 @@
 /.idea
 /.log
 /.vscode
-/.wordpress-org
+# .wordpress-org is kept (contains WordPress.org assets like banners, icons, screenshots)
 /bin
 /github
 /plugin-build
@@ -14,6 +14,7 @@
 /tests
 /tests
 /node_modules
+**/node_modules
 /packages
 /artifacts
 /.changeset


### PR DESCRIPTION
## Problem
The WordPress.org deployment was including `node_modules` and other excluded files because the `10up/action-wordpress-plugin-deploy` action doesn't respect `.distignore` when `BUILD_DIR` is set.

## Solution
- Create a clean build directory using `rsync` with `.distignore` before deployment
- Point `BUILD_DIR` to the clean directory instead of the source directory
- This ensures only production files are deployed to WordPress.org

## Changes
- Updated `.github/workflows/release-please.yml` to create clean build directory before deployment
- Updated `plugins/wp-graphql/.distignore` to include `**/node_modules` pattern

## Testing
This will be tested on the next release when a release PR is merged to main.

Fixes the issue where `node_modules` and other excluded files were being deployed to WordPress.org in v2.7.0.