### PR TITLE
fix(site): generate /docs paths from .md files, retry 404s via ISR

### DIFF
--- a/websites/wpgraphql.com/src/pages/docs/[slug].js
+++ b/websites/wpgraphql.com/src/pages/docs/[slug].js
@@ -1,10 +1,10 @@
 import { MDXRemote } from "next-mdx-remote"
 
 import DocsLayout from "components/Docs/DocsLayout"
-import { getLayoutData, LayoutProvider, request } from "lib/wpgraphql-client"
+import { getLayoutData, LayoutProvider } from "lib/wpgraphql-client"
 import "lib/wpgraphql-client-config"
 
-import { getParsedDoc, getDocsNav } from "lib/parse-mdx-docs"
+import { getAllDocUri, getDocsNav, getParsedDoc } from "lib/parse-mdx-docs"
 
 import components from "components/Docs/MdxComponents"
 
@@ -46,46 +46,30 @@ export async function getStaticProps({ params }) {
   } catch (e) {
     if (e.notFound) {
       console.error(params, e)
-      return e
+      // Include revalidate so a transient build-time fetch failure can't
+      // permanently cache a 404 — without this, ISR never retries the page
+      // even after the underlying .md file becomes reachable again.
+      return { notFound: true, revalidate: 30 }
     }
 
     throw e
   }
 }
 
-const PREBUILD_DOCS_QUERY = /* GraphQL */ `
-  query PrebuildDocsQuery {
-    menu(id: "Primary Nav", idType: NAME) {
-      menuItems {
-        nodes {
-          parentDatabaseId
-          uri
-        }
-      }
-    }
-  }
-`
-
 export async function getStaticPaths() {
-  const result = await request({ query: PREBUILD_DOCS_QUERY })
-  const data = result?.data ?? {}
-
-  const docs_menu_paths = data?.menu?.menuItems?.nodes?.reduce(
-    (acc, menu_item) => {
-      if (
-        menu_item.parentDatabaseId != 0 &&
-        menu_item.uri.startsWith("/docs")
-      ) {
-        acc.push(menu_item.uri)
-      }
-
-      return acc
-    },
-    []
-  )
+  // Pre-render paths sourced from the actual .md files in the docs folder,
+  // not from the WordPress Primary Nav menu. The menu only references ~4 docs
+  // out of ~50, and any drift between menu URIs and real files produced
+  // permanent static 404s for the menu-linked docs.
+  let paths = []
+  try {
+    paths = await getAllDocUri()
+  } catch (e) {
+    console.error("getStaticPaths: failed to enumerate docs from GitHub", e)
+  }
 
   return {
-    paths: docs_menu_paths ?? [],
+    paths,
     fallback: "blocking",
   }
 }


### PR DESCRIPTION
## Summary

- `src/pages/docs/[slug].js` `getStaticPaths` was sourcing the pre-render list from the WordPress Primary Nav menu (only ~4 URIs out of ~50 docs), and `getStaticProps` returned bare `{ notFound: true }` with no `revalidate`. Any transient build-time fetch failure for those 4 menu-linked docs got cached as a permanent static 404 — ISR could never retry.
- Currently `/docs/intro-to-graphql` and `/docs/posts-and-pages` are stuck this way on production (both URIs from the WP nav menu). The other ~46 docs all serve via `fallback: "blocking"` and work fine.
- Switch `getStaticPaths` to enumerate paths from the actual `.md` files in `plugins/wp-graphql/docs/` via the existing `getAllDocUri()` helper, and add `revalidate: 30` to the `notFound` branch so transient failures self-heal.

## Test plan

- [x] Verify `/docs/intro-to-graphql` returns 200 after deploy
- [ ] Verify `/docs/posts-and-pages` returns 200 after deploy
- [x] Spot-check several other docs pages (e.g. `/docs/introduction`, `/docs/custom-post-types`, `/docs/connections`) still serve correctly
- [x] Confirm the docs sidebar links from `/docs/introduction` all resolve to 200