### PR TITLE
ci: reconcile the shared release manifest against main on release PRs

### DIFF
--- a/.github/workflows/update-release-pr.yml
+++ b/.github/workflows/update-release-pr.yml
@@ -9,6 +9,9 @@
 # 2. Updates the Upgrade Notice section in readme.txt if there are breaking changes
 # 3. Regenerates hook docs/audits and updates legacy hook placeholders
 # 4. Regenerates the POT file for translations (if languages/ directory exists)
+# 5. Reconciles the shared .release-please-manifest.json against main so a
+#    release PR does not go stale (and CONFLICTING) when a sibling plugin
+#    releases first
 #
 # The workflow identifies release-please PRs by:
 # - Branch name starting with "release-please--"
@@ -90,6 +93,19 @@ jobs:
           echo "component=$COMPONENT" >> $GITHUB_OUTPUT
           echo "plugin_dir=plugins/${COMPONENT}" >> $GITHUB_OUTPUT
           echo "Detected version: $VERSION for component: $COMPONENT"
+
+      - name: Reconcile shared release manifest with main
+        env:
+          COMPONENT: ${{ steps.version_info.outputs.component }}
+        run: |
+          # The shared .release-please-manifest.json goes stale on an open
+          # release PR when a sibling plugin releases first (release-please
+          # only refreshes a PR when its own changelog changes), which turns
+          # the PR CONFLICTING against main. The script rewrites every sibling
+          # line to match main while keeping this PR's own bump — see
+          # scripts/reconcile-release-manifest.js for the full rationale.
+          git fetch origin main --depth=1
+          node scripts/reconcile-release-manifest.js --component="$COMPONENT"
 
       - name: Replace x-release-please-version placeholders
         if: steps.version_info.outputs.version != ''
@@ -276,15 +292,25 @@ jobs:
         run: |
           CHANGED_FILES=""
 
+          # Paths this workflow may rewrite: the plugin's own files, the
+          # shared hook/recipe generated files, and the shared release
+          # manifest (reconciled against main above).
+          PATHS=(
+            "$PLUGIN_DIR"
+            ".release-please-manifest.json"
+            "scripts/hooks/legacy-hooks.json"
+            "websites/wpgraphql.com/src/generated/recipes-index.json"
+          )
+
           # Check if any files changed
-          if ! git diff --quiet -- "$PLUGIN_DIR" "scripts/hooks/legacy-hooks.json" "websites/wpgraphql.com/src/generated/recipes-index.json"; then
-            CHANGED_FILES=$(git diff --name-only -- "$PLUGIN_DIR" "scripts/hooks/legacy-hooks.json" "websites/wpgraphql.com/src/generated/recipes-index.json")
+          if ! git diff --quiet -- "${PATHS[@]}"; then
+            CHANGED_FILES=$(git diff --name-only -- "${PATHS[@]}")
             echo "changed=true" >> $GITHUB_OUTPUT
             echo "Changes detected in:"
             echo "$CHANGED_FILES"
             echo ""
             echo "Diff:"
-            git diff -- "$PLUGIN_DIR" "scripts/hooks/legacy-hooks.json" "websites/wpgraphql.com/src/generated/recipes-index.json"
+            git diff -- "${PATHS[@]}"
           else
             echo "changed=false" >> $GITHUB_OUTPUT
             echo "No changes detected"
@@ -298,6 +324,6 @@ jobs:
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git add "$PLUGIN_DIR" "scripts/hooks/legacy-hooks.json" "websites/wpgraphql.com/src/generated/recipes-index.json"
+          git add "$PLUGIN_DIR" ".release-please-manifest.json" "scripts/hooks/legacy-hooks.json" "websites/wpgraphql.com/src/generated/recipes-index.json"
           git commit -m "chore: sync release placeholders and generated docs for ${COMPONENT}"
           git push

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,17 @@ Tests and PHP linting run inside the wp-env Docker containers and are invoked pe
 | Smart Cache | `@wpgraphql/wp-graphql-smart-cache` |
 | ACF | `@wpgraphql/wp-graphql-acf` |
 
