### PR TITLE
fix(wp-graphql-ide): stop author-scoping unrelated connections when Smart Cache is active

### DIFF
--- a/plugins/wp-graphql-ide/docs/api-surface.md
+++ b/plugins/wp-graphql-ide/docs/api-surface.md
@@ -76,8 +76,7 @@ Registered in `SmartCacheBridge::register_ide_graphql_fields_on_smart_cache_docu
 
 | Filter | Hook | Purpose |
 | --- | --- | --- |
-| `scope_graphql_connections` | `graphql_connection_query_args` | Adds `author = current_user_id()` to `graphqlDocument` connections so users only see their own. |
-| `restrict_post_visibility` | `graphql_data_is_private` | Marks `graphql_document` posts private when the current user isn't the author. Gates `node(id)` / `graphqlDocument(id)`. |
+| `restrict_post_visibility` | `graphql_data_is_private` | Marks `graphql_document` posts private when the current user isn't the author. Gates connections (private models are dropped from results), `node(id)`, and `graphqlDocument(id)` alike. The IDE's document list also passes an `author` where arg client-side (`src/api/documents.js`) to keep pagination correct; connection-level author scoping in PHP was removed because it over-matched `post_type: 'any'` connections ([#4117](https://github.com/wp-graphql/wp-graphql/issues/4117)). |
 
 ### Client callsites
 

--- a/plugins/wp-graphql-ide/includes/Access.php
+++ b/plugins/wp-graphql-ide/includes/Access.php
@@ -29,52 +29,24 @@ class Access {
 	}
 
 	/**
-	 * Scope GraphQL connections on Smart Cache's `graphql_document` to
-	 * the current user.
-	 *
-	 * Without scoping, anyone holding `manage_graphql_ide` would see
-	 * every other IDE user's saved documents through the
-	 * `graphqlDocuments` connection — wider than the REST endpoint
-	 * already enforces. Mirror the REST behavior here so the per-user
-	 * isolation is the same on both surfaces.
-	 *
-	 * @since 5.0.1
-	 *
-	 * @param array<string, mixed> $query_args  Connection query args (forwarded to WP_Query).
-	 * @param mixed                $source      The parent (root) source for the connection.
-	 * @return array<string, mixed>
-	 */
-	public static function scope_graphql_connections( $query_args, $source ): array {
-		unset( $source ); // Source is unused — scoping is global per current user.
-
-		$post_type = isset( $query_args['post_type'] ) ? $query_args['post_type'] : null;
-
-		// `graphql_document` is Smart Cache's saved-document post type and
-		// only exists when Smart Cache is active.
-		$matches_ide_pt = false;
-		if ( is_string( $post_type ) ) {
-			$matches_ide_pt = 'graphql_document' === $post_type;
-		} elseif ( is_array( $post_type ) ) {
-			$matches_ide_pt = in_array( 'graphql_document', $post_type, true );
-		}
-
-		if ( ! $matches_ide_pt ) {
-			return $query_args;
-		}
-
-		$query_args['author'] = get_current_user_id();
-
-		return $query_args;
-	}
-
-	/**
 	 * Mark Smart Cache `graphql_document` posts as private when the
-	 * current user isn't the author. The connection-level filter
-	 * already scopes list queries, but `node(id: "...")` resolves a
-	 * model directly from the global ID and bypasses connection args
-	 * entirely. Without this filter, a user holding `manage_graphql_ide`
-	 * could read another user's saved Smart Cache document just by
-	 * guessing or sharing its global ID.
+	 * current user isn't the author. This is the GraphQL-side enforcement
+	 * point for per-user document isolation: it covers connections
+	 * (private models are dropped from the results), `node(id: "...")`
+	 * lookups, and any nested field that resolves a document model.
+	 * Without this filter, a user holding `manage_graphql_ide` could read
+	 * another user's saved Smart Cache document just by guessing or
+	 * sharing its global ID.
+	 *
+	 * Historical note: 5.0.1 through 5.4.x also author-scoped connection
+	 * query args via `graphql_connection_query_args`. That filter matched
+	 * any connection whose `post_type` list contained `graphql_document`,
+	 * which — with Smart Cache active — includes every `post_type: 'any'`
+	 * connection (core `contentNodes`, ACF relationship fields), so
+	 * authenticated queries silently lost other authors' posts
+	 * (https://github.com/wp-graphql/wp-graphql/issues/4117). The IDE's
+	 * document list now scopes itself with an `author` where arg
+	 * client-side instead (see `src/api/documents.js`).
 	 *
 	 * Visibility is decided in the WPGraphQL Model layer: returning true
 	 * here marks the data private so the model's restricted fields (id,

--- a/plugins/wp-graphql-ide/src/api/documents.js
+++ b/plugins/wp-graphql-ide/src/api/documents.js
@@ -185,24 +185,44 @@ function buildMutationInput(doc) {
 }
 
 /**
- * Fetch all saved-query documents visible to the current user.
+ * Fetch the current user's saved-query documents.
  *
- * Per-user scoping is enforced server-side by Smart Cache's auth model
- * + the IDE's connection filter — no author arg is needed.
+ * The client states its own scope: the `author` where arg pins the list
+ * to the viewer (`WPGRAPHQL_IDE_DATA.context.currentUserId`). Privacy is
+ * enforced server-side at the model layer (`graphql_data_is_private`
+ * hides other users' documents regardless of what this query asks for);
+ * the author arg is what keeps the list complete and pagination sane —
+ * without it, other users' documents would occupy `first: 100` slots
+ * before being dropped. Don't remove it in favor of server-side
+ * connection scoping: filtering shared connection query args by author
+ * is what broke unrelated `post_type: any` queries in
+ * https://github.com/wp-graphql/wp-graphql/issues/4117.
+ *
+ * A logged-out viewer (public-endpoint mode) sends `author: null`, which
+ * WP_Query ignores; the model layer hides every document for them anyway.
  *
  * @return {Promise<Object[]>}
  */
 export async function getDocuments() {
-	const data = await gql(`
-		query GetSavedDocuments {
+	const currentUserId =
+		Number(
+			typeof window !== 'undefined'
+				? window.WPGRAPHQL_IDE_DATA?.context?.currentUserId
+				: 0
+		) || 0;
+	const data = await gql(
+		`
+		query GetSavedDocuments($author: Int) {
 			graphqlDocuments(
 				first: 100
-				where: { stati: [PUBLISH, DRAFT], orderby: { field: MENU_ORDER, order: ASC } }
+				where: { author: $author, stati: [PUBLISH, DRAFT], orderby: { field: MENU_ORDER, order: ASC } }
 			) {
 				nodes { ${DOCUMENT_FIELDS} }
 			}
 		}
-	`);
+	`,
+		{ author: currentUserId > 0 ? currentUserId : null }
+	);
 	return (data?.graphqlDocuments?.nodes ?? []).map(adaptDocument);
 }
 

--- a/plugins/wp-graphql-ide/tests/unit/specs/api/documents.test.js
+++ b/plugins/wp-graphql-ide/tests/unit/specs/api/documents.test.js
@@ -75,6 +75,64 @@ describe('documents api — content format', () => {
 	});
 });
 
+// The saved-documents list is scoped to the current user by the client:
+// `getDocuments` sends an `author` where arg with the viewer's user ID
+// (from `WPGRAPHQL_IDE_DATA.context.currentUserId`). Server-side, per-user
+// privacy is enforced at the model layer (`graphql_data_is_private`); the
+// author arg is what keeps pagination correct (without it, other users'
+// docs would occupy `first: 100` slots and get dropped post-query). The
+// IDE must NOT rely on any server-side connection-level author scoping —
+// that approach author-scoped unrelated `post_type: any` connections too
+// (https://github.com/wp-graphql/wp-graphql/issues/4117).
+describe('documents api — per-user author scoping on the wire', () => {
+	const ENDPOINT = 'http://example.test/graphql';
+
+	beforeEach(() => {
+		window.WPGRAPHQL_IDE_DATA = {
+			graphqlEndpoint: ENDPOINT,
+			nonce: 'test-nonce',
+			context: { currentUserId: 7 },
+		};
+		global.fetch = jest.fn();
+	});
+
+	afterEach(() => {
+		delete global.fetch;
+		delete window.WPGRAPHQL_IDE_DATA;
+	});
+
+	function mockOk(json) {
+		global.fetch.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: () => Promise.resolve(json),
+		});
+	}
+
+	function lastSentBody() {
+		const lastCall = global.fetch.mock.calls.at(-1);
+		return JSON.parse(lastCall[1].body);
+	}
+
+	it('getDocuments filters by the current user as author', async () => {
+		mockOk({ data: { graphqlDocuments: { nodes: [] } } });
+		await getDocuments();
+		const body = lastSentBody();
+		expect(body.query).toMatch(/author:\s*\$author/);
+		expect(body.variables.author).toBe(7);
+	});
+
+	it('getDocuments sends a null author when there is no logged-in user', async () => {
+		// Public-endpoint mode with a logged-out visitor: no user to scope
+		// to. A null variable reaches WP_Query as an empty author arg,
+		// which it ignores; the model layer hides every document anyway.
+		window.WPGRAPHQL_IDE_DATA.context = { currentUserId: 0 };
+		mockOk({ data: { graphqlDocuments: { nodes: [] } } });
+		await getDocuments();
+		expect(lastSentBody().variables.author).toBeNull();
+	});
+});
+
 // WPGraphQL's `PostStatusEnum` is uppercase (DRAFT / PUBLISH / …) — the
 // IDE stores the post_status string lowercase internally to match what
 // the read side returns. `buildMutationInput` upcases at the wire; this

--- a/plugins/wp-graphql-ide/tests/wpunit-integration/ConnectionAuthorScopingTest.php
+++ b/plugins/wp-graphql-ide/tests/wpunit-integration/ConnectionAuthorScopingTest.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Regression coverage for https://github.com/wp-graphql/wp-graphql/issues/4117
+ *
+ * With Smart Cache active, its `graphql_document` post type is part of
+ * `WPGraphQL::get_allowed_post_types()`, so any connection resolved with
+ * post type `'any'` (core `contentNodes`, ACF relationship fields) carries
+ * `graphql_document` in its `post_type` query arg. The IDE's old
+ * `Access::scope_graphql_connections` filter matched that and forced
+ * `author = get_current_user_id()` onto the whole query, so authenticated
+ * requests silently dropped every post authored by someone else. Public
+ * requests appeared fine only because WP_Query ignores `author = 0`.
+ *
+ * Per-user isolation of saved documents is enforced at the model layer
+ * (`Access::restrict_post_visibility` on `graphql_data_is_private`), and
+ * the IDE's own document list scopes itself client-side with an `author`
+ * where arg — so no connection-level author scoping may leak into
+ * unrelated queries.
+ *
+ * @package WPGraphQLIDE
+ */
+
+namespace Tests\WPGraphQLIDE\Integration;
+
+class ConnectionAuthorScopingTest extends \Codeception\TestCase\WPTestCase {
+
+	/**
+	 * @var int
+	 */
+	private $author_id;
+
+	/**
+	 * @var int
+	 */
+	private $other_user_id;
+
+	/**
+	 * @var int
+	 */
+	private $post_id;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->author_id = self::factory()->user->create( [ 'role' => 'author' ] );
+
+		// The requesting user is an administrator so the failure mode can't
+		// be confused with a capability restriction: admins can read
+		// everything, yet the bug still blanked the results.
+		$this->other_user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+
+		$this->post_id = self::factory()->post->create(
+			[
+				'post_status' => 'publish',
+				'post_author' => $this->author_id,
+				'post_title'  => 'Published post by another author',
+			]
+		);
+	}
+
+	public function tearDown(): void {
+		wp_set_current_user( 0 );
+		parent::tearDown();
+	}
+
+	/**
+	 * Run a `contentNodes` query (post type `'any'` under the hood) scoped
+	 * to the fixture post and return the resolved database IDs.
+	 *
+	 * @return int[]
+	 */
+	private function query_content_node_ids(): array {
+		$result = graphql(
+			[
+				'query'     => '
+					query GetContentNodes($in: [ID!]) {
+						contentNodes(where: { in: $in }) {
+							nodes {
+								databaseId
+							}
+						}
+					}
+				',
+				'variables' => [ 'in' => [ $this->post_id ] ],
+			]
+		);
+
+		$this->assertArrayNotHasKey( 'errors', $result );
+
+		return array_column( $result['data']['contentNodes']['nodes'], 'databaseId' );
+	}
+
+	public function test_authenticated_content_nodes_query_includes_other_authors_posts() {
+		wp_set_current_user( $this->other_user_id );
+
+		$this->assertContains(
+			$this->post_id,
+			$this->query_content_node_ids(),
+			'A published post must resolve for an authenticated user who is not its author (issue #4117).'
+		);
+	}
+
+	public function test_public_content_nodes_query_includes_the_post() {
+		wp_set_current_user( 0 );
+
+		$this->assertContains(
+			$this->post_id,
+			$this->query_content_node_ids(),
+			'A published post must resolve for unauthenticated requests.'
+		);
+	}
+
+	public function test_other_users_documents_stay_private_at_the_model_layer() {
+		// Deleting the connection-level author scoping must not reopen the
+		// hole it was added for: another user's saved document has to stay
+		// unreadable. The model-layer filter
+		// (`Access::restrict_post_visibility`) is the enforcement point.
+		$document_id = self::factory()->post->create(
+			[
+				'post_type'    => 'graphql_document',
+				'post_status'  => 'publish',
+				'post_author'  => $this->author_id,
+				'post_title'   => 'Another users saved query',
+				'post_content' => '{ __typename }',
+			]
+		);
+
+		wp_set_current_user( $this->other_user_id );
+
+		$result = graphql(
+			[
+				'query' => '
+					query GetDocuments {
+						graphqlDocuments(where: { stati: [PUBLISH, DRAFT] }) {
+							nodes {
+								databaseId
+							}
+						}
+					}
+				',
+			]
+		);
+
+		$this->assertArrayNotHasKey( 'errors', $result );
+		$this->assertNotContains(
+			$document_id,
+			array_column( $result['data']['graphqlDocuments']['nodes'], 'databaseId' ),
+			'A saved document authored by another user must never resolve in the connection.'
+		);
+	}
+}

--- a/plugins/wp-graphql-ide/tests/wpunit/Schema/AuthorizationTest.php
+++ b/plugins/wp-graphql-ide/tests/wpunit/Schema/AuthorizationTest.php
@@ -2,12 +2,14 @@
 /**
  * Tests for the IDE's GraphQL authorization filters.
  *
- * Two filters together enforce per-user isolation on Smart Cache's
+ * A single filter enforces per-user isolation on Smart Cache's
  * `graphql_document` post type (the IDE's canonical document owner as
- * of 5.0):
- *   - scope_graphql_connections (list-level — filters connection args)
- *   - restrict_post_visibility  (single-node level — marks foreign
- *     records private at the Model layer)
+ * of 5.0): restrict_post_visibility marks foreign records private at
+ * the Model layer, which drops them from connections and nulls them in
+ * single-node lookups alike. (5.0.1–5.4.x also author-scoped connection
+ * query args, but that filter over-matched `post_type: 'any'`
+ * connections and was removed — see issue #4117 and
+ * ConnectionAuthorScopingTest in the wpunit-integration suite.)
  *
  * These tests are the load-bearing security guarantee. If any go red,
  * a user holding `manage_graphql_ide` can read another user's saved
@@ -70,7 +72,8 @@ class AuthorizationTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 	}
 
 	// ---------------------------------------------------------------
-	// Connection scoping — scope_graphql_connections
+	// Connection isolation — restrict_post_visibility drops foreign
+	// documents from connection results
 	// ---------------------------------------------------------------
 
 	public function test_connection_returns_only_current_users_documents() {
@@ -94,7 +97,8 @@ class AuthorizationTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		wp_set_current_user( 0 );
 		$response = $this->graphql( [ 'query' => '{ graphqlDocuments { nodes { title } } }' ] );
 
-		// Anonymous → author = 0, which matches no posts.
+		// Anonymous → every document is foreign, so the model layer marks
+		// each one private and the connection drops them all.
 		$this->assertEmpty( $response['data']['graphqlDocuments']['nodes'] );
 	}
 

--- a/plugins/wp-graphql-ide/wpgraphql-ide.php
+++ b/plugins/wp-graphql-ide/wpgraphql-ide.php
@@ -151,14 +151,18 @@ function initialize_plugin() {
 	// Custom REST routes.
 	add_action( 'rest_api_init', [ \WPGraphQLIDE\Rest::class, 'register' ] );
 
-	// GraphQL: scope Smart Cache `graphqlDocument` connections to the
-	// current user so the IDE's data is queryable from GraphQL but
-	// isolated per user — same contract as the REST endpoints. The
-	// `graphql_data_is_private` filter closes the single-node lookup
-	// hole left by the connection-only filter: without it,
-	// `node(id: "...")` could resolve another user's document if the
-	// requester knew its global ID.
-	add_filter( 'graphql_connection_query_args', [ \WPGraphQLIDE\Access::class, 'scope_graphql_connections' ], 10, 2 );
+	// GraphQL: per-user isolation of Smart Cache `graphqlDocument` data is
+	// enforced at the model layer — another user's document resolves as
+	// private everywhere a model is built (connections, `node(id: "...")`,
+	// nested fields), matching the REST endpoints' contract. The IDE's own
+	// document list additionally passes an `author` where arg client-side
+	// (see `src/api/documents.js`) so its pagination stays correct without
+	// any connection-level scoping. Do not reintroduce author scoping via
+	// `graphql_connection_query_args`: with Smart Cache active,
+	// `graphql_document` is part of every `post_type: 'any'` connection
+	// (core `contentNodes`, ACF relationship fields), and scoping those
+	// query args blanked unrelated authenticated queries.
+	// See https://github.com/wp-graphql/wp-graphql/issues/4117.
 	add_filter( 'graphql_data_is_private', [ \WPGraphQLIDE\Access::class, 'restrict_post_visibility' ], 10, 6 );
 
 	// Strip a deleted document's id from its owner's personal collections.


### PR DESCRIPTION
## What

Fixes #4117

With WPGraphQL IDE and Smart Cache both active, authenticated requests were returning empty results for any connection resolved with post type `'any'`, which includes core `contentNodes` and ACF relationship fields. Posts authored by the requesting user still showed up, everything else disappeared. Public requests were unaffected.

## Why

Smart Cache registers its `graphql_document` post type with `show_in_graphql: true`, so it is part of `WPGraphQL::get_allowed_post_types()`. That means every `post_type: 'any'` connection carries `graphql_document` in its `post_type` query arg.

The IDE (since 5.0.1) hooked `Access::scope_graphql_connections` onto the global `graphql_connection_query_args` filter to keep users from listing each other's saved documents. It matched whenever `graphql_document` appeared anywhere in the `post_type` array, and then forced `author = get_current_user_id()` onto the whole query. So with both plugins active, unrelated queries got silently scoped to the requesting user. Public requests only looked fine because `WP_Query` ignores `author = 0`.

## How

- Removed the connection-level filter entirely. Per-user isolation of saved documents is enforced at the model layer (`Access::restrict_post_visibility` on `graphql_data_is_private`), which covers connections, `node(id:)` lookups, and nested fields alike. That filter already existed and is unchanged.
- The IDE's saved-documents list now states its own scope client-side: `getDocuments` passes an `author` where arg with the viewer's user ID, which keeps the list complete and pagination correct without any server-side connection scoping. Logged-out viewers on the public endpoint send `author: null`, which `WP_Query` ignores, and the model layer hides every document for them anyway.
- Left warnings at both former hook sites against reintroducing author scoping via `graphql_connection_query_args`.

## Testing

- New regression test `tests/wpunit-integration/ConnectionAuthorScopingTest.php`, written first and confirmed failing on exactly the reported bug (authenticated `contentNodes` missing another author's published post). It also pins that another user's saved documents stay private with the connection filter removed.
- New jest cases assert the `author` variable on the wire: the viewer's ID when logged in, null when logged out.
- Full suites green: IDE wpunit (109 tests), wpunit-integration (36), jest (445), PHPStan, PHPCS, ESLint.
- Reproduced the original report on a live wp-env before the fix and confirmed the same query returns the post after it.