### PR TITLE
feat: add isSticky where arg to post connections

### DIFF
--- a/plugins/wp-graphql/docs/posts-and-pages.md
+++ b/plugins/wp-graphql/docs/posts-and-pages.md
@@ -89,6 +89,24 @@ This example shows querying posts using a search keyword.
 
 ![Screenshot of a GraphQL Query for posts using a search keyword](./images/posts-query-filter-by-keyword.png)
 
+#### Query sticky posts
+
+Use the `isSticky` argument to filter the connection by [sticky](https://wordpress.org/documentation/article/sticky-posts/) status. Pass `true` to return only sticky posts, or `false` to exclude them.
+
+```graphql
+{
+  posts(where: {isSticky: true}) {
+    nodes {
+      id
+      title
+      isSticky
+    }
+  }
+}
+```
+
+> **NOTE:** This filters the result set by sticky status, it does not float sticky posts to the top of the results. Sticky posts are returned in the connection's normal order alongside other posts, so if you need them visually pinned, sort or merge them in your client. This mirrors the WordPress REST API's `sticky` parameter.
+
 ### Single Post by Global ID
 
 Below is an example of querying a single post using the [GraphQL Global ID](/docs/wpgraphql-concepts/).

--- a/plugins/wp-graphql/src/Data/Connection/PostObjectConnectionResolver.php
+++ b/plugins/wp-graphql/src/Data/Connection/PostObjectConnectionResolver.php
@@ -185,7 +185,7 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		 * If the cursor offsets not empty,
 		 * ignore sticky posts on the query
 		 */
-		if ( ! empty( $this->get_after_offset() ) || ! empty( $this->get_after_offset() ) ) {
+		if ( ! empty( $this->get_after_offset() ) || ! empty( $this->get_before_offset() ) ) {
 			$query_args['ignore_sticky_posts'] = true;
 		}
 
@@ -410,6 +410,37 @@ class PostObjectConnectionResolver extends AbstractConnectionResolver {
 		if ( ! empty( $query_args['post_status'] ) ) {
 			$allowed_stati             = $this->sanitize_post_stati( $query_args['post_status'] );
 			$query_args['post_status'] = ! empty( $allowed_stati ) ? $allowed_stati : [ 'publish' ];
+		}
+
+		/**
+		 * Filter the result set by sticky posts.
+		 *
+		 * WPGraphQL never floats sticky posts to the top of the results (ignore_sticky_posts
+		 * is always true, which is also cursor-pagination safe). Instead `isSticky` filters
+		 * the result set, modeling the WP REST API `sticky` parameter: true limits the query
+		 * to sticky posts, false excludes them.
+		 */
+		if ( isset( $where_args['isSticky'] ) ) {
+			$sticky_posts = get_option( 'sticky_posts', [] );
+			$sticky_posts = is_array( $sticky_posts ) ? array_map( 'absint', $sticky_posts ) : [];
+
+			if ( true === $where_args['isSticky'] ) {
+				// Limit to sticky posts, intersecting with any explicit `in` filter.
+				$query_args['post__in'] = ! empty( $query_args['post__in'] )
+					? array_intersect( $sticky_posts, $query_args['post__in'] )
+					: $sticky_posts;
+
+				// WP_Query ignores an empty post__in, so force an impossible ID to return no results.
+				if ( empty( $query_args['post__in'] ) ) {
+					$query_args['post__in'] = [ 0 ];
+				}
+			} elseif ( ! empty( $sticky_posts ) ) {
+				// Exclude sticky posts, merging with any explicit `notIn` filter.
+				$query_args['post__not_in'] = array_merge( // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_post__not_in
+					! empty( $query_args['post__not_in'] ) ? $query_args['post__not_in'] : [],
+					$sticky_posts
+				);
+			}
 		}
 
 		/**

--- a/plugins/wp-graphql/src/Type/Connection/PostObjects.php
+++ b/plugins/wp-graphql/src/Type/Connection/PostObjects.php
@@ -375,6 +375,18 @@ class PostObjects {
 			],
 
 			/**
+			 * Sticky post parameters
+			 *
+			 * @see   : https://developer.wordpress.org/reference/classes/wp_query/#sticky-post-parameters
+			 */
+			'isSticky'    => [
+				'type'        => 'Boolean',
+				'description' => static function () {
+					return __( 'True to limit the results to sticky posts; false to exclude sticky posts. Note: this filters the result set, it does not float sticky posts to the top of the results.', 'wp-graphql' );
+				},
+			],
+
+			/**
 			 * NOTE: post_type is intentionally not supported on connections to Single post types as
 			 * the connection to the singular Post Type already sets this argument as the entry
 			 * point to the Graph

--- a/plugins/wp-graphql/tests/wpunit/PostObjectConnectionQueriesTest.php
+++ b/plugins/wp-graphql/tests/wpunit/PostObjectConnectionQueriesTest.php
@@ -1349,6 +1349,75 @@ class PostObjectConnectionQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQ
 		$this->assertFalse( $actual['data']['posts']['nodes'][1]['isSticky'] );
 	}
 
+	/**
+	 * The `isSticky` where arg filters the connection result set by sticky status,
+	 * modeling the WP REST API `sticky` parameter. It does not float sticky posts.
+	 *
+	 * @see https://github.com/wp-graphql/wp-graphql/issues/786
+	 */
+	public function testIsStickyWhereArgFiltersConnection() {
+		// setUp() already created 6 non-sticky published posts.
+		$sticky_one = $this->createPostObject( [ 'post_title' => 'Sticky One' ] );
+		$sticky_two = $this->createPostObject( [ 'post_title' => 'Sticky Two' ] );
+
+		update_option( 'sticky_posts', [ $sticky_one, $sticky_two ] );
+
+		$query = $this->getQuery();
+
+		// isSticky: true returns only the sticky posts.
+		$actual = $this->graphql(
+			[
+				'query'     => $query,
+				'variables' => [
+					'first' => 100,
+					'where' => [ 'isSticky' => true ],
+				],
+			]
+		);
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$actual_ids = wp_list_pluck( $actual['data']['posts']['nodes'], 'databaseId' );
+		sort( $actual_ids );
+		$expected_ids = [ $sticky_one, $sticky_two ];
+		sort( $expected_ids );
+		$this->assertEquals( $expected_ids, $actual_ids, 'isSticky: true should return only sticky posts.' );
+
+		// isSticky: false excludes the sticky posts but keeps the rest.
+		$actual = $this->graphql(
+			[
+				'query'     => $query,
+				'variables' => [
+					'first' => 100,
+					'where' => [ 'isSticky' => false ],
+				],
+			]
+		);
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$actual_ids = wp_list_pluck( $actual['data']['posts']['nodes'], 'databaseId' );
+		$this->assertNotContains( $sticky_one, $actual_ids, 'isSticky: false should exclude sticky posts.' );
+		$this->assertNotContains( $sticky_two, $actual_ids, 'isSticky: false should exclude sticky posts.' );
+		$this->assertContains( $this->created_post_ids[1], $actual_ids, 'isSticky: false should keep non-sticky posts.' );
+
+		// isSticky: true intersects with an explicit `in` filter (REST parity).
+		$actual = $this->graphql(
+			[
+				'query'     => $query,
+				'variables' => [
+					'first' => 100,
+					'where' => [
+						'isSticky' => true,
+						'in'       => [ $sticky_one, $this->created_post_ids[1] ],
+					],
+				],
+			]
+		);
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$actual_ids = wp_list_pluck( $actual['data']['posts']['nodes'], 'databaseId' );
+		$this->assertEquals( [ $sticky_one ], $actual_ids, 'isSticky: true with `in` should return the intersection.' );
+	}
+
 	public function testWhereArgs() {
 		$query = $this->getQuery();
 


### PR DESCRIPTION
## What

Adds an `isSticky: Boolean` where arg to post object connections:

- `isSticky: true` limits the connection to sticky posts.
- `isSticky: false` excludes sticky posts.
- omitted: no sticky filtering (current behavior).

## Why

Since the two-phase resolution (gather IDs, then batch-load) was introduced, sticky posts have not been handled in GraphQL results. `WP_Query` only floats sticky posts *after* the `fields => ids` early return, so the connection never sees them (#786).

Restoring native floating isn't the right fix: floating is incompatible with cursor pagination (the floated rows aren't part of the ordered/cursored set), and the WP REST API doesn't float either, it forces `ignore_sticky_posts=true` and exposes `sticky` as a *filter*. This change follows REST 1:1: WPGraphQL already sets `ignore_sticky_posts = true`, and `isSticky` now filters the result set.

## How

In `PostObjectConnectionResolver::sanitize_input_fields()`, when `isSticky` is present:

- `true`: `post__in` is set to the sticky IDs, intersected with any explicit `in` filter; if the intersection is empty it falls back to `[0]` so an empty `post__in` doesn't get ignored by `WP_Query` (matches REST).
- `false`: the sticky IDs are merged into `post__not_in` alongside any explicit `notIn` filter.

`ignore_sticky_posts` remains `true`, so nothing is floated.

### Drive-by

The sticky-handling block in `prepare_query_args()` guarded on the cursor offsets but checked `get_after_offset()` twice; the second now correctly checks `get_before_offset()`. Functionally inert today (the default is already `true`), but it makes the guard correct.

## Notes / scope

- Native sticky floating remains intentionally unsupported (cursor-incompatible, and not what REST does). This is the additive, pagination-safe mechanism.
- Mirroring REST's `ignore_sticky` opt-in is possible future work but deferred (cursor-fragile).

## Tests

`PostObjectConnectionQueriesTest::testIsStickyWhereArgFiltersConnection` creates sticky + non-sticky posts and asserts:

- `isSticky: true` returns only sticky posts,
- `isSticky: false` excludes them but keeps the rest,
- `isSticky: true` combined with `in` returns the intersection.

Verified as a real guard: with the resolver handling disabled (field still registered) the filtering assertions fail; with it enabled they pass. Full `PostObjectConnectionQueriesTest`, `AssertValidSchemaTest`, `check-cs`, and `phpstan` (level 8) all pass.

Closes #786