### PR TITLE
ci: extract legacy-hook version replacement into a tested script

### DIFF
--- a/.github/workflows/update-release-pr.yml
+++ b/.github/workflows/update-release-pr.yml
@@ -187,61 +187,9 @@ jobs:
           COMPONENT: ${{ steps.version_info.outputs.component }}
           VERSION: ${{ steps.version_info.outputs.version }}
         run: |
-          node - <<'NODE'
-          const fs = require('fs');
-          const filePath = 'scripts/hooks/legacy-hooks.json';
-          const component = process.env.COMPONENT;
-          const version = process.env.VERSION;
-
-          if (!component || !version) {
-            console.log('Missing COMPONENT or VERSION; skipping legacy hook replacement.');
-            process.exit(0);
-          }
-
-          if (!fs.existsSync(filePath)) {
-            console.log('No scripts/hooks/legacy-hooks.json found; skipping.');
-            process.exit(0);
-          }
-
-          const payload = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-          const entries = payload && typeof payload === 'object' ? payload[component] : null;
-
-          if (!Array.isArray(entries)) {
-            console.log(`No legacy hook entries for ${component}; skipping.`);
-            process.exit(0);
-          }
-
-          const replacePlaceholders = (value) => {
-            if (typeof value === 'string') {
-              return value.replace(/x-release-please-version/g, version);
-            }
-
-            if (Array.isArray(value)) {
-              return value.map(replacePlaceholders);
-            }
-
-            if (value && typeof value === 'object') {
-              return Object.fromEntries(
-                Object.entries(value).map(([key, nested]) => [key, replacePlaceholders(nested)])
-              );
-            }
-
-            return value;
-          };
-
-          const updatedEntries = replacePlaceholders(entries);
-          const before = JSON.stringify(entries);
-          const after = JSON.stringify(updatedEntries);
-
-          if (before === after) {
-            console.log(`No legacy hook placeholders to replace for ${component}.`);
-            process.exit(0);
-          }
-
-          payload[component] = updatedEntries;
-          fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
-          console.log(`✅ Updated scripts/hooks/legacy-hooks.json placeholders for ${component}`);
-          NODE
+          node scripts/hooks/replace-legacy-hook-versions.js \
+            --component="$COMPONENT" \
+            --version="$VERSION"
 
       - name: Check for languages directory
         id: i18n

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"format": "wp-scripts format",
 		"start": "turbo run start",
 		"test": "turbo run test",
-		"test:scripts": "node scripts/update-upgrade-notice.test.js && node scripts/update-version-constants.test.js && node scripts/update-readme-changelog.test.js && node scripts/hooks/generate-hook-docs.test.js && node scripts/functions/generate-function-docs.test.js && node scripts/recipes/recipe-relations.test.js && node scripts/recipes/generate-recipe-docs.test.js",
+		"test:scripts": "node scripts/update-upgrade-notice.test.js && node scripts/update-version-constants.test.js && node scripts/update-readme-changelog.test.js && node scripts/hooks/generate-hook-docs.test.js && node scripts/hooks/replace-legacy-hook-versions.test.js && node scripts/functions/generate-function-docs.test.js && node scripts/recipes/recipe-relations.test.js && node scripts/recipes/generate-recipe-docs.test.js",
 		"hooks:generate": "node scripts/hooks/generate-hook-docs.js",
 		"hooks:check-legacy": "node scripts/hooks/check-legacy-coverage.js",
 		"functions:generate": "node scripts/functions/generate-function-docs.js",

