### PR TITLE
fix(wp-graphql-ide): rank Docs explorer search results by relevance

### DIFF
--- a/plugins/wp-graphql-ide/src/components/DocsExplorerPanel.jsx
+++ b/plugins/wp-graphql-ide/src/components/DocsExplorerPanel.jsx
@@ -91,6 +91,58 @@ function getTypeKind(type) {
 }
 
 /**
+ * Rank a schema name against a search term.
+ *
+ * @param {string} name  GraphQL type or field name.
+ * @param {string} query Lowercase search term.
+ * @return {number} Relevance rank, where lower is better.
+ */
+function getSearchRank(name, query) {
+	const normalizedName = name.toLowerCase();
+	if (normalizedName === query) {
+		return 0;
+	}
+	if (normalizedName.startsWith(query)) {
+		return 1;
+	}
+
+	let index = normalizedName.indexOf(query);
+	while (index !== -1) {
+		const previous = name[index - 1] || '';
+		const current = name[index] || '';
+		const next = name[index + 1] || '';
+		if (
+			/[^A-Za-z0-9]/.test(previous) ||
+			(/[a-z0-9]/.test(previous) && /[A-Z]/.test(current)) ||
+			(/[A-Z]/.test(previous) &&
+				/[A-Z]/.test(current) &&
+				/[a-z]/.test(next))
+		) {
+			return 2;
+		}
+		index = normalizedName.indexOf(query, index + 1);
+	}
+
+	return 3;
+}
+
+/**
+ * Compare schema names by relevance, then length, then alphabetically.
+ *
+ * @param {string} a     First GraphQL name.
+ * @param {string} b     Second GraphQL name.
+ * @param {string} query Lowercase search term.
+ * @return {number} Sort comparison value.
+ */
+function compareSearchNames(a, b, query) {
+	return (
+		getSearchRank(a, query) - getSearchRank(b, query) ||
+		a.length - b.length ||
+		a.localeCompare(b)
+	);
+}
+
+/**
  * Docs Explorer panel content.
  *
  * Provides a browsable tree of the GraphQL schema — types, fields,
@@ -205,11 +257,12 @@ export function DocsExplorerPanel() {
 				}
 			}
 		}
-		types.sort((a, b) => a.name.localeCompare(b.name));
+		types.sort((a, b) => compareSearchNames(a.name, b.name, q));
 		fields.sort((a, b) => {
-			const aKey = `${a.type.name}.${a.field.name}`;
-			const bKey = `${b.type.name}.${b.field.name}`;
-			return aKey.localeCompare(bKey);
+			return (
+				compareSearchNames(a.field.name, b.field.name, q) ||
+				a.type.name.localeCompare(b.type.name)
+			);
 		});
 		return {
 			typeMatches: types.slice(0, 25),

--- a/plugins/wp-graphql-ide/tests/e2e/specs/docs-explorer.spec.js
+++ b/plugins/wp-graphql-ide/tests/e2e/specs/docs-explorer.spec.js
@@ -72,6 +72,18 @@ test.describe('Docs explorer interface relationships', () => {
 		await openDocsPanel(page);
 	});
 
+	test('search ranks an exact type match first', async ({ page }) => {
+		await page.locator('.wpgraphql-ide-docs-search').fill('Post');
+
+		const types = docsPanel(page)
+			.locator('.wpgraphql-ide-docs-search-group')
+			.filter({ hasText: 'Types' });
+
+		await expect(types.getByRole('button').first()).toHaveAccessibleName(
+			typeRow('Post')
+		);
+	});
+
 	test('object type shows the interfaces it implements', async ({ page }) => {
 		// `DefaultTemplate` (from #4028) is also a unique search match —
 		// broader names like `Page` fall outside the capped result list.

--- a/plugins/wp-graphql-ide/tests/unit/specs/components/DocsExplorerPanel.test.js
+++ b/plugins/wp-graphql-ide/tests/unit/specs/components/DocsExplorerPanel.test.js
@@ -99,6 +99,66 @@ const SDL = /* GraphQL */ `
 	}
 `;
 
+const SEARCH_SDL = /* GraphQL */ `
+	type Post {
+		id: ID
+	}
+
+	type PostFormat {
+		id: ID
+	}
+
+	type CreatePostInput {
+		id: ID
+	}
+
+	type CategoryToPostConnection {
+		id: ID
+	}
+
+	type Compost {
+		id: ID
+	}
+
+	type SearchFields {
+		post: String
+		postStatus: String
+		createPostInput: String
+		categoryToPostConnection: String
+		compost: String
+	}
+
+	type Query {
+		search: SearchFields
+	}
+`;
+
+const cappedTypes = Array.from(
+	{ length: 30 },
+	(_, index) => `type Alpha${index}Target { id: ID }`
+).join('\n');
+const cappedFields = Array.from(
+	{ length: 55 },
+	(_, index) => `alpha${index}Target: String`
+).join('\n');
+const CAPPED_SEARCH_SDL = /* GraphQL */ `
+	type Target {
+		id: ID
+	}
+
+	${cappedTypes}
+
+	type FieldContainer {
+		target: String
+		${cappedFields}
+	}
+
+	type Query {
+		target: Target
+		fields: FieldContainer
+	}
+`;
+
 // Type rows carry a composed accessible name so the kind reaches screen
 // readers too: "Page, Object" in a list that mixes kinds, "query: RootQuery"
 // for a root entry, bare "Node" where neither applies. Match the type name