+### Workflow logic lives in `scripts/`, not inlined in YAML
+
+Non-trivial logic a GitHub Actions workflow needs belongs in a committed script (`scripts/*.js`) that the workflow *calls*, not in an inline `run:` block or a `node - <<'NODE'` heredoc. A one-line `sed`/`grep` or a straight tool invocation is fine inline; anything with branching, parsing, or JSON manipulation goes in a script. This keeps the logic testable, reviewable, and runnable locally.
+
+The pattern the release scripts follow (`scripts/update-*.js`, `scripts/reconcile-release-manifest.js`):
+
+- `#!/usr/bin/env node` shebang and a JSDoc header with a `Usage:` line.
+- CLI args as `--key=value`, parsed by a small `parseArgs()`.
+- Pure, exported functions for the core logic; a `main()` that does the IO, guarded by `if (require.main === module)`.
+- A sibling `scripts/<name>.test.js` using Node's built-in `assert` (no test runner), added to the `test:scripts` npm script so it runs in the **Test Release Scripts** workflow. Prefer flags that let the test drive the script without a live git remote/network (e.g. `--main-manifest=<path>` to stand in for a `git show` read).
+
 ### Hook conventions
 
 - Prefer canonical `graphql_*` hook names for new actions/filters.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,8 @@ Tests and PHP linting run inside the wp-env Docker containers and are invoked pe
 
 Non-trivial logic a GitHub Actions workflow needs belongs in a committed script (`scripts/*.js`) that the workflow *calls*, not in an inline `run:` block or a `node - <<'NODE'` heredoc. A one-line `sed`/`grep` or a straight tool invocation is fine inline; anything with branching, parsing, or JSON manipulation goes in a script. This keeps the logic testable, reviewable, and runnable locally.
 
+This is the target for new and changed workflow logic; the codebase isn't fully there yet. `update-release-pr.yml` still carries one inline `node - <<'NODE'` block (the "Replace legacy hook placeholder versions" step) that predates the convention — extract it to a tested script when you next touch it, rather than adding to it.
+
 The pattern the release scripts follow (`scripts/update-*.js`, `scripts/reconcile-release-manifest.js`):
 
 - `#!/usr/bin/env node` shebang and a JSDoc header with a `Usage:` line.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"format": "wp-scripts format",
 		"start": "turbo run start",
 		"test": "turbo run test",
-		"test:scripts": "node scripts/update-upgrade-notice.test.js && node scripts/update-version-constants.test.js && node scripts/update-readme-changelog.test.js && node scripts/hooks/generate-hook-docs.test.js && node scripts/functions/generate-function-docs.test.js && node scripts/recipes/recipe-relations.test.js && node scripts/recipes/generate-recipe-docs.test.js",
+		"test:scripts": "node scripts/update-upgrade-notice.test.js && node scripts/update-version-constants.test.js && node scripts/update-readme-changelog.test.js && node scripts/reconcile-release-manifest.test.js && node scripts/hooks/generate-hook-docs.test.js && node scripts/functions/generate-function-docs.test.js && node scripts/recipes/recipe-relations.test.js && node scripts/recipes/generate-recipe-docs.test.js",
 		"hooks:generate": "node scripts/hooks/generate-hook-docs.js",
 		"hooks:check-legacy": "node scripts/hooks/check-legacy-coverage.js",
 		"functions:generate": "node scripts/functions/generate-function-docs.js",

