### PR TITLE
ci: scope release schema artifact generation to the released component

### DIFF
--- a/.github/workflows/upload-schema-artifact.yml
+++ b/.github/workflows/upload-schema-artifact.yml
@@ -56,6 +56,62 @@ jobs:
       - name: Start wp-env
         run: npm run wp-env start
 
+      # The release schema artifact is the baseline the schema-linter diffs against, so it
+      # MUST be generated with the same plugin context the linter uses for that component
+      # (see schema-linter.yml `active_plugins`). wp-env activates every monorepo plugin by
+      # default, which would otherwise bake other plugins' schema (e.g. the IDE's
+      # `updateGraphqlSetting`) into this component's baseline and produce phantom "breaking
+      # change" diffs when the linter regenerates the component-only schema.
+      - name: Determine released component and required plugins
+        id: component
+        run: |
+          TAG="${{ inputs.tag || github.event.release.tag_name }}"
+          # Tags are component-scoped (e.g. wp-graphql/v2.16.0 -> component wp-graphql).
+          if [[ "$TAG" == */* ]]; then
+            COMPONENT="${TAG%%/*}"
+          else
+            COMPONENT="wp-graphql"
+          fi
+          # Required plugins = wp-graphql (always — registers the CLI command + is the base
+          # dependency) plus the component itself. Mirrors schema-linter.yml's active_plugins.
+          REQUIRED="wp-graphql"
+          if [[ "$COMPONENT" != "wp-graphql" ]]; then
+            REQUIRED="wp-graphql $COMPONENT"
+          fi
+          echo "component=$COMPONENT" >> "$GITHUB_OUTPUT"
+          echo "required_plugins=$REQUIRED" >> "$GITHUB_OUTPUT"
+          echo "Releasing component: $COMPONENT | required plugins: $REQUIRED"
+
+      - name: Scope active plugins for schema generation
+        run: |
+          REQUIRED="${{ steps.component.outputs.required_plugins }}"
+          echo "Active plugins (before):"
+          npm run wp-env run cli -- wp plugin list --status=active || true
+
+          # Deactivate any active plugin not in the required set. Keep wp-graphql active so the
+          # `wp graphql` CLI command stays registered.
+          ACTIVE=$(npm run wp-env run cli -- wp plugin list --status=active 2>/dev/null | awk 'NR>1 {print $1}' | grep -v "^wp-graphql$" || true)
+          for plugin in $ACTIVE; do
+            [ -z "$plugin" ] && continue
+            keep=false
+            for req in $REQUIRED; do
+              if [ "$plugin" = "$req" ]; then keep=true; break; fi
+            done
+            if [ "$keep" = false ]; then
+              echo "Deactivating $plugin"
+              npm run wp-env run cli -- wp plugin deactivate "$plugin" 2>/dev/null || true
+            fi
+          done
+
+          # Ensure required (non-wp-graphql) plugins are active.
+          for plugin in $REQUIRED; do
+            [ "$plugin" = "wp-graphql" ] && continue
+            npm run wp-env run cli -- wp plugin activate "$plugin" 2>/dev/null || echo "Warning: could not activate $plugin"
+          done
+
+          echo "Active plugins (after):"
+          npm run wp-env run cli -- wp plugin list --status=active
+
       - name: Generate the Static Schema
         run: |
           npm run wp-env run cli -- wp graphql generate-static-schema --output=/var/www/html/schema.graphql


### PR DESCRIPTION
## Problem
The release `schema.graphql` artifact (uploaded by `upload-schema-artifact.yml` on each release) is the **baseline** the schema-linter diffs the current schema against. But it was generated with **every monorepo plugin active** (wp-env activates them all by default), so each component's baseline got **polluted with other plugins' schema**.

Concretely: the `wp-graphql` baseline included the IDE plugin's `updateGraphqlSetting` mutation + `UpdateGraphqlSetting*` types. The schema-linter correctly regenerates the **wp-graphql-only** schema (`active_plugins: ''`), which doesn't have those IDE-owned fields — so the inspector reported them as **removed from wp-graphql**, a phantom breaking change. This is what's been failing schema-linter on `main` release PRs (e.g. #3908).

(Root cause confirmed: `updateGraphqlSetting` is registered in `plugins/wp-graphql-ide/includes/settings.php`, not core.)

## Fix
Scope the artifact generation to match `schema-linter.yml`:
- Derive the released component from the tag (`wp-graphql/v2.16.0` → `wp-graphql`).
- Deactivate every plugin except **wp-graphql + that component** before generating.

So `wp-graphql` releases now produce a **wp-graphql-only** baseline; smart-cache/ide/acf releases get **wp-graphql + themselves** — mirroring the linter's `active_plugins` per component.

`schema-linter.yml` already scopes correctly, so it's unchanged.

## Note on the existing baseline
This fixes generation **going forward**. The already-published `wp-graphql/v2.16.0` schema asset is still polluted, so the linter will keep diffing against it until a clean one replaces it. After this merges, the **2.16.0 asset can be regenerated** by running this workflow via `workflow_dispatch` with `tag: wp-graphql/v2.16.0` — that re-uploads a clean wp-graphql-only schema and clears the phantom diff (unblocking #3908).