@@ -134,6 +194,81 @@ function section(title) {
 function sectionToggle(title) {
 	return screen.getByText(title).closest('button');
 }
+
+function searchSchema(term) {
+	fireEvent.change(
+		screen.getByRole('textbox', {
+			name: 'Search GraphQL schema types and fields',
+		}),
+		{ target: { value: term } }
+	);
+}
+
+function searchGroup(title) {
+	return screen.getByText(title).closest('.wpgraphql-ide-docs-search-group');
+}
+
+function fieldPath(row) {
+	const type = row.querySelector('.wpgraphql-ide-docs-field-link-type');
+	const field = row.querySelector('.wpgraphql-ide-docs-field-link-name');
+	return `${type.textContent}.${field.textContent}`;
+}
+
+describe('DocsExplorerPanel — search ranking', () => {
+	beforeEach(() => {
+		__dep.schema = buildSchema(SEARCH_SDL);
+		__dep.docsNavTarget = null;
+		__dep.setDocsNavTarget.mockReset();
+	});
+
+	it('ranks exact, prefix, camel-case segment, and substring type matches', () => {
+		render(<DocsExplorerPanel />);
+		searchSchema('post');
+
+		const names = within(searchGroup('Types'))
+			.getAllByRole('button')
+			.map((row) => row.getAttribute('aria-label'));
+
+		expect(names).toEqual([
+			'Post, Object',
+			'PostFormat, Object',
+			'CreatePostInput, Object',
+			'CategoryToPostConnection, Object',
+			'Compost, Object',
+		]);
+	});
+
+	it('applies the same relevance order to field matches', () => {
+		render(<DocsExplorerPanel />);
+		searchSchema('post');
+
+		const paths = within(searchGroup('Fields'))
+			.getAllByRole('button')
+			.map(fieldPath);
+
+		expect(paths).toEqual([
+			'SearchFields.post',
+			'SearchFields.postStatus',
+			'SearchFields.createPostInput',
+			'SearchFields.categoryToPostConnection',
+			'SearchFields.compost',
+		]);
+	});
+
+	it('applies result caps after ranking', () => {
+		__dep.schema = buildSchema(CAPPED_SEARCH_SDL);
+		render(<DocsExplorerPanel />);
+		searchSchema('target');
+
+		const typeRows = within(searchGroup('Types')).getAllByRole('button');
+		expect(typeRows).toHaveLength(25);
+		expect(typeRows[0]).toHaveAccessibleName('Target, Object');
+
+		const fieldRows = within(searchGroup('Fields')).getAllByRole('button');
+		expect(fieldRows).toHaveLength(50);
+		expect(fieldPath(fieldRows[0])).toBe('FieldContainer.target');
+	});
+});
 
 describe('DocsExplorerPanel — interface relationships', () => {
 	beforeEach(() => {


### PR DESCRIPTION
## What bug does this fix? Explain your changes.

Docs Explorer search matched names by substring and then sorted them alphabetically. Searching for `Post` put `CategoryToPostConnection` first and the exact `Post` type well down the list. Because results are limited to 25 types and 50 fields, an exact match could also disappear entirely when enough earlier names matched.

This changes both type and field results to rank by relevance:

1. Exact match (case-insensitive)
2. Prefix match
3. GraphQL name-segment match, including camel-case and underscore boundaries
4. Plain substring match

Shorter names win within a tier, followed by alphabetical order. The existing result limits remain unchanged and are applied after ranking.

## Does this close any currently open issues?

Closes #4108.

## Testing Strategy

The regression tests were written first. Before the implementation, the new Jest cases failed on type ordering, field ordering, and capped results; the new Playwright case received `CategoryToPostConnection` where it expected `Post`.

### Test Results

- [x] **Failing test added**: The first commit covers the reported behavior before changing the implementation.
- [x] **Fix implemented**: A shared comparator now ranks type and field names before slicing the result lists.
- [x] **All tests passing**: The full IDE unit suite passes (44 suites, 448 tests).
- [x] **Regression tests**: Jest covers each relevance tier and both result caps; Playwright covers the live `Post` search.

### Test Links (if applicable)

Local verification:

- JavaScript lint passed.
- Production build passed.
- Complete Docs Explorer browser spec passed (9 tests).

## Before/After Examples

### Before (Buggy Behavior)

Searching for `Post` showed `CategoryToPostConnection` as the first type result. Exact matches that sorted late could be removed by the result cap.

### After (Fixed Behavior)

The same search shows `Post` first, followed by prefix, GraphQL name-segment, and substring matches. Types and fields remain in their existing separate groups.

## Additional Context

This changes result ordering only. It adds no dependency and does not alter the GraphQL schema, public APIs, or result limits. There are no breaking changes.

Fuzzy matching, match highlighting, type-kind weighting, and a show-more affordance remain possible follow-ups outside this focused fix.
