### PR TITLE
chore: harden CI workflow security

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,49 @@
+# Security Policy
+
+The WPGraphQL team takes the security of WPGraphQL and the plugins in this
+monorepo (WPGraphQL, WPGraphQL IDE, WPGraphQL Smart Cache, WPGraphQL for ACF,
+and WPGraphQL Schema Monitor) seriously. Thank you for helping keep WPGraphQL
+and its users safe.
+
+## Supported Versions
+
+Security fixes are released against the latest published version of each plugin
+on WordPress.org and in this repository. We do not backport fixes to older
+releases, so the most reliable way to stay protected is to run the latest
+version and keep automatic updates enabled.
+
+| Plugin | Supported |
+| --- | --- |
+| Latest released version | :white_check_mark: |
+| Older versions | :x: |
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.**
+
+Instead, report them privately using either of the following:
+
+- **Email:** [info@wpgraphql.com](mailto:info@wpgraphql.com)
+- **GitHub:** open a private advisory via the repository's
+  [Security Advisories](https://github.com/wp-graphql/wp-graphql/security/advisories/new)
+  page (GitHub Private Vulnerability Reporting).
+
+To help us triage and resolve the issue quickly, please include as much of the
+following as you can:
+
+- The plugin(s) and version(s) affected.
+- The type of issue (e.g. authorization bypass, information disclosure,
+  injection).
+- Step-by-step instructions to reproduce the issue, including any required
+  configuration, GraphQL queries, or proof-of-concept.
+- The impact of the issue, including how an attacker might exploit it.
+
+## Response Process
+
+- We aim to acknowledge new reports within **5 business days**.
+- We will work with you to understand and validate the issue, keep you updated
+  on our progress, and let you know when a fix is released.
+- Please give us a reasonable amount of time to release a fix before any public
+  disclosure. We are happy to credit reporters in the release notes once a fix
+  has shipped, unless you prefer to remain anonymous.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,6 +26,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -19,6 +19,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # ===========================================
   # CHANGE DETECTION
@@ -46,8 +49,10 @@ jobs:
 
       - name: Check if release-please PR
         id: check-release-pr
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]] && [[ "${{ github.head_ref }}" =~ ^release-please-- ]]; then
+          if [[ "${{ github.event_name }}" == "pull_request" ]] && [[ "$HEAD_REF" =~ ^release-please-- ]]; then
             echo "is-release-pr=true" >> $GITHUB_OUTPUT
             echo "🔔 Detected Release PR - will run integration tests for all plugins"
           else
@@ -56,10 +61,11 @@ jobs:
 
       - name: Check if PR is from a fork
         id: check-fork-pr
+        env:
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
         run: |
           # Fork PRs cannot receive secrets (e.g. ACF_LICENSE_KEY). Skip wp-graphql-acf job to avoid failure.
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            HEAD_REPO="${{ github.event.pull_request.head.repo.full_name }}"
             BASE_REPO="${{ github.repository }}"
             if [[ -z "$HEAD_REPO" ]] || [[ "$HEAD_REPO" != "$BASE_REPO" ]]; then
               echo "is-fork-pr=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/js-e2e-tests.yml
+++ b/.github/workflows/js-e2e-tests.yml
@@ -19,6 +19,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # ===========================================
   # CHANGE DETECTION

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # ===========================================
   # CHANGE DETECTION
@@ -43,11 +46,13 @@ jobs:
 
       - name: Check context (Release PR or push to main)
         id: check-context
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           TEST_ALL=false
           # Check if Release PR
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            BRANCH_NAME="${{ github.head_ref }}"
+            BRANCH_NAME="$HEAD_REF"
             if [[ "$BRANCH_NAME" =~ ^release-please-- ]]; then
               TEST_ALL=true
               echo "🔔 Detected Release PR - will lint all plugins"

--- a/.github/workflows/schema-linter.yml
+++ b/.github/workflows/schema-linter.yml
@@ -18,6 +18,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # ===========================================
   # CHANGE DETECTION
@@ -43,11 +46,13 @@ jobs:
 
       - name: Check context (Release PR or push to main)
         id: check-context
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           TEST_ALL=false
           # Check if Release PR
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            BRANCH_NAME="${{ github.head_ref }}"
+            BRANCH_NAME="$HEAD_REF"
             if [[ "$BRANCH_NAME" =~ ^release-please-- ]]; then
               TEST_ALL=true
               echo "🔔 Detected Release PR - will schema lint all plugins"

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -41,6 +41,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # ===========================================
   # CHANGE DETECTION

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -28,6 +28,9 @@ on:
     - cron: '0 0 1 * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test-scripts:
     name: Test Release Scripts

--- a/.github/workflows/upload-schema-artifact.yml
+++ b/.github/workflows/upload-schema-artifact.yml
@@ -10,10 +10,16 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   run:
     runs-on: ubuntu-latest
     name: Generate and Upload WPGraphQL Schema Artifact
+    # Needs write access to attach the generated schema to the GitHub release.
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/website-e2e-tests.yml
+++ b/.github/workflows/website-e2e-tests.yml
@@ -26,6 +26,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   detect-changes:
     name: Detect changes


### PR DESCRIPTION
## What

Addresses three OpenSSF Scorecard checks that were scoring **0** on the new `Scorecard` workflow. These are mechanical, low-risk hardening changes to `.github/`.

### Token-Permissions (0 → ~10)
Adds a top-level least-privilege `permissions: contents: read` block to every workflow that was missing one, so the default `GITHUB_TOKEN` is read-only unless a job opts into more:

`integration-tests.yml`, `js-e2e-tests.yml`, `lint.yml`, `schema-linter.yml`, `smoke-test.yml`, `test-scripts.yml`, `website-e2e-tests.yml`, `codeql-analysis.yml`, `upload-schema-artifact.yml`.

The only job that needs write access, `upload-schema-artifact`'s `run` job attaching the schema to a GitHub release, gets a scoped job-level `contents: write`. `codeql-analysis` keeps its existing job-level `security-events: write`.

### Dangerous-Workflow / script injection (0 → 10)
The release-please detection steps in `lint.yml`, `schema-linter.yml`, and `integration-tests.yml` interpolated the attacker-controllable `github.head_ref` (and `github.event.pull_request.head.repo.full_name`) directly into a `run:` shell regex. These now pass through an `env:` var and reference the quoted shell variable, closing the injection vector. The same `env:` pattern is already used elsewhere (`lint-pr.yml`, `update-release-pr.yml`).

### Security-Policy (0 → 10)
Adds `.github/SECURITY.md` pointing at the existing `info@wpgraphql.com` contact (already referenced in `CONTRIBUTING.md`) plus GitHub private vulnerability reporting.

## Notes

This is part of a series of small PRs to raise the Scorecard score; pinning actions to SHAs (Pinned-Dependencies) and branch-protection wiring follow separately. No behavior change to CI other than tighter token scopes.

## Verification

- All 22 workflow files parse cleanly.
- No `github.head_ref` remains inside any `run:` block (only in `concurrency.group` expressions and `env:`).
- Existing CI on this PR exercises the permission scopes end to end.