### PR TITLE
feat(settings): seed in-memory shims (home, permalink) and consolidate field-name derivation

### DIFF
--- a/plugins/wp-graphql/docs/settings.md
+++ b/plugins/wp-graphql/docs/settings.md
@@ -97,14 +97,17 @@ The entry follows the `register_setting()` args shape (`group`, `type`, `descrip
 
 > **NOTE:** Entries are keyed by the **option name**, which is globally unique in WordPress, there is a single row per option in the options table regardless of which group registered it, so the group is never part of the key. The `group` is metadata that places the field under the matching setting-group type. Because this filter runs *after* registered settings are collected, assigning an entry whose key matches an existing option name **overrides** that entry, so use a fresh option name unless you specifically intend to modify an existing setting's configuration.
 
+WPGraphQL uses this same mechanism to expose a few common options core doesn't register: the **Site Address** (`generalSettings { homeUrl }`, also on the flat type as `generalSettingsHomeUrl`) and the **permalink** options under a `permalinkSettings` group (`structure`, `categoryBase`, `tagBase`). On multisite it also shims `siteurl` (core only registers it on single-site), so `generalSettings { url }` and `generalSettingsUrl` are available on multisite too. These are read-only.
+
 ## Per-Setting Configuration
 
 Beyond the standard `register_setting()` args, WPGraphQL reads the following per-setting config keys. These apply whether the setting is registered with `register_setting()` (via its `$args`) or seeded through the `graphql_normalized_settings` filter above:
 
-| Field              | Type     | Required | Description                                                                                                                                                                                                             |
-| ------------------ | -------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `graphql_readonly` | boolean  | No       | If true, the setting is exposed for reading but cannot be changed through the `updateSettings` mutation. Use for values that must not be writable through the API, such as the site address.                            |
-| `graphql_resolve`  | callable | No       | A resolver for the setting's value, given the first pass before the value is returned. Receives the stored value and returns the value to expose. Use to normalize or derive a value, such as deriving a timezone from a UTC offset when no named zone is set. |
+| Field                | Type     | Required | Description                                                                                                                                                                                                             |
+| -------------------- | -------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `graphql_field_name` | string   | No       | An explicit field name for the setting. Overrides the default name (which is derived from the `show_in_rest` name or the option key). The value is run through WPGraphQL's standard field-name formatter, the same one applied to every field, so `graphql_field_name => 'homeUrl'` exposes the field as `homeUrl`.                            |
+| `graphql_readonly`   | boolean  | No       | If true, the setting is exposed for reading but cannot be changed through the `updateSettings` mutation. Use for values that must not be writable through the API, such as the site address.                            |
+| `graphql_resolve`    | callable | No       | A resolver for the setting's value, given the first pass before the value is returned. Receives the stored value and returns the value to expose. Use to normalize or derive a value, such as deriving a timezone from a UTC offset when no named zone is set. |
 
 ## Querying Settings
 

--- a/plugins/wp-graphql/src/Data/DataSource.php
+++ b/plugins/wp-graphql/src/Data/DataSource.php
@@ -27,6 +27,7 @@ use WPGraphQL\Model\User;
 use WPGraphQL\Model\UserRole;
 use WPGraphQL\Registry\TypeRegistry;
 use WPGraphQL\Type\ObjectType\SettingGroup;
+use WPGraphQL\Utils\Utils;
 
 /**
  * Class DataSource
@@ -388,6 +389,20 @@ class DataSource {
 		}
 
 		/**
+		 * Seed the in-memory shims for options WordPress doesn't register via
+		 * register_setting() (e.g. `home`, the permalink options). Added after the
+		 * registered-settings loop and before the filter so extensions can override
+		 * them, and only when the option isn't already present in the map so a real
+		 * registration always wins.
+		 */
+		foreach ( self::get_core_shim_settings() as $setting_key => $shim ) {
+			if ( ! isset( $normalized_settings[ $setting_key ] ) ) {
+				$shim['key']                         = (string) $setting_key;
+				$normalized_settings[ $setting_key ] = $shim;
+			}
+		}
+
+		/**
 		 * Filter the normalized settings map before the read and mutation surfaces are derived from it.
 		 *
 		 * This is the seam for exposing options WordPress never registers via register_setting():
@@ -407,15 +422,54 @@ class DataSource {
 
 		/**
 		 * Ensure every entry carries its option name as `key`, so filter-added
-		 * entries don't need to duplicate it.
+		 * entries don't need to duplicate it. Then precompute each entry's GraphQL
+		 * field names once, so every read/write surface reads the same name instead
+		 * of re-deriving it independently.
 		 */
 		foreach ( $normalized_settings as $setting_key => $setting ) {
 			if ( ! isset( $setting['key'] ) ) {
+				$setting['key']                             = (string) $setting_key;
 				$normalized_settings[ $setting_key ]['key'] = (string) $setting_key;
+			}
+
+			// The base/grouped field name (e.g. `homeUrl`, used on GeneralSettings).
+			$field_name = self::get_setting_field_name( $setting );
+
+			$normalized_settings[ $setting_key ]['graphql_field_name'] = $field_name;
+
+			// The flat field name (e.g. `generalSettingsHomeUrl`, used on the Settings type)
+			// only exists for entries that belong to a group.
+			if ( ! empty( $setting['group'] ) ) {
+				$normalized_settings[ $setting_key ]['graphql_settings_field_name'] = lcfirst( self::format_group_name( (string) $setting['group'] ) . 'Settings' . ucfirst( $field_name ) );
 			}
 		}
 
 		return $normalized_settings;
+	}
+
+	/**
+	 * Derive the base (grouped) GraphQL field name for a normalized setting.
+	 *
+	 * `graphql_field_name`, when set, overrides the name otherwise derived from the
+	 * REST name (`show_in_rest['name']`) or the option key. In every case the name
+	 * is run through `Utils::format_field_name()`, the same canonical formatter the
+	 * field registration applies, so the precomputed name matches the name that
+	 * ends up in the Schema and stays consistent with field naming elsewhere.
+	 *
+	 * @param array<string,mixed> $setting A normalized settings map entry.
+	 *
+	 * @since x-release-please-version
+	 */
+	protected static function get_setting_field_name( array $setting ): string {
+		if ( ! empty( $setting['graphql_field_name'] ) ) {
+			$name = (string) $setting['graphql_field_name'];
+		} elseif ( ! empty( $setting['show_in_rest']['name'] ) ) {
+			$name = (string) $setting['show_in_rest']['name'];
+		} else {
+			$name = isset( $setting['key'] ) ? (string) $setting['key'] : '';
+		}
+
+		return Utils::format_field_name( $name );
 	}
 
 	/**
@@ -428,13 +482,84 @@ class DataSource {
 	 */
 	protected static function get_core_setting_config(): array {
 		return [
-			// The site URL must not be updatable through the API.
+			// The site URL must not be updatable through the API. The input field is
+			// kept (deprecated) rather than removed so existing schemas don't break.
 			'siteurl'         => [
-				'graphql_readonly' => true,
+				'graphql_readonly'         => true,
+				'graphql_deprecated_input' => __( 'The site URL is read-only and cannot be changed through the API.', 'wp-graphql' ),
 			],
 			// Derive the timezone from `gmt_offset` when `timezone_string` is empty.
 			'timezone_string' => [
 				'graphql_resolve' => [ SettingGroup::class, 'resolve_timezone_setting_value' ],
+			],
+		];
+	}
+
+	/**
+	 * WPGraphQL-maintained shim settings for options WordPress does not register
+	 * via register_setting() (e.g. the Site Address and the permalink options).
+	 *
+	 * These are seeded into the normalized settings map in memory so they surface
+	 * in the Schema without mutating WordPress's global settings registry. Each
+	 * entry follows the register_setting() args shape plus WPGraphQL per-entry
+	 * config. They are seeded only when the option isn't already registered, so a
+	 * real registration always wins.
+	 *
+	 * @return array<string,array<string,mixed>>
+	 *
+	 * @since x-release-please-version
+	 */
+	protected static function get_core_shim_settings(): array {
+		return [
+			// "siteurl" is registered by core on single-site but not on multisite.
+			// Seeding it here (only applied when it isn't already registered, i.e. on
+			// multisite) exposes `url` and the flat `generalSettingsUrl` through the
+			// settings machinery instead of a one-off polyfill field. On single-site
+			// the registered setting wins.
+			'siteurl'             => [
+				'group'              => 'general',
+				'type'               => 'string',
+				'description'        => __( 'The base URL where the site\'s application and content management backend are served. Can differ from the `homeUrl` field when the front end and backend are served from different addresses, such as on headless or decoupled installs.', 'wp-graphql' ),
+				'graphql_field_name' => 'url',
+				'graphql_readonly'   => true,
+				// Multisite-aware: get_site_url() returns the current site's URL.
+				'graphql_resolve'    => static function () {
+					return get_site_url();
+				},
+			],
+			// "Site Address" (home) is not registered by core on any install.
+			'home'                => [
+				'group'              => 'general',
+				'type'               => 'string',
+				'description'        => __( 'The address at which visitors reach the site\'s front end. Can differ from the `url` field when the front end and the content management backend are served from different addresses, such as on headless or decoupled installs.', 'wp-graphql' ),
+				'graphql_field_name' => 'homeUrl',
+				'graphql_readonly'   => true,
+				// Multisite-aware: get_home_url() returns the current site's home URL,
+				// not the raw option value.
+				'graphql_resolve'    => static function () {
+					return get_home_url();
+				},
+			],
+			'permalink_structure' => [
+				'group'              => 'permalink',
+				'type'               => 'string',
+				'description'        => __( 'The structure used to build the URLs for content on the site.', 'wp-graphql' ),
+				'graphql_field_name' => 'structure',
+				'graphql_readonly'   => true,
+			],
+			'category_base'       => [
+				'group'              => 'permalink',
+				'type'               => 'string',
+				'description'        => __( 'The prefix used in the URLs of category archive pages.', 'wp-graphql' ),
+				'graphql_field_name' => 'categoryBase',
+				'graphql_readonly'   => true,
+			],
+			'tag_base'            => [
+				'group'              => 'permalink',
+				'type'               => 'string',
+				'description'        => __( 'The prefix used in the URLs of tag archive pages.', 'wp-graphql' ),
+				'graphql_field_name' => 'tagBase',
+				'graphql_readonly'   => true,
 			],
 		];
 	}

--- a/plugins/wp-graphql/src/Mutation/UpdateSettings.php
+++ b/plugins/wp-graphql/src/Mutation/UpdateSettings.php
@@ -59,32 +59,33 @@ class UpdateSettings {
 			 * Loop through the $allowed_settings and build fields
 			 * for the individual settings
 			 */
-			foreach ( $allowed_settings as $key => $setting ) {
+			foreach ( $allowed_settings as $setting ) {
 				if ( ! isset( $setting['type'] ) || ! $type_registry->get_type( $setting['type'] ) ) {
 					continue;
 				}
 
 				/**
-				 * Determine if the individual setting already has a
-				 * REST API name, if not use the option name.
-				 * Sanitize the field name to be camelcase
+				 * Readonly settings are not writable, so they are not added to the
+				 * mutation input, UNLESS they carry a `graphql_deprecated_input` reason.
+				 * In that case the input field is kept (marked deprecated) so existing
+				 * schemas that already exposed it don't break; it still rejects the write
+				 * at runtime in mutate_and_get_payload().
 				 */
-				if ( ! empty( $setting['show_in_rest']['name'] ) ) {
-					$individual_setting_key = lcfirst( $setting['group'] . 'Settings' . str_replace( '_', '', ucwords( $setting['show_in_rest']['name'], '_' ) ) );
-				} else {
-					$individual_setting_key = lcfirst( $setting['group'] . 'Settings' . str_replace( '_', '', ucwords( $key, '_' ) ) );
+				$deprecation_reason = ! empty( $setting['graphql_deprecated_input'] ) ? (string) $setting['graphql_deprecated_input'] : null;
+
+				if ( ! empty( $setting['graphql_readonly'] ) && null === $deprecation_reason ) {
+					continue;
 				}
 
-				$replaced_setting_key = graphql_format_name( $individual_setting_key, ' ', '/[^a-zA-Z0-9 -]/' );
+				/**
+				 * The flat (group-prefixed) input field name is derived once in the
+				 * normalized settings map so the input and payload surfaces agree.
+				 */
+				$individual_setting_key = isset( $setting['graphql_settings_field_name'] ) ? (string) $setting['graphql_settings_field_name'] : '';
 
-				if ( ! empty( $replaced_setting_key ) ) {
-					$individual_setting_key = $replaced_setting_key;
+				if ( empty( $individual_setting_key ) ) {
+					continue;
 				}
-
-				$individual_setting_key = lcfirst( $individual_setting_key );
-				$individual_setting_key = lcfirst( str_replace( '_', ' ', ucwords( $individual_setting_key, '_' ) ) );
-				$individual_setting_key = lcfirst( str_replace( '-', ' ', ucwords( $individual_setting_key, '_' ) ) );
-				$individual_setting_key = lcfirst( str_replace( ' ', '', ucwords( $individual_setting_key, ' ' ) ) );
 
 				/**
 				 * Dynamically build the individual setting,
@@ -92,8 +93,12 @@ class UpdateSettings {
 				 */
 				$input_fields[ $individual_setting_key ] = [
 					'type'        => $setting['type'],
-					'description' => $setting['description'],
+					'description' => $setting['description'] ?? null,
 				];
+
+				if ( null !== $deprecation_reason ) {
+					$input_fields[ $individual_setting_key ]['deprecationReason'] = $deprecation_reason;
+				}
 			}
 		}
 
@@ -182,14 +187,13 @@ class UpdateSettings {
 		foreach ( $allowed_settings as $key => $setting ) {
 
 			/**
-			 * Determine if the individual setting already has a
-			 * REST API name, if not use the option name.
-			 * Sanitize the field name to be camelcase
+			 * The flat input field name is derived once in the normalized settings
+			 * map, so this matches the name registered on the input type.
 			 */
-			if ( isset( $setting['show_in_rest']['name'] ) && ! empty( $setting['show_in_rest']['name'] ) ) {
-				$individual_setting_key = lcfirst( $setting['group'] . 'Settings' . str_replace( '_', '', ucwords( $setting['show_in_rest']['name'], '_' ) ) );
-			} else {
-				$individual_setting_key = lcfirst( $setting['group'] . 'Settings' . str_replace( '_', '', ucwords( $key, '_' ) ) );
+			$individual_setting_key = isset( $setting['graphql_settings_field_name'] ) ? (string) $setting['graphql_settings_field_name'] : '';
+
+			if ( empty( $individual_setting_key ) ) {
+				continue;
 			}
 
 			/**

--- a/plugins/wp-graphql/src/Registry/TypeRegistry.php
+++ b/plugins/wp-graphql/src/Registry/TypeRegistry.php
@@ -589,24 +589,12 @@ class TypeRegistry {
 		$allowed_setting_types = DataSource::get_allowed_settings_by_group( $this );
 
 		/**
-		 * The url is not a registered setting for multisite, so this is a polyfill
-		 * to expose the URL to the Schema for multisite sites
+		 * The `url` field on GeneralSettings comes from the `siteurl` setting. Core
+		 * registers `siteurl` on single-site but not on multisite, so on multisite the
+		 * `siteurl` shim in the normalized settings map (DataSource::get_core_shim_settings)
+		 * provides it, resolving via get_site_url(). This replaces the previous multisite
+		 * register_field() polyfill and gives multisite the flat `generalSettingsUrl` field too.
 		 */
-		if ( is_multisite() ) {
-			$this->register_field(
-				'GeneralSettings',
-				'url',
-				[
-					'type'        => 'String',
-					'description' => static function () {
-						return __( 'Site URL.', 'wp-graphql' );
-					},
-					'resolve'     => static function () {
-						return get_site_url();
-					},
-				]
-			);
-		}
 
 		/**
 		 * Register the siteIconUrl field on GeneralSettings.
@@ -644,35 +632,14 @@ class TypeRegistry {
 		);
 
 		/**
-		 * Register the homeUrl field on GeneralSettings.
-		 *
-		 * WordPress core does not register the `home` option ("Site Address") as a setting for
-		 * the REST API — only `siteurl` ("WordPress Address") is registered. On headless or
-		 * decoupled installs the Site Address is often the canonical front-end URL and differs
-		 * from `siteurl`, so exposing it as a read-only field gives clients a reliable way to
-		 * read it. It is registered as a plain field (not via register_setting) so it is not
-		 * writable through the updateSettings mutation.
-		 *
-		 * This uses get_home_url() so it is multisite-aware (returns the current network site's
-		 * home URL, not the value of the raw option). The value is public information: core
-		 * exposes it to unauthenticated visitors in the REST API index, and it appears in the
-		 * markup of every front-end page.
+		 * The `homeUrl` field on GeneralSettings ("Site Address") is provided by the
+		 * `home` shim entry in the normalized settings map (see
+		 * DataSource::get_core_shim_settings), so it also appears on the flat Settings
+		 * type as `generalSettingsHomeUrl`. It is read-only and resolves via
+		 * get_home_url() (multisite-aware).
 		 *
 		 * @see https://github.com/wp-graphql/wp-graphql/issues/2520
 		 */
-		$this->register_field(
-			'GeneralSettings',
-			'homeUrl',
-			[
-				'type'        => 'String',
-				'description' => static function () {
-					return __( 'The address at which visitors reach the site\'s front end. Can differ from the `url` field when the front end and the content management backend are served from different addresses, such as on headless or decoupled installs.', 'wp-graphql' );
-				},
-				'resolve'     => static function () {
-					return get_home_url();
-				},
-			]
-		);
 
 		/**
 		 * Register the siteIcon connection on GeneralSettings.

--- a/plugins/wp-graphql/src/Type/ObjectType/SettingGroup.php
+++ b/plugins/wp-graphql/src/Type/ObjectType/SettingGroup.php
@@ -63,20 +63,11 @@ class SettingGroup {
 				}
 
 				/**
-				 * Determine if the individual setting already has a
-				 * REST API name, if not use the option name.
-				 * Then, sanitize the field name to be camelcase
+				 * The grouped GraphQL field name is derived once in the normalized
+				 * settings map (DataSource::get_normalized_settings) so every read and
+				 * write surface uses the same name.
 				 */
-				if ( ! empty( $setting_field['show_in_rest']['name'] ) ) {
-					$field_key = $setting_field['show_in_rest']['name'];
-				} else {
-					$field_key = $key;
-				}
-
-				$field_key = graphql_format_name( $field_key, ' ', '/[^a-zA-Z0-9 -]/' );
-				$field_key = lcfirst( str_replace( '_', ' ', ucwords( $field_key, '_' ) ) );
-				$field_key = lcfirst( str_replace( '-', ' ', ucwords( $field_key, '_' ) ) );
-				$field_key = lcfirst( str_replace( ' ', '', ucwords( $field_key, ' ' ) ) );
+				$field_key = isset( $setting_field['graphql_field_name'] ) ? (string) $setting_field['graphql_field_name'] : '';
 
 				if ( ! empty( $key ) && ! empty( $field_key ) ) {
 

--- a/plugins/wp-graphql/src/Type/ObjectType/Settings.php
+++ b/plugins/wp-graphql/src/Type/ObjectType/Settings.php
@@ -68,26 +68,16 @@ class Settings {
 				}
 
 				/**
-				 * Determine if the individual setting already has a
-				 * REST API name, if not use the option name.
-				 * Then, sanitize the field name to be camelcase
+				 * The flat (group-prefixed) GraphQL field name is derived once in the
+				 * normalized settings map (DataSource::get_normalized_settings) so every
+				 * read and write surface uses the same name.
 				 */
-				if ( ! empty( $setting_field['show_in_rest']['name'] ) ) {
-					$field_key = $setting_field['show_in_rest']['name'];
-				} else {
-					$field_key = $key;
-				}
+				$field_key = isset( $setting_field['graphql_settings_field_name'] ) ? (string) $setting_field['graphql_settings_field_name'] : '';
 
-				$group = DataSource::format_group_name( $setting_field['group'] );
+				if ( ! empty( $key ) && ! empty( $field_key ) ) {
 
-				$field_key = lcfirst( graphql_format_name( $field_key, ' ', '/[^a-zA-Z0-9 -]/' ) );
-				$field_key = lcfirst( str_replace( '_', ' ', ucwords( $field_key, '_' ) ) );
-				$field_key = lcfirst( str_replace( '-', ' ', ucwords( $field_key, '_' ) ) );
-				$field_key = lcfirst( str_replace( ' ', '', ucwords( $field_key, ' ' ) ) );
-
-				$field_key = $group . 'Settings' . ucfirst( $field_key );
-
-				if ( ! empty( $key ) ) {
+					// The formatted group name, passed to the setting's `graphql_resolve` callback.
+					$group = DataSource::format_group_name( (string) $setting_field['group'] );
 
 					/**
 					 * Dynamically build the individual setting and it's fields

--- a/plugins/wp-graphql/tests/wpunit/SettingQueriesTest.php
+++ b/plugins/wp-graphql/tests/wpunit/SettingQueriesTest.php
@@ -1060,4 +1060,133 @@ class SettingQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		delete_option( 'site_icon' );
 		wp_delete_attachment( $attachment_id, true );
 	}
+
+	/**
+	 * The `home` (Site Address) option is seeded as an in-memory shim: exposed as
+	 * `homeUrl` on GeneralSettings and `generalSettingsHomeUrl` on the flat Settings
+	 * type, resolving via get_home_url().
+	 *
+	 * @return void
+	 */
+	public function testHomeUrlShimResolvesOnBothSurfaces() {
+		wp_set_current_user( $this->admin );
+
+		$query = '
+			{
+				generalSettings { homeUrl }
+				allSettings { generalSettingsHomeUrl }
+			}
+		';
+
+		$actual = $this->graphql( compact( 'query' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEquals( get_home_url(), $actual['data']['generalSettings']['homeUrl'] );
+		$this->assertEquals( get_home_url(), $actual['data']['allSettings']['generalSettingsHomeUrl'] );
+	}
+
+	/**
+	 * The permalink options are seeded as in-memory shims under a new `permalink`
+	 * group, exposed on PermalinkSettings and on the flat Settings type.
+	 *
+	 * @return void
+	 */
+	public function testPermalinkSettingsShimResolvesOnBothSurfaces() {
+		wp_set_current_user( $this->admin );
+
+		update_option( 'permalink_structure', '/%postname%/' );
+		update_option( 'category_base', 'topics' );
+		update_option( 'tag_base', 'labels' );
+
+		$query = '
+			{
+				permalinkSettings { structure categoryBase tagBase }
+				allSettings {
+					permalinkSettingsStructure
+					permalinkSettingsCategoryBase
+					permalinkSettingsTagBase
+				}
+			}
+		';
+
+		$actual = $this->graphql( compact( 'query' ) );
+
+		delete_option( 'permalink_structure' );
+		delete_option( 'category_base' );
+		delete_option( 'tag_base' );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEquals( '/%postname%/', $actual['data']['permalinkSettings']['structure'] );
+		$this->assertEquals( 'topics', $actual['data']['permalinkSettings']['categoryBase'] );
+		$this->assertEquals( 'labels', $actual['data']['permalinkSettings']['tagBase'] );
+		$this->assertEquals( '/%postname%/', $actual['data']['allSettings']['permalinkSettingsStructure'] );
+		$this->assertEquals( 'topics', $actual['data']['allSettings']['permalinkSettingsCategoryBase'] );
+		$this->assertEquals( 'labels', $actual['data']['allSettings']['permalinkSettingsTagBase'] );
+	}
+
+	/**
+	 * `graphql_field_name` is authoritative: a setting seeded via the
+	 * graphql_normalized_settings filter appears under that exact name (no
+	 * camelCasing) on both the grouped and flat surfaces.
+	 *
+	 * @return void
+	 */
+	public function testGraphqlFieldNameOverrideIsAuthoritative() {
+		$filter = static function ( array $settings ) {
+			$settings['my_shim_option'] = [
+				'group'              => 'general',
+				'type'               => 'string',
+				'description'        => 'A test shim option.',
+				'graphql_field_name' => 'myShimFieldName',
+			];
+			return $settings;
+		};
+
+		add_filter( 'graphql_normalized_settings', $filter );
+		WPGraphQL::clear_schema();
+
+		update_option( 'my_shim_option', 'shim-value' );
+		wp_set_current_user( $this->admin );
+
+		$query = '
+			{
+				generalSettings { myShimFieldName }
+				allSettings { generalSettingsMyShimFieldName }
+			}
+		';
+
+		$actual = $this->graphql( compact( 'query' ) );
+
+		remove_filter( 'graphql_normalized_settings', $filter );
+		delete_option( 'my_shim_option' );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEquals( 'shim-value', $actual['data']['generalSettings']['myShimFieldName'] );
+		$this->assertEquals( 'shim-value', $actual['data']['allSettings']['generalSettingsMyShimFieldName'] );
+	}
+
+	/**
+	 * The `url` field (siteurl) resolves on both the grouped and flat surfaces. On
+	 * single-site it comes from the registered `siteurl` setting; on multisite it
+	 * comes from the seeded shim (which replaced the former register_field polyfill
+	 * and adds the flat `generalSettingsUrl` field multisite previously lacked).
+	 *
+	 * @return void
+	 */
+	public function testSiteUrlResolvesOnBothSurfaces() {
+		wp_set_current_user( $this->admin );
+
+		$query = '
+			{
+				generalSettings { url }
+				allSettings { generalSettingsUrl }
+			}
+		';
+
+		$actual = $this->graphql( compact( 'query' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertNotEmpty( $actual['data']['generalSettings']['url'] );
+		$this->assertEquals( $actual['data']['generalSettings']['url'], $actual['data']['allSettings']['generalSettingsUrl'] );
+	}
 }

--- a/plugins/wp-graphql/tests/wpunit/SettingsMutationsTest.php
+++ b/plugins/wp-graphql/tests/wpunit/SettingsMutationsTest.php
@@ -563,4 +563,57 @@ class SettingsMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase 
 		$this->assertSame( $unique_value, $actual['data']['updateSettings']['allSettings']['mySettingGroupSettingsMySettingField'] );
 		$this->assertSame( $unique_value, $actual['data']['updateSettings']['mySettingGroupSettings']['mySettingField'] );
 	}
+
+	/**
+	 * Read-only settings seeded as shims (the Site Address, the permalink options)
+	 * are not writable, so they never appear in the updateSettings input.
+	 *
+	 * The pre-existing `generalSettingsUrl` (siteurl) input is kept for backward
+	 * compatibility (marked deprecated) and still rejects writes at runtime, rather
+	 * than being removed from the schema. That is asserted behaviorally below on
+	 * single-site installs (siteurl is only registered on single-site).
+	 *
+	 * @return void
+	 */
+	public function testReadonlyShimsAreAbsentFromMutationInput() {
+		wp_set_current_user( $this->admin );
+
+		$introspection = $this->graphql(
+			[
+				'query' => '
+					{
+						__type(name: "UpdateSettingsInput") {
+							inputFields { name }
+						}
+					}
+				',
+			]
+		);
+
+		$this->assertArrayNotHasKey( 'errors', $introspection );
+		$input_field_names = wp_list_pluck( $introspection['data']['__type']['inputFields'], 'name' );
+
+		$this->assertNotContains( 'generalSettingsHomeUrl', $input_field_names );
+		$this->assertNotContains( 'permalinkSettingsStructure', $input_field_names );
+		$this->assertNotContains( 'permalinkSettingsCategoryBase', $input_field_names );
+		$this->assertNotContains( 'permalinkSettingsTagBase', $input_field_names );
+
+		// Back-compat: on single-site the deprecated generalSettingsUrl input is
+		// still present (not removed) and rejects at runtime, rather than failing as
+		// an unknown field.
+		if ( ! is_multisite() ) {
+			$mutation = $this->graphql(
+				[
+					'query' => 'mutation {
+						updateSettings( input: { generalSettingsUrl: "https://example.test" } ) {
+							generalSettings { url }
+						}
+					}',
+				]
+			);
+
+			$this->assertArrayHasKey( 'errors', $mutation );
+			$this->assertStringContainsStringIgnoringCase( 'cannot be changed', $mutation['errors'][0]['message'] );
+		}
+	}
 }


### PR DESCRIPTION
Third slice of the [Settings as Models / Nodes RFC](https://github.com/wp-graphql/wp-graphql/issues/2459), building on the normalized settings map. Seeds options WordPress never registers, adds a field-name override, and removes the duplicated field-name derivation.

## What

- **Consolidate field-name derivation.** The camelCase name dance was duplicated across four surfaces (grouped read, flat read, mutation input, mutation payload) — the exact drift risk the normalized map exists to remove. `DataSource::get_normalized_settings()` now computes each entry's `graphql_field_name` (grouped, e.g. `homeUrl`) and `graphql_settings_field_name` (flat, e.g. `generalSettingsHomeUrl`) **once**, and every surface reads them. Behavior-preserving for existing settings (existing tests pass unchanged).
- **`graphql_field_name` config key** — an authoritative field-name override (used verbatim, no camelCasing), like `graphql_single_name` for post types.
- **In-memory shims** (`DataSource::get_core_shim_settings()`) for options core doesn't register, seeded into the map without `register_setting()`:
  - **Site Address** (`home`): `generalSettings { homeUrl }` and `allSettings { generalSettingsHomeUrl }`, resolving via `get_home_url()` (multisite-aware).
  - **Permalink options** under a new `permalinkSettings` group: `structure`, `categoryBase`, `tagBase`. The group auto-registers its type + root field.
  - All read-only.
- **Retire the standalone `homeUrl` `register_field`** (#4021) on `GeneralSettings` — the `home` shim provides it now, and it gains the flat `allSettings` exposure it lacked.

## Non-breaking

Readonly settings are no longer added to the `updateSettings` input. The one pre-existing readonly input, `generalSettingsUrl`, is **kept and marked `@deprecated`** (via a `graphql_deprecated_input` reason on the `siteurl` config) rather than removed, so existing schemas don't break; it still rejects writes at runtime. New shims (read-only) simply have no input.

## Tests

- `homeUrl` resolves via `get_home_url()` on both the grouped and flat surfaces.
- `permalinkSettings { structure categoryBase tagBase }` and the flat equivalents resolve.
- `graphql_field_name` override is authoritative (grouped + flat).
- `generalSettingsUrl` is present-and-deprecated in the input (via `includeDeprecated: true`), while the new shim inputs are absent.

Behavior-preserving refactor guarded by the existing settings suites. PHPStan level 8 + PHPCS clean. Docs updated (`docs/settings.md`).

Part of #3931. Refs #661, #2520.