### PR TITLE
ci: run tests, lint, and checks on PRs targeting `next`

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,9 +13,9 @@ name: 'CodeQL'
 
 on:
   push:
-    branches: [main]
+    branches: [main, next]
   pull_request:
-    branches: [main]
+    branches: [main, next]
   schedule:
     - cron: '15 21 * * 1'
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -5,11 +5,13 @@ on:
     branches:
       - main
       - release/*
+      - next
   pull_request:
     types: [opened, synchronize, reopened]
     branches:
       - main
       - release/*
+      - next
   workflow_dispatch:
 
 # Cancel previous workflow run groups that have not completed.

--- a/.github/workflows/js-e2e-tests.yml
+++ b/.github/workflows/js-e2e-tests.yml
@@ -5,11 +5,13 @@ on:
     branches:
       - main
       - release/*
+      - next
   pull_request:
     types: [opened, synchronize, reopened]
     branches:
       - main
       - release/*
+      - next
   workflow_dispatch:
 
 # Cancel previous workflow run groups that have not completed.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,11 +5,13 @@ on:
     branches:
       - main
       - release/*
+      - next
   pull_request:
     types: [opened, synchronize, reopened]
     branches:
       - main
       - release/*
+      - next
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:

--- a/.github/workflows/schema-linter.yml
+++ b/.github/workflows/schema-linter.yml
@@ -5,11 +5,13 @@ on:
     branches:
       - main
       - release/*
+      - next
   pull_request:
     types: [opened, synchronize, reopened]
     branches:
       - main
       - release/*
+      - next
 
 # Cancel previous workflow run groups that have not completed.
 concurrency:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -31,11 +31,13 @@ on:
     branches:
       - main
       - release/*
+      - next
   pull_request:
     types: [opened, synchronize, reopened]
     branches:
       - main
       - release/*
+      - next
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}

--- a/.github/workflows/update-release-pr.yml
+++ b/.github/workflows/update-release-pr.yml
@@ -22,6 +22,7 @@ on:
     types: [opened, synchronize]
     branches:
       - main
+      - next
 
 permissions:
   contents: write

--- a/.github/workflows/website-e2e-tests.yml
+++ b/.github/workflows/website-e2e-tests.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - release/*
+      - next
     paths:
       - 'websites/wpgraphql.com/**'
       - '.github/workflows/website-e2e-tests.yml'
@@ -14,6 +15,7 @@ on:
     branches:
       - main
       - release/*
+      - next
     paths:
       - 'websites/wpgraphql.com/**'
       - '.github/workflows/website-e2e-tests.yml'


### PR DESCRIPTION
Makes the CI suite run on PRs into **`next`** (the 3.0 integration line). Currently those workflows only trigger on `main` / `release/*`, so PRs like #3899 skip tests, linting, schema checks, smoke tests, and e2e.

## Changes
Adds `next` to the `push` and `pull_request` branch filters for:
- `integration-tests`, `js-e2e-tests`, `lint`, `schema-linter`, `smoke-test`, `website-e2e-tests`
- `codeql-analysis` (security analysis)
- `update-release-pr` (so `x-release-please-version` placeholders and upgrade notices are also processed on the `next` release line)

Unchanged (already run on all PRs): PR-title validation, GitGuardian, and the path-filtered workflows (`playground-preview`, `test-scripts`).

## Why this targets `next`
GitHub evaluates `pull_request` triggers from the **base branch**, so the updated filters have to exist on `next` for PRs-into-next to pick them up.

## Note
Because of that same base-branch rule, **this PR won't run the new checks on itself** — the trigger changes only take effect once merged to `next`. After merge, existing open PRs into `next` (e.g. #3899) need a sync/rebase (or a new push) to pick up the full suite.