--- a/scripts/hooks/replace-legacy-hook-versions.js
+++ b/scripts/hooks/replace-legacy-hook-versions.js
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+
+/**
+ * Replace x-release-please-version placeholders in a component's legacy-hook
+ * entries with the version being released.
+ *
+ * scripts/hooks/legacy-hooks.json records deprecated hooks per component, and
+ * their `@since`-style version fields carry the x-release-please-version
+ * placeholder until the release PR is cut. release-please rewrites the
+ * placeholder in source files but not in this JSON, so the release workflow
+ * fills it in here.
+ *
+ * Usage:
+ *   node scripts/hooks/replace-legacy-hook-versions.js \
+ *     --component=wp-graphql --version=2.7.0
+ *
+ * Options:
+ *   --component  Component being released (e.g. wp-graphql). Required.
+ *   --version    Version to substitute for the placeholder. Required.
+ *   --file       Path to the legacy-hooks JSON (default
+ *                scripts/hooks/legacy-hooks.json).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const PLACEHOLDER = 'x-release-please-version';
+const DEFAULT_FILE = path.join(__dirname, 'legacy-hooks.json');
+
+function parseArgs() {
+	const args = {};
+	process.argv.slice(2).forEach((arg) => {
+		const [key, value] = arg.replace(/^--/, '').split('=');
+		args[key] = value;
+	});
+	return args;
+}
+
+/**
+ * Recursively replace every placeholder occurrence in a JSON-ish value
+ * (string, array, or plain object) with `version`. Non-strings pass through.
+ *
+ * @param {*}      value   The value to walk.
+ * @param {string} version Replacement version.
+ * @return {*} A new value with placeholders replaced.
+ */
+function replacePlaceholders(value, version) {
+	if (typeof value === 'string') {
+		return value.split(PLACEHOLDER).join(version);
+	}
+
+	if (Array.isArray(value)) {
+		return value.map((item) => replacePlaceholders(item, version));
+	}
+
+	if (value && typeof value === 'object') {
+		return Object.fromEntries(
+			Object.entries(value).map(([key, nested]) => [
+				key,
+				replacePlaceholders(nested, version),
+			])
+		);
+	}
+
+	return value;
+}
+
+/**
+ * Replace placeholders in one component's entries within a legacy-hooks
+ * payload.
+ *
+ * Returns `{ payload, changed }`. `changed` is false (and `payload` is the
+ * input unchanged) when the component has no entries or nothing matched, so
+ * callers can skip writing.
+ *
+ * @param {Object} payload   Parsed legacy-hooks.json.
+ * @param {string} component Component key (e.g. wp-graphql).
+ * @param {string} version   Replacement version.
+ * @return {{ payload: Object, changed: boolean }}
+ */
+function replaceComponentVersions(payload, component, version) {
+	const entries =
+		payload && typeof payload === 'object' ? payload[component] : null;
+
+	if (!Array.isArray(entries)) {
+		return { payload, changed: false };
+	}
+
+	const updated = replacePlaceholders(entries, version);
+	if (JSON.stringify(updated) === JSON.stringify(entries)) {
+		return { payload, changed: false };
+	}
+
+	return { payload: { ...payload, [component]: updated }, changed: true };
+}
+
+function main() {
+	const args = parseArgs();
+
+	if (!args.component || !args.version) {
+		console.error('--component and --version are required');
+		process.exit(1);
+	}
+
+	const filePath = args.file || DEFAULT_FILE;
+
+	if (!fs.existsSync(filePath)) {
+		console.log(`No ${filePath} found; skipping.`);
+		process.exit(0);
+	}
+
+	const payload = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+	const { payload: updated, changed } = replaceComponentVersions(
+		payload,
+		args.component,
+		args.version
+	);
+
+	if (!changed) {
+		console.log(
+			`No legacy hook placeholders to replace for ${args.component}.`
+		);
+		process.exit(0);
+	}
+
+	fs.writeFileSync(filePath, `${JSON.stringify(updated, null, 2)}\n`, 'utf8');
+	console.log(`Updated ${filePath} placeholders for ${args.component}.`);
+}
+
+if (require.main === module) {
+	main();
+}
+
+module.exports = { replacePlaceholders, replaceComponentVersions };

