### PR TITLE
refactor(settings): derive the flat and grouped settings readers from one normalized map

### DIFF
--- a/plugins/wp-graphql/src/Data/DataSource.php
+++ b/plugins/wp-graphql/src/Data/DataSource.php
@@ -331,6 +331,55 @@ class DataSource {
 	}
 
 	/**
+	 * Build the canonical, normalized map of settings WPGraphQL can expose.
+	 *
+	 * The map is keyed by option name and each entry is the setting's registered
+	 * args plus its `key`. Both read surfaces (the flat settings map and the
+	 * grouped settings map) are derived from this single map so a setting cannot
+	 * appear on one surface and not the other.
+	 *
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The WPGraphQL TypeRegistry
+	 *
+	 * @return array<string,array<string,mixed>>
+	 *
+	 * @since x-release-please-version
+	 */
+	protected static function get_normalized_settings( TypeRegistry $type_registry ): array {
+
+		/**
+		 * Get all registered settings
+		 */
+		$registered_settings = get_registered_settings();
+
+		/**
+		 * Loop through the $registered_settings and add the setting to the
+		 * normalized map if it is allowed in GraphQL, or in REST when the
+		 * setting doesn't declare `show_in_graphql`.
+		 */
+		$normalized_settings = [];
+		foreach ( $registered_settings as $key => $setting ) {
+			$setting_key = (string) $key;
+
+			if ( ! isset( $setting['type'] ) || ! $type_registry->get_type( $setting['type'] ) ) {
+				continue;
+			}
+
+			if ( ! isset( $setting['show_in_graphql'] ) ) {
+				if ( ! isset( $setting['show_in_rest'] ) || false === $setting['show_in_rest'] ) {
+					continue;
+				}
+			} elseif ( true !== $setting['show_in_graphql'] ) {
+				continue;
+			}
+
+			$setting['key']                      = $setting_key;
+			$normalized_settings[ $setting_key ] = $setting;
+		}
+
+		return $normalized_settings;
+	}
+
+	/**
 	 * Get all of the allowed settings by group
 	 *
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The WPGraphQL TypeRegistry
@@ -340,18 +389,11 @@ class DataSource {
 	public static function get_allowed_settings_by_group( TypeRegistry $type_registry ) {
 
 		/**
-		 * Get all registered settings
-		 */
-		$registered_settings = get_registered_settings();
-
-		/**
-		 * Loop through the $registered_settings array and build an array of
-		 * settings for each group ( general, reading, discussion, writing, reading, etc. )
-		 * if the setting is allowed in REST or GraphQL
+		 * Group the normalized settings ( general, reading, discussion, writing, etc. ),
+		 * skipping settings that don't have a group.
 		 */
 		$allowed_settings_by_group = [];
