### PR TITLE
fix: support WordPress 7.0 in the integration test matrix

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -158,7 +158,7 @@ jobs:
   # certainly pass for versions in between.
   #
   # - 4 coverage jobs: Latest WP/PHP with all theme × multisite combos
-  # - 3 boundary jobs: Current stable, mid-range, oldest supported
+  # - 3 boundary jobs: Previous stable, mid-range, oldest supported
   # - 1 experimental: WordPress trunk (allowed to fail)
   #
   # Update this matrix when new WP/PHP versions are released:
@@ -166,13 +166,13 @@ jobs:
   # - PHP support: https://www.php.net/supported-versions.php
   # - WP PHP requirements: https://make.wordpress.org/core/handbook/references/php-compatibility-and-target-versions/
   #
-  # Last updated: 2026-01-21
+  # Last updated: 2026-06-18
   # ===========================================
 
   # Job naming strategy:
   # - Parent job name: "Integration: plugin / WP X.X / PHP X.X"
   # - Child job name: "theme (modifiers)" (from reusable workflow)
-  # - Full name in branch protection: "Integration: wp-graphql / WP 6.9 / PHP 8.4 / twentytwentyfive 📊"
+  # - Full name in branch protection: "Integration: wp-graphql / WP 7.0 / PHP 8.4 / twentytwentyfive 📊"
   wp-graphql:
     name: 'Integration: ${{ matrix.name }}'
     needs: detect-changes
@@ -186,34 +186,34 @@ jobs:
       matrix:
         include:
           # Coverage jobs: Latest WP/PHP with all theme × multisite combinations
-          - name: 'wp-graphql / WP 6.9 / PHP 8.4'
+          - name: 'wp-graphql / WP 7.0 / PHP 8.4'
             php: '8.4'
-            wp: '6.9'
+            wp: '7.0'
             theme: twentytwentyfive
             multisite: false
             coverage: true
-          - name: 'wp-graphql / WP 6.9 / PHP 8.4'
+          - name: 'wp-graphql / WP 7.0 / PHP 8.4'
             php: '8.4'
-            wp: '6.9'
+            wp: '7.0'
             theme: twentytwentyfive
             multisite: true
             coverage: true
-          - name: 'wp-graphql / WP 6.9 / PHP 8.4'
+          - name: 'wp-graphql / WP 7.0 / PHP 8.4'
             php: '8.4'
-            wp: '6.9'
+            wp: '7.0'
             theme: twentytwentyone
             multisite: false
             coverage: true
-          - name: 'wp-graphql / WP 6.9 / PHP 8.4'
+          - name: 'wp-graphql / WP 7.0 / PHP 8.4'
             php: '8.4'
-            wp: '6.9'
+            wp: '7.0'
             theme: twentytwentyone
             multisite: true
             coverage: true
-          # Boundary: Current stable
-          - name: 'wp-graphql / WP 6.8 / PHP 8.3'
+          # Boundary: Previous stable
+          - name: 'wp-graphql / WP 6.9 / PHP 8.3'
             php: '8.3'
-            wp: '6.8'
+            wp: '6.9'
             theme: twentytwentyfive
             multisite: false
             coverage: false
@@ -273,16 +273,16 @@ jobs:
       matrix:
         include:
           # Coverage job: Latest WP/PHP
-          - name: 'wp-graphql-smart-cache / WP 6.9 / PHP 8.4'
+          - name: 'wp-graphql-smart-cache / WP 7.0 / PHP 8.4'
             php: '8.4'
-            wp: '6.9'
+            wp: '7.0'
             theme: twentytwentyfive
             multisite: false
             coverage: true
-          # Boundary: Current stable
-          - name: 'wp-graphql-smart-cache / WP 6.8 / PHP 8.3'
+          # Boundary: Previous stable
+          - name: 'wp-graphql-smart-cache / WP 6.9 / PHP 8.3'
             php: '8.3'
-            wp: '6.8'
+            wp: '6.9'
             theme: twentytwentyfive
             multisite: false
             coverage: false
@@ -401,7 +401,7 @@ jobs:
         id: set-matrix
         run: |
           FULL_MATRIX='{"include":[
