### PR TITLE
fix(ci): deploy WordPress.org assets via ASSETS_DIR + dedicated asset-update workflow

### DIFF
--- a/.github/workflows/deploy-wporg-assets.yml
+++ b/.github/workflows/deploy-wporg-assets.yml
@@ -1,0 +1,139 @@
+# Deploy WordPress.org Assets
+#
+# Asset-only deployments to WordPress.org — banners, icons, screenshots, and
+# blueprints that live in each plugin's `.wordpress-org/` directory.
+#
+# WHY THIS EXISTS (separate from release-please.yml):
+# WordPress.org assets are decoupled from plugin versions — the SVN `assets/`
+# directory can (and should) be updated without cutting a release. Using the
+# release workflow's `redeploy_tag` path for an asset tweak is the wrong tool:
+# it deletes/re-creates the SVN tag, re-transmits the whole plugin, and bumps
+# the plugin's "last updated" date. This workflow uses 10up's dedicated
+# asset-update action, which syncs ONLY `.wordpress-org/` -> SVN `assets/`.
+#
+# TRIGGERS:
+# - push to main touching `plugins/*/.wordpress-org/**` — assets go live as soon
+#   as they merge (no release required). Only the changed plugins are deployed.
+# - workflow_dispatch — pick a single plugin or `all` to (re)deploy on demand
+#   (e.g. to backfill assets that pre-date this workflow, like the brand refresh).
+#
+# SLUG MAPPING:
+# WordPress.org slugs are resolved from release-please-config.json on main, the
+# same source release-please.yml uses (e.g. wp-graphql-smart-cache (component)
+# -> wpgraphql-smart-cache (.org slug)). Core has no override and defaults to its
+# folder name `wp-graphql`.
+
+name: Deploy WordPress.org Assets
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'plugins/*/.wordpress-org/**'
+  workflow_dispatch:
+    inputs:
+      component:
+        description: "Which plugin's assets to deploy"
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - wp-graphql
+          - wp-graphql-ide
+          - wp-graphql-acf
+          - wp-graphql-smart-cache
+
+permissions:
+  contents: read
+
+concurrency:
+  # Serialize asset deploys per ref; never cancel an in-flight SVN commit.
+  group: wporg-assets-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  detect:
+    name: Detect components to deploy
+    runs-on: ubuntu-latest
+    outputs:
+      components: ${{ steps.detect.outputs.components }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          # Full history so the push diff range (before..after) always resolves.
+          fetch-depth: 0
+
+      - name: Detect components
+        id: detect
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_COMPONENT: ${{ github.event.inputs.component }}
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            if [[ "$INPUT_COMPONENT" == "all" ]]; then
+              COMPONENTS='["wp-graphql","wp-graphql-ide","wp-graphql-acf","wp-graphql-smart-cache"]'
+            else
+              COMPONENTS=$(jq -nc --arg c "$INPUT_COMPONENT" '[$c]')
+            fi
+          else
+            # push: deploy only the plugins whose .wordpress-org assets changed.
+            if [[ -z "$BEFORE_SHA" || "$BEFORE_SHA" =~ ^0+$ ]]; then
+              RANGE_ARGS="HEAD~1 HEAD"
+            else
+              RANGE_ARGS="$BEFORE_SHA $AFTER_SHA"
+            fi
+            CHANGED=$(git diff --name-only $RANGE_ARGS -- plugins/ \
+              | grep -E '^plugins/[^/]+/\.wordpress-org/' \
+              | sed -E 's#^plugins/([^/]+)/\.wordpress-org/.*#\1#' \
+              | sort -u || true)
+            COMPONENTS=$(printf '%s\n' "$CHANGED" | jq -R . | jq -sc 'map(select(length > 0))')
+          fi
+
+          echo "components=$COMPONENTS" >> "$GITHUB_OUTPUT"
+          echo "Components to deploy: $COMPONENTS"
+
+  deploy:
+    name: Deploy ${{ matrix.component }} assets to WordPress.org
+    needs: detect
+    if: needs.detect.outputs.components != '' && needs.detect.outputs.components != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        component: ${{ fromJSON(needs.detect.outputs.components) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Resolve WordPress.org slug
+        id: slug
+        env:
+          COMPONENT: ${{ matrix.component }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Resolve slug from config on main so it matches release-please.yml.
+          CONFIG_JSON=$(curl -sL "https://raw.githubusercontent.com/${GH_REPO}/main/release-please-config.json")
+          WP_ORG_SLUG=$(echo "$CONFIG_JSON" | jq -r --arg c "$COMPONENT" '.packages["plugins/\($c)"].wp_org_slug // $c')
+          if [[ -z "$WP_ORG_SLUG" || "$WP_ORG_SLUG" == "null" ]]; then
+            echo "::error::Could not resolve WordPress.org slug for component: $COMPONENT"
+            exit 1
+          fi
+          echo "wp_org_slug=${WP_ORG_SLUG}" >> "$GITHUB_OUTPUT"
+          echo "Resolved slug for ${COMPONENT}: ${WP_ORG_SLUG}"
+
+      - name: Deploy assets
+        uses: 10up/action-wordpress-plugin-asset-update@stable
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+          SLUG: ${{ steps.slug.outputs.wp_org_slug }}
+          ASSETS_DIR: plugins/${{ matrix.component }}/.wordpress-org

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -531,6 +531,13 @@ jobs:
           # wp-graphql-smart-cache (component) -> wpgraphql-smart-cache (WordPress.org slug)
           SLUG: ${{ steps.plugin_info.outputs.wp_org_slug }}
           BUILD_DIR: plugin-build/${{ matrix.component }}
+          # WordPress.org assets (banners/icons/screenshots) live in each plugin's
+          # source .wordpress-org dir. The 10up action defaults ASSETS_DIR to a
+          # repo-root .wordpress-org, which does not exist in this monorepo, so it
+          # logged "No assets directory found; skipping asset copy" and never synced
+          # the SVN assets/ folder. Point it at the source dir (always present, and
+          # independent of .distignore, which excludes .wordpress-org from BUILD_DIR).
+          ASSETS_DIR: ${{ steps.plugin_info.outputs.package_path }}/.wordpress-org
           VERSION: ${{ steps.plugin_info.outputs.version }}
           # Note: The 10up action should sync BUILD_DIR to SVN trunk
           # If it's not updating readme.txt, it might be reading from the source tag

--- a/plugins/wp-graphql/.distignore
+++ b/plugins/wp-graphql/.distignore
@@ -3,7 +3,9 @@
 /.idea
 /.log
 /.vscode
-# .wordpress-org is kept (contains WordPress.org assets like banners, icons, screenshots)
+# .wordpress-org holds WordPress.org assets (banners/icons/screenshots) deployed to the
+# SVN assets/ dir via the release workflow's ASSETS_DIR — keep it out of trunk and the zip.
+/.wordpress-org
 /bin
 /github
 /plugin-build


### PR DESCRIPTION
## Problem

The brand refresh assets merged in #3877 are on `main` (and got into the `2.15.0` tag tree), and core `2.15.0` **did** deploy to WordPress.org afterward — yet the new banners/icons/screenshots never appeared on any plugin's `.org` page.

Root cause: the `WordPress Plugin Deploy` step in `release-please.yml` never set `ASSETS_DIR`, so the 10up action defaulted to a repo-root `.wordpress-org` that doesn't exist in this monorepo. Its own log confirms it:

```
ℹ︎ ASSETS_DIR is .wordpress-org
ℹ︎ No assets directory found; skipping asset copy
```

So the SVN `assets/` directory (which `.org` actually displays from) was never synced. The `.wordpress-org` files that *do* show up under `trunk/.wordpress-org/` and `tags/.../.wordpress-org/` are a red herring — `.org` ignores those. **All four plugins** (`wp-graphql`, `wp-graphql-ide`, `wp-graphql-smart-cache`, `wp-graphql-acf`) deployed in the same batch and hit the same skip.

## Changes

1. **`release-please.yml`** — set `ASSETS_DIR` to each plugin's source `.wordpress-org` dir (`package_path`-relative), so releases sync the `assets/` folder. Source-relative rather than build-relative so it works for all four plugins regardless of `.distignore`, and for both new releases and `redeploy_tag` re-deploys.

2. **`plugins/wp-graphql/.distignore`** — exclude `/.wordpress-org` (matching ide/acf/smart-cache) so core stops bundling assets into `trunk/` and the plugin zip. They reach `.org` via `ASSETS_DIR` now, so keeping them in the build was redundant bloat.

3. **`.github/workflows/deploy-wporg-assets.yml`** (new) — asset-only deploys via `10up/action-wordpress-plugin-asset-update`, because `.org` assets are decoupled from plugin versions and shouldn't require a release:
   - **Auto on push to `main`** touching `plugins/*/.wordpress-org/**` → only the changed plugins deploy. Asset changes go live on merge — this is what would have prevented this bug.
   - **Manual `workflow_dispatch`** with a `component` picker (`all` or one plugin) for backfills/redeploys.
   - Reuses the same `component → wp_org_slug` mapping from `release-please-config.json`.

## Getting the current rebrand live

After this merges, run **Deploy WordPress.org Assets** → `workflow_dispatch` → `component: all` to push the already-merged brand assets to all four plugin pages — no release required. (The manual trigger only appears in the Actions UI once the workflow is on `main`.)

## Validation

- Both workflow YAML files parse (`js-yaml`).
- Slug resolution verified against the real `release-please-config.json` for all four components.