### PR TITLE
chore: add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard-analysis.yml
+++ b/.github/workflows/scorecard-analysis.yml
@@ -1,0 +1,43 @@
+name: Scorecard
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '30 1 * * 6'
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code scanning
+        uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/scorecard-analysis.yml
+++ b/.github/workflows/scorecard-analysis.yml
@@ -6,6 +6,7 @@ on:
       - main
   schedule:
     - cron: '30 1 * * 6'
+  workflow_dispatch:
 
 permissions: read-all
 
@@ -13,13 +14,16 @@ jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
+    # Skip on forks: publish_results and code-scanning uploads only work on the
+    # upstream repo, so scheduled runs on forks would fail noisily.
+    if: github.repository == 'wp-graphql/wp-graphql'
     permissions:
       security-events: write
       id-token: write
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           persist-credentials: false
 


### PR DESCRIPTION
## Summary

- Fixes #3107
- Adds an OpenSSF Scorecard workflow that runs on pushes to `main` and weekly on Saturdays
- Publishes Scorecard results for the public API/badge flow
- Uploads SARIF results as both a short-lived workflow artifact and GitHub code scanning data
- Pins all actions in the new workflow to immutable SHAs with version comments

## Testing

- `python3` YAML parse check for `.github/workflows/scorecard-analysis.yml`
- `git diff --check -- .github/workflows/scorecard-analysis.yml`

`actionlint` is not installed in my local environment, so I could not run it locally.
