### PR TITLE
chore: let Scorecard read branch-protection rules

### DIFF
--- a/.github/workflows/scorecard-analysis.yml
+++ b/.github/workflows/scorecard-analysis.yml
@@ -32,6 +32,13 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
+          # A fine-grained PAT (repo administration: read) lets Scorecard read
+          # branch-protection rules, which the default GITHUB_TOKEN cannot. When
+          # the SCORECARD_TOKEN secret is unset this falls back to GITHUB_TOKEN,
+          # so the workflow keeps running (Branch-Protection just stays
+          # unscored). See:
+          # https://github.com/ossf/scorecard-action#authentication-with-fine-grained-pat-optional
+          repo_token: ${{ secrets.SCORECARD_TOKEN || github.token }}
           publish_results: true
 
       - name: Upload SARIF artifact


### PR DESCRIPTION
## What

Adds `repo_token` to the Scorecard analysis step so the **Branch-Protection** check can be evaluated. It currently errors with `some github tokens can't read classic branch protection rules`, because the default `GITHUB_TOKEN` can't read branch-protection settings.

```yaml
repo_token: ${{ secrets.SCORECARD_TOKEN || github.token }}
```

The `|| github.token` fallback means the workflow keeps running even if the secret isn't set yet (Branch-Protection just stays unscored, no worse than today) and upgrades automatically once `SCORECARD_TOKEN` exists.

## Note

`scorecard-analysis.yml` only triggers on push to `main` / schedule / manual dispatch (not on `pull_request`), so this PR won't run Scorecard itself — it takes effect on the first push to `main` after merge.