### PR TITLE
fix(deps): sync package-lock @wordpress/hooks to 4.49.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11798,9 +11798,9 @@
 			}
 		},
 		"node_modules/@wordpress/hooks": {
-			"version": "4.48.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.48.1.tgz",
-			"integrity": "sha512-QZh3Cv9TMJkrCQikuZSsDKTgX+6BBzYJe0MFKp7yP8drj/dtRpkqo5+eYmovBq3pk+HoyP7UJ1vTOb3GPJeU6Q==",
+			"version": "4.49.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.49.0.tgz",
+			"integrity": "sha512-65FZ3UXWkSIwFbELFABmcWn1KTA1AUdGAUH8pQlO7HKNO8F+zIrDkkO8gZA/zUHbI3I2vI1PyTA+rherPXg+Kg==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",


### PR DESCRIPTION
## Problem

`npm ci` is failing on PRs with:

```
npm error Invalid: lock file's @wordpress/hooks@4.48.1 does not satisfy @wordpress/hooks@4.49.0
```

The npm-prod-minor-patch Dependabot bump (#3975) moved sibling `@wordpress/*` packages to the 4.49 line but left the root `node_modules/@wordpress/hooks` node at `4.48.1`, leaving `package-lock.json` out of sync with `package.json`'s resolved tree.

That bump only changed `websites/wpgraphql.com/**`, so the change-detection in the test workflows skipped every job that runs `npm ci`, and the broken lock merged to `main` undetected. It surfaces now on any PR that touches paths which trigger those jobs.

## Fix

Regenerate the lockfile (`npm install --package-lock-only`) so the root `@wordpress/hooks` resolves to `4.49.0`. The diff is a single 3-line node update; `npm ci` passes afterward.

## Note

This is a `main` hotfix that unblocks all open PRs (it is independent of the in-flight OpenSSF Scorecard hardening work). Recommend merging promptly.