--- a/scripts/hooks/replace-legacy-hook-versions.js
+++ b/scripts/hooks/replace-legacy-hook-versions.js
@@ -69,37 +69,49 @@ function replacePlaceholders(value, version) {
  * Replace placeholders in one component's entries within a legacy-hooks
  * payload.
  *
- * Returns `{ payload, changed }`. `changed` is false (and `payload` is the
- * input unchanged) when the component has no entries or nothing matched, so
- * callers can skip writing.
+ * Returns `{ payload, changed, reason }`. `changed` is false (and `payload`
+ * is the input unchanged) when there was nothing to do; `reason` says why, so
+ * callers can log the distinct cases:
+ *   - 'no-entries'     — the component has no entries array (missing/malformed)
+ *   - 'no-placeholders'— entries exist but none held a placeholder
+ *   - 'updated'        — placeholders were replaced (changed === true)
  *
  * @param {Object} payload   Parsed legacy-hooks.json.
  * @param {string} component Component key (e.g. wp-graphql).
  * @param {string} version   Replacement version.
- * @return {{ payload: Object, changed: boolean }}
+ * @return {{ payload: Object, changed: boolean, reason: string }}
  */
 function replaceComponentVersions(payload, component, version) {
 	const entries =
 		payload && typeof payload === 'object' ? payload[component] : null;
 
 	if (!Array.isArray(entries)) {
-		return { payload, changed: false };
+		return { payload, changed: false, reason: 'no-entries' };
 	}
 
 	const updated = replacePlaceholders(entries, version);
 	if (JSON.stringify(updated) === JSON.stringify(entries)) {
-		return { payload, changed: false };
+		return { payload, changed: false, reason: 'no-placeholders' };
 	}
 
-	return { payload: { ...payload, [component]: updated }, changed: true };
+	return {
+		payload: { ...payload, [component]: updated },
+		changed: true,
+		reason: 'updated',
+	};
 }
 
 function main() {
 	const args = parseArgs();
 
+	// A no-op skip, not a hard failure, when a value is missing: this step
+	// only fills placeholders in a JSON that is usually empty, so it must
+	// never block the release PR update. (The workflow also guards with
+	// `if: version != ''`; this keeps the script resilient on its own, as the
+	// original inline step was.)
 	if (!args.component || !args.version) {
-		console.error('--component and --version are required');
-		process.exit(1);
+		console.log('Missing --component or --version; skipping.');
+		process.exit(0);
 	}
 
 	const filePath = args.file || DEFAULT_FILE;
@@ -110,15 +122,17 @@ function main() {
 	}
 
 	const payload = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-	const { payload: updated, changed } = replaceComponentVersions(
-		payload,
-		args.component,
-		args.version
-	);
+	const {
+		payload: updated,
+		changed,
+		reason,
+	} = replaceComponentVersions(payload, args.component, args.version);
 
 	if (!changed) {
 		console.log(
-			`No legacy hook placeholders to replace for ${args.component}.`
+			reason === 'no-entries'
+				? `No legacy hook entries for ${args.component}; skipping.`
+				: `No legacy hook placeholders to replace for ${args.component}.`
 		);
 		process.exit(0);
 	}

--- a/scripts/hooks/replace-legacy-hook-versions.test.js
+++ b/scripts/hooks/replace-legacy-hook-versions.test.js
@@ -142,27 +142,29 @@ const tests = [
 		}),
 
 	() =>
-		test('reports no change when the component is absent', () => {
+		test('reports reason "no-entries" when the component is absent', () => {
 			const payload = { 'wp-graphql': [] };
-			const { changed } = replaceComponentVersions(
+			const { changed, reason } = replaceComponentVersions(
 				payload,
 				'not-a-plugin',
 				'2.18.0'
 			);
 			assert.strictEqual(changed, false);
+			assert.strictEqual(reason, 'no-entries');
 		}),
 
 	() =>
-		test('reports no change when there are no placeholders left', () => {
+		test('reports reason "no-placeholders" when nothing is left to replace', () => {
 			const payload = {
 				'wp-graphql': [{ name: 'hook', since: '2.0.0' }],
 			};
-			const { changed } = replaceComponentVersions(
+			const { changed, reason } = replaceComponentVersions(
 				payload,
 				'wp-graphql',
 				'2.18.0'
 			);
 			assert.strictEqual(changed, false);
+			assert.strictEqual(reason, 'no-placeholders');
 		}),
 
 	() =>
@@ -186,21 +188,33 @@ const tests = [
 		}),
 
 	() =>
-		test('CLI exits non-zero without required args', () => {
+		test('CLI logs "no entries" (not "no placeholders") for a missing component', () => {
+			writeFile({ 'wp-graphql': [{ name: 'h', since: PLACEHOLDER }] });
+			const before = fs.readFileSync(TEST_FILE, 'utf8');
+			const { success, output } = runScript('not-a-plugin', '2.18.0');
+			assert(success, `script failed: ${output}`);
+			assert(/No legacy hook entries/.test(output), output);
+			assert(!/No legacy hook placeholders/.test(output), output);
+			assert.strictEqual(fs.readFileSync(TEST_FILE, 'utf8'), before);
+		}),
+
+	() =>
+		test('CLI skips (exit 0) without required args, as the inline step did', () => {
 			writeFile({ 'wp-graphql': [] });
-			let failed = false;
-			try {
-				execSync(`node "${SCRIPT_PATH}" --file="${TEST_FILE}"`, {
+			const before = fs.readFileSync(TEST_FILE, 'utf8');
+			// Missing --component/--version must not fail the release workflow.
+			const output = execSync(
+				`node "${SCRIPT_PATH}" --file="${TEST_FILE}"`,
+				{
 					cwd: path.join(__dirname, '..', '..'),
-					stdio: 'pipe',
-				});
-			} catch (e) {
-				failed = true;
-			}
-			assert(
-				failed,
-				'expected non-zero exit without --component/--version'
+					encoding: 'utf8',
+				}
 			);
+			assert(
+				/skipping/i.test(output),
+				`expected a skip message, got: ${output}`
+			);
+			assert.strictEqual(fs.readFileSync(TEST_FILE, 'utf8'), before);
 		}),
 ];
 

--- a/scripts/hooks/replace-legacy-hook-versions.test.js
+++ b/scripts/hooks/replace-legacy-hook-versions.test.js
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+
+/**
+ * Tests for replace-legacy-hook-versions.js
+ *
+ * Run with: node scripts/hooks/replace-legacy-hook-versions.test.js
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+const assert = require('assert');
+const {
+	replacePlaceholders,
+	replaceComponentVersions,
+} = require('./replace-legacy-hook-versions');
+
+const SCRIPT_PATH = path.join(__dirname, 'replace-legacy-hook-versions.js');
+const TEST_DIR = path.join(__dirname, '..', '..', '.test-legacy-hook-versions');
+const TEST_FILE = path.join(TEST_DIR, 'legacy-hooks.json');
+
+function setup() {
+	if (fs.existsSync(TEST_DIR)) {
+		fs.rmSync(TEST_DIR, { recursive: true });
+	}
+	fs.mkdirSync(TEST_DIR, { recursive: true });
+}
+
+function cleanup() {
+	if (fs.existsSync(TEST_DIR)) {
+		fs.rmSync(TEST_DIR, { recursive: true });
+	}
+}
+
+function writeFile(obj) {
+	fs.writeFileSync(TEST_FILE, `${JSON.stringify(obj, null, 2)}\n`);
+}
+
+function readFile() {
+	return JSON.parse(fs.readFileSync(TEST_FILE, 'utf8'));
+}
+
+function runScript(component, version) {
+	const cmd = [
+		`node "${SCRIPT_PATH}"`,
+		`--component=${component}`,
+		`--version=${version}`,
+		`--file="${TEST_FILE}"`,
+	].join(' ');
+	try {
+		const output = execSync(cmd, {
+			cwd: path.join(__dirname, '..', '..'),
+			encoding: 'utf8',
+			stdio: ['pipe', 'pipe', 'pipe'],
+		});
+		return { success: true, output };
+	} catch (error) {
+		return { success: false, output: error.stdout || error.message };
+	}
+}
+
+function test(name, fn) {
+	try {
+		setup();
+		fn();
+		console.log(`✅ ${name}`);
+		return true;
+	} catch (error) {
+		console.log(`❌ ${name}`);
+		console.log(`   Error: ${error.message}`);
+		return false;
+	} finally {
+		cleanup();
+	}
+}
+
+const PLACEHOLDER = 'x-release-please-version';
+
+const tests = [
+	() =>
+		test('replaces placeholders in strings, arrays, and nested objects', () => {
+			const input = {
+				since: PLACEHOLDER,
+				list: [PLACEHOLDER, 'literal'],
+				nested: { deprecated: PLACEHOLDER, count: 3, flag: true },
+			};
+			const result = replacePlaceholders(input, '2.7.0');
+			assert.deepStrictEqual(result, {
+				since: '2.7.0',
+				list: ['2.7.0', 'literal'],
+				nested: { deprecated: '2.7.0', count: 3, flag: true },
+			});
+		}),
+
+	() =>
+		test('leaves non-placeholder values untouched', () => {
+			assert.strictEqual(replacePlaceholders(42, '2.7.0'), 42);
+			assert.strictEqual(replacePlaceholders(null, '2.7.0'), null);
+			assert.strictEqual(
+				replacePlaceholders('already 1.0.0', '2.7.0'),
+				'already 1.0.0'
+			);
+		}),
+
+	() =>
+		test('does not treat the version as a regex replacement pattern', () => {
+			// A naive .replace(/.../g, version) would interpret $& etc. in the
+			// replacement; split/join must reproduce the version verbatim.
+			assert.strictEqual(
+				replacePlaceholders(PLACEHOLDER, '$&2.0.0'),
+				'$&2.0.0'
+			);
+		}),
+
+	() =>
+		test('replaceComponentVersions updates only the target component', () => {
+			const payload = {
+				'wp-graphql': [{ name: 'old_hook', since: PLACEHOLDER }],
+				'wp-graphql-acf': [{ name: 'acf_hook', since: PLACEHOLDER }],
+			};
+			const { payload: updated, changed } = replaceComponentVersions(
+				payload,
+				'wp-graphql',
+				'2.18.0'
+			);
+			assert.strictEqual(changed, true);
+			assert.strictEqual(updated['wp-graphql'][0].since, '2.18.0');
+			// sibling untouched
+			assert.strictEqual(updated['wp-graphql-acf'][0].since, PLACEHOLDER);
+		}),
+
+	() =>
+		test('reports no change when the component has no entries', () => {
+			const payload = { 'wp-graphql': [] };
+			const { payload: updated, changed } = replaceComponentVersions(
+				payload,
+				'wp-graphql',
+				'2.18.0'
+			);
+			assert.strictEqual(changed, false);
+			assert.strictEqual(updated, payload);
+		}),
+
+	() =>
+		test('reports no change when the component is absent', () => {
+			const payload = { 'wp-graphql': [] };
+			const { changed } = replaceComponentVersions(
+				payload,
+				'not-a-plugin',
+				'2.18.0'
+			);
+			assert.strictEqual(changed, false);
+		}),
+
+	() =>
+		test('reports no change when there are no placeholders left', () => {
+			const payload = {
+				'wp-graphql': [{ name: 'hook', since: '2.0.0' }],
+			};
+			const { changed } = replaceComponentVersions(
+				payload,
+				'wp-graphql',
+				'2.18.0'
+			);
+			assert.strictEqual(changed, false);
+		}),
+
+	() =>
+		test('CLI rewrites the file for a component with placeholders', () => {
+			writeFile({
+				'wp-graphql': [{ name: 'old_hook', since: PLACEHOLDER }],
+			});
+			const { success, output } = runScript('wp-graphql', '2.18.0');
+			assert(success, `script failed: ${output}`);
+			assert.strictEqual(readFile()['wp-graphql'][0].since, '2.18.0');
+		}),
+
+	() =>
+		test('CLI is a no-op (byte-identical) when nothing matches', () => {
+			writeFile({ 'wp-graphql': [] });
+			const before = fs.readFileSync(TEST_FILE, 'utf8');
+			const { success, output } = runScript('wp-graphql', '2.18.0');
+			assert(success, `script failed: ${output}`);
+			assert(/No legacy hook placeholders/.test(output), output);
+			assert.strictEqual(fs.readFileSync(TEST_FILE, 'utf8'), before);
+		}),
+
+	() =>
+		test('CLI exits non-zero without required args', () => {
+			writeFile({ 'wp-graphql': [] });
+			let failed = false;
+			try {
+				execSync(`node "${SCRIPT_PATH}" --file="${TEST_FILE}"`, {
+					cwd: path.join(__dirname, '..', '..'),
+					stdio: 'pipe',
+				});
+			} catch (e) {
+				failed = true;
+			}
+			assert(
+				failed,
+				'expected non-zero exit without --component/--version'
+			);
+		}),
+];
+
+console.log('\n🧪 Running replace-legacy-hook-versions.js tests...\n');
+
+let passed = 0;
+let failed = 0;
+
+for (const testFn of tests) {
+	if (testFn()) {
+		passed++;
+	} else {
+		failed++;
+	}
+}
+
+console.log(`\n${'─'.repeat(50)}`);
+console.log(`Results: ${passed} passed, ${failed} failed`);
+console.log(`${'─'.repeat(50)}\n`);
+
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## What

Replaces the inline `node - <<'NODE'` heredoc in `update-release-pr.yml`'s **Replace legacy hook placeholder versions** step with a committed, tested script: `scripts/hooks/replace-legacy-hook-versions.js`.

## Why

That step was the one remaining inline Node heredoc in the release workflow — ~55 lines of recursive JSON manipulation with no test coverage. Moving it into `scripts/` matches the pattern every other non-trivial step in this workflow already follows (`update-version-constants.js`, `update-upgrade-notice.js`, `update-readme-changelog.js`) and makes the logic reviewable, runnable locally, and unit-tested.

## How

- `scripts/hooks/replace-legacy-hook-versions.js` — pure exported functions (`replacePlaceholders`, `replaceComponentVersions`) plus a `main()` guarded by `require.main`, args as `--component=` / `--version=` / `--file=`, matching the sibling scripts.
- `scripts/hooks/replace-legacy-hook-versions.test.js` — 10 assertions (recursion over strings/arrays/nested objects, target-only component update, all no-op paths, CLI end-to-end, missing-arg exit), wired into `test:scripts` so it runs in **Test Release Scripts**.
- The workflow step is now a 3-line script call.

## Behavior parity

Identical to the previous heredoc — verified against a sample `legacy-hooks.json` payload (same output, same changed/no-op decision). One deliberate robustness improvement: the substitution uses `split/join` instead of `String.replace(/.../g, version)`, so a version string is never interpreted as a regex replacement pattern (covered by a test).

## Notes

- This is the exception #4113 documents in `CLAUDE.md` ("extract it when you next touch it"). Merge coordination: if #4113 lands first, its note calling this heredoc out as a to-migrate exception should be dropped once this merges — happy to update that in whichever PR merges second.
- Out of scope, flagged as follow-ups: the `version_info` bash parser in the same workflow, and the component/deploy-detection bash in `release-please.yml`. Both sit on the critical release path (the latter is large and bash-based); worth extracting deliberately and separately, not bundled here.