### PR TITLE
chore(deps): ignore query-string major bumps (breaks bundled IDE)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -103,6 +103,13 @@ updates:
       prefix: 'feat'
       prefix-development: 'fix'
       include: 'scope'
+    ignore:
+      # query-string 8.x is pure ESM with breaking changes. The bundled GraphiQL
+      # IDE reaches it transitively through use-query-params@1.x ->
+      # serialize-query-params@1.x, which only support query-string <= 7. Holding
+      # at 7.x until use-query-params is upgraded to 2.x (see PR #3851).
+      - dependency-name: 'query-string'
+        update-types: ['version-update:semver-major']
     groups:
       npm-dev-minor-patch:
         dependency-type: 'development'


### PR DESCRIPTION
## What

Adds a Dependabot ignore rule for `query-string` major-version bumps in the root npm config, holding it at the current 7.x line.

## Why

`query-string` is only used by the legacy GraphiQL IDE bundled in WPGraphQL core, where it comes in transitively through `use-query-params@1.x`. That version chain only supports query-string 7 and earlier. query-string 8 is pure ESM and only works with `use-query-params@2.x`, so bumping it on its own breaks the bundled IDE (see #3851, where it fails the core GraphiQL e2e tests).

This bundled IDE is being removed from WPGraphQL core very soon in favor of the standalone `wp-graphql-ide` plugin, which does not depend on query-string at all. Rather than do a breaking `use-query-params` upgrade for code that is about to be removed, this rule keeps query-string pinned at 7.x and stops Dependabot from re-proposing the incompatible major.

Closes #3851.
