### PR TITLE
test: pin graphql-js v16 behaviors with canary tests, ignore graphql majors in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -111,6 +111,15 @@ updates:
       - dependency-name: 'graphiql'
       - dependency-name: 'use-query-params'
       - dependency-name: 'query-string'
+      # graphql v17 is a coordinated migration we'll do deliberately, after the
+      # legacy bundled GraphiQL is retired: graphiql 1.x and @apollo/client 3.x
+      # peer-depend on graphql ^15 || ^16, so an isolated major bump ships two
+      # graphql copies in the bundles and type checks fail silently across
+      # them. The v16 behaviors we rely on are pinned by canary tests (see
+      # tests named graphql-v16-canary in wp-graphql and wp-graphql-ide);
+      # minor/patch updates within v16 still flow normally.
+      - dependency-name: 'graphql'
+        update-types: ['version-update:semver-major']
     groups:
       npm-dev-minor-patch:
         dependency-type: 'development'

--- a/plugins/wp-graphql-ide/tests/unit/specs/graphql-v16-canary.test.js
+++ b/plugins/wp-graphql-ide/tests/unit/specs/graphql-v16-canary.test.js
@@ -1,0 +1,63 @@
+/* eslint-env jest */
+/**
+ * Canary tests pinning graphql-js v16 behaviors that v17 changes.
+ *
+ * These tests are EXPECTED TO FAIL when the `graphql` dependency is bumped
+ * to v17 (see https://www.graphql-js.org/upgrade-guides/v16-v17). They exist
+ * so a future major bump fails loudly at the exact behaviors our code relies
+ * on, instead of silently misbehaving at runtime. When intentionally
+ * migrating to v17, update each pinned behavior below along with the code
+ * that depends on it — do not just delete this file.
+ *
+ * Dependabot is configured to ignore graphql major updates until the
+ * migration happens deliberately (see .github/dependabot.yml).
+ */
+import { GraphQLError, parse, version as graphqlVersion } from 'graphql';
+import * as GraphQL from 'graphql';
+
+describe('graphql-js v16 canary', () => {
+	it('is the v16 major (bumping to v17 requires a coordinated migration)', () => {
+		// v17 also requires our graphiql-ecosystem peers to support it; as of
+		// graphql 17.0.2, @graphiql/toolkit 0.9.x only allows ^15 || ^16,
+		// which would leave two graphql copies in the bundle.
+		expect(graphqlVersion.split('.')[0]).toBe('16');
+	});
+
+	it('parses empty AST collections as arrays, not undefined', () => {
+		// v17's parser omits empty optional collections (`arguments`,
+		// `directives`, `variableDefinitions`, ...) as `undefined`. Our AST
+		// consumers (App.jsx visit(), api/external-fragments.js,
+		// hooks/useParsedQuery.js, the query-composer-panel utils) iterate
+		// these without optional chaining today.
+		const doc = parse('{ posts { nodes { id } } }');
+		const operation = doc.definitions[0];
+		const field = operation.selectionSet.selections[0];
+
+		expect(operation.variableDefinitions).toEqual([]);
+		expect(operation.directives).toEqual([]);
+		expect(field.arguments).toEqual([]);
+	});
+
+	it('supports the positional GraphQLError constructor', () => {
+		// v17 removed positional arguments; only
+		// `new GraphQLError(message, options)` remains.
+		const doc = parse('{ posts { nodes { id } } }');
+		const node = doc.definitions[0];
+
+		const error = new GraphQLError('boom', node);
+
+		expect(error.nodes).toEqual([node]);
+	});
+
+	it('exposes helpers on the namespace that v17 removes', () => {
+		// src/graphql.js assigns the whole graphql namespace to
+		// `window.graphql` as a public surface for IDE extensions, so
+		// exports removed in v17 are a breaking change for third-party
+		// extension code, not just for us.
+		expect(typeof GraphQL.printError).toBe('function');
+		expect(typeof GraphQL.formatError).toBe('function');
+		expect(typeof GraphQL.getOperationRootType).toBe('function');
+		expect(typeof GraphQL.assertValidName).toBe('function');
+		expect(typeof GraphQL.getVisitFn).toBe('function');
+	});
+});

