### PR TITLE
ci: harden the JS E2E Tests status check and change detection

### DIFF
--- a/.github/workflows/js-e2e-tests.yml
+++ b/.github/workflows/js-e2e-tests.yml
@@ -77,6 +77,9 @@ jobs:
               - package-lock.json
               - .wp-env.json
               - bin/**
+              # The jobs run on the Node version pinned here, so a Node bump
+              # must re-run the suites.
+              - .nvmrc
             wp-graphql-ide:
               - .github/workflows/js-e2e-tests-reusable.yml
               - .github/workflows/js-e2e-tests.yml
@@ -90,6 +93,7 @@ jobs:
               - package-lock.json
               - .wp-env.json
               - bin/**
+              - .nvmrc
             wp-graphql-acf:
               - .github/workflows/js-e2e-tests-reusable.yml
               - .github/workflows/js-e2e-tests.yml
@@ -103,6 +107,7 @@ jobs:
               - package-lock.json
               - .wp-env.json
               - bin/**
+              - .nvmrc
             # Add additional plugins here:
             # WPGraphQL Smart Cache doesn't currently ship any
             # JS so it doesn't have JS tests, but this is an example
@@ -232,30 +237,28 @@ jobs:
     steps:
       - name: Check JS E2E test results
         run: |
-          # Check if any required jobs failed (excluding skipped)
-          if [ "${{ needs.wp-graphql.result }}" == "failure" ]; then
-            echo "❌ wp-graphql JS E2E tests failed"
+          # If change detection itself didn't succeed, downstream jobs were
+          # skipped for the wrong reason — green would be meaningless.
+          if [ "${{ needs.detect-changes.result }}" != "success" ]; then
+            echo "❌ Change detection did not succeed (${{ needs.detect-changes.result }})"
             exit 1
           fi
-          if [ "${{ needs.wp-graphql-ide.result }}" == "failure" ]; then
-            echo "❌ wp-graphql-ide JS E2E tests failed"
-            exit 1
-          fi
-          if [ "${{ needs.wp-graphql-acf.result }}" == "failure" ]; then
-            echo "❌ wp-graphql-acf JS E2E tests failed"
-            exit 1
-          fi
-          # Allow skipped jobs (expected when files don't change)
-          if [ "${{ needs.wp-graphql.result }}" == "skipped" ]; then
-            echo "ℹ️ wp-graphql JS E2E tests skipped (no changes detected)"
-          fi
-          if [ "${{ needs.wp-graphql-ide.result }}" == "skipped" ]; then
-            echo "ℹ️ wp-graphql-ide JS E2E tests skipped (no changes detected)"
-          fi
-          if [ "${{ needs.wp-graphql-acf.result }}" == "skipped" ]; then
-            echo "ℹ️ wp-graphql-acf JS E2E tests skipped (no changes detected)"
-          fi
-          echo "✅ All required JS E2E tests passed"
+          # Allowlist outcomes: only success and an expected skip pass.
+          # Anything else (failure, cancelled, timed out) fails the check.
+          check() {
+            local name="$1" result="$2"
+            if [ "$result" == "skipped" ]; then
+              echo "ℹ️ $name JS E2E tests skipped (no changes detected, or the job is disabled in CI)"
+            elif [ "$result" != "success" ]; then
+              echo "❌ $name JS E2E tests did not succeed ($result)"
+              exit 1
+            else
+              echo "✅ $name JS E2E tests passed"
+            fi
+          }
+          check "wp-graphql" "${{ needs.wp-graphql.result }}"
+          check "wp-graphql-ide" "${{ needs.wp-graphql-ide.result }}"
+          check "wp-graphql-acf" "${{ needs.wp-graphql-acf.result }}"
 
   # ===========================================
   # ADDITIONAL PLUGINS


### PR DESCRIPTION
## What does this do?

Applies to `js-e2e-tests.yml` the same two hardening fixes that landed in `js-unit-tests.yml` via #4147 (both originally Copilot review findings there, and both flagged in those threads as follow-up material for this workflow):

1. **`.nvmrc` added to all three plugins' change-detection sets.** The e2e jobs run on the Node version pinned in `.nvmrc` (via `setup-node` in the reusable workflow), so a Node bump previously wouldn't re-run the suites and the check could go green against an untested Node version.
2. **Status check switched to an outcome allowlist.** The old script only failed when a job's result was exactly `failure`, so cancelled or timed-out jobs (and a failed `detect-changes` job, which silently skips everything downstream) still reported green. Now `detect-changes` must succeed, and each test job's result must be `success` or an expected `skipped`; anything else fails the check. The per-job checks are collapsed into a small bash function since the logic is now identical for all three.

The skip message also no longer claims "no changes detected" unconditionally, since the ACF job is currently skipped because it's hard-disabled in CI, not because of change detection.

## Considered and deferred

The plugins' `composer.json`/`composer.lock` files are also inputs to the e2e jobs (the reusable workflow composer-installs the plugin, wp-graphql, and Smart Cache before booting wp-env, and a missing autoloader changes what loads), but they're not in the change-detection sets. Adding them would trigger full e2e runs on every weekly composer dev-deps bump for coverage of a fairly narrow failure class, so I've left them out deliberately rather than silently — worth revisiting if an autoload-related e2e miss ever actually bites.