### PR TITLE
feat(site): featured extensions homepage section + constellation motif

### DIFF
--- a/websites/wpgraphql.com/src/components/HomePage/HomepageExtensions.js
+++ b/websites/wpgraphql.com/src/components/HomePage/HomepageExtensions.js
@@ -1,0 +1,86 @@
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+import Constellation from "@/components/extensions/Constellation"
+import { featuredExtensions } from "../../data/extensions"
+
+/**
+ * Homepage "Extensions" section — highlights the first-party, sibling-branded
+ * plugins (IDE, ACF, Smart Cache) and links to the full /extensions archive.
+ *
+ * Reuses the canonical `featuredExtensions` data so it stays in sync with the
+ * header dropdown and the /extensions archive. Each card carries its product's
+ * `theme-*` scope, so its logo mark, constellation field, and glow all render
+ * in the sibling brand's accent color — echoing the WordPress.org plugin
+ * banners — while the surrounding homepage chrome stays WPGraphQL-orange.
+ */
+
+export default function HomepageExtensions() {
+  return (
+    <section className="px-4 py-20 sm:px-6 lg:px-8 lg:py-28">
+      <div className="mx-auto max-w-7xl">
+        <div className="mx-auto max-w-3xl text-center">
+          <p className="font-mono text-xs font-medium uppercase tracking-widest text-primary">
+            Extensions
+          </p>
+          <h2 className="mt-3 text-display-sm font-bold tracking-tight text-foreground sm:text-display-md">
+            Take your graph <span className="text-primary">further</span>
+          </h2>
+          <p className="mx-auto mt-5 max-w-prose text-base text-muted-foreground sm:text-lg">
+            Build queries faster, bring every custom field into your schema, and
+            serve responses at the edge — first-party extensions from the team
+            behind WPGraphQL, held to the same standard as core.
+          </p>
+        </div>
+
+        <div className="mt-14 grid gap-6 md:grid-cols-3">
+          {featuredExtensions.map(
+            ({ name, href, description, theme, Mark }, i) => (
+              <Link key={href} href={href} legacyBehavior>
+                <a
+                  className={`${theme} group relative flex flex-col overflow-hidden rounded-2xl border border-border bg-card p-8 transition-all hover:-translate-y-1 hover:border-primary/40 hover:shadow-glow-md`}
+                >
+                  {/* Brand-tinted constellation field + a soft glow behind the
+                      logo mark — a mini echo of the wp.org plugin banner. */}
+                  <Constellation variant={i} />
+                  <div
+                    aria-hidden="true"
+                    className="pointer-events-none absolute -left-4 -top-4 h-40 w-40 rounded-full bg-primary/20 blur-2xl transition-opacity group-hover:bg-primary/30"
+                  />
+                  <div
+                    aria-hidden="true"
+                    className="pointer-events-none absolute inset-0 bg-gradient-to-b from-transparent via-card/30 to-card"
+                  />
+
+                  <div className="relative flex flex-1 flex-col">
+                    <Mark size={64} className="h-16 w-16 rounded-xl" />
+                    <h3 className="mt-6 text-headline font-bold tracking-tight text-foreground">
+                      {name}
+                    </h3>
+                    <p className="mt-2 flex-1 text-base text-muted-foreground">
+                      {description}
+                    </p>
+                    <span className="mt-6 inline-flex items-center gap-1 text-sm font-semibold text-primary">
+                      Explore {name}
+                      <span
+                        aria-hidden="true"
+                        className="transition-transform group-hover:translate-x-0.5"
+                      >
+                        →
+                      </span>
+                    </span>
+                  </div>
+                </a>
+              </Link>
+            )
+          )}
+        </div>
+
+        <div className="mt-12 flex justify-center">
+          <Button asChild variant="outline" size="lg">
+            <Link href="/extensions">Browse all extensions</Link>
+          </Button>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/websites/wpgraphql.com/src/components/HomePage/HomepageHero.js
+++ b/websites/wpgraphql.com/src/components/HomePage/HomepageHero.js
@@ -1,6 +1,7 @@
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
 import MockIDE, { Tok } from "@/components/MockIDE"
+import Constellation from "@/components/extensions/Constellation"
 
 const heroQuery = (
   <>
@@ -35,6 +36,17 @@ const heroResponse = (
 export default function HomepageHero() {
   return (
     <section className="relative overflow-hidden">
+      {/* Full-bleed constellation field (WPGraphQL orange via the default
+          --primary), faded toward the bottom so it never fights the copy. */}
+      <Constellation
+        variant={7}
+        count={48}
+        width={1440}
+        height={720}
+        opacity={0.75}
+        intensity={1.6}
+        className="-z-10 [mask-image:linear-gradient(to_bottom,black,transparent_85%)]"
+      />
       <div className="mx-auto max-w-8xl px-4 py-20 sm:px-6 lg:px-8 lg:py-28">
         <div className="grid items-center gap-12 lg:grid-cols-2">
           <div className="lg:max-w-xl">

--- a/websites/wpgraphql.com/src/components/Site/SiteHeader.js
+++ b/websites/wpgraphql.com/src/components/Site/SiteHeader.js
@@ -19,6 +19,7 @@ import { useLayoutData } from "lib/wpgraphql-client"
 import { socialHeaderLinks } from "../../data/social"
 import { featuredExtensions } from "../../data/extensions"
 import { SearchButton } from "./SearchButton"
+import Constellation from "@/components/extensions/Constellation"
 import { cn } from "@/lib/utils"
 
 // The WP-sourced nav item we enhance with a branded dropdown. Matched by label
@@ -72,14 +73,28 @@ function ExtensionsMenu({ label = "Extensions", viewAllHref = "/extensions" }) {
                 </p>
                 <div className="grid gap-2 px-4 pb-4 sm:px-6">
                   {featuredExtensions.map(
-                    ({ name, href, description, Mark }) => (
+                    ({ name, href, description, theme, Mark }, i) => (
                       <Link key={href} href={href} legacyBehavior>
-                        <a className="-m-2 flex items-start gap-4 rounded-lg p-3 transition-colors hover:bg-accent">
+                        <a
+                          className={`${theme} group relative -m-2 flex items-start gap-4 overflow-hidden rounded-lg p-3 transition-colors hover:bg-accent`}
+                        >
+                          {/* Brand-tinted constellation, revealed on hover. */}
+                          <div className="pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-200 group-hover:opacity-100">
+                            <Constellation
+                              variant={i}
+                              count={16}
+                              width={360}
+                              height={104}
+                              opacity={1}
+                              intensity={1.8}
+                              className="[mask-image:linear-gradient(to_right,black_60%,transparent)]"
+                            />
+                          </div>
                           <Mark
                             size={40}
-                            className="h-10 w-10 flex-shrink-0 rounded-md"
+                            className="relative h-10 w-10 flex-shrink-0 rounded-md"
                           />
-                          <div>
+                          <div className="relative">
                             <p className="text-sm font-semibold text-foreground">
                               {name}
                             </p>

--- a/websites/wpgraphql.com/src/components/extensions/Constellation.js
+++ b/websites/wpgraphql.com/src/components/extensions/Constellation.js
@@ -1,0 +1,129 @@
+/**
+ * Brand-tinted constellation field — the glowing star-node motif from the
+ * WordPress.org plugin banners, as a reusable background layer.
+ *
+ * Color comes from the surrounding `.theme-*` scope via `currentColor`
+ * (`text-primary`), so the same field renders orange on WPGraphQL surfaces,
+ * violet under `.theme-ide`, emerald under `.theme-acf`, rose under
+ * `.theme-smart-cache`, etc.
+ *
+ * The field is generated once per unique `(variant, count, width, height)` with
+ * a seeded PRNG (no `Math.random`) and memoized, so server and client render
+ * identically (no hydration mismatch) and repeated instances are free.
+ *
+ * Render it inside a `relative overflow-hidden` container; it positions itself
+ * absolutely and fills the box (`preserveAspectRatio="xMidYMid slice"`).
+ */
+
+function seededRandom(seed) {
+  let a = seed >>> 0
+  return () => {
+    a = (a + 0x6d2b79f5) | 0
+    let t = Math.imul(a ^ (a >>> 15), 1 | a)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+function buildField(seed, count, width, height) {
+  const rand = seededRandom(seed * 9301 + 49297)
+  const points = Array.from({ length: count }, () => [
+    +(rand() * width).toFixed(1),
+    +(rand() * height).toFixed(1),
+  ])
+  // Brighter "glowing" nodes, chosen deterministically.
+  const bright = points.map(() => rand() < 0.3)
+  // Connect each node to its nearest neighbor (and sometimes a second) to form
+  // loose constellation clusters, skipping links that span too far. The cutoff
+  // scales with node density so it adapts to any field size.
+  const spacing = Math.sqrt((width * height) / count)
+  const maxDistSq = (spacing * 1.7) ** 2
+  const seen = new Set()
+  const edges = []
+  points.forEach((p, i) => {
+    const ranked = points
+      .map((q, j) => [j, (p[0] - q[0]) ** 2 + (p[1] - q[1]) ** 2])
+      .filter(([j]) => j !== i)
+      .sort((a, b) => a[1] - b[1])
+    const links = 1 + (rand() > 0.6 ? 1 : 0)
+    for (let k = 0; k < links && k < ranked.length; k++) {
+      const [j, distSq] = ranked[k]
+      if (distSq > maxDistSq) continue
+      const key = i < j ? `${i}-${j}` : `${j}-${i}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      edges.push([i, j])
+    }
+  })
+  return { points, bright, edges }
+}
+
+const cache = new Map()
+function getField(seed, count, width, height) {
+  const key = `${seed}:${count}:${width}:${height}`
+  let field = cache.get(key)
+  if (!field) {
+    field = buildField(seed, count, width, height)
+    cache.set(key, field)
+  }
+  return field
+}
+
+/**
+ * @param {number} [intensity=1] Multiplies node/line opacity (and nudges node
+ *   size) so the same field can read as a faint backdrop (≈1) or a prominent
+ *   accent (>1, e.g. on hover). Per-node opacities are clamped at 1.
+ */
+export default function Constellation({
+  variant = 0,
+  count = 16,
+  width = 320,
+  height = 360,
+  className = "",
+  opacity = 0.7,
+  intensity = 1,
+}) {
+  const { points, bright, edges } = getField(variant, count, width, height)
+  const clamp = (v) => Math.min(1, +(v * intensity).toFixed(3))
+  const grow = Math.min(1.5, 0.5 + intensity / 2) // 1 → 1×, higher → larger nodes
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox={`0 0 ${width} ${height}`}
+      preserveAspectRatio="xMidYMid slice"
+      style={{ opacity }}
+      className={`pointer-events-none absolute inset-0 h-full w-full text-primary ${className}`}
+    >
+      <g stroke="currentColor" strokeWidth={0.6 * grow}>
+        {edges.map(([i, j], k) => (
+          <line
+            key={k}
+            x1={points[i][0]}
+            y1={points[i][1]}
+            x2={points[j][0]}
+            y2={points[j][1]}
+            strokeOpacity={clamp(0.18)}
+          />
+        ))}
+      </g>
+      <g fill="currentColor">
+        {points.map(([x, y], i) =>
+          bright[i] ? (
+            <g key={i}>
+              <circle cx={x} cy={y} r={3.4 * grow} fillOpacity={clamp(0.12)} />
+              <circle cx={x} cy={y} r={1.5 * grow} fillOpacity={clamp(0.9)} />
+            </g>
+          ) : (
+            <circle
+              cx={x}
+              cy={y}
+              r={1 * grow}
+              fillOpacity={clamp(0.45)}
+              key={i}
+            />
+          )
+        )}
+      </g>
+    </svg>
+  )
+}

--- a/websites/wpgraphql.com/src/components/extensions/ExtensionsArchive.js
+++ b/websites/wpgraphql.com/src/components/extensions/ExtensionsArchive.js
@@ -1,6 +1,7 @@
 import Link from "next/link"
 import { Squares2X2Icon } from "@heroicons/react/20/solid"
 import { SectionHeading } from "@/components/extensions/SectionHeading"
+import Constellation from "@/components/extensions/Constellation"
 import ExtensionPreview from "@/components/Preview/ExtensionPreview"
 import { featuredExtensions, isFeaturedExtension } from "../../data/extensions"
 
@@ -36,27 +37,41 @@ export default function ExtensionsArchive({ nodes = [] }) {
           />
           <div className="mt-14 grid gap-6 md:grid-cols-3">
             {featuredExtensions.map(
-              ({ name, href, description, theme, Mark }) => (
+              ({ name, href, description, theme, Mark }, i) => (
                 <Link key={href} href={href} legacyBehavior>
                   <a
-                    className={`${theme} group flex flex-col rounded-2xl border border-border bg-card p-8 transition-all hover:-translate-y-1 hover:border-primary/40 hover:shadow-glow-md`}
+                    className={`${theme} group relative flex flex-col overflow-hidden rounded-2xl border border-border bg-card p-8 transition-all hover:-translate-y-1 hover:border-primary/40 hover:shadow-glow-md`}
                   >
-                    <Mark size={64} className="h-16 w-16 rounded-xl" />
-                    <h3 className="mt-6 text-headline font-bold tracking-tight text-foreground">
-                      {name}
-                    </h3>
-                    <p className="mt-2 flex-1 text-base text-muted-foreground">
-                      {description}
-                    </p>
-                    <span className="mt-6 inline-flex items-center gap-1 text-sm font-semibold text-primary">
-                      Explore {name}
-                      <span
-                        aria-hidden="true"
-                        className="transition-transform group-hover:translate-x-0.5"
-                      >
-                        →
+                    {/* Brand-tinted constellation field + a soft glow behind the
+                        logo mark — a mini echo of the wp.org plugin banner. */}
+                    <Constellation variant={i} />
+                    <div
+                      aria-hidden="true"
+                      className="pointer-events-none absolute -left-4 -top-4 h-40 w-40 rounded-full bg-primary/20 blur-2xl transition-opacity group-hover:bg-primary/30"
+                    />
+                    <div
+                      aria-hidden="true"
+                      className="pointer-events-none absolute inset-0 bg-gradient-to-b from-transparent via-card/30 to-card"
+                    />
+
+                    <div className="relative flex flex-1 flex-col">
+                      <Mark size={64} className="h-16 w-16 rounded-xl" />
+                      <h3 className="mt-6 text-headline font-bold tracking-tight text-foreground">
+                        {name}
+                      </h3>
+                      <p className="mt-2 flex-1 text-base text-muted-foreground">
+                        {description}
+                      </p>
+                      <span className="mt-6 inline-flex items-center gap-1 text-sm font-semibold text-primary">
+                        Explore {name}
+                        <span
+                          aria-hidden="true"
+                          className="transition-transform group-hover:translate-x-0.5"
+                        >
+                          →
+                        </span>
                       </span>
-                    </span>
+                    </div>
                   </a>
                 </Link>
               )

--- a/websites/wpgraphql.com/src/pages/extensions/wp-graphql-acf.js
+++ b/websites/wpgraphql.com/src/pages/extensions/wp-graphql-acf.js
@@ -15,6 +15,7 @@ import {
   SectionHeading as BaseSectionHeading,
   VisualPanel,
 } from "@/components/extensions/SectionHeading"
+import Constellation from "@/components/extensions/Constellation"
 
 const WP_ORG_URL = "https://wordpress.org/plugins/wpgraphql-acf/"
 // Repo root — issues / security policy live at the monorepo level.
@@ -126,6 +127,16 @@ function Hero() {
             radial-gradient(ellipse 500px 500px at 5% 85%, hsl(var(--primary) / 0.05) 0%, transparent 65%)
           `,
         }}
+      />
+      {/* Emerald constellation field, faded toward the bottom edge. */}
+      <Constellation
+        variant={2}
+        count={48}
+        width={1440}
+        height={720}
+        opacity={0.75}
+        intensity={1.6}
+        className="-z-10 [mask-image:linear-gradient(to_bottom,black,transparent_85%)]"
       />
       <div className="mx-auto max-w-7xl px-6 py-20 lg:py-28">
         <div className="grid gap-12 lg:grid-cols-2 lg:items-center">

--- a/websites/wpgraphql.com/src/pages/extensions/wp-graphql-ide.js
+++ b/websites/wpgraphql.com/src/pages/extensions/wp-graphql-ide.js
@@ -15,6 +15,7 @@ import {
   SectionHeading as BaseSectionHeading,
   VisualPanel,
 } from "@/components/extensions/SectionHeading"
+import Constellation from "@/components/extensions/Constellation"
 
 const WP_ORG_URL = "https://wordpress.org/plugins/wpgraphql-ide/"
 // Repo root — used for issues / security policy (those live at the monorepo level).
@@ -43,6 +44,16 @@ function Hero() {
             radial-gradient(ellipse 500px 500px at 5% 85%, hsl(var(--primary) / 0.06) 0%, transparent 65%)
           `,
         }}
+      />
+      {/* Violet constellation field, faded toward the bottom edge. */}
+      <Constellation
+        variant={1}
+        count={48}
+        width={1440}
+        height={720}
+        opacity={0.75}
+        intensity={1.6}
+        className="-z-10 [mask-image:linear-gradient(to_bottom,black,transparent_85%)]"
       />
       <div className="mx-auto max-w-7xl px-6 py-20 lg:py-28">
         <div className="grid gap-12 lg:grid-cols-2 lg:items-center">

--- a/websites/wpgraphql.com/src/pages/extensions/wp-graphql-smart-cache.js
+++ b/websites/wpgraphql.com/src/pages/extensions/wp-graphql-smart-cache.js
@@ -15,6 +15,7 @@ import {
   SectionHeading as BaseSectionHeading,
   VisualPanel,
 } from "@/components/extensions/SectionHeading"
+import Constellation from "@/components/extensions/Constellation"
 
 const WP_ORG_URL = "https://wordpress.org/plugins/wpgraphql-smart-cache/"
 // Repo root — issues / security policy live at the monorepo level.
@@ -110,6 +111,16 @@ function Hero() {
             radial-gradient(ellipse 500px 500px at 5% 85%, hsl(var(--primary) / 0.05) 0%, transparent 65%)
           `,
         }}
+      />
+      {/* Rose constellation field, faded toward the bottom edge. */}
+      <Constellation
+        variant={4}
+        count={48}
+        width={1440}
+        height={720}
+        opacity={0.75}
+        intensity={1.6}
+        className="-z-10 [mask-image:linear-gradient(to_bottom,black,transparent_85%)]"
       />
       <div className="mx-auto max-w-7xl px-6 py-20 lg:py-28">
         <div className="grid gap-12 lg:grid-cols-2 lg:items-center">

--- a/websites/wpgraphql.com/src/wp-templates/front-page.js
+++ b/websites/wpgraphql.com/src/wp-templates/front-page.js
@@ -1,4 +1,5 @@
 import HomepageCta from "components/HomePage/HomepageCta"
+import HomepageExtensions from "components/HomePage/HomepageExtensions"
 import HomepageFeatures from "components/HomePage/HomepageFeatures"
 import HomepageFrameworks from "components/HomePage/HomepageFrameworks"
 import HomepageHero from "components/HomePage/HomepageHero"
@@ -12,6 +13,7 @@ export default function FrontPage({ data }) {
         <HomepageHero />
         <HomepageFrameworks />
         <HomepageFeatures />
+        <HomepageExtensions />
         <HomePageTrust />
         <HomepageCta />
       </main>


### PR DESCRIPTION
Ships the unshipped website work from `feat/extensions-constellation-branding` (commit `cebacc45d`) as the follow-up its own message called for — now that the extension landing pages, sibling-brand logos, and `featuredExtensions` data it depends on are all on `main`.

## What this adds

- **`Constellation` component** (new) — the glowing star-node motif from the WordPress.org plugin banners, as a reusable background layer. Brand-agnostic (tints via the surrounding `.theme-*` `--primary`/`currentColor`), with `opacity`/`intensity` knobs. Deterministic: a **seeded PRNG (no `Math.random`) + module-level memo cache**, so server and client render identically (no hydration mismatch) and repeated instances are free.
- **`HomepageExtensions` section** (new) — a "Take your graph further" featured-extensions block wired into `front-page.js`, sourced from the canonical `featuredExtensions` data (stays in sync with the header dropdown and `/extensions` archive). Each card carries its product's `theme-*` scope so its logo, constellation field, and glow render in the sibling brand accent.
- **Constellation backgrounds** layered onto the homepage hero, the `/extensions` archive featured cards, each extension's dedicated-page hero, and the Extensions nav-dropdown hover state.

## Scope

9 files, +313/−21, **website-only** (`websites/wpgraphql.com/`). The source branch is the full IDE-rebuild stack; this PR isolates just the genuinely-unshipped branding work via cherry-pick, leaving the IDE plugin changes to their own PR (#3784).

## Verification

- Cherry-picked cleanly onto current `main`.
- All imports resolve on `main` (`Constellation` is new; `featuredExtensions`, `SectionHeading`, the `ui/button`, and the logo marks already shipped). `featuredExtensions` data shape matches what `HomepageExtensions` destructures (`name, href, description, theme, Mark`).
- ESLint clean on all 9 changed files.
- `Constellation` is SSR-safe (no `Math.random`/`Date`/`window` at render).

> Note: a full `next build` requires the headless WordPress backend, so it wasn't run locally — the change is presentational with all dependencies satisfied. Worth a glance at the deploy preview.