### PR TITLE
fix(site): readable active-state for Algolia DocSearch hits

### DIFF
--- a/websites/wpgraphql.com/src/styles/docsearch.css
+++ b/websites/wpgraphql.com/src/styles/docsearch.css
@@ -94,7 +94,10 @@
   display: block;
   padding: 1rem 1.5rem;
   font-size: 0.875rem;
+  color: hsl(var(--foreground));
+  text-decoration: none;
   border-bottom: 1px solid hsl(var(--border));
+  transition: background-color .12s ease, color .12s ease;
 }
 
 .DocSearch-Hit--Result {
@@ -107,10 +110,26 @@
 
 .DocSearch-Hit + .DocSearch-Hit .DocSearch-Hit--Result { margin-top: 0.5rem; }
 
-.DocSearch-Hit[aria-selected='true'] > a { background: hsl(var(--muted)); }
+/*
+   Active / hovered state — applied uniformly to every hit type
+   (Page / Result / RecentItem). Earlier the "selected" state mixed an
+   orange .DocSearch-Hit--Result background with --primary-foreground
+   (navy-950) text, which only works for actual --Result hits. For Page
+   and recent-history hits there is no orange surface, so the dark text
+   ended up on the bg-muted surface → invisible.
+
+   Switch to a consistent subtle treatment: muted bg + foreground text +
+   primary left accent. Works for every hit type, both light and dark.
+*/
+.DocSearch-Hit[aria-selected='true'] > a {
+  background: hsl(var(--accent));
+  color: hsl(var(--foreground));
+  box-shadow: inset 3px 0 0 hsl(var(--primary));
+}
 .DocSearch-Hit[aria-selected='true'] .DocSearch-Hit--Result {
-  background: hsl(var(--primary));
-  color: hsl(var(--primary-foreground));
+  background: hsl(var(--accent));
+  color: hsl(var(--foreground));
+  box-shadow: inset 3px 0 0 hsl(var(--primary));
 }
 
 .DocSearch-MagnifierLabel {
@@ -214,20 +233,20 @@
 }
 
 .DocSearch-Hit[aria-selected='true'] .DocSearch-Hit-icon {
-  background-color: transparent;
-  border-color: hsl(var(--primary-foreground) / 0.3);
-  background-image: url("data:image/svg+xml,%3Csvg width='12' height='12' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M3.75 1v10M8.25 1v10M1 3.75h10M1 8.25h10' stroke='%23ffffff' stroke-width='1.5' stroke-linecap='round'/%3E%3C/svg%3E");
+  border-color: hsl(var(--primary) / 0.5);
+  background-image: url("data:image/svg+xml,%3Csvg width='12' height='12' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M3.75 1v10M8.25 1v10M1 3.75h10M1 8.25h10' stroke='%23FF8C1A' stroke-width='1.5' stroke-linecap='round'/%3E%3C/svg%3E");
 }
 
 .DocSearch-Hit-title {
   color: hsl(var(--foreground));
   line-height: 1.5;
-  truncate: true;
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
 }
-.DocSearch-Hit[aria-selected='true'] .DocSearch-Hit-title { color: hsl(var(--primary-foreground)); }
+/* Title stays at --foreground in active state — the accent shows via the
+   left bar + bg, not via flipping the text colour. */
+.DocSearch-Hit[aria-selected='true'] .DocSearch-Hit-title { color: hsl(var(--foreground)); }
 
 .DocSearch-Hit-title + .DocSearch-Hit-path { margin-bottom: 0.25rem; }
 
@@ -241,7 +260,7 @@
 .DocSearch-Hit-action-button { display: flex; }
 .DocSearch-Hit-action svg    { display: none; }
 .DocSearch-Hit-action path   { stroke-width: 2px; stroke: hsl(var(--muted-foreground)); }
-.DocSearch-Hit[aria-selected='true'] .DocSearch-Hit-action path { stroke: hsl(var(--primary-foreground)); }
+.DocSearch-Hit[aria-selected='true'] .DocSearch-Hit-action path { stroke: hsl(var(--primary)); }
 
 .DocSearch-Hit          { position: relative; }
 .DocSearch-Hit:first-child > a { border-top: 1px solid hsl(var(--border)); }


### PR DESCRIPTION
# Summary                                                                                                                                                                                                    
                                      
  Fixes contrast for the active/hovered hit in the Algolia DocSearch modal. In dark mode, Page hits and recent-history hits were rendering with near-invisible text — navy-950 title on a navy-800 muted     
  background.
                                                                                                                                                                                                             
## Why                                                                                                                                                                                                        
  
  The previous active-state rules only worked for .DocSearch-Hit--Result hits. They:                                                                                                                         
  - Set the inner .DocSearch-Hit--Result div to orange background + navy-950 text (correct for an orange surface), and
  - Set every .DocSearch-Hit-title under [aria-selected='true'] to navy-950 (--primary-foreground)                                                                                                           
                                                                                                  
  For Page and recent-history hits there's no inner .DocSearch-Hit--Result wrapper, so the orange background never rendered — but the title-color flip still ran. That left navy-950 text sitting on the     
  muted-bg <a> (also dark navy), so the entry was unreadable as soon as you arrowed onto it.                                                                                                                 
                                                                                                                                                                                                             
## What changed                                                                                                                                                                                               
                                                         
  src/styles/docsearch.css — replace the mixed treatment with one consistent active state that works for every hit type:                                                                                     
  
  - Active background: hsl(var(--accent)) (subtle panel, swaps per theme)                                                                                                                                    
  - Active text: kept at hsl(var(--foreground)) — no longer flipped
  - Visual cue for the active row: a 3px orange (--primary) inset box-shadow on the left edge                                                                                                                
                                                                                                                                                                                                             
  Applied uniformly to both .DocSearch-Hit > a (Page / RecentItem hits) and .DocSearch-Hit--Result (Result hits). Also updated the active state of .DocSearch-Hit-icon (orange stroke + border instead of a  
  white SVG meant for an orange surface) and .DocSearch-Hit-action path stroke.   