### PR TITLE
docs: update cursor rules for monorepo structure

### DIFF
--- a/.cursor/prd.md
+++ b/.cursor/prd.md
@@ -1,9 +1,45 @@
 # WPGraphQL Product Requirements Document
 
-## Product Overview
-WPGraphQL is a free, open-source WordPress plugin that provides an extendable GraphQL API for WordPress websites. 
+## Monorepo Structure
 
-It provides a modern, performant GraphQL API that directly interfaces with WordPress internal data structures and registries, allowing developers to build headless WordPress applications.
+This repository is a monorepo containing the WPGraphQL ecosystem of plugins and related projects. The repository is organized as follows:
+
+```
+wp-graphql/
+├── plugins/
+│   ├── wp-graphql/              # Core WPGraphQL plugin
+│   ├── wp-graphql-smart-cache/  # Smart Cache extension plugin
+│   └── [future plugins]         # WPGraphQL IDE, WPGraphQL for ACF, etc.
+├── docs/                        # Shared contributor documentation
+├── bin/                         # Shared scripts
+├── .wp-env.json                 # Shared WordPress environment config
+├── package.json                 # Root workspace configuration
+└── turbo.json                   # Turborepo build orchestration
+```
+
+Each plugin in the `plugins/` directory is a self-contained WordPress plugin with its own `composer.json`, `package.json`, and plugin structure. The monorepo uses npm workspaces and Turborepo for managing dependencies and builds across all plugins.
+
+### Benefits of Monorepo Structure
+
+- **Unified Testing**: Test plugins together to catch integration issues
+- **Shared Infrastructure**: One CI/CD setup, one test environment
+- **Atomic Changes**: Changes across plugins can be a single PR
+- **Simplified Dependencies**: Easier to keep plugins compatible
+- **Consistent Tooling**: Same linting, testing, and build tools across all plugins
+
+## Product Overview
+
+WPGraphQL is a free, open-source WordPress plugin that provides an extendable GraphQL API for WordPress websites. This monorepo contains the core WPGraphQL plugin as well as official extension plugins that enhance the WPGraphQL ecosystem.
+
+The core WPGraphQL plugin provides a modern, performant GraphQL API that directly interfaces with WordPress internal data structures and registries, allowing developers to build headless WordPress applications.
+
+### WPGraphQL Ecosystem
+
+- **WPGraphQL** (core): The main GraphQL API plugin for WordPress
+- **WPGraphQL Smart Cache**: Provides caching and cache invalidation for WPGraphQL queries
+- **WPGraphQL IDE** (planned): Enhanced debugging and development tools
+- **WPGraphQL for ACF** (planned): Advanced Custom Fields integration
+- **wpgraphql.com website** (planned): Official website and documentation
 
 ### Core Value Proposition
 - Enable headless WordPress architecture with a modern GraphQL API
@@ -63,7 +99,8 @@ It provides a modern, performant GraphQL API that directly interfaces with WordP
 ### Security & Authentication
 - Can integrate with WordPress authentication
 - Respects WordPress capabilities
-- Supports JWT authentication
+- Supports JWT authentication via extension plugins (e.g., WPGraphQL JWT Authentication)
+- Application Passwords support (WordPress 5.6+, may be enhanced in future releases)
 - Provides options for field-level access control
 - Maintains WordPress access-control model
 
@@ -90,9 +127,9 @@ It provides a modern, performant GraphQL API that directly interfaces with WordP
 ## Technical Requirements
 
 ### WordPress Compatibility
-- WordPress (6.0+ preferred)
-- PHP (7.4+ preferred)
-- MySQL (8+ preferred) or MariaDB (10.0+ preferred)
+- WordPress 6.0+ (required)
+- PHP 7.4+ (required), PHP 8.x recommended
+- MySQL/MariaDB (as required by WordPress, latest versions recommended)
 - Standard WordPress plugin installation. Can be installed via composer as well.
 
 ### Security Requirements
@@ -161,17 +198,18 @@ It provides a modern, performant GraphQL API that directly interfaces with WordP
 
 ### Planned Features
 - Real-time subscriptions
