### PR TITLE
ci: speed up the integration test workflow

### DIFF
--- a/.github/workflows/cleanup-pr-caches.yml
+++ b/.github/workflows/cleanup-pr-caches.yml
@@ -1,0 +1,54 @@
+name: Cleanup PR caches
+
+# When a pull request is closed (merged or not), delete the GitHub Actions
+# caches it created. Caches from a PR run are scoped to refs/pull/<number>/merge
+# and otherwise linger until GitHub LRU-evicts them.
+#
+# The integration test suite is cache-heavy (composer, npm, Playwright) and the
+# repo's 10GB Actions cache budget was thrashing — once over the limit, GitHub
+# evicts least-recently-used caches, which meant the caches that actually speed
+# jobs up kept getting dropped. Proactively reclaiming closed-PR caches keeps the
+# useful base-branch caches hot.
+
+on:
+  pull_request:
+    types:
+      - closed
+
+permissions:
+  contents: read
+
+jobs:
+  cleanup:
+    name: Delete caches for closed PR
+    runs-on: ubuntu-latest
+    permissions:
+      # Required to delete Actions caches via the API.
+      actions: write
+      contents: read
+    steps:
+      - name: Delete caches for this PR's ref
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_REF: refs/pull/${{ github.event.pull_request.number }}/merge
+        run: |
+          gh extension install actions/gh-actions-cache || true
+
+          echo "Fetching caches for $PR_REF ..."
+          cache_keys=$(gh actions-cache list -R "$GH_REPO" -B "$PR_REF" --limit 100 | cut -f1)
+
+          if [ -z "$cache_keys" ]; then
+            echo "No caches found for $PR_REF — nothing to clean up."
+            exit 0
+          fi
+
+          echo "Deleting $(echo "$cache_keys" | wc -l | tr -d ' ') cache(s) for $PR_REF:"
+          # Best-effort: don't abort the whole job if a single delete fails
+          # (e.g. the cache was already evicted between list and delete).
+          set +e
+          for key in $cache_keys; do
+            echo "  - $key"
+            gh actions-cache delete "$key" -R "$GH_REPO" -B "$PR_REF" --confirm
+          done
+          echo "Cache cleanup complete."

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -176,16 +176,21 @@ jobs:
         with:
           timeout_minutes: 10
           max_attempts: 3
-          command: npm ci
+          command: npm ci --prefer-offline --no-audit --no-fund
 
+      # Build only the plugin under test (and its workspace deps) rather than
+      # every plugin in the monorepo. Smart Cache and ACF have no JS build, so
+      # their jobs build nothing; core's built assets are file_exists-guarded
+      # (see Admin/GraphiQL, Admin/Extensions), so dependent-plugin jobs that
+      # load core don't need it built.
       - name: Build JavaScript assets
-        run: npm run build -- --filter='./plugins/*'
+        run: npm run build -- --filter='@wpgraphql/${{ inputs.plugin_name }}...'
 
-      - name: Cache Docker images
-        uses: ScribeMD/docker-cache@0.5.0
-        with:
-          key: docker-${{ runner.os }}-${{ inputs.php }}-${{ inputs.wp }}
-
+      # Note: we intentionally do NOT cache the wp-env Docker images. The repo's
+      # 10GB Actions cache budget is consumed by composer/npm/Playwright caches,
+      # so the multi-GB image caches were always evicted before the next run —
+      # every run missed the cache yet still paid ~30s saving it. wp-env pulls
+      # the images directly, which is no slower than restoring an image tarball.
       - name: Start the Docker testing environment
         uses: nick-fields/retry@v4
         with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -185,7 +185,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Coverage jobs: Latest WP/PHP with all theme × multisite combinations
+          # Latest WP/PHP across all theme × multisite combinations. PCOV adds
+          # ~80s to the WPUnit run, and line coverage barely differs across
+          # theme/multisite, so we collect coverage on ONE representative job
+          # (twentytwentyfive, single-site) and run the other three as plain
+          # test jobs.
           - name: 'wp-graphql / WP 7.0 / PHP 8.4'
             php: '8.4'
             wp: '7.0'
@@ -197,19 +201,19 @@ jobs:
             wp: '7.0'
             theme: twentytwentyfive
             multisite: true
-            coverage: true
+            coverage: false
           - name: 'wp-graphql / WP 7.0 / PHP 8.4'
             php: '8.4'
             wp: '7.0'
             theme: twentytwentyone
             multisite: false
-            coverage: true
+            coverage: false
           - name: 'wp-graphql / WP 7.0 / PHP 8.4'
             php: '8.4'
             wp: '7.0'
             theme: twentytwentyone
             multisite: true
-            coverage: true
+            coverage: false
           # Boundary: Previous stable
           - name: 'wp-graphql / WP 6.9 / PHP 8.3'
             php: '8.3'


### PR DESCRIPTION
## What

Trims removable overhead from the integration test matrix. Four independent changes, each backed by timing/cache data from a recent run.

## Why

A coverage job runs ~7.5 min. Per-step measurement:

| Step | Coverage job | Boundary job |
|---|---|---|
| WPUnit tests | 173s (PCOV) | 94s |
| Start Docker env | 102s | 94s |
| npm ci | 46s | 54s |
| Build JS (all plugins) | 41s | 42s |
| **Post Cache Docker images** | **39s** | 24s |

Some of this is the inherent floor (wp-env boot ~90s, WPUnit ~95s of real work). The rest is removable.

## Changes

### 1. Drop the wp-env Docker image cache (`ScribeMD/docker-cache`)
The repo's **Actions cache is at 10.9 GB, over GitHub's 10 GB limit**, so caches are LRU-evicted. I verified directly: **0 `docker-*` caches survive** — they're evicted before the next run reads them. So every job spent ~24-39s *saving* an image cache that was never restored, while `Start Docker env` pulled images fresh anyway. Removing it is pure savings and frees budget that was evicting the composer/npm caches that *do* help.

### 2. Add `cleanup-pr-caches` workflow
Deletes a PR's caches when it closes (caches are scoped to `refs/pull/<n>/merge` and otherwise linger until eviction). Keeps the 10 GB budget from thrashing so the base-branch composer/npm caches stay hot.

### 3. Collect PCOV coverage on one core job, not four
PCOV adds ~80s to the WPUnit run (173s vs 94s), and line coverage barely differs across theme/multisite. All four jobs still run to exercise theme × multisite; only the `twentytwentyfive` single-site job collects coverage now. Saves ~80s on three core jobs per run.

### 4. Build only the plugin under test
`--filter='@wpgraphql/<plugin>...'` instead of `./plugins/*`. Smart Cache and ACF have no JS build, so their jobs now build nothing; core's built assets are `file_exists`-guarded (`Admin/GraphiQL`, `Admin/Extensions`), so dependent-plugin jobs that load core don't need it built. Core/IDE jobs still build their own (and internal deps).

Also a minor `npm ci --prefer-offline --no-audit --no-fund`.

## Expected impact
Coverage jobs ~7.5 → ~5 min, boundary jobs ~6 → ~5 min, plus a healthier cache budget. CI-only change; no plugin code is touched.

## Note
Overlaps with #3960 (WP 7.0 matrix) on the core coverage rows. Whichever merges second will need a trivial rebase (keep WP 7.0 from #3960 + the per-row `coverage` flags from this PR).