### PR TITLE
fix: return null for restricted setting reads

### DIFF
--- a/plugins/wp-graphql/src/Experimental/Experiment/EmailAddressScalarFieldsExperiment/EmailAddressScalarFieldsExperiment.php
+++ b/plugins/wp-graphql/src/Experimental/Experiment/EmailAddressScalarFieldsExperiment/EmailAddressScalarFieldsExperiment.php
@@ -118,7 +118,16 @@ class EmailAddressScalarFieldsExperiment extends AbstractExperiment {
 				},
 				'resolve'     => static function ( $root, $args, $context, $info ) {
 					if ( ! current_user_can( 'manage_options' ) ) {
-						throw new UserError( esc_html__( 'Sorry, you do not have permission to view this setting.', 'wp-graphql' ) );
+						graphql_debug(
+							__( 'The "GeneralSettings.adminEmail" field requires the "manage_options" capability and resolved to null.', 'wp-graphql' ),
+							[
+								'type'                => 'RESTRICTED_SETTING',
+								'field'               => 'GeneralSettings.adminEmail',
+								'required_capability' => 'manage_options',
+							]
+						);
+
+						return null;
 					}
 
 					return get_option( 'admin_email' );
@@ -225,7 +234,16 @@ class EmailAddressScalarFieldsExperiment extends AbstractExperiment {
 
 				// Fallback resolver (same logic as original)
 				if ( ! current_user_can( 'manage_options' ) ) {
-					throw new UserError( esc_html__( 'Sorry, you do not have permission to view this setting.', 'wp-graphql' ) );
+					graphql_debug(
+						__( 'The "GeneralSettings.email" field requires the "manage_options" capability and resolved to null.', 'wp-graphql' ),
+						[
+							'type'                => 'RESTRICTED_SETTING',
+							'field'               => 'GeneralSettings.email',
+							'required_capability' => 'manage_options',
+						]
+					);
+
+					return null;
 				}
 
 				return get_option( 'admin_email' );

--- a/plugins/wp-graphql/src/Type/ObjectType/SettingGroup.php
+++ b/plugins/wp-graphql/src/Type/ObjectType/SettingGroup.php
@@ -2,7 +2,6 @@
 
 namespace WPGraphQL\Type\ObjectType;
 
-use GraphQL\Error\UserError;
 use WPGraphQL\Data\DataSource;
 use WPGraphQL\Registry\TypeRegistry;
 
@@ -82,16 +81,25 @@ class SettingGroup {
 							// translators: %s is the name of the setting group.
 							return isset( $setting_field['description'] ) && ! empty( $setting_field['description'] ) ? $setting_field['description'] : sprintf( __( 'The %s Settings Group', 'wp-graphql' ), $setting_field['type'] );
 						},
-						'resolve'     => static function () use ( $setting_field, $group_name ) {
+						'resolve'     => static function () use ( $setting_field, $group_name, $field_key ) {
 
 							/**
 							 * Check to see if the user querying the email field has the 'manage_options' capability
 							 * All other options should be public by default
 							 */
-							if ( 'admin_email' === $setting_field['key'] ) {
-								if ( ! current_user_can( 'manage_options' ) ) {
-									throw new UserError( esc_html__( 'Sorry, you do not have permission to view this setting.', 'wp-graphql' ) );
-								}
+							if ( 'admin_email' === $setting_field['key'] && ! current_user_can( 'manage_options' ) ) {
+								$field_name = ucfirst( $group_name ) . 'Settings.' . $field_key;
+								graphql_debug(
+									// translators: 1: GraphQL field name, 2: required WordPress capability.
+									sprintf( __( 'The "%1$s" field requires the "%2$s" capability and resolved to null.', 'wp-graphql' ), $field_name, 'manage_options' ),
+									[
+										'type'  => 'RESTRICTED_SETTING',
+										'field' => $field_name,
+										'required_capability' => 'manage_options',
+									]
+								);
+
+								return null;
 							}
 
 							$option = ! empty( $setting_field['key'] ) ? get_option( $setting_field['key'] ) : null;

--- a/plugins/wp-graphql/src/Type/ObjectType/Settings.php
+++ b/plugins/wp-graphql/src/Type/ObjectType/Settings.php
@@ -2,7 +2,6 @@
 
 namespace WPGraphQL\Type\ObjectType;
 
-use GraphQL\Error\UserError;
 use WPGraphQL\Data\DataSource;
 use WPGraphQL\Registry\TypeRegistry;
 
@@ -90,13 +89,24 @@ class Settings {
 							// translators: %s is the name of the setting group.
 							return sprintf( __( 'Settings of the the %s Settings Group', 'wp-graphql' ), $setting_field['type'] );
 						},
-						'resolve'     => static function () use ( $setting_field, $key, $group ) {
+						'resolve'     => static function () use ( $setting_field, $key, $group, $field_key ) {
 							/**
 							 * Check to see if the user querying the email field has the 'manage_options' capability
 							 * All other options should be public by default
 							 */
 							if ( 'admin_email' === $key && ! current_user_can( 'manage_options' ) ) {
-								throw new UserError( esc_html__( 'Sorry, you do not have permission to view this setting.', 'wp-graphql' ) );
+								$field_name = 'Settings.' . $field_key;
+								graphql_debug(
+									// translators: 1: GraphQL field name, 2: required WordPress capability.
+									sprintf( __( 'The "%1$s" field requires the "%2$s" capability and resolved to null.', 'wp-graphql' ), $field_name, 'manage_options' ),
+									[
+										'type'  => 'RESTRICTED_SETTING',
+										'field' => $field_name,
+										'required_capability' => 'manage_options',
+									]
+								);
+
+								return null;
 							}
 
 							$option = get_option( (string) $key );

--- a/plugins/wp-graphql/tests/wpunit/SettingQueriesTest.php
+++ b/plugins/wp-graphql/tests/wpunit/SettingQueriesTest.php
@@ -30,32 +30,50 @@ class SettingQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 	}
 
 	/**
-	 * Method for testing whether a user can query settings
-	 * if they don't have the 'manage_options' capability
+	 * Restricted settings should resolve to null without affecting public sibling fields.
 	 *
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function testSettingQueryAsEditor() {
-		/**
-		 * Set the editor user
-		 * Set the query
-		 * Make the request
-		 * Validate the request has errors
-		 */
+	public function testRestrictedSettingsReturnNullWithoutAffectingSiblingFields() {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'The admin_email setting is not registered on multisite.' );
+		}
+
 		wp_set_current_user( $this->editor );
+		update_option( 'blogname', 'Public site title' );
+		add_filter( 'graphql_debug_enabled', '__return_true' );
 
 		$query = '
 			query {
 				generalSettings {
-						email
-					}
+					email
+					title
 				}
-			';
+				allSettings {
+					generalSettingsEmail
+					generalSettingsTitle
+				}
+			}
+		';
 
 		$actual = graphql( compact( 'query' ) );
 
-		$this->assertArrayHasKey( 'errors', $actual );
+		remove_filter( 'graphql_debug_enabled', '__return_true' );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertNull( $actual['data']['generalSettings']['email'] );
+		$this->assertSame( 'Public site title', $actual['data']['generalSettings']['title'] );
+		$this->assertNull( $actual['data']['allSettings']['generalSettingsEmail'] );
+		$this->assertSame( 'Public site title', $actual['data']['allSettings']['generalSettingsTitle'] );
+
+		$restricted_fields = array_column( $actual['extensions']['debug'], 'field' );
+		$this->assertContains( 'GeneralSettings.email', $restricted_fields );
+		$this->assertContains( 'Settings.generalSettingsEmail', $restricted_fields );
+		$this->assertSame(
+			[ 'manage_options' ],
+			array_values( array_unique( array_column( $actual['extensions']['debug'], 'required_capability' ) ) )
+		);
 	}
 
 	/**

--- a/plugins/wp-graphql/tests/wpunit/SettingsMutationsTest.php
+++ b/plugins/wp-graphql/tests/wpunit/SettingsMutationsTest.php
@@ -284,6 +284,10 @@ class SettingsMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase 
 	 * @return void
 	 */
 	public function testSettingsQueryAsEditor() {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'The admin_email setting is not registered on multisite.' );
+		}
+
 		wp_set_current_user( $this->editor );
 
 		$query  = '
@@ -294,7 +298,7 @@ class SettingsMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase 
 			}
 		';
 		$actual = $this->graphql( compact( 'query' ) );
-		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual, isset( $actual['errors'] ) ? wp_json_encode( $actual['errors'] ) : '' );
 		$this->assertNull( $actual['data']['allSettings']['generalSettingsEmail'] );
 	}
 

