### PR TITLE
fix: keep deprecationReason for deprecated fields without a description

### DIFF
--- a/plugins/wp-graphql/src/Utils/InstrumentSchema.php
+++ b/plugins/wp-graphql/src/Utils/InstrumentSchema.php
@@ -83,7 +83,7 @@ class InstrumentSchema {
 			 * Sanitize the description and deprecation reason
 			 */
 			$field->description       = ! empty( $field->description ) && is_string( $field->description ) ? esc_html( $field->description ) : '';
-			$field->deprecationReason = ! empty( $field->deprecationReason ) && is_string( $field->description ) ? esc_html( $field->deprecationReason ) : null;
+			$field->deprecationReason = ! empty( $field->deprecationReason ) && is_string( $field->deprecationReason ) ? esc_html( $field->deprecationReason ) : null;
 
 			/**
 			 * Replace the existing field resolve method with a new function that captures data about

--- a/plugins/wp-graphql/tests/wpunit/InstrumentSchemaTest.php
+++ b/plugins/wp-graphql/tests/wpunit/InstrumentSchemaTest.php
@@ -1,0 +1,72 @@
+<?php
+
+class InstrumentSchemaTest extends \lucatume\WPBrowser\TestCase\WPTestCase {
+
+	public function setUp(): void {
+		parent::setUp();
+		WPGraphQL::clear_schema();
+	}
+
+	public function tearDown(): void {
+		WPGraphQL::clear_schema();
+		parent::tearDown();
+	}
+
+	/**
+	 * A deprecated field that has no description should still expose its
+	 * deprecationReason in introspection.
+	 *
+	 * Regression: InstrumentSchema::wrap_fields() guarded the deprecationReason
+	 * sanitization on is_string( $field->description ) (the wrong property), so a
+	 * deprecated field without a description had its deprecationReason dropped to
+	 * null.
+	 *
+	 * @throws \Exception
+	 */
+	public function testDeprecatedFieldWithoutDescriptionKeepsDeprecationReason() {
+		add_action(
+			'graphql_register_types',
+			static function () {
+				register_graphql_field(
+					'RootQuery',
+					'instrumentSchemaDeprecatedNoDescription',
+					[
+						'type'              => 'String',
+						'deprecationReason' => 'Deprecated for testing.',
+						'resolve'           => static function () {
+							return 'value';
+						},
+					]
+				);
+			}
+		);
+
+		$query = '
+		{
+			__type(name: "RootQuery") {
+				fields(includeDeprecated: true) {
+					name
+					isDeprecated
+					deprecationReason
+				}
+			}
+		}
+		';
+
+		$actual = graphql( [ 'query' => $query ] );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+
+		$field = null;
+		foreach ( $actual['data']['__type']['fields'] as $f ) {
+			if ( 'instrumentSchemaDeprecatedNoDescription' === $f['name'] ) {
+				$field = $f;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $field, 'The registered deprecated field should be present in introspection.' );
+		$this->assertTrue( $field['isDeprecated'] );
+		$this->assertSame( 'Deprecated for testing.', $field['deprecationReason'] );
+	}
+}


### PR DESCRIPTION
## What

`InstrumentSchema::wrap_fields()` sanitizes each field's `description` and `deprecationReason`. The `deprecationReason` line guarded on `is_string( $field->description )` — the wrong property (copy-paste from the line above). When a field is deprecated but has **no description**, `is_string( null )` is `false`, so its `deprecationReason` was dropped to `null` in introspection (and `isDeprecated` became `false`). The fix guards on `$field->deprecationReason` itself. Fields that have a description were unaffected, which is why this slipped through.

## Test

Adds `InstrumentSchemaTest::testDeprecatedFieldWithoutDescriptionKeepsDeprecationReason`: registers a deprecated `RootQuery` field with no description and asserts, via introspection, that its `deprecationReason` is preserved. Fails before this change (reason dropped to null), passes after.

I wasn't able to run the wp-env test suite locally (no Docker in my environment), so CI is relied on to confirm.

> AI-assisted: prepared with the help of an AI coding agent and reviewed before submitting.
