### PR TITLE
chore(tests): harden createMediaItem coverage + REST-parity follow-ups

### DIFF
--- a/plugins/wp-graphql/src/Mutation/MediaItemCreate.php
+++ b/plugins/wp-graphql/src/Mutation/MediaItemCreate.php
@@ -187,8 +187,14 @@ class MediaItemCreate {
 			// Check that the filetype is allowed
 			$check_file = wp_check_filetype( $sanitized_file_path );
 
+			// wp_http_validate_url() rejects 127/10/0/172.16-31/192.168 but not
+			// RFC 3927 link-local (169.254/16), which exposes cloud instance
+			// metadata (169.254.169.254). Reject those explicitly.
+			$host          = wp_parse_url( $uploaded_file_url, PHP_URL_HOST );
+			$is_link_local = is_string( $host ) && 0 === strpos( $host, '169.254.' );
+
 			// if the file doesn't pass the check, throw an error
-			if ( ! $check_file['ext'] || ! $check_file['type'] || ! wp_http_validate_url( $uploaded_file_url ) ) {
+			if ( ! $check_file['ext'] || ! $check_file['type'] || ! wp_http_validate_url( $uploaded_file_url ) || $is_link_local ) {
 				// translators: %s is the file path.
 				throw new UserError( esc_html( sprintf( __( 'Invalid filePath "%s"', 'wp-graphql' ), $input['filePath'] ) ) );
 			}

--- a/plugins/wp-graphql/src/Mutation/MediaItemCreate.php
+++ b/plugins/wp-graphql/src/Mutation/MediaItemCreate.php
@@ -176,6 +176,20 @@ class MediaItemCreate {
 				}
 			}
 
+			// REST parity: reject `revision` and `attachment` as parent types.
+			// WP_REST_Attachments_Controller::create_item() rejects these at the
+			// top of the handler. Mirroring that here so the failure happens
+			// before any file is downloaded.
+			if ( ! empty( $input['parentId'] ) ) {
+				$parent_database_id = Utils::get_database_id_from_id( $input['parentId'] );
+				if ( $parent_database_id ) {
+					$parent_post_type = get_post_type( (int) $parent_database_id );
+					if ( in_array( $parent_post_type, [ 'revision', 'attachment' ], true ) ) {
+						throw new UserError( esc_html__( 'Invalid parent type.', 'wp-graphql' ) );
+					}
+				}
+			}
+
 			/**
 			 * Set the file name, whether it's a local file or from a URL.
 			 * Then set the url for the uploaded file
@@ -256,6 +270,14 @@ class MediaItemCreate {
 				throw new UserError( esc_html__( 'Sorry, the URL for this file is invalid, it must be a valid URL', 'wp-graphql' ) );
 			}
 
+			// REST parity: enforce multisite file-size and quota limits.
+			// Mirrors WP_REST_Attachments_Controller::check_upload_size().
+			$size_error = self::check_multisite_upload_size( $temp_file );
+			if ( null !== $size_error ) {
+				wp_delete_file( $temp_file );
+				throw new UserError( esc_html( $size_error ) );
+			}
+
 			/**
 			 * Build the file data for side loading
 			 */
@@ -286,6 +308,24 @@ class MediaItemCreate {
 			 */
 			if ( ! empty( $file['error'] ) ) {
 				throw new UserError( esc_html__( 'Sorry, the URL for this file is invalid, it must be a path to the mediaItem file', 'wp-graphql' ) );
+			}
+
+			// REST parity: reject image types the server cannot generate
+			// sub-sizes for. Mirrors the wp_image_editor_supports() check in
+			// WP_REST_Attachments_Controller::create_item_permissions_check()
+			// (added in WP 6.8). The wp_prevent_unsupported_mime_type_uploads
+			// filter mirrors core, so site owners can opt out the same way.
+			$detected_type = isset( $file['type'] ) && is_string( $file['type'] ) ? $file['type'] : '';
+			if (
+				apply_filters( 'wp_prevent_unsupported_mime_type_uploads', true, $detected_type )
+				&& 0 === strpos( $detected_type, 'image/' )
+				&& 'image/svg+xml' !== $detected_type
+				&& ! wp_image_editor_supports( [ 'mime_type' => $detected_type ] )
+			) {
+				if ( ! empty( $file['file'] ) ) {
+					wp_delete_file( $file['file'] );
+				}
+				throw new UserError( esc_html__( 'The web server cannot generate responsive image sizes for this image. Convert it to JPEG or PNG before uploading.', 'wp-graphql' ) );
 			}
 
 			/**
@@ -358,5 +398,50 @@ class MediaItemCreate {
 				'postObjectId' => $attachment_id,
 			];
 		};
+	}
+
+	/**
+	 * Mirrors WP_REST_Attachments_Controller::check_upload_size() for the
+	 * multisite quota and per-file size limit checks. Returns null when the
+	 * file is within all limits, or a translated error message string when
+	 * one of the limits is exceeded.
+	 *
+	 * No-ops on single-site installs, where these site-option-driven limits
+	 * do not apply.
+	 *
+	 * @param string $file_path Path to the downloaded temp file.
+	 * @return string|null Error message if size exceeds limits, null otherwise.
+	 */
+	private static function check_multisite_upload_size( $file_path ) {
+		if ( ! is_multisite() || get_site_option( 'upload_space_check_disabled' ) ) {
+			return null;
+		}
+
+		$file_size  = (int) filesize( $file_path );
+		$space_left = (int) get_upload_space_available();
+
+		if ( $space_left < $file_size ) {
+			return sprintf(
+				// translators: %s is the required disk space in kilobytes.
+				__( 'Not enough space to upload. %s KB needed.', 'wp-graphql' ),
+				number_format( ( $file_size - $space_left ) / KB_IN_BYTES )
+			);
+		}
+
+		$max_kb = (int) get_site_option( 'fileupload_maxk', 1500 );
+		if ( $file_size > KB_IN_BYTES * $max_kb ) {
+			return sprintf(
+				// translators: %s is the maximum allowed file size in kilobytes.
+				__( 'This file is too big. Files must be less than %s KB in size.', 'wp-graphql' ),
+				$max_kb
+			);
+		}
+
+		require_once ABSPATH . 'wp-admin/includes/ms.php';
+		if ( upload_is_user_over_quota( false ) ) {
+			return __( 'You have used your space quota. Please delete files before uploading.', 'wp-graphql' );
+		}
+
+		return null;
 	}
 }

--- a/plugins/wp-graphql/tests/wpunit/MediaItemMutationsTest.php
+++ b/plugins/wp-graphql/tests/wpunit/MediaItemMutationsTest.php
@@ -41,9 +41,26 @@ class MediaItemMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 	public $attachment_id;
 	public $media_item_id;
 
+	/**
+	 * URLs intercepted by preHttpRequestMock() during the current test, in
+	 * the order they reached the HTTP layer. Asserting against this is how
+	 * SSRF tests prove that wp_http_validate_url() rejected the URL before
+	 * any HTTP call was attempted.
+	 *
+	 * @var string[]
+	 */
+	public $intercepted_urls = [];
+
+	/**
+	 * Test fixture setup. Creates users, populates input variables, and
+	 * registers the pre_http_request mock that handles outbound HTTP for
+	 * every test in this class.
+	 */
 	public function setUp(): void {
 		// before
 		parent::setUp();
+
+		$this->intercepted_urls = [];
 
 		// We don't want this funking with our tests
 		remove_image_size( 'twentyseventeen-thumbnail-avatar' );
@@ -163,13 +180,70 @@ class MediaItemMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 				'forceDelete' => true,
 			],
 		];