--- a/plugins/wp-graphql/packages/wpgraphiql/graphql-v16-canary.test.js
+++ b/plugins/wp-graphql/packages/wpgraphiql/graphql-v16-canary.test.js
@@ -1,0 +1,63 @@
+/**
+ * Canary tests pinning graphql-js v16 behaviors that v17 changes.
+ *
+ * These tests are EXPECTED TO FAIL when the `graphql` dependency is bumped
+ * to v17 (see https://www.graphql-js.org/upgrade-guides/v16-v17). The legacy
+ * bundled GraphiQL app cannot take that bump at all today: graphiql 1.11.5
+ * and @apollo/client 3.x peer-depend on graphql ^15 || ^16, so a v17 bump
+ * leaves two graphql copies in the bundle and cross-copy `instanceof` /
+ * type-guard checks fail silently in production builds.
+ *
+ * Dependabot is configured to ignore graphql major updates until the legacy
+ * IDE is retired and the migration happens deliberately (see
+ * .github/dependabot.yml). If you are intentionally migrating to v17, update
+ * each pinned behavior below along with the code that depends on it — do not
+ * just delete this file.
+ */
+// Deep import mirrors packages/wpgraphiql/index.js, which exposes this whole
+// namespace on `window` for GraphiQL extensions.
+import * as GraphQL from 'graphql/index.js';
+
+const { GraphQLError, parse, version: graphqlVersion } = GraphQL;
+
+describe('graphql-js v16 canary', () => {
+	it('is the v16 major (graphiql 1.x and @apollo/client 3.x cannot use v17)', () => {
+		expect(graphqlVersion.split('.')[0]).toBe('16');
+	});
+
+	it('parses empty AST collections as arrays, not undefined', () => {
+		// v17's parser omits empty optional collections (`arguments`,
+		// `directives`, `variableDefinitions`, ...) as `undefined`. The
+		// graphiql-query-composer utils and GraphiQLContext walk these
+		// without optional chaining today.
+		const doc = parse('{ posts { nodes { id } } }');
+		const operation = doc.definitions[0];
+		const field = operation.selectionSet.selections[0];
+
+		expect(operation.variableDefinitions).toEqual([]);
+		expect(operation.directives).toEqual([]);
+		expect(field.arguments).toEqual([]);
+	});
+
+	it('supports the positional GraphQLError constructor', () => {
+		// v17 removed positional arguments; only
+		// `new GraphQLError(message, options)` remains.
+		const doc = parse('{ posts { nodes { id } } }');
+		const node = doc.definitions[0];
+
+		const error = new GraphQLError('boom', node);
+
+		expect(error.nodes).toEqual([node]);
+	});
+
+	it('exposes helpers on the namespace that v17 removes', () => {
+		// The whole namespace is public via `window` (see index.js), so
+		// exports removed in v17 break third-party GraphiQL extension code,
+		// not just ours.
+		expect(typeof GraphQL.printError).toBe('function');
+		expect(typeof GraphQL.formatError).toBe('function');
+		expect(typeof GraphQL.getOperationRootType).toBe('function');
+		expect(typeof GraphQL.assertValidName).toBe('function');
+		expect(typeof GraphQL.getVisitFn).toBe('function');
+	});
+});


### PR DESCRIPTION
## What does this do?

Dependabot opened #4139 to bump `graphql` (graphql-js) from 16.14.2 to 17.0.2. CI was green on it, but the upgrade isn't actually safe to take yet:

- `graphiql@1.11.5` (the legacy IDE bundled in core), its nested `@graphiql/react` / `@graphiql/toolkit` / `codemirror-graphql`, `@apollo/client@3.x`, and the IDE plugin's `@graphiql/toolkit@0.9.x` all peer-depend on `graphql ^15 || ^16`. The lockfile in that PR keeps `graphql@16.14.2` hoisted at the root for those peers while nesting `17.0.2` in each workspace, so our webpack bundles would contain both copies. graphql-js type guards and `instanceof` checks fail across copies, and v17 moved its multiple-copies diagnostic behind an opt-in dev mode, so in production builds the failure mode is silent misbehavior in things like the docs explorer, query composer, and variable linting rather than a visible error.
- v17 also changes behaviors our code relies on directly: empty AST collections (`arguments`, `directives`, `variableDefinitions`) parse as `undefined` instead of `[]`, the positional `GraphQLError` constructor is removed, and several exports (`printError`, `formatError`, `getOperationRootType`, `assertValidName`, `getVisitFn`) are removed from the namespace we expose on `window.graphql` as a public surface for IDE extensions.

The plan is to take v17 deliberately after the legacy bundled GraphiQL is retired in favor of the standalone IDE plugin, alongside upgrades of the graphiql ecosystem packages. Until then, this PR:

1. **Adds canary tests** (in the IDE plugin's jest suite and the legacy core packages) pinning the v16 behaviors listed above. Each assertion was verified to pass on graphql 16.14.2 and fail on 17.0.2, so a future bump fails loudly at the exact behaviors that need auditing, instead of shipping silent breakage. The test files say explicitly that they are expected to fail on a v17 bump and should be updated as part of the migration, not deleted.
2. **Tells dependabot to ignore `graphql` semver-major updates.** Minor and patch updates within v16 still flow normally.

Replaces #4139.