### PR TITLE
fix: don't force a SQL LIMIT on childOf term queries

### DIFF
--- a/plugins/wp-graphql/src/Data/Config.php
+++ b/plugins/wp-graphql/src/Data/Config.php
@@ -455,8 +455,15 @@ class Config {
 			return $pieces;
 		}
 
-		// Determine the limit for the query
-		if ( isset( $args['number'] ) && absint( $args['number'] ) ) {
+		// Determine the limit for the query.
+		//
+		// WP_Term_Query intentionally omits the SQL LIMIT when it has to descend the
+		// term hierarchy (e.g. a `child_of` query): it queries the full set, filters
+		// the descendants in PHP, then applies `number`/`offset` in PHP. Forcing a
+		// SQL LIMIT here would truncate the result set before that descendant
+		// filtering runs, dropping children that fall outside the LIMIT window. In
+		// that case we defer to WP's PHP-side pagination. See #2739.
+		if ( empty( $args['child_of'] ) && isset( $args['number'] ) && absint( $args['number'] ) ) {
 			$pieces['limits'] = sprintf( ' LIMIT 0, %d', absint( $args['number'] ) );
 		}
 

--- a/plugins/wp-graphql/tests/wpunit/TermObjectConnectionQueriesTest.php
+++ b/plugins/wp-graphql/tests/wpunit/TermObjectConnectionQueriesTest.php
@@ -998,4 +998,66 @@ class TermObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 
 		wp_delete_term( $parent_category, 'category' );
 	}
+
+	/**
+	 * A `childOf` query must return the term's children even when there are more
+	 * sibling/unrelated terms than the query limit.
+	 *
+	 * WP_Term_Query intentionally omits the SQL LIMIT when it has to descend the
+	 * term hierarchy (e.g. `child_of`), filtering descendants in PHP and applying
+	 * `number`/`offset` afterwards. WPGraphQL's cursor-pagination clause used to
+	 * force a SQL LIMIT unconditionally, which truncated the result set before the
+	 * descendant filtering ran, so children outside the LIMIT window disappeared.
+	 *
+	 * @see https://github.com/wp-graphql/wp-graphql/issues/2739
+	 */
+	public function testChildOfReturnsChildrenBeyondTheQueryLimit() {
+		$query = $this->getQuery();
+
+		// Create more decoy terms than the default query limit (10). These sort
+		// alphabetically before the children, so they fill the SQL LIMIT window.
+		for ( $i = 1; $i <= 15; $i++ ) {
+			$this->createTermObject(
+				[
+					'taxonomy' => 'category',
+					'name'     => sprintf( 'Aaa Decoy %02d', $i ),
+				]
+			);
+		}
+
+		$parent_id = $this->createTermObject(
+			[
+				'taxonomy' => 'category',
+				'name'     => 'Zzz Parent',
+			]
+		);
+
+		$expected_children = [];
+		for ( $i = 1; $i <= 5; $i++ ) {
+			$expected_children[] = $this->createTermObject(
+				[
+					'taxonomy' => 'category',
+					'name'     => sprintf( 'Zzz Parent Child %d', $i ),
+					'parent'   => $parent_id,
+				]
+			);
+		}
+
+		$variables = [
+			'where' => [
+				'childOf' => $parent_id,
+			],
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+
+		$actual_ids = wp_list_pluck( $actual['data']['categories']['nodes'], 'databaseId' );
+
+		$this->assertCount( 5, $actual_ids, 'All 5 children should be returned even though decoy terms exceed the query limit.' );
+		sort( $actual_ids );
+		sort( $expected_children );
+		$this->assertEquals( $expected_children, $actual_ids );
+	}
 }


### PR DESCRIPTION
## What

When a term connection is filtered by `childOf`, the cursor-pagination clause no longer forces a SQL `LIMIT` on the `WP_Term_Query`. WP descends the term hierarchy and paginates in PHP for these queries, so the forced limit was truncating the result before the descendants were resolved.

## Why

`WP_Term_Query` intentionally omits the SQL `LIMIT` when it has to descend the term family tree (e.g. `child_of`):

```php
// wp-includes/class-wp-term-query.php
// Don't limit the query results when we have to descend the family tree.
if ( $number && ! $hierarchical && ! $child_of && '' === $parent ) {
	$limits = $offset ? "LIMIT $offset,$number" : "LIMIT $number";
} else {
	$limits = '';
}
```

For a `child_of` query it queries the full set, filters the descendants in PHP (`_get_term_children()`), and then applies `number`/`offset` in PHP.

WPGraphQL's `terms_clauses` filter (`Config::graphql_wp_term_query_cursor_pagination_support()`) set `$pieces['limits'] = 'LIMIT 0, N'` whenever a `number` was present. With `child_of` that capped the SQL result to N rows _before_ the descendant filtering ran, so any child outside that LIMIT window was dropped. On a taxonomy with more terms than the limit, `childOf` returned an empty or partial set even though children existed.

Reported in #2739 (sharp repro: 0 of 25 children returned).

## How

Skip forcing the SQL `LIMIT` when `child_of` is set, deferring to WP's own PHP-side pagination (which still honors the connection's `number`, so `first`/`after` page sizing and next-page detection keep working). All other term connections are unaffected.

## Tests

`TermObjectConnectionQueriesTest::testChildOfReturnsChildrenBeyondTheQueryLimit` creates more decoy terms than the default query limit (sorted ahead of the children so they fill the LIMIT window), then asserts a `childOf` query returns all of the term's children. Fails before this change (0 returned), passes after.

The full `TermObjectConnectionQueriesTest` suite (forward/backward pagination, first/last, duplicate-name ordering), `TermObjectCursorTest`, and `CustomTaxonomyTest` stay green. `composer check-cs` and `composer phpstan` (level 8) pass.

Closes #2739