### PR TITLE
fix(release): release script writes changelog entries into the right readme section

### DIFF
--- a/scripts/update-readme-changelog.js
+++ b/scripts/update-readme-changelog.js
@@ -187,29 +187,14 @@ function upsertVersionInReadme(readmeContent, versionBlock, version) {
 		throw new Error('Could not find "== Changelog ==" section in readme.txt');
 	}
 
-	// Scope all changelog mutations to the slice that starts at the heading.
-	// Everything before (Description, Upgrade Notice, …) is untouchable
-	// prefix and can never be matched by the replace below — this is what
-	// stops the bug where, on a release-please run, the FIRST `= X.Y.Z =`
-	// in readme.txt is in the Upgrade Notice section (already written by
-	// the prior `update-upgrade-notice.js` step) and the changelog block
-	// silently overwrites it.
+	// Scope mutations to the slice that starts at the heading; anything
+	// before is pass-through prefix.
 	const changelogStart = headingMatch.index;
 	const prefix = readmeContent.slice(0, changelogStart);
 	const changelogSection = readmeContent.slice(changelogStart);
 
-	// Lookahead alternatives (all evaluated within `changelogSection`):
-	//   `\n= [digit]…` — next sibling version heading
-	//   `\n== `        — next major section heading
-	//   `$`            — end of input (i.e. end of section / file)
-	// Lookbehind `(?<=^|\n)` anchors to a line-start `= X.Y.Z =` heading
-	// without consuming the preceding `\n`, so the replacement preserves it.
-	//
-	// (The prior implementation used `\Z` in the lookahead, which is NOT a
-	// valid JS regex escape — it matched the literal character `Z`. When
-	// neither sibling alternative fired, the lazy match failed entirely and
-	// the script fell through to the `inserted` branch, prepending a
-	// duplicate `= X.Y.Z =` block.)
+	// Match a `= X.Y.Z =` heading bounded by the next sibling version
+	// heading, the next major section heading, or end of input.
 	const versionPattern = new RegExp(
 		`(?<=^|\\n)= ${escapeRegExp(version)} =[\\s\\S]*?(?=\\n= [0-9]+\\.[0-9]+\\.[0-9]+(?:-[\\w.-]+)? =\\s*(?:\\n|$)|\\n== |$)`
 	);

