### PR TITLE
docs: update docs to reflect wp-graphql-acf in monorepo

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -21,6 +21,7 @@ This directory contains GitHub Actions workflows that automate our development, 
 - Compares schema against previous releases to detect breaking changes
 - Each plugin's schema is compared against its own release history (e.g., `wp-graphql/v2.7.0`, `wp-graphql-smart-cache/v1.0.0`)
 - Supports plugins that extend the schema (e.g., smart-cache tests with both wp-graphql and smart-cache active)
+- wp-graphql-acf is in the monorepo; a commented example job in `schema-linter.yml` can be uncommented to enable schema linting for it
 
 ### 3. Testing Integration (`testing-integration.yml`)
 
@@ -49,7 +50,7 @@ This directory contains GitHub Actions workflows that automate our development, 
 - Handles plugin dependencies (e.g., builds wp-graphql first if required by another plugin)
 - Installs plugins in a clean WordPress environment
 - Runs smoke tests to verify core functionality
-- Currently tests: wp-graphql (WP 6.8/PHP 8.3, WP 6.1/PHP 7.4) and wp-graphql-smart-cache (same versions)
+- Currently tests: wp-graphql, wp-graphql-ide, wp-graphql-smart-cache, and wp-graphql-acf (WP 6.8/PHP 8.3, WP 6.1–6.2/PHP 7.4 boundary versions)
 
 ### 6. CodeQL Analysis (`codeql-analysis.yml`)
 

--- a/.github/workflows/schema-linter.yml
+++ b/.github/workflows/schema-linter.yml
@@ -107,7 +107,7 @@ jobs:
   # 4. Add change detection output in detect-changes job above
   # 5. Add the job to the status-check job's needs array
   #
