### PR TITLE
fix: sync readme.txt changelogs with releases

### DIFF
--- a/.github/workflows/update-release-pr.yml
+++ b/.github/workflows/update-release-pr.yml
@@ -151,6 +151,16 @@ jobs:
             --version="$VERSION" \
             --plugin-dir="$PLUGIN_DIR"
 
+      - name: Update readme changelog
+        if: steps.version_info.outputs.version != ''
+        env:
+          VERSION: ${{ steps.version_info.outputs.version }}
+          PLUGIN_DIR: ${{ steps.version_info.outputs.plugin_dir }}
+        run: |
+          node scripts/update-readme-changelog.js \
+            --version="$VERSION" \
+            --plugin-dir="$PLUGIN_DIR"
+
       - name: Check for languages directory
         id: i18n
         env:

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"format": "wp-scripts format",
 		"start": "turbo run start",
 		"test": "turbo run test",
-		"test:scripts": "node scripts/update-upgrade-notice.test.js && node scripts/update-version-constants.test.js",
+		"test:scripts": "node scripts/update-upgrade-notice.test.js && node scripts/update-version-constants.test.js && node scripts/update-readme-changelog.test.js",
 		"lint": "turbo run lint",
 		"zip": "turbo run zip",
 		"zip:wp-graphql": "composer -d plugins/wp-graphql run-script build-plugin",

--- a/plugins/wp-graphql-acf/readme.txt
+++ b/plugins/wp-graphql-acf/readme.txt
@@ -120,6 +120,29 @@ This release is a complete re-architecture of WPGraphQL for ACF, introducing bre
 
 == Changelog ==
 