--- a/scripts/update-readme-changelog.js
+++ b/scripts/update-readme-changelog.js
@@ -182,34 +182,57 @@ function normalizeChangelogSpacing(readmeContent) {
 
 function upsertVersionInReadme(readmeContent, versionBlock, version) {
 	const changelogHeadingRegex = /^== Changelog ==[ \t]*$/m;
-	if (!changelogHeadingRegex.test(readmeContent)) {
+	const headingMatch = readmeContent.match(changelogHeadingRegex);
+	if (!headingMatch) {
 		throw new Error('Could not find "== Changelog ==" section in readme.txt');
 	}
 
+	// Scope all changelog mutations to the slice that starts at the heading.
+	// Everything before (Description, Upgrade Notice, …) is untouchable
+	// prefix and can never be matched by the replace below — this is what
+	// stops the bug where, on a release-please run, the FIRST `= X.Y.Z =`
+	// in readme.txt is in the Upgrade Notice section (already written by
+	// the prior `update-upgrade-notice.js` step) and the changelog block
+	// silently overwrites it.
+	const changelogStart = headingMatch.index;
+	const prefix = readmeContent.slice(0, changelogStart);
+	const changelogSection = readmeContent.slice(changelogStart);
+
+	// Lookahead alternatives (all evaluated within `changelogSection`):
+	//   `\n= [digit]…` — next sibling version heading
+	//   `\n== `        — next major section heading
+	//   `$`            — end of input (i.e. end of section / file)
+	// Lookbehind `(?<=^|\n)` anchors to a line-start `= X.Y.Z =` heading
+	// without consuming the preceding `\n`, so the replacement preserves it.
+	//
+	// (The prior implementation used `\Z` in the lookahead, which is NOT a
+	// valid JS regex escape — it matched the literal character `Z`. When
+	// neither sibling alternative fired, the lazy match failed entirely and
+	// the script fell through to the `inserted` branch, prepending a
+	// duplicate `= X.Y.Z =` block.)
 	const versionPattern = new RegExp(
-		`^= ${escapeRegExp(version)} =[\\s\\S]*?(?=^= [0-9]+\\.[0-9]+\\.[0-9]+(?:-[\\w.-]+)? =\\s*$|^== |\\Z)`,
-		'm'
+		`(?<=^|\\n)= ${escapeRegExp(version)} =[\\s\\S]*?(?=\\n= [0-9]+\\.[0-9]+\\.[0-9]+(?:-[\\w.-]+)? =\\s*(?:\\n|$)|\\n== |$)`
 	);
 
-	if (versionPattern.test(readmeContent)) {
-		const updatedContent = readmeContent.replace(
+	if (versionPattern.test(changelogSection)) {
+		const updatedSection = changelogSection.replace(
 			versionPattern,
 			versionBlock.trimEnd() + '\n\n'
 		);
 		return {
-			updatedContent: normalizeChangelogSpacing(updatedContent),
+			updatedContent: normalizeChangelogSpacing(prefix + updatedSection),
 			action: 'updated',
 		};
 	}
 
-	const headingMatch = readmeContent.match(changelogHeadingRegex);
-	const insertAt = headingMatch.index + headingMatch[0].length;
-	const prefix = readmeContent.slice(0, insertAt);
-	const suffix = readmeContent.slice(insertAt);
+	// Insert at the top of the Changelog section.
+	const insertAt = headingMatch[0].length;
+	const sectionPrefix = changelogSection.slice(0, insertAt);
+	const sectionSuffix = changelogSection.slice(insertAt);
 
 	return {
 		updatedContent: normalizeChangelogSpacing(
-			`${prefix}\n\n${versionBlock.trimEnd()}\n\n${suffix.replace(/^\n+/, '')}`
+			`${prefix}${sectionPrefix}\n\n${versionBlock.trimEnd()}\n\n${sectionSuffix.replace(/^\n+/, '')}`
 		),
 		action: 'inserted',
 	};

--- a/scripts/update-readme-changelog.test.js
+++ b/scripts/update-readme-changelog.test.js
@@ -221,6 +221,141 @@ Stable tag: 1.0.0
 			assert.strictEqual(readReadme(), originalReadme, 'readme should stay unchanged');
 		}),
 
+	// Regression — scoping to the Changelog section.
+	// PR #3892's failure shape: by the time this script runs, the Upgrade
+	// Notice section already contains a `= X.Y.Z =` heading written by the
+	// `update-upgrade-notice.js` step. The original script's full-content
+	// regex matched the FIRST `= X.Y.Z =` (in Upgrade Notice) and silently
+	// overwrote it with changelog markup. Scoping the operation to the
+	// Changelog slice makes that impossible by construction.
+	() =>
+		test('upgrade notice section with the same `= X.Y.Z =` heading is not touched', () => {
+			createChangelog(`# Changelog
+
+## [3.0.0](https://example.com) (2026-01-20)
+
+### Bug Fixes
+
+* canonical changelog body ([#1](https://example.com/issues/1))
+`);
+
+			const upgradeNoticeBody =
+				'**⚠️ BREAKING CHANGES**: This release contains breaking changes that may require updates to your code.\n\n* upgrade-notice body line\n\nPlease review these changes before upgrading.';
+
+			createReadme(`=== Test ===
+Stable tag: 3.0.0
+
+== Upgrade Notice ==
+
+= 3.0.0 =
+
+${upgradeNoticeBody}
+
+== Changelog ==
+
+= 3.0.0 =
+
+* old stale changelog body
+
+= 2.0.0 =
+
+* previous
+`);
+
+			const result = runScript('3.0.0');
+			assert(result.success, 'script should succeed');
+
+			const readme = readReadme();
+			// Upgrade Notice body is untouched.
+			assert(
+				readme.includes('upgrade-notice body line'),
+				'Upgrade Notice body must survive the changelog upsert'
+			);
+			assert(
+				readme.includes(
+					'**⚠️ BREAKING CHANGES**: This release contains breaking changes'
+				),
+				'Upgrade Notice marker must survive verbatim'
+			);
+			// Changelog body was replaced with the canonical bullet.
+			assert(
+				readme.includes('* canonical changelog body'),
+				'Changelog `= 3.0.0 =` block should be replaced with the CHANGELOG.md bullet'
+			);
+			assert(
+				!readme.includes('* old stale changelog body'),
+				'Old changelog body for 3.0.0 must be gone'
+			);
+			// Exactly one `= 3.0.0 =` per section.
+			const threeZero = readme.match(/= 3\.0\.0 =/g) || [];
+			assert.strictEqual(
+				threeZero.length,
+				2,
+				`Expected exactly 2 occurrences of "= 3.0.0 =" (one per section), got ${threeZero.length}`
+			);
+			// Order check: the Upgrade Notice's `= 3.0.0 =` precedes Changelog's.
+			const upgradeNoticeIdx = readme.indexOf('== Upgrade Notice ==');
+			const changelogIdx = readme.indexOf('== Changelog ==');
+			const firstThree = readme.indexOf('= 3.0.0 =');
+			const secondThree = readme.indexOf('= 3.0.0 =', firstThree + 1);
+			assert(
+				firstThree > upgradeNoticeIdx && firstThree < changelogIdx,
+				'First `= 3.0.0 =` must remain in Upgrade Notice'
+			);
+			assert(
+				secondThree > changelogIdx,
+				'Second `= 3.0.0 =` must be in Changelog'
+			);
+		}),
+
+	// Regression — the `\Z` literal bug. When the target version is the
+	// only `= X.Y.Z =` in the readme AND no `== ` section follows it, the
+	// previous regex's lookahead (which used the invalid `\Z` escape, JS
+	// treats it as literal `Z`) failed to match, the script fell through to
+	// the `inserted` branch, and the result was a duplicate version heading.
+	() =>
+		test('updates the only `= X.Y.Z =` heading in the file without inserting a duplicate', () => {
+			createChangelog(`# Changelog
+
+## [1.0.0](https://example.com) (2026-01-20)
+
+### Bug Fixes
+
+* the fix ([#1](https://example.com/issues/1))
+`);
+
+			createReadme(`=== Test ===
+Stable tag: 1.0.0
+
+== Changelog ==
+
+= 1.0.0 =
+
+* old stale body
+`);
+
+			const result = runScript('1.0.0');
+			assert(result.success, `script should succeed. Output: ${result.output}`);
+			assert(
+				result.output.includes('updated readme changelog'),
+				'should take the "updated" branch, not "inserted"'
+			);
+
+			const readme = readReadme();
+			assert(
+				!readme.includes('* old stale body'),
+				'old body must be replaced'
+			);
+			assert(readme.includes('* the fix'), 'new body must be present');
+			// Exactly one occurrence — no duplicate prepended.
+			const matches = readme.match(/= 1\.0\.0 =/g) || [];
+			assert.strictEqual(
+				matches.length,
+				1,
+				`Expected exactly 1 occurrence of "= 1.0.0 =", got ${matches.length}`
+			);
+		}),
+
 	() =>
 		test('collapses excessive blank lines in changelog section', () => {
 			createChangelog(`# Changelog


### PR DESCRIPTION
Before this, the release script (`update-readme-changelog.js`) edited the first matching version block it found anywhere in `readme.txt` — which on a release where the upgrade-notice script ran first is the one in the Upgrade Notice section. The Changelog silently never got the new entry, and the Upgrade Notice got rewritten with changelog markup instead of upgrade guidance.

Scopes the script to the slice of the file that starts at `== Changelog ==`. Also fixes a latent bug where the lookahead used `\Z` — not a valid JS regex escape, so it matched the literal character `Z` instead of end-of-input. On single-version readmes the lazy match silently fell through to the `inserted` branch, prepending a duplicate heading.

Tests cover both the cross-section overwrite and the duplicate-heading path.

---

**Merge order:**
1. 👉 **#3917 (this PR)** — safe to land first; prevents the corruption pathway #3916 would otherwise expose
2. #3916 — release-script crash fix
3. #3918 — deploy-time backstop