### PR TITLE
fix(ide): derive saved-document name from operation and fix frozen tab title

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,9 @@ Tests and PHP linting run inside the wp-env Docker containers and are invoked pe
 
 ## Development Workflow
 
-- **TDD preferred**: For bug fixes, write failing tests first, confirm they fail, implement the fix, confirm they pass.
+- **Every bug fix ships with a regression test.** A fix is not done until a test that fails before the fix and passes after it is committed alongside the change. No fix-only commits for reproducible bugs.
+- **Test the widest user-facing surface first.** Prefer the test that exercises the software the way a user does — e2e (Playwright) and integration/functional/acceptance (Codeception) — over a narrow unit test. Reach for the broadest layer that can reproduce the bug; reproduce it there first. Unit tests are valuable and we want them, but the core priority is proving the software works as a whole, not that one function does. When a unit test is faster or more precise for the specific logic, add it _in addition to_ — not _instead of_ — the surface-level test.
+- **TDD preferred**: For bug fixes, write the failing test(s) first, confirm they fail, implement the fix, confirm they pass.
 - **Conventional Commits**: PR titles must follow the format (`feat:`, `fix:`, `perf:`, `docs:`, `chore:`, etc.). PRs are squash-merged, so the title becomes the commit message. The `!` suffix (e.g., `feat!:`) signals a breaking change.
 - **CI matrix**: Tests run across WordPress 6.1–trunk, PHP 7.4–8.4, block and classic themes, single and multisite.
 

