### PR TITLE
fix: read use_featured_image for the PostType useFeaturedImage label

### DIFF
--- a/plugins/wp-graphql/src/Type/ObjectType/PostTypeLabelDetails.php
+++ b/plugins/wp-graphql/src/Type/ObjectType/PostTypeLabelDetails.php
@@ -200,7 +200,7 @@ class PostTypeLabelDetails {
 								return __( 'Label in the media frame for using a featured image.', 'wp-graphql' );
 							},
 							'resolve'     => static function ( $labels ) {
-								return ! empty( $labels->use_featured_item ) ? $labels->use_featured_item : null;
+								return ! empty( $labels->use_featured_image ) ? $labels->use_featured_image : null;
 							},
 						],
 						'menuName'            => [

--- a/plugins/wp-graphql/tests/wpunit/PostTypeObjectQueriesTest.php
+++ b/plugins/wp-graphql/tests/wpunit/PostTypeObjectQueriesTest.php
@@ -185,7 +185,7 @@ class PostTypeObjectQueriesTest extends \lucatume\WPBrowser\TestCase\WPTestCase 
 									'featuredImage'       => $post_type_object->labels->featured_image,
 									'setFeaturedImage'    => 'Set featured image',
 									'removeFeaturedImage' => 'Remove featured image',
-									'useFeaturedImage'    => null,
+									'useFeaturedImage'    => $post_type_object->labels->use_featured_image,
 									'menuName'            => 'Posts',
 									'filterItemsList'     => 'Filter posts list',
 									'itemsListNavigation' => 'Posts list navigation',


### PR DESCRIPTION
## What

The `useFeaturedImage` resolver in `PostTypeLabelDetails` read `$labels->use_featured_item`, which does not exist in WordPress core — the post-type label property is `use_featured_image`. The `! empty()` guard therefore always failed and the field returned `null` for every post type. The sibling resolvers (`featuredImage`, `setFeaturedImage`, `removeFeaturedImage`) all use the correct property names; this was the lone typo.

## Test

`PostTypeObjectQueriesTest::testPostTypeQueryForPosts` previously asserted `useFeaturedImage => null` (encoding the bug). It now asserts the real label (`$post_type_object->labels->use_featured_image`), which fails before this change (resolver returned null) and passes after.

I wasn't able to run the wp-env test suite locally (no Docker in my environment), so CI is relied on to confirm.

> AI-assisted: prepared with the help of an AI coding agent and reviewed before submitting.
