### PR TITLE
feat!: start the 3.0 prerelease line (remove SendPasswordResetEmailPayload.user)

### DIFF
--- a/plugins/wp-graphql/docs/upgrading.md
+++ b/plugins/wp-graphql/docs/upgrading.md
@@ -94,6 +94,12 @@ WPGraphQL may deprecate certain functionality before fully removing or changing 
 
 Deprecations will be clearly communicated in release notes and upgrade guides, providing users with sufficient time to adapt their projects before the feature is fully removed or changed.
 
+### Removed in 3.0
+
+The next major release (**3.0**) removes long-deprecated code. Removals are tracked in the [v3.0 master tracking issue](https://github.com/wp-graphql/wp-graphql/issues/3902), and release candidates are published on the `next` branch ahead of the stable release. Notable removals so far:
+
+- **`SendPasswordResetEmailPayload.user`** — the deprecated `user` field has been removed. Select `success` instead; the `sendPasswordResetEmail` mutation intentionally exposes only `success` so it cannot be used for user enumeration.
+
 ## Support Policy
 
 WPGraphQL will support only the latest `minor.patch` version of the **last 2 major versions**. This means that older versions within a major release (e.g., `1.1.x` if `1.2.x` exists) and versions beyond this window will no longer receive official support, and users will be encouraged to upgrade to the latest version.


### PR DESCRIPTION
Corrective PR to start the `next` release line at **3.0.0-rc.0**.

## Why this is needed
#3899 removed the deprecated `SendPasswordResetEmailPayload.user` field, but it merged as a **merge commit** rather than a squash. This repo's release-please credits the conventional commit from the **squash** title, so the `feat!:` was never seen → the `next` release PR (#3898) stayed at `2.16.0-rc` and its changelog omitted the removal.

## What this does
1. **`Release-As: 3.0.0-rc.0`** footer → explicitly pins the next `next`-line release to `3.0.0-rc.0`, regardless of how `versioning: "prerelease"` would otherwise compute it.
2. **`BREAKING CHANGE:` footer** → release-please credits the `user`-field removal in the 3.0.0-rc.0 changelog.
3. Adds a **"Removed in 3.0"** section to the upgrade guide (links the v3.0 tracking issue #3902).

## ⚠️ Merge instructions
- **Squash and merge** (not a merge commit — that's the mistake that caused this).
- When merging, **keep the `BREAKING CHANGE:` and `Release-As: 3.0.0-rc.0` lines in the squash commit body** (GitHub pre-fills them from the branch commit). If they're stripped, the version won't be forced.

## After merge
- #3898 should re-title to **`chore(next): release wp-graphql 3.0.0-rc.0`**.
- This also tells us whether `versioning: "prerelease"` escalates a `feat!` to a major on its own — if the *next* squash-merged breaking PR doesn't reach `3.0.0`, we'll know the strategy needs adjusting (and can keep using `Release-As`).
- **Squash-merge all future 3.0 breaking-change PRs.**