--- a/plugins/wp-graphql/tests/wpunit/SettingsMutationsTest.php
+++ b/plugins/wp-graphql/tests/wpunit/SettingsMutationsTest.php
@@ -279,21 +279,11 @@ class SettingsMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase 
 	}
 
 	/**
-	 * Method for testing whether a user can query settings
-	 * if they don't have the 'manage_options' capability
-	 *
-	 * They should not be able to query for the admin email
-	 * so we should receive an error back
+	 * Restricted settings return null when queried without manage_options.
 	 *
 	 * @return void
 	 */
 	public function testSettingsQueryAsEditor() {
-		/**
-		 * Set the editor user
-		 * Set the query
-		 * Make the request
-		 * Validate the request has errors
-		 */
 		wp_set_current_user( $this->editor );
 
 		$query  = '
@@ -304,7 +294,8 @@ class SettingsMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase 
 			}
 		';
 		$actual = $this->graphql( compact( 'query' ) );
-		$this->assertArrayHasKey( 'errors', $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertNull( $actual['data']['allSettings']['generalSettingsEmail'] );
 	}
 
 	/**

--- a/plugins/wp-graphql/tests/wpunit/SettingsQueriesTest.php
+++ b/plugins/wp-graphql/tests/wpunit/SettingsQueriesTest.php
@@ -31,6 +31,10 @@ class WP_GraphQL_Test_Settings_Queries extends \Tests\WPGraphQL\TestCase\WPGraph
 	 * @return void
 	 */
 	public function testAllSettingsQueryAsEditor() {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'The admin_email setting is not registered on multisite.' );