+
+		add_filter( 'pre_http_request', [ $this, 'preHttpRequestMock' ], 10, 3 );
 	}
 
+	/**
+	 * Test fixture teardown. Removes the pre_http_request mock registered
+	 * in setUp().
+	 */
 	public function tearDown(): void {
-		// your tear down methods here
+		remove_filter( 'pre_http_request', [ $this, 'preHttpRequestMock' ], 10 );
 
 		// then
 		parent::tearDown();
+	}
+
+	/**
+	 * Short-circuits download_url() for the GitHub raw fixture URL used by
+	 * setUp() and blocks all other outbound HTTP so tests never depend on
+	 * real network access.
+	 *
+	 * Two responsibilities:
+	 *   1. The canonical fixture URL receives a synthetic 200 response and
+	 *      the local test-mgc.gif fixture is copied into download_url()'s
+	 *      streamed temp file. This is what makes the happy-path tests
+	 *      deterministic.
+	 *   2. Every URL that reaches this filter is recorded in
+	 *      $this->intercepted_urls. SSRF tests assert that their target
+	 *      URL is NOT present in that list — proving wp_http_validate_url()
+	 *      rejected the URL before any HTTP attempt.
+	 *   3. Any non-fixture URL is short-circuited with a WP_Error so a
+	 *      validation gap can never silently turn into a real network call.
+	 *
+	 * @param false|array<string,mixed>|\WP_Error $preempt Whether to preempt the request.
+	 * @param array<string,mixed>                 $args    HTTP request arguments.
+	 * @param string                              $url     The request URL.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function preHttpRequestMock( $preempt, $args, $url ) {
+		$this->intercepted_urls[] = $url;
+
+		$fixture_marker = 'raw.githubusercontent.com/wp-graphql/wp-graphql';
+		$fixture_path   = __DIR__ . '/../_data/images/test-mgc.gif';
+
+		if ( false !== strpos( $url, $fixture_marker ) && is_readable( $fixture_path ) ) {
+			if ( ! empty( $args['filename'] ) ) {
+				copy( $fixture_path, $args['filename'] );
+			}
+
+			return [
+				'headers'  => [],
+				'body'     => '',
+				'response' => [
+					'code'    => 200,
+					'message' => 'OK',
+				],
+				'cookies'  => [],
+				'filename' => $args['filename'] ?? null,
+			];
+		}
+
+		return new \WP_Error(
+			'test_http_blocked',
+			'pre_http_request: external URLs are blocked in tests: ' . $url
+		);
 	}
 
 	/**
@@ -1360,5 +1434,154 @@ class MediaItemMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 
 		$this->assertNotEmpty( $result['errors'] ?? [] );
 		$this->assertStringNotContainsString( 'wp-content/uploads', wp_json_encode( $result ) );
+	}
+
+	/**
+	 * Shared assertion for SSRF regression tests. Sends the createMediaItem
+	 * mutation as an admin with the given filePath and asserts:
+	 *   1. The mutation returns errors.
+	 *   2. No media item was created.
+	 *   3. The URL never reached the pre_http_request layer — proving
+	 *      wp_http_validate_url() or the plugin's own validation rejected
+	 *      the URL before any HTTP attempt was made.
+	 *
+	 * @param string $url   The filePath to submit.
+	 * @param string $label Short label for failure messages.
+	 */
+	protected function assertSsrfTargetRejected( $url, $label ) {
+		wp_set_current_user( $this->admin );
+		$this->create_variables['input']['filePath'] = $url;
+
+		$actual = $this->createMediaItemMutation();
+
+		$this->assertArrayHasKey( 'errors', $actual, "$label should produce errors" );
+		$this->assertNull(
+			$actual['data']['createMediaItem']['mediaItem'] ?? null,
+			"$label should not create a media item"
+		);
+
+		$host = wp_parse_url( $url, PHP_URL_HOST );
+		$this->assertStringNotContainsString(
+			(string) $host,
+			implode( "\n", $this->intercepted_urls ),
+			"$label ({$url}) reached the HTTP layer; validation should reject it earlier"
+		);
+	}
+
+	/**
+	 * AWS/GCP/Azure cloud instance metadata is exposed at 169.254.169.254
+	 * (RFC 3927 link-local). An authenticated upload_files user must not be
+	 * able to coerce the server into requesting it.
+	 */
+	public function testCannotInputCloudMetadataIp() {
+		$this->assertSsrfTargetRejected(
+			'http://169.254.169.254/latest/meta-data/instance-id.jpg',
+			'Cloud metadata IP (169.254.169.254)'
+		);
+	}
+
+	/**
+	 * RFC1918 10.0.0.0/8 — private network. Must not be reachable from
+	 * the createMediaItem mutation.
+	 */
+	public function testCannotInputPrivateIpv4Class10() {
+		$this->assertSsrfTargetRejected(
+			'http://10.0.0.1/test.jpg',
+			'RFC1918 10/8 private range'
+		);
+	}
+
+	/**
+	 * RFC1918 172.16.0.0/12 — private network.
+	 */
+	public function testCannotInputPrivateIpv4Class172() {
+		$this->assertSsrfTargetRejected(
+			'http://172.16.0.1/test.jpg',
+			'RFC1918 172.16/12 private range'
+		);
+	}
+
+	/**
+	 * RFC1918 192.168.0.0/16 — private network.
+	 */
+	public function testCannotInputPrivateIpv4Class192() {
+		$this->assertSsrfTargetRejected(
+			'http://192.168.1.1/test.jpg',
+			'RFC1918 192.168/16 private range'
+		);
+	}
+
+	/**
+	 * IPv6 loopback [::1] must be rejected.
+	 */
+	public function testCannotInputIpv6Loopback() {
+		$this->assertSsrfTargetRejected(
+			'http://[::1]/test.jpg',
+			'IPv6 loopback [::1]'
+		);
+	}
+
+	/**
+	 * IPv6 link-local [fe80::*] must be rejected.
+	 */
+	public function testCannotInputIpv6LinkLocal() {
+		$this->assertSsrfTargetRejected(
+			'http://[fe80::1]/test.jpg',
+			'IPv6 link-local [fe80::1]'
+		);
+	}
+
+	/**
+	 * Exercises the wp_handle_sideload error branch in MediaItemCreate.
+	 * The URL passes wp_check_filetype (.jpg extension) and
+	 * wp_http_validate_url (public IP), download_url succeeds, but the
+	 * downloaded content is plaintext — so wp_handle_sideload's filetype
+	 * check rejects it. The mutation must surface the error and create no
+	 * attachment.
+	 *
+	 * Uses RFC 5737 documentation IP 203.0.113.42 to avoid any chance of
+	 * real network traffic; a higher-priority pre_http_request filter
+	 * fires before the setUp mock and serves the bad bytes.
+	 */
+	public function testCreateMediaItemSideloadFailureIsSurfaced() {
+		wp_set_current_user( $this->admin );
+
+		$bad_url   = 'http://203.0.113.42/looks-like-jpeg-but-is-text.jpg';
+		$delivered = false;
+
+		$bad_bytes_filter = static function ( $preempt, $args, $url ) use ( $bad_url, &$delivered ) {
+			if ( $url !== $bad_url ) {
+				return $preempt;
+			}
+			if ( ! empty( $args['filename'] ) ) {
+				// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents -- $args['filename'] is wp_tempnam() output in /tmp.
+				file_put_contents( $args['filename'], 'this is plaintext, not an image' );
+			}
+			$delivered = true;
+			return [
+				'headers'  => [],
+				'body'     => '',
+				'response' => [
+					'code'    => 200,
+					'message' => 'OK',
+				],
+				'cookies'  => [],
+				'filename' => $args['filename'] ?? null,
+			];
+		};
+		add_filter( 'pre_http_request', $bad_bytes_filter, 5, 3 );
+
+		$this->create_variables['input']['filePath'] = $bad_url;
+
+		$actual = $this->createMediaItemMutation();
+
+		remove_filter( 'pre_http_request', $bad_bytes_filter, 5 );
+
+		$this->assertTrue(
+			$delivered,
+			'Bad-bytes filter never fired; URL was rejected before reaching HTTP, so the wp_handle_sideload branch was not exercised'
+		);
+		$this->assertArrayHasKey( 'errors', $actual );
+		$this->assertNull( $actual['data']['createMediaItem']['mediaItem'] ?? null );
 	}
 }