-- Enhanced caching system (see WPGraphQL Smart Cache)
-- Improved debugging tools (see WPGraphQL IDE)
+- Improved debugging tools (WPGraphQL IDE - planned)
 - Better error reporting
 - Performance optimizations
 - Custom Scalars
 - Support for additional directives
 
+**Note:** WPGraphQL Smart Cache is already available in `plugins/wp-graphql-smart-cache/` and is listed in the WPGraphQL Ecosystem section above.
+
 ### Scalability Goals
 - Increased Support for high-traffic sites
 - Enterprise-level performance
-- Multi-site network support (tbd)
+- Multi-site network support (currently works with per-site endpoints; network-level endpoint may be considered in the future)
 
 ### Community Growth
 - Documentation expansion
@@ -185,7 +223,7 @@ It provides a modern, performant GraphQL API that directly interfaces with WordP
 ### Code Standards
 - WordPress Coding Standards
 - PHPStan Level 10 compliance
-- 85+% unit test coverage
+- Code coverage maintained and improved (enforced via Codecov with auto-target and 1% threshold)
 - Integration test suite
 - E2E test coverage
 

--- a/.cursor/rules/README.md
+++ b/.cursor/rules/README.md
@@ -1,29 +1,45 @@
 # WPGraphQL Cursor Rules
 
-This directory contains project-specific rules for Cursor, an AI-powered code editor. These rules help the AI understand the structure and patterns of the WPGraphQL codebase.
+This directory contains project-specific rules for Cursor, an AI-powered code editor. These rules help the AI understand the structure and patterns of the WPGraphQL monorepo codebase.
+
+## Monorepo Structure
+
+This repository is a monorepo containing multiple WordPress plugins in the `plugins/` directory:
+- **WPGraphQL** (core): The main GraphQL API plugin
+- **WPGraphQL Smart Cache**: Caching and cache invalidation extension
+- **Future plugins**: WPGraphQL IDE, WPGraphQL for ACF, and others
+
+File patterns in the rules are relative to the repository root. For example, `plugins/wp-graphql/src/**/*.php` refers to the core plugin's source code.
 
 ## Rule Files
 
-- **wpgraphql.json**: The main rule file that contains information about the WPGraphQL project, including frameworks, key concepts, file patterns, dependencies, and more.
+- **wpgraphql.json**: The main rule file that contains information about the WPGraphQL monorepo, including frameworks, key concepts, file patterns, dependencies, development workflows, and more.
+- **php_files.json**: PHP-specific coding standards and conventions that apply to all plugins in the monorepo.
 
 ## How These Rules Help
 
-These rules provide context to the AI when working with the WPGraphQL codebase, enabling it to:
+These rules provide context to the AI when working with the WPGraphQL monorepo, enabling it to:
 
-1. Understand the project structure and architecture
-2. Recognize common code patterns
-3. Identify key files and directories
-4. Understand the purpose of different components
-5. Provide more accurate and relevant suggestions
+1. Understand the monorepo structure and architecture
+2. Navigate between different plugins in the `plugins/` directory
+3. Recognize common code patterns across plugins
+4. Identify key files and directories (with correct paths relative to repository root)
+5. Understand development workflows (conventional commits, testing, building)
+6. Provide accurate commands for npm workspaces and Turborepo
+7. Understand the purpose of different components across the ecosystem
 
 ## For Contributors
 
-If you're contributing to WPGraphQL and using Cursor, these rules will automatically be applied when you open the project in Cursor. This ensures that all contributors have the same context when working with the codebase.
+If you're contributing to any plugin in the WPGraphQL monorepo and using Cursor, these rules will automatically be applied when you open the project in Cursor. This ensures that all contributors have the same context when working with the codebase, regardless of which plugin they're working on.
+
+The rules apply to all plugins in the monorepo, providing consistent guidance whether you're working on the core WPGraphQL plugin, WPGraphQL Smart Cache, or any future plugins.
 
 ## Updating Rules
 
