### PR TITLE
fix: allow public menuItems queries to opt out of the location restriction

### DIFF
--- a/plugins/wp-graphql/docs/menus.md
+++ b/plugins/wp-graphql/docs/menus.md
@@ -12,6 +12,29 @@ In WordPress, Navigation Menus consist of 2 types of entities: Menus and MenuIte
 
 > **NOTE:** Menus and Menu Items in WordPress are not viewable by public requests until they are assigned to a Menu Location. WPGraphQL respects this access control right, so if you are not seeing data in your queries for menus and menu items, make sure the menu is assigned to a location.
 
+### Making Menus and Menu Items public
+
+If you want public (unauthenticated) requests to query menus and menu items that are _not_ assigned to a menu location, there are two access checks to relax:
+
+1. The **Model** privacy gate, which marks a menu or menu item private when it is not assigned to a location. Override it with the `graphql_data_is_private` filter.
+2. The **connection** location restriction, which limits the `menuItems` connection to items assigned to a location for public requests. Override it with the `graphql_menu_item_connection_restrict_to_locations` filter.
+
+```php
+// 1. Make Menu and MenuItem models public.
+add_filter( 'graphql_data_is_private', function ( $is_private, $model_name ) {
+	if ( in_array( $model_name, [ 'MenuObject', 'MenuItemObject' ], true ) ) {
+		return false;
+	}
+
+	return $is_private;
+}, 10, 2 );
+
+// 2. Allow the menuItems connection to return items of menus with no assigned location.
+add_filter( 'graphql_menu_item_connection_restrict_to_locations', '__return_false' );
+```
+
+An explicit `location` where arg always restricts the connection to that location and is unaffected by the second filter.
+
 ## Querying Menus and Menu Items
 
 Below are some examples of querying Menus and Menu Items

--- a/plugins/wp-graphql/src/Data/Connection/MenuItemConnectionResolver.php
+++ b/plugins/wp-graphql/src/Data/Connection/MenuItemConnectionResolver.php
@@ -48,8 +48,11 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 		// Public queries should only be allowed to query for Menu Items assigned to a Menu Location.
 		$locations = is_array( $menu_locations ) && ! empty( $menu_locations ) ? array_unique( array_values( $menu_locations ) ) : [];
 
+		// Whether a location was explicitly requested via the `location` where arg.
+		$has_explicit_location = ! empty( $args['where']['location'] );
+
 		// If the location argument is set, set the argument to the input argument
