### PR TITLE
feat(wpgraphql.com): add prev/next navigation to the main docs pages

### DIFF
--- a/websites/wpgraphql.com/src/lib/parse-mdx-docs.ts
+++ b/websites/wpgraphql.com/src/lib/parse-mdx-docs.ts
@@ -248,6 +248,33 @@ export async function getDocsNav() {
   return resp.json()
 }
 
+/**
+ * Flatten the grouped docs nav (`{ [section]: [{ title, href }] }`) into a
+ * single ordered list of `{ href, label }` items, preserving the section and
+ * item order. This is the front-to-back reading sequence used to build the
+ * prev/next footer on docs pages.
+ */
+export function flattenDocsNav(
+  nav: Record<string, Array<{ title?: string; href?: string }>>
+): Array<{ href: string; label: string }> {
+  if (!nav || typeof nav !== "object") {
+    return []
+  }
+
+  const items: Array<{ href: string; label: string }> = []
+  for (const group of Object.values(nav)) {
+    if (!Array.isArray(group)) {
+      continue
+    }
+    for (const item of group) {
+      if (item && typeof item.href === "string") {
+        items.push({ href: item.href, label: item.title ?? item.href })
+      }
+    }
+  }
+  return items
+}
+
 export async function getAllDocUri(): Promise<string[]> {
   try {
     const localUris = await getLocalDocUris()

--- a/websites/wpgraphql.com/src/lib/sibling-nav.js
+++ b/websites/wpgraphql.com/src/lib/sibling-nav.js
@@ -16,3 +16,22 @@ export function siblingNav(items, currentSlug) {
     next: index < list.length - 1 ? list[index + 1] : null,
   }
 }
+
+/**
+ * Given an ordered list of `{ href, label }` items already in the intended
+ * reading order and the current href, return the previous/next neighbors.
+ * Unlike `siblingNav`, the order is preserved as-is: the docs sidebar nav
+ * defines a deliberate front-to-back sequence, so we walk it in place rather
+ * than re-sorting.
+ */
+export function orderedSiblings(items, currentHref) {
+  const list = Array.isArray(items) ? items : []
+  const index = list.findIndex((item) => item.href === currentHref)
+  if (index === -1) {
+    return { prev: null, next: null }
+  }
+  return {
+    prev: index > 0 ? list[index - 1] : null,
+    next: index < list.length - 1 ? list[index + 1] : null,
+  }
+}

--- a/websites/wpgraphql.com/src/pages/docs/[[...slug]].js
+++ b/websites/wpgraphql.com/src/pages/docs/[[...slug]].js
@@ -1,16 +1,19 @@
 import { MDXRemote } from "next-mdx-remote"
 
 import DocsLayout from "components/Docs/DocsLayout"
+import PrevNext from "components/Docs/PrevNext"
 import { getLayoutData, LayoutProvider } from "lib/wpgraphql-client"
 import "lib/wpgraphql-client-config"
 
 import {
+  flattenDocsNav,
   getAllDocUri,
   getDocsNav,
   getParsedDoc,
   isDeveloperReferenceDocUri,
   toCanonicalDocUri,
 } from "lib/parse-mdx-docs"
+import { orderedSiblings } from "lib/sibling-nav"
 
 import components from "components/Docs/MdxComponents"
 
@@ -44,7 +47,7 @@ function toSlugParams(uri) {
   return { params: { slug: slug.split("/") } }
 }
 
-export default function Doc({ source, toc, docsNavData, layoutData, hasMarkdownH1 }) {
+export default function Doc({ source, toc, docsNavData, layoutData, hasMarkdownH1, nav }) {
   return (
     <LayoutProvider value={layoutData}>
       <DocsLayout toc={toc} docsNavData={docsNavData}>
@@ -58,6 +61,7 @@ export default function Doc({ source, toc, docsNavData, layoutData, hasMarkdownH
             </header>
           )}
           <MDXRemote {...source} components={components} />
+          <PrevNext prev={nav?.prev} next={nav?.next} />
         </div>
       </DocsLayout>
     </LayoutProvider>
@@ -88,6 +92,10 @@ export async function getStaticProps({ params }) {
     const docsNavData = await getDocsNav()
     const layoutData = await getLayoutData()
 
+    // Prev/next follows the sidebar nav's front-to-back reading order rather
+    // than an alphabetical sort — the docs are meant to be read in sequence.
+    const nav = orderedSiblings(flattenDocsNav(docsNavData), requestedUri)
+
     return {
       props: {
         toc,
@@ -95,6 +103,7 @@ export async function getStaticProps({ params }) {
         docsNavData,
         hasMarkdownH1,
         layoutData,
+        nav,
       },
       revalidate: 30,
     }


### PR DESCRIPTION
## What

Extends the PrevNext footer added in #4031 (actions / filters / functions / recipes) to the **main docs pages** (`/docs/*`), reusing the existing `PrevNext` component.

## How

The reference sections order siblings alphabetically, but the main docs have a deliberate front-to-back reading order defined by the sidebar nav (`docs_nav.json`). So rather than sorting, we flatten that grouped nav and walk it in place. Navigation crosses section boundaries in the intended reading sequence (e.g. the last "Beginner Guides" page flows into the first "Using WPGraphQL" page).

- `src/lib/sibling-nav.js` — new `orderedSiblings(items, currentHref)`, a companion to the existing alphabetical `siblingNav` that finds neighbors in a pre-ordered list without re-sorting.
- `src/lib/parse-mdx-docs.ts` — new `flattenDocsNav(nav)` that linearizes the grouped `{ section: [{ title, href }] }` nav into an ordered `[{ href, label }]` list, preserving section and item order.
- `src/pages/docs/[[...slug]].js` — imports both helpers plus `PrevNext`, computes `nav` in `getStaticProps`, and renders the footer at the bottom of the content.

## Behavior (verified against the real 51-doc nav)

- First doc (`introduction`) renders next only, no prev.
- Last doc (`submit-extension`) renders prev only, no next.
- Section boundaries flow into each other in reading order.
- A doc not present in the nav renders no footer (both neighbors null, so `PrevNext` returns null).
