### PR TITLE
fix(deps): sync package-lock.json with @wordpress/hooks 4.50.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13191,9 +13191,9 @@
 			}
 		},
 		"node_modules/@wordpress/hooks": {
-			"version": "4.49.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.49.0.tgz",
-			"integrity": "sha512-65FZ3UXWkSIwFbELFABmcWn1KTA1AUdGAUH8pQlO7HKNO8F+zIrDkkO8gZA/zUHbI3I2vI1PyTA+rherPXg+Kg==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.50.0.tgz",
+			"integrity": "sha512-dV/AeP9iH1UydVWoUoCPuM8FUx2XvL1i65dhiwRHmZxK/zz8nR5Rq75WISpwFzRYfsyRThjl4LwUxhFAQnHrDw==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",


### PR DESCRIPTION
## Problem

CI is red across the board on `main`. Every job fails at the **Install NPM dependencies** step:

```
npm error `npm ci` can only install packages when your package.json and package-lock.json ... are in sync.
npm error Invalid: lock file's @wordpress/hooks@4.49.0 does not satisfy @wordpress/hooks@4.50.0
```

`@wordpress/hooks@4.50.0` was published, and a transitive `@wordpress/*` dependency now requires it, but the committed `package-lock.json` still pins `4.49.0`. Because `npm ci` runs at the start of **every** workflow, this fails the PHP-side jobs too (Integration Tests, Smoke Test, Schema Linter, Lint), even though nothing PHP changed. It surfaced on the `@babel/core` bump commit (#4022), whose lockfile regeneration didn't pick up the newer `@wordpress/hooks`.

## Fix

Regenerate the lockfile so `@wordpress/hooks` is in sync. `npm install --package-lock-only` produces a surgical one-dependency change (4.49.0 → 4.50.0), and `npm ci` then passes.

No source or dependency-range changes; `package.json` is untouched. This just brings the lockfile back in sync so CI can install dependencies again.