### PR TITLE
fix(release): release script no longer crashes mid-run updating readme.txt

### DIFF
--- a/plugins/wp-graphql-ide/readme.txt
+++ b/plugins/wp-graphql-ide/readme.txt
@@ -3,7 +3,7 @@ Contributors: jasonbahl, joefusco
 Tags: headless, decoupled, graphql, devtools
 Requires at least: 6.1
 Tested up to: 7.0
-Stable tag: 4.5.0
+Stable tag: 5.0.0
 Requires PHP: 7.4
 License: GPL-3.0
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/plugins/wp-graphql-ide/wpgraphql-ide.php
+++ b/plugins/wp-graphql-ide/wpgraphql-ide.php
@@ -9,7 +9,7 @@
  * License URI:       https://www.gnu.org/licenses/gpl-3.0.html
  * Text Domain:       wpgraphql-ide
  * Domain Path:       /languages
- * Version:           4.5.0
+ * Version:           5.0.0
  * Requires at least: 6.1
  * Tested up to:      7.0
  * Requires PHP:      7.4
@@ -28,7 +28,7 @@ if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 	require_once __DIR__ . '/vendor/autoload.php';
 }
 
-define( 'WPGRAPHQL_IDE_VERSION', '4.5.0' );
+define( 'WPGRAPHQL_IDE_VERSION', '5.0.0' );
 define( 'WPGRAPHQL_IDE_ROOT_ELEMENT_ID', 'wpgraphql-ide-root' );
 define( 'WPGRAPHQL_IDE_PLUGIN_DIR_PATH', plugin_dir_path( __FILE__ ) );
 define( 'WPGRAPHQL_IDE_PLUGIN_URL', plugin_dir_url( __FILE__ ) );