-            {"name":"wp-graphql-acf / WP 6.9 / PHP 8.4 / ACF Pro + ACF Extended Pro","php":"8.4","wp":"6.9","theme":"twentytwentyfive","multisite":false,"coverage":true,"acf_pro":true,"acf_extended":true,"acf_extended_pro":true,"experimental":false},
+            {"name":"wp-graphql-acf / WP 7.0 / PHP 8.4 / ACF Pro + ACF Extended Pro","php":"8.4","wp":"7.0","theme":"twentytwentyfive","multisite":false,"coverage":true,"acf_pro":true,"acf_extended":true,"acf_extended_pro":true,"experimental":false},
             {"name":"wp-graphql-acf / WP 6.8 / PHP 8.3 / ACF Free","php":"8.3","wp":"6.8","theme":"twentytwentyfive","multisite":false,"coverage":false,"acf_pro":false,"acf_extended":false,"acf_extended_pro":false,"experimental":false},
             {"name":"wp-graphql-acf / WP 6.8 / PHP 8.3 / ACF Pro","php":"8.3","wp":"6.8","theme":"twentytwentyfive","multisite":false,"coverage":false,"acf_pro":true,"acf_extended":false,"acf_extended_pro":false,"experimental":false},
             {"name":"wp-graphql-acf / WP 6.8 / PHP 8.3 / ACF Free + ACF Extended Free","php":"8.3","wp":"6.8","theme":"twentytwentyfive","multisite":false,"coverage":false,"acf_pro":false,"acf_extended":true,"acf_extended_pro":false,"experimental":false},

--- a/plugins/wp-graphql-acf/readme.txt
+++ b/plugins/wp-graphql-acf/readme.txt
@@ -2,7 +2,7 @@
 Contributors: jasonbahl
 Tags: GraphQL, ACF, API, NextJS, Headless
 Requires at least: 5.9
-Tested up to: 6.5
+Tested up to: 7.0
 Requires PHP: 7.3
 Stable tag: 2.6.3
 License: GPL-3

--- a/plugins/wp-graphql-acf/wpgraphql-acf.php
+++ b/plugins/wp-graphql-acf/wpgraphql-acf.php
@@ -8,7 +8,7 @@
  * Text Domain: wpgraphql-acf
  * Requires PHP: 7.3
  * Requires at least: 5.9
- * Tested up to: 6.5
+ * Tested up to: 7.0
  * License: GPL-3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  * Requires Plugins: wp-graphql

--- a/plugins/wp-graphql-smart-cache/readme.txt
+++ b/plugins/wp-graphql-smart-cache/readme.txt
@@ -2,7 +2,7 @@
 Contributors: jasonbahl, markkelnar
 Tags: WPGraphQL, Cache, API, Persisted Queries, Performance
 Requires at least: 5.6
-Tested up to: 6.9
+Tested up to: 7.0
 Requires PHP: 7.4
 Stable tag: 2.2.1
 Requires WPGraphQL: 2.0.0

--- a/plugins/wp-graphql-smart-cache/wp-graphql-smart-cache.php
+++ b/plugins/wp-graphql-smart-cache/wp-graphql-smart-cache.php
@@ -7,7 +7,7 @@
  * Author: WPGraphQL
  * Author URI: http://www.wpgraphql.com
  * Requires at least: 6.0
- * Tested up to: 6.9
+ * Tested up to: 7.0
  * Requires PHP: 7.4
  * Requires WPGraphQL: 2.0.0
  * WPGraphQL Tested Up To: 2.0.0

--- a/plugins/wp-graphql/readme.txt
+++ b/plugins/wp-graphql/readme.txt
@@ -2,7 +2,7 @@
 Contributors: jasonbahl, tylerbarnes1, ryankanner, chopinbach, kidunot89, justlevine
 Tags: GraphQL, Headless, REST API, Decoupled, React
 Requires at least: 6.0
-Tested up to: 6.9
+Tested up to: 7.0
 Requires PHP: 7.4
 Stable tag: 2.16.0
 License: GPL-3

--- a/plugins/wp-graphql/tests/wpunit/I18nTest.php
+++ b/plugins/wp-graphql/tests/wpunit/I18nTest.php
@@ -21,6 +21,19 @@ class I18nTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 			$this->setExpectedIncorrectUsage( 'WP_Block_Bindings_Registry::register' );
 		}
 
+		// WordPress 7.0 ships the core/breadcrumbs block, which the test
+		// bootstrap registers a second time during `init`, producing a
+		// "Block type ... is already registered" incorrect usage notice for
+		// WP_Block_Type_Registry::register. It is unrelated to WPGraphQL i18n,
+		// so declare it as expected on WordPress 7.0+. We scope this narrowly to
+		// this single notice (rather than suppressing all incorrect usage) so the
+		// trunk integration job still surfaces any *other* incorrect-usage notice
+		// a future WordPress release might introduce. Must run before
+		// parent::setUp() because the notice fires during WordPress initialization.
+		if ( version_compare( $GLOBALS['wp_version'], '7.0', '>=' ) ) {
+			$this->setExpectedIncorrectUsage( 'WP_Block_Type_Registry::register' );
+		}
+
 		// Suppress doing_it_wrong notices before parent::setUp() to catch theme notices early.
 		//
 		// This prevents false failures from theme-related notices that are unrelated to

