### PR TITLE
docs: add wp-graphql-ide to release-please manifest and document requirement

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -202,8 +202,15 @@ When adding a new plugin:
    - Set `needs_build: true` if plugin requires JS asset building
    - Add WP/PHP version matrix entries
 5. Ensure plugin is added to `release-please-config.json` (see [Architecture Docs](../docs/ARCHITECTURE.md#future-plugins))
-6. **Add version constant mapping** in `scripts/update-version-constants.js` if your plugin defines a version constant (see [Architecture Docs](../docs/ARCHITECTURE.md#4-version-constants-script))
-7. **Add plugin to Schema Linter matrix** in `schema-linter.yml`:
+6. **Add plugin to `.release-please-manifest.json`** with the current version number:
+   ```json
+   {
+     "plugins/your-plugin-name": "1.0.0"
+   }
+   ```
+   > **⚠️ Important:** If you forget this step, release-please will default to version `1.0.0` for the first release, even if your plugin is already at a higher version. Always check the plugin's main PHP file for the current version and add it to the manifest.
+7. **Add version constant mapping** in `scripts/update-version-constants.js` if your plugin defines a version constant (see [Architecture Docs](../docs/ARCHITECTURE.md#4-version-constants-script))
+8. **Add plugin to Schema Linter matrix** in `schema-linter.yml`:
    - Set `component` to match release tag prefix
    - Configure `active_plugins` for schema generation
 

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,5 @@
 {
   "plugins/wp-graphql": "2.8.0",
-  "plugins/wp-graphql-smart-cache": "2.0.1"
+  "plugins/wp-graphql-smart-cache": "2.0.1",
+  "plugins/wp-graphql-ide": "4.0.24"
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -278,6 +278,20 @@ Add a new entry in the `packages` object:
 - `package.json` (if it has a version field)
 - Any PHP constants files with version constants
 
+**Add to `.release-please-manifest.json`:**
+
+After adding the plugin to `release-please-config.json`, you **must** also add it to `.release-please-manifest.json` with the current version number:
+
+```json
+{
+  "plugins/wp-graphql": "2.8.0",
+  "plugins/wp-graphql-smart-cache": "2.0.1",
+  "plugins/your-plugin-name": "1.0.0"
+}
+```
+
+> **⚠️ Critical:** The manifest file tells release-please what the current version is. If you forget this step, release-please will default to `1.0.0` for the first release, even if your plugin is already at a higher version (e.g., `4.0.24`). Always check the plugin's main PHP file for the current version number and add it to the manifest.
+
 ### 4. Version Constants Script
 
 **Update `scripts/update-version-constants.js`:**


### PR DESCRIPTION
Fixes issue where release-please created 1.0.0 release for wp-graphql-ide (already at 4.0.24). Adds wp-graphql-ide to manifest and documents the requirement to prevent this in the future.