### PR TITLE
docs(ci): note why release-please detection stays inline bash

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -93,7 +93,7 @@ jobs:
       # bash, unlike the release helpers under scripts/. Both jobs run WITHOUT
       # an actions/checkout step (they only transform release-please's output
       # JSON, so they never needed the repo on disk). Moving this to a tested
-      # scripts/release/*.js would mean adding a checkout to a checkout-less
+      # scripts/*.js helper would mean adding a checkout to a checkout-less
       # job on the deploy path, a bigger change than the extraction is worth
       # today. If this logic grows, do both: add the checkout AND extract.
       # The transform is pure and was parity-verified once: take the output

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -88,6 +88,17 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
+      # NOTE (future us): this detection logic — and the "Detect components
+      # for deployment" step in the next job — is intentionally left as inline
+      # bash, unlike the release helpers under scripts/. Both jobs run WITHOUT
+      # an actions/checkout step (they only transform release-please's output
+      # JSON, so they never needed the repo on disk). Moving this to a tested
+      # scripts/release/*.js would mean adding a checkout to a checkout-less
+      # job on the deploy path, a bigger change than the extraction is worth
+      # today. If this logic grows, do both: add the checkout AND extract.
+      # The transform is pure and was parity-verified once: take the output
+      # keys ending in `--release_created` whose value is "true", strip the
+      # `plugins/` prefix, sorted the way `jq keys` sorts (lexicographically).
       - name: Detect components with releases
         id: components
         env:


### PR DESCRIPTION
## What

Adds a comment in `release-please.yml` recording why the two component-detection steps are intentionally left as inline bash, rather than extracted into tested `scripts/release/*.js` like the other release helpers.

## Why

While extracting workflow logic into tested scripts (#4114, #4115), the detection steps in `release-please.yml` looked like the next candidates. They aren't a clean fit: both the `release-please` and `detect-deploy-components` jobs run **without an `actions/checkout` step** (they only transform release-please's output JSON via `jq`, so they never needed the repo on disk). Calling a repo script would require adding a checkout to a checkout-less job on the deploy path — a bigger structural change than the extraction is worth right now.

Rather than leave that reasoning to be rediscovered, the note captures it and records the shape of the pure transform (keys ending `--release_created` == "true" → strip `plugins/` prefix, sorted like `jq keys`), so a future extraction starts from the right place. The logic was prototyped and byte-parity-verified during this exploration; if it ever grows enough to warrant testing, the note says to add the checkout and extract together.

## Scope

Comment-only, no logic change. Closes out the workflow-extraction series (#4113 manifest reconcile, #4114 legacy-hook replacement, #4115 version/component parsing) with a deliberate 'stop here, and here's why' for the remaining candidate.