### PR TITLE
ci(website): default WPGRAPHQL_URL so fork PRs can build

### DIFF
--- a/.github/workflows/website-e2e-tests.yml
+++ b/.github/workflows/website-e2e-tests.yml
@@ -99,7 +99,9 @@ jobs:
         run: npm run build -w @wpgraphql/wpgraphql-com
         env:
           NEXT_PUBLIC_SITE_URL: ${{ secrets.NEXT_PUBLIC_SITE_URL || 'https://www.wpgraphql.com' }}
-          WPGRAPHQL_URL: ${{ secrets.WPGRAPHQL_URL }}
+          # Public GraphQL endpoint default so fork PRs (which can't read repo
+          # secrets) still prerender against live data instead of throwing.
+          WPGRAPHQL_URL: ${{ secrets.WPGRAPHQL_URL || 'https://content.wpgraphql.com/graphql' }}
           NEXT_PUBLIC_WORDPRESS_URL: ${{ secrets.NEXT_PUBLIC_WORDPRESS_URL }}
           FAUSTWP_SECRET_KEY: ${{ secrets.FAUSTWP_SECRET_KEY }}
 
@@ -123,7 +125,7 @@ jobs:
           exit 1
         env:
           NEXT_PUBLIC_SITE_URL: ${{ secrets.NEXT_PUBLIC_SITE_URL || 'https://www.wpgraphql.com' }}
-          WPGRAPHQL_URL: ${{ secrets.WPGRAPHQL_URL }}
+          WPGRAPHQL_URL: ${{ secrets.WPGRAPHQL_URL || 'https://content.wpgraphql.com/graphql' }}
           NEXT_PUBLIC_WORDPRESS_URL: ${{ secrets.NEXT_PUBLIC_WORDPRESS_URL }}
           FAUSTWP_SECRET_KEY: ${{ secrets.FAUSTWP_SECRET_KEY }}
 


### PR DESCRIPTION
## Problem

The **Website E2E Tests** workflow fails to build on PRs from forks (e.g. #3784):

```
Error occurred prerendering page "/extensions/wp-graphql-acf".
Error: wpgraphql-client: NEXT_PUBLIC_WPGRAPHQL_URL or WPGRAPHQL_URL must be set
```

GitHub doesn't expose repository secrets to `pull_request` runs triggered from a fork, so `${{ secrets.WPGRAPHQL_URL }}` expands to an empty string. `getGraphqlEndpoint()` then throws during prerender, failing every page that calls `getLayoutData()` in `getStaticProps` — `/extensions/wp-graphql-acf` is simply the first one alphabetically, so the build exits there.

`NEXT_PUBLIC_SITE_URL` already has a public fallback; `WPGRAPHQL_URL` did not.

## Fix

Fall back to the public GraphQL endpoint (`https://content.wpgraphql.com/graphql`) when the secret is absent, in both the **Build website** and **Start production server** steps — mirroring the existing `NEXT_PUBLIC_SITE_URL` pattern. Same-repo branches and `main` still use the secret.

## Notes

- The endpoint is public, so no secret is required for a build/e2e run.
- `NEXT_PUBLIC_WORDPRESS_URL` and `FAUSTWP_SECRET_KEY` remain bare secrets; they won't throw the build, but a follow-up may be needed if any page/e2e assertion depends on them on fork PRs.