### PR TITLE
ci: probe wp-env readiness after start to fix intermittent "Environment not initialized"

### DIFF
--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -104,6 +104,16 @@ jobs:
     env:
       WP_ENV_PHP_VERSION: ${{ inputs.php }}
       WP_ENV_CORE: ${{ inputs.wp == 'trunk' && 'WordPress/WordPress' || format('https://wordpress.org/wordpress-{0}.zip', inputs.wp) }}
+      # Pin wp-env's home to a fixed absolute path for the whole job. By default
+      # @wordpress/env derives this per-invocation: `~/wp-env` when `/snap`
+      # exists, else `~/.wp-env` (see @wordpress/env's get-cache-directory.js,
+      # which does a live `fs.stat('/snap')` on every command). On GitHub runners
+      # that check can resolve inconsistently between the `start` step and a later
+      # `run` step, so they point at different instance directories and `run`
+      # fails intermittently with "Environment not initialized. Run `wp-env start`
+      # first." (a fresh job re-run clears it). Pinning WP_ENV_HOME removes that
+      # branch so every step in the job resolves the same instance.
+      WP_ENV_HOME: ${{ runner.temp }}/wp-env
 
     steps:
       - name: Configure environment variables
@@ -199,24 +209,10 @@ jobs:
           command: |
             ${{ inputs.coverage && github.actor != 'dependabot[bot]' && 'PCOV_ENABLED=1 ' || '' }}npm run wp-env start -- ${{ secrets.ACTIONS_STEP_DEBUG && '--debug' || '' }}
 
-      # `wp-env start` can report success a beat before the instance is fully
-      # queryable, so the first `wp-env run` after it intermittently fails with
-      # "Environment not initialized. Run `wp-env start` first." A manual job
-      # re-run "fixes" it, which is the tell-tale sign of a start/run race rather
-      # than a real problem. Retry to absorb the race in-job. This is also the
-      # first command to touch each environment after start, so it doubles as a
-      # readiness gate for the test steps below (it exercises both the dev `cli`
-      # and the `tests-cli` the suite actually uses).
-      - name: Log versions (waits for wp-env to be ready)
-        uses: nick-fields/retry@v4
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          retry_wait_seconds: 10
-          command: |
-            npm run wp-env -- run cli php -- -v
-            npm run wp-env -- run cli wp core version
-            npm run wp-env -- run tests-cli wp core version
+      - name: Log versions
+        run: |
+          npm run wp-env -- run cli php -- -v
+          npm run wp-env -- run cli wp core version
 
       - name: Activate test theme
         run: |

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -104,22 +104,24 @@ jobs:
     env:
       WP_ENV_PHP_VERSION: ${{ inputs.php }}
       WP_ENV_CORE: ${{ inputs.wp == 'trunk' && 'WordPress/WordPress' || format('https://wordpress.org/wordpress-{0}.zip', inputs.wp) }}
-      # Pin wp-env's home to a fixed absolute path for the whole job. By default
-      # @wordpress/env derives this per-invocation: `~/wp-env` when `/snap`
-      # exists, else `~/.wp-env` (see @wordpress/env's get-cache-directory.js,
-      # which does a live `fs.stat('/snap')` on every command). On GitHub runners
-      # that check can resolve inconsistently between the `start` step and a later
-      # `run` step, so they point at different instance directories and `run`
-      # fails intermittently with "Environment not initialized. Run `wp-env start`
-      # first." (a fresh job re-run clears it). Pinning WP_ENV_HOME removes that
-      # branch so every step in the job resolves the same instance.
-      WP_ENV_HOME: ${{ runner.temp }}/wp-env
 
     steps:
       - name: Configure environment variables
         run: |
           echo "PHP_FPM_UID=$(id -u)" >> "$GITHUB_ENV"
           echo "PHP_FPM_GID=$(id -g)" >> "$GITHUB_ENV"
