### PR TITLE
docs: fix broken project board links and update Slack to Discord

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -35,35 +35,24 @@ When contributing please ensure you follow the guidelines below so that we can k
 At this point you're waiting on us to merge your pull request. We'll review all pull requests, and make suggestions and changes if necessary.
 
 ## Issue Triage
-Below is an outline on the process we follow for issue triage. 
 
-There are 4 Github Project Boards for the WPGraphQL organization:
+We use a single GitHub Project Board to manage issue triage across the WPGraphQL organization. The board provides various filtered views to help with different aspects of the triage process.
 
-- **1: Issue Intake** https://github.com/orgs/wp-graphql/projects/5
-  - Each day this board is used to do initial "first touch" triage of issues. When new issues are opened on any of the WPGraphQL repos, they will be brought into this Project. 
-  - Once open issues are in this project, time should be taken to read the issue and label it with appropriate labels. Some of the key labels would be:
-    - **:rocket: Actionable**: This signifies that the issue has enough detail for someone to take action and create a Pull Request to resolve it.
-    - **Needs Discussion**: This signifies that there is some ambiguity with the issue and more detail is needed before it can be actionable.
-    - **Question**: This signifies that the issue was a question that needs answered, but isn't an actionable item that will lead to a pull request.
-  - Along with labeling, related issues, if any, should also be tagged at this time. 
-  
- - **2: Question Triage**: https://github.com/orgs/wp-graphql/projects/6
-   - Each day this board is used to triage issues labeled as "Question"
-   - If the question needs more information from the issue creator, it can be replied to, labeled with "Awaiting Response" and placed in the "Waiting for Response" Project column.
-   - Once a question has been answered and the issue is closed, it can be closed and moved to the "Done" column.
+**Main Project Board**: [WPGraphQL Issue Triage](https://github.com/orgs/wp-graphql/projects/11)
 
-- **3: Discussion Triage**: https://github.com/orgs/wp-graphql/projects/7
-  - Each day this board is used to triage issues labeled as "Needs Discussion"
-  - Once enough discussion has occurred and there are enough details to take action the issue should be labeled as "Actionable"
-    - If the discussion deems that the Issue cannot/should not be addressed, the issue should be closed and moved to the "Done" column.
-    
-- **4: Actionable Issues**: https://github.com/orgs/wp-graphql/projects/1
-  - Each day this board is used to dictate the priorities of the issues across the organization. 
-  - Issues that are actionable will first be placed into the "Needs Prioritized" column
-  - Issues will then be moved to the "Prioritized" Column in order of where they fall in priority. 
-  - When an issue is being worked on, it should be moved from the "Prioritized" Column to the "In Progress" Column
-    - When an issue is completed, it should be closed and moved to the "Done" column
-    - If an issue couldn't be completed for whatever, but still needs to be, it should be moved out of the "In Progress" column and back into the top of "Prioritized" column.
+The project board includes the following filtered views to help with triage:
+
+- **[Issue Triage](https://github.com/orgs/wp-graphql/projects/11/views/7)** - Initial triage of new issues, including labeling with appropriate labels such as:
+  - **:rocket: Actionable**: Issues with enough detail for someone to create a Pull Request
+  - **Needs Discussion**: Issues that need more detail or discussion before they can be actionable
+  - **Question**: Questions that need to be answered but won't lead to a pull request
+- **[Close Candidates](https://github.com/orgs/wp-graphql/projects/11/views/8)** - Issues that may be ready to close
+- **[Questions](https://github.com/orgs/wp-graphql/projects/11/views/9)** - Issues labeled as questions that need responses
+- **[Needs Response](https://github.com/orgs/wp-graphql/projects/11/views/21)** - Issues awaiting responses from issue creators
+- **[Needs Reproduction](https://github.com/orgs/wp-graphql/projects/11/views/22)** - Issues that need reproduction steps or examples
+- **[Bugs](https://github.com/orgs/wp-graphql/projects/11/views/23)** - Issues identified as bugs
+- **[Issues by Scope](https://github.com/orgs/wp-graphql/projects/11/views/13)** - Issues organized by their scope
+- **[Issues by Priority](https://github.com/orgs/wp-graphql/projects/11/views/11)** - Issues organized by priority level
 
 ## Automated Release Processes
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-Remember, an issue is not the place to ask general questions. You can use [Slack](https://wp-graphql.slack.com) for that ([join here](https://join.slack.com/t/wp-graphql/shared_invite/zt-3vloo60z-PpJV2PFIwEathWDOxCTTLA)).
+Remember, an issue is not the place to ask general questions. You can use [Discord](https://wpgraphql.com/discord) for that.
 
 Before you open an issue, please check if a similar issue already exists or has been closed before.
 


### PR DESCRIPTION
Fixes #3552

## Changes

- Replace broken project board links (projects/5, 6, 7, 1) with active board 11
- Document all 8 filtered views available in the project board:
  - Issue Triage
  - Close Candidates
  - Questions
  - Needs Response
  - Needs Reproduction
  - Bugs
  - Issues by Scope
  - Issues by Priority
- Replace expired Slack link with Discord link in ISSUE_TEMPLATE.md

## Summary

This PR addresses issue #3552 by fixing all broken URLs in the CONTRIBUTING.md file and updating the Slack reference to use Discord instead.