### PR TITLE
fix: hide DocSearch visually hidden accessibility element

### DIFF
--- a/websites/wpgraphql.com/src/styles/docsearch.css
+++ b/websites/wpgraphql.com/src/styles/docsearch.css
@@ -2,6 +2,18 @@
   @apply overflow-hidden !important;
 }
 
+.DocSearch-VisuallyHiddenForAccessibility {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
 .DocSearch-Container {
   @apply w-screen h-screen fixed z-[200] top-0 left-0 cursor-auto flex flex-col bg-black/20 backdrop-blur-sm p-4 sm:p-6 md:p-[10vh] lg:p-[12vh] dark:bg-slate-900/80;
 }


### PR DESCRIPTION
Fixes #3559

The `DocSearch-VisuallyHiddenForAccessibility` span was appearing visually, causing the text 'Search' to appear twice in the search bar when clicking the search icon.

## Changes
- Added CSS rule to properly hide the `.DocSearch-VisuallyHiddenForAccessibility` element using standard screen-reader-only techniques
- The element is now visually hidden but remains accessible to screen readers

## Testing
- ✅ Verified the search modal opens correctly
- ✅ Confirmed the duplicate 'Search' text is no longer visible
- ✅ Element remains accessible to screen readers (maintains accessibility)

Closes #3559