### PR TITLE
docs: backfill 2.15.1 security entry in changelog and readme

### DIFF
--- a/plugins/wp-graphql/CHANGELOG.md
+++ b/plugins/wp-graphql/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## [2.15.1](https://github.com/wp-graphql/wp-graphql/compare/wp-graphql/v2.15.0...wp-graphql/v2.15.1) (2026-06-09)
 
 
+### Security
+
+* prevent user enumeration via the deprecated `SendPasswordResetEmailPayload.user` field. The field could reveal whether a username/email belonged to a registered account (and expose author-class user data) to unauthenticated requests; it is now gated on the `list_users` capability. See [GHSA-jhh7-832h-f8hv](https://github.com/wp-graphql/wp-graphql/security/advisories/GHSA-jhh7-832h-f8hv)
+
+
 ### Bug Fixes
 
 * **ci:** deploy WordPress.org assets via ASSETS_DIR + dedicated asset-update workflow ([#3880](https://github.com/wp-graphql/wp-graphql/issues/3880)) ([5f301b1](https://github.com/wp-graphql/wp-graphql/commit/5f301b16bf9e3c36d145d33ba568876f27884e17))

--- a/plugins/wp-graphql/readme.txt
+++ b/plugins/wp-graphql/readme.txt
@@ -78,6 +78,10 @@ Learn more about how [Appsero collects and uses this data](https://appsero.com/p
 
 == Upgrade Notice ==
 
+= 2.15.1 =
+
+**Security release.** Fixes a user-enumeration issue in the `sendPasswordResetEmail` mutation via the deprecated `user` payload field. Updating is recommended. See GHSA-jhh7-832h-f8hv.
+
 = 2.6.0 =
 
 **New Features**
@@ -307,6 +311,10 @@ Composer dependencies are no longer versioned in Github. Recommended install sou
 == Changelog ==
 
 = 2.15.1 =
+
+**Security**
+
+* prevent user enumeration via the deprecated `SendPasswordResetEmailPayload.user` field; it is now gated on the `list_users` capability. See [GHSA-jhh7-832h-f8hv](https://github.com/wp-graphql/wp-graphql/security/advisories/GHSA-jhh7-832h-f8hv)
 
 **Bug Fixes**
 


### PR DESCRIPTION
Backfills documentation for the **2.15.1** security fix (GHSA-jhh7-832h-f8hv).

## Why

The fix was merged via the advisory's temporary private fork, which GitHub squashes with a generic **"Merge commit from fork"** message (intentional, to avoid pre-disclosure). Because that isn't a conventional commit, release-please couldn't generate a changelog entry — so the released 2.15.1 changelog only listed the unrelated `ci:` change. The fix **code** shipped correctly in 2.15.1; this just backfills the human-readable record.

## Changes

- **`CHANGELOG.md`** — adds a `### Security` entry to the (already-released) 2.15.1 section.
- **`readme.txt`** — adds a matching `**Security**` changelog entry and a **2.15.1 Upgrade Notice** so WordPress.org prompts users to update.

The v2.15.1 GitHub Release notes were already updated with the same Security section.

## Notes

- **Docs-only** (`docs:`) — does not trigger a release, and release-please leaves already-released sections untouched, so the manual entries persist.
- Editing past-release sections is a deliberate exception to the "don't hand-edit changelogs" rule, necessary because the GHSA squash-merge bypasses release-please's changelog generation.