### PR TITLE
chore: remove settings per-entry config accidentally merged via #4063

### DIFF
--- a/plugins/wp-graphql/src/Data/DataSource.php
+++ b/plugins/wp-graphql/src/Data/DataSource.php
@@ -26,7 +26,6 @@ use WPGraphQL\Model\Theme;
 use WPGraphQL\Model\User;
 use WPGraphQL\Model\UserRole;
 use WPGraphQL\Registry\TypeRegistry;
-use WPGraphQL\Type\ObjectType\SettingGroup;
 
 /**
  * Class DataSource
@@ -377,66 +376,7 @@ class DataSource {
 			$normalized_settings[ $setting_key ] = $setting;
 		}
 
-		/**
-		 * Apply WPGraphQL-managed config to core settings that need behavior
-		 * beyond what their registration args declare.
-		 */
-		foreach ( self::get_core_setting_config() as $setting_key => $config ) {
-			if ( isset( $normalized_settings[ $setting_key ] ) ) {
-				$normalized_settings[ $setting_key ] = array_merge( $normalized_settings[ $setting_key ], $config );
-			}
-		}
-
-		/**
-		 * Filter the normalized settings map before the read and mutation surfaces are derived from it.
-		 *
-		 * This is the seam for exposing options WordPress never registers via register_setting():
-		 * seed an entry here, in memory, instead of mutating the global settings registry. Entries
-		 * follow the register_setting() args shape (`group`, `type`, `description`, ...) plus a `key`
-		 * holding the option name, and support WPGraphQL-specific config: `graphql_readonly` (bool)
-		 * rejects updates to the setting through the updateSettings mutation, and `graphql_resolve`
-		 * (callable) normalizes the setting's resolved value.
-		 *
-		 * @param array<string,array<string,mixed>> $normalized_settings The normalized settings map, keyed by option name.
-		 * @param \WPGraphQL\Registry\TypeRegistry  $type_registry       The WPGraphQL TypeRegistry.
-		 *
-		 * @hookGroup settings
-		 * @since x-release-please-version
-		 */
-		$normalized_settings = apply_filters( 'graphql_normalized_settings', $normalized_settings, $type_registry );
-
-		/**
-		 * Ensure every entry carries its option name as `key`, so filter-added
-		 * entries don't need to duplicate it.
-		 */
-		foreach ( $normalized_settings as $setting_key => $setting ) {
-			if ( ! isset( $setting['key'] ) ) {
-				$normalized_settings[ $setting_key ]['key'] = (string) $setting_key;
-			}
-		}
-
 		return $normalized_settings;
-	}
-
-	/**
-	 * WPGraphQL-managed config for core settings, applied on top of their
-	 * registered args in the normalized settings map.
-	 *
-	 * @return array<string,array<string,mixed>>
-	 *
-	 * @since x-release-please-version
-	 */
-	protected static function get_core_setting_config(): array {
-		return [
-			// The site URL must not be updatable through the API.
-			'siteurl'         => [
-				'graphql_readonly' => true,
-			],
-			// Derive the timezone from `gmt_offset` when `timezone_string` is empty.
-			'timezone_string' => [
-				'graphql_resolve' => [ SettingGroup::class, 'resolve_timezone_setting_value' ],
-			],
-		];
 	}
 
 	/**

--- a/plugins/wp-graphql/src/Mutation/UpdateSettings.php
+++ b/plugins/wp-graphql/src/Mutation/UpdateSettings.php
@@ -156,7 +156,7 @@ class UpdateSettings {
 	 * @param array<string,mixed>              $input The mutation input
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The WPGraphQL TypeRegistry
 	 *
-	 * @return array<string,array<string,mixed>>
+	 * @return array<string,array<string,string>>
 	 *
 	 * @throws \GraphQL\Error\UserError
 	 */