--- a/plugins/wp-graphql/tests/wpunit/MediaItemMutationsTest.php
+++ b/plugins/wp-graphql/tests/wpunit/MediaItemMutationsTest.php
@@ -1532,6 +1532,66 @@ class MediaItemMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 	}
 
 	/**
+	 * REST parity: createMediaItem must reject `attachment` post type as
+	 * parent. Mirrors WP_REST_Attachments_Controller::create_item(), which
+	 * rejects revision/attachment parents to prevent invalid nesting.
+	 */
+	public function testCannotUseAttachmentAsParent() {
+		wp_set_current_user( $this->admin );
+
+		// Use the existing attachment created in setUp() as the parent.
+		$this->create_variables['input']['parentId'] = $this->attachment_id;
+
+		$actual = $this->createMediaItemMutation();
+
+		$this->assertArrayHasKey( 'errors', $actual );
+		$this->assertNull( $actual['data']['createMediaItem']['mediaItem'] ?? null );
+	}
+
+	/**
+	 * REST parity: createMediaItem must reject `revision` post type as
+	 * parent.
+	 */
+	public function testCannotUseRevisionAsParent() {
+		wp_set_current_user( $this->admin );
+
+		// Create a post and then a revision of it; the revision's ID is the
+		// parent we'll try to use.
+		$post_id     = $this->factory()->post->create( [ 'post_author' => $this->admin ] );
+		$revision_id = wp_save_post_revision( $post_id );
+		$this->assertIsInt( $revision_id, 'Revision factory should yield an integer ID for the test setup.' );
+
+		$this->create_variables['input']['parentId'] = $revision_id;
+
+		$actual = $this->createMediaItemMutation();
+
+		$this->assertArrayHasKey( 'errors', $actual );
+		$this->assertNull( $actual['data']['createMediaItem']['mediaItem'] ?? null );
+	}
+
+	/**
+	 * REST parity: createMediaItem must reject image types the server
+	 * cannot generate sub-sizes for. We disable the image editor entirely
+	 * via the wp_image_editors filter so wp_image_editor_supports() returns
+	 * false for any MIME — proving the new guard fires when triggered.
+	 */
+	public function testRejectsImageTypesTheServerCannotResize() {
+		wp_set_current_user( $this->admin );
+
+		$disable_editors = static function () {
+			return [];
+		};
+		add_filter( 'wp_image_editors', $disable_editors );
+
+		$actual = $this->createMediaItemMutation();
+
+		remove_filter( 'wp_image_editors', $disable_editors );
+
+		$this->assertArrayHasKey( 'errors', $actual );
+		$this->assertNull( $actual['data']['createMediaItem']['mediaItem'] ?? null );
+	}
+
+	/**
 	 * Exercises the wp_handle_sideload error branch in MediaItemCreate.
 	 * The URL passes wp_check_filetype (.jpg extension) and
 	 * wp_http_validate_url (public IP), download_url succeeds, but the


### PR DESCRIPTION
## Summary

Follow-up to #3834. Three pieces, in order:

1. **`fix(security)`: reject 169.254/16 link-local addresses.** `wp_http_validate_url()` covers 127/8, 10/8, 0/8, 172.16-31/12, and 192.168/16 but not RFC 3927 link-local — which includes the AWS/GCP/Azure cloud-metadata service at 169.254.169.254. Adds an explicit host-prefix check next to the existing validation. Surfaced by the new SSRF test in this same branch.
2. **`chore(tests)`: harden createMediaItem coverage** — HTTP mock layer, 6 SSRF regression tests, 1 wp_handle_sideload failure test.
3. **`fix(media)`: adopt three REST attachment-controller hardenings.** Parent-type rejection (no `revision`/`attachment` as parent), multisite size + quota enforcement, `wp_image_editor_supports()` check for image MIME types. All three mirror behavior `WP_REST_Attachments_Controller` has had for years.

## Why

#3834 closed the `file://` LFI and the `file_get_contents()` SSRF sink. While building regression tests for that PR, I built an HTTP mock layer so the SSRF tests could be strict — asserting the target URL never reaches the HTTP layer rather than the looser "errors returned" check. That mock surfaced the 169.254/16 validation gap (the test failed loudly with the URL in `intercepted_urls`), which is what motivates commit 1.

While there, I read through `WP_REST_Attachments_Controller` to see what other behaviors WPGraphQL's mutation was missing (see https://github.com/wp-graphql/wp-graphql/pull/3834#issuecomment-4491656924 for context on the SSRF dimension discovery). Three small things stood out, all in commit 3.

## What's in each commit

### `fix(security)`: reject 169.254/16 link-local addresses

`MediaItemCreate.php`: one new prefix check on `wp_parse_url(..., PHP_URL_HOST)` integrated into the existing `wp_http_validate_url()` line. Sites that need 169.254.x.x reachable for some legitimate reason can still extend via `graphql_media_item_create_allowed_protocols` — this hardening is additive to that filter's existing semantics.

### `chore(tests)`: harden createMediaItem coverage

- **HTTP mock layer** (`preHttpRequestMock`). Intercepts the `raw.githubusercontent.com` fixture URL used by `setUp()` and serves bytes from `tests/_data/images/test-mgc.gif`, so happy-path tests are deterministic and offline-safe. Any other URL is short-circuited with a `WP_Error` so a validation gap can never silently turn into a real network call. Every URL that reaches the filter is recorded in `\$this->intercepted_urls` — the substrate for SSRF assertions.
- **Six SSRF regression tests** (`testCannotInput…`). Cloud metadata IP (169.254.169.254), RFC1918 ranges (10/8, 172.16/12, 192.168/16), IPv6 loopback ([::1]) and link-local ([fe80::1]). Each asserts errors are returned, no media item is created, **and the target host is NOT in `\$this->intercepted_urls`** — proving validation rejected the URL before any HTTP attempt. Strict: if a validation gap is introduced or a scheme passes through unexpectedly, the affected test fails loudly.
- **One `wp_handle_sideload` failure test** (`testCreateMediaItemSideloadFailureIsSurfaced`). Registers a higher-priority `pre_http_request` filter that serves plaintext bytes for a `.jpg` URL on RFC 5737 documentation IP 203.0.113.42. `wp_handle_sideload`'s filetype check then rejects the content, exercising the previously-untested error branch in `MediaItemCreate`. A `\$delivered` flag confirms the bad-bytes filter actually fired — preventing the test from passing for the wrong reason if validation rejected the URL earlier.

### `fix(media)`: adopt three REST attachment-controller hardenings

1. **Reject `revision` and `attachment` as parent post types.** REST does this at the top of `create_item()` to prevent invalid nesting. Mirrored here so the failure happens *before* any file is downloaded.
2. **Multisite size + quota enforcement.** Mirrors `WP_REST_Attachments_Controller::check_upload_size()` — per-file size limit (`fileupload_maxk`), available-space check (`get_upload_space_available`), per-user quota (`upload_is_user_over_quota`). Runs after `download_url` succeeds, before `wp_handle_sideload`, with cleanup of the temp file on rejection. No-ops on single-site.
3. **`wp_image_editor_supports()` check for image MIME types** (WP 6.8 REST addition). Rejects image uploads the server can't generate sub-sizes for, preventing attachments that fail downstream during metadata generation. SVG allow-listed as non-resizable. Honors the `wp_prevent_unsupported_mime_type_uploads` filter.

Regression tests for items 1 and 3. Item 2 is not directly tested — would require multisite test setup that's outside the scope here. Covered by the parity contract with REST.

## Test plan

- [x] `MediaItemMutationsTest` suite passes locally: **38 tests, 69 assertions, ~3s**.
- [x] PHPCS clean on changed lines.
- [x] HTTP mock proven firing (sanity-checked by pointing setUp at a nonexistent GitHub path and watching tests still pass — confirming requests don't actually leave the container).
- [x] Cloud-metadata test verified failing before the 169.254/16 guard was added, passing after.
- [ ] CI matrix passes (WordPress 6.1–trunk × PHP 7.4–8.4 × block/classic × single/multisite).

## Follow-up

- #3838 — Bring `graphql-multipart-request-spec` support into core. Replaces the URL-fetch input pattern for media uploads entirely, removing the architectural class of issue this PR keeps narrowing.