-		foreach ( $registered_settings as $key => $setting ) {
-			// Bail if the setting doesn't have a group.
+		foreach ( self::get_normalized_settings( $type_registry ) as $setting_key => $setting ) {
 			if ( ! isset( $setting['group'] ) || empty( $setting['group'] ) ) {
 				continue;
 			}
@@ -360,27 +402,8 @@ class DataSource {
 			$setting_group = $setting['group'];
 			$group         = self::format_group_name( $setting_group );
 
-			if ( ! isset( $setting['type'] ) || ! $type_registry->get_type( $setting['type'] ) ) {
-				continue;
-			}
-
-			$setting_key = (string) $key;
-
-			if ( ! isset( $setting['show_in_graphql'] ) ) {
-				if ( isset( $setting['show_in_rest'] ) && false !== $setting['show_in_rest'] ) {
-					$setting['key']                                      = $setting_key;
-					$allowed_settings_by_group[ $group ][ $setting_key ] = $setting;
-				}
-			} elseif ( true === $setting['show_in_graphql'] ) {
-				$setting['key']                                      = $setting_key;
-				$allowed_settings_by_group[ $group ][ $setting_key ] = $setting;
-			}
+			$allowed_settings_by_group[ $group ][ $setting_key ] = $setting;
 		}
-
-		/**
-		 * Set the setting groups that are allowed
-		 */
-		$allowed_settings_by_group = ! empty( $allowed_settings_by_group ) ? $allowed_settings_by_group : [];
 
 		/**
 		 * Filter the $allowed_settings_by_group to allow enabling or disabling groups in the GraphQL Schema.
@@ -403,44 +426,9 @@ class DataSource {
 	public static function get_allowed_settings( TypeRegistry $type_registry ) {
 
 		/**
-		 * Get all registered settings
+		 * The flat view is the normalized map itself.
 		 */
-		$registered_settings = get_registered_settings();
-
-		/**
-		 * Set allowed settings variable.
-		 */
-		$allowed_settings = [];
-
-		if ( ! empty( $registered_settings ) ) {
-
-			/**
-			 * Loop through the $registered_settings and if the setting is allowed in REST or GraphQL
-			 * add it to the $allowed_settings array
-			 */
-			foreach ( $registered_settings as $key => $setting ) {
-				$setting_key = (string) $key;
-
-				if ( ! isset( $setting['type'] ) || ! $type_registry->get_type( $setting['type'] ) ) {
-					continue;
-				}
-
-				if ( ! isset( $setting['show_in_graphql'] ) ) {
-					if ( isset( $setting['show_in_rest'] ) && false !== $setting['show_in_rest'] ) {
-						$setting['key']                   = $setting_key;
-						$allowed_settings[ $setting_key ] = $setting;
-					}
-				} elseif ( true === $setting['show_in_graphql'] ) {
-					$setting['key']                   = $setting_key;
-					$allowed_settings[ $setting_key ] = $setting;
-				}
-			}
-		}
-
-		/**
-		 * Verify that we have the allowed settings
-		 */
-		$allowed_settings = ! empty( $allowed_settings ) ? $allowed_settings : [];
+		$allowed_settings = self::get_normalized_settings( $type_registry );
 
 		/**
 		 * Filter the $allowed_settings to allow some to be enabled or disabled from showing in

--- a/plugins/wp-graphql/tests/wpunit/SettingQueriesTest.php
+++ b/plugins/wp-graphql/tests/wpunit/SettingQueriesTest.php
@@ -518,6 +518,136 @@ class SettingQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		unregister_setting( 'zool', 'points' );
 	}
 
+	/**
+	 * A setting registered with a group must surface on both read surfaces:
+	 * as a field on its group type and as a group-prefixed field on the
+	 * flat Settings type.
+	 */
+	public function testRegisteredSettingAppearsInFlatAndGroupedTypes() {
+		wp_set_current_user( $this->admin );
+
+		register_setting(
+			'zool',
+			'points',
+			[
+				'type'            => 'number',
+				'description'     => __( 'Test how many points we have in Zool.' ),
+				'show_in_graphql' => true,
+			]
+		);
+
+		$query = '
+		query GetTypes {
+			grouped: __type(name: "ZoolSettings") {
+				fields {
+					name
+				}
+			}
+			flat: __type(name: "Settings") {
+				fields {
+					name
+				}
+			}
+		}
+		';
+
+		$actual = $this->graphql( compact( 'query' ) );
+
+		unregister_setting( 'zool', 'points' );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$grouped_fields = wp_list_pluck( $actual['data']['grouped']['fields'], 'name' );
+		$flat_fields    = wp_list_pluck( $actual['data']['flat']['fields'], 'name' );
+		$this->assertContains( 'points', $grouped_fields );
+		$this->assertContains( 'zoolSettingsPoints', $flat_fields );
+	}
+
+	/**
+	 * A setting registered with `show_in_rest` (and no explicit
+	 * `show_in_graphql`) must also surface on both read surfaces.
+	 */
+	public function testSettingRegisteredForRestAppearsInFlatAndGroupedTypes() {
+		wp_set_current_user( $this->admin );
+
+		register_setting(
+			'zool',
+			'points',
+			[
+				'type'         => 'number',
+				'description'  => __( 'Test how many points we have in Zool.' ),
+				'show_in_rest' => true,
+			]
+		);
+
+		$query = '
+		query GetTypes {
+			grouped: __type(name: "ZoolSettings") {
+				fields {
+					name
+				}
+			}
+			flat: __type(name: "Settings") {
+				fields {
+					name
+				}
+			}
+		}
+		';
+
+		$actual = $this->graphql( compact( 'query' ) );
+
+		unregister_setting( 'zool', 'points' );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$grouped_fields = wp_list_pluck( $actual['data']['grouped']['fields'], 'name' );
+		$flat_fields    = wp_list_pluck( $actual['data']['flat']['fields'], 'name' );
+		$this->assertContains( 'points', $grouped_fields );
+		$this->assertContains( 'zoolSettingsPoints', $flat_fields );
+	}
+
+	/**
+	 * The grouped and flat read surfaces terminate in independent filters:
+	 * emptying `graphql_allowed_settings_by_group` removes the per-group
+	 * root fields but leaves the flat allSettings surface intact.
+	 */
+	public function testFilteringGroupedSettingsDoesNotAffectFlatSettings() {
+		wp_set_current_user( $this->admin );
+
+		$filter = static function () {
+			return [];
+		};
+
+		add_filter( 'graphql_allowed_settings_by_group', $filter, 99 );
+		$this->clearSchema();
+
+		$query = '
+		query GetTypes {
+			__type(name: "RootQuery") {
+				fields {
+					name
+				}
+			}
+			flat: __type(name: "Settings") {
+				fields {
+					name
+				}
+			}
+		}
+		';
+
+		$actual = $this->graphql( compact( 'query' ) );
+
+		remove_filter( 'graphql_allowed_settings_by_group', $filter, 99 );
+		$this->clearSchema();
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$root_fields = wp_list_pluck( $actual['data']['__type']['fields'], 'name' );
+		$this->assertNotContains( 'generalSettings', $root_fields, 'Expected per-group root fields to be removed when the grouped settings are filtered out' );
+		$this->assertContains( 'allSettings', $root_fields, 'Expected the flat allSettings surface to be unaffected by the grouped settings filter' );
+		$flat_fields = wp_list_pluck( $actual['data']['flat']['fields'], 'name' );
+		$this->assertContains( 'generalSettingsTitle', $flat_fields );
+	}
+
 	public function testUnregisteringSettingPreventsItFromBeingInTheSchema() {
 
 		register_setting(


### PR DESCRIPTION
## What

First slice of the [Settings as Models / Nodes RFC](https://github.com/wp-graphql/wp-graphql/issues/2459#issuecomment-4919744973): collapses the two independent settings readers in `DataSource` into one canonical normalized settings map, with the flat and grouped views derived from it.

`get_allowed_settings()` and `get_allowed_settings_by_group()` each re-read `get_registered_settings()`, re-implemented the same `show_in_graphql` / `show_in_rest` filtering, and terminated in their own filter. That duplication is how a setting can land on one read surface and not the other. Both now derive from a single `get_normalized_settings()` builder, and each view still terminates in its existing public filter (`graphql_allowed_setting_groups`, `graphql_allowed_settings_by_group`), so nothing changes for anyone hooking those.

## Behavior

No schema or behavior changes. New characterization tests (committed first, passing before and after the refactor) pin the parity and filter semantics:

- a setting registered with a group surfaces on both read surfaces, its group type and the flat `Settings` type
- a setting registered with `show_in_rest` and no explicit `show_in_graphql` surfaces on both
- the two public filters stay independent: emptying `graphql_allowed_settings_by_group` removes the per-group root fields but leaves `allSettings` intact

## What's next (not in this PR)

The in-memory shim set for options core never registers (`home`, `permalink_structure`), per-entry config (`readonly` flag, access-control hook, per-setting `resolve`), and replacing the `generalSettingsUrl` guard in `UpdateSettings` all build on this map in a follow-up PR.

Part of #3931. Design details in the RFC on #2459.