+		}
+
 		wp_set_current_user( $this->editor );
 		$query  = '
 			query {
@@ -41,7 +45,7 @@ class WP_GraphQL_Test_Settings_Queries extends \Tests\WPGraphQL\TestCase\WPGraph
 		';
 		$actual = $this->graphql( compact( 'query' ) );
 
-		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual, isset( $actual['errors'] ) ? wp_json_encode( $actual['errors'] ) : '' );
 		$this->assertNull( $actual['data']['allSettings']['generalSettingsEmail'] );
 	}
 

--- a/plugins/wp-graphql/tests/wpunit/SettingsQueriesTest.php
+++ b/plugins/wp-graphql/tests/wpunit/SettingsQueriesTest.php
@@ -26,21 +26,11 @@ class WP_GraphQL_Test_Settings_Queries extends \Tests\WPGraphQL\TestCase\WPGraph
 	}
 
 	/**
-	 * Method for testing whether a user can query settings
-	 * if they don't have the 'manage_options' capability
-	 *
-	 * They should not be able to query for the admin email
-	 * so we should receive an error back
+	 * Restricted settings return null when queried without manage_options.
 	 *
 	 * @return void
 	 */
 	public function testAllSettingsQueryAsEditor() {
-		/**
-		 * Set the editor user
-		 * Set the query
-		 * Make the request
-		 * Validate the request has errors
-		 */
 		wp_set_current_user( $this->editor );
 		$query  = '
 			query {
@@ -51,7 +41,8 @@ class WP_GraphQL_Test_Settings_Queries extends \Tests\WPGraphQL\TestCase\WPGraph
 		';
 		$actual = $this->graphql( compact( 'query' ) );
 
-		$this->assertArrayHasKey( 'errors', $actual );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertNull( $actual['data']['allSettings']['generalSettingsEmail'] );
 	}
 
 	/**

--- a/plugins/wp-graphql/tests/wpunit/experiments/email-address-scalar-fields/UserEmailAddressFieldsTest.php
+++ b/plugins/wp-graphql/tests/wpunit/experiments/email-address-scalar-fields/UserEmailAddressFieldsTest.php
@@ -417,4 +417,39 @@ class UserEmailAddressFieldsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTest
 			$this->assertEquals( 'String', $emailField['type']['name'] );
 		}
 	}
+
+	/**
+	 * Restricted adminEmail reads return null while public siblings still resolve.
+	 */
+	public function testRestrictedAdminEmailReturnsNullWithoutAFieldError() {
+		$editor = $this->factory->user->create(
+			[
+				'role' => 'editor',
+			]
+		);
+
+		wp_set_current_user( $editor );
+		update_option( 'blogname', 'Public site title' );
+		add_filter( 'graphql_debug_enabled', '__return_true' );
+
+		$query = '
+			query {
+				generalSettings {
+					adminEmail
+					title
+				}
+			}
+		';
+
+		$actual = $this->graphql( compact( 'query' ) );
+
+		remove_filter( 'graphql_debug_enabled', '__return_true' );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertNull( $actual['data']['generalSettings']['adminEmail'] );
+		$this->assertSame( 'Public site title', $actual['data']['generalSettings']['title'] );
+
+		$restricted_fields = array_column( $actual['extensions']['debug'], 'field' );
+		$this->assertContains( 'GeneralSettings.adminEmail', $restricted_fields );
+	}
 }


### PR DESCRIPTION
## What bug does this fix? Explain your changes.

Restricted `admin_email` reads currently throw a field error for users without `manage_options`. That error reaches the top-level `errors` array and can null out sibling settings that are safe to expose.

I changed the grouped, flat, and experimental email-setting resolvers to return `null` for restricted reads instead. In debug mode, I also record the affected GraphQL field and the required `manage_options` capability so the reason remains discoverable.

## Does this close any currently open issues?

Fixes #4072

## Testing Strategy

I added regression coverage for both settings surfaces and the experimental `adminEmail` field. The tests verify that restricted fields resolve to `null`, public sibling fields still resolve, no field error is emitted, and debug entries identify the field and required capability.

### Test Results

- [x] Full WPUnit suite: 1,097 tests, 7,010 assertions; exit 0 (4 skipped, 7 incomplete)
- [x] Focused settings and email experiment suites: 45 tests, 158 assertions
- [x] PHP CodeSniffer
- [x] PHPStan on the changed source files
- [x] `git diff --check`

## Before/After Examples

### Before

```graphql
query {
  generalSettings {
    email
    title
  }
}
```

The restricted email field adds a top-level authorization error and can null out allowed siblings.

### After

I return `null` for the restricted email field while `title` continues to resolve normally. When GraphQL debug logging is enabled, the debug entry names the field and the `manage_options` capability.