--- a/scripts/reconcile-release-manifest.js
+++ b/scripts/reconcile-release-manifest.js
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+
+/**
+ * Reconcile the shared .release-please-manifest.json on a release PR branch
+ * against main.
+ *
+ * The manifest holds every plugin's released version in one file, but
+ * release-please only refreshes a given release PR when THAT plugin's own
+ * changelog changes. So when a sibling plugin releases and main's manifest
+ * advances, an open release PR keeps the sibling's old version. git can no
+ * longer auto-merge the stale line against main and the PR goes
+ * CONFLICTING/DIRTY — and, if force-merged, would regress the sibling's
+ * version back down on main.
+ *
+ * The correct resolution is deterministic: take every line from main except
+ * this PR's own component, which keeps its release bump. Doing that keeps the
+ * PR mergeable no matter how many sibling releases land first.
+ *
+ * Usage:
+ *   node scripts/reconcile-release-manifest.js --component=wp-graphql-ide
+ *
+ * Options:
+ *   --component        Component being released (e.g. wp-graphql-ide). Required.
+ *   --manifest         Path to the branch manifest (default
+ *                      .release-please-manifest.json).
+ *   --main-manifest    Path to a file holding main's manifest. When omitted,
+ *                      it is read from git as origin/main:<manifest>. The flag
+ *                      exists so tests can run without a git remote.
+ */
+
+const fs = require('fs');
+const { execSync } = require('child_process');
+
+const DEFAULT_MANIFEST = '.release-please-manifest.json';
+
+function parseArgs() {
+	const args = {};
+	process.argv.slice(2).forEach((arg) => {
+		const [key, value] = arg.replace(/^--/, '').split('=');
+		args[key] = value;
+	});
+	return args;
+}
+
+/**
+ * Compute the reconciled manifest: main's versions for every plugin, with the
+ * released component's own bump preserved from the branch.
+ *
+ * Returns the branch manifest unchanged when there is nothing to reconcile
+ * (component missing on either side, or already in sync), so callers can treat
+ * "no change" as "input === output".
+ *
+ * @param {Object} mainManifest   Parsed manifest from main.
+ * @param {Object} branchManifest Parsed manifest from the release PR branch.
+ * @param {string} component      Component being released (e.g. wp-graphql-ide).
+ * @return {Object} The reconciled manifest.
+ */
+function reconcileManifest(mainManifest, branchManifest, component) {
+	const ownKey = `plugins/${component}`;
+
+	// If the branch doesn't track this component, or main has no opinion on
+	// it, there's nothing safe to reconcile — leave the branch as-is.
+	if (!(ownKey in branchManifest) || !(ownKey in mainManifest)) {
+		return branchManifest;
+	}
+
+	// Start from main so every sibling line matches the released truth and
+	// main's key order is preserved, then keep this PR's own bump.
+	return { ...mainManifest, [ownKey]: branchManifest[ownKey] };
+}
+
+function readMainManifest(args, manifestPath) {
+	if (args['main-manifest']) {
+		return fs.readFileSync(args['main-manifest'], 'utf8');
+	}
+	return execSync(`git show origin/main:${manifestPath}`, {
+		encoding: 'utf8',
+	});
+}
+
+function main() {
+	const args = parseArgs();
+
+	if (!args.component) {
+		console.error('--component is required');
+		process.exit(1);
+	}
+
+	const manifestPath = args.manifest || DEFAULT_MANIFEST;
+
+	if (!fs.existsSync(manifestPath)) {
+		console.log(`No ${manifestPath} found; skipping reconcile.`);
+		process.exit(0);
+	}
+
+	const branchManifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+
+	let mainManifest;
+	try {
+		mainManifest = JSON.parse(readMainManifest(args, manifestPath));
+	} catch (e) {
+		console.log(
+			`Could not read manifest from main (${e.message}); skipping reconcile.`
+		);
+		process.exit(0);
+	}
+
+	const reconciled = reconcileManifest(
+		mainManifest,
+		branchManifest,
+		args.component
+	);
+
+	if (JSON.stringify(reconciled) === JSON.stringify(branchManifest)) {
+		console.log('Manifest already reconciled with main; nothing to do.');
+		process.exit(0);
+	}
+
+	fs.writeFileSync(
+		manifestPath,
+		`${JSON.stringify(reconciled, null, 2)}\n`,
+		'utf8'
+	);
+	console.log(
+		`Reconciled ${manifestPath} sibling versions with main for ${args.component}.`
+	);
+}
+
+if (require.main === module) {
+	main();
+}
+
+module.exports = { reconcileManifest };

