### PR TITLE
fix(wp-graphql-ide): render modals above the drawer in drawer mode

### DIFF
--- a/plugins/wp-graphql-ide/styles/wpgraphql-ide.css
+++ b/plugins/wp-graphql-ide/styles/wpgraphql-ide.css
@@ -104,10 +104,16 @@
 /* Fix layout shift from drawer opening everywhere except the dedicated IDE page */
 /* Removed - was causing jump when drawer opens. Vaul handles body scroll locking. */
 
-/* Fix popover/dropdown visibility and interaction within drawer */
+/* Fix popover/dropdown/modal visibility and interaction within drawer.
+   The Modal overlay is included because @wordpress/components portals
+   modals to document.body at z-index 100000, which the drawer (999999)
+   would otherwise cover — hiding every Modal-based dialog (save,
+   confirm/prompt, share, export) in drawer mode. See
+   https://github.com/wp-graphql/wp-graphql/issues/4163 */
 [data-radix-popper-content-wrapper],
 .components-popover,
-.components-dropdown-menu__popover {
+.components-dropdown-menu__popover,
+.components-modal__screen-overlay {
   z-index: 1000000 !important; /* Above drawer */
   pointer-events: auto !important;
 }

--- a/plugins/wp-graphql-ide/tests/e2e/specs/drawer.spec.js
+++ b/plugins/wp-graphql-ide/tests/e2e/specs/drawer.spec.js
@@ -104,6 +104,45 @@ test.describe('Drawer mode — IDE functionality parity with the dedicated page'
 		expect(request.url()).toMatch(/graphql/);
 	});
 
+	test('modals render above the drawer and stay interactive (regression guard for z-index)', async ({
+		page,
+	}) => {
+		// @wordpress/components Modal portals to document.body with WP
+		// core's .components-modal__screen-overlay at z-index 100000.
+		// The Vaul drawer is z-index 999999, so without the "above
+		// drawer" bump in styles/wpgraphql-ide.css every Modal-based
+		// dialog (SaveDialog, DialogProvider confirm/prompt, share,
+		// export, ...) paints underneath the drawer: the dialog is in
+		// the DOM and "visible", but the user sees nothing and can't
+		// click it. https://github.com/wp-graphql/wp-graphql/issues/4163
+		await page.click(selectors.addTab);
+		await typeQuery(page, '{ posts { nodes { id } } }');
+		await page.getByRole('button', { name: 'Save draft' }).click();
+
+		const dialog = page.locator('.wpgraphql-ide-save-dialog');
+		await expect(dialog).toBeVisible({ timeout: 5000 });
+
+		// Same deterministic check as the autocomplete guard below:
+		// computed z-index must clear the drawer overlay. (See that
+		// test's comment for why we don't hit-test coordinates.)
+		const overlay = page
+			.locator('.components-modal__screen-overlay')
+			.last();
+		const computedZ = await overlay.evaluate(
+			(el) => parseInt(getComputedStyle(el).zIndex, 10) || 0
+		);
+		expect(
+			computedZ,
+			`modal overlay z-index is ${computedZ}, expected > 999999 to clear the drawer overlay — likely .components-modal__screen-overlay is missing from the above-drawer rules in styles/wpgraphql-ide.css`
+		).toBeGreaterThan(999999);
+
+		// And the dialog must actually receive pointer events:
+		// Playwright refuses to click an element another element would
+		// intercept, so this fails if the drawer still covers the modal.
+		await dialog.getByRole('button', { name: 'Cancel' }).click();
+		await expect(dialog).toBeHidden();
+	});
+
 	test('autocomplete dropdown renders above the drawer (regression guard for z-index)', async ({
 		page,
 	}) => {


### PR DESCRIPTION
## What

Fixes #4163.

With the IDE open in drawer mode, every `@wordpress/components` `Modal` rendered behind the drawer: the dialog was in the DOM and technically "visible", but the user saw nothing and couldn't interact with it. The same dialogs work fine on the dedicated IDE page. This affected all 8 Modal consumers: `SaveDialog`, `DialogProvider` (every confirm/prompt/choose in the IDE, including delete confirmations and the duplicate-publish flow), `ShareDialog`, `ShareCollectionDialog`, `NewCollectionDialog`, `DeleteCollectionDialog`, `ExportDialog`, and `SignInPromptDialog`.

## Why

The Vaul drawer is `z-index: 999999`. Popovers, dropdowns, radix poppers, and CodeMirror tooltips all already have "above drawer" overrides at `1000000` in `styles/wpgraphql-ide.css`, but the Modal overlay was never included. `Modal` portals to `document.body` with WP core's `.components-modal__screen-overlay` at `z-index: 100000`, so the drawer covered it.

## Fix

Adds `.components-modal__screen-overlay` to the existing above-drawer rule block. Like the popover rules it sits next to, the override is global to pages where the IDE styles load rather than scoped to drawer-open state, keeping the pattern consistent with what already ships. Popovers and the modal overlay both land at `1000000`, and popovers portal later in the DOM, so dropdowns inside modals still stack correctly (covered by the existing document-settings and export dialog e2e tests, which stay green).

## Tests

New e2e regression guard in `drawer.spec.js`, following the existing autocomplete z-index guard: opens the drawer, triggers the SaveDialog, asserts the overlay's computed z-index clears the drawer, and clicks the dialog's Cancel button (Playwright's actionability check fails if the drawer intercepts the click). Red before the fix (`modal overlay z-index is 100000, expected > 999999`), green after. The drawer, save-flow, publish-flow, document-settings, and saved-queries specs all pass locally.
