### PR TITLE
ci: configure acf, ide, and smart-cache for prereleases on `next`

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -97,7 +97,9 @@
 			"bump-minor-pre-major": false,
 			"bump-patch-for-minor-pre-major": false,
 			"draft": false,
-			"prerelease": false,
+			"prerelease": true,
+			"prerelease-type": "rc",
+			"versioning": "prerelease",
 			"changelog-path": "CHANGELOG.md",
 			"changelog-sections": [
 				{ "type": "feat", "section": "New Features", "hidden": false },
@@ -164,7 +166,9 @@
 			"bump-minor-pre-major": false,
 			"bump-patch-for-minor-pre-major": false,
 			"draft": false,
-			"prerelease": false,
+			"prerelease": true,
+			"prerelease-type": "rc",
+			"versioning": "prerelease",
 			"changelog-path": "CHANGELOG.md",
 			"changelog-sections": [
 				{ "type": "feat", "section": "New Features", "hidden": false },
@@ -226,7 +230,9 @@
 			"bump-minor-pre-major": false,
 			"bump-patch-for-minor-pre-major": false,
 			"draft": false,
-			"prerelease": false,
+			"prerelease": true,
+			"prerelease-type": "rc",
+			"versioning": "prerelease",
 			"changelog-path": "CHANGELOG.md",
 			"changelog-sections": [
 				{ "type": "feat", "section": "New Features", "hidden": false },


### PR DESCRIPTION
Extends the prerelease config from `wp-graphql` to **all four plugins** on `next`, so the whole branch is one consistent prerelease line. Per the decision to use `next` as the integration branch for *every* plugin's next major.

## Change
Adds to `wp-graphql-smart-cache`, `wp-graphql-ide`, and `wp-graphql-acf` (matching `wp-graphql`):
```json
"prerelease": true,
"prerelease-type": "rc",
"versioning": "prerelease",
```

## Why
With only `wp-graphql` configured, the inherited "shadow" release PRs on `next` (which mirror `main`'s in-flight releases until `next` has its own breaking changes for that plugin) proposed **bare** versions like `wp-graphql-acf 2.6.3` (#3912) / `wp-graphql-ide 5.0.0` (#3910). Bare versions (a) collide with `main`'s release tags if a shadow is accidentally merged, and (b) look like real releases. Now they show as `2.6.3-rc.0` etc. — clearly prerelease, collision-proof, and safe even if merged by mistake (the branch guard already prevents stable `.org` deploys from `next`).

## Operating model (unchanged)
Shadow PRs are expected while `main` has unreleased work for a plugin; don't merge them. They auto-close after `main` releases that version **and** `main` → `next` is synced (which advances `next`'s manifest).

## Merge-back note
At each plugin's GA, revert that package's `prerelease` to `false` on the merge into `main` (same checklist item as wp-graphql).