### PR TITLE
fix(site): restore docs-sitemap.xml

### DIFF
--- a/websites/wpgraphql.com/src/lib/parse-mdx-docs.ts
+++ b/websites/wpgraphql.com/src/lib/parse-mdx-docs.ts
@@ -18,9 +18,14 @@ import rehypePrism from "rehype-prism-plus"
 import rehypeExternalLinks from "rehype-external-links"
 import rehypeUrlInspector from "@jsdevtools/rehype-url-inspector"
 
-const octokit = new Octokit({
-  auth: process.env.GITHUB_TOKEN,
-})
+// Only pass `auth` when the token is a non-empty string. Passing a missing
+// or revoked token causes GitHub to 401 ("Bad credentials") on every request;
+// without auth we still get 60 unauth req/hr, which is plenty for the docs
+// sitemap and dev-time doc fetches.
+const githubToken = process.env.GITHUB_TOKEN?.trim()
+const octokit = new Octokit(
+  githubToken ? { auth: githubToken } : {}
+)
 
 const DOCS_REPO = "wp-graphql"
 const DOCS_OWNER = "wp-graphql"

--- a/websites/wpgraphql.com/src/pages/docs-sitemap.xml.ts
+++ b/websites/wpgraphql.com/src/pages/docs-sitemap.xml.ts
@@ -8,17 +8,20 @@ const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL
 export default function Sitemap() {}
 
 export const getServerSideProps: GetServerSideProps = async (ctx) => {
-  // collect all the docs
-  const docUris = await getAllDocUri()
+  // Fetching the doc list hits GitHub's contents API and can fail at
+  // runtime (rate-limit, revoked token, network error). Don't let that
+  // tank the response — log the error and emit an empty <urlset>, which
+  // sitemap consumers handle gracefully.
+  let docUris: string[] = []
+  try {
+    docUris = await getAllDocUri()
+  } catch (err) {
+    console.error("[docs-sitemap] failed to fetch doc URIs:", err)
+  }
 
-  // create
-  const allDocsSitemap = docUris.map((docUri) => {
-    return {
-      loc: `${SITE_URL}${docUri}`,
-    }
-  })
-
-  //  fetch all the post and pass into getServerSideSitemap. but make sure your allPasts in array.
+  const allDocsSitemap = docUris.map((docUri) => ({
+    loc: `${SITE_URL}${docUri}`,
+  }))
 
   return await getServerSideSitemap(ctx, allDocsSitemap)
 }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                    
                                                                                                                                                                                                           
  https://www.wpgraphql.com/docs-sitemap.xml was returning 500 Internal Server Error in production. Reproduced locally and confirmed the cause: the deploy env's GITHUB_TOKEN is invalid (revoked / expired), so Octokit's call to GitHub's contents API in `getAllDocMeta()` returns 401 Bad credentials, the exception bubbles out of `getServerSideProps`, and Next renders the error page.
                                                                                                                                                                                                             
### Fix                                                                                                                                                                                                                                                                                                                                                                           
                                                         
1. `src/lib/parse-mdx-docs.ts`: only pass auth to Octokit when `GITHUB_TOKEN` is a non-empty trimmed string. A missing or blank token now falls back to unauthenticated GitHub requests (60 req/hr plenty for an SSR sitemap and dev-time doc fetches). Previously, a blank token was still passed and produced the same 401 a revoked token produces.

2. `src/pages/docs-sitemap.xml.ts`: wrap `getAllDocUri()` in a try/catch. If anything in the GitHub chain still fails (rate limit, network, downstream API change), log the error and emit a valid empty <urlset> instead of crashing.                                                                                                                                                                              
                                                                                                                                                                                                             
### Test plan                                              

  - **Local**: curl http://localhost:3000/docs-sitemap.xml returns 200 with 51 entries (no token)                                                                                                                
  - **Local**: same returns 200 with empty `<urlset>` (invalid token), error logged to server
  - **Deploy preview**: confirm route returns 200 and a populated sitemap (assuming env is updated per above), and Search Console / sitemap consumers re-index successfully  