### PR TITLE
fix: ensure all required workflows run for release-please PRs

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -24,6 +24,7 @@ jobs:
   # ===========================================
   # Detects which plugins have changes to determine which test suites to run.
   # Each plugin job depends on this and only runs if its files changed.
+  # Release-please PRs (branches starting with "release-please--") will run all tests.
   # ===========================================
 
   detect-changes:
@@ -36,9 +37,20 @@ jobs:
       wp-graphql-smart-cache: ${{ steps.filter.outputs.wp-graphql-smart-cache_any_changed }}
       # Add outputs for additional plugins here:
       # wpgraphql-acf: ${{ steps.filter.outputs.wpgraphql-acf_any_changed }}
+      is-release-pr: ${{ steps.check-release-pr.outputs.is-release-pr }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+
+      - name: Check if release-please PR
+        id: check-release-pr
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]] && [[ "${{ github.head_ref }}" =~ ^release-please-- ]]; then
+            echo "is-release-pr=true" >> $GITHUB_OUTPUT
+            echo "🔔 Detected Release PR - will run integration tests for all plugins"
+          else
+            echo "is-release-pr=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Detect changed files
         id: filter
@@ -55,6 +67,7 @@ jobs:
               - plugins/wp-graphql/package-lock.json
               - plugins/wp-graphql/tests/**
               - plugins/wp-graphql/codeception.dist.yml
+              - .release-please-manifest.json
               - package.json
               - package-lock.json
               - .wp-env.json
@@ -70,6 +83,7 @@ jobs:
               - plugins/wp-graphql-smart-cache/tests/**
               - plugins/wp-graphql-smart-cache/codeception.dist.yml
               - plugins/wp-graphql/**/*.php
+              - .release-please-manifest.json
               - package.json
               - package-lock.json
               - .wp-env.json
@@ -84,6 +98,7 @@ jobs:
         run: |
           echo "wp-graphql changed: ${{ steps.filter.outputs.wp-graphql_any_changed }}"
           echo "wp-graphql-smart-cache changed: ${{ steps.filter.outputs.wp-graphql-smart-cache_any_changed }}"
+          echo "is-release-pr: ${{ steps.check-release-pr.outputs.is-release-pr }}"
 
   # ===========================================
   # TEST MATRIX
@@ -111,7 +126,11 @@ jobs:
   wp-graphql:
     name: "Integration: ${{ matrix.name }}"
     needs: detect-changes
-    if: needs.detect-changes.outputs.wp-graphql == 'true' || github.event_name == 'workflow_dispatch'
+    # Run if: plugin has changes OR it's a release-please PR OR manual dispatch
+    if: |
+      (needs.detect-changes.outputs.wp-graphql == 'true' || 
+       needs.detect-changes.outputs.is-release-pr == 'true' || 
+       github.event_name == 'workflow_dispatch')
     strategy:
       fail-fast: false
       matrix:
@@ -194,7 +213,11 @@ jobs:
   wp-graphql-smart-cache:
     name: "Integration: ${{ matrix.name }}"
     needs: detect-changes
-    if: needs.detect-changes.outputs.wp-graphql-smart-cache == 'true' || github.event_name == 'workflow_dispatch'
+    # Run if: plugin has changes OR it's a release-please PR OR manual dispatch
+    if: |
+      (needs.detect-changes.outputs.wp-graphql-smart-cache == 'true' || 
+       needs.detect-changes.outputs.is-release-pr == 'true' || 
+       github.event_name == 'workflow_dispatch')
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/js-e2e-tests.yml
+++ b/.github/workflows/js-e2e-tests.yml
@@ -64,6 +64,7 @@ jobs:
               - plugins/wp-graphql/tests/e2e/**
               - plugins/wp-graphql/package.json
               - plugins/wp-graphql/package-lock.json
+              - .release-please-manifest.json
               - package.json
               - package-lock.json
               - .wp-env.json

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,7 +47,7 @@ jobs:
           # Check if Release PR
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             BRANCH_NAME="${{ github.head_ref }}"
-            if [[ "$BRANCH_NAME" == release-please--* ]]; then
+            if [[ "$BRANCH_NAME" =~ ^release-please-- ]]; then
               TEST_ALL=true
               echo "🔔 Detected Release PR - will lint all plugins"
             fi
@@ -71,6 +71,7 @@ jobs:
               - plugins/wp-graphql/composer.lock
               - plugins/wp-graphql/phpcs.xml.dist
               - plugins/wp-graphql/phpstan.neon.dist
+              - .release-please-manifest.json
             wp-graphql-smart-cache:
               - .github/workflows/lint-reusable.yml
               - .github/workflows/lint.yml
@@ -81,6 +82,7 @@ jobs:
               - plugins/wp-graphql-smart-cache/phpstan.neon.dist
               # Smart cache depends on wp-graphql, so wp-graphql changes trigger smart-cache linting
               - plugins/wp-graphql/**/*.php
+              - .release-please-manifest.json
             # Add additional plugins here:
             # wpgraphql-acf:
             #   - .github/workflows/lint-reusable.yml

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -70,7 +70,7 @@ jobs:
           # Check if Release PR
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             BRANCH_NAME="${{ github.head_ref }}"
-            if [[ "$BRANCH_NAME" == release-please--* ]]; then
+            if [[ "$BRANCH_NAME" =~ ^release-please-- ]]; then
               TEST_ALL=true
               echo "🔔 Detected Release PR - will smoke test all plugins"
             fi
@@ -94,6 +94,7 @@ jobs:
               - plugins/wp-graphql/package.json
               - plugins/wp-graphql/packages/**
               - plugins/wp-graphql/webpack.config.js
+              - .release-please-manifest.json
               - package.json
               - .wp-env.json
               - bin/smoke-test.sh
@@ -103,6 +104,7 @@ jobs:
               - plugins/wp-graphql-smart-cache/composer.json
               - plugins/wp-graphql-smart-cache/.distignore
               - plugins/wp-graphql-smart-cache/package.json
+              - .release-please-manifest.json
               - package.json
               - .wp-env.json
               - bin/smoke-test.sh


### PR DESCRIPTION
## Problem

Integration tests and other required workflows were not running for release-please PRs because they only checked for file changes. Release PRs typically only change version files and \`.release-please-manifest.json\`, which weren't included in change detection paths.

## Solution

- ✅ Added release PR detection to \`integration-tests.yml\` (branches starting with \`release-please--\`)
- ✅ Added \`.release-please-manifest.json\` to change detection paths in all workflows
- ✅ Fixed pattern matching in \`lint.yml\` and \`smoke-test.yml\` to use \`=~\` for consistency
- ✅ All workflows now run for release-please PRs

## Workflows Updated

1. **Integration Tests** - Now detects release PRs and runs all tests
2. **JS E2E Tests** - Already had detection, added manifest to paths
3. **Lint** - Already had detection, fixed pattern and added manifest
4. **Smoke Test** - Already had detection, fixed pattern and added manifest
5. **Schema Linter** - No changes needed (always runs)

## Testing

This ensures all required workflows run for release PRs like PR #3503, providing proper validation before merging releases.