### PR TITLE
docs(settings): document graphql_normalized_settings filter and per-setting config keys

### DIFF
--- a/plugins/wp-graphql/docs/settings.md
+++ b/plugins/wp-graphql/docs/settings.md
@@ -72,6 +72,40 @@ This could now be queried like so:
 
 > \*\*NOTE: \*\*If a setting is registered without a group defined it will appear under `generalSettings`.
 
+## Exposing Options WordPress Doesn't Register
+
+Some options are never registered through `register_setting()`, for example values a plugin saved with `update_option()`, or core options that WordPress simply doesn't register. WPGraphQL can't see those by default.
+
+Rather than calling `register_setting()` yourself (which mutates global state for the rest of the request, affecting internal `graphql()` calls, block render callbacks, cron, and WP-CLI), use the `graphql_normalized_settings` filter to add an entry to WPGraphQL's own settings map, in memory:
+
+```php
+add_filter( 'graphql_normalized_settings', function ( array $settings ) {
+    // Expose an option that was saved via update_option() but never
+    // registered with register_setting(), so WPGraphQL can't see it by default.
+    $settings['my_legacy_option'] = [
+        'group'            => 'general',
+        'type'             => 'string',
+        'description'      => __( 'A value stored by a legacy plugin.', 'my-textdomain' ),
+        'graphql_readonly' => true,
+    ];
+
+    return $settings;
+} );
+```
+
+The entry follows the `register_setting()` args shape (`group`, `type`, `description`, …) plus the WPGraphQL-specific config in the next section. It then surfaces on both read surfaces like any registered setting, in this example as `generalSettings { myLegacyOption }` and `allSettings { generalSettingsMyLegacyOption }`.
+
+> **NOTE:** Entries are keyed by the **option name**, which is globally unique in WordPress, there is a single row per option in the options table regardless of which group registered it, so the group is never part of the key. The `group` is metadata that places the field under the matching setting-group type. Because this filter runs *after* registered settings are collected, assigning an entry whose key matches an existing option name **overrides** that entry, so use a fresh option name unless you specifically intend to modify an existing setting's configuration.
+
+## Per-Setting Configuration
+
+Beyond the standard `register_setting()` args, WPGraphQL reads the following per-setting config keys. These apply whether the setting is registered with `register_setting()` (via its `$args`) or seeded through the `graphql_normalized_settings` filter above:
+
+| Field              | Type     | Required | Description                                                                                                                                                                                                             |
+| ------------------ | -------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `graphql_readonly` | boolean  | No       | If true, the setting is exposed for reading but cannot be changed through the `updateSettings` mutation. Use for values that must not be writable through the API, such as the site address.                            |
+| `graphql_resolve`  | callable | No       | A resolver for the setting's value, given the first pass before the value is returned. Receives the stored value and returns the value to expose. Use to normalize or derive a value, such as deriving a timezone from a UTC offset when no named zone is set. |
+
 ## Querying Settings
 
 ### All Settings


### PR DESCRIPTION
Documents the new settings-mapping surface for developers, extending the existing [Settings guide](../plugins/wp-graphql/docs/settings.md).

## Adds
- **Exposing Options WordPress Doesn't Register** — the `graphql_normalized_settings` filter for seeding options core never registers (in memory, without `register_setting()` and its global-state side effects). Includes the clarification that entries are keyed by the **globally-unique option name** (not the group), that `group` is metadata routing the field into its setting-group type, and that a filter entry with an existing option name **overrides** that entry.
- **Per-Setting Configuration** — a `Field | Type | Required | Description` table for `graphql_readonly` and `graphql_resolve`, matching the style of the Custom Post Types doc.

Only shipped keys are documented; the planned config keys (`graphql_field_name`, `graphql_capability`, `graphql_description`) will be added as each slice ships.

The `graphql_normalized_settings` filter reference page is generated from its call-site docblock at release; this PR is the narrative guide.

## Sequencing
Documents behavior added in **#4076** (the per-entry config code). Merge after #4076 lands. Refs #2459, #3931.