### PR TITLE
chore: complete Scorecard Token-Permissions and Dangerous-Workflow hardening

### DIFF
--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -76,6 +76,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   # Job naming strategy:
   # The parent workflow sets name to "Integration: plugin / WP X.X / PHP X.X".

--- a/.github/workflows/js-e2e-tests-reusable.yml
+++ b/.github/workflows/js-e2e-tests-reusable.yml
@@ -26,6 +26,9 @@ on:
         type: string
         default: 'false'
 
+permissions:
+  contents: read
+
 jobs:
   # Runs JavaScript e2e tests for a WordPress plugin using Playwright.
   #

--- a/.github/workflows/js-e2e-tests.yml
+++ b/.github/workflows/js-e2e-tests.yml
@@ -49,8 +49,10 @@ jobs:
 
       - name: Check if release-please PR
         id: check-release-pr
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]] && [[ "${{ github.head_ref }}" =~ ^release-please-- ]]; then
+          if [[ "${{ github.event_name }}" == "pull_request" ]] && [[ "$HEAD_REF" =~ ^release-please-- ]]; then
             echo "is-release-pr=true" >> $GITHUB_OUTPUT
             echo "🔔 Detected Release PR - will run e2e tests for all plugins with e2e tests"
           else

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -7,20 +7,22 @@ on:
       - edited
       - synchronize
 
-# `amannn/action-semantic-pull-request` posts a commit status to report
-# the PR-title check result. That requires `statuses: write`, which the
-# default `GITHUB_TOKEN` doesn't have on `pull_request_target` — the
-# action then fails with "Resource not accessible by integration" even
-# when the title itself is valid. Granting just the two permissions the
-# action needs (and nothing else) keeps the token narrowly scoped.
 permissions:
-  pull-requests: read
-  statuses: write
+  contents: read
 
 jobs:
   main:
     name: Validate Pull Request Title
     runs-on: ubuntu-latest
+    # `amannn/action-semantic-pull-request` posts a commit status to report
+    # the PR-title check result. That requires `statuses: write`, which the
+    # default `GITHUB_TOKEN` doesn't have on `pull_request_target` — the
+    # action then fails with "Resource not accessible by integration" even
+    # when the title itself is valid. Granting just the two permissions the
+    # action needs (and nothing else) keeps the token narrowly scoped.
+    permissions:
+      pull-requests: read
+      statuses: write
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
@@ -55,6 +57,8 @@ jobs:
   check-breaking-change:
     name: Validate Breaking Change Marker
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Check for breaking change marker on non-release types
         env:

--- a/.github/workflows/lint-reusable.yml
+++ b/.github/workflows/lint-reusable.yml
@@ -11,6 +11,10 @@ on:
         description: 'Name of the plugin (e.g., wp-graphql)'
         required: true
         type: string
+
+permissions:
+  contents: read
+
 jobs:
   # Runs the PHP coding standards checks.
   #

--- a/.github/workflows/playground-preview-comment.yml
+++ b/.github/workflows/playground-preview-comment.yml
@@ -20,8 +20,7 @@ on:
     types: [completed]
 
 permissions:
-  pull-requests: write
-  actions: read   # required by actions/download-artifact to read from another run
+  contents: read
 
 jobs:
   comment:
@@ -31,6 +30,9 @@ jobs:
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write   # post the sticky PR comment
+      actions: read          # required by actions/download-artifact to read from another run
     steps:
       - name: Download PR metadata artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -61,14 +61,18 @@ on:
         default: ''
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   release-please:
     name: Release Please
     if: github.event.inputs.redeploy_tag == '' || github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
+    # Opens/updates the release PR and creates releases + tags. (The action
+    # authenticates with REPO_PAT; these scopes cover any GITHUB_TOKEN paths.)
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
       # Output all release-please outputs for dynamic component detection
@@ -148,6 +152,8 @@ jobs:
     needs: release-please
     if: always()
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       components: ${{ steps.detect.outputs.components }}
     steps:
@@ -240,6 +246,9 @@ jobs:
         (github.event_name == 'workflow_dispatch' && github.event.inputs.redeploy_tag != '')
       )
     runs-on: ubuntu-latest
