### PR TITLE
ci: allow intended breaking schema changes on the `next` line

### DIFF
--- a/.github/workflows/schema-linter-reusable.yml
+++ b/.github/workflows/schema-linter-reusable.yml
@@ -252,6 +252,10 @@ jobs:
 
       - name: Run Schema Inspector
         if: steps.get-latest-tag.outputs.tag_found == 'true' && steps.get-previous-schema.outputs.schema_available == 'true'
+        # Breaking schema changes are intentional on the `next` (3.0) integration line, so the
+        # inspector runs and reports them but does not fail the build there. On `main` and
+        # `release/*` it stays blocking — an accidental breaking change should fail CI.
+        continue-on-error: ${{ github.base_ref == 'next' || github.ref_name == 'next' }}
         run: |
           # This schema and previous release schema
           node_modules/.bin/graphql-inspector diff /tmp/${{ steps.get-previous-schema.outputs.safe_tag }}.graphql /tmp/schema-${{ inputs.component }}.graphql


### PR DESCRIPTION
## Problem
The schema-linter's `graphql-inspector diff` step hard-fails on breaking schema changes vs the last release. On `next` (the 3.0 integration line) breaking changes are intentional, so this **blocks every 3.0 PR** — e.g. #3899 removing `SendPasswordResetEmailPayload.user` fails with:

```
✖ Field user (deprecated) was removed from object type SendPasswordResetEmailPayload
[error] Detected N breaking changes → exit code 1
```

(The *structural* linter passes — `✔ 0 errors detected`; only the breaking-change diff fails.)

## Fix
Add `continue-on-error: ${{ github.base_ref == 'next' || github.ref_name == 'next' }}` to the inspector step. It still **runs and reports** the breaking changes (useful for documenting them in 3.0 PRs), but doesn't fail the build when targeting `next`. `main` and `release/*` keep the blocking guardrail, so accidental breaking changes there still fail CI.

## Note
This is the schema-linter analogue of the other `next`-line accommodations (release-please prerelease config, CI triggers). Needed before #3899 (and any deprecation-removal PR) can go green on `next`.