### PR TITLE
refactor(settings): resolve the normalized settings map without a built schema

### DIFF
--- a/plugins/wp-graphql/src/Data/DataSource.php
+++ b/plugins/wp-graphql/src/Data/DataSource.php
@@ -371,13 +371,12 @@ class DataSource {
 		foreach ( $registered_settings as $key => $setting ) {
 			$setting_key = (string) $key;
 
-			if ( ! isset( $setting['type'] ) ) {
-				continue;
-			}
-
-			// Only exclude by unknown GraphQL type when building the schema; when
-			// the map is resolved without a registry the field-type gate doesn't apply.
-			if ( null !== $type_registry && ! $type_registry->get_type( $setting['type'] ) ) {
+			// Skip settings without a type, and, only when building the schema (a
+			// registry is provided), settings whose declared type has no
+			// corresponding GraphQL type. When the map is resolved without a
+			// registry the field-type gate doesn't apply, since the map is used to
+			// identify settings, not to register fields.
+			if ( ! isset( $setting['type'] ) || ( null !== $type_registry && ! $type_registry->get_type( $setting['type'] ) ) ) {
 				continue;
 			}
 

--- a/plugins/wp-graphql/src/Data/DataSource.php
+++ b/plugins/wp-graphql/src/Data/DataSource.php
@@ -341,13 +341,21 @@ class DataSource {
 	 * grouped settings map) are derived from this single map so a setting cannot
 	 * appear on one surface and not the other.
 	 *
-	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The WPGraphQL TypeRegistry
+	 * The map is resolvable without a built schema. When a `TypeRegistry` is
+	 * provided (the schema-build path) settings whose declared type has no
+	 * corresponding GraphQL type are excluded, since they can't become fields.
+	 * When resolved without one (e.g. cache invalidation reading the map outside a
+	 * GraphQL request) that gate is skipped: the map is used to identify settings,
+	 * not to register fields, so over-inclusion is harmless and no schema build is
+	 * forced.
+	 *
+	 * @param \WPGraphQL\Registry\TypeRegistry|null $type_registry The WPGraphQL TypeRegistry, or null to resolve the map without a built schema.
 	 *
 	 * @return array<string,array<string,mixed>>
 	 *
 	 * @since x-release-please-version
 	 */
-	protected static function get_normalized_settings( TypeRegistry $type_registry ): array {
+	protected static function get_normalized_settings( ?TypeRegistry $type_registry = null ): array {
 
 		/**
 		 * Get all registered settings
@@ -363,7 +371,13 @@ class DataSource {
 		foreach ( $registered_settings as $key => $setting ) {
 			$setting_key = (string) $key;
 
-			if ( ! isset( $setting['type'] ) || ! $type_registry->get_type( $setting['type'] ) ) {
+			if ( ! isset( $setting['type'] ) ) {
+				continue;
+			}
+
+			// Only exclude by unknown GraphQL type when building the schema; when
+			// the map is resolved without a registry the field-type gate doesn't apply.
+			if ( null !== $type_registry && ! $type_registry->get_type( $setting['type'] ) ) {
 				continue;
 			}
 
@@ -413,8 +427,8 @@ class DataSource {
 		 * rejects updates to the setting through the updateSettings mutation, and `graphql_resolve`
 		 * (callable) normalizes the setting's resolved value.
 		 *
-		 * @param array<string,array<string,mixed>> $normalized_settings The normalized settings map, keyed by option name.
-		 * @param \WPGraphQL\Registry\TypeRegistry  $type_registry       The WPGraphQL TypeRegistry.
+		 * @param array<string,array<string,mixed>>     $normalized_settings The normalized settings map, keyed by option name.
+		 * @param \WPGraphQL\Registry\TypeRegistry|null $type_registry       The WPGraphQL TypeRegistry, or null when the map is resolved without a built schema.
 		 *
 		 * @hookGroup settings
 		 * @since x-release-please-version
@@ -580,11 +594,11 @@ class DataSource {
 	/**
 	 * Get all of the allowed settings by group
 	 *
-	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The WPGraphQL TypeRegistry
+	 * @param \WPGraphQL\Registry\TypeRegistry|null $type_registry The WPGraphQL TypeRegistry, or null to resolve the grouped map without a built schema.
 	 *
 	 * @return array<string,array<string,mixed>> $allowed_settings_by_group
 	 */
-	public static function get_allowed_settings_by_group( TypeRegistry $type_registry ) {
+	public static function get_allowed_settings_by_group( ?TypeRegistry $type_registry = null ) {
 
 		/**
 		 * Group the normalized settings ( general, reading, discussion, writing, etc. ),
@@ -617,11 +631,11 @@ class DataSource {
 	/**
 	 * Get all of the $allowed_settings
 	 *
-	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The WPGraphQL TypeRegistry
+	 * @param \WPGraphQL\Registry\TypeRegistry|null $type_registry The WPGraphQL TypeRegistry, or null to resolve the flat map without a built schema.
 	 *
 	 * @return array<string,array<string,mixed>> $allowed_settings
 	 */
-	public static function get_allowed_settings( TypeRegistry $type_registry ) {
+	public static function get_allowed_settings( ?TypeRegistry $type_registry = null ) {
 
 		/**
 		 * The flat view is the normalized map itself.

--- a/plugins/wp-graphql/tests/wpunit/SettingsPurgeAllConfigTest.php
+++ b/plugins/wp-graphql/tests/wpunit/SettingsPurgeAllConfigTest.php
@@ -122,4 +122,34 @@ class SettingsPurgeAllConfigTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTest
 		$this->assertNotEmpty( $by_group['permalink']['permalink_structure']['graphql_purge_all'] ?? null );
 		$this->assertNotEmpty( $by_group['permalink']['tag_base']['graphql_purge_all'] ?? null );
 	}
+
+	/**
+	 * The type gate is conditional on a TypeRegistry being provided. A setting
+	 * whose declared type has no corresponding GraphQL type is excluded from the
+	 * map when a registry is passed (the schema-build path, where it couldn't
+	 * become a field), but included when the map is resolved without one (where
+	 * the map only identifies settings).
+	 */
+	public function testTypeGateAppliesOnlyWhenRegistryProvided() {
+		register_setting(
+			'general',
+			'wpgraphql_test_unknown_type_option',
+			[
+				'type'         => 'wpgraphql_nonexistent_type',
+				'show_in_rest' => true,
+			]
+		);
+
+		// Boot the schema so the type registry is built, then resolve the flat map
+		// WITH the registry: the unresolved-type setting is gated out.
+		$this->graphql( [ 'query' => '{ __typename }' ] );
+		$with_registry = \WPGraphQL\Data\DataSource::get_allowed_settings( \WPGraphQL::get_type_registry() );
+		$this->assertArrayNotHasKey( 'wpgraphql_test_unknown_type_option', $with_registry );
+
+		// Resolve the same map WITHOUT a registry: the gate is skipped, so it's kept.
+		$without_registry = \WPGraphQL\Data\DataSource::get_allowed_settings();
+		$this->assertArrayHasKey( 'wpgraphql_test_unknown_type_option', $without_registry );
+
+		unregister_setting( 'general', 'wpgraphql_test_unknown_type_option' );
+	}
 }

--- a/plugins/wp-graphql/tests/wpunit/SettingsPurgeAllConfigTest.php
+++ b/plugins/wp-graphql/tests/wpunit/SettingsPurgeAllConfigTest.php
@@ -99,4 +99,27 @@ class SettingsPurgeAllConfigTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTest
 
 		$this->assertNotEmpty( $by_group['general']['my_broad_option']['graphql_purge_all'] ?? null );
 	}
+
+	/**
+	 * The grouped settings map is resolvable without a built schema. Cache
+	 * invalidation reads it on `updated_option` outside a GraphQL request, where
+	 * the type registry is not initialized, so `get_allowed_settings_by_group()`
+	 * must work when called with no TypeRegistry.
+	 *
+	 * This test deliberately does NOT boot the schema (no graphql() call) before
+	 * reading the map.
+	 */
+	public function testGroupedMapResolvesWithoutBuiltSchema() {
+		// No registry passed, and the schema is never booted in this test.
+		$by_group = \WPGraphQL\Data\DataSource::get_allowed_settings_by_group();
+
+		// A registered core setting still maps to its group.
+		$this->assertArrayHasKey( 'general', $by_group );
+		$this->assertArrayHasKey( 'blogname', $by_group['general'] );
+
+		// The in-memory permalink shims (and their broad-impact flag) are present
+		// too, so a permalink change escalates correctly with no schema built.
+		$this->assertNotEmpty( $by_group['permalink']['permalink_structure']['graphql_purge_all'] ?? null );
+		$this->assertNotEmpty( $by_group['permalink']['tag_base']['graphql_purge_all'] ?? null );
+	}
 }


### PR DESCRIPTION
The normalized settings map is built through `DataSource::get_normalized_settings()`, which gated each setting on its GraphQL type resolving and so needed a built type registry. That is fine during a schema build, but it means the map can't be read where the schema isn't instantiated. Cache invalidation needs to read it on `updated_option` (admin saves, REST, WP-CLI), and forcing a schema build on the option-write hot path would be a real performance regression.

This mirrors how post types and taxonomies already work: we inject our keys onto the WordPress registries so `get_post_types(['show_in_graphql'=>true])` reads them without the schema. Make the `TypeRegistry` argument optional on `get_normalized_settings()`, `get_allowed_settings_by_group()`, and `get_allowed_settings()`. When a registry is passed (every schema-build call) the type gate applies exactly as before, so schema behavior is unchanged. When called with no registry the map resolves schema-free, since it's being used to identify settings, not to register fields.

New test proves the grouped map resolves with no schema built. All existing settings suites stay green.

Refs #2459, #3931
