### PR TITLE
fix: reflect a revision's own featured image in asPreview queries

### DIFF
--- a/plugins/wp-graphql/src/Model/Post.php
+++ b/plugins/wp-graphql/src/Model/Post.php
@@ -542,13 +542,30 @@ class Post extends Model {
 					return $this->html_entity_decode( apply_filters( 'the_excerpt', $excerpt ), 'excerptRendered' );
 				},
 				'featuredImageDatabaseId'   => function () {
-					if ( $this->isRevision ) {
-						$id = $this->parentDatabaseId;
-					} else {
-						$id = $this->data->ID;
+					// For non-revisions, the featured image is simply this post's thumbnail.
+					if ( ! $this->isRevision ) {
+						$thumbnail_id = get_post_thumbnail_id( $this->data->ID );
+
+						return ! empty( $thumbnail_id ) ? absint( $thumbnail_id ) : null;
 					}
 
-					$thumbnail_id = get_post_thumbnail_id( $id );
+					// For revisions (e.g. `asPreview`), prefer the revision's own _thumbnail_id
+					// when it has one, so an in-progress featured image change is reflected in
+					// the preview. The Preview meta filter resolves revision meta from the parent
+					// by default, so opt that single key out to read the revision's own value, and
+					// fall back to the parent's published featured image only when the revision
+					// does not override it.
+					$resolve_own_thumbnail = static function ( $should, $object_id, $meta_key ) {
+						return '_thumbnail_id' === $meta_key ? false : $should;
+					};
+
+					add_filter( 'graphql_resolve_revision_meta_from_parent', $resolve_own_thumbnail, 10, 3 );
+					$thumbnail_id = get_post_meta( $this->data->ID, '_thumbnail_id', true );
+					remove_filter( 'graphql_resolve_revision_meta_from_parent', $resolve_own_thumbnail, 10 );
+
+					if ( empty( $thumbnail_id ) ) {
+						$thumbnail_id = get_post_thumbnail_id( $this->parentDatabaseId );
+					}
 
 					return ! empty( $thumbnail_id ) ? absint( $thumbnail_id ) : null;
 				},

--- a/plugins/wp-graphql/tests/wpunit/PreviewTest.php
+++ b/plugins/wp-graphql/tests/wpunit/PreviewTest.php
@@ -1300,4 +1300,98 @@ class PreviewTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		WPGraphQL::clear_schema();
 	}
+
+	/**
+	 * The featuredImage on a preview should reflect the revision's own featured image
+	 * (an in-progress change), not the parent's published one.
+	 *
+	 * @see https://github.com/wp-graphql/wp-graphql/issues/2664
+	 */
+	public function testFeaturedImageReflectsRevisionOwnThumbnail() {
+		wp_set_current_user( $this->admin );
+
+		// The published post's featured image is $this->featured_image (set in setUp).
+		// Simulate an in-progress featured image change by storing a *different*
+		// _thumbnail_id on the revision itself.
+		$filename       = WPGRAPHQL_PLUGIN_DIR . 'tests/_data/images/test.png';
+		$revision_image = $this->factory()->attachment->create_upload_object( $filename );
+		update_metadata( 'post', $this->preview, '_thumbnail_id', $revision_image );
+
+		$query = '
+		query Preview( $id: ID! ) {
+			post( id: $id, idType: DATABASE_ID, asPreview: true ) {
+				featuredImageDatabaseId
+				featuredImage {
+					node {
+						databaseId
+					}
+				}
+			}
+		}
+		';
+
+		$actual = $this->graphql(
+			[
+				'query'     => $query,
+				'variables' => [ 'id' => $this->post ],
+			]
+		);
+
+		self::assertQuerySuccessful(
+			$actual,
+			[
+				$this->expectedField( 'post.featuredImageDatabaseId', $revision_image ),
+				$this->expectedField( 'post.featuredImage.node.databaseId', $revision_image ),
+			]
+		);
+
+		$this->assertNotEquals(
+			$this->featured_image,
+			$actual['data']['post']['featuredImageDatabaseId'],
+			'The preview must not return the parent post\'s published featured image when the revision overrides it'
+		);
+
+		wp_delete_attachment( $revision_image, true );
+	}
+
+	/**
+	 * When a revision does not override the featured image, the preview should fall back
+	 * to the parent post's published featured image (the fix must be conditional, not a
+	 * blind swap that would drop the featured image on previews that don't change it).
+	 *
+	 * @see https://github.com/wp-graphql/wp-graphql/issues/2664
+	 */
+	public function testFeaturedImageFallsBackToParentWhenRevisionHasNoThumbnail() {
+		wp_set_current_user( $this->admin );
+
+		// $this->preview has no _thumbnail_id of its own, so the preview should resolve
+		// the parent post's published featured image ($this->featured_image).
+		$query = '
+		query Preview( $id: ID! ) {
+			post( id: $id, idType: DATABASE_ID, asPreview: true ) {
+				featuredImageDatabaseId
+				featuredImage {
+					node {
+						databaseId
+					}
+				}
+			}
+		}
+		';
+
+		$actual = $this->graphql(
+			[
+				'query'     => $query,
+				'variables' => [ 'id' => $this->post ],
+			]
+		);
+
+		self::assertQuerySuccessful(
+			$actual,
+			[
+				$this->expectedField( 'post.featuredImageDatabaseId', $this->featured_image ),
+				$this->expectedField( 'post.featuredImage.node.databaseId', $this->featured_image ),
+			]
+		);
+	}
 }


### PR DESCRIPTION
## What

`featuredImageDatabaseId` (and the `featuredImage` connection and `featuredImageId` that derive from it) now resolve a revision's own featured image when querying a post with `asPreview: true`, instead of always returning the parent post's published featured image.

## Why

When previewing an in-progress change (`asPreview: true`), the model resolved the featured image from the parent (published) post unconditionally. So a draft that changed the featured image still showed the old, published image in the preview, even though the title and other fields reflected the draft. Reported in #2664.

## How

For revisions, read the revision's own `_thumbnail_id` first and fall back to the parent's published featured image only when the revision does not override it. The Preview meta filter (`WPGraphQL\Utils\Preview`) resolves revision meta from the parent by default, so this opts the single `_thumbnail_id` key out via the existing `graphql_resolve_revision_meta_from_parent` filter while reading the revision's own value.

The fallback is conditional, not a blind swap: previews that do not change the featured image continue to show the parent's published image, so the common case is unchanged. The non-revision path is untouched.

## Test

Two regression tests in `PreviewTest`:

- `testFeaturedImageReflectsRevisionOwnThumbnail`: the revision stores a different `_thumbnail_id`; the preview must return the revision's image, not the parent's. Fails before the change, passes after.
- `testFeaturedImageFallsBackToParentWhenRevisionHasNoThumbnail`: the revision has no `_thumbnail_id`; the preview must still return the parent's published featured image. Locks in the conditional fallback.

`composer check-cs` and `composer phpstan` (level 8) pass; the full `PreviewTest` suite is green.

Closes #2664