### PR TITLE
fix: resolve menu(idType: LOCATION) when given a MenuLocationEnum name

### DIFF
--- a/plugins/wp-graphql/src/Type/ObjectType/RootQuery.php
+++ b/plugins/wp-graphql/src/Type/ObjectType/RootQuery.php
@@ -16,6 +16,7 @@ use WPGraphQL\Data\Connection\UserRoleConnectionResolver;
 use WPGraphQL\Data\DataSource;
 use WPGraphQL\Model\Post;
 use WPGraphQL\Type\Connection\PostObjects;
+use WPGraphQL\Type\WPEnumType;
 use WPGraphQL\Utils\Utils;
 
 /**
@@ -434,12 +435,27 @@ class RootQuery {
 										break;
 									case 'location':
 										$locations = get_nav_menu_locations();
+										$location  = (string) $args['id'];
 
-										if ( ! isset( $locations[ $args['id'] ] ) || ! absint( $locations[ $args['id'] ] ) ) {
+										// The schema's vocabulary for menu locations is the
+										// MenuLocationEnum name (e.g. MY_LOCATION for a location
+										// registered as my-location), but the `id` arg is an ID
+										// scalar, so no enum-to-value coercion happens. Accept the
+										// enum-style name by mapping it back to the registered key.
+										if ( ! isset( $locations[ $location ] ) ) {
+											foreach ( array_keys( $locations ) as $registered_location ) {
+												if ( WPEnumType::get_safe_name( (string) $registered_location ) === $location ) {
+													$location = (string) $registered_location;
+													break;
+												}
+											}
+										}
+
+										if ( ! isset( $locations[ $location ] ) || ! absint( $locations[ $location ] ) ) {
 											throw new UserError( esc_html__( 'No menu set for the provided location', 'wp-graphql' ) );
 										}
 
-										$id = absint( $locations[ $args['id'] ] );
+										$id = absint( $locations[ $location ] );
 										break;
 									case 'name':
 										$menu = new \WP_Term_Query(

--- a/plugins/wp-graphql/tests/wpunit/MenuQueriesTest.php
+++ b/plugins/wp-graphql/tests/wpunit/MenuQueriesTest.php
@@ -151,6 +151,24 @@ class MenuQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->assertEquals( WPEnumType::get_safe_name( array_search( $this->menu_id, $locations, true ) ), $actual['data']['menu']['locations'][0] );
 	}
 
+	public function testMenuQueryByLocationEnumName() {
+		set_theme_mod( 'nav_menu_locations', [ $this->location_name => $this->menu_id ] );
+
+		$query = $this->get_query();
+
+		// The schema exposes menu locations as MenuLocationEnum names (e.g.
+		// TEST_LOCATION for a location registered as test-location), so the
+		// enum-style name must resolve the same menu as the raw location key.
+		$variables = [
+			'id'     => WPEnumType::get_safe_name( $this->location_name ),
+			'idType' => 'LOCATION',
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertEquals( $this->menu_id, $actual['data']['menu']['databaseId'] );
+	}
+
 	public function testUnicodeSlugsAreDecoded() {
 		$unicode_slug = 'חדשות';
 		$menu_id      = wp_create_nav_menu( $unicode_slug );


### PR DESCRIPTION
## What

Fixes `menu(idType: LOCATION)` so it resolves when given a menu location's `MenuLocationEnum`-style name (e.g. `WEBPORTRAY_PRIMARY`), not just the raw registered key (`webportray_primary`).

Fixes #4162

## Why

The `menu` field's `id` arg is an `ID` scalar, so GraphQL never coerces an enum name back to its underlying value the way it does for `menus(where: { location })`. But the enum vocabulary is what the schema teaches: introspecting `MenuLocationEnum` shows `WEBPORTRAY_PRIMARY`, and the `Menu.locations` field returns those same enum-style names. Feeding that name back into `menu(idType: LOCATION)` hit a literal, case-sensitive array lookup against the registered key and failed with "No menu set for the provided location".

This isn't specific to plugin-registered locations. Any location whose registered key differs from its SCREAMING_SNAKE enum form fails the same way, including a theme location registered as `menu-1` queried as `MENU_1`.

## How

In the `location` case of the `menu` resolver, try the raw registered key first (fully backward compatible), and if that misses, map the enum-safe name back to a registered location key via `WPEnumType::get_safe_name()` before giving up. Unmatched input still throws the same `UserError`.

## Testing

- New regression test `testMenuQueryByLocationEnumName` queries by `TEST_LOCATION` for a location registered as `test-location`, covering both the case folding and the hyphen to underscore mapping. It fails before the fix and passes after.
- Existing `testMenuQueryByLocation` (raw key) and the rest of `MenuQueriesTest` still pass (4 tests, 26 assertions).
- PHPCS clean, PHPStan level 8 clean.