+          # Pin wp-env's home to a fixed absolute path for the whole job. By
+          # default @wordpress/env derives this per-invocation: `~/wp-env` when
+          # `/snap` exists, else `~/.wp-env` (see get-cache-directory.js, which
+          # does a live `fs.stat('/snap')` on every command). On GitHub runners
+          # that check can resolve inconsistently between the `start` step and a
+          # later `run` step, so they point at different instance directories and
+          # `run` fails intermittently with "Environment not initialized. Run
+          # `wp-env start` first." (a fresh job re-run clears it). Pinning
+          # WP_ENV_HOME removes that branch so every step resolves the same
+          # instance. (Set here via $GITHUB_ENV because the `runner` context is
+          # not available in a job-level `env:` block.)
+          echo "WP_ENV_HOME=${RUNNER_TEMP}/wp-env" >> "$GITHUB_ENV"
 
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -110,18 +110,6 @@ jobs:
         run: |
           echo "PHP_FPM_UID=$(id -u)" >> "$GITHUB_ENV"
           echo "PHP_FPM_GID=$(id -g)" >> "$GITHUB_ENV"
-          # Pin wp-env's home to a fixed absolute path for the whole job. By
-          # default @wordpress/env derives this per-invocation: `~/wp-env` when
-          # `/snap` exists, else `~/.wp-env` (see get-cache-directory.js, which
-          # does a live `fs.stat('/snap')` on every command). On GitHub runners
-          # that check can resolve inconsistently between the `start` step and a
-          # later `run` step, so they point at different instance directories and
-          # `run` fails intermittently with "Environment not initialized. Run
-          # `wp-env start` first." (a fresh job re-run clears it). Pinning
-          # WP_ENV_HOME removes that branch so every step resolves the same
-          # instance. (Set here via $GITHUB_ENV because the `runner` context is
-          # not available in a job-level `env:` block.)
-          echo "WP_ENV_HOME=${RUNNER_TEMP}/wp-env" >> "$GITHUB_ENV"
 
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -220,8 +208,11 @@ jobs:
             # diagnosable from the logs.
             if ! npm run wp-env -- run tests-cli wp core version; then
               echo "::warning::wp-env reported a successful start but is not initialized; dumping state and retrying start"
-              echo "WP_ENV_HOME=${WP_ENV_HOME:-<unset>}"
-              ls -la "${WP_ENV_HOME:-$HOME/.wp-env}" 2>/dev/null || true
+              # wp-env's home defaults to ~/wp-env on snap runners, else ~/.wp-env
+              # (or $WP_ENV_HOME when set). Dump whichever exists for diagnosis.
+              for d in "$WP_ENV_HOME" "$HOME/wp-env" "$HOME/.wp-env"; do
+                [ -n "$d" ] && [ -d "$d" ] && { echo "== $d =="; ls -la "$d"; }
+              done
               exit 1
             fi
 

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -194,10 +194,24 @@ jobs:
           command: |
             ${{ inputs.coverage && github.actor != 'dependabot[bot]' && 'PCOV_ENABLED=1 ' || '' }}npm run wp-env start -- ${{ secrets.ACTIONS_STEP_DEBUG && '--debug' || '' }}
 
-      - name: Log versions
-        run: |
-          npm run wp-env -- run cli php -- -v
-          npm run wp-env -- run cli wp core version
+      # `wp-env start` can report success a beat before the instance is fully
+      # queryable, so the first `wp-env run` after it intermittently fails with
+      # "Environment not initialized. Run `wp-env start` first." A manual job
+      # re-run "fixes" it, which is the tell-tale sign of a start/run race rather
+      # than a real problem. Retry to absorb the race in-job. This is also the
+      # first command to touch each environment after start, so it doubles as a
+      # readiness gate for the test steps below (it exercises both the dev `cli`
+      # and the `tests-cli` the suite actually uses).
+      - name: Log versions (waits for wp-env to be ready)
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          retry_wait_seconds: 10
+          command: |
+            npm run wp-env -- run cli php -- -v
+            npm run wp-env -- run cli wp core version
+            npm run wp-env -- run tests-cli wp core version
 
       - name: Activate test theme
         run: |

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -206,10 +206,24 @@ jobs:
       - name: Start the Docker testing environment
         uses: nick-fields/retry@v4
         with:
-          timeout_minutes: 10
+          timeout_minutes: 15
           max_attempts: 3
           command: |
             ${{ inputs.coverage && github.actor != 'dependabot[bot]' && 'PCOV_ENABLED=1 ' || '' }}npm run wp-env start -- ${{ secrets.ACTIONS_STEP_DEBUG && '--debug' || '' }}
+            # wp-env intermittently reports a successful start but leaves the
+            # instance uninitialized: the next `wp-env run` then fails with
+            # "Environment not initialized. Run `wp-env start` first." for the
+            # rest of the job, and only a fresh start clears it. Probe readiness
+            # here so a bad start fails THIS step and retries `wp-env start`
+            # (which re-creates the instance) instead of poisoning every step
+            # below. On failure, dump the wp-env home so a recurrence is
+            # diagnosable from the logs.
+            if ! npm run wp-env -- run tests-cli wp core version; then
+              echo "::warning::wp-env reported a successful start but is not initialized; dumping state and retrying start"
+              echo "WP_ENV_HOME=${WP_ENV_HOME:-<unset>}"
+              ls -la "${WP_ENV_HOME:-$HOME/.wp-env}" 2>/dev/null || true
+              exit 1
+            fi
 
       - name: Log versions
         run: |


### PR DESCRIPTION
## What

Makes `wp-env start` reliable in CI by **probing readiness right after start and retrying `start` if the instance isn't actually initialized**.

## The bug

Integration jobs intermittently fail right after **Start the Docker testing environment** with `✖ Environment not initialized. Run \`wp-env start\` first.` — `start` reports success and brings the sites up, but the next `wp-env run` can't use the instance, it persists for the whole job, and only a fresh start clears it.

Diagnostics confirmed the mechanism: `run` needs `WP_ENV_HOME/md5(configPath)` to exist; after a bad start that work dir is missing, and a second `start` creates it. Retrying `run` never helps (only `start` writes it); retrying `start` does.

## Fix

Inside the start step (already wrapped in `nick-fields/retry`), after `wp-env start` run a cheap readiness probe (`wp-env run tests-cli wp core version`). If it fails, dump the wp-env home for diagnosis and exit non-zero so the step **retries `wp-env start`** (which re-creates the instance) instead of a bad start poisoning every downstream step. Timeout bumped 10m → 15m to allow a re-start.

## Validation + what we learned

A run with this fix was **green on all 22 jobs on the first attempt** (no manual re-run). But the probe fired in **15/22 jobs** — far above the ~1/22 visible failure rate before any of this work.

An earlier iteration of this PR also pinned `WP_ENV_HOME` (on a since-disproven cache-dir theory). The probe only *measures* the half-init rate; it can't cause it — so the pin, which changed *where* wp-env writes and never actually fixed the failures, was the prime suspect for inflating 15/22. **This PR drops the pin** and keeps the probe as both the green-keeping safety net and the measurement instrument:
- if the fire rate falls back toward ~1/22 on upcoming runs, the pin was the aggravator;
- if it stays high, the half-init is inherent to `wp-env start` and the cheap retry handles it regardless.

## Honest status

Intermittent CI-runner behavior I can't reproduce locally; the real confirmation is the fire rate across upcoming runs (now observable from the probe). [Gutenberg's CI](https://github.com/WordPress/gutenberg/blob/trunk/.github/workflows/unit-test.yml) uses the same start/run-in-separate-steps pattern, so the pattern isn't at fault. CI-only change; no plugin code touched.
