### PR TITLE
feat(settings): make setting groups Nodes with an id and Node interface

### DIFF
--- a/plugins/wp-graphql/docs/settings.md
+++ b/plugins/wp-graphql/docs/settings.md
@@ -201,6 +201,34 @@ And that will return data similar to:
 }
 ```
 
+### Settings Groups are Nodes
+
+Each settings group implements the `Node` interface and exposes a globally unique `id`, so a group can be fetched like any other node:
+
+```graphql
+{
+  generalSettings {
+    id
+    title
+  }
+}
+```
+
+The `id` can be passed back to the `node` field to re-fetch the group:
+
+```graphql
+query GetSettingGroupNode($id: ID!) {
+  node(id: $id) {
+    ... on GeneralSettings {
+      id
+      title
+    }
+  }
+}
+```
+
+The global ID encodes the `setting_group` type and the group's key (e.g. `general`, `permalink`), and clients can treat it as an opaque cache identifier. The flat `allSettings` field is a convenience view across every group and does not implement `Node`.
+
 ## Mutations
 
 Settings can be updated using GraphQL through a mutation. Custom settings would follow the `allSettings` naming conventions where the group name is prepended before the setting field name.

--- a/plugins/wp-graphql/src/AppContext.php
+++ b/plugins/wp-graphql/src/AppContext.php
@@ -10,6 +10,7 @@ use WPGraphQL\Data\Loader\EnqueuedStylesheetLoader;
 use WPGraphQL\Data\Loader\PluginLoader;
 use WPGraphQL\Data\Loader\PostObjectLoader;
 use WPGraphQL\Data\Loader\PostTypeLoader;
+use WPGraphQL\Data\Loader\SettingGroupLoader;
 use WPGraphQL\Data\Loader\TaxonomyLoader;
 use WPGraphQL\Data\Loader\TermObjectLoader;
 use WPGraphQL\Data\Loader\ThemeLoader;
@@ -42,6 +43,7 @@ class AppContext {
 		'nav_menu_item'       => PostObjectLoader::class,
 		'post'                => PostObjectLoader::class,
 		'post_type'           => PostTypeLoader::class,
+		'setting_group'       => SettingGroupLoader::class,
 		'taxonomy'            => TaxonomyLoader::class,
 		'term'                => TermObjectLoader::class,
 		'theme'               => ThemeLoader::class,

--- a/plugins/wp-graphql/src/Data/DataSource.php
+++ b/plugins/wp-graphql/src/Data/DataSource.php
@@ -20,6 +20,7 @@ use WPGraphQL\Model\Menu;
 use WPGraphQL\Model\Plugin;
 use WPGraphQL\Model\Post;
 use WPGraphQL\Model\PostType;
+use WPGraphQL\Model\SettingGroup as SettingGroupModel;
 use WPGraphQL\Model\Taxonomy;
 use WPGraphQL\Model\Term;
 use WPGraphQL\Model\Theme;
@@ -696,6 +697,9 @@ class DataSource {
 					break;
 				case $node instanceof PostType:
 					$type = 'ContentType';
+					break;
+				case $node instanceof SettingGroupModel:
+					$type = SettingGroup::get_type_name( $node->get_group_key() );
 					break;
 				case $node instanceof Taxonomy:
 					$type = 'Taxonomy';

--- a/plugins/wp-graphql/src/Data/Loader/SettingGroupLoader.php
+++ b/plugins/wp-graphql/src/Data/Loader/SettingGroupLoader.php
@@ -1,0 +1,47 @@
+<?php
+namespace WPGraphQL\Data\Loader;
+
+use WPGraphQL\Data\DataSource;
+use WPGraphQL\Model\SettingGroup;
+
+/**
+ * Class SettingGroupLoader
+ *
+ * Loads settings groups (keyed by their normalized group key, e.g. "general",
+ * "permalink") from the normalized settings map and returns them as
+ * SettingGroup models.
+ *
+ * @package WPGraphQL\Data\Loader
+ */
+class SettingGroupLoader extends AbstractDataLoader {
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @param array<string,array<string,mixed>> $entry The group's entries from the normalized settings map.
+	 *
+	 * @return \WPGraphQL\Model\SettingGroup
+	 * @throws \Exception
+	 */
+	protected function get_model( $entry, $key ) {
+		return new SettingGroup( (string) $key, $entry );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @param string[] $keys Normalized settings group keys.
+	 * @return array<string,array<string,array<string,mixed>>|null>
+	 */
+	public function loadKeys( array $keys ) {
+		$groups = DataSource::get_allowed_settings_by_group( \WPGraphQL::get_type_registry() );
+
+		$loaded = [];
+
+		foreach ( $keys as $key ) {
+			$loaded[ $key ] = ! empty( $groups[ $key ] ) ? $groups[ $key ] : null;
+		}
+
+		return $loaded;
+	}
+}

--- a/plugins/wp-graphql/src/Model/SettingGroup.php
+++ b/plugins/wp-graphql/src/Model/SettingGroup.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace WPGraphQL\Model;
+
+use GraphQLRelay\Relay;
+
+/**
+ * Class SettingGroup - Models the data for a settings group
+ *
+ * This is the data-layer Model for a settings group (general, reading,
+ * discussion, permalink, etc.), giving each group a globally unique
+ * identifier so it can be resolved as a Node. Not to be confused with
+ * \WPGraphQL\Type\ObjectType\SettingGroup, which registers the GraphQL
+ * object types for setting groups.
+ *
+ * @property ?string $id
+ *
+ * @package WPGraphQL\Model
+ *
+ * @extends \WPGraphQL\Model\Model<array<string,array<string,mixed>>>
+ */
+class SettingGroup extends Model {
+	/**
+	 * The normalized settings group key (e.g. "general", "permalink").
+	 *
+	 * @var string
+	 */
+	protected $group_key;
+
+	/**
+	 * SettingGroup constructor.
+	 *
+	 * @param string                            $group_key The normalized settings group key.
+	 * @param array<string,array<string,mixed>> $settings  The group's entries from the normalized settings map.
+	 *
+	 * @throws \Exception
+	 */
+	public function __construct( string $group_key, array $settings ) {
+		$this->group_key = $group_key;
+		$this->data      = $settings;
+
+		parent::__construct();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * Setting groups are publicly readable by default; individual settings
+	 * within a group can restrict reads at the field level.
+	 */
+	protected function is_private() {
+		return false;
+	}
+
+	/**
+	 * Returns the normalized settings group key the model was loaded for.
+	 */
+	public function get_group_key(): string {
+		return $this->group_key;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function init() {
+		if ( empty( $this->fields ) ) {
+			$this->fields = [
+				'id' => function () {
+					return Relay::toGlobalId( 'setting_group', $this->group_key );
+				},
+			];
+		}
+	}
+}

--- a/plugins/wp-graphql/src/Registry/TypeRegistry.php
+++ b/plugins/wp-graphql/src/Registry/TypeRegistry.php
@@ -691,11 +691,11 @@ class TypeRegistry {
 							return sprintf(
 								// translators: %s is the GraphQL name of the settings group.
 								__( "Fields of the '%s' settings group", 'wp-graphql' ),
-								ucfirst( $group_name ) . 'Settings'
+								SettingGroup::get_type_name( $group_name )
 							);
 						},
-						'resolve'     => static function () use ( $setting_type ) {
-							return $setting_type;
+						'resolve'     => static function ( $root, array $args, AppContext $context ) use ( $group_name ) {
+							return $context->get_loader( 'setting_group' )->load_deferred( $group_name );
 						},
 					]
 				);

--- a/plugins/wp-graphql/src/Type/ObjectType/SettingGroup.php
+++ b/plugins/wp-graphql/src/Type/ObjectType/SettingGroup.php
@@ -5,7 +5,27 @@ namespace WPGraphQL\Type\ObjectType;
 use WPGraphQL\Data\DataSource;
 use WPGraphQL\Registry\TypeRegistry;
 
+/**
+ * Class SettingGroup
+ *
+ * Registers the GraphQL object types for setting groups. Not to be confused
+ * with \WPGraphQL\Model\SettingGroup, the data-layer Model a settings group
+ * resolves through.
+ */
 class SettingGroup {
+
+	/**
+	 * Given the normalized settings group key, return the GraphQL Type name
+	 * registered for the group.
+	 *
+	 * Single source of the group-key -> type-name derivation, shared by the
+	 * type registration and node-type resolution so the two cannot drift.
+	 *
+	 * @param string $group_name The normalized settings group key.
+	 */
+	public static function get_type_name( string $group_name ): string {
+		return ucfirst( $group_name ) . 'Settings';
+	}
 
 	/**
 	 * Register each settings group to the GraphQL Schema
@@ -27,19 +47,31 @@ class SettingGroup {
 			return null;
 		}
 
+		// The Node interface provides the `id` field; it is declared here only
+		// to carry a settings-specific description. The value resolves through
+		// the SettingGroup Model the group's root field returns.
+		$fields['id'] = [
+			'type'        => [ 'non_null' => 'ID' ],
+			'description' => static function () {
+				return __( 'The globally unique identifier of the settings group.', 'wp-graphql' );
+			},
+		];
+
 		register_graphql_object_type(
-			ucfirst( $group_name ) . 'Settings',
+			self::get_type_name( $group_name ),
 			[
 				// translators: %s is the name of the setting group.
 				'description' => static function () use ( $group_name ) {
 					// translators: %s is the name of the setting group.
 					return sprintf( __( 'The %s setting type', 'wp-graphql' ), $group_name );
 				},
+				'interfaces'  => [ 'Node' ],
+				'model'       => \WPGraphQL\Model\SettingGroup::class,
 				'fields'      => $fields,
 			]
 		);
 
-		return ucfirst( $group_name ) . 'Settings';
+		return self::get_type_name( $group_name );
 	}
 
 	/**

--- a/plugins/wp-graphql/tests/wpunit/SettingGroupNodeQueriesTest.php
+++ b/plugins/wp-graphql/tests/wpunit/SettingGroupNodeQueriesTest.php
@@ -1,0 +1,172 @@
+<?php
+
+/**
+ * Tests that setting groups are Nodes: they expose a globally unique `id`,
+ * implement the `Node` interface, and resolve through the `node(id:)` field
+ * via the `setting_group` loader.
+ *
+ * @see https://github.com/wp-graphql/wp-graphql/issues/2459
+ */
+class SettingGroupNodeQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		WPGraphQL::clear_schema();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		WPGraphQL::clear_schema();
+	}
+
+	/**
+	 * The generalSettings group should expose a globally unique id derived
+	 * from the `setting_group` type and the group key.
+	 *
+	 * @throws \Exception
+	 */
+	public function testGeneralSettingsExposesGlobalId() {
+		$global_id = \GraphQLRelay\Relay::toGlobalId( 'setting_group', 'general' );
+
+		$query = '
+			query {
+				generalSettings {
+					id
+				}
+			}
+		';
+
+		$actual = graphql( compact( 'query' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertSame( $global_id, $actual['data']['generalSettings']['id'] );
+	}
+
+	/**
+	 * A group seeded purely from in-memory shims (permalink) should expose an
+	 * id the same way as a group backed by registered settings.
+	 *
+	 * @throws \Exception
+	 */
+	public function testPermalinkSettingsExposesGlobalId() {
+		$global_id = \GraphQLRelay\Relay::toGlobalId( 'setting_group', 'permalink' );
+
+		$query = '
+			query {
+				permalinkSettings {
+					id
+				}
+			}
+		';
+
+		$actual = graphql( compact( 'query' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertSame( $global_id, $actual['data']['permalinkSettings']['id'] );
+	}
+
+	/**
+	 * A setting group's global id should round-trip through the node(id:)
+	 * field, resolving to the group's type with its fields intact.
+	 *
+	 * @throws \Exception
+	 */
+	public function testSettingGroupResolvesThroughNodeField() {
+		update_option( 'blogname', 'Setting Group Node Test' );
+
+		$global_id = \GraphQLRelay\Relay::toGlobalId( 'setting_group', 'general' );
+
+		$query = '
+			query GetSettingGroupNode( $id: ID! ) {
+				node( id: $id ) {
+					__typename
+					id
+					... on GeneralSettings {
+						title
+					}
+				}
+			}
+		';
+
+		$actual = graphql(
+			[
+				'query'     => $query,
+				'variables' => [
+					'id' => $global_id,
+				],
+			]
+		);
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertSame( 'GeneralSettings', $actual['data']['node']['__typename'] );
+		$this->assertSame( $global_id, $actual['data']['node']['id'] );
+		$this->assertSame( 'Setting Group Node Test', $actual['data']['node']['title'] );
+	}
+
+	/**
+	 * The node(id:) field with an unknown group key should resolve to null, not error.
+	 *
+	 * @throws \Exception
+	 */
+	public function testNodeQueryForUnknownSettingGroupReturnsNull() {
+		$global_id = \GraphQLRelay\Relay::toGlobalId( 'setting_group', 'notARealGroup' );
+
+		$query = '
+			query GetSettingGroupNode( $id: ID! ) {
+				node( id: $id ) {
+					__typename
+					id
+				}
+			}
+		';
+
+		$actual = graphql(
+			[
+				'query'     => $query,
+				'variables' => [
+					'id' => $global_id,
+				],
+			]
+		);
+
+		$this->assertNull( $actual['data']['node'] );
+	}
+
+	/**
+	 * Setting group object types should implement the Node interface.
+	 *
+	 * @throws \Exception
+	 */
+	public function testSettingGroupTypesImplementNodeInterface() {
+		$query = '
+			query {
+				general: __type( name: "GeneralSettings" ) {
+					interfaces {
+						name
+					}
+				}
+				permalink: __type( name: "PermalinkSettings" ) {
+					interfaces {
+						name
+					}
+				}
+			}
+		';
+
+		$actual = graphql( compact( 'query' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+
+		$general_interfaces   = array_column( $actual['data']['general']['interfaces'], 'name' );
+		$permalink_interfaces = array_column( $actual['data']['permalink']['interfaces'], 'name' );
+
+		$this->assertContains( 'Node', $general_interfaces );
+		$this->assertContains( 'Node', $permalink_interfaces );
+	}
+}


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

Setting groups (`generalSettings`, `permalinkSettings`, etc.) now implement the `Node` interface and expose a globally unique `id`, resolved through a Model and a batched DataLoader. This is the node-identity slice of the Settings as Models / Nodes initiative (#2459): additive only, no change to how setting values resolve.

- **`Model\SettingGroup`** wraps a group's slice of the normalized settings map and derives its `id` via `Relay::toGlobalId( 'setting_group', <group key> )`
- **`SettingGroupLoader`** loads groups by their normalized key (`general`, `permalink`, ...) and is registered in `AppContext::DEFAULT_LOADERS` as `setting_group`
- the RootQuery group fields resolve through the loader (deferred) instead of returning a bare group-name string
- `node(id:)` round-trips a setting group id back to its group type via a new case in `DataSource::resolve_node_type()`
- the group-key -> type-name derivation is consolidated in `SettingGroup::get_type_name()` so type registration and node resolution share one source

```graphql
{
  generalSettings {
    id
    title
  }
}
```

```graphql
query GetSettingGroupNode($id: ID!) {
  node(id: $id) {
    ... on GeneralSettings {
      id
      title
    }
  }
}
```

The flat `allSettings` field stays a convenience view across groups and does not implement `Node`.

## Does this close any currently open issues?

Part of #2459 (with a follow-up slice routing value resolution through the Model). Refs #3931.

## Any other comments?

- **Additive / non-breaking**: existing setting fields, names, and values are untouched. The existing settings suites (`SettingQueriesTest`, `SettingsQueriesTest`, `SettingsMutationsTest`), `AssertValidSchemaTest`, and `NodesTest` pass unchanged.
- New tests in `SettingGroupNodeQueriesTest` cover the `id` field (registered and shim-seeded groups), the `node(id:)` round-trip, null resolution for unknown group keys, and `Node` interface introspection.
- Node identity is what lets clients cache setting groups like any other node, and gives WPGraphQL Smart Cache a stable handle for tracking/evicting settings (the second motivation in #2459); wiring option-update purges is Smart Cache follow-up work.
- Next slice routes per-field value resolution through the Model so field-level access control becomes declarative.