--- a/scripts/reconcile-release-manifest.js
+++ b/scripts/reconcile-release-manifest.js
@@ -36,8 +36,12 @@ const DEFAULT_MANIFEST = '.release-please-manifest.json';
 function parseArgs() {
 	const args = {};
 	process.argv.slice(2).forEach((arg) => {
-		const [key, value] = arg.replace(/^--/, '').split('=');
-		args[key] = value;
+		// Split on the first "=" only, so values that themselves contain "="
+		// (e.g. a path) survive intact.
+		const eq = arg.indexOf('=');
+		if (arg.startsWith('--') && eq !== -1) {
+			args[arg.slice(2, eq)] = arg.slice(eq + 1);
+		}
 	});
 	return args;
 }
@@ -104,8 +108,27 @@ function main() {
 	try {
 		mainManifest = JSON.parse(readMainManifest(args, manifestPath));
 	} catch (e) {
+		// A release PR's own manifest always exists on main, so a read failure
+		// here is a real problem (bad ref, renamed file), not an expected
+		// no-op. Fail loudly rather than exit 0 and leave the PR silently
+		// unreconciled behind a green check.
+		console.error(`Could not read manifest from main: ${e.message}`);
+		process.exit(1);
+	}
+
+	// Distinguish "nothing to reconcile" from "couldn't find the component".
+	// A missing key usually means --component was parsed wrong, which would
+	// otherwise hide behind the "already reconciled" no-op message below.
+	const ownKey = `plugins/${args.component}`;
+	if (!(ownKey in branchManifest)) {
 		console.log(
-			`Could not read manifest from main (${e.message}); skipping reconcile.`
+			`${ownKey} is not in ${manifestPath}; skipping reconcile (is --component "${args.component}" correct?).`
+		);
+		process.exit(0);
+	}
+	if (!(ownKey in mainManifest)) {
+		console.log(
+			`${ownKey} is not in main's manifest yet (new component?); skipping reconcile.`
 		);
 		process.exit(0);
 	}

--- a/scripts/reconcile-release-manifest.js
+++ b/scripts/reconcile-release-manifest.js
@@ -29,7 +29,7 @@
  */
 
 const fs = require('fs');
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 
 const DEFAULT_MANIFEST = '.release-please-manifest.json';
 
@@ -46,9 +46,11 @@ function parseArgs() {
  * Compute the reconciled manifest: main's versions for every plugin, with the
  * released component's own bump preserved from the branch.
  *
- * Returns the branch manifest unchanged when there is nothing to reconcile
- * (component missing on either side, or already in sync), so callers can treat
- * "no change" as "input === output".
+ * When the component is absent from either manifest there is nothing safe to
+ * reconcile, so the branch manifest is returned by reference. Otherwise a new
+ * object is returned; it may be deep-equal to the branch manifest when nothing
+ * has drifted, so callers decide "no change" by value (see `main()`), not by
+ * reference identity.
  *
  * @param {Object} mainManifest   Parsed manifest from main.
  * @param {Object} branchManifest Parsed manifest from the release PR branch.
@@ -73,7 +75,10 @@ function readMainManifest(args, manifestPath) {
 	if (args['main-manifest']) {
 		return fs.readFileSync(args['main-manifest'], 'utf8');
 	}
-	return execSync(`git show origin/main:${manifestPath}`, {
+	// execFileSync (not execSync) so manifestPath is passed as an argv entry
+	// rather than interpolated into a shell string — no shell, no quoting or
+	// injection surface.
+	return execFileSync('git', ['show', `origin/main:${manifestPath}`], {
 		encoding: 'utf8',
 	});
 }

--- a/scripts/reconcile-release-manifest.test.js
+++ b/scripts/reconcile-release-manifest.test.js
@@ -212,6 +212,58 @@ const tests = [
 			}
 			assert(failed, 'expected non-zero exit without --component');
 		}),
+
+	() =>
+		test("CLI fails fast when main's manifest cannot be read", () => {
+			writeJson('branch.json', STALE_IDE_BRANCH);
+			// Point --main-manifest at a file that does not exist, standing in
+			// for a broken `git show origin/main:…` read.
+			let failed = false;
+			let output = '';
+			try {
+				execSync(
+					`node "${SCRIPT_PATH}" --component=wp-graphql-ide --manifest=.test-reconcile-manifest/branch.json --main-manifest=.test-reconcile-manifest/does-not-exist.json`,
+					{ cwd: path.join(__dirname, '..'), stdio: 'pipe' }
+				);
+			} catch (e) {
+				failed = true;
+				output = e.stderr ? e.stderr.toString() : '';
+			}
+			assert(
+				failed,
+				'expected a non-zero exit on unreadable main manifest'
+			);
+			assert(
+				/Could not read manifest from main/.test(output),
+				`expected a clear error, got: ${output}`
+			);
+		}),
+
+	() =>
+		test('CLI warns (not "already reconciled") when the component is absent', () => {
+			writeJson('main.json', MAIN);
+			writeJson('branch.json', STALE_IDE_BRANCH);
+			const before = fs.readFileSync(
+				path.join(TEST_DIR, 'branch.json'),
+				'utf8'
+			);
+			// A component neither manifest tracks — e.g. a misparsed name.
+			const { success, output } = runScript('not-a-plugin');
+			assert(success, `expected exit 0, got: ${output}`);
+			assert(
+				/skipping reconcile/.test(output),
+				`expected a distinct skip message, got: ${output}`
+			);
+			assert(
+				!/already reconciled/.test(output),
+				'must not claim the manifest is already reconciled'
+			);
+			assert.strictEqual(
+				fs.readFileSync(path.join(TEST_DIR, 'branch.json'), 'utf8'),
+				before,
+				'file should be untouched'
+			);
+		}),
 ];
 
 console.log('\n🧪 Running reconcile-release-manifest.js tests...\n');

--- a/scripts/reconcile-release-manifest.test.js
+++ b/scripts/reconcile-release-manifest.test.js
@@ -1,0 +1,234 @@
+#!/usr/bin/env node
+
+/**
+ * Tests for reconcile-release-manifest.js
+ *
+ * Run with: node scripts/reconcile-release-manifest.test.js
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+const assert = require('assert');
+const { reconcileManifest } = require('./reconcile-release-manifest');
+
+const SCRIPT_PATH = path.join(__dirname, 'reconcile-release-manifest.js');
+const TEST_DIR = path.join(__dirname, '..', '.test-reconcile-manifest');
+
+function setup() {
+	if (fs.existsSync(TEST_DIR)) {
+		fs.rmSync(TEST_DIR, { recursive: true });
+	}
+	fs.mkdirSync(TEST_DIR, { recursive: true });
+}
+
+function cleanup() {
+	if (fs.existsSync(TEST_DIR)) {
+		fs.rmSync(TEST_DIR, { recursive: true });
+	}
+}
+
+function writeJson(name, obj) {
+	fs.writeFileSync(
+		path.join(TEST_DIR, name),
+		`${JSON.stringify(obj, null, 2)}\n`
+	);
+}
+
+// Runs the real CLI against files in TEST_DIR, using --main-manifest to stand
+// in for the git read so the test needs no remote.
+function runScript(component) {
+	const cmd = [
+		`node "${SCRIPT_PATH}"`,
+		`--component=${component}`,
+		`--manifest=.test-reconcile-manifest/branch.json`,
+		`--main-manifest=.test-reconcile-manifest/main.json`,
+	].join(' ');
+	try {
+		const output = execSync(cmd, {
+			cwd: path.join(__dirname, '..'),
+			encoding: 'utf8',
+			stdio: ['pipe', 'pipe', 'pipe'],
+		});
+		return { success: true, output };
+	} catch (error) {
+		return { success: false, output: error.stdout || error.message };
+	}
+}
+
+function readBranch() {
+	return JSON.parse(
+		fs.readFileSync(path.join(TEST_DIR, 'branch.json'), 'utf8')
+	);
+}
+
+function test(name, fn) {
+	try {
+		setup();
+		fn();
+		console.log(`✅ ${name}`);
+		return true;
+	} catch (error) {
+		console.log(`❌ ${name}`);
+		console.log(`   Error: ${error.message}`);
+		return false;
+	} finally {
+		cleanup();
+	}
+}
+
+// The real-world case: main released wp-graphql 2.18.0 and acf 2.7.0 while an
+// IDE release PR sat open, so the IDE branch's copy of those lines went stale.
+const MAIN = {
+	'plugins/wp-graphql': '2.18.0',
+	'plugins/wp-graphql-smart-cache': '2.2.2',
+	'plugins/wp-graphql-ide': '5.2.0',
+	'plugins/wp-graphql-acf': '2.7.0',
+};
+
+const STALE_IDE_BRANCH = {
+	'plugins/wp-graphql': '2.17.0',
+	'plugins/wp-graphql-smart-cache': '2.2.2',
+	'plugins/wp-graphql-ide': '5.3.0',
+	'plugins/wp-graphql-acf': '2.6.5',
+};
+
+const tests = [
+	() =>
+		test('adopts main sibling versions and keeps the own bump', () => {
+			const result = reconcileManifest(
+				MAIN,
+				STALE_IDE_BRANCH,
+				'wp-graphql-ide'
+			);
+			assert.deepStrictEqual(result, {
+				'plugins/wp-graphql': '2.18.0',
+				'plugins/wp-graphql-smart-cache': '2.2.2',
+				'plugins/wp-graphql-ide': '5.3.0', // own bump preserved
+				'plugins/wp-graphql-acf': '2.7.0', // pulled from main
+			});
+		}),
+
+	() =>
+		test('preserves main key order', () => {
+			const result = reconcileManifest(
+				MAIN,
+				STALE_IDE_BRANCH,
+				'wp-graphql-ide'
+			);
+			assert.deepStrictEqual(Object.keys(result), Object.keys(MAIN));
+		}),
+
+	() =>
+		test('is a no-op when already reconciled', () => {
+			const current = {
+				'plugins/wp-graphql': '2.18.0',
+				'plugins/wp-graphql-smart-cache': '2.2.2',
+				'plugins/wp-graphql-ide': '5.3.0',
+				'plugins/wp-graphql-acf': '2.7.0',
+			};
+			const result = reconcileManifest(MAIN, current, 'wp-graphql-ide');
+			assert.deepStrictEqual(result, current);
+		}),
+
+	() =>
+		test('does not touch the released component even if main is ahead', () => {
+			// main somehow shows a higher version for the component being
+			// released; the branch bump must still win, never regress.
+			const mainAhead = { ...MAIN, 'plugins/wp-graphql-ide': '9.9.9' };
+			const result = reconcileManifest(
+				mainAhead,
+				STALE_IDE_BRANCH,
+				'wp-graphql-ide'
+			);
+			assert.strictEqual(result['plugins/wp-graphql-ide'], '5.3.0');
+		}),
+
+	() =>
+		test('leaves the branch untouched when the component is unknown', () => {
+			const result = reconcileManifest(
+				MAIN,
+				STALE_IDE_BRANCH,
+				'not-a-plugin'
+			);
+			assert.deepStrictEqual(result, STALE_IDE_BRANCH);
+		}),
+
+	() =>
+		test('CLI rewrites a stale branch manifest', () => {
+			writeJson('main.json', MAIN);
+			writeJson('branch.json', STALE_IDE_BRANCH);
+
+			const { success, output } = runScript('wp-graphql-ide');
+			assert(success, `script failed: ${output}`);
+			assert.deepStrictEqual(readBranch(), {
+				'plugins/wp-graphql': '2.18.0',
+				'plugins/wp-graphql-smart-cache': '2.2.2',
+				'plugins/wp-graphql-ide': '5.3.0',
+				'plugins/wp-graphql-acf': '2.7.0',
+			});
+		}),
+
+	() =>
+		test('CLI leaves an already-reconciled manifest byte-identical', () => {
+			const current = {
+				'plugins/wp-graphql': '2.18.0',
+				'plugins/wp-graphql-smart-cache': '2.2.2',
+				'plugins/wp-graphql-ide': '5.3.0',
+				'plugins/wp-graphql-acf': '2.7.0',
+			};
+			writeJson('main.json', MAIN);
+			writeJson('branch.json', current);
+			const before = fs.readFileSync(
+				path.join(TEST_DIR, 'branch.json'),
+				'utf8'
+			);
+
+			const { success, output } = runScript('wp-graphql-ide');
+			assert(success, `script failed: ${output}`);
+			assert(
+				/nothing to do/.test(output),
+				`expected no-op message, got: ${output}`
+			);
+			const after = fs.readFileSync(
+				path.join(TEST_DIR, 'branch.json'),
+				'utf8'
+			);
+			assert.strictEqual(after, before, 'file should be unchanged');
+		}),
+
+	() =>
+		test('CLI exits non-zero without --component', () => {
+			writeJson('main.json', MAIN);
+			writeJson('branch.json', STALE_IDE_BRANCH);
+			let failed = false;
+			try {
+				execSync(
+					`node "${SCRIPT_PATH}" --manifest=.test-reconcile-manifest/branch.json --main-manifest=.test-reconcile-manifest/main.json`,
+					{ cwd: path.join(__dirname, '..'), stdio: 'pipe' }
+				);
+			} catch (e) {
+				failed = true;
+			}
+			assert(failed, 'expected non-zero exit without --component');
+		}),
+];
+
+console.log('\n🧪 Running reconcile-release-manifest.js tests...\n');
+
+let passed = 0;
+let failed = 0;
+
+for (const testFn of tests) {
+	if (testFn()) {
+		passed++;
+	} else {
+		failed++;
+	}
+}
+
+console.log(`\n${'─'.repeat(50)}`);
+console.log(`Results: ${passed} passed, ${failed} failed`);
+console.log(`${'─'.repeat(50)}\n`);
+
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## What

Adds a step to `update-release-pr.yml` that reconciles the shared `.release-please-manifest.json` against main on every release PR, backed by a new tested script `scripts/reconcile-release-manifest.js`.

## Why

The manifest holds every plugin's version in one file, but release-please only refreshes a release PR when **that plugin's own changelog** changes. So when a sibling plugin releases first and main's manifest advances, an open release PR keeps the sibling's stale version. git can no longer auto-merge the stale line against main and the PR flips to `CONFLICTING/DIRTY`. Force-merging it would regress the sibling's version back down on main.

We hit exactly this in the 2.18.0 / acf 2.7.0 / ide 5.3.0 / smart-cache 2.3.0 batch: each merge knocked the next open release PR into conflict, and I resolved #4104 and #4074 by hand. The correct resolution is deterministic, so it should be automated.

## How

`scripts/reconcile-release-manifest.js` rewrites every sibling line to match main while keeping the PR's own release bump — i.e. `{ ...mainManifest, [ownComponent]: branchBump }`. That preserves main's key order and can never regress a sibling or the released component. The reconciled file rides the workflow's existing single "sync release placeholders" commit (no extra CI trigger).

Logic lives in a tested script rather than inline YAML, matching the other release helpers under `scripts/`. That convention is now documented in `CLAUDE.md`, and the script's test is wired into `test:scripts` (so it runs in the **Test Release Scripts** workflow).

## Testing

- `npm run test:scripts` — 8 new assertions covering: adopts main's sibling versions + keeps own bump, preserves key order, no-op when already reconciled, never regresses the released component even if main is ahead, unknown-component safety, and the CLI end-to-end (rewrite / byte-identical no-op / missing-`--component` exit).
- The pure function reproduces the exact by-hand resolutions already pushed to #4104 and #4074.

## Notes

Process-only baseline still applies: merging a batch of release PRs promptly limits drift. This makes the drift self-healing so a slow batch no longer produces conflicts.