-If you need to update these rules, please modify the appropriate JSON file in this directory. Make sure to follow the existing structure and format.
+If you need to update these rules, please modify the appropriate JSON file in this directory. Make sure to follow the existing structure and format. Remember that file patterns should be relative to the repository root (e.g., `plugins/wp-graphql/src/**/*.php`).
 
 ## Learn More
 
 For more information about Cursor rules, visit the [Cursor documentation](https://docs.cursor.com/context/rules-for-ai).
+
+For information about the monorepo structure, see [docs/ARCHITECTURE.md](../../docs/ARCHITECTURE.md) in the repository.

--- a/.cursor/rules/php_files.json
+++ b/.cursor/rules/php_files.json
@@ -14,7 +14,7 @@
     },
     "php_version": {
       "min": "7.4",
-      "max": "8.3"
+      "recommended": "8.x (8.4 tested in CI)"
     },
     "wordpress_version": {
       "min": "6.0"

--- a/.cursor/rules/wpgraphql.json
+++ b/.cursor/rules/wpgraphql.json
@@ -1,5 +1,5 @@
 {
-  "description": "WPGraphQL is a WordPress plugin that adds a /graphql endpoint to the WordPress site and defines a GraphQL Schema based on internal WordPress registries.",
+  "description": "WPGraphQL is a monorepo containing the WPGraphQL ecosystem of WordPress plugins. The core WPGraphQL plugin adds a /graphql endpoint to WordPress sites and defines a GraphQL Schema based on internal WordPress registries. The repository uses npm workspaces and Turborepo for managing multiple plugins.",
   "file_patterns": ["**/*"],
   "rules": {
     "frameworks_and_technologies": {
@@ -11,6 +11,22 @@
       "api": "graphql"
     },
     "key_concepts": [
+      {
+        "name": "Monorepo",
+        "description": "Single repository containing multiple related WordPress plugins. All plugins are in the plugins/ directory, each as a self-contained WordPress plugin."
+      },
+      {
+        "name": "npm Workspaces",
+        "description": "Package management system that manages dependencies across all plugins in the monorepo. Workspaces are defined in the root package.json as plugins/*"
+      },
+      {
+        "name": "Turborepo",
+        "description": "Build orchestration tool that runs tasks across workspaces in parallel, with caching and dependency awareness"
+      },
+      {
+        "name": "Plugin Ecosystem",
+        "description": "Related plugins that extend WPGraphQL, including WPGraphQL Smart Cache, and future plugins like WPGraphQL IDE and WPGraphQL for ACF"
+      },
       {
         "name": "GraphQL Schema",
         "description": "The structure that defines the types, queries, and mutations available in the WPGraphQL API"
@@ -30,72 +46,88 @@
       {
         "name": "GraphiQL IDE",
         "description": "An interactive development environment for testing GraphQL queries"
+      },
+      {
+        "name": "Authentication",
+        "description": "WPGraphQL does not include built-in authentication. Authentication is handled via extension plugins (e.g., WPGraphQL JWT Authentication, WPGraphQL Headless Login). Application Passwords (WordPress 5.6+) are supported and may be enhanced in future releases."
+      },
+      {
+        "name": "Multisite Support",
+        "description": "WPGraphQL works with WordPress Multisite installations. Each site in the network has its own GraphQL endpoint. Network-level endpoints are not currently supported but may be considered in the future."
       }
     ],
     "file_patterns": [
       {
-        "pattern": "src/Admin/*.php",
-        "description": "WordPress admin interface implementations"
+        "pattern": "plugins/wp-graphql/src/Admin/*.php",
+        "description": "WordPress admin interface implementations for core WPGraphQL plugin"
       },
       {
-        "pattern": "src/Connection/*.php",
+        "pattern": "plugins/wp-graphql/src/Connection/*.php",
         "description": "Classes handling GraphQL connections and pagination"
       },
       {
-        "pattern": "src/Data/*.php",
+        "pattern": "plugins/wp-graphql/src/Data/*.php",
         "description": "Data manipulation and transformation classes"
       },
       {
-        "pattern": "src/Model/*.php",
+        "pattern": "plugins/wp-graphql/src/Model/*.php",
         "description": "Model classes that handle data access and authorization"
       },
       {
-        "pattern": "src/Mutation/*.php",
+        "pattern": "plugins/wp-graphql/src/Mutation/*.php",
         "description": "Classes defining GraphQL mutations"
       },
       {
-        "pattern": "src/Registry/*.php",
+        "pattern": "plugins/wp-graphql/src/Registry/*.php",
         "description": "Classes for registering types and fields"
       },
       {
-        "pattern": "src/Server/*.php",
+        "pattern": "plugins/wp-graphql/src/Server/*.php",
         "description": "Validation Rules and other configuration for the GraphQL Server"
       },
       {
-        "pattern": "src/Type/*.php",
+        "pattern": "plugins/wp-graphql/src/Type/*.php",
         "description": "GraphQL type definitions"
       },
       {
-        "pattern": "src/Utils/*.php",
+        "pattern": "plugins/wp-graphql/src/Utils/*.php",
         "description": "Utility classes and helper functions"
       },
       {
-        "pattern": "tests/**/*.php",
-        "description": "PHPUnit test files"
+        "pattern": "plugins/*/src/**/*.php",
+        "description": "PHP source code for all plugins in the monorepo"
       },
       {
-        "pattern": "access-functions.php",
-        "description": "Global access functions"
+        "pattern": "plugins/wp-graphql/tests/**/*.php",
+        "description": "PHPUnit test files for core WPGraphQL plugin"
       },
       {
-        "pattern": "docs/*.md",
-        "description": "User documentation for the plugin"
+        "pattern": "plugins/*/tests/**/*.php",
+        "description": "Test files for all plugins in the monorepo"
       },
       {
-        "pattern": "cli/*.php",
-        "description": "WP-CLI commands for interacting with WPGraphQL using WP-CLI"
+        "pattern": "plugins/wp-graphql/access-functions.php",
+        "description": "Global access functions for WPGraphQL"
       },
       {
-        "pattern": "phpstan/*.php",
-        "description": "Stubs for use with phpstan for static analysis"
+        "pattern": "plugins/wp-graphql/docs/*.md",
+        "description": "User documentation for the core plugin"
       },
       {
-        "pattern": "packages/**/*.js",
+        "pattern": "plugins/wp-graphql/packages/**/*.js",
         "description": "JavaScript packages that make up the GraphiQL IDE"
       },
       {
-        "pattern": ".wordpress-org/",
-        "description": "Files used for building and deploying the plugin to WordPress.org"
+        "pattern": "plugins/wp-graphql-smart-cache/**/*.php",
+        "description": "WPGraphQL Smart Cache plugin source code"
+      },
+      {
+        "pattern": "docs/**/*.md",
+        "description": "Shared contributor documentation"
+      },
+      {
+        "pattern": "bin/**/*.sh",
+        "description": "Shared scripts for development and CI"
       }
     ],
     "dependencies": [
@@ -139,82 +171,94 @@
     },
     "key_directories": [
       {
-        "directory": "src/",
-        "description": "Core plugin source code"
+        "directory": "plugins/",
+        "description": "Root directory containing all WordPress plugins in the monorepo. Each subdirectory is a self-contained plugin."
       },
       {
-        "directory": "includes/",
-        "description": "Plugin includes and utilities"
+        "directory": "plugins/wp-graphql/",
+        "description": "Core WPGraphQL plugin directory"
       },
       {
-        "directory": "tests/",
-        "description": "Test files"
+        "directory": "plugins/wp-graphql/src/",
+        "description": "Core plugin PHP source code"
+      },
+      {
+        "directory": "plugins/wp-graphql/tests/",
+        "description": "Test files for core WPGraphQL plugin"
+      },
+      {
+        "directory": "plugins/wp-graphql-smart-cache/",
+        "description": "WPGraphQL Smart Cache extension plugin"
+      },
+      {
+        "directory": "plugins/*/src/",
+        "description": "PHP source code for any plugin in the monorepo"
       },
       {
         "directory": "docs/",
-        "description": "Documentation"
-      },
-      {
-        "directory": "languages/",
-        "description": "Translation files"
-      },
-      {
-        "directory": ".github/",
-        "description": "Files used for interacting with GitHub"
-      },
-      {
-        "directory": ".wordpress-org/",
-        "description": "Files used for building and deploying the plugin to WordPress.org"
-      },
-      {
-        "directory": "build/",
-        "description": "Contains the built assets for the GraphiQL IDE"
+        "description": "Shared contributor documentation (DEVELOPMENT.md, CONTRIBUTING.md, TESTING.md, ARCHITECTURE.md)"
       },
       {
         "directory": "bin/",
-        "description": "Contains scripts used in CI"
+        "description": "Shared scripts for development and CI"
       },
       {
-        "directory": "img",
-        "description": "Contains images used in documentation"
+        "directory": ".github/",
+        "description": "GitHub workflows, templates, and configuration"
       },
       {
-        "directory": "phpstan/",
-        "description": "PHPStan configuration and stubs"
+        "directory": "plugins/wp-graphql/docs/",
+        "description": "User documentation for the core plugin (published to wpgraphql.com)"
+      },
+      {
+        "directory": "plugins/wp-graphql/build/",
+        "description": "Built assets for the GraphiQL IDE"
       }
     ],
     "important_files": [
       {
-        "file": "wp-graphql.php",
-        "description": "Main plugin file"
+        "file": "package.json",
+        "description": "Root workspace configuration for npm workspaces and Turborepo"
       },
       {
-        "file": "composer.json",
-        "description": "Dependency management"
-      },
-      {
-        "file": ".phpcs.xml.dist",
-        "description": "PHP CodeSniffer configuration"
-      },
-      {
-        "file": "phpunit.xml.dist",
-        "description": "PHPUnit configuration"
-      },
-      {
-        "file": "access-functions.php",
-        "description": "Global access functions"
-      },
-      {
-        "file": "phpstan.neon.dist",
-        "description": "PHPStan configuration"
+        "file": "turbo.json",
+        "description": "Turborepo build orchestration configuration"
       },
       {
         "file": ".wp-env.json",
-        "description": "@wordpress/env (Docker) configuration for local development and testing"
+        "description": "@wordpress/env (Docker) configuration for local development and testing. Shared across all plugins."
       },
       {
-        "file": ".wordpress-org/blueprints/blueprint.json",
-        "description": "Blueprint for running WPGraphQL in WordPress Playground, a WASM environment that runs WordPress fully in the browser"
+        "file": "plugins/wp-graphql/wp-graphql.php",
+        "description": "Main plugin file for core WPGraphQL plugin"
+      },
+      {
+        "file": "plugins/wp-graphql/composer.json",
+        "description": "PHP dependency management for core plugin"
+      },
+      {
+        "file": "plugins/wp-graphql/package.json",
+        "description": "JavaScript dependency management for core plugin"
+      },
+      {
+        "file": "plugins/wp-graphql/access-functions.php",
+        "description": "Global access functions for WPGraphQL"
+      },
+      {
+        "file": "plugins/wp-graphql-smart-cache/wp-graphql-smart-cache.php",
+        "description": "Main plugin file for WPGraphQL Smart Cache"
+      },
+      {
+        "file": "docs/DEVELOPMENT.md",
+        "description": "Development setup guide for the monorepo"
+      },
+      {
+        "file": "docs/CONTRIBUTING.md",
+        "description": "Contributing guide with conventional commits and PR workflow"
+      },
+      {
+        "file": "docs/ARCHITECTURE.md",
+        "description": "Architecture overview of the monorepo structure"
       }
     ],
     "debug_tools": [
@@ -230,6 +274,90 @@
         "name": "Query Tracing",
         "description": "Shows trace data for resolvers (i.e. timing for execution). Enabled via WPGraphQL Settings and available in GraphiQL when debug mode is enabled"
       }
-    ]
+    ],
+    "development_workflows": {
+      "conventional_commits": {
+        "description": "PR titles must follow Conventional Commits format. PRs are squash merged, so the PR title becomes the commit message.",
+        "formats": {
+          "feat:": "New feature (minor version bump)",
+          "fix:": "Bug fix (patch version bump)",
+          "perf:": "Performance improvement (patch version bump)",
+          "docs:": "Documentation only (no version bump)",
+          "refactor:": "Code change without feature/fix (no version bump)",
+          "test:": "Adding/fixing tests (no version bump)",
+          "chore:": "Maintenance tasks (no version bump)",
+          "ci:": "CI/CD changes (no version bump)",
+          "feat!:": "Breaking change feature (major version bump)",
+          "fix!:": "Breaking change fix (major version bump)",
+          "perf!:": "Breaking change performance (major version bump)"
+        },
+        "note": "The ! suffix can only be used with feat, fix, or perf prefixes. release-please uses these to determine version bumps."
+      },
+      "pr_workflow": {
+        "description": "PRs are squash merged to main. The PR title must follow conventional commits format as it becomes the commit message.",
+        "process": [
+          "1. Create feature branch from main",
+          "2. Make changes and commit (individual commits don't need conventional format)",
+          "3. Open PR with conventional commit title",
+          "4. PR is validated by CI",
+          "5. PR is squash merged to main",
+          "6. release-please creates/updates Release PR automatically"
+        ]
+      },
+      "testing_commands": {
+        "run_all_tests": "npm run -w @wpgraphql/wp-graphql test:codecept:wpunit",
+        "run_specific_test": "npm run -w @wpgraphql/wp-graphql test:codecept:wpunit -- tests/wpunit/PostObjectQueriesTest.php",
+        "run_acceptance_tests": "npm run -w @wpgraphql/wp-graphql test:codecept:acceptance",
+        "run_functional_tests": "npm run -w @wpgraphql/wp-graphql test:codecept:functional",
+        "run_e2e_tests": "npm run -w @wpgraphql/wp-graphql test:e2e",
+        "run_with_coverage": "PCOV_ENABLED=1 npm run wp-env start && npm run -w @wpgraphql/wp-graphql test:codecept:coverage",
+        "test_environment": "Test site runs at localhost:8889 via wp-env, development site at localhost:8888"
+      },
+      "build_commands": {
+        "build_all": "npm run build (uses Turborepo to build all plugins in parallel)",
+        "build_specific_plugin": "npm run -w @wpgraphql/wp-graphql build",
+        "turborepo_cache": "Turborepo caches build outputs, skipping unchanged work"
+      },
+      "environment_commands": {
+        "start": "npm run wp-env start (starts development site at localhost:8888 and test site at localhost:8889)",
+        "start_with_xdebug": "npm run wp-env start -- --xdebug",
+        "stop": "npm run wp-env stop",
+        "destroy": "npm run wp-env destroy (removes all data)",
+        "wp_cli": "npm run wp-env run cli -- wp <command>",
+        "test_wp_cli": "npm run wp-env run tests-cli -- wp <command>"
+      },
+      "dependency_management": {
+        "install_all": "npm install (installs dependencies for all workspaces)",
+        "install_plugin_dep": "npm install <package> -w @wpgraphql/wp-graphql",
+        "composer_install": "Composer dependencies are installed automatically in Docker container when wp-env starts"
+      }
+    },
+    "common_tasks": {
+      "running_tests": {
+        "description": "Run tests for a specific plugin using npm workspaces",
+        "example": "npm run -w @wpgraphql/wp-graphql test:codecept:wpunit"
+      },
+      "building_assets": {
+        "description": "Build assets using Turborepo for parallel builds and caching",
+        "example": "npm run build (builds all plugins) or npm run -w @wpgraphql/wp-graphql build (specific plugin)"
+      },
+      "adding_dependencies": {
+        "description": "Add dependencies to a specific plugin workspace",
+        "example": "npm install <package> -w @wpgraphql/wp-graphql"
+      },
+      "creating_new_plugin": {
+        "description": "When adding a new plugin to the monorepo, create it in plugins/ directory with standard WordPress plugin structure",
+        "structure": "plugins/your-plugin-name/your-plugin-name.php, src/, tests/, composer.json, package.json"
+      },
+      "local_development": {
+        "description": "Start local WordPress environment with all plugins",
+        "steps": [
+          "1. npm install (install all workspace dependencies)",
+          "2. npm run wp-env start (start Docker environment)",
+          "3. Access development site at localhost:8888",
+          "4. Access test site at localhost:8889"
+        ]
+      }
+    }
   }
 }

