### PR TITLE
Fix/tab name derivation

### DIFF
--- a/plugins/wp-graphql-ide/src/hooks/useAutoSave.js
+++ b/plugins/wp-graphql-ide/src/hooks/useAutoSave.js
@@ -58,13 +58,23 @@ export function useAutoSave({
 				return;
 			}
 			const payload = { [field]: value };
-			if (field === 'query' && isAutoTitle(activeDocument.title)) {
+			// Skip sticky-title persist for temp drafts — they save
+			// per-keystroke, so persisting here would freeze the
+			// title at the first incomplete name (`query G {` locks
+			// at "G"). IDELayout already renders the live derivation
+			// for unsaved drafts.
+			const isTempDraft = String(activeDocument.id).startsWith('temp-');
+			if (
+				field === 'query' &&
+				!isTempDraft &&
+				isAutoTitle(activeDocument.title)
+			) {
 				const stable = deriveStableDocTitle(value);
 				if (stable) {
 					payload.title = stable;
 				}
 			}
-			if (String(activeDocument.id).startsWith('temp-')) {
+			if (isTempDraft) {
 				saveDocument(activeDocument.id, payload);
 				return;
 			}

--- a/plugins/wp-graphql-ide/tests/unit/specs/hooks/useAutoSave.test.js
+++ b/plugins/wp-graphql-ide/tests/unit/specs/hooks/useAutoSave.test.js
@@ -1,0 +1,55 @@
+import { renderHook, act } from '@testing-library/react';
+import { useAutoSave } from '../../../../src/hooks/useAutoSave';
+
+// Regression guard: tab title used to lock at the first character of
+// the operation name. See the sticky-title comment in useAutoSave.js.
+describe('useAutoSave — title persistence on query change', () => {
+	const baseProps = {
+		setQuery: jest.fn(),
+		setVariables: jest.fn(),
+		setHeaders: jest.fn(),
+		setDocSettingsValues: jest.fn(),
+	};
+
+	it('does not persist a derived title for temp drafts', () => {
+		const saveDocument = jest.fn();
+		const { result } = renderHook(() =>
+			useAutoSave({
+				...baseProps,
+				activeDocument: { id: 'temp-1', title: 'Untitled', query: '' },
+				saveDocument,
+			})
+		);
+
+		act(() => result.current.scheduleAutoSave('query', 'query G {'));
+
+		expect(saveDocument).toHaveBeenCalledTimes(1);
+		const payload = saveDocument.mock.calls[0][1];
+		expect(payload.query).toBe('query G {');
+		expect(payload).not.toHaveProperty('title');
+	});
+
+	it('persists the derived title on the debounced save for saved docs', () => {
+		jest.useFakeTimers();
+		const saveDocument = jest.fn();
+		const { result } = renderHook(() =>
+			useAutoSave({
+				...baseProps,
+				activeDocument: { id: 42, title: 'Untitled', query: '' },
+				saveDocument,
+			})
+		);
+
+		act(() =>
+			result.current.scheduleAutoSave(
+				'query',
+				'query GetPosts { posts { id } }'
+			)
+		);
+		act(() => jest.runAllTimers());
+		jest.useRealTimers();
+
+		expect(saveDocument).toHaveBeenCalledTimes(1);
+		expect(saveDocument.mock.calls[0][1].title).toBe('GetPosts');
+	});
+});


### PR DESCRIPTION
## Summary

Typing `query G { … }` in a fresh tab and then continuing to `query GetPosts { … }` left the tab title stuck at `G`. Same shape for `mutation` / `subscription` drafts.

<img width="289" height="279" alt="image" src="https://github.com/user-attachments/assets/d8b6a51a-4be1-46b0-a672-b447fa40bddb" />

For `temp-` drafts, `useAutoSave.scheduleAutoSave` fires `saveDocument` immediately on every keystroke (bypassing the 2s debounce that exists for saved docs). The sticky-title branch ran `deriveStableDocTitle` on every keystroke, and the regex `\b(query|mutation|subscription)\s+(NAME)\s*[({]` matched the moment the body opener was typed — `query G {` returned `"G"`. That `"G"` was persisted to `doc.title` instantly; from then on `isAutoTitle('G')` was false, so subsequent keystrokes never re-derived the title.

Skip the sticky-title persist entirely for temp drafts. The active tab title already paints the live derivation in `IDELayout` (`isAutoTitle(doc.title) ? deriveDocTitle(query) : displayDocTitle(doc)`), so dropping the persist for drafts keeps the tab title in sync with what the user is actually typing — no UI plumbing change needed.

Once the draft graduates to a saved doc via `SaveDialog`, the title comes from the user's dialog input rather than auto-derivation, and from then on the slug-freezes-after-publish semantics the sticky-title branch was designed for kick in naturally. Saved-doc behavior is preserved: the sticky-title branch still runs for non-temp docs whose stored title is the auto sentinel.

## Test plan

- [x] `npm run -w @wpgraphql/wp-graphql-ide test:unit -- tests/unit/specs/hooks/useAutoSave.test.js` — two assertions (temp drafts omit `title` from the immediate save; saved docs persist the derived title on the debounced save).
- [x] Full suite: 420 / 420 unit tests pass; `lint:js` clean.
- [x] Manual repro in the IDE: type `query G {` then continue to `query GetPosts { pages { nodes { id } } }`; tab title tracks each keystroke and ends on `GetPosts`. Save via SaveDialog; subsequent query edits leave the saved title alone.