### PR TITLE
feat: add hour, minute, and second to DateInput for sub-day date filtering

### DIFF
--- a/plugins/wp-graphql/src/Type/Input/DateInput.php
+++ b/plugins/wp-graphql/src/Type/Input/DateInput.php
@@ -17,22 +17,40 @@ class DateInput {
 				},
 				'fields'      => static function () {
 					return [
-						'year'  => [
+						'year'   => [
 							'type'        => 'Int',
 							'description' => static function () {
 								return __( '4 digit year (e.g. 2017)', 'wp-graphql' );
 							},
 						],
-						'month' => [
+						'month'  => [
 							'type'        => 'Int',
 							'description' => static function () {
 								return __( 'Month number (from 1 to 12)', 'wp-graphql' );
 							},
 						],
-						'day'   => [
+						'day'    => [
 							'type'        => 'Int',
 							'description' => static function () {
 								return __( 'Day of the month (from 1 to 31)', 'wp-graphql' );
+							},
+						],
+						'hour'   => [
+							'type'        => 'Int',
+							'description' => static function () {
+								return __( 'Hour of the day (from 0 to 23)', 'wp-graphql' );
+							},
+						],
+						'minute' => [
+							'type'        => 'Int',
+							'description' => static function () {
+								return __( 'Minute of the hour (from 0 to 59)', 'wp-graphql' );
+							},
+						],
+						'second' => [
+							'type'        => 'Int',
+							'description' => static function () {
+								return __( 'Second of the minute (from 0 to 59)', 'wp-graphql' );
 							},
 						],
 					];

--- a/plugins/wp-graphql/tests/wpunit/PostObjectConnectionQueriesTest.php
+++ b/plugins/wp-graphql/tests/wpunit/PostObjectConnectionQueriesTest.php
@@ -197,6 +197,68 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 		}
 	}
 
+	/**
+	 * The dateQuery before/after bounds should be able to constrain the time of day,
+	 * not just the calendar day. WP_Query's date_query supports hour/minute/second on
+	 * before/after natively, so exposing those fields on DateInput lets clients filter
+	 * sub-day windows.
+	 *
+	 * @see https://github.com/wp-graphql/wp-graphql/issues/1234
+	 */
+	public function testDateQueryAfterFiltersByHour() {
+		// Two posts on the same calendar day, twelve hours apart. Use a fixed past
+		// date so both remain `publish` (a future date would flip to `future`).
+		$early = $this->createPostObject(
+			[
+				'post_title' => 'Early sub-day post',
+				'post_date'  => '2020-01-15 08:30:00',
+			]
+		);
+		$late = $this->createPostObject(
+			[
+				'post_title' => 'Late sub-day post',
+				'post_date'  => '2020-01-15 20:30:00',
+			]
+		);
+
+		$query = '
+		query postsByHour($where:RootQueryToPostConnectionWhereArgs) {
+			posts(first:100 where:$where) {
+				nodes {
+					databaseId
+				}
+			}
+		}
+		';
+
+		$variables = [
+			'where' => [
+				'dateQuery' => [
+					'column' => 'DATE',
+					'after'  => [
+						'year'  => 2020,
+						'month' => 1,
+						'day'   => 15,
+						'hour'  => 12,
+					],
+				],
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual, 'The hour bound should be a valid DateInput field' );
+
+		$returned_ids = wp_list_pluck( $actual['data']['posts']['nodes'], 'databaseId' );
+
+		// The 20:30 post is after the 12:00 bound, the 08:30 post is before it.
+		$this->assertContains( $late, $returned_ids, 'The post published after the hour bound should be returned' );
+		$this->assertNotContains( $early, $returned_ids, 'The post published before the hour bound should be filtered out' );
+
+		wp_delete_post( $early, true );
+		wp_delete_post( $late, true );
+	}
+
 	public function testDefaultQueryAmount() {
 		// Create some additional posts to test a large query.
 		$post_ids = $this->create_posts( 25 );


### PR DESCRIPTION
## What

Adds `hour`, `minute`, and `second` (Int) fields to the `DateInput` type so a `dateQuery`'s `before`/`after` bounds can constrain the time of day, not just the calendar day.

## Why

`DateInput` only exposed `year`, `month`, and `day`. Because `DateQueryInput.before`/`after` are typed as `DateInput`, clients could not narrow a query to a sub-day window, even though `WP_Query`'s `date_query` supports `hour`/`minute`/`second` on `before`/`after` natively. This is a long-standing, heavily requested ask (#1234).

## How

Purely additive on the GraphQL input side. The new fields pass straight through `Utils::map_input` into `WP_Query`'s `date_query`, so there is no resolver or query-cost change. The fields are optional, so existing queries are unaffected.

This is a non-breaking quick win toward the eventual ideal (a proper `DateTime` scalar input, deferred to the filter/sort RFC #1385). The decomposed fields stay optional and do not lock the schema in, so a future `DateTime`-scalar input can supersede `DateInput` cleanly.

## Test

Regression test in `PostObjectConnectionQueriesTest::testDateQueryAfterFiltersByHour`: creates two posts on the same calendar day twelve hours apart, filters with an `after` bound of `hour: 12`, and asserts only the later post is returned. The test fails before the change (the `hour` field is rejected by GraphQL validation) and passes after.

Closes #1234