-  # Example for wpgraphql-acf (when added to monorepo):
+  # Example for wp-graphql-acf (in monorepo; uncomment to enable schema linting):
   # wp-graphql-acf:
   #   name: Lint wp-graphql-acf Schema
   #   needs: detect-changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ WPGraphQL is a monorepo containing the WPGraphQL ecosystem of WordPress plugins.
 - **plugins/wp-graphql/** — Core GraphQL API plugin (PHP 7.4+, WP 6.0+)
 - **plugins/wp-graphql-ide/** — GraphiQL IDE for WordPress admin (React-based)
 - **plugins/wp-graphql-smart-cache/** — Caching and cache invalidation
+- **plugins/wp-graphql-acf/** — ACF field groups and fields in GraphQL
 - **plugins/wp-graphql-schema-monitor/** — Schema change monitoring (experimental)
 
 ## Development Environment

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ wp-graphql/
 ├── plugins/
 │   ├── wp-graphql/          # WPGraphQL core plugin
 │   ├── wp-graphql-ide/      # IDE extension plugin
-│   └── wp-graphql-smart-cache/ # Smart Cache extension plugin
+│   ├── wp-graphql-smart-cache/ # Smart Cache extension plugin
+│   └── wp-graphql-acf/      # ACF extension plugin
 ├── websites/
 │   └── wpgraphql.com/        # WPGraphQL.com Next.js website
 ├── .wp-env.json             # Shared WordPress environment config
@@ -102,7 +103,7 @@ This focus keeps WPGraphQL maintainable while enabling a rich ecosystem of exten
 
 - **Flexible API**: Access posts, pages, custom post types, taxonomies, users, and more.
 - **Extendable Schema**: Easily add functionality with functions like `register_graphql_field` and `register_graphql_connection`.
-  - Plugins like [WPGraphQL Smart Cache](https://github.com/wp-graphql/wp-graphql/tree/main/plugins/wp-graphql-smart-cache), [WPGraphQL for ACF](https://github.com/wp-graphql/wp-graphql-acf) and [other extension plugins](https://wpgraphql.com/extensions) demonstrate the power of extendability.
+  - Plugins like [WPGraphQL Smart Cache](https://github.com/wp-graphql/wp-graphql/tree/main/plugins/wp-graphql-smart-cache), [WPGraphQL for ACF](https://github.com/wp-graphql/wp-graphql/tree/main/plugins/wp-graphql-acf) and [other extension plugins](https://wpgraphql.com/extensions) demonstrate the power of extendability.
 - **Modern Framework Integration**: Works seamlessly with [Next.js](https://vercel.com/guides/wordpress-with-vercel), [Svelte](https://www.okupter.com/blog/headless-wordpress-graphql-sveltekit), [Astro](https://docs.astro.build/en/guides/cms/wordpress/) and other frameworks.
 - **Optimized Performance**: Query only the data you need. Collect multiple resources in one request, reducing round-trips. Use [WPGraphQL Smart Cache](https://github.com/wp-graphql/wp-graphql/tree/main/plugins/wp-graphql-smart-cache) for enhanced performance and network-level caching and cache-invalidation.
 - **Developer Tools**: Explore the schema with tools like the [GraphiQL IDE](https://www.wpgraphql.com/docs/wp-graphiql) and [WordPress Playground](https://wordpress.org/plugins/wp-graphql/?preview=1).

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -36,12 +36,10 @@ The WordPress site will be available at:
 ```
 wp-graphql/
 ├── plugins/
-│   └── wp-graphql/           # WPGraphQL core plugin
-│       ├── src/              # PHP source code
-│       ├── tests/            # Test suites
-│       ├── packages/         # JavaScript packages (GraphiQL)
-│       ├── docs/             # User documentation (→ wpgraphql.com)
-│       └── package.json      # Plugin-specific npm config
+│   ├── wp-graphql/           # WPGraphQL core plugin
+│   ├── wp-graphql-ide/       # IDE extension plugin
+│   ├── wp-graphql-smart-cache/ # Smart Cache extension plugin
+│   └── wp-graphql-acf/       # ACF extension plugin
 ├── bin/
 │   └── setup-wp-env.sh       # Shared environment setup script
 ├── docs/                     # Contributor documentation (this folder)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -56,7 +56,7 @@ node scripts/update-version-constants.js --version=X.Y.Z --component=wp-graphql 
 | Argument | Required | Description |
 |----------|----------|-------------|
 | `--version` | Yes | The version number to set |
-| `--component` | Yes | Component name (e.g., `wp-graphql`, `wp-graphql-smart-cache`) |
+| `--component` | Yes | Component name (e.g., `wp-graphql`, `wp-graphql-smart-cache`, `wp-graphql-acf`) |
 | `--plugin-dir` | Yes | Path to plugin directory (relative to repo root) |
 
 **How it works**:

--- a/scripts/TESTING.md
+++ b/scripts/TESTING.md
@@ -21,6 +21,7 @@ The `update-version-constants.test.js` test suite includes:
 - ✅ `wp-graphql` (uses `constants.php` + `wp-graphql.php`)
 - ✅ `wp-graphql-smart-cache` (uses `wp-graphql-smart-cache.php` for both)
 - ✅ `wp-graphql-ide` (uses `wpgraphql-ide.php` for both)
+- ✅ `wp-graphql-acf` (uses `wpgraphql-acf.php` for both)
 - Edge cases, placeholders, error handling, etc.
 
 **Integration Test (1 test)** that:


### PR DESCRIPTION
After merging PR #3581, wp-graphql-acf lives at `plugins/wp-graphql-acf/`. This PR updates documentation so the monorepo is accurately described everywhere.

## Changes

- **README.md**: Add wp-graphql-acf to repo structure tree; point "WPGraphQL for ACF" link to monorepo path
- **docs/DEVELOPMENT.md**: List all four plugins in repository structure (wp-graphql, wp-graphql-ide, wp-graphql-smart-cache, wp-graphql-acf)
- **CLAUDE.md**: Add wp-graphql-acf to "Plugins in the Monorepo" list
- **.github/workflows/README.md**: Update Smoke Test "Currently tests" to include wp-graphql-ide and wp-graphql-acf; add note about wp-graphql-acf schema linting
- **.github/workflows/schema-linter.yml**: Update commented example from "when added to monorepo" to "in monorepo; uncomment to enable schema linting"
- **scripts/TESTING.md**: Add wp-graphql-acf to plugins with distinct version constant patterns
- **scripts/README.md**: Add wp-graphql-acf to component example for update-version-constants.js

Documentation-only; no workflow or code logic changes.