-		if ( ! empty( $args['where']['location'] ) ) {
+		if ( $has_explicit_location ) {
 			$locations = isset( $menu_locations[ $args['where']['location'] ] ) ? [ $menu_locations[ $args['where']['location'] ] ] : []; // We use an empty array to prevent fetching all media items if the location has no items assigned.
 
 		} elseif ( current_user_can( 'edit_theme_options' ) ) {
@@ -57,8 +60,30 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 			$locations = null;
 		}
 
+		/**
+		 * Filter whether the menu item connection should be restricted to items
+		 * assigned to a registered menu location.
+		 *
+		 * By default, public (unauthenticated) requests are limited to menu items
+		 * assigned to a menu location. Return `false` to allow public requests to
+		 * query menu items belonging to menus that are not assigned to any location
+		 * (e.g. when using the "Make Menus and Menu Items public" recipe, which also
+		 * flips the MenuItem Model privacy gate via `graphql_data_is_private`).
+		 *
+		 * An explicit `location` where arg always restricts to that location and is
+		 * unaffected by this filter.
+		 *
+		 * @param bool                 $restrict_to_locations Whether to restrict the connection to assigned menu locations. Default true.
+		 * @param int[]|null           $locations             The menu location term IDs the connection is being restricted to, or null when unrestricted (privileged user).
+		 * @param array<string,mixed>  $args                  The GraphQL args passed to the resolver.
+		 * @param array<string,mixed>  $unfiltered_args       Array of arguments input in the field as part of the GraphQL query.
+		 *
+		 * @since x-release-please-version
+		 */
+		$restrict_to_locations = $has_explicit_location || apply_filters( 'graphql_menu_item_connection_restrict_to_locations', true, $locations, $args, $this->get_unfiltered_args() );
+
 		// Only query for menu items in assigned locations.
-		if ( isset( $locations ) ) {
+		if ( $restrict_to_locations && isset( $locations ) ) {
 
 			// unset the location arg
 			// we don't need this passed as a taxonomy parameter to wp_query

--- a/plugins/wp-graphql/tests/wpunit/MenuItemConnectionResolverTest.php
+++ b/plugins/wp-graphql/tests/wpunit/MenuItemConnectionResolverTest.php
@@ -33,4 +33,82 @@ class MenuItemConnectionResolverTest extends \lucatume\WPBrowser\TestCase\WPTest
 		$this->assertEmpty( $actual['data']['menuItems']['nodes'] );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 	}
+
+	/**
+	 * Create a nav menu that is NOT assigned to any menu location, with a single
+	 * published menu item, and return the menu item database ID.
+	 *
+	 * @return int
+	 */
+	private function create_unassigned_menu_item() {
+		$menu_id = wp_create_nav_menu( 'unassigned-menu-' . uniqid() );
+		$post_id = self::factory()->post->create( [ 'post_status' => 'publish' ] );
+
+		return wp_update_nav_menu_item(
+			$menu_id,
+			0,
+			[
+				'menu-item-title'     => 'Unassigned item',
+				'menu-item-object'    => 'post',
+				'menu-item-object-id' => $post_id,
+				'menu-item-status'    => 'publish',
+				'menu-item-type'      => 'post_type',
+			]
+		);
+	}
+
+	/**
+	 * By default, public requests should only see menu items assigned to a
+	 * registered menu location. Items belonging to a menu with no location
+	 * stay hidden. This locks the privacy default (see #3043).
+	 */
+	public function testUnassignedMenuItemsHiddenFromPublicByDefault() {
+		$menu_item_id = $this->create_unassigned_menu_item();
+
+		wp_set_current_user( 0 );
+
+		$query  = '{ menuItems { nodes { databaseId } } }';
+		$actual = do_graphql_request( $query );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEmpty( $actual['data']['menuItems']['nodes'] );
+	}
+
+	/**
+	 * The "Make Menus and Menu Items public" recipe flips the MenuItem Model
+	 * privacy gate via `graphql_data_is_private`, but prior to this fix the
+	 * connection's location `tax_query` still stripped items belonging to a
+	 * menu with no assigned location, so the recipe had no effect (#3080).
+	 *
+	 * With the Model gate flipped AND the connection location restriction
+	 * disabled via `graphql_menu_item_connection_restrict_to_locations`, an
+	 * anonymous request should see the unassigned menu's items.
+	 */
+	public function testUnassignedMenuItemsVisibleToPublicWhenLocationRestrictionDisabled() {
+		$menu_item_id = $this->create_unassigned_menu_item();
+
+		wp_set_current_user( 0 );
+
+		// Mirror the recipe: make MenuItem models public.
+		$model_filter = static function ( $is_private, $model_name ) {
+			return 'MenuItemObject' === $model_name ? false : $is_private;
+		};
+		add_filter( 'graphql_data_is_private', $model_filter, 10, 2 );
+
+		// Lift the connection's implicit location restriction for public requests.
+		$connection_filter = static function () {
+			return false;
+		};
+		add_filter( 'graphql_menu_item_connection_restrict_to_locations', $connection_filter );
+
+		$query  = '{ menuItems { nodes { databaseId } } }';
+		$actual = do_graphql_request( $query );
+
+		remove_filter( 'graphql_data_is_private', $model_filter, 10 );
+		remove_filter( 'graphql_menu_item_connection_restrict_to_locations', $connection_filter );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$database_ids = wp_list_pluck( $actual['data']['menuItems']['nodes'], 'databaseId' );
+		$this->assertContains( $menu_item_id, $database_ids );
+	}
 }


### PR DESCRIPTION
## What

Adds a `graphql_menu_item_connection_restrict_to_locations` filter (defaulting to current behavior) so the `menuItems` connection's implicit location restriction can be lifted for public requests, the same way the Model privacy gate can be lifted via `graphql_data_is_private`.

## Why

Menus and menu items not assigned to a menu location are hidden from public requests by two independent access checks:

1. the **Model** privacy gate (`MenuItem::is_private()` / `Menu::is_private()`), and
2. the **connection** location `tax_query` in `MenuItemConnectionResolver`.

The documented [Make Menus and Menu Items public](https://www.wpgraphql.com/recipes/making-menus-and-menu-items-public/) recipe only flips the Model gate. That worked in v1.12.2 because the connection skipped the `tax_query` when the resolved location list was empty (`! empty( $locations )`). In #3043 the guard changed to `isset( $locations )` (correct fix for "filter by an empty location returns everything"), which made the location restriction unconditional for public requests with no override. The recipe stopped working: `menus` returns the menu, but `menuItems` is empty.

This was reported in #3080 as a regression between v1.12.2 and v1.22.1.

## How

`MenuItemConnectionResolver::prepare_query_args()` now consults a new filter before applying the location `tax_query`:

- Default `true` preserves today's behavior exactly (public requests restricted to assigned locations).
- Return `false` (e.g. `__return_false`) to let public requests query items of menus with no assigned location, completing the recipe.
- An explicit `location` where arg always restricts to that location and bypasses the filter, so #3043's behavior is unchanged.

The `docs/menus.md` Access Control section now documents both halves of the recipe (Model gate + connection filter).

## Tests

Regression tests in `tests/wpunit/MenuItemConnectionResolverTest.php`:

- `testUnassignedMenuItemsHiddenFromPublicByDefault` locks the privacy default (no filter, anon sees nothing) so #3043 does not regress.
- `testUnassignedMenuItemsVisibleToPublicWhenLocationRestrictionDisabled` mirrors the recipe (flip the Model gate + disable the connection restriction) and asserts the anon request now sees the unassigned menu's item. Fails before this change, passes after.

`MenuItemConnectionQueriesTest` (including the #3043 `location` cases) stays green. `composer check-cs` and `composer phpstan` (level 8) pass.

Closes #3080