--- a/scripts/update-upgrade-notice.js
+++ b/scripts/update-upgrade-notice.js
@@ -158,9 +158,14 @@ function updateUpgradeNotice(readmePath, version, breakingChanges) {
 		const hasVersionNotice = versionNoticeRegex.test(upgradeNoticeMatch[2]);
 
 		if (hasVersionNotice) {
-			// Replace existing notice for this version
+			// Replace existing notice for this version.
+			// The trailing lookahead must also stop at the next `== ` major section
+			// heading (e.g. `== Changelog ==`); otherwise, when no later
+			// `= <digit>` heading exists in the Upgrade Notice block, the lazy
+			// match runs all the way to EOF and the replacement wipes the
+			// Changelog out of readme.txt.
 			const existingNoticeRegex = new RegExp(
-				`(= ${escapedVersion} =[\\s\\S]*?)(?=\\n= \\d|$)`
+				`(= ${escapedVersion} =[\\s\\S]*?)(?=\\n= \\d|\\n== |$)`
 			);
 			content = content.replace(existingNoticeRegex, upgradeNotice);
 			console.log(

--- a/scripts/update-upgrade-notice.js
+++ b/scripts/update-upgrade-notice.js
@@ -146,11 +146,9 @@ function updateUpgradeNotice(readmePath, version, breakingChanges) {
 
 	upgradeNotice += '\nPlease review these changes before upgrading.\n';
 
-	// Find the Upgrade Notice section. The outer regex bounds the body slice
-	// at the next `\n==` heading (or EOF) — that bound is the load-bearing
-	// invariant: every mutation below operates inside `sectionBody` and is
-	// spliced back, so no inner regex can ever escape the section and wipe
-	// a sibling section (the regression that stranded the IDE 5.0.0 release).
+	// Find the Upgrade Notice body. The outer regex bounds the slice at
+	// the next `\n==` heading (or EOF); inner mutations operate on
+	// `sectionBody` and are spliced back, so they cannot escape the section.
 	const upgradeNoticeMatch = content.match(
 		/(== Upgrade Notice ==\n\n?)([\s\S]*?)(?=\n==|$)/
 	);
@@ -160,19 +158,16 @@ function updateUpgradeNotice(readmePath, version, breakingChanges) {
 		const sectionPrefix = upgradeNoticeMatch[1];
 		let sectionBody = upgradeNoticeMatch[2];
 
-		// Anchor `= X.Y.Z =` to a line start so prose mentions
-		// (e.g. "Upgraded from = 5.0.0 = to ...") don't false-positive into
-		// the replace branch.
+		// Anchor `= X.Y.Z =` to a line start so prose mentions don't
+		// false-positive into the replace branch.
 		const versionNoticeRegex = new RegExp(
 			`(^|\\n)= ${escapedVersion} =`
 		);
 		const hasVersionNotice = versionNoticeRegex.test(sectionBody);
 
 		if (hasVersionNotice) {
-			// Replace within the body slice only. `$` here is end-of-slice
-			// (the outer regex already bounded the section), so the lazy
-			// match cannot consume past the section even if no sibling
-			// `= <digit>` heading exists.
+			// Replace within the body slice only. `$` is end-of-slice
+			// (the outer regex bounded the section).
 			const existingNoticeRegex = new RegExp(
 				`(^|\\n)= ${escapedVersion} =[\\s\\S]*?(?=\\n= \\d|$)`
 			);

--- a/scripts/update-upgrade-notice.js
+++ b/scripts/update-upgrade-notice.js
@@ -146,39 +146,61 @@ function updateUpgradeNotice(readmePath, version, breakingChanges) {
 
 	upgradeNotice += '\nPlease review these changes before upgrading.\n';
 
-	// Find the Upgrade Notice section
+	// Find the Upgrade Notice section. The outer regex bounds the body slice
+	// at the next `\n==` heading (or EOF) — that bound is the load-bearing
+	// invariant: every mutation below operates inside `sectionBody` and is
+	// spliced back, so no inner regex can ever escape the section and wipe
+	// a sibling section (the regression that stranded the IDE 5.0.0 release).
 	const upgradeNoticeMatch = content.match(
 		/(== Upgrade Notice ==\n\n?)([\s\S]*?)(?=\n==|$)/
 	);
 	const escapedVersion = escapeRegExp(version);
 
 	if (upgradeNoticeMatch) {
-		// Check if this version's notice already exists
-		const versionNoticeRegex = new RegExp(`= ${escapedVersion} =`);
-		const hasVersionNotice = versionNoticeRegex.test(upgradeNoticeMatch[2]);
+		const sectionPrefix = upgradeNoticeMatch[1];
+		let sectionBody = upgradeNoticeMatch[2];
+
+		// Anchor `= X.Y.Z =` to a line start so prose mentions
+		// (e.g. "Upgraded from = 5.0.0 = to ...") don't false-positive into
+		// the replace branch.
+		const versionNoticeRegex = new RegExp(
+			`(^|\\n)= ${escapedVersion} =`
+		);
+		const hasVersionNotice = versionNoticeRegex.test(sectionBody);
 
 		if (hasVersionNotice) {
-			// Replace existing notice for this version.
-			// The trailing lookahead must also stop at the next `== ` major section
-			// heading (e.g. `== Changelog ==`); otherwise, when no later
-			// `= <digit>` heading exists in the Upgrade Notice block, the lazy
-			// match runs all the way to EOF and the replacement wipes the
-			// Changelog out of readme.txt.
+			// Replace within the body slice only. `$` here is end-of-slice
+			// (the outer regex already bounded the section), so the lazy
+			// match cannot consume past the section even if no sibling
+			// `= <digit>` heading exists.
 			const existingNoticeRegex = new RegExp(
-				`(= ${escapedVersion} =[\\s\\S]*?)(?=\\n= \\d|\\n== |$)`
+				`(^|\\n)= ${escapedVersion} =[\\s\\S]*?(?=\\n= \\d|$)`
 			);
-			content = content.replace(existingNoticeRegex, upgradeNotice);
+			sectionBody = sectionBody.replace(
+				existingNoticeRegex,
+				(match) => {
+					const leadingNewline = match.startsWith('\n') ? '\n' : '';
+					return `${leadingNewline}${upgradeNotice}`;
+				}
+			);
 			console.log(
 				`Updated existing upgrade notice for version ${version}`
 			);
 		} else {
-			// Add new notice at the top of the section
-			content = content.replace(
-				/(== Upgrade Notice ==\n\n?)/,
-				`$1${upgradeNotice}\n`
-			);
+			// Prepend a fresh notice at the top of the body.
+			sectionBody = `${upgradeNotice}\n${sectionBody.replace(/^\n+/, '')}`;
 			console.log(`Added new upgrade notice for version ${version}`);
 		}
+
+		// Splice the modified body back, leaving everything before/after the
+		// section untouched.
+		const sectionStart = upgradeNoticeMatch.index;
+		const sectionEnd = sectionStart + upgradeNoticeMatch[0].length;
+		content =
+			content.slice(0, sectionStart) +
+			sectionPrefix +
+			sectionBody +
+			content.slice(sectionEnd);
 	} else {
 		// Add Upgrade Notice section before Changelog
 		const changelogMatch = content.match(/\n== Changelog ==/);

--- a/scripts/update-upgrade-notice.test.js
+++ b/scripts/update-upgrade-notice.test.js
@@ -264,6 +264,16 @@ Please review these changes before upgrading.
 				matches && matches.length === 1,
 				'Should have exactly one version header'
 			);
+			// Regression guard: the existing Changelog section must survive
+			// being adjacent to the upserted Upgrade Notice block.
+			assert(
+				readme.includes('== Changelog =='),
+				'Should preserve the existing Changelog section'
+			);
+			assert(
+				readme.includes('= 2.0.0 ='),
+				'Should preserve the existing 2.0.0 changelog entry'
+			);
 		}),
 
 	// Test 5: Alternative breaking changes header format
@@ -371,6 +381,75 @@ Stable tag: 2.0.0
 			);
 			assert(readme.includes('#100'), 'Should include correct PR link');
 			assert(!readme.includes('#200'), 'Should NOT include v4 PR link');
+		}),
+
+	// Test 8a: Regression — wp-graphql-ide 5.0.0 release PR shape (PR #3892).
+	// The release-please flow pre-populated `= 5.0.0 =` in the Upgrade Notice
+	// section with no later `= <digit>` heading after it, immediately followed
+	// by `== Changelog ==`. The buggy lazy match swallowed the Changelog header
+	// up to EOF and the downstream `update-readme-changelog.js` then threw.
+	() =>
+		test('preserves "== Changelog ==" when upserting an upgrade notice with no later = <digit> heading', () => {
+			createChangelog(`# Changelog
+
+## [5.0.0](https://github.com/wp-graphql/wp-graphql/compare/v4.5.0...v5.0.0) (2026-06-09)
+
+### ⚠ BREAKING CHANGES
+
+* Rebuild IDE UI on @wordpress/components ([#3784](https://github.com/wp-graphql/wp-graphql/pull/3784))
+`);
+
+			createReadme(`=== Test Plugin ===
+Stable tag: 4.5.0
+
+== Upgrade Notice ==
+
+= 5.0.0 =
+Hand-written upgrade-notice paragraph from the feature PR.
+
+WPGraphQL IDE follows Semver versioning. Breaking changes will be documented in the Upgrade Notice section above.
+
+== Changelog ==
+
+= 5.0.0 =
+
+**Breaking changes**
+
+* IDE UI rebuilt on @wordpress/components.
+
+= 4.5.0 =
+* Previous release.
+`);
+
+			const result = runScript('5.0.0');
+			assert(result.success, `Script should succeed. Output: ${result.output}`);
+
+			const readme = readReadme();
+			assert(
+				readme.includes('== Changelog =='),
+				'Must preserve the == Changelog == section heading'
+			);
+			assert(
+				readme.includes('= 4.5.0 ='),
+				'Must preserve earlier changelog entries'
+			);
+			// New upgrade-notice content for 5.0.0 should be present.
+			assert(
+				readme.includes('Rebuild IDE UI on @wordpress/components'),
+				'Should write the new breaking change into the upgrade notice'
+			);
+			// The pre-existing 5.0.0 Changelog body should still be there.
+			assert(
+				readme.includes('IDE UI rebuilt on @wordpress/components'),
+				'Must preserve the pre-existing 5.0.0 changelog body'
+			);
+			// `= 5.0.0 =` should appear exactly twice: once in Upgrade Notice,
+			// once in Changelog.
+			const fiveZero = readme.match(/= 5\.0\.0 =/g) || [];
+			assert(
+				fiveZero.length === 2,
+				`Expected exactly 2 occurrences of "= 5.0.0 =" (one per section), got ${fiveZero.length}`
+			);
 		}),
 
 	// Test 8: Scoped breaking changes (e.g., **resolver:**)

--- a/scripts/update-upgrade-notice.test.js
+++ b/scripts/update-upgrade-notice.test.js
@@ -452,6 +452,127 @@ WPGraphQL IDE follows Semver versioning. Breaking changes will be documented in 
 			);
 		}),
 
