### PR TITLE
feat: allow additional valid hosts

### DIFF
--- a/plugins/wp-graphql/phpstan.neon.dist
+++ b/plugins/wp-graphql/phpstan.neon.dist
@@ -42,9 +42,3 @@ parameters:
       analyseAndScan:
         - node_modules (?)
 
-    # Ignore errors for build assets that may not exist during static analysis.
-    # These files are gitignored and only generated via `npm run build`.
-    # The code validates with file_exists() before including, so this is safe.
-    ignoreErrors:
-        - '#Path in include\(\) ".*build/.*\.asset\.php" is not a file or it does not exist#'
-

--- a/plugins/wp-graphql/phpstan.neon.dist
+++ b/plugins/wp-graphql/phpstan.neon.dist
@@ -42,3 +42,9 @@ parameters:
       analyseAndScan:
         - node_modules (?)
 
+    # Ignore errors for build assets that may not exist during static analysis.
+    # These files are gitignored and only generated via npm run build.
+    # The code validates with file_exists() before including, so this is safe.
+    ignoreErrors:
+        - '#Path in include\(\) ".*build/.*\.asset\.php" is not a file or it does not exist#'
+

--- a/plugins/wp-graphql/src/Data/NodeResolver.php
+++ b/plugins/wp-graphql/src/Data/NodeResolver.php
@@ -362,21 +362,11 @@ class NodeResolver {
 
 		// Bail if external URI.
 		if ( isset( $parsed_url['host'] ) ) {
-			$site_url = wp_parse_url( site_url() );
-			$home_url = wp_parse_url( home_url() );
+			$site_url      = wp_parse_url( site_url() );
+			$home_url      = wp_parse_url( home_url() );
+			$allowed_hosts = apply_filters( 'graphql_allowed_hosts', [ $site_url['host'], $home_url['host'] ] );
 
-			/**
-			 * @var array<string,mixed> $home_url
-			 * @var array<string,mixed> $site_url
-			 */
-			if ( ! in_array(
-				$parsed_url['host'],
-				[
-					$site_url['host'],
-					$home_url['host'],
-				],
-				true
-			) ) {
+			if ( ! in_array( $parsed_url['host'], $allowed_hosts, true ) ) {
 				graphql_debug(
 					__( 'Cannot return a resource for an external URI', 'wp-graphql' ),
 					[

--- a/plugins/wp-graphql/src/Data/NodeResolver.php
+++ b/plugins/wp-graphql/src/Data/NodeResolver.php
@@ -362,8 +362,19 @@ class NodeResolver {
 
 		// Bail if external URI.
 		if ( isset( $parsed_url['host'] ) ) {
-			$site_url      = wp_parse_url( site_url() );
-			$home_url      = wp_parse_url( home_url() );
+			$site_url = wp_parse_url( site_url() );
+			$home_url = wp_parse_url( home_url() );
+
+			/**
+			 * Filters hostnames treated as belonging to this WordPress install when resolving node URIs.
+			 *
+			 * By default includes the hosts from `site_url()` and `home_url()`. Extensions may append
+			 * hosts (for example language-specific domains mapped to the same site).
+			 *
+			 * @param string[] $allowed_hosts Hostnames permitted when comparing the parsed URI host.
+			 *
+			 * @since x-release-please-version
+			 */
 			$allowed_hosts = apply_filters( 'graphql_allowed_hosts', [ $site_url['host'], $home_url['host'] ] );
 
 			if ( ! in_array( $parsed_url['host'], $allowed_hosts, true ) ) {

--- a/plugins/wp-graphql/src/Data/NodeResolver.php
+++ b/plugins/wp-graphql/src/Data/NodeResolver.php
@@ -362,8 +362,16 @@ class NodeResolver {
 
 		// Bail if external URI.
 		if ( isset( $parsed_url['host'] ) ) {
-			$site_url = wp_parse_url( site_url() );
-			$home_url = wp_parse_url( home_url() );
+			$site_parts = wp_parse_url( site_url() );
+			$home_parts = wp_parse_url( home_url() );
+
+			$default_allowed_hosts = [];
+			if ( is_array( $site_parts ) && isset( $site_parts['host'] ) ) {
+				$default_allowed_hosts[] = $site_parts['host'];
+			}
+			if ( is_array( $home_parts ) && isset( $home_parts['host'] ) ) {
+				$default_allowed_hosts[] = $home_parts['host'];
+			}
 
 			/**
 			 * Filters hostnames treated as belonging to this WordPress install when resolving node URIs.
@@ -375,7 +383,7 @@ class NodeResolver {
 			 *
 			 * @since x-release-please-version
 			 */
-			$allowed_hosts = apply_filters( 'graphql_allowed_hosts', [ $site_url['host'], $home_url['host'] ] );
+			$allowed_hosts = apply_filters( 'graphql_allowed_hosts', $default_allowed_hosts );
 
 			if ( ! in_array( $parsed_url['host'], $allowed_hosts, true ) ) {
 				graphql_debug(


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨 Please review the guidelines for contributing to this repository: https://github.com/wp-graphql/wp-graphql/blob/main/docs/CONTRIBUTING.md

- [ ] Make sure your PR title follows Conventional Commit standards. See: https://www.conventionalcommits.org/en/v1.0.0/#specification . Allowed prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
- [ ] Make sure you are making a pull request against the **main branch** (left side). Also you should start *your branch* off *our main*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your main!

-->

## What does this implement/fix? Explain your changes.

### Update NodeResolver.php to allow additional valid hosts

Adds a new filter called 'graphql_allowed_hosts' which allows additional domains to be registered by other plugins. For example a translation plugin will want to add language speciffic domains running on the same install.

## Does this close any currently open issues?

<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
closes #3777
## Any other comments?

<!-- Please add any additional context that would be helpful. Feel free to include screenshots of the GraphiQL IDE or other relevant screenshotes, logs, error output, etc -->
