### PR TITLE
fix: show interface relationships in Docs explorer with collapsible, sticky sections

### DIFF
--- a/plugins/wp-graphql-ide/src/components/DocsExplorerPanel.jsx
+++ b/plugins/wp-graphql-ide/src/components/DocsExplorerPanel.jsx
@@ -490,7 +490,7 @@ function RootView({ schema, onSelectType }) {
  * @param {Object}          props
  * @param {string}          props.title       Section heading label.
  * @param {number}          props.count       Number of entries in the section.
- * @param {boolean}         [props.forceOpen] When truthy, expand the section (used to reveal a cmd-click focus target inside a collapsed section).
+ * @param {*}               [props.forceOpen] Expands the section whenever this changes to something truthy, revealing a focus target the user had collapsed out of view. Pass the identity of the thing being focused (a field name), not a boolean — a boolean stays `true` between two focus targets and would only fire once.
  * @param {React.ReactNode} props.children    Section content.
  */
 function DocsSection({ title, count, forceOpen, children }) {
@@ -695,7 +695,11 @@ function FieldsList({ fields, focusField, onSelectType }) {
 		<DocsSection
 			title={__('Fields', 'wpgraphql-ide')}
 			count={fields.length}
-			forceOpen={Boolean(focusField)}
+			// The field name itself, not a boolean: `TypeView` is keyed by
+			// type, so moving between two fields of the same type doesn't
+			// remount it, and a boolean would stay `true` across the move
+			// and never re-trigger the re-open.
+			forceOpen={focusField}
 		>
 			{fields.map((field) => (
 				<FieldItem
@@ -814,9 +818,12 @@ function FieldItem({ field, isFocused, onSelectType }) {
  * Clickable row that navigates to a type's detail view.
  *
  * The whole row is the button, not just the type name: the row is what
- * lights up on hover, so the row is what has to be clickable. The label
- * and kind are decorative context, hidden from assistive tech so the
- * button announces as just the type name.
+ * lights up on hover, so the row is what has to be clickable.
+ *
+ * The accessible name is composed rather than left to the row's text so it
+ * carries the same information the row shows — in an Implementations list
+ * the kind is what separates an object from an interface — and so it stays
+ * put regardless of the `text-transform` the kind is styled with.
  *
  * @param {Object}   props
  * @param {string}   [props.label] Optional label prefix (e.g. "query").
@@ -825,28 +832,25 @@ function FieldItem({ field, isFocused, onSelectType }) {
  * @param {Function} props.onClick Click handler.
  */
 function TypeLink({ label, kind, type, onClick }) {
+	const accessibleName = [
+		label ? `${label}: ` : '',
+		type.name,
+		kind ? `, ${kind}` : '',
+	].join('');
+
 	return (
 		<button
 			type="button"
 			className="wpgraphql-ide-docs-type-entry"
+			aria-label={accessibleName}
 			onClick={onClick}
 		>
 			{label && (
-				<span
-					className="wpgraphql-ide-docs-type-label"
-					aria-hidden="true"
-				>
-					{label}:
-				</span>
+				<span className="wpgraphql-ide-docs-type-label">{label}:</span>
 			)}
 			<span className="wpgraphql-ide-docs-type-link">{type.name}</span>
 			{kind && (
-				<span
-					className="wpgraphql-ide-docs-type-kind"
-					aria-hidden="true"
-				>
-					{kind}
-				</span>
+				<span className="wpgraphql-ide-docs-type-kind">{kind}</span>
 			)}
 		</button>
 	);

--- a/plugins/wp-graphql-ide/src/components/DocsExplorerPanel.jsx
+++ b/plugins/wp-graphql-ide/src/components/DocsExplorerPanel.jsx
@@ -811,7 +811,12 @@ function FieldItem({ field, isFocused, onSelectType }) {
 }
 
 /**
- * Clickable type name link.
+ * Clickable row that navigates to a type's detail view.
+ *
+ * The whole row is the button, not just the type name: the row is what
+ * lights up on hover, so the row is what has to be clickable. The label
+ * and kind are decorative context, hidden from assistive tech so the
+ * button announces as just the type name.
  *
  * @param {Object}   props
  * @param {string}   [props.label] Optional label prefix (e.g. "query").
@@ -821,20 +826,28 @@ function FieldItem({ field, isFocused, onSelectType }) {
  */
 function TypeLink({ label, kind, type, onClick }) {
 	return (
-		<div className="wpgraphql-ide-docs-type-entry">
+		<button
+			type="button"
+			className="wpgraphql-ide-docs-type-entry"
+			onClick={onClick}
+		>
 			{label && (
-				<span className="wpgraphql-ide-docs-type-label">{label}:</span>
+				<span
+					className="wpgraphql-ide-docs-type-label"
+					aria-hidden="true"
+				>
+					{label}:
+				</span>
 			)}
-			<button
-				type="button"
-				className="wpgraphql-ide-docs-type-link"
-				onClick={onClick}
-			>
-				{type.name}
-			</button>
+			<span className="wpgraphql-ide-docs-type-link">{type.name}</span>
 			{kind && (
-				<span className="wpgraphql-ide-docs-type-kind">{kind}</span>
+				<span
+					className="wpgraphql-ide-docs-type-kind"
+					aria-hidden="true"
+				>
+					{kind}
+				</span>
 			)}
-		</div>
+		</button>
 	);
 }

--- a/plugins/wp-graphql-ide/src/components/DocsExplorerPanel.jsx
+++ b/plugins/wp-graphql-ide/src/components/DocsExplorerPanel.jsx
@@ -1,7 +1,13 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
-import { Icon, arrowLeft, search } from '@wordpress/icons';
+import {
+	Icon,
+	arrowLeft,
+	chevronDown,
+	chevronUp,
+	search,
+} from '@wordpress/icons';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	isObjectType,
@@ -317,7 +323,11 @@ function renderBody({
 	}
 	return (
 		<TypeView
+			// Keyed by type name so per-section collapse state resets to the
+			// expanded default whenever the user navigates to another type.
+			key={type.name}
 			type={type}
+			schema={schema}
 			focusField={current.focusField || null}
 			onSelectType={selectType}
 			onBack={goBack}
@@ -466,30 +476,143 @@ function RootView({ schema, onSelectType }) {
 }
 
 /**
+ * Collapsible section with a sticky heading.
+ *
+ * The heading is a toggle button that stays pinned just below the sticky
+ * type header while its section scrolls, so the user always knows which
+ * section (Fields, Implements, …) the rows under the cursor belong to.
+ * Collapse state is per-mount — `TypeView` is keyed by type name, so every
+ * type opens with all sections expanded.
+ *
+ * @param {Object}          props
+ * @param {string}          props.title       Section heading label.
+ * @param {number}          props.count       Number of entries in the section.
+ * @param {boolean}         [props.forceOpen] When truthy, expand the section (used to reveal a cmd-click focus target inside a collapsed section).
+ * @param {React.ReactNode} props.children    Section content.
+ */
+function DocsSection({ title, count, forceOpen, children }) {
+	const [open, setOpen] = useState(true);
+
+	useEffect(() => {
+		if (forceOpen) {
+			setOpen(true);
+		}
+	}, [forceOpen]);
+
+	return (
+		<div className="wpgraphql-ide-docs-section">
+			<button
+				type="button"
+				className="wpgraphql-ide-docs-section-title"
+				onClick={() => setOpen((prev) => !prev)}
+				aria-expanded={open}
+			>
+				<span className="wpgraphql-ide-docs-section-label">
+					{title}
+				</span>
+				<span className="wpgraphql-ide-docs-section-count">
+					{count}
+				</span>
+				{/* Trailing up/down chevron — the Gutenberg PanelBody idiom,
+					also used by DocumentNotices. */}
+				<span
+					className="wpgraphql-ide-docs-section-chevron"
+					aria-hidden="true"
+				>
+					<Icon icon={open ? chevronUp : chevronDown} size={18} />
+				</span>
+			</button>
+			{open && children}
+		</div>
+	);
+}
+
+/**
  * Detailed view for a single type — shows description, fields, enum
  * values, or union members.
  *
  * @param {Object}      props
  * @param {Object}      props.type         GraphQL type.
+ * @param {Object}      props.schema       Active GraphQL schema (used to look up interface implementations).
  * @param {string|null} props.focusField   Optional field name to scroll to / highlight.
  * @param {Function}    props.onSelectType Callback when a type is clicked.
  * @param {Function}    props.onBack       Back navigation callback.
  */
-function TypeView({ type, focusField, onSelectType, onBack }) {
+function TypeView({ type, schema, focusField, onSelectType, onBack }) {
+	// Object and interface types can implement interfaces; interfaces can
+	// also be implemented by other types. Both directions are shown so the
+	// user can hop between an interface and its implementations.
+	const implementedInterfaces =
+		isObjectType(type) || isInterfaceType(type) ? type.getInterfaces() : [];
+	// `getImplementations()` (rather than `getPossibleTypes()`) so the list
+	// includes interfaces that implement this interface, not just objects —
+	// e.g. `ContentNode` shows up as an implementation of `Node`.
+	let implementations = [];
+	if (isInterfaceType(type)) {
+		const { objects, interfaces } = schema.getImplementations(type);
+		implementations = [...objects, ...interfaces].sort((a, b) =>
+			a.name.localeCompare(b.name)
+		);
+	}
+
+	// Section headings stick just below the type header, so they need its
+	// rendered height as a CSS offset. Measured (rather than hardcoded)
+	// because the type name can wrap.
+	const rootRef = useRef(null);
+	const headerRef = useRef(null);
+	useEffect(() => {
+		const root = rootRef.current;
+		const header = headerRef.current;
+		if (!root || !header) {
+			return undefined;
+		}
+		const update = () => {
+			root.style.setProperty(
+				'--wpgraphql-ide-docs-header-h',
+				`${header.offsetHeight}px`
+			);
+		};
+		update();
+		if (typeof window.ResizeObserver === 'undefined') {
+			return undefined;
+		}
+		const observer = new window.ResizeObserver(update);
+		observer.observe(header);
+		return () => observer.disconnect();
+	}, []);
+
 	return (
-		<div className="wpgraphql-ide-docs-panel">
-			{/* Sticky header — pins the Back button, type name, and description
-				to the top of the panel's scroll container so they stay visible
-				as the user scrolls through long fields lists. */}
-			<header className="wpgraphql-ide-docs-type-header">
+		<div ref={rootRef} className="wpgraphql-ide-docs-panel">
+			{/* Sticky header — pins the Back button and type name to the top
+				of the panel's scroll container so the user can always see what
+				type they're looking at. The description intentionally lives
+				outside the header: it scrolls away so long descriptions don't
+				eat vertical space while browsing fields. */}
+			<header ref={headerRef} className="wpgraphql-ide-docs-type-header">
 				<BackButton onClick={onBack} />
 				<div className="wpgraphql-ide-docs-type-name">{type.name}</div>
-				{type.description && (
-					<p className="wpgraphql-ide-docs-description">
-						{decodeEntities(type.description)}
-					</p>
-				)}
 			</header>
+
+			{type.description && (
+				<p className="wpgraphql-ide-docs-description wpgraphql-ide-docs-type-description">
+					{decodeEntities(type.description)}
+				</p>
+			)}
+
+			{implementedInterfaces.length > 0 && (
+				<DocsSection
+					title={__('Implements', 'wpgraphql-ide')}
+					count={implementedInterfaces.length}
+				>
+					{implementedInterfaces.map((iface) => (
+						<TypeLink
+							key={iface.name}
+							type={iface}
+							onClick={() => onSelectType(iface)}
+						/>
+					))}
+				</DocsSection>
+			)}
 
 			{(isObjectType(type) ||
 				isInputObjectType(type) ||
@@ -501,11 +624,27 @@ function TypeView({ type, focusField, onSelectType, onBack }) {
 				/>
 			)}
 
+			{implementations.length > 0 && (
+				<DocsSection
+					title={__('Implementations', 'wpgraphql-ide')}
+					count={implementations.length}
+				>
+					{implementations.map((t) => (
+						<TypeLink
+							key={t.name}
+							type={t}
+							kind={getTypeKind(t)}
+							onClick={() => onSelectType(t)}
+						/>
+					))}
+				</DocsSection>
+			)}
+
 			{isEnumType(type) && (
-				<div className="wpgraphql-ide-docs-section">
-					<div className="wpgraphql-ide-docs-section-title">
-						{__('Values', 'wpgraphql-ide')}
-					</div>
+				<DocsSection
+					title={__('Values', 'wpgraphql-ide')}
+					count={type.getValues().length}
+				>
 					{type.getValues().map((val) => (
 						<div
 							key={val.name}
@@ -519,14 +658,14 @@ function TypeView({ type, focusField, onSelectType, onBack }) {
 							)}
 						</div>
 					))}
-				</div>
+				</DocsSection>
 			)}
 
 			{isUnionType(type) && (
-				<div className="wpgraphql-ide-docs-section">
-					<div className="wpgraphql-ide-docs-section-title">
-						{__('Possible Types', 'wpgraphql-ide')}
-					</div>
+				<DocsSection
+					title={__('Possible Types', 'wpgraphql-ide')}
+					count={type.getTypes().length}
+				>
 					{type.getTypes().map((t) => (
 						<TypeLink
 							key={t.name}
@@ -534,7 +673,7 @@ function TypeView({ type, focusField, onSelectType, onBack }) {
 							onClick={() => onSelectType(t)}
 						/>
 					))}
-				</div>
+				</DocsSection>
 			)}
 		</div>
 	);
@@ -550,10 +689,11 @@ function TypeView({ type, focusField, onSelectType, onBack }) {
  */
 function FieldsList({ fields, focusField, onSelectType }) {
 	return (
-		<div className="wpgraphql-ide-docs-section">
-			<div className="wpgraphql-ide-docs-section-title">
-				{__('Fields', 'wpgraphql-ide')}
-			</div>
+		<DocsSection
+			title={__('Fields', 'wpgraphql-ide')}
+			count={fields.length}
+			forceOpen={Boolean(focusField)}
+		>
 			{fields.map((field) => (
 				<FieldItem
 					key={field.name}
@@ -562,7 +702,7 @@ function FieldsList({ fields, focusField, onSelectType }) {
 					onSelectType={onSelectType}
 				/>
 			))}
-		</div>
+		</DocsSection>
 	);
 }
 

--- a/plugins/wp-graphql-ide/src/components/DocsExplorerPanel.jsx
+++ b/plugins/wp-graphql-ide/src/components/DocsExplorerPanel.jsx
@@ -447,7 +447,10 @@ function RootView({ schema, onSelectType }) {
 
 	return (
 		<div className="wpgraphql-ide-docs-section">
-			<div className="wpgraphql-ide-docs-section-title">
+			{/* A plain heading, not a `DocsSection`: the root view has no
+				sticky type header to offset against, and its single group
+				of entry points has nothing worth collapsing. */}
+			<div className="wpgraphql-ide-docs-root-title">
 				{__('Root Types', 'wpgraphql-ide')}
 			</div>
 			{queryType && (

--- a/plugins/wp-graphql-ide/src/components/ide-layout.css
+++ b/plugins/wp-graphql-ide/src/components/ide-layout.css
@@ -4794,18 +4794,32 @@ input.wpgraphql-ide-docs-search[type="text"]:focus {
 	font-size: var(--wpgraphql-ide-text-11, 11px);
 }
 
-/* Root type entries (query, mutation, subscription) */
+/* Type entry rows — root entry points (query, mutation, subscription),
+   Implements / Implementations lists, union members, and search results.
+   The whole row is the button, so the full-width hover band and the pointer
+   are honest: anywhere in the row navigates. */
 .wpgraphql-ide-docs-type-entry {
 	display: flex;
 	align-items: center;
 	gap: var(--wpgraphql-ide-space-8, 8px);
+	width: 100%;
+	margin: 0;
 	padding: 8px;
+	border: 0;
 	border-radius: var(--wpgraphql-ide-radius-sm, 2px);
+	background: none;
 	cursor: pointer;
+	text-align: left;
+	font-family: inherit;
 }
 
 .wpgraphql-ide-docs-type-entry:hover {
 	background: var(--wp-components-color-gray-100, #f0f0f1);
+}
+
+.wpgraphql-ide-docs-type-entry:focus-visible {
+	outline: 2px solid var(--wpgraphql-ide-accent);
+	outline-offset: -2px;
 }
 
 .wpgraphql-ide-docs-type-label {
@@ -4815,17 +4829,14 @@ input.wpgraphql-ide-docs-search[type="text"]:focus {
 }
 
 .wpgraphql-ide-docs-type-link {
-	background: none;
-	border: none;
-	padding: 0;
 	color: var(--gql-color-type);
-	cursor: pointer;
 	font-family: monospace;
 	font-size: var(--wpgraphql-ide-text-13, 13px);
-	text-align: left;
 }
 
-.wpgraphql-ide-docs-type-link:hover {
+/* Underline the name on row hover — the row is the target, so the cue
+   belongs to the row, not to the name it happens to sit under. */
+.wpgraphql-ide-docs-type-entry:hover .wpgraphql-ide-docs-type-link {
 	text-decoration: underline;
 }
 
@@ -4862,7 +4873,10 @@ input.wpgraphql-ide-docs-search[type="text"]:focus {
 	padding: 0 4px;
 }
 
-/* Field list items */
+/* Field list items — deliberately no hover treatment. A field row has
+   nowhere to navigate to; only the type badge and the args toggle inside it
+   are interactive, and they carry their own affordances. Tinting the row
+   would advertise a click target that isn't there. */
 .wpgraphql-ide-docs-field {
 	padding: 8px;
 	border-radius: var(--wpgraphql-ide-radius-sm, 2px);
@@ -4870,10 +4884,6 @@ input.wpgraphql-ide-docs-search[type="text"]:focus {
 
 .wpgraphql-ide-docs-field + .wpgraphql-ide-docs-field {
 	border-top: 1px solid var(--wp-components-color-gray-100, #f0f0f1);
-}
-
-.wpgraphql-ide-docs-field:hover {
-	background: var(--wpgraphql-ide-surface-soft, #f6f7f7);
 }
 
 /* Field that was cmd-clicked from the editor — give it a steady tint so the

--- a/plugins/wp-graphql-ide/src/components/ide-layout.css
+++ b/plugins/wp-graphql-ide/src/components/ide-layout.css
@@ -4540,6 +4540,16 @@ input.wpgraphql-ide-tab-input:focus {
 	overflow-y: auto;
 }
 
+/* A type detail view rendered inside the scrolling body reuses the panel
+   class but must grow with its content — `height: 100%` would cap the
+   sticky elements' containing block at one viewport, un-pinning the type
+   header and section headings once the user scrolls past it. */
+.wpgraphql-ide-docs-body > .wpgraphql-ide-docs-panel {
+	display: block;
+	height: auto;
+	min-height: 100%;
+}
+
 .wpgraphql-ide-docs-empty {
 	color: var(--wpgraphql-ide-text-muted, #646970);
 	font-size: var(--wpgraphql-ide-text-13, 13px);
@@ -4561,12 +4571,15 @@ input.wpgraphql-ide-tab-input:focus {
 	color: var(--wpgraphql-ide-accent);
 }
 
-/* Sticky header for the type detail view — pins Back + name + description
-   to the top of the panel's scroll container so the user can always see
-   *what type they're looking at* while scrolling its (often long) field list.
+/* Sticky header for the type detail view — pins Back + name to the top of
+   the panel's scroll container so the user can always see *what type they're
+   looking at* while scrolling its (often long) field list. The description
+   is rendered outside the header and scrolls away with the content.
    The negative top/horizontal offsets and matching padding cancel out the
    16px padding `.wpgraphql-ide-plugin` applies, so the sticky surface spans
-   the panel's full width and reaches all the way to the top edge. */
+   the panel's full width and reaches all the way to the top edge.
+   Its measured height is written to `--wpgraphql-ide-docs-header-h` (see
+   `TypeView`) so section titles can stick directly below it. */
 .wpgraphql-ide-docs-type-header {
 	position: sticky;
 	top: -16px;
@@ -4574,7 +4587,16 @@ input.wpgraphql-ide-tab-input:focus {
 	padding: 16px 16px 8px;
 	background: var(--wp-components-color-background, #fff);
 	border-bottom: 1px solid var(--wp-components-color-gray-100, #f0f0f1);
-	z-index: 1;
+	z-index: 2;
+}
+
+/* Type description in the type detail view — in normal flow (not sticky),
+   below the pinned header. Generous bottom margin so the first section
+   heading doesn't crowd it. Compound selector: the base
+   `.wpgraphql-ide-docs-description` rule below sets `margin: 0` and
+   would otherwise win on source order. */
+.wpgraphql-ide-docs-description.wpgraphql-ide-docs-type-description {
+	margin: 0 0 24px;
 }
 
 /* Type detail heading */
@@ -4602,14 +4624,77 @@ input.wpgraphql-ide-tab-input:focus {
 	margin-bottom: 16px;
 }
 
-.wpgraphql-ide-docs-section-title {
-	font-size: var(--wpgraphql-ide-text-11, 11px);
+/* Section heading — a collapse/expand toggle that also sticks just below
+   the type header (offset by the header's measured height) so the user
+   always knows which section the rows under the cursor belong to. The
+   negative horizontal margins + matching padding span the panel padding,
+   giving the sticky surface a full-width background to hide rows that
+   scroll beneath it. */
+/* Section heading — Gutenberg PanelBody idiom: 13px medium title at the
+   left (flush with the section content below it), muted count, trailing
+   up/down chevron at the right edge. Spans the content width only — the
+   panel's 16px side padding lives OUTSIDE the docs-body scroll container,
+   so full-bleed negative margins would just get clipped by the scrollport
+   (they were, cutting off the chevron). Content width is all a pinned
+   heading needs to cover scrolling rows. Kept opaque with a persistent
+   bottom border so rows slide cleanly beneath it while stuck. */
+button.wpgraphql-ide-docs-section-title {
+	display: flex;
+	align-items: center;
+	width: 100%;
+	height: 36px;
+	margin: 0 0 8px;
+	padding: 0;
+	border: 0;
+	border-bottom: 1px solid var(--wpgraphql-ide-border-subtle, #e0e0e0);
+	background: var(--wp-components-color-background, #fff);
+	cursor: pointer;
+	text-align: left;
+	position: sticky;
+	top: calc(var(--wpgraphql-ide-docs-header-h, 56px) - 16px);
+	z-index: 1;
+	font-family: inherit;
+}
+
+button.wpgraphql-ide-docs-section-title:hover {
+	background: var(--wpgraphql-ide-surface-soft, #f6f7f7);
+}
+
+button.wpgraphql-ide-docs-section-title:focus-visible {
+	outline: 2px solid var(--wpgraphql-ide-accent);
+	outline-offset: -2px;
+}
+
+.wpgraphql-ide-docs-section-chevron {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	margin-left: auto;
+	flex-shrink: 0;
+	color: var(--wp-components-color-foreground, #1e1e1e);
+}
+
+.wpgraphql-ide-docs-section-chevron svg {
+	display: block;
+	fill: currentColor;
+}
+
+.wpgraphql-ide-docs-section-label {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-size: var(--wpgraphql-ide-text-13, 13px);
 	font-weight: var(--wpgraphql-ide-weight-medium, 500);
-	text-transform: uppercase;
-	letter-spacing: 0.5px;
-	color: var(--wpgraphql-ide-text-muted, #646970);
-	margin-bottom: 4px;
-	padding: 8px 0 4px;
+	color: var(--wp-components-color-foreground, #1e1e1e);
+}
+
+.wpgraphql-ide-docs-section-count {
+	margin-left: 6px;
+	flex-shrink: 0;
+	font-size: var(--wpgraphql-ide-text-13, 13px);
+	font-weight: 400;
+	color: #757575;
 }
 
 /* Search input */

--- a/plugins/wp-graphql-ide/src/components/ide-layout.css
+++ b/plugins/wp-graphql-ide/src/components/ide-layout.css
@@ -4575,16 +4575,20 @@ input.wpgraphql-ide-tab-input:focus {
    the panel's scroll container so the user can always see *what type they're
    looking at* while scrolling its (often long) field list. The description
    is rendered outside the header and scrolls away with the content.
-   The negative top/horizontal offsets and matching padding cancel out the
-   16px padding `.wpgraphql-ide-plugin` applies, so the sticky surface spans
-   the panel's full width and reaches all the way to the top edge.
+   The negative top offset and matching top padding cancel out the 16px
+   padding `.wpgraphql-ide-plugin` applies, so the sticky surface reaches
+   the top edge. Horizontally it spans the content width only, for the same
+   reason the section titles below do: that 16px side padding sits OUTSIDE
+   the docs-body scroll container, so nothing ever scrolls through the
+   gutter, and negative side margins would just overhang the scrollport and
+   scroll the whole panel sideways.
    Its measured height is written to `--wpgraphql-ide-docs-header-h` (see
    `TypeView`) so section titles can stick directly below it. */
 .wpgraphql-ide-docs-type-header {
 	position: sticky;
 	top: -16px;
-	margin: -16px -16px 12px;
-	padding: 16px 16px 8px;
+	margin: -16px 0 12px;
+	padding: 16px 0 8px;
 	background: var(--wp-components-color-background, #fff);
 	border-bottom: 1px solid var(--wp-components-color-gray-100, #f0f0f1);
 	z-index: 2;
@@ -4803,6 +4807,9 @@ input.wpgraphql-ide-docs-search[type="text"]:focus {
 	align-items: center;
 	gap: var(--wpgraphql-ide-space-8, 8px);
 	width: 100%;
+	/* This sheet has no global border-box reset, so 100% + padding would
+	   make the row wider than the list it sits in. */
+	box-sizing: border-box;
 	margin: 0;
 	padding: 8px;
 	border: 0;
@@ -4847,9 +4854,14 @@ input.wpgraphql-ide-docs-search[type="text"]:focus {
 	text-transform: lowercase;
 }
 
-/* Type badge — inline pill for return types and arg types */
+/* Type badge — inline pill for return types and arg types. Connection type
+   names get long (`ContentNodeToEnqueuedStylesheetConnection`), and as a
+   flex item the badge won't shrink below its content, so it has to be
+   allowed to wrap or it pushes the whole panel sideways. */
 .wpgraphql-ide-docs-type-badge {
 	display: inline;
+	min-width: 0;
+	max-width: 100%;
 	background: var(--wp-components-color-gray-100, #f0f0f1);
 	border: none;
 	border-radius: var(--wpgraphql-ide-radius-sm, 2px);
@@ -4859,7 +4871,8 @@ input.wpgraphql-ide-docs-search[type="text"]:focus {
 	font-family: monospace;
 	font-size: var(--wpgraphql-ide-text-11, 11px);
 	line-height: var(--wpgraphql-ide-leading-normal, 1.5);
-	white-space: nowrap;
+	overflow-wrap: anywhere;
+	text-align: left;
 }
 
 .wpgraphql-ide-docs-type-badge:hover {

--- a/plugins/wp-graphql-ide/src/components/ide-layout.css
+++ b/plugins/wp-graphql-ide/src/components/ide-layout.css
@@ -4626,18 +4626,18 @@ input.wpgraphql-ide-tab-input:focus {
 
 /* Section heading — a collapse/expand toggle that also sticks just below
    the type header (offset by the header's measured height) so the user
-   always knows which section the rows under the cursor belong to. The
-   negative horizontal margins + matching padding span the panel padding,
-   giving the sticky surface a full-width background to hide rows that
-   scroll beneath it. */
-/* Section heading — Gutenberg PanelBody idiom: 13px medium title at the
-   left (flush with the section content below it), muted count, trailing
-   up/down chevron at the right edge. Spans the content width only — the
-   panel's 16px side padding lives OUTSIDE the docs-body scroll container,
-   so full-bleed negative margins would just get clipped by the scrollport
-   (they were, cutting off the chevron). Content width is all a pinned
-   heading needs to cover scrolling rows. Kept opaque with a persistent
-   bottom border so rows slide cleanly beneath it while stuck. */
+   always knows which section the rows under the cursor belong to.
+   Gutenberg PanelBody idiom: 13px medium title at the left (flush with the
+   section content below it), muted count, trailing up/down chevron at the
+   right edge. Spans the content width only — the panel's 16px side padding
+   lives OUTSIDE the docs-body scroll container, so full-bleed negative
+   margins would just get clipped by the scrollport (they were, cutting off
+   the chevron). Content width is all a pinned heading needs to cover
+   scrolling rows. Kept opaque with a persistent bottom border so rows slide
+   cleanly beneath it while stuck.
+
+   Scoped to `button` because the root view's heading uses the plain
+   `-root-title` rule below instead. */
 button.wpgraphql-ide-docs-section-title {
 	display: flex;
 	align-items: center;
@@ -4695,6 +4695,18 @@ button.wpgraphql-ide-docs-section-title:focus-visible {
 	font-size: var(--wpgraphql-ide-text-13, 13px);
 	font-weight: 400;
 	color: #757575;
+}
+
+/* Root view heading ("Root Types") — a static label rather than a section
+   toggle, so it keeps the older muted-caps treatment and never sticks. */
+.wpgraphql-ide-docs-root-title {
+	font-size: var(--wpgraphql-ide-text-11, 11px);
+	font-weight: var(--wpgraphql-ide-weight-medium, 500);
+	text-transform: uppercase;
+	letter-spacing: 0.5px;
+	color: var(--wpgraphql-ide-text-muted, #646970);
+	margin-bottom: 4px;
+	padding: 8px 0 4px;
 }
 
 /* Search input */

--- a/plugins/wp-graphql-ide/tests/e2e/specs/docs-explorer.spec.js
+++ b/plugins/wp-graphql-ide/tests/e2e/specs/docs-explorer.spec.js
@@ -224,6 +224,24 @@ test.describe('Docs explorer interface relationships', () => {
 		).toHaveText('Page');
 	});
 
+	// The panel is narrow and scrolls vertically. Anything that overflows it
+	// horizontally (a full-width row whose padding isn't inside its width,
+	// say) puts a sideways scrollbar under a long field list.
+	test('the panel does not scroll horizontally', async ({ page }) => {
+		const body = page.locator('.wpgraphql-ide-docs-body');
+
+		// Root view, then a type with long rows and every section on show.
+		for (const open of [null, 'ContentNode']) {
+			if (open) {
+				await openType(page, open);
+			}
+			const overflow = await body.evaluate(
+				(el) => el.scrollWidth - el.clientWidth
+			);
+			expect(overflow).toBeLessThanOrEqual(0);
+		}
+	});
+
 	test('field rows do not take a hover highlight', async ({ page }) => {
 		await openType(page, 'ContentNode');
 

--- a/plugins/wp-graphql-ide/tests/e2e/specs/docs-explorer.spec.js
+++ b/plugins/wp-graphql-ide/tests/e2e/specs/docs-explorer.spec.js
@@ -14,6 +14,11 @@ const activityBarButton = (page, label) =>
 		.locator(selectors.activityBar)
 		.getByRole('button', { name: label, exact: true });
 
+// Type rows carry a composed accessible name so the kind reaches screen
+// readers too ("Page, Object"). Match the type name wherever it sits in that
+// name, without matching a longer type that merely contains it.
+const typeRow = (name) => new RegExp(`(^|: )${name}(,|$)`);
+
 const docsPanel = (page) => page.locator('.wpgraphql-ide-docs-panel').first();
 
 const docsSection = (page, title) =>
@@ -52,7 +57,7 @@ async function openType(page, typeName) {
 	await docsPanel(page)
 		.locator('.wpgraphql-ide-docs-search-group')
 		.filter({ hasText: 'Types' })
-		.getByRole('button', { name: typeName, exact: true })
+		.getByRole('button', { name: typeRow(typeName) })
 		.click();
 	await expect(
 		docsPanel(page).locator('.wpgraphql-ide-docs-type-name')
@@ -76,8 +81,7 @@ test.describe('Docs explorer interface relationships', () => {
 		await expect(implementsSection).toBeVisible();
 		await expect(
 			implementsSection.getByRole('button', {
-				name: 'ContentTemplate',
-				exact: true,
+				name: typeRow('ContentTemplate'),
 			})
 		).toBeVisible();
 	});
@@ -99,15 +103,15 @@ test.describe('Docs explorer interface relationships', () => {
 		const implementations = docsSection(page, 'Implementations');
 		await expect(implementations).toBeVisible();
 		await expect(
-			implementations.getByRole('button', { name: 'Page', exact: true })
+			implementations.getByRole('button', { name: typeRow('Page') })
 		).toBeVisible();
 		await expect(
-			implementations.getByRole('button', { name: 'Post', exact: true })
+			implementations.getByRole('button', { name: typeRow('Post') })
 		).toBeVisible();
 
 		// Clicking an implementation navigates to that type's view…
 		await implementations
-			.getByRole('button', { name: 'Page', exact: true })
+			.getByRole('button', { name: typeRow('Page') })
 			.click();
 		await expect(
 			docsPanel(page).locator('.wpgraphql-ide-docs-type-name')
@@ -115,7 +119,7 @@ test.describe('Docs explorer interface relationships', () => {
 
 		// …and its Implements link navigates back to the interface.
 		await docsSection(page, 'Implements')
-			.getByRole('button', { name: 'ContentNode', exact: true })
+			.getByRole('button', { name: typeRow('ContentNode') })
 			.click();
 		await expect(
 			docsPanel(page).locator('.wpgraphql-ide-docs-type-name')
@@ -139,8 +143,7 @@ test.describe('Docs explorer interface relationships', () => {
 			'.wpgraphql-ide-docs-section-title'
 		);
 		const pageLink = implementations.getByRole('button', {
-			name: 'Page',
-			exact: true,
+			name: typeRow('Page'),
 		});
 
 		await expect(toggle).toHaveAttribute('aria-expanded', 'true');
@@ -203,8 +206,7 @@ test.describe('Docs explorer interface relationships', () => {
 		await openType(page, 'ContentNode');
 
 		const row = docsSection(page, 'Implementations').getByRole('button', {
-			name: 'Page',
-			exact: true,
+			name: typeRow('Page'),
 		});
 
 		// The button has to BE the row rather than a smaller element inside

--- a/plugins/wp-graphql-ide/tests/e2e/specs/docs-explorer.spec.js
+++ b/plugins/wp-graphql-ide/tests/e2e/specs/docs-explorer.spec.js
@@ -1,0 +1,196 @@
+import {
+	loginToWordPressAdmin,
+	visitDedicatedIde,
+	ensureDocumentOpen,
+	selectors,
+} from '../utils.js';
+
+const { test, expect } = require('@wordpress/e2e-test-utils-playwright');
+
+// Activity-bar buttons share their label text with kebab/close buttons
+// inside the panel header. Restrict to the activity bar specifically.
+const activityBarButton = (page, label) =>
+	page
+		.locator(selectors.activityBar)
+		.getByRole('button', { name: label, exact: true });
+
+const docsPanel = (page) => page.locator('.wpgraphql-ide-docs-panel').first();
+
+const docsSection = (page, title) =>
+	docsPanel(page)
+		.locator('.wpgraphql-ide-docs-section')
+		.filter({
+			has: page.locator('.wpgraphql-ide-docs-section-title', {
+				hasText: title,
+			}),
+		});
+
+/**
+ * Open the Docs panel and wait for the schema-backed search input —
+ * its presence means introspection has completed and the panel is
+ * browsable.
+ * @param page
+ */
+async function openDocsPanel(page) {
+	const btn = activityBarButton(page, 'Docs');
+	if ((await btn.getAttribute('aria-pressed')) !== 'true') {
+		await btn.click();
+	}
+	await expect(page.locator('.wpgraphql-ide-docs-search')).toBeVisible({
+		timeout: 15000,
+	});
+}
+
+/**
+ * Navigate the Docs panel to a type's detail view via search.
+ * @param page
+ * @param typeName
+ */
+async function openType(page, typeName) {
+	const searchInput = page.locator('.wpgraphql-ide-docs-search');
+	await searchInput.fill(typeName);
+	await docsPanel(page)
+		.locator('.wpgraphql-ide-docs-search-group')
+		.filter({ hasText: 'Types' })
+		.getByRole('button', { name: typeName, exact: true })
+		.click();
+	await expect(
+		docsPanel(page).locator('.wpgraphql-ide-docs-type-name')
+	).toHaveText(typeName);
+}
+
+test.describe('Docs explorer interface relationships', () => {
+	test.beforeEach(async ({ page }) => {
+		await loginToWordPressAdmin(page);
+		await visitDedicatedIde(page);
+		await ensureDocumentOpen(page);
+		await openDocsPanel(page);
+	});
+
+	test('object type shows the interfaces it implements', async ({ page }) => {
+		// `DefaultTemplate` (from #4028) is also a unique search match —
+		// broader names like `Page` fall outside the capped result list.
+		await openType(page, 'DefaultTemplate');
+
+		const implementsSection = docsSection(page, 'Implements');
+		await expect(implementsSection).toBeVisible();
+		await expect(
+			implementsSection.getByRole('button', {
+				name: 'ContentTemplate',
+				exact: true,
+			})
+		).toBeVisible();
+	});
+
+	test('interface type shows its implementations and navigates between them', async ({
+		page,
+	}) => {
+		await openType(page, 'ContentNode');
+
+		// ContentNode itself implements Node.
+		await expect(
+			docsSection(page, 'Implements').getByRole('button', {
+				name: 'Node',
+				exact: true,
+			})
+		).toBeVisible();
+
+		// And built-in content types implement ContentNode.
+		const implementations = docsSection(page, 'Implementations');
+		await expect(implementations).toBeVisible();
+		await expect(
+			implementations.getByRole('button', { name: 'Page', exact: true })
+		).toBeVisible();
+		await expect(
+			implementations.getByRole('button', { name: 'Post', exact: true })
+		).toBeVisible();
+
+		// Clicking an implementation navigates to that type's view…
+		await implementations
+			.getByRole('button', { name: 'Page', exact: true })
+			.click();
+		await expect(
+			docsPanel(page).locator('.wpgraphql-ide-docs-type-name')
+		).toHaveText('Page');
+
+		// …and its Implements link navigates back to the interface.
+		await docsSection(page, 'Implements')
+			.getByRole('button', { name: 'ContentNode', exact: true })
+			.click();
+		await expect(
+			docsPanel(page).locator('.wpgraphql-ide-docs-type-name')
+		).toHaveText('ContentNode');
+	});
+
+	test('types without interface relationships show neither section', async ({
+		page,
+	}) => {
+		await openType(page, 'RootQuery');
+
+		await expect(docsSection(page, 'Implements')).toHaveCount(0);
+		await expect(docsSection(page, 'Implementations')).toHaveCount(0);
+	});
+
+	test('sections collapse and expand', async ({ page }) => {
+		await openType(page, 'ContentNode');
+
+		const implementations = docsSection(page, 'Implementations');
+		const toggle = implementations.locator(
+			'.wpgraphql-ide-docs-section-title'
+		);
+		const pageLink = implementations.getByRole('button', {
+			name: 'Page',
+			exact: true,
+		});
+
+		await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+		await expect(pageLink).toBeVisible();
+
+		await toggle.click();
+		await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+		await expect(pageLink).toHaveCount(0);
+
+		await toggle.click();
+		await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+		await expect(pageLink).toBeVisible();
+
+		// Fields collapses too.
+		const fieldsToggle = docsSection(page, 'Fields').locator(
+			'.wpgraphql-ide-docs-section-title'
+		);
+		await fieldsToggle.click();
+		await expect(fieldsToggle).toHaveAttribute('aria-expanded', 'false');
+	});
+
+	test('section headings stay pinned below the type header while scrolling', async ({
+		page,
+	}) => {
+		// ContentNode has a long field list — plenty of scroll room.
+		await openType(page, 'ContentNode');
+
+		// Scroll deep into the field list (`toBeVisible()` can't catch an
+		// un-pinned sticky element — it ignores scroll containers — so we
+		// assert on bounding boxes relative to the scrollport instead).
+		const body = page.locator('.wpgraphql-ide-docs-body');
+		await body.evaluate((el) => {
+			el.scrollTop = el.scrollHeight * 0.6;
+		});
+
+		const bodyBox = await body.boundingBox();
+
+		// The slim type header is pinned at the top of the scrollport…
+		const headerBox = await page
+			.locator('.wpgraphql-ide-docs-type-header')
+			.boundingBox();
+		expect(headerBox.y).toBeGreaterThanOrEqual(bodyBox.y - 20);
+		expect(headerBox.y - bodyBox.y).toBeLessThan(20);
+
+		// …and the Fields heading is pinned directly below it, not 60% of
+		// the list off-screen.
+		const titleBox = await docsSection(page, 'Fields')
+			.locator('.wpgraphql-ide-docs-section-title')
+			.boundingBox();
+		expect(titleBox.y).toBeGreaterThanOrEqual(headerBox.y);
+		expect(titleBox.y - bodyBox.y).toBeLessThan(120);
+	});
+});

--- a/plugins/wp-graphql-ide/tests/e2e/specs/docs-explorer.spec.js
+++ b/plugins/wp-graphql-ide/tests/e2e/specs/docs-explorer.spec.js
@@ -193,4 +193,48 @@ test.describe('Docs explorer interface relationships', () => {
 		expect(titleBox.y).toBeGreaterThanOrEqual(headerBox.y);
 		expect(titleBox.y - bodyBox.y).toBeLessThan(120);
 	});
+
+	// Hover feedback has to match what actually responds to a click: every
+	// row that lights up must navigate, and every row that doesn't navigate
+	// must not light up.
+	test('the whole type entry row is clickable, not just the type name', async ({
+		page,
+	}) => {
+		await openType(page, 'ContentNode');
+
+		const row = docsSection(page, 'Implementations').getByRole('button', {
+			name: 'Page',
+			exact: true,
+		});
+
+		// The button has to BE the row rather than a smaller element inside
+		// it. The row is what takes the hover highlight, so the row is what
+		// must respond to a click.
+		await expect(row).toHaveClass(/wpgraphql-ide-docs-type-entry/);
+
+		// Click the far right of the row — empty space well past the type
+		// name, which used to sit outside the click target even though the
+		// hover highlight covered it. Positional click (not page.mouse) so
+		// Playwright scrolls the row into view first.
+		const box = await row.boundingBox();
+		await row.click({ position: { x: box.width - 8, y: box.height / 2 } });
+
+		await expect(
+			docsPanel(page).locator('.wpgraphql-ide-docs-type-name')
+		).toHaveText('Page');
+	});
+
+	test('field rows do not take a hover highlight', async ({ page }) => {
+		await openType(page, 'ContentNode');
+
+		const field = docsPanel(page)
+			.locator('.wpgraphql-ide-docs-field')
+			.first();
+		const background = () =>
+			field.evaluate((el) => window.getComputedStyle(el).backgroundColor);
+
+		const before = await background();
+		await field.hover();
+		expect(await background()).toBe(before);
+	});
 });

--- a/plugins/wp-graphql-ide/tests/unit/specs/components/DocsExplorerPanel.test.js
+++ b/plugins/wp-graphql-ide/tests/unit/specs/components/DocsExplorerPanel.test.js
@@ -230,6 +230,51 @@ describe('DocsExplorerPanel — interface relationships', () => {
 	});
 });
 
+describe('DocsExplorerPanel — click affordances', () => {
+	beforeEach(() => {
+		__dep.schema = buildSchema(SDL);
+		__dep.docsNavTarget = null;
+		__dep.setDocsNavTarget.mockReset();
+	});
+
+	// The whole row is tinted on hover, so the whole row has to be the
+	// button. Previously the row was an inert div wrapping a smaller button,
+	// so most of the highlighted area did nothing when clicked.
+	it('makes the entire type entry row the click target', () => {
+		render(<DocsExplorerPanel />);
+		openType('ContentTemplate');
+
+		const row = section('Implementations').getByRole('button', {
+			name: 'PageNoTitle',
+		});
+		expect(row).toHaveClass('wpgraphql-ide-docs-type-entry');
+
+		// The kind badge is inside that same button, not a sibling of it —
+		// clicking it navigates rather than landing on dead space.
+		expect(
+			within(row).getByText('object', { exact: false })
+		).toBeInTheDocument();
+	});
+
+	// A field row has nowhere to navigate to, so it must not be a button or
+	// announce itself as one; only the type badge and args toggle inside it
+	// are interactive.
+	it('leaves field rows non-interactive', () => {
+		render(<DocsExplorerPanel />);
+		openType('DefaultTemplate');
+
+		const fieldName = screen.getByText('templateName', {
+			selector: '.wpgraphql-ide-docs-field-name',
+		});
+		const fieldRow = fieldName.closest('.wpgraphql-ide-docs-field');
+
+		expect(fieldRow).not.toBeNull();
+		expect(fieldRow.tagName).toBe('DIV');
+		expect(fieldRow).not.toHaveAttribute('role');
+		expect(fieldRow).not.toHaveAttribute('onclick');
+	});
+});
+
 describe('DocsExplorerPanel — collapsible sections', () => {
 	beforeEach(() => {
 		__dep.schema = buildSchema(SDL);

--- a/plugins/wp-graphql-ide/tests/unit/specs/components/DocsExplorerPanel.test.js
+++ b/plugins/wp-graphql-ide/tests/unit/specs/components/DocsExplorerPanel.test.js
@@ -1,0 +1,307 @@
+/* eslint-env browser, jest */
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { buildSchema } from 'graphql';
+
+// `@wordpress/components` probes matchMedia at render time; jsdom doesn't
+// ship it. Stub before the component imports.
+if (typeof window.matchMedia !== 'function') {
+	window.matchMedia = () => ({
+		matches: false,
+		media: '',
+		onchange: null,
+		addListener: () => {},
+		removeListener: () => {},
+		addEventListener: () => {},
+		removeEventListener: () => {},
+		dispatchEvent: () => false,
+	});
+}
+
+// The real `@wordpress/components` drags an untransformed ESM `uuid`
+// into jest; the panel only uses `Button`, so stub it with a plain
+// button element.
+jest.mock('@wordpress/components', () => ({
+	// eslint-disable-next-line react/prop-types
+	Button: ({ children, onClick, className }) => (
+		<button type="button" className={className} onClick={onClick}>
+			{children}
+		</button>
+	),
+}));
+
+// Mock the wp-data app store the panel reads its schema from. Stash on
+// global so jest.mock's factory can reach the same refs without tripping
+// the "no out-of-scope variables" guard.
+global.__dep = {
+	schema: null,
+	docsNavTarget: null,
+	setDocsNavTarget: jest.fn(),
+};
+
+jest.mock('@wordpress/data', () => {
+	const stores = {
+		'wpgraphql-ide/app': {
+			schema: () => global.__dep.schema,
+			getDocsNavTarget: () => global.__dep.docsNavTarget,
+		},
+	};
+	return {
+		useSelect: (cb) => cb((name) => stores[name]),
+		useDispatch: () => ({
+			setDocsNavTarget: global.__dep.setDocsNavTarget,
+		}),
+	};
+});
+
+const { __dep } = global;
+
+// eslint-disable-next-line import/first
+import { DocsExplorerPanel } from '../../../../src/components/DocsExplorerPanel';
+
+// Mirrors the shape from issue #4028: an interface hierarchy (interfaces
+// implementing interfaces) plus object types implementing them, and a
+// union to confirm existing sections are untouched.
+const SDL = /* GraphQL */ `
+	interface Node {
+		id: ID!
+	}
+
+	interface ContentTemplate implements Node {
+		id: ID!
+		templateName: String
+	}
+
+	type DefaultTemplate implements ContentTemplate & Node {
+		id: ID!
+		templateName: String
+	}
+
+	type PageNoTitle implements ContentTemplate & Node {
+		id: ID!
+		templateName: String
+	}
+
+	type Plain {
+		note: String
+	}
+
+	type Query {
+		node: Node
+		plain: Plain
+	}
+`;
+
+// Navigate the panel to a type detail view via the schema search input —
+// the same path a user takes.
+function openType(name) {
+	fireEvent.change(
+		screen.getByRole('textbox', {
+			name: 'Search GraphQL schema types and fields',
+		}),
+		{ target: { value: name } }
+	);
+	const typesGroup = screen
+		.getByText('Types')
+		.closest('.wpgraphql-ide-docs-search-group');
+	fireEvent.click(within(typesGroup).getByRole('button', { name }));
+}
+
+function section(title) {
+	const el = screen
+		.queryByText(title)
+		?.closest('.wpgraphql-ide-docs-section');
+	return el ? within(el) : null;
+}
+
+// The collapse/expand toggle button for a section heading.
+function sectionToggle(title) {
+	return screen.getByText(title).closest('button');
+}
+
+describe('DocsExplorerPanel — interface relationships', () => {
+	beforeEach(() => {
+		__dep.schema = buildSchema(SDL);
+		__dep.docsNavTarget = null;
+		__dep.setDocsNavTarget.mockReset();
+	});
+
+	it('shows an Implements section on an object type, linking each interface', () => {
+		render(<DocsExplorerPanel />);
+		openType('DefaultTemplate');
+
+		const implementsSection = section('Implements');
+		expect(implementsSection).not.toBeNull();
+		expect(
+			implementsSection.getByRole('button', { name: 'ContentTemplate' })
+		).toBeInTheDocument();
+		expect(
+			implementsSection.getByRole('button', { name: 'Node' })
+		).toBeInTheDocument();
+	});
+
+	it('shows Implements and Implementations sections on an interface type', () => {
+		render(<DocsExplorerPanel />);
+		openType('ContentTemplate');
+
+		// ContentTemplate implements Node…
+		const implementsSection = section('Implements');
+		expect(implementsSection).not.toBeNull();
+		expect(
+			implementsSection.getByRole('button', { name: 'Node' })
+		).toBeInTheDocument();
+
+		// …and is implemented by the two templates.
+		const implementationsSection = section('Implementations');
+		expect(implementationsSection).not.toBeNull();
+		expect(
+			implementationsSection.getByRole('button', {
+				name: 'DefaultTemplate',
+			})
+		).toBeInTheDocument();
+		expect(
+			implementationsSection.getByRole('button', { name: 'PageNoTitle' })
+		).toBeInTheDocument();
+	});
+
+	it('lists interfaces that implement an interface among its implementations', () => {
+		render(<DocsExplorerPanel />);
+		openType('Node');
+
+		const implementationsSection = section('Implementations');
+		expect(implementationsSection).not.toBeNull();
+		// Objects and the implementing interface both appear.
+		expect(
+			implementationsSection.getByRole('button', {
+				name: 'ContentTemplate',
+			})
+		).toBeInTheDocument();
+		expect(
+			implementationsSection.getByRole('button', {
+				name: 'DefaultTemplate',
+			})
+		).toBeInTheDocument();
+	});
+
+	it('navigates to the interface when an Implements link is clicked', () => {
+		render(<DocsExplorerPanel />);
+		openType('DefaultTemplate');
+
+		fireEvent.click(
+			section('Implements').getByRole('button', {
+				name: 'ContentTemplate',
+			})
+		);
+
+		// Now on the ContentTemplate detail view — it has its own
+		// Implementations section.
+		expect(
+			screen.getByText('ContentTemplate', {
+				selector: '.wpgraphql-ide-docs-type-name',
+			})
+		).toBeInTheDocument();
+		expect(section('Implementations')).not.toBeNull();
+	});
+
+	it('navigates to the implementing type when an Implementations link is clicked', () => {
+		render(<DocsExplorerPanel />);
+		openType('ContentTemplate');
+
+		fireEvent.click(
+			section('Implementations').getByRole('button', {
+				name: 'PageNoTitle',
+			})
+		);
+
+		expect(
+			screen.getByText('PageNoTitle', {
+				selector: '.wpgraphql-ide-docs-type-name',
+			})
+		).toBeInTheDocument();
+	});
+
+	it('omits both sections for types with no interface relationships', () => {
+		render(<DocsExplorerPanel />);
+		openType('Plain');
+
+		expect(screen.queryByText('Implements')).not.toBeInTheDocument();
+		expect(screen.queryByText('Implementations')).not.toBeInTheDocument();
+	});
+});
+
+describe('DocsExplorerPanel — collapsible sections', () => {
+	beforeEach(() => {
+		__dep.schema = buildSchema(SDL);
+		__dep.docsNavTarget = null;
+		__dep.setDocsNavTarget.mockReset();
+	});
+
+	it('sections start expanded and show an entry count', () => {
+		render(<DocsExplorerPanel />);
+		openType('DefaultTemplate');
+
+		const toggle = sectionToggle('Implements');
+		expect(toggle).toHaveAttribute('aria-expanded', 'true');
+		// DefaultTemplate implements ContentTemplate & Node.
+		expect(within(toggle).getByText('2')).toBeInTheDocument();
+	});
+
+	it('collapses and re-expands a relationship section', () => {
+		render(<DocsExplorerPanel />);
+		openType('DefaultTemplate');
+
+		const toggle = sectionToggle('Implements');
+		fireEvent.click(toggle);
+		expect(toggle).toHaveAttribute('aria-expanded', 'false');
+		expect(
+			screen.queryByRole('button', { name: 'ContentTemplate' })
+		).not.toBeInTheDocument();
+
+		fireEvent.click(toggle);
+		expect(toggle).toHaveAttribute('aria-expanded', 'true');
+		expect(
+			screen.getByRole('button', { name: 'ContentTemplate' })
+		).toBeInTheDocument();
+	});
+
+	it('collapses the Fields section', () => {
+		render(<DocsExplorerPanel />);
+		openType('DefaultTemplate');
+
+		expect(screen.getByText('templateName')).toBeInTheDocument();
+
+		fireEvent.click(sectionToggle('Fields'));
+		expect(screen.queryByText('templateName')).not.toBeInTheDocument();
+	});
+
+	it('resets collapse state to expanded when navigating to another type', () => {
+		render(<DocsExplorerPanel />);
+		openType('DefaultTemplate');
+
+		fireEvent.click(sectionToggle('Implements'));
+		expect(sectionToggle('Implements')).toHaveAttribute(
+			'aria-expanded',
+			'false'
+		);
+
+		// A different type's view starts expanded…
+		openType('PageNoTitle');
+		expect(sectionToggle('Implements')).toHaveAttribute(
+			'aria-expanded',
+			'true'
+		);
+
+		// …and so does the original type when revisited via Back.
+		fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+		expect(
+			screen.getByText('DefaultTemplate', {
+				selector: '.wpgraphql-ide-docs-type-name',
+			})
+		).toBeInTheDocument();
+		expect(sectionToggle('Implements')).toHaveAttribute(
+			'aria-expanded',
+			'true'
+		);
+	});
+});

--- a/plugins/wp-graphql-ide/tests/unit/specs/components/DocsExplorerPanel.test.js
+++ b/plugins/wp-graphql-ide/tests/unit/specs/components/DocsExplorerPanel.test.js
@@ -19,6 +19,12 @@ if (typeof window.matchMedia !== 'function') {
 	});
 }
 
+// Focusing a field scrolls its row into view; jsdom has no layout, so the
+// method doesn't exist there.
+if (typeof window.Element.prototype.scrollIntoView !== 'function') {
+	window.Element.prototype.scrollIntoView = () => {};
+}
+
 // The real `@wordpress/components` drags an untransformed ESM `uuid`
 // into jest; the panel only uses `Button`, so stub it with a plain
 // button element.
@@ -93,6 +99,13 @@ const SDL = /* GraphQL */ `
 	}
 `;
 
+// Type rows carry a composed accessible name so the kind reaches screen
+// readers too: "Page, Object" in a list that mixes kinds, "query: RootQuery"
+// for a root entry, bare "Node" where neither applies. Match the type name
+// wherever it sits in that name, without matching a longer type that merely
+// contains it (`Node` must not match `ContentNode, Object`).
+const typeRow = (name) => new RegExp(`(^|: )${name}(,|$)`);
+
 // Navigate the panel to a type detail view via the schema search input —
 // the same path a user takes.
 function openType(name) {
@@ -105,7 +118,9 @@ function openType(name) {
 	const typesGroup = screen
 		.getByText('Types')
 		.closest('.wpgraphql-ide-docs-search-group');
-	fireEvent.click(within(typesGroup).getByRole('button', { name }));
+	fireEvent.click(
+		within(typesGroup).getByRole('button', { name: typeRow(name) })
+	);
 }
 
 function section(title) {
@@ -134,10 +149,12 @@ describe('DocsExplorerPanel — interface relationships', () => {
 		const implementsSection = section('Implements');
 		expect(implementsSection).not.toBeNull();
 		expect(
-			implementsSection.getByRole('button', { name: 'ContentTemplate' })
+			implementsSection.getByRole('button', {
+				name: typeRow('ContentTemplate'),
+			})
 		).toBeInTheDocument();
 		expect(
-			implementsSection.getByRole('button', { name: 'Node' })
+			implementsSection.getByRole('button', { name: typeRow('Node') })
 		).toBeInTheDocument();
 	});
 
@@ -149,7 +166,7 @@ describe('DocsExplorerPanel — interface relationships', () => {
 		const implementsSection = section('Implements');
 		expect(implementsSection).not.toBeNull();
 		expect(
-			implementsSection.getByRole('button', { name: 'Node' })
+			implementsSection.getByRole('button', { name: typeRow('Node') })
 		).toBeInTheDocument();
 
 		// …and is implemented by the two templates.
@@ -157,11 +174,13 @@ describe('DocsExplorerPanel — interface relationships', () => {
 		expect(implementationsSection).not.toBeNull();
 		expect(
 			implementationsSection.getByRole('button', {
-				name: 'DefaultTemplate',
+				name: typeRow('DefaultTemplate'),
 			})
 		).toBeInTheDocument();
 		expect(
-			implementationsSection.getByRole('button', { name: 'PageNoTitle' })
+			implementationsSection.getByRole('button', {
+				name: typeRow('PageNoTitle'),
+			})
 		).toBeInTheDocument();
 	});
 
@@ -174,12 +193,12 @@ describe('DocsExplorerPanel — interface relationships', () => {
 		// Objects and the implementing interface both appear.
 		expect(
 			implementationsSection.getByRole('button', {
-				name: 'ContentTemplate',
+				name: typeRow('ContentTemplate'),
 			})
 		).toBeInTheDocument();
 		expect(
 			implementationsSection.getByRole('button', {
-				name: 'DefaultTemplate',
+				name: typeRow('DefaultTemplate'),
 			})
 		).toBeInTheDocument();
 	});
@@ -190,7 +209,7 @@ describe('DocsExplorerPanel — interface relationships', () => {
 
 		fireEvent.click(
 			section('Implements').getByRole('button', {
-				name: 'ContentTemplate',
+				name: typeRow('ContentTemplate'),
 			})
 		);
 
@@ -210,7 +229,7 @@ describe('DocsExplorerPanel — interface relationships', () => {
 
 		fireEvent.click(
 			section('Implementations').getByRole('button', {
-				name: 'PageNoTitle',
+				name: typeRow('PageNoTitle'),
 			})
 		);
 
@@ -245,7 +264,7 @@ describe('DocsExplorerPanel — click affordances', () => {
 		openType('ContentTemplate');
 
 		const row = section('Implementations').getByRole('button', {
-			name: 'PageNoTitle',
+			name: typeRow('PageNoTitle'),
 		});
 		expect(row).toHaveClass('wpgraphql-ide-docs-type-entry');
 
@@ -253,6 +272,26 @@ describe('DocsExplorerPanel — click affordances', () => {
 		// clicking it navigates rather than landing on dead space.
 		expect(
 			within(row).getByText('object', { exact: false })
+		).toBeInTheDocument();
+	});
+
+	// The kind is the only thing separating an object from an interface in
+	// an Implementations list, so it has to reach a screen reader and not
+	// just the eye.
+	it('names each type row with its kind', () => {
+		render(<DocsExplorerPanel />);
+		openType('Node');
+
+		const implementations = section('Implementations');
+		expect(
+			implementations.getByRole('button', {
+				name: 'ContentTemplate, Interface',
+			})
+		).toBeInTheDocument();
+		expect(
+			implementations.getByRole('button', {
+				name: 'DefaultTemplate, Object',
+			})
 		).toBeInTheDocument();
 	});
 
@@ -306,7 +345,7 @@ describe('DocsExplorerPanel — collapsible sections', () => {
 		fireEvent.click(toggle);
 		expect(toggle).toHaveAttribute('aria-expanded', 'true');
 		expect(
-			screen.getByRole('button', { name: 'ContentTemplate' })
+			screen.getByRole('button', { name: typeRow('ContentTemplate') })
 		).toBeInTheDocument();
 	});
 
@@ -348,5 +387,37 @@ describe('DocsExplorerPanel — collapsible sections', () => {
 			'aria-expanded',
 			'true'
 		);
+	});
+
+	// `TypeView` is keyed by type name, so hopping between two fields of the
+	// SAME type never remounts it and the collapse state carries over. The
+	// Fields section still has to re-open, or the field the user asked for
+	// sits inside a collapsed section.
+	it('re-expands Fields when the focus target moves within one type', () => {
+		__dep.docsNavTarget = {
+			typeName: 'DefaultTemplate',
+			fieldName: 'templateName',
+		};
+		const { rerender } = render(<DocsExplorerPanel />);
+		expect(screen.getByText('templateName')).toBeInTheDocument();
+
+		fireEvent.click(sectionToggle('Fields'));
+		expect(sectionToggle('Fields')).toHaveAttribute(
+			'aria-expanded',
+			'false'
+		);
+
+		// Same type, different field — e.g. a second cmd-click in the editor.
+		__dep.docsNavTarget = {
+			typeName: 'DefaultTemplate',
+			fieldName: 'id',
+		};
+		rerender(<DocsExplorerPanel />);
+
+		expect(sectionToggle('Fields')).toHaveAttribute(
+			'aria-expanded',
+			'true'
+		);
+		expect(screen.getByText('id')).toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
## What

Fixes #4028

The Docs explorer's type view now surfaces how types and interfaces relate to each other, like the legacy GraphiQL docs did:

- **Implements**: object and interface types list the interfaces they implement, each linking to that interface's detail view.
- **Implementations**: interface types list every type that implements them. This uses `schema.getImplementations()` rather than `getPossibleTypes()` so interfaces that implement an interface show up too (e.g. `ContentNode` appears under `Node`), each entry with an object/interface kind badge.

Both sections navigate the same way the union Possible Types links do, so you can hop between an interface and its implementations.

## UX changes along the way

- **All sections are collapsible** (Implements, Fields, Implementations, Values, Possible Types), expanded by default, and reset to expanded when you navigate to another type. Headings follow the Gutenberg PanelBody idiom, 13px medium title, entry count, trailing up/down chevron.
- **Sticky section headings**: while scrolling a long section, its heading stays pinned just below the type header so you always know which section you're in. The type header measures its own height into a CSS variable (type names can wrap) so the heading offset tracks it.
- **Slim pinned header**: the type description now scrolls away with the content, only Back + type name stay pinned, so long descriptions don't eat reading room.

## Bug fix

The sticky type header was silently unpinning once you scrolled past about one panel-height of fields, because the type view's root reused `.wpgraphql-ide-docs-panel` and its `height: 100%` capped the sticky elements' containing block. A scoped rule now lets the type view grow with its content.

## Testing

- New Jest suite for the panel (10 tests): both sections, link navigation in both directions, interfaces implementing interfaces, collapse/expand, collapse state resetting per navigation, and types with no relationships showing neither section.
- New Playwright spec (5 tests) against the live schema: `DefaultTemplate`, `ContentNode`, `RootQuery`, collapse/expand, and a sticky test that asserts bounding-box geometry relative to the scrollport after scrolling deep into `ContentNode`'s fields (a plain `toBeVisible()` check can't catch an unpinned sticky element, it ignores scroll containers).