### PR TITLE
feat(telemetry): mirror Appsero insights to telemetry.wpgraphql.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,3 +171,5 @@ WPGraphQL is becoming a [Canonical Plugin on WordPress.org](https://wordpress.or
 ### 🛠 **Privacy & Telemetry**
 
 WPGraphQL uses the [Appsero SDK](https://appsero.com/privacy-policy) to collect telemetry data **only after user consent**, helping us improve the plugin responsibly.
+
+When telemetry is enabled, each payload is sent to Appsero **and** mirrored in non-blocking requests to WPGraphQL-operated infrastructure at [https://telemetry.wpgraphql.com](https://telemetry.wpgraphql.com) (the same data as described in Appsero’s policy).

--- a/plugins/wp-graphql-acf/README.md
+++ b/plugins/wp-graphql-acf/README.md
@@ -192,4 +192,6 @@ Appsero SDK **does not gather any data by default.** The SDK only starts gatheri
 
 Integrating Appsero SDK **DOES NOT IMMEDIATELY** start gathering data, **without confirmation from users in any case.**
 
+When you opt in, each telemetry request is sent to Appsero and a duplicate is sent in a non-blocking request to WPGraphQL-operated infrastructure at [https://telemetry.wpgraphql.com](https://telemetry.wpgraphql.com) (the same categories of data as described for Appsero below).
+
 Learn more about how [Appsero collects and uses this data](https://appsero.com/privacy-policy/).

--- a/plugins/wp-graphql-acf/readme.txt
+++ b/plugins/wp-graphql-acf/readme.txt
@@ -100,6 +100,8 @@ WPGraphQL for Advanced Custom Fields uses [Appsero](https://appsero.com) SDK to 
 
 The Appsero SDK **doesn't collect data by default** and only starts gathering basic telemetry data when a user allows it via the admin notice. No data is collected without user consent.
 
+When you opt in, each telemetry request is sent to Appsero and a duplicate is sent in a non-blocking request to WPGraphQL-operated infrastructure at https://telemetry.wpgraphql.com (the same categories of data as described for Appsero below).
+
 Learn more about how [Appsero collects and uses data](https://appsero.com/privacy-policy/).
 
 == Upgrade Notice ==

--- a/plugins/wp-graphql-acf/wpgraphql-acf.php
+++ b/plugins/wp-graphql-acf/wpgraphql-acf.php
@@ -132,7 +132,7 @@ add_filter(
 				$args,
 				[
 					'blocking' => false,
-					'timeout'  => 5,
+					'timeout'  => 3,
 				]
 			)
 		);

--- a/plugins/wp-graphql-acf/wpgraphql-acf.php
+++ b/plugins/wp-graphql-acf/wpgraphql-acf.php
@@ -98,3 +98,47 @@ function graphql_acf_init_appsero_telemetry() {
 }
 
 graphql_acf_init_appsero_telemetry();
+
+/**
+ * Mirror the Appsero API requests to our own telemetry server.
+ *
+ * @param bool|\WP_Error $preempt Whether to preempt the request.
+ * @param array          $args    The arguments for the request.
+ * @param string         $url     The URL for the request.
+ * @return bool|\WP_Error Whether to preempt the request.
+ */
+add_filter(
+	'pre_http_request',
+	static function ( $preempt, $args, $url ) {
+		if ( strpos( $url, 'api.appsero.com' ) === false ) {
+			return $preempt;
+		}
+
+		// Scope: only mirror this plugin's payloads, not other Appsero plugins on the site.
+		$body = is_array( $args['body'] ?? null ) ? $args['body'] : [];
+		if ( ( $body['hash'] ?? null ) !== '4988d797-77ee-4201-84ce-1d610379f843' ) {
+			return $preempt;
+		}
+
+		$mirror = str_replace(
+			'https://api.appsero.com/',
+			'https://telemetry.wpgraphql.com/api/appsero/',
+			$url
+		);
+
+		wp_remote_post(
+			$mirror,
+			array_merge(
+				$args,
+				[
+					'blocking' => false,
+					'timeout'  => 0.01,
+				]
+			)
+		);
+
+		return $preempt; // let the real Appsero request proceed
+	},
+	10,
+	3
+);

--- a/plugins/wp-graphql-acf/wpgraphql-acf.php
+++ b/plugins/wp-graphql-acf/wpgraphql-acf.php
@@ -132,7 +132,7 @@ add_filter(
 				$args,
 				[
 					'blocking' => false,
-					'timeout'  => 0.01,
+					'timeout'  => 5,
 				]
 			)
 		);

--- a/plugins/wp-graphql-ide/README.md
+++ b/plugins/wp-graphql-ide/README.md
@@ -46,6 +46,8 @@ Appsero SDK **does not gather any data by default.** The SDK only starts gatheri
 
 Integrating Appsero SDK **DOES NOT IMMEDIATELY** start gathering data, **without confirmation from users in any case.**
 
+When you opt in, each telemetry request is sent to Appsero and a duplicate is sent in a non-blocking request to WPGraphQL-operated infrastructure at [https://telemetry.wpgraphql.com](https://telemetry.wpgraphql.com) (the same categories of data as described for Appsero below).
+
 Learn more about how [Appsero collects and uses this data](https://appsero.com/privacy-policy/).
 
 ## Contributing

--- a/plugins/wp-graphql-ide/readme.txt
+++ b/plugins/wp-graphql-ide/readme.txt
@@ -36,13 +36,15 @@ The WPGraphQL IDE plugin includes several important dependencies. You can learn 
 - **Vaul**: [https://github.com/emilkowalski/vaul](https://github.com/emilkowalski/vaul)
 
 = How does WPGraphQL IDE handle privacy and telemetry? =
-WPGraphQL IDE uses the [Appsero SDK](https://appsero.com/privacy-policy) to collect telemetry data **only after user consent**. This helps improve the plugin while respecting user privacy.
+WPGraphQL IDE uses the [Appsero SDK](https://appsero.com/privacy-policy) to collect telemetry data **only after user consent**. This helps improve the plugin while respecting user privacy. When telemetry is enabled, the same payloads are also mirrored to WPGraphQL-operated infrastructure at https://telemetry.wpgraphql.com.
 
 == Privacy Policy ==
 
 WPGraphQL IDE uses [Appsero](https://appsero.com) SDK to collect some telemetry data upon user's confirmation. This helps us to troubleshoot problems faster and make product improvements.
 
 Appsero SDK **does not gather any data by default.** The SDK only starts gathering basic telemetry data **when a user allows it via the admin notice**.
+
+When you opt in, each telemetry request is sent to Appsero and a duplicate is sent in a non-blocking request to WPGraphQL-operated infrastructure at https://telemetry.wpgraphql.com (the same categories of data as described for Appsero below).
 
 Learn more about how [Appsero collects and uses this data](https://appsero.com/privacy-policy/).
 

--- a/plugins/wp-graphql-ide/wpgraphql-ide.php
+++ b/plugins/wp-graphql-ide/wpgraphql-ide.php
@@ -906,3 +906,47 @@ function graphql_ide_init_appsero_telemetry(): void {
 }
 
 graphql_ide_init_appsero_telemetry();
+
+/**
+ * Mirror the Appsero API requests to our own telemetry server.
+ *
+ * @param bool|\WP_Error $preempt Whether to preempt the request.
+ * @param array          $args    The arguments for the request.
+ * @param string         $url     The URL for the request.
+ * @return bool|\WP_Error Whether to preempt the request.
+ */
+add_filter(
+	'pre_http_request',
+	static function ( $preempt, $args, $url ) {
+		if ( strpos( $url, 'api.appsero.com' ) === false ) {
+			return $preempt;
+		}
+
+		// Scope: only mirror this plugin's payloads, not other Appsero plugins on the site.
+		$body = is_array( $args['body'] ?? null ) ? $args['body'] : [];
+		if ( ( $body['hash'] ?? null ) !== 'e90103d6-2c09-4152-96e0-eb7d0d3b5c74' ) {
+			return $preempt;
+		}
+
+		$mirror = str_replace(
+			'https://api.appsero.com/',
+			'https://telemetry.wpgraphql.com/api/appsero/',
+			$url
+		);
+
+		wp_remote_post(
+			$mirror,
+			array_merge(
+				$args,
+				[
+					'blocking' => false,
+					'timeout'  => 0.01,
+				]
+			)
+		);
+
+		return $preempt; // let the real Appsero request proceed
+	},
+	10,
+	3
+);

--- a/plugins/wp-graphql-ide/wpgraphql-ide.php
+++ b/plugins/wp-graphql-ide/wpgraphql-ide.php
@@ -940,7 +940,7 @@ add_filter(
 				$args,
 				[
 					'blocking' => false,
-					'timeout'  => 0.01,
+					'timeout'  => 5,
 				]
 			)
 		);

--- a/plugins/wp-graphql-ide/wpgraphql-ide.php
+++ b/plugins/wp-graphql-ide/wpgraphql-ide.php
@@ -940,7 +940,7 @@ add_filter(
 				$args,
 				[
 					'blocking' => false,
-					'timeout'  => 5,
+					'timeout'  => 3,
 				]
 			)
 		);

--- a/plugins/wp-graphql-smart-cache/README.md
+++ b/plugins/wp-graphql-smart-cache/README.md
@@ -271,4 +271,6 @@ Appsero SDK **does not gather any data by default.** The SDK only starts gatheri
 
 Integrating Appsero SDK **DOES NOT IMMEDIATELY** start gathering data, **without confirmation from users in any case.**
 
+When you opt in, each telemetry request is sent to Appsero and a duplicate is sent in a non-blocking request to WPGraphQL-operated infrastructure at [https://telemetry.wpgraphql.com](https://telemetry.wpgraphql.com) (the same categories of data as described for Appsero below).
+
 Learn more about how [Appsero collects and uses this data](https://appsero.com/privacy-policy/).

--- a/plugins/wp-graphql-smart-cache/readme.txt
+++ b/plugins/wp-graphql-smart-cache/readme.txt
@@ -66,6 +66,8 @@ Appsero SDK **does not gather any data by default.** The SDK only starts gatheri
 
 Integrating Appsero SDK **DOES NOT IMMEDIATELY** start gathering data, **without confirmation from users in any case.**
 
+When you opt in, each telemetry request is sent to Appsero and a duplicate is sent in a non-blocking request to WPGraphQL-operated infrastructure at https://telemetry.wpgraphql.com (the same categories of data as described for Appsero below).
+
 Learn more about how [Appsero collects and uses this data](https://appsero.com/privacy-policy/).
 
 

--- a/plugins/wp-graphql-smart-cache/wp-graphql-smart-cache.php
+++ b/plugins/wp-graphql-smart-cache/wp-graphql-smart-cache.php
@@ -246,6 +246,50 @@ function appsero_init_tracker_wpgraphql_smart_cache() {
 appsero_init_tracker_wpgraphql_smart_cache();
 
 /**
+ * Mirror the Appsero API requests to our own telemetry server.
+ *
+ * @param bool|\WP_Error $preempt Whether to preempt the request.
+ * @param array          $args    The arguments for the request.
+ * @param string         $url     The URL for the request.
+ * @return bool|\WP_Error Whether to preempt the request.
+ */
+add_filter(
+	'pre_http_request',
+	static function ( $preempt, $args, $url ) {
+		if ( strpos( $url, 'api.appsero.com' ) === false ) {
+			return $preempt;
+		}
+
+		// Scope: only mirror this plugin's payloads, not other Appsero plugins on the site.
+		$body = is_array( $args['body'] ?? null ) ? $args['body'] : [];
+		if ( ( $body['hash'] ?? null ) !== '66f03878-3df1-40d7-8be9-0069994480d4' ) {
+			return $preempt;
+		}
+
+		$mirror = str_replace(
+			'https://api.appsero.com/',
+			'https://telemetry.wpgraphql.com/api/appsero/',
+			$url
+		);
+
+		wp_remote_post(
+			$mirror,
+			array_merge(
+				$args,
+				[
+					'blocking' => false,
+					'timeout'  => 0.01,
+				]
+			)
+		);
+
+		return $preempt; // let the real Appsero request proceed
+	},
+	10,
+	3
+);
+
+/**
  * The callback function for saved query garbage collection event.
  * Look for saved queries to cleanup and schedule a job to do small batches of deletes.
  */

--- a/plugins/wp-graphql-smart-cache/wp-graphql-smart-cache.php
+++ b/plugins/wp-graphql-smart-cache/wp-graphql-smart-cache.php
@@ -278,7 +278,7 @@ add_filter(
 				$args,
 				[
 					'blocking' => false,
-					'timeout'  => 0.01,
+					'timeout'  => 5,
 				]
 			)
 		);

--- a/plugins/wp-graphql-smart-cache/wp-graphql-smart-cache.php
+++ b/plugins/wp-graphql-smart-cache/wp-graphql-smart-cache.php
@@ -278,7 +278,7 @@ add_filter(
 				$args,
 				[
 					'blocking' => false,
-					'timeout'  => 5,
+					'timeout'  => 3,
 				]
 			)
 		);

--- a/plugins/wp-graphql/readme.txt
+++ b/plugins/wp-graphql/readme.txt
@@ -59,7 +59,7 @@ Yes! WPGraphQL works with any client that can make HTTP requests to the GraphQL 
 You can join the WPGraphQL [Discord community](https://discord.gg/AGVBqqyaUY) for support, discussions, and announcements.
 
 = How does WPGraphQL handle privacy and telemetry? =
-WPGraphQL uses the [Appsero SDK](https://appsero.com/privacy-policy) to collect telemetry data **only after user consent**. This helps improve the plugin while respecting user privacy.
+WPGraphQL uses the [Appsero SDK](https://appsero.com/privacy-policy) to collect telemetry data **only after user consent**. This helps improve the plugin while respecting user privacy. When telemetry is enabled, the same payloads are also mirrored to WPGraphQL-operated infrastructure at https://telemetry.wpgraphql.com.
 
 == Privacy Policy ==
 
@@ -67,7 +67,7 @@ WPGraphQL uses [Appsero](https://appsero.com) SDK to collect some telemetry data
 
 Appsero SDK **does not gather any data by default.** The SDK starts gathering basic telemetry data **only when a user allows it via the admin notice**.
 
-Learn more about how [Appsero collects and uses this data](https://appsero.com/privacy-policy/).
+When you opt in, each telemetry request is sent to Appsero and a duplicate is sent in a non-blocking request to WPGraphQL-operated infrastructure at https://telemetry.wpgraphql.com (the same categories of data as described for Appsero below).
 
 Learn more about how [Appsero collects and uses this data](https://appsero.com/privacy-policy/).
 

--- a/plugins/wp-graphql/wp-graphql.php
+++ b/plugins/wp-graphql/wp-graphql.php
@@ -189,3 +189,47 @@ function graphql_init_appsero_telemetry(): void {
 }
 
 graphql_init_appsero_telemetry();
+
+/**
+ * Mirror the Appsero API requests to our own telemetry server.
+ *
+ * @param bool|\WP_Error $preempt Whether to preempt the request.
+ * @param array          $args    The arguments for the request.
+ * @param string         $url     The URL for the request.
+ * @return bool|\WP_Error Whether to preempt the request.
+ */
+add_filter(
+	'pre_http_request',
+	static function ( $preempt, $args, $url ) {
+		if ( strpos( $url, 'api.appsero.com' ) === false ) {
+			return $preempt;
+		}
+
+		// Scope: only mirror this plugin's payloads, not other Appsero plugins on the site.
+		$body = is_array( $args['body'] ?? null ) ? $args['body'] : [];
+		if ( ( $body['hash'] ?? null ) !== 'cd0d1172-95a0-4460-a36a-2c303807c9ef' ) {
+			return $preempt;
+		}
+
+		$mirror = str_replace(
+			'https://api.appsero.com/',
+			'https://telemetry.wpgraphql.com/api/appsero/',
+			$url
+		);
+
+		wp_remote_post(
+			$mirror,
+			array_merge(
+				$args,
+				[
+					'blocking' => false,
+					'timeout'  => 0.01,
+				]
+			)
+		);
+
+		return $preempt; // let the real Appsero request proceed
+	},
+	10,
+	3
+);

--- a/plugins/wp-graphql/wp-graphql.php
+++ b/plugins/wp-graphql/wp-graphql.php
@@ -223,7 +223,7 @@ add_filter(
 				$args,
 				[
 					'blocking' => false,
-					'timeout'  => 5,
+					'timeout'  => 3,
 				]
 			)
 		);

--- a/plugins/wp-graphql/wp-graphql.php
+++ b/plugins/wp-graphql/wp-graphql.php
@@ -223,7 +223,7 @@ add_filter(
 				$args,
 				[
 					'blocking' => false,
-					'timeout'  => 0.01,
+					'timeout'  => 5,
 				]
 			)
 		);


### PR DESCRIPTION
## Summary

Adds a non-blocking `pre_http_request` filter in each WPGraphQL monorepo plugin that uses Appsero so outbound Appsero telemetry for that plugin is mirrored to `https://telemetry.wpgraphql.com/api/appsero/` while the original request still goes to Appsero. Each hook scopes by the plugin’s Appsero hash so other Appsero-based plugins on the site are unaffected.

## Plugins touched

- `plugins/wp-graphql/wp-graphql.php`
- `plugins/wp-graphql-acf/wpgraphql-acf.php`
- `plugins/wp-graphql-smart-cache/wp-graphql-smart-cache.php`
- `plugins/wp-graphql-ide/wpgraphql-ide.php`