### PR TITLE
ci: extract release version/component parsing into a tested script

### DIFF
--- a/.github/workflows/update-release-pr.yml
+++ b/.github/workflows/update-release-pr.yml
@@ -63,33 +63,13 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           BRANCH_NAME: ${{ github.head_ref }}
         run: |
-          # Extract version and component from the PR title or branch name
-          # Release-please PR titles are like "chore(main): release wp-graphql 2.7.0"
-          # Branch names are like "release-please--branches--main--components--wp-graphql"
-
-          # Extract component from PR title (e.g., "wp-graphql" from "release wp-graphql 2.7.0")
-          COMPONENT=$(echo "$PR_TITLE" | grep -oE 'release\s+([a-z0-9-]+)' | awk '{print $2}' || echo "")
-
-          if [ -z "$COMPONENT" ]; then
-            # Fallback: extract from branch name
-            COMPONENT=$(echo "$BRANCH_NAME" | sed 's/.*--components--//' || echo "wp-graphql")
-          fi
-
-          # Try to get version from PR title first
-          VERSION=$(echo "$PR_TITLE" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-
-          if [ -z "$VERSION" ]; then
-            # Fallback: extract from CHANGELOG.md (first version header)
-            PLUGIN_DIR="plugins/${COMPONENT}"
-            if [ -f "${PLUGIN_DIR}/CHANGELOG.md" ]; then
-              VERSION=$(grep -oE '## \[?[0-9]+\.[0-9]+\.[0-9]+' "${PLUGIN_DIR}/CHANGELOG.md" | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-            fi
-          fi
-
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "component=$COMPONENT" >> $GITHUB_OUTPUT
-          echo "plugin_dir=plugins/${COMPONENT}" >> $GITHUB_OUTPUT
-          echo "Detected version: $VERSION for component: $COMPONENT"
+          # Resolves version/component/plugin_dir from the PR title (falling
+          # back to the branch name and the component CHANGELOG). The script
+          # prints them as key=value lines and logs a summary to stderr — see
+          # scripts/extract-release-version-info.js.
+          node scripts/extract-release-version-info.js \
+            --pr-title="$PR_TITLE" \
+            --branch="$BRANCH_NAME" >> "$GITHUB_OUTPUT"
 
       - name: Replace x-release-please-version placeholders
         if: steps.version_info.outputs.version != ''

--- a/.github/workflows/update-release-pr.yml
+++ b/.github/workflows/update-release-pr.yml
@@ -67,12 +67,12 @@ jobs:
           BRANCH_NAME: ${{ github.head_ref }}
         run: |
           # Resolves version/component/plugin_dir from the PR title (falling
-          # back to the branch name and the component CHANGELOG). The script
-          # prints them as key=value lines and logs a summary to stderr — see
+          # back to the branch name and the component CHANGELOG). Reads
+          # PR_TITLE / BRANCH_NAME from the env above rather than as command
+          # arguments, so PR-controlled strings never reach the shell. Prints
+          # key=value lines and logs a summary to stderr — see
           # scripts/extract-release-version-info.js.
-          node scripts/extract-release-version-info.js \
-            --pr-title="$PR_TITLE" \
-            --branch="$BRANCH_NAME" >> "$GITHUB_OUTPUT"
+          node scripts/extract-release-version-info.js >> "$GITHUB_OUTPUT"
 
       - name: Reconcile shared release manifest with main
         env:

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"format": "wp-scripts format",
 		"start": "turbo run start",
 		"test": "turbo run test",
-		"test:scripts": "node scripts/update-upgrade-notice.test.js && node scripts/update-version-constants.test.js && node scripts/update-readme-changelog.test.js && node scripts/hooks/generate-hook-docs.test.js && node scripts/functions/generate-function-docs.test.js && node scripts/recipes/recipe-relations.test.js && node scripts/recipes/generate-recipe-docs.test.js",
+		"test:scripts": "node scripts/extract-release-version-info.test.js && node scripts/update-upgrade-notice.test.js && node scripts/update-version-constants.test.js && node scripts/update-readme-changelog.test.js && node scripts/hooks/generate-hook-docs.test.js && node scripts/functions/generate-function-docs.test.js && node scripts/recipes/recipe-relations.test.js && node scripts/recipes/generate-recipe-docs.test.js",
 		"hooks:generate": "node scripts/hooks/generate-hook-docs.js",
 		"hooks:check-legacy": "node scripts/hooks/check-legacy-coverage.js",
 		"functions:generate": "node scripts/functions/generate-function-docs.js",

--- a/scripts/extract-release-version-info.js
+++ b/scripts/extract-release-version-info.js
@@ -16,8 +16,9 @@
  * Prints `key=value` lines (version, component, plugin_dir) to stdout so the
  * workflow can append them to $GITHUB_OUTPUT. Inputs come from the PR_TITLE
  * and BRANCH_NAME env vars, so the workflow never builds a command out of
- * PR-controlled strings:
+ * PR-controlled strings.
  *
+ * Usage:
  *   PR_TITLE="$PR_TITLE" BRANCH_NAME="$BRANCH_NAME" \
  *     node scripts/extract-release-version-info.js >> "$GITHUB_OUTPUT"
  *

--- a/scripts/extract-release-version-info.js
+++ b/scripts/extract-release-version-info.js
@@ -22,11 +22,12 @@
  *   PR_TITLE="$PR_TITLE" BRANCH_NAME="$BRANCH_NAME" \
  *     node scripts/extract-release-version-info.js >> "$GITHUB_OUTPUT"
  *
- * Options (override the env vars; mainly for tests and local runs):
- *   --pr-title     Pull request title.
- *   --branch       Head branch name.
- *   --plugins-dir  Directory holding the plugin folders (default "plugins").
- *                  Exists so tests can point at a fixture tree.
+ * Options (override the env vars; mainly for tests and local runs). All use
+ * the `--key=value` form — `parseArgs()` ignores flags without an `=`:
+ *   --pr-title=<title>     Pull request title.
+ *   --branch=<name>        Head branch name.
+ *   --plugins-dir=<dir>    Directory holding the plugin folders (default
+ *                          "plugins"). Exists so tests can point at a fixture tree.
  */
 
 const fs = require('fs');

--- a/scripts/extract-release-version-info.js
+++ b/scripts/extract-release-version-info.js
@@ -14,14 +14,16 @@
  * CHANGELOG.md.
  *
  * Prints `key=value` lines (version, component, plugin_dir) to stdout so the
- * workflow can append them to $GITHUB_OUTPUT:
+ * workflow can append them to $GITHUB_OUTPUT. Inputs come from the PR_TITLE
+ * and BRANCH_NAME env vars, so the workflow never builds a command out of
+ * PR-controlled strings:
  *
- *   node scripts/extract-release-version-info.js \
- *     --pr-title="$PR_TITLE" --branch="$BRANCH_NAME" >> "$GITHUB_OUTPUT"
+ *   PR_TITLE="$PR_TITLE" BRANCH_NAME="$BRANCH_NAME" \
+ *     node scripts/extract-release-version-info.js >> "$GITHUB_OUTPUT"
  *
- * Options:
- *   --pr-title     Pull request title. Required (may be empty).
- *   --branch       Head branch name. Required (may be empty).
+ * Options (override the env vars; mainly for tests and local runs):
+ *   --pr-title     Pull request title.
+ *   --branch       Head branch name.
  *   --plugins-dir  Directory holding the plugin folders (default "plugins").
  *                  Exists so tests can point at a fixture tree.
  */
@@ -46,9 +48,15 @@ function parseArgs() {
  * Component being released: the word after "release " in the PR title, else
  * the segment after "--components--" in the branch name.
  *
+ * When the branch has no "--components--" marker, the whole branch name is
+ * returned unchanged — matching the original `sed 's/.*--components--//'`.
+ * That is deliberate: a bogus-but-non-empty component points downstream steps
+ * at a non-existent `plugins/<branch>` dir (fail fast), whereas an empty
+ * component would resolve to `plugins/` and risk operating on every plugin.
+ *
  * @param {string} prTitle Pull request title.
  * @param {string} branch  Head branch name.
- * @return {string} Component (empty string if neither source yields one).
+ * @return {string} Component (empty only when there is no title match and no branch).
  */
 function parseComponent(prTitle, branch) {
 	const fromTitle = (prTitle || '').match(/release\s+([a-z0-9-]+)/);
@@ -56,7 +64,7 @@ function parseComponent(prTitle, branch) {
 		return fromTitle[1];
 	}
 
-	if (branch && branch.includes('--components--')) {
+	if (branch) {
 		return branch.replace(/.*--components--/, '');
 	}
 
@@ -129,9 +137,12 @@ function extractVersionInfo({ prTitle, branch, pluginsDir = 'plugins' }) {
 
 function main() {
 	const args = parseArgs();
+	// Prefer env vars (PR_TITLE / BRANCH_NAME) so the workflow never has to
+	// build a shell command out of PR-controlled strings — the CLI flags stay
+	// available as an override for tests and local runs.
 	const info = extractVersionInfo({
-		prTitle: args['pr-title'] || '',
-		branch: args.branch || '',
+		prTitle: args['pr-title'] || process.env.PR_TITLE || '',
+		branch: args.branch || process.env.BRANCH_NAME || '',
 		pluginsDir: args['plugins-dir'] || 'plugins',
 	});
 

--- a/scripts/extract-release-version-info.js
+++ b/scripts/extract-release-version-info.js
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+
+/**
+ * Extract the component, version, and plugin directory for a release PR from
+ * its title and branch name.
+ *
+ * Mirrors what release-please PRs look like:
+ *   - title:  "chore(main): release wp-graphql 2.7.0"
+ *   - branch: "release-please--branches--main--components--wp-graphql"
+ *
+ * The component comes from the title ("release <component>"), falling back to
+ * the branch's "--components--<component>" suffix. The version comes from the
+ * title (first X.Y.Z), falling back to the newest heading in the component's
+ * CHANGELOG.md.
+ *
+ * Prints `key=value` lines (version, component, plugin_dir) to stdout so the
+ * workflow can append them to $GITHUB_OUTPUT:
+ *
+ *   node scripts/extract-release-version-info.js \
+ *     --pr-title="$PR_TITLE" --branch="$BRANCH_NAME" >> "$GITHUB_OUTPUT"
+ *
+ * Options:
+ *   --pr-title     Pull request title. Required (may be empty).
+ *   --branch       Head branch name. Required (may be empty).
+ *   --plugins-dir  Directory holding the plugin folders (default "plugins").
+ *                  Exists so tests can point at a fixture tree.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const SEMVER = /[0-9]+\.[0-9]+\.[0-9]+/;
+
+function parseArgs() {
+	const args = {};
+	process.argv.slice(2).forEach((arg) => {
+		const eq = arg.indexOf('=');
+		if (arg.startsWith('--') && eq !== -1) {
+			args[arg.slice(2, eq)] = arg.slice(eq + 1);
+		}
+	});
+	return args;
+}
+
+/**
+ * Component being released: the word after "release " in the PR title, else
+ * the segment after "--components--" in the branch name.
+ *
+ * @param {string} prTitle Pull request title.
+ * @param {string} branch  Head branch name.
+ * @return {string} Component (empty string if neither source yields one).
+ */
+function parseComponent(prTitle, branch) {
+	const fromTitle = (prTitle || '').match(/release\s+([a-z0-9-]+)/);
+	if (fromTitle) {
+		return fromTitle[1];
+	}
+
+	if (branch && branch.includes('--components--')) {
+		return branch.replace(/.*--components--/, '');
+	}
+
+	return '';
+}
+
+/**
+ * Newest version in a CHANGELOG body: the first `## [x.y.z` / `## x.y.z`
+ * heading.
+ *
+ * @param {string} changelog CHANGELOG.md contents.
+ * @return {string} Version, or empty string if no heading matches.
+ */
+function parseVersionFromChangelog(changelog) {
+	for (const line of (changelog || '').split('\n')) {
+		if (/^##\s+\[?[0-9]+\.[0-9]+\.[0-9]+/.test(line)) {
+			return line.match(SEMVER)[0];
+		}
+	}
+	return '';
+}
+
+/**
+ * Version being released: first X.Y.Z in the PR title, else the newest
+ * CHANGELOG heading for the component.
+ *
+ * @param {string} prTitle   Pull request title.
+ * @param {string} component Component name.
+ * @param {string} pluginsDir Directory holding plugin folders.
+ * @return {string} Version, or empty string when none can be determined.
+ */
+function parseVersion(prTitle, component, pluginsDir) {
+	const fromTitle = (prTitle || '').match(SEMVER);
+	if (fromTitle) {
+		return fromTitle[0];
+	}
+
+	if (!component) {
+		return '';
+	}
+
+	const changelogPath = path.join(pluginsDir, component, 'CHANGELOG.md');
+	if (fs.existsSync(changelogPath)) {
+		return parseVersionFromChangelog(
+			fs.readFileSync(changelogPath, 'utf8')
+		);
+	}
+
+	return '';
+}
+
+/**
+ * Resolve all three outputs for a release PR.
+ *
+ * @param {Object} opts
+ * @param {string} opts.prTitle    Pull request title.
+ * @param {string} opts.branch     Head branch name.
+ * @param {string} [opts.pluginsDir] Directory holding plugin folders.
+ * @return {{ version: string, component: string, plugin_dir: string }}
+ */
+function extractVersionInfo({ prTitle, branch, pluginsDir = 'plugins' }) {
+	const component = parseComponent(prTitle, branch);
+	const version = parseVersion(prTitle, component, pluginsDir);
+	return {
+		version,
+		component,
+		plugin_dir: `${pluginsDir}/${component}`,
+	};
+}
+
+function main() {
+	const args = parseArgs();
+	const info = extractVersionInfo({
+		prTitle: args['pr-title'] || '',
+		branch: args.branch || '',
+		pluginsDir: args['plugins-dir'] || 'plugins',
+	});
+
+	process.stdout.write(
+		`version=${info.version}\n` +
+			`component=${info.component}\n` +
+			`plugin_dir=${info.plugin_dir}\n`
+	);
+	process.stderr.write(
+		`Detected version: ${info.version} for component: ${info.component}\n`
+	);
+}
+
+if (require.main === module) {
+	main();
+}
+
+module.exports = {
+	parseComponent,
+	parseVersionFromChangelog,
+	parseVersion,
+	extractVersionInfo,
+};

--- a/scripts/extract-release-version-info.test.js
+++ b/scripts/extract-release-version-info.test.js
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+
+/**
+ * Tests for extract-release-version-info.js
+ *
+ * Run with: node scripts/extract-release-version-info.test.js
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+const assert = require('assert');
+const {
+	parseComponent,
+	parseVersionFromChangelog,
+	extractVersionInfo,
+} = require('./extract-release-version-info');
+
+const SCRIPT_PATH = path.join(__dirname, 'extract-release-version-info.js');
+const TEST_DIR = path.join(__dirname, '..', '.test-version-info');
+
+function setup() {
+	if (fs.existsSync(TEST_DIR)) {
+		fs.rmSync(TEST_DIR, { recursive: true });
+	}
+	fs.mkdirSync(TEST_DIR, { recursive: true });
+}
+
+function cleanup() {
+	if (fs.existsSync(TEST_DIR)) {
+		fs.rmSync(TEST_DIR, { recursive: true });
+	}
+}
+
+function writeChangelog(component, body) {
+	const dir = path.join(TEST_DIR, component);
+	fs.mkdirSync(dir, { recursive: true });
+	fs.writeFileSync(path.join(dir, 'CHANGELOG.md'), body);
+}
+
+function runScript(prTitle, branch, pluginsDir) {
+	const args = [
+		`node "${SCRIPT_PATH}"`,
+		`--pr-title=${JSON.stringify(prTitle)}`,
+		`--branch=${JSON.stringify(branch)}`,
+	];
+	if (pluginsDir) {
+		args.push(`--plugins-dir=${JSON.stringify(pluginsDir)}`);
+	}
+	const output = execSync(args.join(' '), {
+		cwd: path.join(__dirname, '..'),
+		encoding: 'utf8',
+	});
+	// Parse the key=value stdout the workflow appends to $GITHUB_OUTPUT.
+	const out = {};
+	output
+		.trim()
+		.split('\n')
+		.forEach((line) => {
+			const [k, ...rest] = line.split('=');
+			out[k] = rest.join('=');
+		});
+	return out;
+}
+
+function test(name, fn) {
+	try {
+		setup();
+		fn();
+		console.log(`✅ ${name}`);
+		return true;
+	} catch (error) {
+		console.log(`❌ ${name}`);
+		console.log(`   Error: ${error.message}`);
+		return false;
+	} finally {
+		cleanup();
+	}
+}
+
+const RELEASE_PLEASE_CHANGELOG = `# Changelog
+
+## [2.18.0](https://github.com/wp-graphql/wp-graphql/compare/v2.17.0...v2.18.0) (2026-07-22)
+
+### New Features
+
+* something ([#4025](https://x))
+
+## [2.17.0](https://github.com/wp-graphql/wp-graphql/compare/v2.16.0...v2.17.0) (2026-07-01)
+`;
+
+const tests = [
+	() =>
+		test('parseComponent reads the component from the PR title', () => {
+			assert.strictEqual(
+				parseComponent(
+					'chore(main): release wp-graphql 2.7.0',
+					'release-please--branches--main--components--wp-graphql'
+				),
+				'wp-graphql'
+			);
+		}),
+
+	() =>
+		test('parseComponent handles hyphenated components', () => {
+			assert.strictEqual(
+				parseComponent('chore(main): release wp-graphql-acf 2.7.0', ''),
+				'wp-graphql-acf'
+			);
+		}),
+
+	() =>
+		test('parseComponent falls back to the branch --components-- suffix', () => {
+			assert.strictEqual(
+				parseComponent(
+					'no component here',
+					'release-please--branches--main--components--wp-graphql-smart-cache'
+				),
+				'wp-graphql-smart-cache'
+			);
+		}),
+
+	() =>
+		test('parseComponent returns empty when neither source has one', () => {
+			assert.strictEqual(parseComponent('nothing', 'nothing'), '');
+		}),
+
+	() =>
+		test('parseVersionFromChangelog returns the newest heading version', () => {
+			assert.strictEqual(
+				parseVersionFromChangelog(RELEASE_PLEASE_CHANGELOG),
+				'2.18.0'
+			);
+		}),
+
+	() =>
+		test('parseVersionFromChangelog returns empty with no version heading', () => {
+			assert.strictEqual(
+				parseVersionFromChangelog('# Changelog\n\nNo versions yet.\n'),
+				''
+			);
+		}),
+
+	() =>
+		test('extractVersionInfo prefers the version in the PR title', () => {
+			const info = extractVersionInfo({
+				prTitle: 'chore(main): release wp-graphql 2.7.0',
+				branch: 'release-please--branches--main--components--wp-graphql',
+			});
+			assert.deepStrictEqual(info, {
+				version: '2.7.0',
+				component: 'wp-graphql',
+				plugin_dir: 'plugins/wp-graphql',
+			});
+		}),
+
+	() =>
+		test('extractVersionInfo falls back to the CHANGELOG when the title has no version', () => {
+			writeChangelog('wp-graphql', RELEASE_PLEASE_CHANGELOG);
+			const info = extractVersionInfo({
+				prTitle: 'chore(main): release wp-graphql',
+				branch: 'release-please--branches--main--components--wp-graphql',
+				pluginsDir: TEST_DIR,
+			});
+			assert.strictEqual(info.version, '2.18.0');
+			assert.strictEqual(info.component, 'wp-graphql');
+		}),
+
+	() =>
+		test('extractVersionInfo yields empty version when nothing resolves it', () => {
+			const info = extractVersionInfo({
+				prTitle: 'chore(main): release wp-graphql',
+				branch: 'release-please--branches--main--components--wp-graphql',
+				pluginsDir: TEST_DIR, // no CHANGELOG written
+			});
+			assert.strictEqual(info.version, '');
+			assert.strictEqual(info.component, 'wp-graphql');
+		}),
+
+	() =>
+		test('CLI prints version/component/plugin_dir as key=value lines', () => {
+			const out = runScript(
+				'chore(main): release wp-graphql-ide 5.3.0',
+				'release-please--branches--main--components--wp-graphql-ide'
+			);
+			assert.strictEqual(out.version, '5.3.0');
+			assert.strictEqual(out.component, 'wp-graphql-ide');
+			assert.strictEqual(out.plugin_dir, 'plugins/wp-graphql-ide');
+		}),
+
+	() =>
+		test('CLI resolves the version from a fixture CHANGELOG when the title omits it', () => {
+			writeChangelog('wp-graphql-acf', RELEASE_PLEASE_CHANGELOG);
+			const out = runScript(
+				'chore(main): release wp-graphql-acf',
+				'release-please--branches--main--components--wp-graphql-acf',
+				TEST_DIR
+			);
+			assert.strictEqual(out.version, '2.18.0');
+			assert.strictEqual(out.component, 'wp-graphql-acf');
+		}),
+];
+
+console.log('\n🧪 Running extract-release-version-info.js tests...\n');
+
+let passed = 0;
+let failed = 0;
+
+for (const testFn of tests) {
+	if (testFn()) {
+		passed++;
+	} else {
+		failed++;
+	}
+}
+
+console.log(`\n${'─'.repeat(50)}`);
+console.log(`Results: ${passed} passed, ${failed} failed`);
+console.log(`${'─'.repeat(50)}\n`);
+
+process.exit(failed > 0 ? 1 : 0);

--- a/scripts/extract-release-version-info.test.js
+++ b/scripts/extract-release-version-info.test.js
@@ -8,7 +8,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 const assert = require('assert');
 const {
 	parseComponent,
@@ -39,15 +39,13 @@ function writeChangelog(component, body) {
 }
 
 function runScript(prTitle, branch, pluginsDir) {
-	const args = [
-		`node "${SCRIPT_PATH}"`,
-		`--pr-title=${JSON.stringify(prTitle)}`,
-		`--branch=${JSON.stringify(branch)}`,
-	];
+	// execFileSync (args array, no shell) so the values pass through as argv
+	// entries — no quoting or injection surface, even for exotic titles.
+	const args = [SCRIPT_PATH, `--pr-title=${prTitle}`, `--branch=${branch}`];
 	if (pluginsDir) {
-		args.push(`--plugins-dir=${JSON.stringify(pluginsDir)}`);
+		args.push(`--plugins-dir=${pluginsDir}`);
 	}
-	const output = execSync(args.join(' '), {
+	const output = execFileSync('node', args, {
 		cwd: path.join(__dirname, '..'),
 		encoding: 'utf8',
 	});
@@ -121,8 +119,19 @@ const tests = [
 		}),
 
 	() =>
-		test('parseComponent returns empty when neither source has one', () => {
-			assert.strictEqual(parseComponent('nothing', 'nothing'), '');
+		test('parseComponent returns the whole branch when there is no --components-- marker', () => {
+			// Matches the original sed fallback: a bogus-but-non-empty
+			// component fails fast downstream rather than resolving to
+			// plugins/ and touching every plugin.
+			assert.strictEqual(
+				parseComponent('no version-y title', 'release-please--odd'),
+				'release-please--odd'
+			);
+		}),
+
+	() =>
+		test('parseComponent returns empty only when there is no title match and no branch', () => {
+			assert.strictEqual(parseComponent('nothing', ''), '');
 		}),
 
 	() =>
@@ -198,6 +207,32 @@ const tests = [
 			);
 			assert.strictEqual(out.version, '2.18.0');
 			assert.strictEqual(out.component, 'wp-graphql-acf');
+		}),
+
+	() =>
+		test('CLI reads PR_TITLE / BRANCH_NAME from the env (the workflow path)', () => {
+			// No CLI args — the workflow passes these via env so no PR-controlled
+			// string reaches the command line.
+			const output = execFileSync('node', [SCRIPT_PATH], {
+				cwd: path.join(__dirname, '..'),
+				encoding: 'utf8',
+				env: {
+					...process.env,
+					PR_TITLE: 'chore(main): release wp-graphql-ide 5.3.0',
+					BRANCH_NAME:
+						'release-please--branches--main--components--wp-graphql-ide',
+				},
+			});
+			const out = {};
+			output
+				.trim()
+				.split('\n')
+				.forEach((line) => {
+					const [k, ...rest] = line.split('=');
+					out[k] = rest.join('=');
+				});
+			assert.strictEqual(out.version, '5.3.0');
+			assert.strictEqual(out.component, 'wp-graphql-ide');
 		}),
 ];
 


### PR DESCRIPTION
## What

Replaces the inline bash in `update-release-pr.yml`'s **Extract version and component from PR** step with a committed, tested script: `scripts/extract-release-version-info.js`.

## Why

The step parsed the component and version from the PR title — falling back to the branch name, then the component's `CHANGELOG.md` — with a chain of `grep`/`sed`/`awk` and no test coverage. It feeds `version` / `component` / `plugin_dir` to ~every downstream step (placeholder replacement, version constants, changelog, hook docs), so it's worth having under test. Extracting it continues the same script-per-step pattern as the other release helpers.

## How

- `scripts/extract-release-version-info.js` — pure exported functions (`parseComponent`, `parseVersionFromChangelog`, `parseVersion`, `extractVersionInfo`) plus a `main()` that prints `version=` / `component=` / `plugin_dir=` lines to stdout, so the step appends them to `$GITHUB_OUTPUT` unchanged. The human-readable "Detected …" summary goes to stderr so it doesn't pollute the outputs stream.
- `--plugins-dir=` flag lets the test drive the CHANGELOG fallback against a fixture tree.
- `scripts/extract-release-version-info.test.js` — 11 assertions (title/branch/changelog component resolution, version precedence and fallback, empty-result paths, CLI output format), wired into `test:scripts`.

## Behavior parity

Byte-identical to the previous bash. Verified with a side-by-side harness running the original shell logic and the new script on all four release PR title/branch shapes **and** the title-without-version case that reads the real plugin `CHANGELOG.md` — same `version`/`component`/`plugin_dir` in every case.

## Context

Third in the workflow-extraction series after #4113 (manifest reconcile) and #4114 (legacy-hook version replacement). Independent of both — different step region, no conflicts. Remaining candidate, deliberately not bundled: the component/deploy-detection bash in `release-please.yml`, which sits on the wp.org deploy path and warrants its own focused review.