### PR TITLE
fix: make lintjs failures blocking in CI

### DIFF
--- a/.github/workflows/lint-reusable.yml
+++ b/.github/workflows/lint-reusable.yml
@@ -162,7 +162,6 @@ jobs:
     permissions:
       contents: read
     timeout-minutes: 10
-    continue-on-error: true
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- Remove `continue-on-error: true` from the reusable `lintjs` workflow job so JavaScript lint failures fail CI.
- This reflects the current passing lint baseline across `wp-graphql`, `wp-graphql-ide`, and `wp-graphql-acf`.
- Closes #3553.

## Test plan
- [x] Run `npm run -w @wpgraphql/wp-graphql lint:js -- --max-warnings=0`
- [x] Run `npm run -w @wpgraphql/wp-graphql-ide lint:js -- --max-warnings=0`
- [x] Run `npm run -w @wpgraphql/wp-graphql-acf lint:js -- --max-warnings=0`