--- a/plugins/wp-graphql-ide/src/components/IDELayout.jsx
+++ b/plugins/wp-graphql-ide/src/components/IDELayout.jsx
@@ -1211,7 +1211,15 @@ export function IDELayout({ fetcher, onClose }) {
 					defaultTitle={
 						saveDialogMode === 'rename'
 							? activeDocument.title || ''
-							: ''
+							: // Prefill the first-save name from the operation,
+								// matching the tab title. deriveDocTitle returns
+								// the 'Untitled' sentinel for empty/unparseable
+								// queries — leave the field blank then so the
+								// placeholder shows instead of "Untitled".
+								(() => {
+									const derived = deriveDocTitle(query);
+									return isAutoTitle(derived) ? '' : derived;
+								})()
 					}
 					defaultCollectionIds={
 						saveDialogMode === 'rename' &&

--- a/plugins/wp-graphql-ide/src/hooks/useAutoSave.js
+++ b/plugins/wp-graphql-ide/src/hooks/useAutoSave.js
@@ -58,15 +58,26 @@ export function useAutoSave({
 				return;
 			}
 			const payload = { [field]: value };
+			// Temp drafts are local-only and fire synchronously on every
+			// keystroke — there's no debounce to let the op name settle.
+			// Persisting a derived title here froze it on the first character
+			// whenever a body brace already followed the name (an autoclosed
+			// `{}`, or the body typed before the name), which is how tabs
+			// ended up titled "G" instead of "GetPosts". Skip it: while the
+			// title is auto the tab derives live from the query (see
+			// displayDocTitle), and the first explicit save sets a real one.
+			if (String(activeDocument.id).startsWith('temp-')) {
+				saveDocument(activeDocument.id, payload);
+				return;
+			}
+			// Real docs save on a 2s debounce, so by the time this fires the
+			// op name has settled — freeze the derived name so an auto-titled
+			// doc round-trips as e.g. "GetPosts" rather than "Untitled".
 			if (field === 'query' && isAutoTitle(activeDocument.title)) {
 				const stable = deriveStableDocTitle(value);
 				if (stable) {
 					payload.title = stable;
 				}
-			}
-			if (String(activeDocument.id).startsWith('temp-')) {
-				saveDocument(activeDocument.id, payload);
-				return;
 			}
 			debouncedSave(activeDocument.id, payload);
 		},

--- a/plugins/wp-graphql-ide/tests/e2e/specs/save-flow.spec.js
+++ b/plugins/wp-graphql-ide/tests/e2e/specs/save-flow.spec.js
@@ -31,6 +31,22 @@ test.describe('Save flow', () => {
 		await expect(page.getByLabel('Document name')).toBeVisible();
 	});
 
+	test('SaveDialog prefills the Document name from the operation', async ({
+		page,
+	}) => {
+		// First-save should seed the name field from the operation name,
+		// matching the tab title — not open blank.
+		await page.click(selectors.addTab);
+		await typeQuery(page, 'query GetPosts { posts { nodes { id } } }');
+		await page.getByRole('button', { name: 'Save draft' }).click();
+
+		const dialog = page.locator('.wpgraphql-ide-save-dialog');
+		await expect(dialog).toBeVisible({ timeout: 5000 });
+		await expect(dialog.getByLabel('Document name')).toHaveValue(
+			'GetPosts'
+		);
+	});
+
 	test('SaveDialog closes on Escape without saving', async ({ page }) => {
 		await page.click(selectors.addTab);
 		await typeQuery(page, '{ posts { nodes { id } } }');

--- a/plugins/wp-graphql-ide/tests/e2e/specs/tabs.spec.js
+++ b/plugins/wp-graphql-ide/tests/e2e/specs/tabs.spec.js
@@ -50,6 +50,28 @@ test.describe('Tab management', () => {
 		await expect(page.locator(`${selectors.tab}.is-active`)).toHaveCount(1);
 	});
 
+	test('tab title tracks the full operation name when a body brace precedes the name', async ({
+		page,
+	}) => {
+		// Regression: the tab froze to the first character of the op name
+		// (e.g. "G" instead of "GetPosts") whenever a body brace already
+		// followed the name being typed. Reproduce that exact condition by
+		// putting the `{` in place first, then typing the name in front of
+		// it one character at a time.
+		await page.click(selectors.addTab);
+		// Seed `query ` then drop the body opener; one ArrowLeft lands the
+		// caret before the `{` (works whether or not autoclose adds a `}`).
+		await typeQuery(page, 'query ');
+		await page.keyboard.type('{');
+		await page.keyboard.press('ArrowLeft');
+		await page.keyboard.type('GetPosts');
+
+		const activeTitle = page
+			.locator(`${selectors.tab}.is-active .wpgraphql-ide-tab-text`)
+			.first();
+		await expect(activeTitle).toHaveText('GetPosts', { timeout: 5000 });
+	});
+
 	test('open tabs persist across a full page reload', async ({ page }) => {
 		const stamp = Date.now();
 		const body = `{ posts(where: {search: "persist-${stamp}"}) { nodes { id } } }`;

--- a/plugins/wp-graphql-ide/tests/unit/specs/hooks/useAutoSave.test.js
+++ b/plugins/wp-graphql-ide/tests/unit/specs/hooks/useAutoSave.test.js
@@ -1,0 +1,53 @@
+import { renderHook, act } from '@testing-library/react';
+import { useAutoSave } from '../../../../src/hooks/useAutoSave';
+
+// Regression coverage for the tab-title freeze: a temp draft must never
+// persist a derived title mid-type. The tab derives live from the query
+// while the title is auto, so persisting "G" (captured when a body brace
+// already follows the partially-typed op name) froze the tab at the first
+// character instead of tracking through to "GetPosts".
+describe('useAutoSave — temp draft title', () => {
+	const setup = (activeDocument) => {
+		const saveDocument = jest.fn();
+		const noop = jest.fn();
+		const { result } = renderHook(() =>
+			useAutoSave({
+				activeDocument,
+				saveDocument,
+				setQuery: noop,
+				setVariables: noop,
+				setHeaders: noop,
+				setDocSettingsValues: noop,
+			})
+		);
+		return { saveDocument, result };
+	};
+
+	it('does not freeze a title while typing the op name (body brace present)', () => {
+		// The pre-existing `{` is what made deriveStableDocTitle match "G".
+		const { saveDocument, result } = setup({
+			id: 'temp-1',
+			title: '',
+		});
+
+		act(() => result.current.scheduleAutoSave('query', 'query G{}'));
+
+		expect(saveDocument).toHaveBeenCalledTimes(1);
+		const payload = saveDocument.mock.calls[0][1];
+		expect(payload).toEqual({ query: 'query G{}' });
+		expect(payload.title).toBeUndefined();
+	});
+
+	it('still persists the full query for a temp draft synchronously', () => {
+		const { saveDocument, result } = setup({
+			id: 'temp-1',
+			title: '',
+		});
+
+		const query = 'query GetPosts { posts { nodes { id } } }';
+		act(() => result.current.scheduleAutoSave('query', query));
+
+		expect(saveDocument).toHaveBeenCalledWith('temp-1', { query });
+		expect(saveDocument.mock.calls[0][1].title).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## What & why

Two related fixes to how the IDE derives titles from the GraphQL operation when the Smart Cache saved-documents feature is available.

### 1. Save dialog prefills the Document Name from the operation
Clicking **Save draft** on a new draft opened the modal with an empty **Document name** field. It now prefills from the operation name — the same value the tab shows — so saving `query GetPosts { … }` opens the modal pre-filled with **GetPosts**. Anonymous queries (`{ posts { … } }`) prefill the first field (`posts`), matching the tab. Empty/unparseable queries leave the field blank so the `e.g. Recent Posts by Author` placeholder still shows. The name remains editable before saving.

### 2. Fix the frozen tab title ("G" instead of "GetPosts")
A temp draft could freeze its tab title to the **first character** of the operation name whenever a body brace already followed the name being typed — an autoclosed `{}`, or the body typed before the name. The active tab derives its title live from the query only while the stored title is still auto; the autosave hook persisted a derived title synchronously on every keystroke for temp drafts, and `deriveStableDocTitle` matched on the first character (`query G{` → `"G"`), flipping the title out of the auto state and stranding the tab at "G".

Temp drafts no longer persist a derived title — they're local-only, the tab already derives live from the query while the title is auto, and the first explicit save sets a real title. The settle-on-debounce title freeze is preserved for real (non-temp) documents, where the 2s debounce guarantees the op name has settled.

## Scope note
This fixes new drafts going forward. A draft whose title was *already* frozen to a single character in a prior session keeps that persisted title until renamed.

## Tests
- **Unit** (`useAutoSave.test.js`): a temp draft does not persist a derived title mid-type (the `query G{}` regression).
- **e2e** (`tabs.spec.js`): the tab title tracks the full op name when a body brace precedes the name — reproduces the exact freeze condition.
- **e2e** (`save-flow.spec.js`): the SaveDialog prefills the Document name from the operation.

All 420 unit tests pass; both new e2e specs pass locally against wp-env (Smart Cache + IDE active).