### PR TITLE
feat(deps)!: upgrade next 15.5.18 → 16.2.6 for wpgraphql.com

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5205,9 +5205,9 @@
 			}
 		},
 		"node_modules/@next/swc-darwin-arm64": {
-			"version": "15.5.18",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.18.tgz",
-			"integrity": "sha512-w0WvQf1n+txiwns/9pwIQteCJpZTbxzO2SE0FLcwuD4v0WEh1JPOjdyxWL21XwJsdpx8cFRjyzxzCS/siP7HcQ==",
+			"version": "16.2.6",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.6.tgz",
+			"integrity": "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==",
 			"cpu": [
 				"arm64"
 			],
@@ -5221,9 +5221,9 @@
 			}
 		},
 		"node_modules/@next/swc-darwin-x64": {
-			"version": "15.5.18",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.18.tgz",
-			"integrity": "sha512-znn71QmDuxm+BOaglihMZfvyySMnNljkVIY5Z2TCssBmm+WqL6c19VhtH5ktFkHa8EZ2bnTUpcNcmNSQsg67og==",
+			"version": "16.2.6",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.6.tgz",
+			"integrity": "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==",
 			"cpu": [
 				"x64"
 			],
@@ -5237,9 +5237,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-gnu": {
-			"version": "15.5.18",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.18.tgz",
-			"integrity": "sha512-yPPe5MNL+igZUa+OsqQJisqSfh6oarIuA1Q0BDxljGJhRQyZeP+WRHh7rs/jZUGMh5aY0YdIjXZG0VohkKkUdw==",
+			"version": "16.2.6",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.6.tgz",
+			"integrity": "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==",
 			"cpu": [
 				"arm64"
 			],
@@ -5253,9 +5253,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-musl": {
-			"version": "15.5.18",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.18.tgz",
-			"integrity": "sha512-glaCczEWIrHsokFZ3pP08U4BpKxwIdnT+txdOM32OBgpL9Yw4aqx8NejmgtZQZOdstQ5f0L3CasIZudzCuD+nw==",
+			"version": "16.2.6",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.6.tgz",
+			"integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
 			"cpu": [
 				"arm64"
 			],
@@ -5269,9 +5269,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-gnu": {
-			"version": "15.5.18",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.18.tgz",
-			"integrity": "sha512-oUfg2EgJmU3R0OCOWiokGFUTvZiPfXtriXiuF3YNxRoROCdgvTedHIzYoeKH34gsZxS/V7mHbfq2hpAHwhH1/A==",
+			"version": "16.2.6",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.6.tgz",
+			"integrity": "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==",
 			"cpu": [
 				"x64"
 			],
@@ -5285,9 +5285,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-musl": {
-			"version": "15.5.18",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.18.tgz",
-			"integrity": "sha512-JLxSP3KTd9iu/bvUMQxH7RJo9xKSHf55/6RPE4a6FTSZygGn7uvZbCej0AHXydwkggQGSD9UddSjwv6Xz5ESfA==",
+			"version": "16.2.6",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.6.tgz",
+			"integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
 			"cpu": [
 				"x64"
 			],
@@ -5301,9 +5301,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-arm64-msvc": {
-			"version": "15.5.18",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.18.tgz",
-			"integrity": "sha512-ir1v7enP52K2HNz3tQQvwF+x7VNxBk1ciiZ18WBPvxf4C59IqdfmHPJYK3vH7rSxpuCVw/8C712wTXNAtEp+NA==",
+			"version": "16.2.6",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.6.tgz",
+			"integrity": "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==",
 			"cpu": [
 				"arm64"
 			],
@@ -5317,9 +5317,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-x64-msvc": {
-			"version": "15.5.18",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.18.tgz",
-			"integrity": "sha512-LIu5me6QTANCd25E7I5uIEfvgQ06RK7tvHAbYo3zCb3VpxQEPvMcSpd87NwUABDT6MbGPdEGR5VRiK4PPTJhQg==",
+			"version": "16.2.6",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.6.tgz",
+			"integrity": "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==",
 			"cpu": [
 				"x64"
 			],
@@ -15263,7 +15263,6 @@
 			"version": "2.10.14",
 			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.14.tgz",
 			"integrity": "sha512-fOVLPAsFTsQfuCkvahZkzq6nf8KvGWanlYoTh0SVA0A/PIUxQGU2AOZAoD95n2gFLVDW/jP6sbGLny95nmEuHA==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"baseline-browser-mapping": "dist/cli.cjs"
@@ -31256,13 +31255,14 @@
 			}
 		},
 		"node_modules/next": {
-			"version": "15.5.18",
-			"resolved": "https://registry.npmjs.org/next/-/next-15.5.18.tgz",
-			"integrity": "sha512-eKL8zUJkX9Y5lE+RX/2YJoItVdGlIscyVyboeD9wSpp0PaGqjoA4tTpT2qPqz9ax+5IzGESyLSeZ/RCwbSZ2uQ==",
+			"version": "16.2.6",
+			"resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
+			"integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
 			"license": "MIT",
 			"dependencies": {
-				"@next/env": "15.5.18",
+				"@next/env": "16.2.6",
 				"@swc/helpers": "0.5.15",
+				"baseline-browser-mapping": "^2.9.19",
 				"caniuse-lite": "^1.0.30001579",
 				"postcss": "8.4.31",
 				"styled-jsx": "5.1.6"
@@ -31271,18 +31271,18 @@
 				"next": "dist/bin/next"
 			},
 			"engines": {
-				"node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
+				"node": ">=20.9.0"
 			},
 			"optionalDependencies": {
-				"@next/swc-darwin-arm64": "15.5.18",
-				"@next/swc-darwin-x64": "15.5.18",
-				"@next/swc-linux-arm64-gnu": "15.5.18",
-				"@next/swc-linux-arm64-musl": "15.5.18",
-				"@next/swc-linux-x64-gnu": "15.5.18",
-				"@next/swc-linux-x64-musl": "15.5.18",
-				"@next/swc-win32-arm64-msvc": "15.5.18",
-				"@next/swc-win32-x64-msvc": "15.5.18",
-				"sharp": "^0.34.3"
+				"@next/swc-darwin-arm64": "16.2.6",
+				"@next/swc-darwin-x64": "16.2.6",
+				"@next/swc-linux-arm64-gnu": "16.2.6",
+				"@next/swc-linux-arm64-musl": "16.2.6",
+				"@next/swc-linux-x64-gnu": "16.2.6",
+				"@next/swc-linux-x64-musl": "16.2.6",
+				"@next/swc-win32-arm64-msvc": "16.2.6",
+				"@next/swc-win32-x64-msvc": "16.2.6",
+				"sharp": "^0.34.5"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.1.0",
@@ -31418,9 +31418,9 @@
 			}
 		},
 		"node_modules/next/node_modules/@next/env": {
-			"version": "15.5.18",
-			"resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.18.tgz",
-			"integrity": "sha512-hAV85Ckd9QR6RvH04MEKwsfLTksvFpO47j9xwtoIuvuPnlwecpSi+uZTtm8HirVbtlI2Fnz//xpcSTjFdyJk+g==",
+			"version": "16.2.6",
+			"resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
+			"integrity": "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==",
 			"license": "MIT"
 		},
 		"node_modules/next/node_modules/postcss": {
@@ -42107,7 +42107,7 @@
 		},
 		"plugins/wp-graphql": {
 			"name": "@wpgraphql/wp-graphql",
-			"version": "2.13.0",
+			"version": "2.14.0",
 			"dependencies": {
 				"@ant-design/icons": "6.2.2",
 				"@apollo/client": "3.14.0",
@@ -42155,7 +42155,7 @@
 		},
 		"plugins/wp-graphql-acf": {
 			"name": "@wpgraphql/wp-graphql-acf",
-			"version": "2.6.0",
+			"version": "2.6.1",
 			"license": "GPL-3.0-or-later",
 			"devDependencies": {
 				"eslint": "^8.57.1"
@@ -43952,9 +43952,9 @@
 				"graphql-tag": "^2.12.6",
 				"http-status-codes": "^2.2.0",
 				"lucide-react": "^1.14.0",
-				"next": "15.5.18",
+				"next": "16.2.6",
 				"next-mdx-remote": "^4.1.0",
-				"next-sitemap": "^4.2.3",
+				"next-sitemap": "4.2.3",
 				"next-themes": "^0.4.6",
 				"octokit": "^5.0.5",
 				"postinstall-postinstall": "^2.1.0",

--- a/websites/wpgraphql.com/next.config.js
+++ b/websites/wpgraphql.com/next.config.js
@@ -2,12 +2,16 @@ const withBundleAnalyzer = require("@next/bundle-analyzer")({
   enabled: process.env.ANALYZE === "true",
 })
 
-function getWpHostname() {
+function getWpRemotePattern() {
   const url = process.env.NEXT_PUBLIC_WORDPRESS_URL || "https://wp.wpgraphql.com"
   try {
-    return new URL(url).hostname
+    const parsed = new URL(url)
+    return {
+      protocol: parsed.protocol.replace(":", ""),
+      hostname: parsed.hostname,
+    }
   } catch {
-    return "wp.wpgraphql.com"
+    return { protocol: "https", hostname: "wp.wpgraphql.com" }
   }
 }
 
@@ -29,10 +33,10 @@ const getHeaders = async () => {
 const nextConfig = withBundleAnalyzer({
   pageExtensions: ["ts", "tsx", "js", "jsx"],
   images: {
-    domains: [
-      "secure.gravatar.com",
-      "raw.githubusercontent.com",
-      getWpHostname(),
+    remotePatterns: [
+      { protocol: "https", hostname: "secure.gravatar.com" },
+      { protocol: "https", hostname: "raw.githubusercontent.com" },
+      getWpRemotePattern(),
     ],
     disableStaticImages: true,
   },

--- a/websites/wpgraphql.com/package.json
+++ b/websites/wpgraphql.com/package.json
@@ -41,7 +41,7 @@
     "graphql-tag": "^2.12.6",
     "http-status-codes": "^2.2.0",
     "lucide-react": "^1.14.0",
-    "next": "15.5.18",
+    "next": "16.2.6",
     "next-mdx-remote": "^4.1.0",
     "next-sitemap": "4.2.3",
     "next-themes": "^0.4.6",

--- a/websites/wpgraphql.com/package.json
+++ b/websites/wpgraphql.com/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
-    "build": "next build",
+    "dev": "next dev --webpack",
+    "build": "next build --webpack",
     "start": "next start",
     "lint": "npm run test:lint -- --fix",
     "test:format": "prettier '*.{js,jsx,ts,tsx,css,mdx,json}'",

--- a/websites/wpgraphql.com/tsconfig.json
+++ b/websites/wpgraphql.com/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
@@ -13,13 +17,23 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "baseUrl": "./",
     "paths": {
-      "@/*": ["src/*"],
-      "*": ["src/*"]
+      "@/*": [
+        "src/*"
+      ],
+      "*": [
+        "src/*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary

Picks up Next.js 16.2.6 in `websites/wpgraphql.com` (a security release with several high-severity advisories) and applies the minimum set of changes required for the website to build and the e2e tests to pass.

Dependabot has tried to open this bump four times (#3622, #3648, #3718, #3824); each PR was auto-closed with *"Looks like next is no longer updatable, so this is no longer needed"* — Dependabot's resolver gives up because it doesn't regenerate the root `package-lock.json` for the workspace package.json change, so `npm ci` rejects the install with `EUSAGE`. This PR is the bump plus the migrations Next 16 requires.

### Changes

- **package-lock.json** — regenerated so `npm ci` succeeds (root lockfile was untouched by Dependabot when only the workspace `package.json` was updated).
- **websites/wpgraphql.com/package.json** — pin `next dev` and `next build` to `--webpack`. Next 16 promotes Turbopack to the default for builds and aborts when it detects an un-migrated webpack config; `@next/bundle-analyzer` always installs a webpack hook (even when `ANALYZE=false`), so the explicit opt-in preserves current behavior with no codepath changes.
- **websites/wpgraphql.com/tsconfig.json** — adopt Next 16's mandatory `jsx: "react-jsx"` change (React 17+ automatic runtime). Next applies this on first build; committing it keeps subsequent builds no-ops. The other diff lines are JSON reformatting Next 16 emits.
- **websites/wpgraphql.com/next.config.js** — migrate `images.domains` → `images.remotePatterns` (deprecated in Next 16). Protocol is hardcoded `https` for the two static hosts and derived from `NEXT_PUBLIC_WORDPRESS_URL` for the WP host so http (local dev) and https (prod) both work.

### Not in this PR
- `eslint-config-next` is still pinned to `^15.5.18`; `next lint` isn't part of CI for this workspace, so it doesn't block. Worth a follow-up.
- React stays on 18 (Next 16 still supports it as a peer).

## Test plan

- [x] `npm install` (Node 22) reconciles the lockfile with no peer-dep warnings.
- [x] `npm run build -w @wpgraphql/wpgraphql-com` succeeds; no Next 16 warnings (only pre-existing large-page-data warnings).
- [x] `npm run start` serves the prod build; `/`, `/docs-sitemap.xml`, `/wordpress-sitemap.xml` all return HTTP 200.
- [x] `npm run test:e2e -w @wpgraphql/wpgraphql-com` — 3/4 pass locally; the 1 failure (`should have working navigation`) is environmental (no backend secrets locally so `<nav>` is empty/zero-size). CI with `WPGRAPHQL_URL` / `NEXT_PUBLIC_WORDPRESS_URL` / `FAUSTWP_SECRET_KEY` set should pass all 4.
- [ ] CI Website E2E Tests workflow green.