+    # Uploads the schema/build assets to the GitHub release (softprops/action-gh-release).
+    permissions:
+      contents: write
     strategy:
       matrix:
         component: ${{ fromJSON(needs.detect-deploy-components.outputs.components) }}

--- a/.github/workflows/schema-linter-reusable.yml
+++ b/.github/workflows/schema-linter-reusable.yml
@@ -20,6 +20,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   lint-schema:
     name: Lint ${{ inputs.component }} Schema

--- a/.github/workflows/smoke-test-reusable.yml
+++ b/.github/workflows/smoke-test-reusable.yml
@@ -48,6 +48,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   smoke-test:
     name: '${{ inputs.name }}'

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -69,11 +69,13 @@ jobs:
 
       - name: Check context (Release PR or push to main)
         id: check-context
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           TEST_ALL=false
           # Check if Release PR
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            BRANCH_NAME="${{ github.head_ref }}"
+            BRANCH_NAME="$HEAD_REF"
             if [[ "$BRANCH_NAME" =~ ^release-please-- ]]; then
               TEST_ALL=true
               echo "🔔 Detected Release PR - will smoke test all plugins"

--- a/.github/workflows/update-release-pr.yml
+++ b/.github/workflows/update-release-pr.yml
@@ -24,8 +24,7 @@ on:
       - main
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   update-release-pr:
@@ -33,6 +32,10 @@ jobs:
     # Only run on release-please PRs
     if: startsWith(github.head_ref, 'release-please--')
     runs-on: ubuntu-latest
+    # Commits the placeholder/version/translation updates back to the release PR branch.
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/website-e2e-tests.yml
+++ b/.github/workflows/website-e2e-tests.yml
@@ -44,8 +44,10 @@ jobs:
 
       - name: Check if release-please PR
         id: check-release-pr
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]] && [[ "${{ github.head_ref }}" =~ ^release-please-- ]]; then
+          if [[ "${{ github.event_name }}" == "pull_request" ]] && [[ "$HEAD_REF" =~ ^release-please-- ]]; then
             echo "is-release-pr=true" >> $GITHUB_OUTPUT
             echo "🔔 Detected Release PR - will run e2e tests for all websites"
           else


### PR DESCRIPTION
## Why

The first hardening pass (#3988) only partially moved two checks — the published Scorecard run still showed **Token-Permissions: 0** and **Dangerous-Workflow: 0**. The `details` from that run pinpointed exactly what was left; this PR closes it out.

## Dangerous-Workflow (0 → 10)

The initial audit found 3 `github.head_ref` script-injection sinks; there were actually **6**. This env-vars the three that were missed, matching the fix already applied to the other three:

- `js-e2e-tests.yml`
- `smoke-test.yml`
- `website-e2e-tests.yml`

This check is all-or-nothing, so one remaining sink kept it at 0.

## Token-Permissions (0 → high)

Scorecard penalizes **top-level write** and **undefined top-level** permissions. Two gaps remained:

1. **Five `*-reusable.yml` workflows had no top-level `permissions:`** — added `permissions: contents: read` to each (integration-tests, js-e2e-tests, lint, schema-linter, smoke-test reusables).
2. **Four workflows declared write at the top level** — moved those scopes down to the specific jobs that use them, leaving each workflow read-only at the top:
   - `lint-pr.yml` → `statuses: write` now on the `main` job only
   - `playground-preview-comment.yml` → `pull-requests: write` + `actions: read` on the `comment` job
   - `release-please.yml` → `contents`/`pull-requests: write` on `release-please`, `contents: write` on `deploy-plugin`, `contents: read` on `detect-deploy-components`
   - `update-release-pr.yml` → `contents`/`pull-requests: write` on its single job

**No behavior change:** every job keeps the exact write scope it previously inherited from the top-level block; only the placement moved. `release-please.yml` was handled carefully since it's release-critical — its CI exercises the structure.

## Verification

- All workflow files parse cleanly.
- No top-level `write` permission remains in any workflow.
- Every workflow now has a top-level `permissions:` block.
- No `github.head_ref` remains inside any `run:` block (only in `concurrency`, `if:`, `with: ref:`, and `env:`).

## After merge

A push to `main` re-runs Scorecard; expected: Dangerous-Workflow 0→10, Token-Permissions 0→~9-10, aggregate moving toward ~7.