--- a/plugins/wp-graphql/tests/wpunit/UserObjectQueriesTest.php
+++ b/plugins/wp-graphql/tests/wpunit/UserObjectQueriesTest.php
@@ -1104,8 +1104,14 @@ class UserObjectQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase 
 		$actual = $this->graphql( compact( 'query' ) );
 
 		$this->assertArrayNotHasKey( 'errors', $actual );
-		// Default admin color in WordPress is 'fresh'
-		$this->assertEquals( 'fresh', $actual['data']['user']['adminColor'] );
+		// Derive the expected admin color the same way the resolver does
+		// ( WPGraphQL\Model\User: get_user_option( 'admin_color' ) with a 'fresh'
+		// fallback ) instead of hardcoding it. WordPress 7.0 changed the default
+		// scheme from 'fresh' to 'modern', and hardcoding made this assertion
+		// brittle across WordPress versions.
+		$expected_admin_color = get_user_option( 'admin_color', $user_id );
+		$expected_admin_color = ! empty( $expected_admin_color ) ? $expected_admin_color : 'fresh';
+		$this->assertEquals( $expected_admin_color, $actual['data']['user']['adminColor'] );
 		// Rich editing defaults to enabled
 		$this->assertTrue( $actual['data']['user']['hasRichEditingEnabled'] );
 		// Syntax highlighting defaults to enabled

--- a/plugins/wp-graphql/wp-graphql.php
+++ b/plugins/wp-graphql/wp-graphql.php
@@ -9,7 +9,7 @@
  * Text Domain: wp-graphql
  * Domain Path: /languages/
  * Requires at least: 6.0
- * Tested up to: 6.9
+ * Tested up to: 7.0
  * Requires PHP: 7.4
  * License: GPL-3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
## What

WordPress 7.0 has been released. This promotes it from the experimental "trunk" slot to the **stable coverage tier** in the integration test matrix (core, Smart Cache, and ACF; the IDE was already on 7.0), and fixes the two WP 7.0 changes that were making the trunk integration job fail on every PR.

## Why

The "Integration: wp-graphql / WP trunk / PHP 8.4" job failed on every PR. It's `experimental: true` (`continue-on-error`), so it never blocked merges, but because it was *permanently* red it gave us no signal: a genuinely new trunk regression would have been invisible behind the same 10 known failures. Now that 7.0 is a required row, these failures had to be fixed or they'd start blocking merges.

Both failures were real WP 7.0 changes, reproduced locally against WP 7.0:

### 1. Default admin color scheme changed `fresh` → `modern`
`UserObjectQueriesTest::testUserAdminPreferencesDefaultValues` hardcoded `'fresh'`. It now derives the expected value the same way the resolver does (`get_user_option('admin_color')` with a `'fresh'` fallback, per `WPGraphQL\Model\User`), so the assertion is no longer brittle across WordPress versions.

### 2. New `core/breadcrumbs` block double-registers in the test bootstrap
WP 7.0 ships the `core/breadcrumbs` block, which the test bootstrap registers twice, emitting a `WP_Block_Type_Registry::register` "already registered" incorrect-usage notice that failed all 9 `I18nTest` cases. The fix declares **that single notice** as expected on WP 7.0+ (version-guarded so the 6.x boundary rows stay clean). It's scoped narrowly on purpose, so the trunk job still surfaces any *other* incorrect-usage notice a future WordPress release introduces.

## Matrix changes

| Plugin | Coverage | Previous-stable boundary | Oldest | Experimental |
|---|---|---|---|---|
| wp-graphql | **7.0** / 8.4 (×4 theme × multisite) | 6.9 / 8.3 | 6.1 / 7.4 | trunk |
| smart-cache | **7.0** / 8.4 | 6.9 / 8.3 | 6.1 / 7.4 | trunk |
| acf | **7.0** / 8.4 (Pro + Ext Pro) | 6.8 rows | 6.2 / 7.4 | trunk |

The PHP version ladder (8.4 / 8.3 / 8.1 / 7.4) is preserved. Trunk stays experimental, now tracking 7.1-dev.

## "Tested up to" headers

Bumped to `7.0` in core, Smart Cache, and ACF (ACF was a stale `6.5`), in both the plugin header and `readme.txt`. The IDE was already at 7.0.

## Testing

Verified locally against WordPress 7.0:

- `I18nTest` — OK (9 tests, 34 assertions)
- `UserObjectQueriesTest::testUserAdminPreferencesDefaultValues` — OK (1 test, 5 assertions)

ACF's 7.0 coverage is additionally backed by its already-passing trunk job (trunk ⊇ 7.0 changes).