### PR TITLE
docs: add missing @hookGroup to the graphql_setting_field_value filter docblock

### DIFF
--- a/plugins/wp-graphql/src/Model/SettingGroup.php
+++ b/plugins/wp-graphql/src/Model/SettingGroup.php
@@ -168,6 +168,7 @@ class SettingGroup extends Model {
 		 * @param array<string,mixed> $setting_field The setting field config, including its `key` and `type`.
 		 * @param string              $group_name    The name of the settings group the field belongs to.
 		 *
+		 * @hookGroup settings
 		 * @since x-release-please-version
 		 */
 		return apply_filters( 'graphql_setting_field_value', $value, $setting_field, $this->group_key );


### PR DESCRIPTION
## What

Adds the missing `@hookGroup settings` tag to the `graphql_setting_field_value` filter docblock in `src/Model/SettingGroup.php`.

## Why

Every `apply_filters()` call site is expected to declare a hook group, and this one was missed when the filter was introduced. The generated hooks lint report on the 2.18.0 release PR flags it as `missing_hook_group`, and the generated doc page files the hook under Uncategorized instead of Settings and Admin alongside its sibling filters (`graphql_normalized_settings`, `graphql_allowed_setting_groups`, `graphql_allowed_settings_by_group`).

Flagged by the Copilot review on #3999: https://github.com/wp-graphql/wp-graphql/pull/3999#discussion_r3623801304

No behavior change, docblock only. The generated docs on the release PR will pick this up the next time release-please regenerates it.