### PR TITLE
docs: add a defensive-coding checklist for workflow scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,14 @@ The pattern the release scripts follow (`scripts/update-*.js`, `scripts/reconcil
 - Pure, exported functions for the core logic; a `main()` that does the IO, guarded by `if (require.main === module)`.
 - A sibling `scripts/<name>.test.js` using Node's built-in `assert` (no test runner), added to the `test:scripts` npm script so it runs in the **Test Release Scripts** workflow. Prefer flags that let the test drive the script without a live git remote/network (e.g. `--main-manifest=<path>` to stand in for a `git show` read).
 
+**Write them defensively.** These are the points review keeps raising on these scripts — get them right up front:
+
+- **Take untrusted input through the environment, not the command line.** PR titles, branch names, and any user- or PR-controlled string should reach the script via an env var it reads (`process.env.X`), so the workflow never interpolates them into a shell command. When a script *or its test* shells out (to `git`, or to invoke another script), use `execFileSync(cmd, [args])` — never `execSync` with an interpolated string.
+- **Fail loud or skip quiet — match the step's criticality, and say which in a comment.** If the step must succeed for correctness, exit non-zero on an unexpected failure so it can't go green while leaving things broken (e.g. main's manifest is unreadable). If it's best-effort and must never block the pipeline, log and `exit 0` (e.g. a missing value for an optional placeholder fill). Pick deliberately; don't default to whichever is easier.
+- **Give distinct no-ops distinct messages.** A "nothing to do / already done" log must not also fire when the real cause is "couldn't find the target" (usually a mis-parsed arg). Return a `reason` and log each case, so a malformed input is visible instead of silently skipped.
+- **When extracting existing logic, preserve its edge-case behavior — and prove it.** Reproduce the fallbacks and fail-fast semantics of the code you're replacing (a `sed` that returns the whole branch on no match is safer than an empty string that resolves to `plugins/`); don't "tidy" an edge case into different behavior. Back the parity claim with a test or a side-by-side check, and flag any intentional divergence.
+- **Small correctness traps:** parse `--key=value` by splitting on the *first* `=` only (values can contain `=`); build dynamic string replacements with `split(x).join(v)` or a replacer function, not `String.replace(/x/g, v)` (a `$&`/`$1` in `v` would be interpreted).
+
 ### Hook conventions
 
 - Prefer canonical `graphql_*` hook names for new actions/filters.


### PR DESCRIPTION
## What

Adds a **Write them defensively** checklist to the `scripts/` convention in `CLAUDE.md`, codifying the review feedback that recurred across the workflow-extraction PRs (#4113 / #4114 / #4115).

## Why

Across those PRs nearly every Copilot / CodeQL finding fell into the same five buckets — and several were things later scripts did right but earlier ones didn't, i.e. the knowledge existed but wasn't written down. Documenting it means we write the scripts right the first time instead of round-tripping through review:

1. **Untrusted input via env, not the command line** — pass PR titles / branch names through env vars the script reads, and use `execFileSync([args])` over `execSync(string)` (the injection + shell-from-path findings).
2. **Fail loud vs skip quiet, matched to criticality** — exit non-zero when a silent success would hide breakage; `exit 0` for best-effort steps that must not block the pipeline. We hit *both* directions (reconcile fails fast on an unreadable manifest; the legacy-hook fill skips on a missing value), so it's framed as a deliberate choice, not a rule.
3. **Distinct no-ops get distinct messages** — don't let "nothing to do" mask "couldn't find the target."
4. **Preserve + prove edge-case parity when extracting** — the `parseComponent` empty-string-vs-whole-branch regression.
5. **Small traps** — split `--key=value` on the first `=`; `split/join` over `String.replace(regex, value)` for dynamic replacements.

## Scope

Docs-only, 8 lines added to the existing convention section.

## Optional follow-up (separate PR)

For a *mechanical* backstop rather than a checklist: wire `eslint-plugin-security` into the scripts lint (its `detect-child-process` rule flags `execSync` interpolation, automating bucket 1) and/or make **CodeQL** a required check so the shell-injection class fails CI instead of relying on review.