+= 2.5.2 =
+
+**Bug Fixes**
+
+* **deps-dev:** bump guzzlehttp/psr7 from 2.8.0 to 2.9.0 in /plugins/wp-graphql-acf in the wp-graphql-acf-composer-dev-minor-patch group ([#3643](https://github.com/wp-graphql/wp-graphql/issues/3643))
+* **deps:** bump appsero/client from 1.2.1 to 1.4.0 in /plugins/wp-graphql-acf ([#3726](https://github.com/wp-graphql/wp-graphql/issues/3726))
+
+= 2.5.1 =
+
+**Bug Fixes**
+
+* **wp-graphql-acf:** ACF-registered post types/taxonomies not in GraphQL schema (init priority) ([#3609](https://github.com/wp-graphql/wp-graphql/issues/3609))
+
+= 2.5.0 =
+
+**New Features**
+
+* migrate WPGraphQL for ACF to monorepo ([#3581](https://github.com/wp-graphql/wp-graphql/issues/3581))
+
+**Bug Fixes**
+
+* allow null/empty meta_key in preview_support() for get_post_meta filter ([#3599](https://github.com/wp-graphql/wp-graphql/issues/3599))
+
 = 2.4.1 =
 
 **Chores / Bugfixes**

--- a/plugins/wp-graphql-ide/readme.txt
+++ b/plugins/wp-graphql-ide/readme.txt
@@ -43,6 +43,204 @@ WPGraphQL IDE follows Semver versioning. Breaking changes will be documented in 
 
 == Changelog ==
 
-WPGraphQL IDE publishes [release notes on GitHub](https://github.com/wp-graphql/wp-graphql/releases). Look for releases tagged with `wp-graphql-ide/v*`.
+= 4.2.0 =
 
-[View the full changelog](https://github.com/wp-graphql/wp-graphql/blob/main/plugins/wp-graphql-ide/CHANGELOG.md)
+**New Features**
+
+* **deps:** bump @babel/runtime from 7.24.1 to 7.29.2 in /plugins/wp-graphql-ide ([#3700](https://github.com/wp-graphql/wp-graphql/issues/3700))
+* **deps:** bump axios from 1.7.6 to 1.14.0 in /plugins/wp-graphql-ide ([#3706](https://github.com/wp-graphql/wp-graphql/issues/3706))
+* **deps:** bump basic-ftp from 5.0.5 to 5.2.0 in /plugins/wp-graphql-ide ([#3684](https://github.com/wp-graphql/wp-graphql/issues/3684))
+* **deps:** bump flatted from 3.3.1 to 3.4.2 in /plugins/wp-graphql-ide ([#3689](https://github.com/wp-graphql/wp-graphql/issues/3689))
+* **deps:** bump form-data from 4.0.0 to 4.0.5 in /plugins/wp-graphql-ide ([#3693](https://github.com/wp-graphql/wp-graphql/issues/3693))
+* **deps:** bump http-proxy-middleware from 2.0.6 to 2.0.9 in /plugins/wp-graphql-ide ([#3702](https://github.com/wp-graphql/wp-graphql/issues/3702))
+* **deps:** bump immutable from 4.3.5 to 4.3.8 in /plugins/wp-graphql-ide ([#3687](https://github.com/wp-graphql/wp-graphql/issues/3687))
+* **deps:** bump lodash from 4.17.21 to 4.18.1 in /plugins/wp-graphql-ide ([#3691](https://github.com/wp-graphql/wp-graphql/issues/3691))
+* **deps:** bump node-forge from 1.3.1 to 1.4.0 in /plugins/wp-graphql-ide ([#3686](https://github.com/wp-graphql/wp-graphql/issues/3686))
+* **deps:** bump on-headers and compression in /plugins/wp-graphql-ide ([#3678](https://github.com/wp-graphql/wp-graphql/issues/3678))
+* **deps:** bump picomatch from 2.3.1 to 2.3.2 in /plugins/wp-graphql-ide ([#3688](https://github.com/wp-graphql/wp-graphql/issues/3688))
+* **deps:** bump qs and body-parser in /plugins/wp-graphql-ide ([#3696](https://github.com/wp-graphql/wp-graphql/issues/3696))
+* **deps:** bump simple-git from 3.23.0 to 3.33.0 in /plugins/wp-graphql-ide ([#3675](https://github.com/wp-graphql/wp-graphql/issues/3675))
+* **deps:** bump svgo from 3.2.0 to 3.3.3 in /plugins/wp-graphql-ide ([#3690](https://github.com/wp-graphql/wp-graphql/issues/3690))
+* **deps:** bump the npm-prod-minor-patch group across 1 directory with 5 updates ([#3739](https://github.com/wp-graphql/wp-graphql/issues/3739))
+* **deps:** bump webpack from 5.94.0 to 5.105.4 in /plugins/wp-graphql-ide ([#3677](https://github.com/wp-graphql/wp-graphql/issues/3677))
+* **deps:** bump yaml from 1.10.2 to 1.10.3 in /plugins/wp-graphql-ide ([#3698](https://github.com/wp-graphql/wp-graphql/issues/3698))
+* migrate WPGraphQL for ACF to monorepo ([#3581](https://github.com/wp-graphql/wp-graphql/issues/3581))
+
+**Bug Fixes**
+
+* **deps-dev:** bump rimraf from 5.0.10 to 6.1.3 ([#3666](https://github.com/wp-graphql/wp-graphql/issues/3666))
+* resolve post by percent-encoded slug/URI when post_name is stored encoded ([#3582](https://github.com/wp-graphql/wp-graphql/issues/3582)) ([#3611](https://github.com/wp-graphql/wp-graphql/issues/3611))
+
+= 4.1.0 =
+
+**New Features**
+
+* import WPGraphQL IDE into monorepo ([#3542](https://github.com/wp-graphql/wp-graphql/issues/3542))
+
+**Bug Fixes**
+
+* resolve all JavaScript linting errors in wp-graphql-ide ([#3548](https://github.com/wp-graphql/wp-graphql/issues/3548))
+
+= 4.0.24 =
+
+**Patch Changes**
+
+* fde59ee: test13
+
+= 4.0.23 =
+
+**Patch Changes**
+
+* dc527b3: test12
+
+= 4.0.22 =
+
+**Patch Changes**
+
+* 3af6609: test11
+
+= 4.0.21 =
+
+**Patch Changes**
+
+* 4bebba0: test10
+
+= 4.0.20 =
+
+**Patch Changes**
+
+* f0194e1: test9
+
+= 4.0.19 =
+
+**Patch Changes**
+
+* 002a858: test8
+
+= 4.0.18 =
+
+**Patch Changes**
+
+* 4c4fd15: test7
+
+= 4.0.17 =
+
+**Patch Changes**
+
+* fbd12e3: test6
+
+= 4.0.16 =
+
+**Patch Changes**
+
+* 55d17f2: test5
+
+= 4.0.15 =
+
+**Patch Changes**
+
+* 7fd23b6: test4
+
+= 4.0.14 =
+
+**Patch Changes**
+
+* 47bac26: test3
+
+= 4.0.13 =
+
+**Patch Changes**
+
+* 81c75a8: test2
+
+= 4.0.12 =
+
+**Patch Changes**
+
+* 5f99ebc: test
+
+= 4.0.11 =
+
+**Patch Changes**
+
+* 7a53dbc: chore: trigger release
+
+= 4.0.10 =
+
+**Patch Changes**
+
+* 74c832c: chore: add period to description in readme.txt
+
+= 4.0.9 =
+
+**Patch Changes**
+
+* 2eab1a7: chore: update license format in readme.txt to GPL-3.0
+
+= 4.0.8 =
+
+**Patch Changes**
+
+* f610132: fix: remove duplicate git tag creation in release workflow
+
+= 4.0.7 =
+
+**Patch Changes**
+
+* bf627cc: Fixed an issue with plugin updates not appearing on WordPress.org
+* b47b46d: ci: attempt to fix GitHub actions auto deploy to wp.org.
+
+= 4.0.6 =
+
+**Patch Changes**
+
+* d1df1d4: chore: update tested WordPress version to 6.8
+
+= 4.0.5 =
+
+**Patch Changes**
+
+* c6cfbc1: fix: linting tooltips are now visible when using the IDE in the drawer
+* 6500ef3: fix: broken query composer by adding missing import statements for AbstractArgView and FieldView components. Props to @hacknug for the fix!
+
+= 4.0.4 =
+
+**Patch Changes**
+
+* b4d7302: Test
+
+= 4.0.3 =
+
+**Patch Changes**
+
+* fd9d099: chore: set workflow environment
+
+= 4.0.2 =
+
+**Patch Changes**
+
+* a2b5fbd: - chore: Bump supported WordPress version
+
+= 4.0.1 =
+
+**Patch Changes**
+
+* 477a555: ### Added
+
+* Introduced `wp_localize_escaped_data()` function for recursively escaping data before localizing it in WordPress. This ensures safe output of strings, URLs, integers, and nested arrays when passing data to JavaScript, using native WordPress functions like `wp_kses_post()` and `esc_url()`.
+
+**Improved**
+
+* Enhanced security by ensuring all localized data is properly sanitized before being passed to `wp_localize_script()`, preventing potential XSS vulnerabilities and ensuring safe use of dynamic data in JavaScript.
+
+* 4da3973: - chore: Bump the npm_and_yarn group across 1 directory with 7 updates
+
+= 4.0.0 =
+
+**Major Changes**
+
+* eda911d: Updated the plugin's custom filter and action names to be consistent across the plugin
+
+**Patch Changes**
+
+* eda911d: Fixed bug where credentials were being sent in the headers unnecessarily under certain conditions

--- a/plugins/wp-graphql-ide/readme.txt
+++ b/plugins/wp-graphql-ide/readme.txt
@@ -81,89 +81,11 @@ WPGraphQL IDE follows Semver versioning. Breaking changes will be documented in 
 
 * resolve all JavaScript linting errors in wp-graphql-ide ([#3548](https://github.com/wp-graphql/wp-graphql/issues/3548))
 
-= 4.0.24 =
+= 4.0.11 - 4.0.24 =
 
 **Patch Changes**
 
-* fde59ee: test13
-
-= 4.0.23 =
-
-**Patch Changes**
-
-* dc527b3: test12
-
-= 4.0.22 =
-
-**Patch Changes**
-
-* 3af6609: test11
-
-= 4.0.21 =
-
-**Patch Changes**
-
-* 4bebba0: test10
-
-= 4.0.20 =
-
-**Patch Changes**
-
-* f0194e1: test9
-
-= 4.0.19 =
-
-**Patch Changes**
-
-* 002a858: test8
-
-= 4.0.18 =
-
-**Patch Changes**
-
-* 4c4fd15: test7
-
-= 4.0.17 =
-
-**Patch Changes**
-
-* fbd12e3: test6
-
-= 4.0.16 =
-
-**Patch Changes**
-
-* 55d17f2: test5
-
-= 4.0.15 =
-
-**Patch Changes**
-
-* 7fd23b6: test4
-
-= 4.0.14 =
-
-**Patch Changes**
-
-* 47bac26: test3
-
-= 4.0.13 =
-
-**Patch Changes**
-
-* 81c75a8: test2
-
-= 4.0.12 =
-
-**Patch Changes**
-
-* 5f99ebc: test
-
-= 4.0.11 =
-
-**Patch Changes**
-
-* 7a53dbc: chore: trigger release
+* debugging release scripts
 
 = 4.0.10 =
 

--- a/plugins/wp-graphql/readme.txt
+++ b/plugins/wp-graphql/readme.txt
@@ -77,17 +77,17 @@ Learn more about how [Appsero collects and uses this data](https://appsero.com/p
 
 **New Features**
 
-* feat: refactor experiment registry for better testability (https://github.com/jasonbahl/automation-tests/pull/3453)
+* feat: refactor experiment registry for better testability ([#3453](https://github.com/jasonbahl/automation-tests/pull/3453))
 
 **Other Changes**
 
-* ci: optimize CI matrix with minimal/full modes (https://github.com/jasonbahl/automation-tests/pull/3465)
-* ci: evaluate Codecov alongside Coveralls for code coverage (https://github.com/jasonbahl/automation-tests/pull/3463)
-* ci: gitignore build directory and improve asset loading (https://github.com/jasonbahl/automation-tests/pull/3461)
-* test: only apply URL rewriting for Codeception tests, not Playwright e2e (https://github.com/jasonbahl/automation-tests/pull/3460)
-* test: bump Codeception to v3.7 (https://github.com/jasonbahl/automation-tests/pull/3456)
-* chore: update node, npm, and composer deps (https://github.com/jasonbahl/automation-tests/pull/3454)
-* ci: replace custom docker with wp-env (https://github.com/jasonbahl/automation-tests/pull/3451)
+* ci: optimize CI matrix with minimal/full modes ([#3465](https://github.com/jasonbahl/automation-tests/pull/3465))
+* ci: evaluate Codecov alongside Coveralls for code coverage ([#3463](https://github.com/jasonbahl/automation-tests/pull/3463))
+* ci: gitignore build directory and improve asset loading ([#3461](https://github.com/jasonbahl/automation-tests/pull/3461))
+* test: only apply URL rewriting for Codeception tests, not Playwright e2e ([#3460](https://github.com/jasonbahl/automation-tests/pull/3460))
+* test: bump Codeception to v3.7 ([#3456](https://github.com/jasonbahl/automation-tests/pull/3456))
+* chore: update node, npm, and composer deps ([#3454](https://github.com/jasonbahl/automation-tests/pull/3454))
+* ci: replace custom docker with wp-env ([#3451](https://github.com/jasonbahl/automation-tests/pull/3451))
 
 = 2.0.0 =
 
@@ -301,6 +301,102 @@ Composer dependencies are no longer versioned in Github. Recommended install sou
 
 == Changelog ==
 
+= 2.11.1 =
+
+**Bug Fixes**
+
+* reject non-numeric user loader keys to prevent SQL injection
+
+= 2.11.0 =
+
+**New Features**
+
+* **deps:** bump basic-ftp from 5.1.0 to 5.2.0 in /plugins/wp-graphql ([#3676](https://github.com/wp-graphql/wp-graphql/issues/3676))
+* **deps:** bump flatted from 3.3.3 to 3.4.2 in /plugins/wp-graphql ([#3679](https://github.com/wp-graphql/wp-graphql/issues/3679))
+* **deps:** bump immutable from 5.1.4 to 5.1.5 in /plugins/wp-graphql ([#3685](https://github.com/wp-graphql/wp-graphql/issues/3685))
+* **deps:** bump lodash from 4.17.21 to 4.18.1 in /plugins/wp-graphql ([#3673](https://github.com/wp-graphql/wp-graphql/issues/3673))
+* **deps:** bump node-forge from 1.3.3 to 1.4.0 in /plugins/wp-graphql ([#3681](https://github.com/wp-graphql/wp-graphql/issues/3681))
+* **deps:** bump picomatch in /plugins/wp-graphql ([#3682](https://github.com/wp-graphql/wp-graphql/issues/3682))
+* **deps:** bump qs from 6.14.1 to 6.14.2 in /plugins/wp-graphql ([#3670](https://github.com/wp-graphql/wp-graphql/issues/3670))
+* **deps:** bump simple-git from 3.30.0 to 3.33.0 in /plugins/wp-graphql ([#3680](https://github.com/wp-graphql/wp-graphql/issues/3680))
+* **deps:** bump svgo from 3.3.2 to 3.3.3 in /plugins/wp-graphql ([#3674](https://github.com/wp-graphql/wp-graphql/issues/3674))
+* **deps:** bump the npm-prod-minor-patch group across 1 directory with 5 updates ([#3739](https://github.com/wp-graphql/wp-graphql/issues/3739))
+* **deps:** bump yaml in /plugins/wp-graphql ([#3671](https://github.com/wp-graphql/wp-graphql/issues/3671))
+
+**Bug Fixes**
+
+* **deps-dev:** bump phpstan/phpstan from 2.1.40 to 2.1.44 in /plugins/wp-graphql in the wp-graphql-composer-dev-minor-patch group ([#3642](https://github.com/wp-graphql/wp-graphql/issues/3642))
+* **deps:** bump appsero/client from 2.0.5 to 2.0.6 in /plugins/wp-graphql in the wp-graphql-composer-patch group ([#3644](https://github.com/wp-graphql/wp-graphql/issues/3644))
+* **deps:** bump webonyx/graphql-php from 15.30.2 to 15.31.2 in /plugins/wp-graphql ([#3646](https://github.com/wp-graphql/wp-graphql/issues/3646))
+* **deps:** bump webonyx/graphql-php from 15.31.2 to 15.31.3 in /plugins/wp-graphql in the wp-graphql-composer-patch group ([#3729](https://github.com/wp-graphql/wp-graphql/issues/3729))
+
+= 2.10.1 =
+
+**Bug Fixes**
+
+* no-cache headers for authenticated requests ([#3340](https://github.com/wp-graphql/wp-graphql/issues/3340)) ([#3619](https://github.com/wp-graphql/wp-graphql/issues/3619))
+
+= 2.10.0 =
+
+**New Features**
+
+* migrate WPGraphQL for ACF to monorepo ([#3581](https://github.com/wp-graphql/wp-graphql/issues/3581))
+
+**Bug Fixes**
+
+* add capability check for comment update mutation ([#3616](https://github.com/wp-graphql/wp-graphql/issues/3616))
+* incorrect wpml_is_redirected filter hook types ([#3615](https://github.com/wp-graphql/wp-graphql/issues/3615))
+* resolve post by percent-encoded slug/URI when post_name is stored encoded ([#3582](https://github.com/wp-graphql/wp-graphql/issues/3582)) ([#3611](https://github.com/wp-graphql/wp-graphql/issues/3611))
+
+= 2.9.1 =
+
+**Bug Fixes**
+
+* Add class_exists check to is_graphql_http_request() to prevent fatal errors ([#3580](https://github.com/wp-graphql/wp-graphql/issues/3580))
+* **deps:** bump webonyx/graphql-php from 15.30.0 to 15.30.1 in /plugins/wp-graphql in the composer-minor-patch group across 1 directory ([#3564](https://github.com/wp-graphql/wp-graphql/issues/3564))
+* **deps:** bump webonyx/graphql-php from 15.30.1 to 15.30.2 in /plugins/wp-graphql in the composer-minor-patch group across 1 directory ([#3584](https://github.com/wp-graphql/wp-graphql/issues/3584))
+
+= 2.9.0 =
+
+**New Features**
+
+* add core user admin preferences fields to User type ([#3571](https://github.com/wp-graphql/wp-graphql/issues/3571))
+* import WPGraphQL IDE into monorepo ([#3542](https://github.com/wp-graphql/wp-graphql/issues/3542))
+
+**Bug Fixes**
+
+* correct version numbers in plugin files and improve version update script ([#3574](https://github.com/wp-graphql/wp-graphql/issues/3574))
+* resolve all JavaScript linting errors in wp-graphql-ide ([#3548](https://github.com/wp-graphql/wp-graphql/issues/3548))
+
+= 2.8.0 =
+
+**New Features**
+
+* Add internationalization (i18n) support for translations ([#3501](https://github.com/wp-graphql/wp-graphql/issues/3501))
+* import wp-graphql-smart-cache into monorepo ([#3504](https://github.com/wp-graphql/wp-graphql/issues/3504))
+
+**Bug Fixes**
+
+* add step to replace x-release-please-version placeholders during deployment
+* **deps:** bump webonyx/graphql-php from 15.29.4 to 15.30.0 in /plugins/wp-graphql in the composer-minor-patch group across 1 directory ([#3521](https://github.com/wp-graphql/wp-graphql/issues/3521))
+* nodeByUri returns null for REST API endpoints and static file paths ([#3530](https://github.com/wp-graphql/wp-graphql/issues/3530))
+* Prevent password from being changed when updating user without password field ([#3532](https://github.com/wp-graphql/wp-graphql/issues/3532))
+* replace x-release-please-version placeholders with 2.7.0
+* use clean build directory for WordPress.org deployment ([#3502](https://github.com/wp-graphql/wp-graphql/issues/3502))
+
+= 2.7.0 =
+
+**New Features**
+
+* add siteIcon and siteIconUrl fields to GeneralSettings ([#3475](https://github.com/wp-graphql/wp-graphql/issues/3475))
+
+**Bug Fixes**
+
+* add sanitization to additional settings fields ([#3480](https://github.com/wp-graphql/wp-graphql/issues/3480))
+* add sanitization to graphql_endpoint setting ([#3476](https://github.com/wp-graphql/wp-graphql/issues/3476))
+* **deps:** bump webonyx/graphql-php from 15.29.3 to 15.29.4 in /plugins/wp-graphql in the composer-minor-patch group across 1 directory ([#3487](https://github.com/wp-graphql/wp-graphql/issues/3487))
+* GraphiQL IDE improvements for LocalWP and toolbar buttons ([#3486](https://github.com/wp-graphql/wp-graphql/issues/3486))
+
 = 2.5.4 =
 
 **New Features**
@@ -510,7 +606,6 @@ We've written more about the update here:
 
 - [#3308](https://github.com/wp-graphql/wp-graphql/pull/3308): fix: update term mutation was preventing terms from removing the parentId
 
-
 = 1.32.0 =
 
 **New Features**
@@ -567,7 +662,6 @@ We've written more about the update here:
 - [#3235](https://github.com/wp-graphql/wp-graphql/pull/3235): chore: general updates to README.md and readme.txt
 - [#3234](https://github.com/wp-graphql/wp-graphql/pull/3234): chore: update quick-start.md to provide more clarity around using wpackagist
 
-
 = 1.29.2 =
 
 **Chores / Bugfixes**
@@ -585,7 +679,6 @@ We've written more about the update here:
 - [#3219](https://github.com/wp-graphql/wp-graphql/pull/3219): test: add tests for querying different sizes of media items
 - [#3229](https://github.com/wp-graphql/wp-graphql/pull/3229): fix: Deprecated null value warning in titleRendered callback
 
-
 = 1.29.0 =
 
 **New Features**
@@ -600,7 +693,6 @@ We've written more about the update here:
 - [#3211](https://github.com/wp-graphql/wp-graphql/pull/3211): chore: add LABELS.md
 - [#3201](https://github.com/wp-graphql/wp-graphql/pull/3201): fix: ensure connectedTerms returns terms for the specified taxonomy only
 - [#3199](https://github.com/wp-graphql/wp-graphql/pull/3199): chore(deps-dev): bump the npm_and_yarn group across 1 directory with 2 updates
-
 
 = 1.28.1 =
 
@@ -641,7 +733,6 @@ This release contains an internal refactor for how the Type Registry is generate
 - [#3155](https://github.com/wp-graphql/wp-graphql/pull/3155): chore(deps-dev): bump the npm_and_yarn group across 1 directory with 2 updates
 - [#3160](https://github.com/wp-graphql/wp-graphql/pull/3160): chore: Update branding assets
 - [#3162](https://github.com/wp-graphql/wp-graphql/pull/3162): fix: set_query_arg should not merge args
-
 
 = 1.27.0 =
 
@@ -709,7 +800,6 @@ This release contains an internal refactor for how the Type Registry is generate
 - [#3100](https://github.com/wp-graphql/wp-graphql/pull/3100): fix: recursion issues with interfaces
 - [#3082](https://github.com/wp-graphql/wp-graphql/pull/3082): chore: prepare ConnectionResolver classes for v2 backport
 
-
 = 1.23.0 =
 
 **New Features**
@@ -724,7 +814,6 @@ This release contains an internal refactor for how the Type Registry is generate
 - [#3092](https://github.com/wp-graphql/wp-graphql/pull/3092): ci: test against wp 6.5
 - [#3093](https://github.com/wp-graphql/wp-graphql/pull/3093): ci: Update actions in GitHub workflows and cleanup. Thanks @justlevine!
 - [#3093](https://github.com/wp-graphql/wp-graphql/pull/3093): chore: update Composer dev-deps and lint. Thanks @justlevine!
-
 
 = 1.22.1 =
 
@@ -762,7 +851,6 @@ This release contains an internal refactor for how the Type Registry is generate
 - [#3038](https://github.com/wp-graphql/wp-graphql/pull/3038): chore(deps-dev): bump the composer group across 1 directories with 1 update. Thanks @dependabot!
 - [#3033](https://github.com/wp-graphql/wp-graphql/pull/3033): fix: php deprecation error for dynamic properties on AppContext class
 - [#3031](https://github.com/wp-graphql/wp-graphql/pull/3031): fix(graphiql): Allow GraphiQL to run even if a valid schema cannot be returned. Thanks @linucks!
-
 
 = 1.20.0 =
 

--- a/scripts/update-readme-changelog.js
+++ b/scripts/update-readme-changelog.js
@@ -1,0 +1,276 @@
+#!/usr/bin/env node
+
+/**
+ * Sync one version from CHANGELOG.md to readme.txt changelog format.
+ *
+ * Usage:
+ *   node scripts/update-readme-changelog.js --version=1.2.3 --plugin-dir=plugins/wp-graphql
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+function parseArgs() {
+	const args = {};
+	process.argv.slice(2).forEach((arg) => {
+		const [key, value] = arg.replace(/^--/, '').split('=');
+		args[key] = value;
+	});
+	return args;
+}
+
+function escapeRegExp(value) {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function getVersionFromHeading(line) {
+	const trimmed = line.trim();
+	const bracketed = trimmed.match(/^##\s+\[v?([0-9]+\.[0-9]+\.[0-9]+(?:-[\w.-]+)?)\]/i);
+	if (bracketed) {
+		return bracketed[1];
+	}
+
+	const plain = trimmed.match(/^##\s+v?([0-9]+\.[0-9]+\.[0-9]+(?:-[\w.-]+)?)(?:\s|$)/i);
+	return plain ? plain[1] : null;
+}
+
+function extractVersionSection(changelogContent, version) {
+	const lines = changelogContent.split('\n');
+	const targetVersion = version.toLowerCase();
+	let start = -1;
+	let end = lines.length;
+
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i];
+		if (!line.trim().startsWith('## ')) {
+			continue;
+		}
+		const foundVersion = getVersionFromHeading(line);
+		if (foundVersion && foundVersion.toLowerCase() === targetVersion) {
+			start = i + 1;
+			break;
+		}
+	}
+
+	if (start === -1) {
+		return null;
+	}
+
+	for (let i = start; i < lines.length; i++) {
+		if (lines[i].trim().startsWith('## ')) {
+			end = i;
+			break;
+		}
+	}
+
+	return lines.slice(start, end).join('\n').trim();
+}
+
+function stripTrailingCommitHashLink(line) {
+	return line.replace(
+		/\s+\(\[[a-f0-9]{7,40}\]\([^)]+\/commit\/[a-f0-9]{7,40}\)\)\s*$/i,
+		''
+	);
+}
+
+function normalizeMarkdownLine(line) {
+	const trimmed = line.trim();
+	if (!trimmed) {
+		return '';
+	}
+
+	if (trimmed.startsWith('### ')) {
+		return `**${trimmed.replace(/^###\s+/, '').trim()}**`;
+	}
+
+	if (trimmed.startsWith('#### ')) {
+		return `**${trimmed.replace(/^####\s+/, '').trim()}**`;
+	}
+
+	if (trimmed.startsWith('> ')) {
+		const note = trimmed.replace(/^>\s*/, '');
+		return note;
+	}
+
+	if (/^[-*]\s+/.test(trimmed)) {
+		const withoutCommitHash = stripTrailingCommitHashLink(trimmed);
+		const normalizedBullet = withoutCommitHash.replace(/^-\s+/, '* ');
+		return normalizedBullet;
+	}
+
+	return stripTrailingCommitHashLink(trimmed);
+}
+
+function normalizeSectionForReadme(sectionContent) {
+	const lines = sectionContent.split('\n');
+	const output = [];
+	let previousBlank = true;
+
+	lines.forEach((line) => {
+		const normalized = normalizeMarkdownLine(line);
+
+		if (!normalized) {
+			if (!previousBlank) {
+				output.push('');
+			}
+			previousBlank = true;
+			return;
+		}
+
+		output.push(normalized);
+		previousBlank = false;
+	});
+
+	while (output.length > 0 && output[output.length - 1] === '') {
+		output.pop();
+	}
+
+	return output.join('\n');
+}
+
+function buildReadmeVersionBlock(version, normalizedSection) {
+	let block = `= ${version} =\n\n`;
+	if (normalizedSection.trim()) {
+		block += `${normalizedSection.trim()}\n`;
+	} else {
+		block += '* No changelog details provided.\n';
+	}
+	return block;
+}
+
+function normalizeChangelogSpacing(readmeContent) {
+	const headingRegex = /^== Changelog ==[ \t]*$/m;
+	const headingMatch = readmeContent.match(headingRegex);
+
+	if (!headingMatch) {
+		return readmeContent;
+	}
+
+	const sectionStart = headingMatch.index + headingMatch[0].length;
+	const afterHeading = readmeContent.slice(sectionStart);
+	const nextHeadingMatch = afterHeading.match(/^== [^=\n].*? ==\s*$/m);
+	const sectionEnd = nextHeadingMatch
+		? sectionStart + nextHeadingMatch.index
+		: readmeContent.length;
+
+	const prefix = readmeContent.slice(0, sectionStart);
+	let sectionBody = readmeContent.slice(sectionStart, sectionEnd);
+	const suffix = readmeContent.slice(sectionEnd);
+
+	const lines = sectionBody.split('\n');
+	const collapsed = [];
+	let previousWasBlank = false;
+
+	for (const line of lines) {
+		const isBlank = line.trim() === '';
+		if (isBlank) {
+			if (!previousWasBlank) {
+				collapsed.push('');
+			}
+			previousWasBlank = true;
+		} else {
+			collapsed.push(line);
+			previousWasBlank = false;
+		}
+	}
+
+	sectionBody = collapsed.join('\n').trim();
+	sectionBody = sectionBody ? `\n\n${sectionBody}\n` : '\n\n';
+
+	return `${prefix}${sectionBody}${suffix}`;
+}
+
+function upsertVersionInReadme(readmeContent, versionBlock, version) {
+	const changelogHeadingRegex = /^== Changelog ==[ \t]*$/m;
+	if (!changelogHeadingRegex.test(readmeContent)) {
+		throw new Error('Could not find "== Changelog ==" section in readme.txt');
+	}
+
+	const versionPattern = new RegExp(
+		`^= ${escapeRegExp(version)} =[\\s\\S]*?(?=^= [0-9]+\\.[0-9]+\\.[0-9]+(?:-[\\w.-]+)? =\\s*$|^== |\\Z)`,
+		'm'
+	);
+
+	if (versionPattern.test(readmeContent)) {
+		const updatedContent = readmeContent.replace(
+			versionPattern,
+			versionBlock.trimEnd() + '\n\n'
+		);
+		return {
+			updatedContent: normalizeChangelogSpacing(updatedContent),
+			action: 'updated',
+		};
+	}
+
+	const headingMatch = readmeContent.match(changelogHeadingRegex);
+	const insertAt = headingMatch.index + headingMatch[0].length;
+	const prefix = readmeContent.slice(0, insertAt);
+	const suffix = readmeContent.slice(insertAt);
+
+	return {
+		updatedContent: normalizeChangelogSpacing(
+			`${prefix}\n\n${versionBlock.trimEnd()}\n\n${suffix.replace(/^\n+/, '')}`
+		),
+		action: 'inserted',
+	};
+}
+
+function main() {
+	const args = parseArgs();
+
+	if (!args.version) {
+		console.error('Error: --version is required');
+		process.exit(1);
+	}
+
+	const pluginDir = args['plugin-dir'] || 'plugins/wp-graphql';
+	const repoRoot = process.cwd();
+	const changelogPath = path.join(repoRoot, pluginDir, 'CHANGELOG.md');
+	const readmePath = path.join(repoRoot, pluginDir, 'readme.txt');
+
+	if (!fs.existsSync(changelogPath)) {
+		console.error(`CHANGELOG.md not found: ${changelogPath}`);
+		process.exit(1);
+	}
+
+	if (!fs.existsSync(readmePath)) {
+		console.error(`readme.txt not found: ${readmePath}`);
+		process.exit(1);
+	}
+
+	const changelogContent = fs.readFileSync(changelogPath, 'utf8');
+	const readmeContent = fs.readFileSync(readmePath, 'utf8');
+
+	const section = extractVersionSection(changelogContent, args.version);
+	if (!section) {
+		console.log(`No changelog entry found for version ${args.version}`);
+		process.exit(0);
+	}
+
+	const normalizedSection = normalizeSectionForReadme(section);
+	const versionBlock = buildReadmeVersionBlock(args.version, normalizedSection);
+	const { updatedContent, action } = upsertVersionInReadme(
+		readmeContent,
+		versionBlock,
+		args.version
+	);
+
+	if (updatedContent === readmeContent) {
+		console.log(`No changes needed for readme changelog ${args.version}`);
+		process.exit(0);
+	}
+
+	fs.writeFileSync(readmePath, updatedContent);
+	console.log(`Successfully ${action} readme changelog for version ${args.version}`);
+}
+
+if (require.main === module) {
+	main();
+}
+
+module.exports = {
+	extractVersionSection,
+	normalizeSectionForReadme,
+	buildReadmeVersionBlock,
+	upsertVersionInReadme,
+};

--- a/scripts/update-readme-changelog.test.js
+++ b/scripts/update-readme-changelog.test.js
@@ -1,0 +1,279 @@
+#!/usr/bin/env node
+
+/**
+ * Tests for update-readme-changelog.js
+ *
+ * Run with: node scripts/update-readme-changelog.test.js
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+const assert = require('assert');
+
+const SCRIPT_PATH = path.join(__dirname, 'update-readme-changelog.js');
+const TEST_DIR = path.join(__dirname, '..', '.test-readme-changelog');
+
+function setup() {
+	if (fs.existsSync(TEST_DIR)) {
+		fs.rmSync(TEST_DIR, { recursive: true });
+	}
+	fs.mkdirSync(TEST_DIR, { recursive: true });
+}
+
+function cleanup() {
+	if (fs.existsSync(TEST_DIR)) {
+		fs.rmSync(TEST_DIR, { recursive: true });
+	}
+}
+
+function createChangelog(content) {
+	fs.writeFileSync(path.join(TEST_DIR, 'CHANGELOG.md'), content);
+}
+
+function createReadme(content) {
+	fs.writeFileSync(path.join(TEST_DIR, 'readme.txt'), content);
+}
+
+function readReadme() {
+	return fs.readFileSync(path.join(TEST_DIR, 'readme.txt'), 'utf8');
+}
+
+function runScript(version) {
+	const cmd = `node "${SCRIPT_PATH}" --version=${version} --plugin-dir=.test-readme-changelog`;
+	try {
+		const output = execSync(cmd, {
+			cwd: path.join(__dirname, '..'),
+			encoding: 'utf8',
+			stdio: ['pipe', 'pipe', 'pipe'],
+		});
+		return { success: true, output };
+	} catch (error) {
+		return { success: false, output: error.stdout || error.message };
+	}
+}
+
+function test(name, fn) {
+	try {
+		setup();
+		fn();
+		console.log(`✅ ${name}`);
+		return true;
+	} catch (error) {
+		console.log(`❌ ${name}`);
+		console.log(`   Error: ${error.message}`);
+		return false;
+	} finally {
+		cleanup();
+	}
+}
+
+const tests = [
+	() =>
+		test('extracts bracketed version header and inserts top changelog entry', () => {
+			createChangelog(`# Changelog
+
+## [2.1.0](https://example.com/compare/v2.0.0...v2.1.0) (2026-01-01)
+
+### New Features
+
+* add feature ([#1](https://example.com/issues/1)) ([abcdef1](https://example.com/commit/abcdef1))
+
+## 2.0.0
+
+### Bug Fixes
+
+* fixed old bug
+`);
+
+			createReadme(`=== Test ===
+Stable tag: 2.1.0
+
+== Changelog ==
+
+= 2.0.0 =
+
+**Bug Fixes**
+
+* fixed old bug
+`);
+
+			const result = runScript('2.1.0');
+			assert(result.success, 'script should succeed');
+			const readme = readReadme();
+			assert(readme.includes('= 2.1.0 ='), 'should insert version header');
+			assert(
+				readme.indexOf('= 2.1.0 =') < readme.indexOf('= 2.0.0 ='),
+				'should insert new version at top'
+			);
+			assert(readme.includes('**New Features**'), 'should map section heading');
+			assert(
+				readme.includes('* add feature ([#1](https://example.com/issues/1))'),
+				'should preserve issue link'
+			);
+			assert(!readme.includes('abcdef1'), 'should strip trailing commit hash link');
+		}),
+
+	() =>
+		test('extracts plain version header and replaces existing block', () => {
+			createChangelog(`# Changelog
+
+## 1.4.0
+
+### Bug Fixes
+
+* fix current issue ([#2](https://example.com/issues/2))
+`);
+
+			createReadme(`=== Test ===
+Stable tag: 1.4.0
+
+== Changelog ==
+
+= 1.4.0 =
+
+**Bug Fixes**
+
+* old stale content
+
+= 1.3.0 =
+
+* previous
+`);
+
+			const result = runScript('1.4.0');
+			assert(result.success, 'script should succeed');
+
+			const readme = readReadme();
+			assert(
+				!readme.includes('* old stale content'),
+				'should replace existing version block content'
+			);
+			assert(
+				readme.includes('* fix current issue ([#2](https://example.com/issues/2))'),
+				'should contain replacement content'
+			);
+		}),
+
+	() =>
+		test('normalizes markdown note blockquote and heading spacing', () => {
+			createChangelog(`# Changelog
+
+## [3.0.0](https://example.com) (2026-02-02)
+
+> **Note:** Important release note.
+
+### Other Changes
+
+- adjust text
+`);
+
+			createReadme(`=== Test ===
+Stable tag: 3.0.0
+
+== Changelog ==
+
+= 2.0.0 =
+
+* old
+`);
+
+			const result = runScript('3.0.0');
+			assert(result.success, 'script should succeed');
+			const readme = readReadme();
+			assert(
+				readme.includes('**Note:** Important release note.'),
+				'should preserve note content without blockquote marker'
+			);
+			assert(readme.includes('**Other Changes**'), 'should normalize heading');
+			assert(readme.includes('* adjust text'), 'should normalize dash to bullet');
+		}),
+
+	() =>
+		test('returns no-op when requested version is missing', () => {
+			createChangelog(`# Changelog
+
+## [1.0.0](https://example.com) (2026-01-01)
+
+### Bug Fixes
+
+* fix
+`);
+
+			const originalReadme = `=== Test ===
+Stable tag: 1.0.0
+
+== Changelog ==
+
+= 1.0.0 =
+
+* fix
+`;
+
+			createReadme(originalReadme);
+
+			const result = runScript('9.9.9');
+			assert(result.success, 'script should exit successfully on no-op');
+			assert(
+				result.output.includes('No changelog entry found'),
+				'should report missing version'
+			);
+			assert.strictEqual(readReadme(), originalReadme, 'readme should stay unchanged');
+		}),
+
+	() =>
+		test('collapses excessive blank lines in changelog section', () => {
+			createChangelog(`# Changelog
+
+## [5.0.0](https://example.com) (2026-03-03)
+
+### Bug Fixes
+
+* spacing fix
+`);
+
+			createReadme(`=== Test ===
+Stable tag: 5.0.0
+
+== Changelog ==
+
+
+
+
+= 4.9.0 =
+
+* old
+`);
+
+			const result = runScript('5.0.0');
+			assert(result.success, 'script should succeed');
+			const readme = readReadme();
+			assert(
+				readme.includes('== Changelog ==\n\n= 5.0.0 ='),
+				'should normalize heading-to-first-version spacing'
+			);
+			assert(
+				!readme.includes('== Changelog ==\n\n\n'),
+				'should not leave triple blank lines'
+			);
+		}),
+];
+
+console.log('\n🧪 Running update-readme-changelog.js tests...\n');
+
+let passed = 0;
+let failed = 0;
+
+for (const testFn of tests) {
+	if (testFn()) {
+		passed++;
+	} else {
+		failed++;
+	}
+}
+
+console.log(`\n${'─'.repeat(50)}`);
+console.log(`Results: ${passed} passed, ${failed} failed`);
+console.log(`${'─'.repeat(50)}\n`);
+
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- add a new release helper script that syncs a target `CHANGELOG.md` version section into plugin `readme.txt` changelog format for WordPress.org
- run the readme changelog sync during `update-release-pr.yml` so release-please PRs update `readme.txt` changelog entries automatically
- backfill missing readme changelog entries for `wp-graphql` (2.6.0-2.11.1), `wp-graphql-acf` (2.5.0-2.5.2), and `wp-graphql-ide` (4.0.0-4.2.0)

Closes #3638

## Test plan
- [x] Run `npm run test:scripts`
- [x] Confirm new `update-readme-changelog` tests pass
- [x] Verify `readme.txt` changelog sections now include current versions for each updated plugin