@@ -197,36 +197,28 @@ class UpdateSettings {
 			 * then add it to $updatable_settings_options
 			 */
 			$updatable_settings_options[ Utils::format_field_name( $individual_setting_key ) ] = [
-				'option'   => $key,
-				'group'    => $setting['group'],
-				'readonly' => ! empty( $setting['graphql_readonly'] ),
+				'option' => $key,
+				'group'  => $setting['group'],
 			];
 		}
 
 		foreach ( $input as $key => $value ) {
 			/**
-			 * Check to see that the input field exists in settings, if so grab the option
-			 * name and update the option
+			 * Throw an error if the input field is the site url,
+			 * as we do not want users changing it and breaking all
+			 * the things
 			 */
-			if ( ! array_key_exists( $key, $updatable_settings_options ) ) {
-				continue;
+			if ( 'generalSettingsUrl' === $key ) {
+				throw new UserError( esc_html__( 'Sorry, that is not allowed, speak with your site administrator to change the site URL.', 'wp-graphql' ) );
 			}
 
 			/**
-			 * Throw an error if the setting is readonly, e.g. the site url,
-			 * as we do not want users changing it and breaking all the things
+			 * Check to see that the input field exists in settings, if so grab the option
+			 * name and update the option
 			 */
-			if ( ! empty( $updatable_settings_options[ $key ]['readonly'] ) ) {
-				throw new UserError(
-					sprintf(
-						/* translators: %s is the name of the readonly settings input field. */
-						esc_html__( 'Sorry, the %s setting cannot be changed with this mutation, speak with your site administrator to change it.', 'wp-graphql' ),
-						esc_html( $key )
-					)
-				);
+			if ( array_key_exists( $key, $updatable_settings_options ) ) {
+				update_option( $updatable_settings_options[ $key ]['option'], $value );
 			}
-
-			update_option( $updatable_settings_options[ $key ]['option'], $value );
 		}
 
 		return $updatable_settings_options;

--- a/plugins/wp-graphql/src/Type/ObjectType/SettingGroup.php
+++ b/plugins/wp-graphql/src/Type/ObjectType/SettingGroup.php
@@ -127,18 +127,11 @@ class SettingGroup {
 							}
 
 							/**
-							 * Give the setting's own resolver, declared as `graphql_resolve`
-							 * in the normalized settings map, the first pass at the value.
-							 */
-							if ( isset( $setting_field['graphql_resolve'] ) && is_callable( $setting_field['graphql_resolve'] ) ) {
-								$value = call_user_func( $setting_field['graphql_resolve'], $value, $setting_field, $group_name );
-							}
-
-							/**
 							 * Filters the resolved value of a single settings field before it is returned in the Schema.
 							 *
 							 * This gives extensions a seam to normalize or override a setting's resolved value
-							 * without adding one-off special cases to the core resolver.
+							 * (for example, deriving `timezone` from the `gmt_offset` option when `timezone_string`
+							 * is empty) without adding one-off special cases to the core resolver.
 							 *
 							 * @param mixed               $value         The resolved (and type-cast) value of the setting field.
 							 * @param array<string,mixed> $setting_field The setting field config, including its `key` and `type`.
@@ -157,8 +150,7 @@ class SettingGroup {
 	}
 
 	/**
-	 * Resolver for the timezone setting, assigned as the `graphql_resolve` config
-	 * of the `timezone_string` entry in the normalized settings map.
+	 * Default callback for the `graphql_setting_field_value` filter.
 	 *
 	 * When a site is configured with a manual UTC offset instead of a named timezone,
 	 * WordPress stores the offset in the `gmt_offset` option and leaves `timezone_string`
@@ -174,7 +166,7 @@ class SettingGroup {
 	 *
 	 * @since x-release-please-version
 	 */
-	public static function resolve_timezone_setting_value( $value, array $setting_field ) {
+	public static function resolve_default_setting_field_value( $value, array $setting_field ) {
 		if ( isset( $setting_field['key'] ) && 'timezone_string' === $setting_field['key'] && empty( $value ) ) {
 			return wp_timezone_string();
 		}

--- a/plugins/wp-graphql/src/Type/ObjectType/Settings.php
+++ b/plugins/wp-graphql/src/Type/ObjectType/Settings.php
@@ -62,11 +62,6 @@ class Settings {
 					continue;
 				}
 
-				// The flat field name is prefixed with the group, so entries without a group can't be exposed here.
-				if ( ! isset( $setting_field['group'] ) || empty( $setting_field['group'] ) ) {
-					continue;
-				}
-
 				/**
 				 * Determine if the individual setting already has a
 				 * REST API name, if not use the option name.
@@ -100,7 +95,7 @@ class Settings {
 							// translators: %s is the name of the setting group.
 							return sprintf( __( 'Settings of the the %s Settings Group', 'wp-graphql' ), $setting_field['type'] );
 						},
-						'resolve'     => static function () use ( $setting_field, $key, $group ) {
+						'resolve'     => static function () use ( $setting_field, $key ) {
 							/**
 							 * Check to see if the user querying the email field has the 'manage_options' capability
 							 * All other options should be public by default
@@ -126,29 +121,7 @@ class Settings {
 									break;
 							}
 
-							$option = isset( $option ) ? $option : null;
-
-							/**
-							 * Give the setting's own resolver, declared as `graphql_resolve`
-							 * in the normalized settings map, the first pass at the value.
-							 */
-							if ( isset( $setting_field['graphql_resolve'] ) && is_callable( $setting_field['graphql_resolve'] ) ) {
-								$option = call_user_func( $setting_field['graphql_resolve'], $option, $setting_field, $group );
-							}
-
-							/**
-							 * Filters the resolved value of a single settings field before it is returned in the Schema.
-							 *
-							 * This is the same seam applied by the grouped setting types, so a setting's
-							 * value resolves consistently on both read surfaces.
-							 *
-							 * @param mixed               $value         The resolved (and type-cast) value of the setting field.
-							 * @param array<string,mixed> $setting_field The setting field config, including its `key` and `type`.
-							 * @param string              $group_name    The name of the settings group the field belongs to.
-							 *
-							 * @since x-release-please-version
-							 */
-							return apply_filters( 'graphql_setting_field_value', $option, $setting_field, $group );
+							return isset( $option ) ? $option : null;
 						},
 					];
 				}

--- a/plugins/wp-graphql/src/WPGraphQL.php
+++ b/plugins/wp-graphql/src/WPGraphQL.php
@@ -10,6 +10,7 @@ use WPGraphQL\AppContext;
 use WPGraphQL\Registry\SchemaRegistry;
 use WPGraphQL\Registry\TypeRegistry;
 use WPGraphQL\Router;
+use WPGraphQL\Type\ObjectType\SettingGroup;
 use WPGraphQL\Utils\InstrumentSchema;
 use WPGraphQL\Utils\Preview;
 
@@ -417,6 +418,18 @@ final class WPGraphQL {
 			],
 			10,
 			4
+		);
+
+		// Provide default resolved values for settings fields (e.g. deriving the
+		// `timezone` from `gmt_offset` when `timezone_string` is empty).
+		add_filter(
+			'graphql_setting_field_value',
+			[
+				SettingGroup::class,
+				'resolve_default_setting_field_value',
+			],
+			10,
+			2
 		);
 
 		/**

--- a/plugins/wp-graphql/tests/wpunit/SettingQueriesTest.php
+++ b/plugins/wp-graphql/tests/wpunit/SettingQueriesTest.php
@@ -648,58 +648,6 @@ class SettingQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->assertContains( 'generalSettingsTitle', $flat_fields );
 	}
 
-	/**
-	 * An entry seeded into the normalized settings map via the
-	 * `graphql_normalized_settings` filter surfaces on both read surfaces
-	 * without calling register_setting(), and its `graphql_resolve` callback
-	 * normalizes the resolved value.
-	 */
-	public function testNormalizedSettingsFilterCanAddSetting() {
-		wp_set_current_user( $this->admin );
-
-		update_option( 'shim_option', 'raw value' );
-
-		$filter = static function ( $settings ) {
-			$settings['shim_option'] = [
-				'key'             => 'shim_option',
-				'group'           => 'shimmed',
-				'type'            => 'string',
-				'description'     => 'A setting seeded into the normalized map without register_setting().',
-				'graphql_resolve' => static function ( $value ) {
-					return strtoupper( (string) $value );
-				},
-			];
-			return $settings;
-		};
-
-		add_filter( 'graphql_normalized_settings', $filter );
-		$this->clearSchema();
-
-		$query = '
-		query {
-			shimmedSettings {
-				shimOption
-			}
-			flat: __type(name: "Settings") {
-				fields {
-					name
-				}
-			}
-		}
-		';
-
-		$actual = $this->graphql( compact( 'query' ) );
-
-		remove_filter( 'graphql_normalized_settings', $filter );
-		delete_option( 'shim_option' );
-		$this->clearSchema();
-
-		$this->assertArrayNotHasKey( 'errors', $actual );
-		$this->assertSame( 'RAW VALUE', $actual['data']['shimmedSettings']['shimOption'] );
-		$flat_fields = wp_list_pluck( $actual['data']['flat']['fields'], 'name' );
-		$this->assertContains( 'shimmedSettingsShimOption', $flat_fields );
-	}
-
 	public function testUnregisteringSettingPreventsItFromBeingInTheSchema() {
 
 		register_setting(

--- a/plugins/wp-graphql/tests/wpunit/SettingsMutationsTest.php
+++ b/plugins/wp-graphql/tests/wpunit/SettingsMutationsTest.php
@@ -308,54 +308,6 @@ class SettingsMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase 
 	}
 
 	/**
-	 * A setting registered with `graphql_readonly` must reject updates through
-	 * the updateSettings mutation and leave the stored option untouched.
-	 */
-	public function testReadonlySettingCannotBeUpdated() {
-		wp_set_current_user( $this->admin );
-
-		register_setting(
-			'vault',
-			'locked_value',
-			[
-				'type'             => 'string',
-				'description'      => __( 'Test a readonly setting.' ),
-				'show_in_graphql'  => true,
-				'graphql_readonly' => true,
-			]
-		);
-
-		update_option( 'locked_value', 'original' );
-
-		$query = '
-		mutation UpdateReadonlySetting( $input: UpdateSettingsInput! ) {
-			updateSettings( input: $input ) {
-				clientMutationId
-			}
-		}
-		';
-
-		$actual = $this->graphql(
-			[
-				'query'     => $query,
-				'variables' => [
-					'input' => [
-						'clientMutationId'         => 'readonlyTest',
-						'vaultSettingsLockedValue' => 'changed',
-					],
-				],
-			]
-		);
-
-		unregister_setting( 'vault', 'locked_value' );
-
-		$this->assertArrayHasKey( 'errors', $actual );
-		$this->assertSame( 'original', get_option( 'locked_value' ) );
-
-		delete_option( 'locked_value' );
-	}
-
-	/**
 	 * This function tests whether we receive an error or success
 	 * when trying to update the site's URL
 	 *

--- a/plugins/wp-graphql/tests/wpunit/SettingsQueriesTest.php
+++ b/plugins/wp-graphql/tests/wpunit/SettingsQueriesTest.php
@@ -259,31 +259,6 @@ class WP_GraphQL_Test_Settings_Queries extends \Tests\WPGraphQL\TestCase\WPGraph
 	 *
 	 * @return void
 	 */
-	/**
-	 * The timezone fallback (deriving the value from `gmt_offset` when
-	 * `timezone_string` is empty) must apply on the flat allSettings surface,
-	 * not just the grouped generalSettings surface.
-	 */
-	public function testFlatTimezoneSettingFallsBackToUtcOffset() {
-		wp_set_current_user( $this->admin );
-
-		update_option( 'timezone_string', '' );
-		update_option( 'gmt_offset', '2' );
-
-		$query = '
-		query {
-			allSettings {
-				generalSettingsTimezone
-			}
-		}
-		';
-
-		$actual = $this->graphql( compact( 'query' ) );
-
-		$this->assertArrayNotHasKey( 'errors', $actual );
-		$this->assertSame( '+02:00', $actual['data']['allSettings']['generalSettingsTimezone'] );
-	}
-
 	public function testAllSettingsFieldIsHiddenWhenNoSettingsAreExposed() {
 		$filter = static function () {
 			return [];

--- a/plugins/wp-graphql/tests/wpunit/WPGraphQLTest.php
+++ b/plugins/wp-graphql/tests/wpunit/WPGraphQLTest.php
@@ -65,6 +65,17 @@ class WPGraphQLTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$filters->invoke( $instance );
 
 		$this->assertTrue( isset( $wp_filter['graphql_get_type']->callbacks ) );
+
+		// The default settings value normalization (e.g. deriving `timezone` from
+		// `gmt_offset` when `timezone_string` is empty) must be hooked to the
+		// graphql_setting_field_value filter.
+		$this->assertSame(
+			10,
+			has_filter(
+				'graphql_setting_field_value',
+				[ \WPGraphQL\Type\ObjectType\SettingGroup::class, 'resolve_default_setting_field_value' ]
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
PR #4063 ("chore: ignore graphiql Dependabot updates for the deprecated bundled IDE") was branched on top of the unmerged per-entry settings-config commit, so its squash-merge (149abc177) swept the entire feature onto `main` mislabeled as a `chore(deps)` change.

This restores the affected settings source and test files to their post-#4048 state (`b73662143`) so the feature can land properly via #4049 as `feat(settings)`. The `dependabot.yml` ignore rule from #4063 is intact; no other `main` changes are touched.

## What this does
- Removes the per-entry settings config (`graphql_normalized_settings`, `graphql_readonly`, `graphql_resolve`, the timezone fallback move) and its three test files from `main`, restoring them to their post-#4048 state.
- Leaves the `dependabot.yml` ignore rule from #4063 in place.
- Touches nothing else on `main`.

## Sequencing
Sequenced with #4049, which is rebased and re-merged as `feat(settings)` once this lands, so the feature keeps proper `feat` attribution, changelog entry, and version bump.

Refs #2459, #3931