### PR TITLE
ci: make the `next` line emit RC versions and never deploy stable

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -320,11 +320,14 @@ jobs:
             echo "Deploying new release: ${COMPONENT} v${VERSION} (tag: ${TAG})"
           fi
 
-          # Detect a prerelease by the SemVer prerelease identifier (e.g. 3.0.0-rc.0).
-          # Prereleases are deployed to a WordPress.org SVN tag ONLY and never touch
-          # trunk or the Stable tag, so the auto-update audience stays on the current
-          # stable release while opt-in testers can install the tagged RC.
-          if [[ "$VERSION" == *"-"* ]]; then
+          # Treat anything that isn't a release from `main` as a prerelease. Stable
+          # WordPress.org deploys (trunk + Stable tag) come ONLY from `main`; every other
+          # branch (notably `next`) deploys to an SVN tag only and never moves the Stable
+          # tag. We also treat any SemVer-prerelease version (e.g. 3.0.0-rc.0) as a
+          # prerelease. Keying on the branch — not just the version string — is the safety
+          # net: even if release-please ever emits a non-`-rc` version on a non-main branch,
+          # it can never publish to the stable channel.
+          if [[ "$GITHUB_REF_NAME" != "main" || "$VERSION" == *"-"* ]]; then
             echo "is_prerelease=true" >> $GITHUB_OUTPUT
           else
             echo "is_prerelease=false" >> $GITHUB_OUTPUT

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -15,6 +15,7 @@
 			"draft": false,
 			"prerelease": true,
 			"prerelease-type": "rc",
+			"versioning": "prerelease",
 			"changelog-path": "CHANGELOG.md",
 			"changelog-sections": [
 				{ "type": "feat", "section": "New Features", "hidden": false },


### PR DESCRIPTION
Hardening for the `next` prerelease release line (follow-up to the `next` scaffold).

## Problem
On `next`, release-please proposed plain versions like `2.15.1`/`5.0.0` with **no `-rc` suffix** (see #3898, #3901). `prerelease: true` alone only flags the GitHub release as a prerelease — it doesn't change the version string. A non-`-rc` version is dangerous because the deploy guard keyed "is this a prerelease?" off the `-` in the version, so a plain version on `next` would have taken the **stable** WordPress.org deploy path (trunk + Stable tag) using `next`'s code.

## Fix
1. **`release-please-config.json`** — add `"versioning": "prerelease"` to the `wp-graphql` package so it emits `-rc.N` versions (e.g. `3.0.0-rc.0`).
2. **`release-please.yml`** — harden the deploy guard to `is_prerelease = (branch != main) || (version contains "-")`. Stable `.org` deploys now come **only from `main`**; `next` always uses the tag-only SVN import. Keying on the branch is the safety net — `next` can never publish to the stable channel regardless of the version string.

## Validation
The exact `-rc` format should be confirmed on the first real `next` release (after a breaking change merges). Even if release-please's version output isn't perfect, the branch-based guard guarantees no stable deploy from `next`.