### PR TITLE
fix(wpgraphql.com): bundle @docsearch/react into the server build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44431,7 +44431,7 @@
 		},
 		"plugins/wp-graphql": {
 			"name": "@wpgraphql/wp-graphql",
-			"version": "2.18.0",
+			"version": "2.19.0",
 			"dependencies": {
 				"@ant-design/icons": "6.3.2",
 				"@apollo/client": "3.14.1",
@@ -44775,7 +44775,7 @@
 		},
 		"plugins/wp-graphql-ide": {
 			"name": "@wpgraphql/wp-graphql-ide",
-			"version": "5.3.0",
+			"version": "5.4.0",
 			"dependencies": {
 				"@codemirror/autocomplete": "^6.20.3",
 				"@codemirror/commands": "^6.10.4",

--- a/websites/wpgraphql.com/next.config.js
+++ b/websites/wpgraphql.com/next.config.js
@@ -33,6 +33,11 @@ const getHeaders = async () => {
 /** @type {import('next').NextConfig} */
 const nextConfig = withBundleAnalyzer({
   pageExtensions: ["ts", "tsx", "js", "jsx"],
+  // @docsearch/react v4 is ESM-only (its exports map has no `require`
+  // condition), so the serverless runtime crashes require()ing it during
+  // on-demand ISR renders. Bundling it into the server build avoids the
+  // runtime require entirely.
+  transpilePackages: ["@docsearch/react"],
   images: {
     remotePatterns: [
       { protocol: "https", hostname: "secure.gravatar.com" },

--- a/websites/wpgraphql.com/tests/e2e/blog.spec.js
+++ b/websites/wpgraphql.com/tests/e2e/blog.spec.js
@@ -1,0 +1,29 @@
+/**
+ * E2E tests for the wpgraphql.com blog archive.
+ *
+ * /blog resolves through the [...wordpressNode] catch-all, which uses
+ * fallback: "blocking" with no prerendered paths, so it only renders on
+ * demand. A crash anywhere in the shared server bundle surfaces on these
+ * on-demand routes, while build-time prerendered pages keep serving from
+ * cache.
+ */
+import { test, expect } from "@playwright/test"
+
+test.describe("Blog archive", () => {
+  test("renders on demand with a list of posts", async ({ page }) => {
+    const response = await page.goto("/blog", {
+      waitUntil: "domcontentloaded",
+      timeout: 30000,
+    })
+
+    expect(response?.status()).toBe(200)
+
+    await expect(
+      page.getByRole("heading", { name: "Blog", level: 1 })
+    ).toBeVisible({ timeout: 10000 })
+
+    // Post previews link to dated permalinks like /2025/02/13/slug/
+    const postLinks = page.locator('main a[href*="/20"]')
+    expect(await postLinks.count()).toBeGreaterThan(0)
+  })
+})

--- a/websites/wpgraphql.com/tests/e2e/search.spec.js
+++ b/websites/wpgraphql.com/tests/e2e/search.spec.js
@@ -1,0 +1,55 @@
+/**
+ * E2E tests for the site search (Algolia DocSearch).
+ *
+ * The DocSearch modal only mounts client-side, so build-time checks never
+ * exercise it; these tests are what proves a @docsearch/react upgrade
+ * actually works in the browser. Queries hit the live Algolia index, same
+ * as the rest of the e2e suite hits live site data.
+ */
+import { test, expect } from "@playwright/test"
+
+test.describe("Site search", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/", { waitUntil: "domcontentloaded", timeout: 30000 })
+    await page.waitForLoadState("networkidle", { timeout: 30000 })
+  })
+
+  test("opens the search modal from the header button", async ({ page }) => {
+    await page.getByRole("button", { name: "Search" }).click()
+
+    await expect(page.locator(".DocSearch-Modal")).toBeVisible({
+      timeout: 10000,
+    })
+    await expect(page.locator(".DocSearch-Input")).toBeFocused()
+  })
+
+  test("opens the search modal with the keyboard shortcut", async ({
+    page,
+  }) => {
+    await page.keyboard.press("ControlOrMeta+k")
+
+    await expect(page.locator(".DocSearch-Modal")).toBeVisible({
+      timeout: 10000,
+    })
+  })
+
+  test("returns results for a query and closes on Escape", async ({ page }) => {
+    await page.getByRole("button", { name: "Search" }).click()
+    await page.locator(".DocSearch-Input").fill("interface")
+
+    // Results come from the live Algolia index, so allow for network time.
+    const hits = page.locator(".DocSearch-Hit a[href]")
+    await expect(hits.first()).toBeVisible({ timeout: 15000 })
+
+    // Hits should link somewhere real on the site. Hrefs are absolute
+    // production URLs, so assert rather than click (a click would
+    // navigate the test away from the server under test).
+    const href = await hits.first().getAttribute("href")
+    expect(href).toContain("wpgraphql.com")
+
+    await page.keyboard.press("Escape")
+    await expect(page.locator(".DocSearch-Modal")).toBeHidden({
+      timeout: 10000,
+    })
+  })
+})


### PR DESCRIPTION
## What

wpgraphql.com/blog (and any other page rendered on demand) has been returning a 500 in production. This adds `transpilePackages: ["@docsearch/react"]` to the site's `next.config.js` so webpack bundles the package into the server build instead of leaving a runtime `require()`, and adds e2e coverage for the blog archive and the search modal.

## Why

Dependabot bumped `@docsearch/react` from 3.x to 4.6.3. v4 is ESM-only, its `exports` map points `.` at `dist/esm/index.js` with no `require` condition and no `"type": "module"`. The Pages Router externalizes `node_modules` in the server build, so the built `_app.js` contained a literal `require("@docsearch/react")` executed at request time. Vercel's serverless module loader compiles that ESM file as CommonJS and throws:

```
SyntaxError: Cannot use import statement outside a module
    at /var/task/node_modules/ (docsearch/react/dist/esm/index.js:1)
```

Since the import lives in `_app`, every on-demand render crashed. Pages prerendered at build time (home, docs) kept serving from the ISR cache, but `/blog` goes through the `[...wordpressNode]` catch-all with `fallback: "blocking"` and no prerendered paths, so a redeploy cleared its cache and the next request rendered live and 500'd.

This never reproduced locally for two reasons: stale local `node_modules` still had docsearch 3.9.0, and even on 4.6.3, Node 22's module loader detects ESM syntax in ambiguous files and tolerates the `require`. Only Vercel's bytecode-caching loader chokes.

## Verification

- Before the fix, `.next/server/pages/_app.js` contained `require("@docsearch/react")` and the file trace shipped `dist/esm/index.js` to the lambda. After the fix, no `require("@docsearch/*")` remains anywhere in the server output (`@docsearch/core` declares `"type": "module"` so webpack bundles it too).
- The Vercel preview deployment for this branch serves `/blog` with a 200, which is the fix proven on the same serverless runtime where production crashes.
- `next build` + `next start` locally on Node 22: `/blog`, `/`, and `/docs/introduction` all serve 200.

## Tests

The crash itself is only reproducible in Vercel's runtime, so no local test can regress-guard the exact failure, but these cover the surfaces this bug and this upgrade put at risk:

- `tests/e2e/blog.spec.js`: `/blog` renders on demand with a 200 and a list of post links, exercising the catch-all path where server-bundle crashes surface.
- `tests/e2e/search.spec.js`: opens the DocSearch modal via the header button and the keyboard shortcut, gets results for a query from the live Algolia index, and closes on Escape. The modal only mounts client-side, so this is the first check that actually proves the docsearch v4 UI works in a browser.

Also includes a 2-line `package-lock.json` sync of workspace versions (2.18.0 to 2.19.0, 5.3.0 to 5.4.0) that release commits had left stale.
