### PR TITLE
fix: keep graphql_document on the classic editor when the WPGraphQL IDE is active

### DIFF
--- a/plugins/wp-graphql-ide/includes/SmartCacheBridge.php
+++ b/plugins/wp-graphql-ide/includes/SmartCacheBridge.php
@@ -55,6 +55,17 @@ class SmartCacheBridge {
 		add_filter( 'register_post_type_args', [ self::class, 'add_rest_to_smart_cache_post_type' ], 10, 2 );
 		add_filter( 'register_taxonomy_args', [ self::class, 'add_rest_to_smart_cache_taxonomies' ], 10, 2 );
 
+		// Keep `graphql_document` on the classic editor. Adding `show_in_rest`
+		// above (which the IDE's REST client and REST-exposed meta need) is
+		// enough to flip WordPress's `use_block_editor_for_post_type()` to
+		// true, since the post type already supports `editor`. The block
+		// editor is not a Smart Cache feature and the IDE has no business
+		// changing Smart Cache's native edit screen, so opt the post type
+		// back out. Priority 9 (below the default 10) makes this the default
+		// while still letting a site that genuinely wants Gutenberg here
+		// override it with a later-priority filter.
+		add_filter( 'use_block_editor_for_post_type', [ self::class, 'disable_block_editor_for_smart_cache_document' ], 9, 2 );
+
 		// Register IDE-specific meta on graphql_document. Runs on `init`
 		// priority 11 so it lands after Smart Cache's own init at 10.
 		add_action( 'init', [ self::class, 'register_ide_meta_on_smart_cache_document' ], 11 );
@@ -134,6 +145,33 @@ class SmartCacheBridge {
 		}
 
 		return $args;
+	}
+
+	/**
+	 * Keep Smart Cache's `graphql_document` on the classic editor.
+	 *
+	 * The IDE only enables `show_in_rest` on this post type so its REST
+	 * client and the `_graphql_ide_*` meta work. A side effect of that is
+	 * WordPress switching the post type to the block editor, because
+	 * `use_block_editor_for_post_type()` returns true once a post type both
+	 * supports `editor` and is REST-exposed. Gutenberg was never part of
+	 * Smart Cache's document UI, so the IDE forces it back off here.
+	 *
+	 * Hooked at priority 9 (below the default 10) so it sets the default
+	 * rather than the final word: a site that deliberately wants the block
+	 * editor for `graphql_document` can still re-enable it from a callback
+	 * at priority 10 or later.
+	 *
+	 * @param bool   $use_block_editor Whether the post type uses the block editor.
+	 * @param string $post_type        Post type being checked.
+	 * @return bool
+	 */
+	public static function disable_block_editor_for_smart_cache_document( $use_block_editor, $post_type ) {
+		if ( 'graphql_document' === $post_type ) {
+			return false;
+		}
+
+		return $use_block_editor;
 	}
 
 	/**

--- a/plugins/wp-graphql-ide/tests/wpunit-integration/SmartCacheBridgeTest.php
+++ b/plugins/wp-graphql-ide/tests/wpunit-integration/SmartCacheBridgeTest.php
@@ -87,6 +87,58 @@ class SmartCacheBridgeTest extends \Codeception\TestCase\WPTestCase {
 		];
 	}
 
+	// ---------------------------------------------------------------
+	// Block editor opt-out (regression: #4018)
+	//
+	// Enabling `show_in_rest` on `graphql_document` is enough to flip
+	// WordPress to the block editor, since the post type also supports
+	// `editor`. Gutenberg is not a Smart Cache feature, so the bridge
+	// must opt the post type back out and leave Smart Cache's native
+	// classic-editor admin UI untouched, while keeping REST exposure.
+	// ---------------------------------------------------------------
+
+	public function test_graphql_document_stays_on_the_classic_editor() {
+		// Both block-editor preconditions are still satisfied: the bridge
+		// added `show_in_rest`, and the post type supports `editor`. The
+		// only thing keeping Gutenberg off is the bridge's
+		// `use_block_editor_for_post_type` opt-out.
+		$post_type = get_post_type_object( 'graphql_document' );
+		$this->assertNotNull( $post_type );
+		$this->assertTrue( (bool) $post_type->show_in_rest, 'REST exposure must remain on.' );
+		$this->assertTrue( post_type_supports( 'graphql_document', 'editor' ), 'editor support must remain on.' );
+
+		$this->assertFalse(
+			use_block_editor_for_post_type( 'graphql_document' ),
+			'`graphql_document` must stay on the classic editor even though it is REST-exposed and supports the editor.'
+		);
+	}
+
+	public function test_block_editor_opt_out_is_overridable_by_sites() {
+		// The opt-out is hooked at priority 9 so it sets the default, not
+		// the final word. A site that genuinely wants Gutenberg here can
+		// re-enable it from a later-priority callback.
+		$re_enable = static function ( $use_block_editor, $post_type ) {
+			return 'graphql_document' === $post_type ? true : $use_block_editor;
+		};
+		add_filter( 'use_block_editor_for_post_type', $re_enable, 10, 2 );
+
+		$this->assertTrue(
+			use_block_editor_for_post_type( 'graphql_document' ),
+			'A priority-10 filter must be able to override the bridge default at priority 9.'
+		);
+
+		remove_filter( 'use_block_editor_for_post_type', $re_enable, 10 );
+	}
+
+	public function test_block_editor_opt_out_does_not_touch_other_post_types() {
+		// The opt-out is post-type-scoped: a normal block-editor post type
+		// must be unaffected by the bridge's callback.
+		$this->assertTrue(
+			use_block_editor_for_post_type( 'post' ),
+			'`post` must keep its default block-editor behavior.'
+		);
+	}
+
 	public function test_unrelated_taxonomies_are_not_touched_by_the_bridge_filter() {
 		// Smoke-check: the filter is taxonomy-scoped, so registering a
 		// fresh taxonomy without `show_in_rest` should NOT be flipped on.


### PR DESCRIPTION
## What

Keeps Smart Cache's `graphql_document` post type on the classic editor when the WPGraphQL IDE is active, instead of silently switching it to the block editor (Gutenberg).

Fixes #4018.

## Why

Smart Cache registers `graphql_document` without `show_in_rest`, so its native admin edit screen uses the classic editor. The IDE's `SmartCacheBridge` filters in `show_in_rest => true` because the IDE's REST client and the `_graphql_ide_variables` / `_graphql_ide_headers` meta need it. That single change is enough to flip the post type to the block editor, because WordPress's `use_block_editor_for_post_type()` returns true once a post type both supports `editor` and is REST-exposed.

The block editor was never part of Smart Cache's document UI. The IDE adds its own surfaces inside the IDE app, but it should not change Smart Cache's native post type admin behavior. So this is a regression the IDE introduces just by being active.

## How

`SmartCacheBridge::register()` now hooks `use_block_editor_for_post_type` and returns `false` for `graphql_document`, while leaving `show_in_rest` in place so the REST client and meta keep working.

The filter is registered at priority 9 (below WordPress's default 10) on purpose: it sets the default rather than the final word, so a site that genuinely wants the block editor for `graphql_document` can re-enable it from a later-priority callback. Using the filter (instead of stripping `editor` support) is what makes that override possible.

## Testing

Regression coverage added to `tests/wpunit-integration/SmartCacheBridgeTest.php`:

- `test_graphql_document_stays_on_the_classic_editor` — asserts the post type stays on the classic editor while still being REST-exposed and supporting `editor` (this fails before the fix: `use_block_editor_for_post_type('graphql_document')` returns true).
- `test_block_editor_opt_out_is_overridable_by_sites` — a priority-10 filter can override the bridge default back to the block editor.
- `test_block_editor_opt_out_does_not_touch_other_post_types` — the callback is post-type-scoped, so `post` keeps its block-editor behavior.

Confirmed the first test fails without the fix and all 21 bridge tests pass with it. PHPStan clean.
