### PR TITLE
feat(smart-cache): invalidate settings-group caches on option updates

### DIFF
--- a/plugins/wp-graphql-smart-cache/docs/cache-invalidation.md
+++ b/plugins/wp-graphql-smart-cache/docs/cache-invalidation.md
@@ -57,7 +57,7 @@ When a cache is tagged with `skipped:$type_name` it will be purged more often th
 
 ## Tracked Events
 
-WPGraphQL Smart Cache tracks events related to all the core WordPress data types, with the current exception of Options.
+WPGraphQL Smart Cache tracks events related to all the core WordPress data types.
 
 ### Posts, Pages, Custom Post Types
 
@@ -94,9 +94,36 @@ WPGraphQL Smart Cache tracks events related to all the core WordPress data types
 
 ### Settings / Options
 
-Currently WPGraphQL Smart Cache does not track events related to updating settings.
+WPGraphQL core exposes each settings group (General, Reading, Writing, etc.) as a
+Node, so a query like `{ generalSettings { title } }` is tagged with that group's
+node key. When a setting in the group changes, Smart Cache purges the queries that
+touched it.
 
-There is a lot of nuance to consider. You can read more about this here: [#158](https://github.com/wp-graphql/wp-graphql-smart-cache/issues/158)
+- **Per-group purge (default).** Changing a setting purges only the queries that
+  read its group. Changing a General setting does not evict a `readingSettings`
+  query.
+- **Broad-impact settings purge everything.** A few settings affect data well
+  beyond their own group — the permalink options (`permalink_structure`,
+  `category_base`, `tag_base`) change the `uri` of every content node and term.
+  Core flags these as broad-impact, and a change to one triggers a full purge.
+- **One listener, every write path.** Invalidation keys off WordPress's
+  `updated_option`, so it covers the admin Settings screens, the REST API, WP-CLI
+  (`wp option update`), and the `updateSettings` GraphQL mutation alike.
+- **Unmapped options and transients are ignored.** Only options that map to an
+  exposed setting are tracked; transient writes never purge.
+
+Sites can escalate additional raw option keys to a full purge (for options that
+are not registered settings, such as `gmt_offset`) with the
+`graphql_cache_purge_all_option_keys` filter:
+
+```php
+add_filter( 'graphql_cache_purge_all_option_keys', function ( $option_keys ) {
+    $option_keys[] = 'gmt_offset';
+    return $option_keys;
+} );
+```
+
+Background on the design tradeoffs: [#158](https://github.com/wp-graphql/wp-graphql-smart-cache/issues/158)
 
 ----
 

--- a/plugins/wp-graphql-smart-cache/phpstan.neon.dist
+++ b/plugins/wp-graphql-smart-cache/phpstan.neon.dist
@@ -32,3 +32,9 @@ parameters:
         # Document::class exists at analysis time; runtime check for when WPGraphQL not loaded
         - identifier: deadCode.unreachable
           path: wp-graphql-smart-cache.php
+        # DataSource::get_allowed_settings_by_group()'s TypeRegistry argument is
+        # optional as of the (unreleased) core settings-as-nodes work; the pinned
+        # wp-graphql-stubs still type it as required. We intentionally call it with
+        # no argument to resolve the settings map without forcing a schema build.
+        - message: '#get_allowed_settings_by_group\(\) invoked with 0 parameters, 1 required#'
+          path: src/Cache/Invalidation.php

--- a/plugins/wp-graphql-smart-cache/src/Cache/Invalidation.php
+++ b/plugins/wp-graphql-smart-cache/src/Cache/Invalidation.php
@@ -26,6 +26,14 @@ class Invalidation {
 	protected static $ignored_meta_keys = null;
 
 	/**
+	 * Memoized map of option name => settings-group invalidation info, built once
+	 * per request from core's normalized settings map. Null until first built.
+	 *
+	 * @var array<string,array{group:string,purge_all:bool}>|null
+	 */
+	protected $setting_option_group_map = null;
+
+	/**
 	 * Instantiate the Cache Invalidation class
 	 *
 	 * @param Collection $collection
@@ -128,6 +136,17 @@ class Invalidation {
 
 		add_action( 'wp_insert_comment', [ $this, 'on_insert_comment_cb' ], 10, 2 );
 		add_action( 'transition_comment_status', [ $this, 'on_comment_transition_cb' ], 10, 3 );
+
+		## Settings actions
+
+		// A single updated_option listener covers every write path (REST, wp-admin,
+		// WP-CLI, and the updateSettings mutation all call update_option()).
+		add_action( 'updated_option', [ $this, 'on_updated_option_cb' ], 10, 3 );
+
+		// The option => settings-group map is memoized per request; drop it when the
+		// type registry is (re)built so a schema change is reflected on the next
+		// lookup (also keeps the map deterministic across a long-lived process).
+		add_action( 'graphql_register_types', [ $this, 'reset_setting_option_group_map' ], 10, 0 );
 	}
 
 	/**
@@ -1096,5 +1115,158 @@ class Invalidation {
 	 */
 	public function on_purge_all_cb() {
 		$this->purge( 'graphql:Query', 'purge all' );
+	}
+
+	/**
+	 * Listen for option updates and purge the caches for the settings group the
+	 * option belongs to.
+	 *
+	 * Settings groups are exposed as Nodes by WPGraphQL core, so a settings query
+	 * is tagged with its group's node id (`setting_group:<group>`). When a mapped
+	 * setting changes we purge that node id; a setting core flags as broad-impact
+	 * (`graphql_purge_all`) escalates to a full purge instead.
+	 *
+	 * A single updated_option listener covers every write path — REST, wp-admin,
+	 * WP-CLI, and the updateSettings mutation all call update_option().
+	 *
+	 * @param string $option    Name of the updated option.
+	 * @param mixed  $old_value The old option value.
+	 * @param mixed  $value     The new option value.
+	 *
+	 * @return void
+	 */
+	public function on_updated_option_cb( $option, $old_value, $value ) {
+		$target = $this->get_setting_invalidation_target( (string) $option );
+
+		// Not a mapped setting (or a transient / unrelated write): no-op.
+		if ( null === $target ) {
+			return;
+		}
+
+		// A broad-impact setting escalates to a full purge, using the same
+		// primitive as the admin "Purge Cache Now" action.
+		if ( 'all' === $target['scope'] ) {
+			//phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+			do_action( 'wpgraphql_cache_purge_all' );
+			return;
+		}
+
+		// Otherwise purge only the queries that touched the changed group.
+		$this->purge_nodes( 'setting_group', $target['group'], 'setting_updated' );
+	}
+
+	/**
+	 * Resolve an option name to the settings-group node it should invalidate and
+	 * the scope of that invalidation, or null when the write should be ignored.
+	 *
+	 * This is the one WP-specific translation unit ("updated_option => node id +
+	 * scope"): the transient short-circuit, the mapping gate, and the broad-impact
+	 * escalation all live here so the callback is a thin dispatcher. It is the
+	 * clean seam to lift into the core event pipeline (wp-graphql#2517) later,
+	 * where core emits the event and Smart Cache only consumes it.
+	 *
+	 * @param string $option Name of the updated option.
+	 *
+	 * @return array{group:string,scope:string}|null Purge target, or null for a no-op.
+	 */
+	public function get_setting_invalidation_target( string $option ) {
+
+		// Transients are stored as options and churn constantly (including Smart
+		// Cache's own storage). Short-circuit before any map work so high-frequency
+		// transient writes don't pay the lookup and can't trigger a purge loop.
+		if ( 0 === strpos( $option, '_transient_' ) || 0 === strpos( $option, '_site_transient_' ) ) {
+			return null;
+		}
+
+		/**
+		 * Raw option keys that should escalate to a full purge when changed.
+		 *
+		 * The `graphql_purge_all` per-entry config in core's settings map already
+		 * escalates mapped settings; this filter covers option keys that are not
+		 * themselves mapped settings (e.g. `gmt_offset`, which backs the timezone
+		 * field but isn't registered as a setting) and lets operators override
+		 * core's per-setting opinion without touching registration.
+		 *
+		 * @param string[] $option_keys Option names that force a full purge on change.
+		 *
+		 * @since x-release-please-version
+		 */
+		//phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+		$purge_all_option_keys = apply_filters( 'graphql_cache_purge_all_option_keys', [] );
+
+		if ( is_array( $purge_all_option_keys ) && in_array( $option, $purge_all_option_keys, true ) ) {
+			return [
+				'group' => '',
+				'scope' => 'all',
+			];
+		}
+
+		$map = $this->get_setting_option_group_map();
+
+		// The mapping gate: an option that isn't a mapped setting is a no-op. This
+		// also excludes Smart Cache's own option keys and every unrelated write.
+		if ( ! isset( $map[ $option ] ) ) {
+			return null;
+		}
+
+		$entry = $map[ $option ];
+
+		return [
+			'group' => $entry['group'],
+			'scope' => ! empty( $entry['purge_all'] ) ? 'all' : 'group',
+		];
+	}
+
+	/**
+	 * Reset the memoized option => settings-group map.
+	 *
+	 * Hooked to `graphql_register_types` so a (re)built type registry re-derives
+	 * the map on the next lookup.
+	 *
+	 * @return void
+	 */
+	public function reset_setting_option_group_map() {
+		$this->setting_option_group_map = null;
+	}
+
+	/**
+	 * Build (and memoize per request) the option name => settings-group map, so a
+	 * changed option resolves to the group node id core's SettingGroup model emits
+	 * (`setting_group:<group>`), plus whether the change is broad-impact.
+	 *
+	 * Reads core's normalized settings map (`get_allowed_settings_by_group()`) as
+	 * the single source of truth: it is keyed by the same group core's SettingGroup
+	 * model emits, includes the in-memory shims core seeds (the permalink options,
+	 * etc.) and any `graphql_normalized_settings` filter additions, and carries the
+	 * per-entry `graphql_purge_all` flag. Called with no TypeRegistry so it resolves
+	 * without a built schema — `updated_option` fires on many writes outside a
+	 * GraphQL request (admin saves, REST, WP-CLI, cron), and forcing a schema build
+	 * on the option-write hot path would be a real performance regression.
+	 *
+	 * Degrades to an empty map (everything a no-op) on core without the settings map.
+	 *
+	 * @return array<string,array{group:string,purge_all:bool}>
+	 */
+	protected function get_setting_option_group_map(): array {
+		if ( null !== $this->setting_option_group_map ) {
+			return $this->setting_option_group_map;
+		}
+
+		$map = [];
+
+		if ( class_exists( '\WPGraphQL\Data\DataSource' ) && method_exists( '\WPGraphQL\Data\DataSource', 'get_allowed_settings_by_group' ) ) {
+			foreach ( \WPGraphQL\Data\DataSource::get_allowed_settings_by_group() as $group_key => $settings ) {
+				foreach ( $settings as $option_key => $setting ) {
+					$map[ (string) $option_key ] = [
+						'group'     => (string) $group_key,
+						'purge_all' => ! empty( $setting['graphql_purge_all'] ),
+					];
+				}
+			}
+		}
+
+		$this->setting_option_group_map = $map;
+
+		return $map;
 	}
 }

--- a/plugins/wp-graphql-smart-cache/tests/wpunit/SettingsCacheInvalidationTest.php
+++ b/plugins/wp-graphql-smart-cache/tests/wpunit/SettingsCacheInvalidationTest.php
@@ -1,84 +1,230 @@
 <?php
-namespace WPGraphQL\SmartCache;
+/**
+ * Proves the purge half of settings caching: when a mapped setting's option
+ * changes, Smart Cache purges the owning settings-group node key (or purges all
+ * for broad-impact settings), while unmapped options and transient writes are
+ * no-ops (the loop guard).
+ *
+ * The tagging half — a settings query being tagged with its group's node key —
+ * is covered by SettingsCacheKeysTest. This test keys off that same node id on
+ * the invalidation side.
+ */
 
-use WPGraphQL\SmartCache\Cache\Collection;
+use TestCase\WPGraphQLSmartCache\TestCase\WPGraphQLSmartCacheTestCaseWithSeedDataAndPopulatedCaches;
+use WPGraphQL\SmartCache\Cache\Invalidation;
 
-class SettingsCacheInvalidationTest extends \Codeception\TestCase\WPTestCase {
+class SettingsCacheInvalidationTest extends WPGraphQLSmartCacheTestCaseWithSeedDataAndPopulatedCaches {
 
-	protected $collection;
+	/**
+	 * Merge settings-group queries into the seeded/populated cache fixture so
+	 * getEvictedCaches() tracks them alongside the post/term/user queries.
+	 *
+	 * `expectedCacheKeys` asserts (at populate time, in setUp) that each query is
+	 * tagged with its group's node id, so any failure here isolates to the
+	 * invalidation listener rather than the tagging.
+	 *
+	 * @return array<string,array<string,mixed>>
+	 */
+	public function getQueries() {
+		$queries = parent::getQueries();
 
-	public function setUp(): void {
+		$queries['generalSettings'] = [
+			'name'              => 'generalSettings',
+			'query'             => 'query GetGeneralSettings { generalSettings { id title } }',
+			'variables'         => null,
+			'assertions'        => [],
+			'expectedCacheKeys' => [
+				$this->toRelayId( 'setting_group', 'general' ),
+			],
+		];
+
+		$queries['readingSettings'] = [
+			'name'              => 'readingSettings',
+			'query'             => 'query GetReadingSettings { readingSettings { id } }',
+			'variables'         => null,
+			'assertions'        => [],
+			'expectedCacheKeys' => [
+				$this->toRelayId( 'setting_group', 'reading' ),
+			],
+		];
+
+		return $queries;
+	}
+
+	/**
+	 * A change to a mapped setting purges only the owning group's node key.
+	 * blogname is the `title` field of the general group.
+	 */
+	public function testMappedSettingUpdatePurgesOwningGroup() {
+
+		// all fixture queries are cached to start
+		$this->assertEmpty( $this->getEvictedCaches() );
+
+		update_option( 'blogname', 'Changed Title' );
+
+		$evicted = $this->getEvictedCaches();
+
+		// the general group query is purged
+		$this->assertContains( 'generalSettings', $evicted );
+
+		// per-group granularity: a different group's query is untouched
+		$this->assertNotContains( 'readingSettings', $evicted );
+
+		// and it does not spill over to unrelated (post/term) queries
+		$this->assertNotContains( 'listPost', $evicted );
+		$this->assertNotContains( 'singlePost', $evicted );
+	}
+
+	/**
+	 * Updating an option that is not a mapped setting is a no-op. This is the
+	 * primary gate that also covers Smart Cache's own option storage.
+	 */
+	public function testUnmappedOptionUpdateDoesNotPurge() {
+
+		$this->assertEmpty( $this->getEvictedCaches() );
+
+		// add then update so `updated_option` (not `added_option`) fires
+		add_option( 'some_unmapped_test_option', 'first' );
+		update_option( 'some_unmapped_test_option', 'second' );
+
+		$this->assertEmpty( $this->getEvictedCaches() );
+	}
+
+	/**
+	 * Transient writes (stored as options) must never purge, or Smart Cache's own
+	 * transient churn would evict caches on unrelated activity / loop.
+	 */
+	public function testTransientUpdateDoesNotPurge() {
+
+		$this->assertEmpty( $this->getEvictedCaches() );
+
+		// set twice so the second write fires `updated_option` for the
+		// `_transient_*` option key, exercising the short-circuit
+		set_transient( 'my_test_transient', 'a', HOUR_IN_SECONDS );
+		set_transient( 'my_test_transient', 'b', HOUR_IN_SECONDS );
+
+		// site transients travel the same path (`_site_transient_*`)
+		set_site_transient( 'my_test_site_transient', 'a', HOUR_IN_SECONDS );
+		set_site_transient( 'my_test_site_transient', 'b', HOUR_IN_SECONDS );
+
+		$this->assertEmpty( $this->getEvictedCaches() );
+	}
+
+	/**
+	 * A broad-impact setting (carrying `graphql_purge_all` in core's normalized
+	 * map — the permalink shims) escalates to a full purge, evicting queries in
+	 * every group and unrelated content queries too.
+	 */
+	public function testBroadImpactSettingEscalatesToPurgeAll() {
+
+		$this->assertEmpty( $this->getEvictedCaches() );
+
+		update_option( 'permalink_structure', '/%postname%/' );
+
+		// purge_all: nothing survives, across every group and content type
+		$this->assertEmpty( $this->getNonEvictedCaches() );
+	}
+
+	/**
+	 * The `graphql_cache_purge_all_option_keys` filter lets a site escalate a raw
+	 * option key that is not itself a mapped setting (e.g. `gmt_offset`, which
+	 * backs the timezone field but is not registered as a setting).
+	 */
+	public function testPurgeAllOptionKeysFilterEscalatesRawKey() {
+
+		$this->assertEmpty( $this->getEvictedCaches() );
+
+		// Without the filter, gmt_offset is unmapped -> no-op
+		update_option( 'gmt_offset', 3 );
+		$this->assertEmpty( $this->getEvictedCaches() );
+
+		// With the filter, the raw key escalates to purge_all
+		$callback = static function ( $keys ) {
+			$keys[] = 'gmt_offset';
+			return $keys;
+		};
+		add_filter( 'graphql_cache_purge_all_option_keys', $callback );
+
+		update_option( 'gmt_offset', 5 );
+
+		$this->assertEmpty( $this->getNonEvictedCaches() );
+
+		remove_filter( 'graphql_cache_purge_all_option_keys', $callback );
+	}
+
+	/**
+	 * The updateSettings mutation purges through the same `updated_option`
+	 * listener (it calls update_option under the hood) — no separate mutation
+	 * hook, no double purge.
+	 */
+	public function testUpdateSettingsMutationPurgesGroup() {
+
+		$this->assertEmpty( $this->getEvictedCaches() );
+
+		wp_set_current_user( $this->admin->ID );
+
+		$mutation = 'mutation Update( $input: UpdateSettingsInput! ) {
+			updateSettings( input: $input ) {
+				generalSettings { title }
+			}
+		}';
+
+		$response = graphql(
+			[
+				'query'     => $mutation,
+				'variables' => [
+					'input' => [ 'generalSettingsTitle' => 'Mutated Title' ],
+				],
+			]
+		);
+
+		$this->assertArrayNotHasKey( 'errors', $response );
+
+		$evicted = $this->getEvictedCaches();
+
+		$this->assertContains( 'generalSettings', $evicted );
+		$this->assertNotContains( 'readingSettings', $evicted );
+	}
+
+	/**
+	 * The primary production path: an option write outside a GraphQL request (an
+	 * admin Settings save, REST, WP-CLI) runs with no schema built, so the GraphQL
+	 * type registry is not initialized. The option => group map must still resolve
+	 * from WordPress's raw settings registry rather than needing a schema build.
+	 *
+	 * Invoked on a fresh Invalidation instance (bypassing the process-lifetime
+	 * memoized map) with the schema cleared, so the raw-registry path is exercised.
+	 */
+	public function testMappedSettingPurgesWithUninitializedRegistry() {
+
+		$this->assertEmpty( $this->getEvictedCaches() );
+
+		// Simulate a non-GraphQL request: no schema, uninitialized type registry.
 		\WPGraphQL::clear_schema();
 
-		if ( ! defined( 'GRAPHQL_DEBUG' ) ) {
-			define( 'GRAPHQL_DEBUG', true );
-		}
+		$invalidation = new Invalidation( $this->collection );
+		$invalidation->on_updated_option_cb( 'blogname', 'Old Title', 'New Title' );
 
-		$this->collection = new Collection();
+		$evicted = $this->getEvictedCaches();
 
-		// enable caching for the whole test suite
-		add_option( 'graphql_cache_section', [ 'cache_toggle' => 'on' ] );
-
-		parent::setUp();
+		$this->assertContains( 'generalSettings', $evicted );
+		$this->assertNotContains( 'readingSettings', $evicted );
 	}
 
-	public function tearDown(): void {
+	/**
+	 * The broad-impact escalation must also work with no schema built: the
+	 * permalink shims (which WordPress does not register via register_setting())
+	 * resolve from Smart Cache's shim fallback and escalate to purge_all.
+	 */
+	public function testPermalinkPurgesAllWithUninitializedRegistry() {
+
+		$this->assertEmpty( $this->getEvictedCaches() );
+
 		\WPGraphQL::clear_schema();
-		// disable caching
-		delete_option( 'graphql_cache_section' );
-		parent::tearDown();
+
+		$invalidation = new Invalidation( $this->collection );
+		$invalidation->on_updated_option_cb( 'permalink_structure', '', '/%postname%/' );
+
+		$this->assertEmpty( $this->getNonEvictedCaches() );
 	}
-
-	public function testItWorks() {
-		$this->assertTrue( true );
-	}
-
-	// @todo I think many updates to settings might require a purge_all.
-	// for example, if I change something like the timezone or the site language,
-	// that will likely have wide impact on how resolvers execute and should probably
-	// trigger wide reaching purge event.
-	// I think there's probably going to need to be some
-	// case-by-case decisions made here for how settings should
-	// actually impact cache.
-	//
-	// like the "general" settings group seems pretty far reaching
-	// but the "writing" settings doesn't seem like
-	// it would have _as much_ of an impact.
-	// if I were to change some setting like the "default post category" in the writing settings,
-	// that wouldn't necessitate a purge_all()
-	//
-	// the reading settings probably have wider reach though too.
-	// if I change the homepage display option, that will impact several things.
-	//
-	// I'm thinking we need some way to either purge queries for a settings group,
-	// purge_all or do nothing.
-	//
-	//
-	// for example,
-	// a change to general_settings group should probably purge_all
-	// a change to writing settings should probably only purge queries like { writingSettings { ... } }
-
-
-
-
-
-
-
-
-	// update untracked options (no purge)
-	// update tracked option (purge group?)
-	// set transient doesn't purge (don't want weird infinite loops)
-
-
-
-	// new post types detected?
-	// post type removed?
-	// new taxonomy added?
-	// taxonomy removed?
-	// schema breaking change detected?
-	// update permalinks (purge all?)
-
-
-
-
 }


### PR DESCRIPTION
Core exposes each settings group as a Node, so a settings query like `{ generalSettings { title } }` is tagged with its group's node key (`setting_group:general`). Smart Cache collected that key but never purged it, so the query kept serving a stale title after the setting changed. This wires up the purge half.

- Adds an `updated_option` listener that purges the changed setting's group node by default (a General change evicts `generalSettings` queries, leaves `readingSettings` alone).
- Broad-impact settings escalate to a full purge. The permalink options drive the `uri` of every content node and term, so core flags them with `graphql_purge_all` and a change purges everything.
- One listener covers every write path: admin Settings screens, REST, WP-CLI, and the `updateSettings` mutation.
- Transients short-circuit (the loop guard), unmapped options are a no-op, and sites can escalate raw option keys with the `graphql_cache_purge_all_option_keys` filter.

The option to group map reads core's normalized map with no `TypeRegistry`, so it resolves without a built schema. Core stays the single source of truth: it keys the map by group, seeds the in-memory shims, and carries `graphql_purge_all`. The hook to node-id-plus-scope translation is isolated in one method so it can move into a core event pipeline later (#2517).

Depends on #4094 (makes core's settings map resolvable without a built schema). This PR is stacked on that branch; retarget to `main` once it merges.

Testing: 8 new invalidation tests (incl. two no-schema production-path tests), full Smart Cache suite green (197 tests), PHPCS and PHPStan L8 clean.

Refs #2459, #3931
