### PR TITLE
fix(security): drop file:// support from createMediaItem mutation

### DIFF
--- a/plugins/wp-graphql/src/Mutation/MediaItemCreate.php
+++ b/plugins/wp-graphql/src/Mutation/MediaItemCreate.php
@@ -228,16 +228,6 @@ class MediaItemCreate {
 			 */
 			require_once ABSPATH . 'wp-admin/includes/file.php';
 
-			$file_contents = file_get_contents( $input['filePath'] );
-
-			/**
-			 * If the mediaItem file is from a local server, use wp_upload_bits before saving it to the uploads folder
-			 */
-			if ( 'file' === wp_parse_url( $input['filePath'], PHP_URL_SCHEME ) && ! empty( $file_contents ) ) {
-				$uploaded_file     = wp_upload_bits( $file_name, null, $file_contents );
-				$uploaded_file_url = ( empty( $uploaded_file['error'] ) ? $uploaded_file['url'] : null );
-			}
-
 			/**
 			 * Ensure we have a valid URL before attempting download
 			 */

--- a/plugins/wp-graphql/src/Mutation/MediaItemCreate.php
+++ b/plugins/wp-graphql/src/Mutation/MediaItemCreate.php
@@ -196,7 +196,7 @@ class MediaItemCreate {
 			$protocol = wp_parse_url( $input['filePath'], PHP_URL_SCHEME );
 
 			// prevent the filePath from being submitted with a non-allowed protocols
-			$allowed_protocols = [ 'https', 'http', 'file' ];
+			$allowed_protocols = [ 'https', 'http' ];
 
 			/**
 			 * Filter the allowed protocols for the mutation

--- a/plugins/wp-graphql/tests/wpunit/MediaItemMutationsTest.php
+++ b/plugins/wp-graphql/tests/wpunit/MediaItemMutationsTest.php
@@ -1335,4 +1335,30 @@ class MediaItemMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 
 		$this->assertQueryError( $actual, $expected );
 	}
+
+	/**
+	 * Asserts that a filePath using the file:// protocol is rejected and no
+	 * media item is created. Regression test for the local file inclusion
+	 * vector previously enabled by including 'file' in the default
+	 * $allowed_protocols list.
+	 */
+	public function testFileProtocolIsRejected() {
+		wp_set_current_user( $this->admin );
+
+		$result = graphql(
+			[
+				'query'     => 'mutation($i:CreateMediaItemInput!){createMediaItem(input:$i){mediaItem{sourceUrl}}}',
+				'variables' => [
+					'i' => [
+						'filePath' => 'file:///etc/hostname#.jpg',
+						'title'    => 'LFI',
+						'fileType' => 'IMAGE_JPG',
+					],
+				],
+			]
+		);
+
+		$this->assertNotEmpty( $result['errors'] ?? [] );
+		$this->assertStringNotContainsString( 'wp-content/uploads', wp_json_encode( $result ) );
+	}
 }


### PR DESCRIPTION
## Summary

- Removes `'file'` from the default `$allowed_protocols` list in `createMediaItem`, so the mutation no longer advertises local-file sideload as supported.
- Deletes the now-unreachable `file_get_contents()` + `wp_upload_bits` branch that consumed `file://` paths — including the `file_get_contents()` call named as the sink in a recent external security report.
- Adds a regression test (`testFileProtocolIsRejected`) asserting `file://` filePaths are rejected and no attachment URL is returned.

## Why

`'file'` was added to the default `$allowed_protocols` in v1.14.6 (#2840) alongside a `wp_http_validate_url()` check pushed in the same PR. `wp_http_validate_url()` strips non-`http`/`https` schemes and requires a non-empty host, so `file://...` URLs have been rejected by core validation before the protocol allowlist is ever consulted. That made:

- the `'file'` allowlist entry effectively a no-op,
- the `wp_upload_bits` branch (lines 236–239 prior) unreachable in stock WordPress,
- the `graphql_media_item_create_allowed_protocols` filter unable to serve as a real escape hatch for `file://`, since `wp_http_validate_url()` runs first and has no filter inside it.

A public GitHub code search for `graphql_media_item_create_allowed_protocols` returns only WPGraphQL's own source (vendored copies), no consumer code calling `add_filter()`. So removing `file` from the default has no known compatibility impact.

An external security researcher (@gokul965) reported the design intent (allowing `file` + calling `file_get_contents()` on user input) as a Critical LFI vulnerability. The exploit as written is not reachable on stock WordPress for the reasons above, but the design smell is real defense-in-depth weakness: anything that loosened `wp_http_validate_url()` would flip this to exploitable. This PR removes both the smell and the sink.

## What changed

1. `plugins/wp-graphql/src/Mutation/MediaItemCreate.php`
   - Line 199: `$allowed_protocols = [ 'https', 'http', 'file' ]` → `[ 'https', 'http' ]`
   - Removed `$file_contents = file_get_contents( $input['filePath'] )` and the conditional `wp_upload_bits` branch that depended on it.
2. `plugins/wp-graphql/tests/wpunit/MediaItemMutationsTest.php`
   - Added `testFileProtocolIsRejected` regression test.

## Test plan

- [x] `MediaItemMutationsTest` runs green locally (28 tests, 41 assertions)
- [x] PHPCS clean on changed lines
- [x] CI matrix passes (WordPress 6.1–trunk × PHP 7.4–8.4 × block/classic × single/multisite)

## Follow-up (not in this PR)

Adjacent `createMediaItem` test coverage is fragile and SSRF-thin. A separate PR will:
- mock the HTTP layer so happy-path tests don't depend on `raw.githubusercontent.com`,
- add SSRF regression tests for `169.254.169.254`, RFC1918 ranges, IPv6 loopback, and redirects to private IPs,
- add a `wp_handle_sideload` failure test.