### PR TITLE
test(smart-cache): confirm settings group nodes are collected as cache keys

### DIFF
--- a/plugins/wp-graphql-smart-cache/tests/wpunit/SettingsCacheKeysTest.php
+++ b/plugins/wp-graphql-smart-cache/tests/wpunit/SettingsCacheKeysTest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Confirms that settings groups, now that they are Nodes backed by a Model and
+ * a DataLoader in WPGraphQL core (#2459), are collected by the Query Analyzer
+ * and mapped into the Smart Cache node -> query collection like any other node.
+ *
+ * This is the tagging half of settings caching: it proves a settings query is
+ * tagged with the group's node key. Purging that key when the underlying option
+ * changes is a separate concern (see SettingsCacheInvalidationTest).
+ */
+
+namespace WPGraphQL\SmartCache;
+
+use GraphQLRelay\Relay;
+use WPGraphQL\SmartCache\Cache\Collection;
+
+class SettingsCacheKeysTest extends \Codeception\TestCase\WPTestCase {
+
+	public function setUp(): void {
+		\WPGraphQL::clear_schema();
+
+		if ( ! defined( 'GRAPHQL_DEBUG' ) ) {
+			define( 'GRAPHQL_DEBUG', true );
+		}
+
+		// Enable the node -> query cache maps so save_query_mapping_cb records nodes.
+		add_filter( 'wpgraphql_cache_enable_cache_maps', '__return_true' );
+
+		parent::setUp();
+	}
+
+	public function tearDown(): void {
+		remove_filter( 'wpgraphql_cache_enable_cache_maps', '__return_true' );
+		\WPGraphQL::clear_schema();
+		parent::tearDown();
+	}
+
+	/**
+	 * A query for a settings group should map that query's request key to the
+	 * group's node id in the Smart Cache collection.
+	 */
+	public function testSettingsGroupQueryIsTaggedWithGroupNodeKey() {
+		$query = 'query GetGeneralSettings {
+			generalSettings {
+				id
+			}
+		}';
+
+		$response = graphql( [ 'query' => $query ] );
+
+		// Sanity check: the group exposes a node id (core #2459 behavior).
+		$expected_id = Relay::toGlobalId( 'setting_group', 'general' );
+		$this->assertArrayNotHasKey( 'errors', $response );
+		$this->assertSame( $expected_id, $response['data']['generalSettings']['id'] );
+
+		// The collection should have mapped this query to the group's node key.
+		$collection    = new Collection();
+		$mapped_queries = $collection->get( $expected_id );
+
+		$this->assertNotEmpty(
+			$mapped_queries,
+			'Expected the settings group node key to be collected for the query.'
+		);
+	}
+
+	/**
+	 * Distinct settings groups should be tagged with distinct node keys, so a
+	 * future change to one group can purge only the queries that touched it.
+	 */
+	public function testDistinctSettingsGroupsProduceDistinctNodeKeys() {
+		graphql(
+			[
+				'query' => 'query GetGeneral {
+					generalSettings {
+						id
+					}
+				}',
+			]
+		);
+
+		graphql(
+			[
+				'query' => 'query GetReading {
+					readingSettings {
+						id
+					}
+				}',
+			]
+		);
+
+		$collection = new Collection();
+
+		$general_id = Relay::toGlobalId( 'setting_group', 'general' );
+		$reading_id = Relay::toGlobalId( 'setting_group', 'reading' );
+
+		$general_queries = $collection->get( $general_id );
+		$reading_queries = $collection->get( $reading_id );
+
+		$this->assertNotEmpty( $general_queries );
+		$this->assertNotEmpty( $reading_queries );
+
+		// The general-only query should not be tagged under the reading group's key.
+		$this->assertEmpty(
+			array_intersect( (array) $general_queries, (array) $reading_queries ),
+			'A query for one settings group should not be mapped to another group\'s node key.'
+		);
+	}
+}


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

Now that WPGraphQL core exposes settings groups as Nodes backed by a Model and a DataLoader (wp-graphql/wp-graphql#2459, shipped via #4081), a settings query flows through the same node-collection path as any other node: the Query Analyzer picks up the group's `model` from the query AST, `track_nodes` collects the group's node `id` off the loader, and Smart Cache maps the query to that key.

This PR adds tests that **confirm** that behavior and lock it in as a regression guard. No production code changes.

- `generalSettings { id }` maps its request key to the `setting_group:general` node key in the `Collection`.
- Distinct groups (`general` vs `reading`) produce distinct node keys, so a future change to one group can purge only the queries that touched it, rather than a blanket purge.

## Does this close any currently open issues?

Part of the settings-as-nodes work (wp-graphql/wp-graphql#2459). This is the **tagging** half.

## Any other comments?

Purging these keys when the underlying option changes is **not** wired yet: `Invalidation.php` has no `updated_option` listener, so a settings change currently purges nothing. That is tracked as a separate feature (the existing `SettingsCacheInvalidationTest` stub is its designated home), and it carries real design decisions (per-group purge vs `purge_all`, and guarding against transient/option-write churn). This PR deliberately scopes to confirming the tagging that already works.

**Progressive enhancement, not a version bump.** Settings caching is additive: on older WPGraphQL core that doesn't expose setting-group nodes, Smart Cache keeps caching posts/terms/users exactly as before, so no `Requires WPGraphQL` / min-version change is warranted. No version/feature guard is added to these tests: there is no test matrix running Smart Cache against older core, so in the monorepo they only run against the sibling core (which always has the feature) and any such guard could never fire.