--- a/.cursor/rules/wpgraphql.mdc
+++ b/.cursor/rules/wpgraphql.mdc
@@ -1,9 +1,69 @@
 ---
-description:
-globs:
+description: Quick reference guide for working with the WPGraphQL monorepo
+globs: ["**/*"]
 ---
 
-# Your rule content
+# WPGraphQL Monorepo Quick Reference
 
-- You can @ files here
-- You can use markdown but dont have to
+## Repository Structure
+
+This is a monorepo containing multiple WordPress plugins:
+- `plugins/wp-graphql/` - Core WPGraphQL plugin
+- `plugins/wp-graphql-smart-cache/` - Smart Cache extension
+- Future plugins will be added to `plugins/` directory
+
+## Common Commands
+
+### Development Environment
+- `npm run wp-env start` - Start WordPress environment (dev: localhost:8888, test: localhost:8889)
+- `npm run wp-env stop` - Stop environment
+- `npm run wp-env destroy` - Remove all data and containers
+
+### Testing
+- `npm run -w @wpgraphql/wp-graphql test:codecept:wpunit` - Run WPUnit tests
+- `npm run -w @wpgraphql/wp-graphql test:codecept:acceptance` - Run acceptance tests
+- `npm run -w @wpgraphql/wp-graphql test:codecept:functional` - Run functional tests
+- `npm run -w @wpgraphql/wp-graphql test:e2e` - Run E2E (Playwright) tests
+- `PCOV_ENABLED=1 npm run wp-env start` - Start with coverage enabled
+
+### Building
+- `npm run build` - Build all plugins (uses Turborepo)
+- `npm run -w @wpgraphql/wp-graphql build` - Build specific plugin
+
+### Dependencies
+- `npm install` - Install all workspace dependencies
+- `npm install <package> -w @wpgraphql/wp-graphql` - Add dependency to specific plugin
+
+## Key Files
+
+- `@.cursor/prd.md` - Product Requirements Document
+- `@docs/DEVELOPMENT.md` - Development setup guide
+- `@docs/CONTRIBUTING.md` - Contributing guide with conventional commits
+- `@docs/ARCHITECTURE.md` - Monorepo architecture overview
+- `@.wp-env.json` - WordPress environment configuration
+- `@turbo.json` - Turborepo build configuration
+- `@package.json` - Root workspace configuration
+
+## Conventional Commits
+
+PR titles must follow conventional commits format:
+- `feat:` - New feature (minor version)
+- `fix:` - Bug fix (patch version)
+- `feat!:` - Breaking change (major version)
+- See `@.cursor/rules/wpgraphql.json` for full list
+
+## File Paths
+
+All file paths in this monorepo are relative to the repository root:
+- Core plugin: `plugins/wp-graphql/src/**/*.php`
+- Smart Cache: `plugins/wp-graphql-smart-cache/src/**/*.php`
+- Tests: `plugins/*/tests/**/*.php`
+- Documentation: `docs/**/*.md`
+
+## Plugin Structure
+
+Each plugin in `plugins/` is a self-contained WordPress plugin with:
+- Main plugin file: `plugins/{plugin-name}/{plugin-name}.php`
+- Source code: `plugins/{plugin-name}/src/`
+- Tests: `plugins/{plugin-name}/tests/`
+- `composer.json` and `package.json` for dependencies


### PR DESCRIPTION
## Summary

This PR updates the Cursor rules and PRD to accurately reflect the current monorepo structure and project state.

## Changes

### PRD Updates (.cursor/prd.md)
- Added monorepo structure section describing the repository organization
- Updated product overview to mention the WPGraphQL ecosystem
- Clarified authentication (JWT via extensions, not built-in; Application Passwords support)
- Updated WordPress/PHP/database requirements to be more accurate (required vs preferred)
- Clarified multisite support status (works with per-site endpoints)
- Updated test coverage requirements to match Codecov configuration

### Rules Updates (.cursor/rules/)
- **wpgraphql.json**: Added authentication and multisite key concepts, enhanced testing commands
- **php_files.json**: Updated PHP version to reflect PHP 8.4 testing in CI
- **wpgraphql.mdc**: Added E2E test commands and coverage setup
- **README.md**: Already updated in previous work

## Verification

- All JSON files validated
- All changes align with actual codebase structure
- Consistent with updated PRD information