### PR TITLE
chore(ide): repoint plugin meta links and add Docs/Support row-meta

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# Each line is a file pattern followed by one or more owners.
+# Code owners are auto-requested as reviewers on matching PRs.
+# Whether their review is required to merge is controlled by
+# the "Require review from Code Owners" toggle in the `main`
+# ruleset, not by this file. Order matters — the last matching
+# pattern takes precedence.
+
+# Default owner for everything in the repo. Unless a later
+# pattern matches, @jasonbahl is requested for review when
+# someone opens a pull request.
+*                           @jasonbahl
+
+# WPGraphQL IDE — @josephfusco is requested for review on any
+# change inside the plugin directory.
+/plugins/wp-graphql-ide/    @josephfusco

--- a/plugins/wp-graphql-ide/includes/AdminUI.php
+++ b/plugins/wp-graphql-ide/includes/AdminUI.php
@@ -269,6 +269,33 @@ class AdminUI {
 	}
 
 	/**
+	 * Adds Docs and Support row-meta links to the plugin listing on the Plugins screen.
+	 *
+	 * @param array<int, string> $links The existing row-meta links.
+	 * @param string             $file  The plugin file path being filtered.
+	 * @return array<int, string> The modified row-meta links.
+	 */
+	public static function add_plugin_row_meta( array $links, string $file ): array {
+		if ( plugin_basename( WPGRAPHQL_IDE_PLUGIN_FILE ) !== $file ) {
+			return $links;
+		}
+
+		$links[] = sprintf(
+			'<a href="%s" target="_blank" rel="noopener noreferrer">%s</a>',
+			esc_url( 'https://github.com/wp-graphql/wp-graphql/tree/main/plugins/wp-graphql-ide/docs' ),
+			esc_html__( 'Docs', 'wpgraphql-ide' )
+		);
+
+		$links[] = sprintf(
+			'<a href="%s" target="_blank" rel="noopener noreferrer">%s</a>',
+			esc_url( 'https://github.com/wp-graphql/wp-graphql/issues' ),
+			esc_html__( 'Support', 'wpgraphql-ide' )
+		);
+
+		return $links;
+	}
+
+	/**
 	 * Returns the WPGraphQL elephant mark, used by the admin bar entry's
 	 * `:before` mask. The mask renders the SVG's alpha shape — fills are
 	 * ignored — so we can use core wp-graphql's `wpgraphql-elephant.svg`

--- a/plugins/wp-graphql-ide/wpgraphql-ide.php
+++ b/plugins/wp-graphql-ide/wpgraphql-ide.php
@@ -1,10 +1,11 @@
 <?php
 /**
  * Plugin Name:       WPGraphQL IDE
+ * Plugin URI:        https://wordpress.org/plugins/wpgraphql-ide/
  * Description:       A next-gen query editor for WPGraphQL.
- * Author:            WPGraphQL, Joseph Fusco
- * Author URI:        https://github.com/josephfusco
- * GitHub Plugin URI: https://github.com/wp-graphql/wpgraphql-ide
+ * Author:            WPGraphQL
+ * Author URI:        https://www.wpgraphql.com
+ * GitHub Plugin URI: https://github.com/wp-graphql/wp-graphql
  * License:           GPL-3
  * License URI:       https://www.gnu.org/licenses/gpl-3.0.html
  * Text Domain:       wpgraphql-ide
@@ -128,6 +129,7 @@ function initialize_plugin() {
 	add_filter( 'graphql_setting_field_config', [ \WPGraphQLIDE\SettingsPage::class, 'rewrite_legacy_graphiql_link' ], 10, 3 );
 	add_filter( 'graphql_get_setting_section_field_value', [ \WPGraphQLIDE\SettingsPage::class, 'force_legacy_graphiql_off' ], 10, 5 );
 	add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), [ \WPGraphQLIDE\AdminUI::class, 'add_settings_link' ] );
+	add_filter( 'plugin_row_meta', [ \WPGraphQLIDE\AdminUI::class, 'add_plugin_row_meta' ], 10, 2 );
 
 	// Scope REST queries to the current user's own documents.
 	// `graphql_document` is Smart Cache's saved-document post type — the


### PR DESCRIPTION
Closes #3816.

The IDE's plugin header pointed at links from before it moved into the monorepo — `Author URI` went to a personal GitHub profile and `GitHub Plugin URI` went to the archived `wp-graphql/wpgraphql-ide` repo. Repoints both, adds a standard `Plugin URI` for the WP.org listing, and adds Docs + Support row-meta so the Plugins screen surfaces current destinations.

Also adds a `CODEOWNERS` file so IDE changes auto-request review from @josephfusco, with @jasonbahl as the default owner for everything else.

## Test plan
- [x] Plugins screen: `Visit plugin site` → `wordpress.org/plugins/wpgraphql-ide/`; author → `wpgraphql.com`
- [x] Row meta shows `Docs` and `Support`, each opening in a new tab
- [x] Existing `Settings` action link still appears
- [x] Opening a PR that touches `plugins/wp-graphql-ide/` auto-requests review from @josephfusco