### PR TITLE
docs: route breaking changes to the `next` branch

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -65,6 +65,10 @@ The following are handled automatically by our CI/CD workflows. **Please do not 
 | Changelog entries | `CHANGELOG.md` | release-please |
 | **Upgrade Notice** | `readme.txt` | `update-release-pr.yml` workflow |
 
+### Breaking changes target the `next` branch
+
+`main` is the current stable (2.x) release line. Breaking changes (`feat!:` / `fix!:` / `perf!:`) for the next major (e.g. 3.0) are collected on the long-lived **`next`** branch — which cuts release candidates — **not `main`**, where they would force the next release to be a major. Open breaking-change PRs against `next`. See the [full Contributing guide](../docs/CONTRIBUTING.md#1-pr-titles-and-conventional-commits).
+
 ### Breaking Changes & Upgrade Notices
 
 When a release contains breaking changes (commits with `feat!:`, `fix!:`, or `perf!:` prefix):

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -42,6 +42,8 @@ Thank you for your interest in contributing to WPGraphQL! This guide covers how 
 
 **Breaking Change Marker (`!`)**: The `!` suffix can only be used with `feat`, `fix`, or `perf` prefixes. Using `!` with other prefixes (like `chore!:` or `ci!:`) will fail CI validation since those types don't trigger releases.
 
+> **⚠️ Breaking changes target the `next` branch, not `main`.** `main` is the current stable (2.x) release line — a breaking change merged there would force its next release to be a major. Breaking changes for the next major (e.g. 3.0) are collected on the long-lived **`next`** branch, which cuts release candidates. Open `feat!:` / `fix!:` / `perf!:` PRs against `next`.
+
 **Examples:**
 - `feat: add support for custom post type archives`
 - `fix: resolve N+1 query issue in connections`


### PR DESCRIPTION
Adds a pointer to both CONTRIBUTING guides so breaking-change PRs (`feat!:` / `fix!:` / `perf!:`) are opened against the new long-lived **`next`** branch rather than `main`.

`main` is the current stable (2.x) release line — a breaking change merged there would force its next release to be a major. The next major (3.0) is integrated on `next`, which cuts release candidates (see the [`next` scaffold](https://github.com/wp-graphql/wp-graphql/tree/next) and `.github/workflows/README.md`).

Docs-only; no release impact.