### PR TITLE
feat(ide): query composer reveals the field at the editor cursor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11799,9 +11799,9 @@
 			}
 		},
 		"node_modules/@wordpress/hooks": {
-			"version": "4.48.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.48.0.tgz",
-			"integrity": "sha512-rU1yGEy0Mb+2oRG5QX/bKIIwKQmYAvATfUQeXIF20/mbR0qutYeVTCIvWEyb4pf71tvnQFiN18RWRXWsvKrDbQ==",
+			"version": "4.48.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.48.1.tgz",
+			"integrity": "sha512-QZh3Cv9TMJkrCQikuZSsDKTgX+6BBzYJe0MFKp7yP8drj/dtRpkqo5+eYmovBq3pk+HoyP7UJ1vTOb3GPJeU6Q==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",

--- a/plugins/wp-graphql-ide/plugins/query-composer-panel/src/components/ExplorerView.jsx
+++ b/plugins/wp-graphql-ide/plugins/query-composer-panel/src/components/ExplorerView.jsx
@@ -138,10 +138,22 @@ class ExplorerView extends React.PureComponent {
 		if (!el) {
 			return;
 		}
-		// `center` keeps the row away from the panel's sticky operation
-		// title-bar at the top and the bottom edge of the scroll area —
-		// both clip a row aligned to the nearest edge.
-		el.scrollIntoView({ block: 'center', behavior: 'smooth' });
+		// Drive the panel's own scroll container instead of calling
+		// `el.scrollIntoView` — smooth scroll otherwise chains up through
+		// every scrollable ancestor and the IDE drawer slides its header
+		// out of view. Centering also keeps the row away from the sticky
+		// operation title-bar at the top and the bottom edge, which both
+		// clip a row aligned to the nearest edge.
+		const scrollContainer =
+			container.querySelector('.graphiql-explorer-operations') ||
+			container;
+		const elRect = el.getBoundingClientRect();
+		const containerRect = scrollContainer.getBoundingClientRect();
+		const targetTop =
+			scrollContainer.scrollTop +
+			(elRect.top - containerRect.top) -
+			(scrollContainer.clientHeight - elRect.height) / 2;
+		scrollContainer.scrollTo({ top: targetTop, behavior: 'smooth' });
 		el.classList.add(CURSOR_TARGET_CLASS);
 		this._cursorHighlightEl = el;
 		this._cursorHighlightTimer = setTimeout(() => {

--- a/plugins/wp-graphql-ide/plugins/query-composer-panel/src/components/ExplorerView.jsx
+++ b/plugins/wp-graphql-ide/plugins/query-composer-panel/src/components/ExplorerView.jsx
@@ -122,13 +122,26 @@ class ExplorerView extends React.PureComponent {
 		if (!container || !pathKey) {
 			return;
 		}
-		// querySelector with a data-attribute selector — pathKey is built from
-		// AST field names (validated identifiers), so it's safe to embed.
-		const el = container.querySelector(`[data-field-path="${pathKey}"]`);
+		// findCursorPath walks AST Field nodes — it will surface names the
+		// user typed that aren't in the schema (and so have no DOM row).
+		// Walk back up the path until a row that exists is found so the
+		// reveal still lands on the nearest visible ancestor.
+		//
+		// querySelector with a data-attribute selector — pathKey is built
+		// from AST field names (validated identifiers), so it's safe to embed.
+		let candidate = pathKey;
+		let el = container.querySelector(`[data-field-path="${candidate}"]`);
+		while (!el && candidate.includes('|')) {
+			candidate = candidate.substring(0, candidate.lastIndexOf('|'));
+			el = container.querySelector(`[data-field-path="${candidate}"]`);
+		}
 		if (!el) {
 			return;
 		}
-		el.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+		// `center` keeps the row away from the panel's sticky operation
+		// title-bar at the top and the bottom edge of the scroll area —
+		// both clip a row aligned to the nearest edge.
+		el.scrollIntoView({ block: 'center', behavior: 'smooth' });
 		el.classList.add(CURSOR_TARGET_CLASS);
 		this._cursorHighlightEl = el;
 		this._cursorHighlightTimer = setTimeout(() => {

--- a/plugins/wp-graphql-ide/plugins/query-composer-panel/src/components/ExplorerView.jsx
+++ b/plugins/wp-graphql-ide/plugins/query-composer-panel/src/components/ExplorerView.jsx
@@ -138,22 +138,28 @@ class ExplorerView extends React.PureComponent {
 		if (!el) {
 			return;
 		}
-		// Drive the panel's own scroll container instead of calling
-		// `el.scrollIntoView` — smooth scroll otherwise chains up through
-		// every scrollable ancestor and the IDE drawer slides its header
-		// out of view. Centering also keeps the row away from the sticky
-		// operation title-bar at the top and the bottom edge, which both
-		// clip a row aligned to the nearest edge.
+		// Drive the panel's own scroll container, skip the scroll when the
+		// row is already in view, and write `scrollTop` directly instead of
+		// `scrollIntoView` / smooth `scrollTo`. Both `scrollIntoView` and a
+		// smooth scroll dispatch scroll events that the Vaul drawer picks
+		// up as drag input — it then nudges itself up or down in response.
+		// A direct `scrollTop` assignment doesn't dispatch a synthetic
+		// gesture and is contained to the explorer's operations container.
 		const scrollContainer =
 			container.querySelector('.graphiql-explorer-operations') ||
 			container;
 		const elRect = el.getBoundingClientRect();
 		const containerRect = scrollContainer.getBoundingClientRect();
-		const targetTop =
-			scrollContainer.scrollTop +
-			(elRect.top - containerRect.top) -
-			(scrollContainer.clientHeight - elRect.height) / 2;
-		scrollContainer.scrollTo({ top: targetTop, behavior: 'smooth' });
+		const elTop = elRect.top - containerRect.top;
+		const elBottom = elTop + elRect.height;
+		const visibleHeight = scrollContainer.clientHeight;
+		if (elTop < 0 || elBottom > visibleHeight) {
+			const targetTop =
+				scrollContainer.scrollTop +
+				elTop -
+				(visibleHeight - elRect.height) / 2;
+			scrollContainer.scrollTop = Math.max(0, targetTop);
+		}
 		el.classList.add(CURSOR_TARGET_CLASS);
 		this._cursorHighlightEl = el;
 		this._cursorHighlightTimer = setTimeout(() => {

--- a/plugins/wp-graphql-ide/plugins/query-composer-panel/src/components/ExplorerView.jsx
+++ b/plugins/wp-graphql-ide/plugins/query-composer-panel/src/components/ExplorerView.jsx
@@ -6,7 +6,9 @@ import {
 	defaultGetDefaultFieldNames,
 	defaultGetDefaultScalarArgValue,
 	defaultStyles,
+	findCursorPath,
 	memoizeParseQuery,
+	operationKey,
 } from '../utils';
 import { GraphQLObjectType, print } from 'graphql';
 import RootView from './RootView';
@@ -14,34 +16,17 @@ import { defaultCheckboxChecked, defaultCheckboxUnchecked } from './Checkbox';
 import ArrowOpen from './ArrowOpen';
 import ArrowClosed from './ArrowClosed';
 
-// Stable key for an operation/fragment so user-toggled collapse state survives
-// re-parses (the AST node object identity changes on every keystroke).
-function operationKey(operation, index) {
-	const name = operation && operation.name && operation.name.value;
-	const kind =
-		operation.kind === 'FragmentDefinition'
-			? 'fragment'
-			: operation.operation || 'query';
-	return name ? `${kind}:${name}` : `${kind}:_${index}`;
-}
-
-// Find the operation key whose AST loc spans the given cursor offset. Returns
-// null if the cursor isn't inside any named operation (or locations are absent).
-function findOpKeyAtCursor(operations, cursorOffset) {
-	if (typeof cursorOffset !== 'number') {
+// Pipe-delimited path key for matching FieldView's `data-field-path`
+// attribute. Pipes can't appear in GraphQL identifiers so collisions are
+// impossible. Returns null when there's no field-level target (cursor is
+// outside every operation, or inside an operation but not on a field).
+const CURSOR_TARGET_CLASS = 'graphiql-explorer-row--cursor-target';
+const CURSOR_HIGHLIGHT_MS = 1500;
+function fieldPathKey(cursor) {
+	if (!cursor || !cursor.fieldPath || cursor.fieldPath.length === 0) {
 		return null;
 	}
-	for (let i = 0; i < operations.length; i++) {
-		const op = operations[i];
-		if (
-			op.loc &&
-			cursorOffset >= op.loc.start &&
-			cursorOffset <= op.loc.end
-		) {
-			return operationKey(op, i);
-		}
-	}
-	return null;
+	return `${cursor.opKey}|${cursor.fieldPath.join('|')}`;
 }
 
 class ExplorerView extends React.PureComponent {
@@ -54,11 +39,12 @@ class ExplorerView extends React.PureComponent {
 		// Tracks which op the cursor was last in, so we can wipe stale user
 		// toggles when the cursor moves to a different operation.
 		lastCursorOpKey: null,
+		// Tracks the last cursor field-path key we revealed, so typing within
+		// the same field doesn't re-trigger scroll/highlight on every keystroke.
+		lastFieldPathKey: null,
 	};
 
 	static getDerivedStateFromProps(props, state) {
-		// When the cursor enters a new operation, drop user toggles so the
-		// composer refocuses on the active op.
 		const ops = (() => {
 			try {
 				return memoizeParseQuery(props.query).definitions.filter(
@@ -70,11 +56,20 @@ class ExplorerView extends React.PureComponent {
 				return [];
 			}
 		})();
-		const cursorOpKey = findOpKeyAtCursor(ops, props.cursorOffset);
+		const cursor = findCursorPath(ops, props.cursorOffset);
+		const cursorOpKey = cursor ? cursor.opKey : null;
+		const nextFieldPathKey = fieldPathKey(cursor);
+		const patch = {};
+		// When the cursor enters a new operation, drop user toggles so the
+		// composer refocuses on the active op.
 		if (cursorOpKey && cursorOpKey !== state.lastCursorOpKey) {
-			return { lastCursorOpKey: cursorOpKey, collapsedByKey: {} };
+			patch.lastCursorOpKey = cursorOpKey;
+			patch.collapsedByKey = {};
 		}
-		return null;
+		if (nextFieldPathKey !== state.lastFieldPathKey) {
+			patch.lastFieldPathKey = nextFieldPathKey;
+		}
+		return Object.keys(patch).length ? patch : null;
 	}
 
 	_setCollapsed = (key, collapsed) => {
@@ -84,6 +79,8 @@ class ExplorerView extends React.PureComponent {
 	};
 
 	_ref;
+	_cursorHighlightEl = null;
+	_cursorHighlightTimer = null;
 	_resetScroll = () => {
 		const container = this._ref;
 		if (container) {
@@ -92,7 +89,56 @@ class ExplorerView extends React.PureComponent {
 	};
 	componentDidMount() {
 		this._resetScroll();
+		// Reveal the row for the cursor's initial position (e.g. when the
+		// panel opens with the editor already focused on a field).
+		this._revealCursorTarget(this.state.lastFieldPathKey);
 	}
+
+	componentDidUpdate(_prevProps, prevState) {
+		if (this.state.lastFieldPathKey !== prevState.lastFieldPathKey) {
+			this._revealCursorTarget(this.state.lastFieldPathKey);
+		}
+	}
+
+	componentWillUnmount() {
+		if (this._cursorHighlightTimer) {
+			clearTimeout(this._cursorHighlightTimer);
+			this._cursorHighlightTimer = null;
+		}
+	}
+
+	// Scroll the row matching `pathKey` into view and apply a brief highlight
+	// class. No-op when there's no container, no key, or no matching row.
+	_revealCursorTarget = (pathKey) => {
+		const container = this._ref;
+		if (this._cursorHighlightTimer) {
+			clearTimeout(this._cursorHighlightTimer);
+			this._cursorHighlightTimer = null;
+		}
+		if (this._cursorHighlightEl) {
+			this._cursorHighlightEl.classList.remove(CURSOR_TARGET_CLASS);
+			this._cursorHighlightEl = null;
+		}
+		if (!container || !pathKey) {
+			return;
+		}
+		// querySelector with a data-attribute selector — pathKey is built from
+		// AST field names (validated identifiers), so it's safe to embed.
+		const el = container.querySelector(`[data-field-path="${pathKey}"]`);
+		if (!el) {
+			return;
+		}
+		el.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+		el.classList.add(CURSOR_TARGET_CLASS);
+		this._cursorHighlightEl = el;
+		this._cursorHighlightTimer = setTimeout(() => {
+			if (this._cursorHighlightEl) {
+				this._cursorHighlightEl.classList.remove(CURSOR_TARGET_CLASS);
+				this._cursorHighlightEl = null;
+			}
+			this._cursorHighlightTimer = null;
+		}, CURSOR_HIGHLIGHT_MS);
+	};
 
 	_onEdit = (query) => this.props.onEdit(query);
 
@@ -178,10 +224,11 @@ class ExplorerView extends React.PureComponent {
 				? DEFAULT_DOCUMENT.definitions
 				: _relevantOperations;
 
-		const cursorOpKey = findOpKeyAtCursor(
+		const cursor = findCursorPath(
 			_relevantOperations,
 			this.props.cursorOffset
 		);
+		const cursorOpKey = cursor ? cursor.opKey : null;
 
 		const renameOperation = (targetOperation, name) => {
 			const newName =
@@ -610,6 +657,7 @@ class ExplorerView extends React.PureComponent {
 								}}
 								styleConfig={styleConfig}
 								availableFragments={availableFragments}
+								opKey={opKey}
 							/>
 						);
 					})}

--- a/plugins/wp-graphql-ide/plugins/query-composer-panel/src/components/FieldView.jsx
+++ b/plugins/wp-graphql-ide/plugins/query-composer-panel/src/components/FieldView.jsx
@@ -180,6 +180,14 @@ class FieldView extends React.PureComponent {
 			className += ' graphiql-explorer-deprecated';
 		}
 
+		// Path used to match against the editor cursor's AST position. The
+		// pipe delimiter is safe because it's not valid in GraphQL identifiers.
+		const pathSegments = this.props.pathSegments || [];
+		const myPath = [...pathSegments, field.name];
+		const dataFieldPath = this.props.opKey
+			? `${this.props.opKey}|${myPath.join('|')}`
+			: null;
+
 		const applicableFragments =
 			isObjectType(type) || isInterfaceType(type) || isUnionType(type)
 				? this.props.availableFragments &&
@@ -200,6 +208,7 @@ class FieldView extends React.PureComponent {
 						className="graphiql-explorer-row"
 						data-field-name={field.name}
 						data-field-type={type.name}
+						data-field-path={dataFieldPath}
 						onClick={this._handleUpdateSelections}
 						onKeyDown={(e) => {
 							if (e.key === 'Enter' || e.key === ' ') {
@@ -418,6 +427,8 @@ class FieldView extends React.PureComponent {
 									availableFragments={
 										this.props.availableFragments
 									}
+									opKey={this.props.opKey}
+									pathSegments={myPath}
 								/>
 							))}
 						{isInterfaceType(type) || isUnionType(type)

--- a/plugins/wp-graphql-ide/plugins/query-composer-panel/src/components/RootView.jsx
+++ b/plugins/wp-graphql-ide/plugins/query-composer-panel/src/components/RootView.jsx
@@ -221,6 +221,8 @@ class RootView extends React.PureComponent {
 									availableFragments={
 										this.props.availableFragments
 									}
+									opKey={this.props.opKey}
+									pathSegments={[]}
 								/>
 							))}
 					</div>

--- a/plugins/wp-graphql-ide/plugins/query-composer-panel/src/style.css
+++ b/plugins/wp-graphql-ide/plugins/query-composer-panel/src/style.css
@@ -549,3 +549,13 @@
 	border-color: var(--wp-admin-theme-color, #3858e9);
 	color: var(--wp-admin-theme-color, #3858e9);
 }
+
+/* Cursor-target highlight: the row matching the editor cursor briefly tints
+   with the WP admin accent so the user can orient when the composer scrolls
+   to it. The class is added by ExplorerView for ~1.5s, then removed —
+   the transition fades the residual background out. */
+#wpgraphql-ide-app .wpgraphql-ide-query-composer-inline .graphiql-explorer-row.graphiql-explorer-row--cursor-target {
+	background: rgba(var(--wp-admin-theme-color--rgb, 56, 88, 233), 0.18);
+	box-shadow: inset 2px 0 0 var(--wp-admin-theme-color, #3858e9);
+	transition: background-color 1.2s ease-out, box-shadow 1.2s ease-out;
+}

--- a/plugins/wp-graphql-ide/plugins/query-composer-panel/src/utils.js
+++ b/plugins/wp-graphql-ide/plugins/query-composer-panel/src/utils.js
@@ -332,6 +332,63 @@ export function defaultArgs(getDefaultScalarArgValue, makeDefaultArg, field) {
 	return args;
 }
 
+// Stable key for an operation/fragment so user-toggled collapse state survives
+// re-parses (the AST node object identity changes on every keystroke).
+export function operationKey(operation, index) {
+	const name = operation && operation.name && operation.name.value;
+	const kind =
+		operation.kind === 'FragmentDefinition'
+			? 'fragment'
+			: operation.operation || 'query';
+	return name ? `${kind}:${name}` : `${kind}:_${index}`;
+}
+
+// Walk the operations to find the deepest Field whose loc spans the cursor.
+// Returns `{ opKey, fieldPath }` where fieldPath is the chain of field names
+// from operation root → leaf (empty when the cursor is inside an operation
+// but not on a field). Returns null when the cursor is outside every
+// operation, locations are absent, or the offset is not a number.
+//
+// Aliases are ignored: matching is by `field.name.value` to stay consistent
+// with how FieldView resolves selections. Fragment spreads and inline
+// fragments are not descended into in v1 — the path stops at the nearest
+// containing field.
+export function findCursorPath(operations, cursorOffset) {
+	if (typeof cursorOffset !== 'number') {
+		return null;
+	}
+	for (let i = 0; i < operations.length; i++) {
+		const op = operations[i];
+		if (
+			!op.loc ||
+			cursorOffset < op.loc.start ||
+			cursorOffset > op.loc.end
+		) {
+			continue;
+		}
+		const fieldPath = [];
+		let selectionSet = op.selectionSet;
+		// Descend through Field selections until no child Field's loc spans
+		// the cursor. The deepest match wins.
+		while (selectionSet && Array.isArray(selectionSet.selections)) {
+			const match = selectionSet.selections.find(
+				(sel) =>
+					sel.kind === 'Field' &&
+					sel.loc &&
+					cursorOffset >= sel.loc.start &&
+					cursorOffset <= sel.loc.end
+			);
+			if (!match) {
+				break;
+			}
+			fieldPath.push(match.name.value);
+			selectionSet = match.selectionSet;
+		}
+		return { opKey: operationKey(op, i), fieldPath };
+	}
+	return null;
+}
+
 export function parseQuery(text) {
 	try {
 		if (!text.trim()) {

--- a/plugins/wp-graphql-ide/tests/e2e/specs/query-composer-cursor-follow.spec.js
+++ b/plugins/wp-graphql-ide/tests/e2e/specs/query-composer-cursor-follow.spec.js
@@ -1,0 +1,90 @@
+import {
+	loginToWordPressAdmin,
+	visitDedicatedIde,
+	ensureDocumentOpen,
+	typeQuery,
+	selectors,
+} from '../utils.js';
+
+const { test, expect } = require('@wordpress/e2e-test-utils-playwright');
+
+// CodeMirror 6 renders each syntactic token as a text node inside `.cm-line`.
+// Clicking the literal token text places the cursor inside it, which is the
+// same surface a user would interact with — preferable to driving the
+// EditorView via private APIs.
+const clickTokenInEditor = async (page, token) =>
+	page
+		.locator(`${selectors.graphqlEditorContent} .cm-line`)
+		.getByText(token, { exact: true })
+		.first()
+		.click();
+
+const composerPanel = (page) =>
+	page.locator('.wpgraphql-ide-query-composer-inline');
+
+const fieldRow = (page, path) =>
+	composerPanel(page).locator(`[data-field-path="${path}"]`);
+
+const openQueryComposer = async (page) => {
+	const btn = page
+		.locator(selectors.activityBar)
+		.getByRole('button', { name: 'Query Composer', exact: true });
+	if ((await btn.getAttribute('aria-pressed')) !== 'true') {
+		await btn.click();
+	}
+	await expect(btn).toHaveAttribute('aria-pressed', 'true');
+};
+
+test.describe('Query Composer follows the editor cursor', () => {
+	test.beforeEach(async ({ page }) => {
+		await loginToWordPressAdmin(page);
+		await visitDedicatedIde(page);
+		await ensureDocumentOpen(page);
+		await openQueryComposer(page);
+	});
+
+	test('reveals the row matching the cursor position at field granularity', async ({
+		page,
+	}) => {
+		await typeQuery(
+			page,
+			'query MyQuery { posts { nodes { title excerpt } } }'
+		);
+
+		// Composer rendered the rows we're going to navigate to.
+		await expect(
+			fieldRow(page, 'query:MyQuery|posts|nodes|title')
+		).toBeVisible();
+		await expect(
+			fieldRow(page, 'query:MyQuery|posts|nodes|excerpt')
+		).toBeVisible();
+
+		// Cursor onto `title` → that row gets the cursor-target class.
+		await clickTokenInEditor(page, 'title');
+		await expect(
+			fieldRow(page, 'query:MyQuery|posts|nodes|title')
+		).toHaveClass(/graphiql-explorer-row--cursor-target/);
+
+		// Cursor onto `excerpt` → highlight moves, title's class clears.
+		await clickTokenInEditor(page, 'excerpt');
+		await expect(
+			fieldRow(page, 'query:MyQuery|posts|nodes|excerpt')
+		).toHaveClass(/graphiql-explorer-row--cursor-target/);
+		await expect(
+			fieldRow(page, 'query:MyQuery|posts|nodes|title')
+		).not.toHaveClass(/graphiql-explorer-row--cursor-target/);
+	});
+
+	test('cursor on a parent field reveals the parent row, not a child', async ({
+		page,
+	}) => {
+		await typeQuery(page, 'query MyQuery { posts { nodes { title } } }');
+
+		await expect(fieldRow(page, 'query:MyQuery|posts')).toBeVisible();
+
+		await clickTokenInEditor(page, 'posts');
+		await expect(fieldRow(page, 'query:MyQuery|posts')).toHaveClass(
+			/graphiql-explorer-row--cursor-target/
+		);
+	});
+});

--- a/plugins/wp-graphql-ide/tests/e2e/specs/query-composer-cursor-follow.spec.js
+++ b/plugins/wp-graphql-ide/tests/e2e/specs/query-composer-cursor-follow.spec.js
@@ -25,10 +25,13 @@ const composerPanel = (page) =>
 const fieldRow = (page, path) =>
 	composerPanel(page).locator(`[data-field-path="${path}"]`);
 
+// The Query Composer is rendered inline next to the editor (not as an
+// activity-bar panel), so the toggle lives in the editor toolbar. The
+// button's accessible name flips between "Show Query Composer" and
+// "Hide Query Composer" with state, so target it by its stable class.
 const openQueryComposer = async (page) => {
-	const btn = page
-		.locator(selectors.activityBar)
-		.getByRole('button', { name: 'Query Composer', exact: true });
+	const btn = page.locator('.wpgraphql-ide-toolbar-composer-btn');
+	await expect(btn).toBeVisible();
 	if ((await btn.getAttribute('aria-pressed')) !== 'true') {
 		await btn.click();
 	}

--- a/plugins/wp-graphql-ide/tests/e2e/specs/query-composer-cursor-follow.spec.js
+++ b/plugins/wp-graphql-ide/tests/e2e/specs/query-composer-cursor-follow.spec.js
@@ -87,4 +87,22 @@ test.describe('Query Composer follows the editor cursor', () => {
 			/graphiql-explorer-row--cursor-target/
 		);
 	});
+
+	test('cursor on a name that is not a schema field falls back to the nearest ancestor row', async ({
+		page,
+	}) => {
+		// `fakeSlugXYZ` is not a field on Post — the cursor still resolves
+		// to a parsed Field AST node, but no row exists for it in the
+		// explorer. The reveal should fall back to the deepest ancestor
+		// that does have a row (here: `nodes`).
+		await typeQuery(
+			page,
+			'query MyQuery { posts { nodes { fakeSlugXYZ } } }'
+		);
+
+		await clickTokenInEditor(page, 'fakeSlugXYZ');
+		await expect(fieldRow(page, 'query:MyQuery|posts|nodes')).toHaveClass(
+			/graphiql-explorer-row--cursor-target/
+		);
+	});
 });

--- a/plugins/wp-graphql-ide/tests/unit/specs/query-composer/find-cursor-path.test.js
+++ b/plugins/wp-graphql-ide/tests/unit/specs/query-composer/find-cursor-path.test.js
@@ -1,0 +1,126 @@
+/* eslint-env browser, jest */
+
+import { parse } from 'graphql';
+import { findCursorPath } from '../../../../plugins/query-composer-panel/src/utils';
+
+// Helper: parse a document and return its operation-like definitions
+// (OperationDefinition + FragmentDefinition) — the same shape ExplorerView
+// passes to findCursorPath.
+function operationsFrom(source) {
+	return parse(source).definitions.filter(
+		(d) =>
+			d.kind === 'OperationDefinition' || d.kind === 'FragmentDefinition'
+	);
+}
+
+// Helper: return the character offset of the cursor marker `|` in `source`
+// and the source with the marker stripped out. Lets each test express the
+// cursor inline at the field of interest.
+function offsetAt(source) {
+	const at = source.indexOf('|');
+	if (at < 0) {
+		throw new Error('Test source missing cursor marker "|"');
+	}
+	return { offset: at, text: source.slice(0, at) + source.slice(at + 1) };
+}
+
+describe('findCursorPath', () => {
+	it('returns null for a non-numeric cursor offset', () => {
+		const ops = operationsFrom('{ __typename }');
+		expect(findCursorPath(ops, null)).toBeNull();
+		expect(findCursorPath(ops, undefined)).toBeNull();
+		expect(findCursorPath(ops, 'nope')).toBeNull();
+	});
+
+	it('returns null when the cursor is outside every operation', () => {
+		// Anonymous query — its loc starts at the `{`. Offset 0 lands before.
+		const ops = operationsFrom('   { __typename }');
+		expect(findCursorPath(ops, 0)).toBeNull();
+	});
+
+	it('returns the deepest field path for a nested cursor', () => {
+		const { offset, text } = offsetAt(
+			'query MyQuery { posts { nodes { tit|le excerpt } } }'
+		);
+		const result = findCursorPath(operationsFrom(text), offset);
+		expect(result).toEqual({
+			opKey: 'query:MyQuery',
+			fieldPath: ['posts', 'nodes', 'title'],
+		});
+	});
+
+	it('returns the containing field when cursor is on whitespace inside its selection set', () => {
+		const { offset, text } = offsetAt(
+			'query MyQuery { posts { nodes {| title } } }'
+		);
+		const result = findCursorPath(operationsFrom(text), offset);
+		expect(result).toEqual({
+			opKey: 'query:MyQuery',
+			fieldPath: ['posts', 'nodes'],
+		});
+	});
+
+	it('returns an empty fieldPath when the cursor is on the operation keyword', () => {
+		const { offset, text } = offsetAt('qu|ery MyQuery { posts { title } }');
+		const result = findCursorPath(operationsFrom(text), offset);
+		expect(result).toEqual({
+			opKey: 'query:MyQuery',
+			fieldPath: [],
+		});
+	});
+
+	it('picks the operation whose loc spans the cursor among multiple', () => {
+		const { offset, text } = offsetAt(
+			'query A { posts { title } }\nquery B { pages { ti|tle } }'
+		);
+		const result = findCursorPath(operationsFrom(text), offset);
+		expect(result).toEqual({
+			opKey: 'query:B',
+			fieldPath: ['pages', 'title'],
+		});
+	});
+
+	it('uses positional keys for anonymous operations', () => {
+		const { offset, text } = offsetAt('{ pos|ts { title } }');
+		const result = findCursorPath(operationsFrom(text), offset);
+		expect(result).toEqual({
+			opKey: 'query:_0',
+			fieldPath: ['posts'],
+		});
+	});
+
+	it('returns the containing field path when cursor is on a fragment spread', () => {
+		const { offset, text } = offsetAt(
+			`query MyQuery { posts { nodes { ...Post|Bits } } }
+			 fragment PostBits on Post { title }`
+		);
+		const result = findCursorPath(operationsFrom(text), offset);
+		// We do not descend into the fragment in v1 — stop at the parent field.
+		expect(result).toEqual({
+			opKey: 'query:MyQuery',
+			fieldPath: ['posts', 'nodes'],
+		});
+	});
+
+	it('matches inside arguments by treating them as part of the field', () => {
+		const { offset, text } = offsetAt(
+			'query MyQuery { posts(fir|st: 5) { nodes { title } } }'
+		);
+		const result = findCursorPath(operationsFrom(text), offset);
+		expect(result).toEqual({
+			opKey: 'query:MyQuery',
+			fieldPath: ['posts'],
+		});
+	});
+
+	it('handles fragment definitions', () => {
+		const { offset, text } = offsetAt(
+			'fragment PostBits on Post { ti|tle excerpt }'
+		);
+		const result = findCursorPath(operationsFrom(text), offset);
+		expect(result).toEqual({
+			opKey: 'fragment:PostBits',
+			fieldPath: ['title'],
+		});
+	});
+});


### PR DESCRIPTION
## What feature does this implement? Explain your changes.

When the cursor lands on a field in the GraphQL editor, the Query Composer panel scrolls to that field's row and briefly highlights it. The panel already received the cursor position, but used it only to expand the operation containing the cursor — invisible in a single-operation document.

## Does this close any currently open issues?

Closes #3933.

## Feature Design

### Schema Changes

None.

### User Experience

The matching row scrolls into the middle of the panel and highlights with the panel's accent color, then fades. No new shortcut; composes with the existing cmd-click jump-to-Docs.

Tracked follow-ups (#3933):

- An explicit "Reveal in Query Composer" command that opens the panel when it's closed.
- Following the cursor into inline fragments or fragment spreads — the reveal stops at the nearest enclosing field.

## Implementation Details

### Performance Considerations

The cursor offset updates on every keystroke and arrow press:

- The panel remembers which row was last revealed and skips when nothing changed; typing inside the same field triggers no scroll, highlight, or other DOM work.
- Walking the parsed GraphQL document is O(depth × siblings per level); the parse itself is already memoized upstream.
- The scroll is a no-op when the row is already visible.

## Testing Strategy

### Test Coverage

Unit (Jest) and end-to-end (Playwright).

## Documentation Updates

No public API or user-facing documentation changes. The changelog is generated by release-please from the PR title at the next IDE release.

### Breaking Changes

None.