+	// Test 8b: Regression for boundary asymmetry — wp.org's readme parser
+	// accepts `==Section==` without spaces. The fix's outer regex already
+	// bounds the body slice at `\n==` (no space required), so even with the
+	// non-canonical heading the upserted upgrade notice cannot escape into
+	// the next section.
+	() =>
+		test('preserves a no-space ==Changelog== heading (boundary tolerates non-canonical form)', () => {
+			createChangelog(`# Changelog
+
+## [3.0.0] (2026-01-20)
+
+### ⚠ BREAKING CHANGES
+
+* Big change ([#400](https://github.com/wp-graphql/wp-graphql/pull/400))
+`);
+
+			createReadme(`=== Test Plugin ===
+Stable tag: 2.0.0
+
+== Upgrade Notice ==
+
+= 3.0.0 =
+Old hand-written notice for 3.0.0.
+
+==Changelog==
+
+= 3.0.0 =
+
+* Old changelog entry.
+
+= 2.0.0 =
+* Initial.
+`);
+
+			const result = runScript('3.0.0');
+			assert(result.success, `Script should succeed. Output: ${result.output}`);
+
+			const readme = readReadme();
+			assert(
+				readme.includes('==Changelog=='),
+				'Must preserve the no-space ==Changelog== heading'
+			);
+			assert(
+				readme.includes('Old changelog entry.'),
+				'Must preserve the Changelog body content untouched'
+			);
+			assert(
+				readme.includes('= 2.0.0 ='),
+				'Must preserve earlier changelog entries'
+			);
+			assert(
+				readme.includes('Big change'),
+				'Should write the new breaking change into the upgrade notice'
+			);
+			// `= 3.0.0 =` appears once in Upgrade Notice + once in Changelog = 2.
+			const threeZero = readme.match(/= 3\.0\.0 =/g) || [];
+			assert(
+				threeZero.length === 2,
+				`Expected exactly 2 occurrences of "= 3.0.0 =" (one per section), got ${threeZero.length}`
+			);
+		}),
+
+	// Test 8c: Regression — `versionNoticeRegex` must be anchored to a line
+	// start so prose mentions of the version don't false-positive into the
+	// "replace existing notice" branch. Pre-fix, an in-body string like
+	// "Upgraded from = 3.0.0 = to ..." would set `hasVersionNotice = true`
+	// and the replace would anchor mid-paragraph, corrupting prose.
+	() =>
+		test('prose mention of "= X.Y.Z =" does not trigger the replace branch', () => {
+			createChangelog(`# Changelog
+
+## [3.0.0] (2026-01-20)
+
+### ⚠ BREAKING CHANGES
+
+* Migration required ([#500](https://github.com/wp-graphql/wp-graphql/pull/500))
+`);
+
+			createReadme(`=== Test Plugin ===
+Stable tag: 2.0.0
+
+== Upgrade Notice ==
+
+Existing intro: upgraded from = 2.0.0 = to a newer release.
+
+== Changelog ==
+
+= 2.0.0 =
+* Initial.
+`);
+
+			const result = runScript('3.0.0');
+			assert(result.success, `Script should succeed. Output: ${result.output}`);
+
+			const readme = readReadme();
+			assert(
+				readme.includes('Added new upgrade notice for version 3.0.0') ||
+					result.output.includes('Added new upgrade notice'),
+				'Should take the "Added new" branch, not "Updated existing"'
+			);
+			// The prose mention of "= 2.0.0 =" must be intact.
+			assert(
+				readme.includes('upgraded from = 2.0.0 = to a newer release'),
+				'Must preserve the prose mention of an older version verbatim'
+			);
+			// New 3.0.0 notice was prepended.
+			assert(
+				readme.includes('= 3.0.0 ='),
+				'Should prepend the new 3.0.0 notice'
+			);
+			assert(
+				readme.includes('Migration required'),
+				'Should include the new breaking change'
+			);
+			// Changelog section must be intact.
+			assert(
+				readme.includes('== Changelog =='),
+				'Must preserve the Changelog section heading'
+			);
+		}),
+
 	// Test 8: Scoped breaking changes (e.g., **resolver:**)
 	() =>
 		test('preserves scope prefix in breaking changes', () => {


### PR DESCRIPTION
Fixes the release-PR workflow that crashed mid-run on the wpgraphql-ide 5.0.0 release ([#3892](https://github.com/wp-graphql/wp-graphql/pull/3892)) and stranded the plugin headers at `Version: 4.5.0` inside the wp.org `/tags/5.0.0/` SVN tag. Restructures `update-upgrade-notice.js` to operate on the captured section body slice so its replacement cannot escape into a sibling section, and anchors the version-heading check so prose mentions don't trigger the replace path.

Also catches up the stranded IDE 5.0.0 source state by bumping `Version:`, `WPGRAPHQL_IDE_VERSION`, and `Stable tag:` from 4.5.0 to 5.0.0.

---

**Merge order:**
1. #3917 — section-scope fix (must land first; prevents silent corruption this PR would otherwise expose)
2. 👉 **#3916 (this PR)** — release-script crash fix
3. #3918 — deploy-time backstop