### PR TITLE
fix(wpgraphql.com): pin eslint to v9 to unbreak Website Lint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -120,6 +120,15 @@ updates:
       # minor/patch updates within v16 still flow normally.
       - dependency-name: 'graphql'
         update-types: ['version-update:semver-major']
+      # eslint v10 requires @typescript-eslint v8+ across the whole install,
+      # but npm hoists @typescript-eslint v6 to the monorepo root via
+      # @wordpress/scripts in the plugin workspaces, and eslint 10 crashes
+      # loading its scope-manager (scopeManager.addGlobals is not a
+      # function). The wpgraphql.com workspace pins eslint ^9 (see the
+      # header of its eslint.config.js). Drop this ignore when
+      # @wordpress/scripts ships a typescript-eslint v8+ tree.
+      - dependency-name: 'eslint'
+        update-types: ['version-update:semver-major']
     groups:
       npm-dev-minor-patch:
         dependency-type: 'development'

--- a/package-lock.json
+++ b/package-lock.json
@@ -44431,7 +44431,7 @@
 		},
 		"plugins/wp-graphql": {
 			"name": "@wpgraphql/wp-graphql",
-			"version": "2.18.0",
+			"version": "2.19.0",
 			"dependencies": {
 				"@ant-design/icons": "6.3.2",
 				"@apollo/client": "3.14.1",
@@ -44775,7 +44775,7 @@
 		},
 		"plugins/wp-graphql-ide": {
 			"name": "@wpgraphql/wp-graphql-ide",
-			"version": "5.3.0",
+			"version": "5.4.1",
 			"dependencies": {
 				"@codemirror/autocomplete": "^6.20.3",
 				"@codemirror/commands": "^6.10.4",
@@ -47927,7 +47927,7 @@
 			"devDependencies": {
 				"@next/eslint-plugin-next": "^16.2.12",
 				"@playwright/test": "^1.62.0",
-				"eslint": "^10.8.0",
+				"eslint": "^9.39.5",
 				"eslint-config-next": "^16.2.10",
 				"eslint-config-prettier": "^10.1.8",
 				"eslint-plugin-unused-imports": "^4.4.1",
@@ -47939,6 +47939,183 @@
 				"prettier": "^3.9.6",
 				"tailwindcss": "^4.2.4",
 				"typescript": "^5.9.3"
+			}
+		},
+		"websites/wpgraphql.com/node_modules/@eslint/config-array": {
+			"version": "0.21.2",
+			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+			"integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@eslint/object-schema": "^2.1.7",
+				"debug": "^4.3.1",
+				"minimatch": "^3.1.5"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"websites/wpgraphql.com/node_modules/@eslint/config-array/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"websites/wpgraphql.com/node_modules/@eslint/config-array/node_modules/brace-expansion": {
+			"version": "1.1.18",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"websites/wpgraphql.com/node_modules/@eslint/config-array/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"websites/wpgraphql.com/node_modules/@eslint/config-helpers": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+			"integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@eslint/core": "^0.17.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"websites/wpgraphql.com/node_modules/@eslint/core": {
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+			"integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@types/json-schema": "^7.0.15"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"websites/wpgraphql.com/node_modules/@eslint/eslintrc": {
+			"version": "3.3.6",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+			"integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ajv": "^6.14.0",
+				"debug": "^4.3.2",
+				"espree": "^10.0.1",
+				"globals": "^14.0.0",
+				"ignore": "^5.2.0",
+				"import-fresh": "^3.2.1",
+				"js-yaml": "^4.3.0",
+				"minimatch": "^3.1.5",
+				"strip-json-comments": "^3.1.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"websites/wpgraphql.com/node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"websites/wpgraphql.com/node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+			"version": "1.1.18",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"websites/wpgraphql.com/node_modules/@eslint/eslintrc/node_modules/globals": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+			"integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"websites/wpgraphql.com/node_modules/@eslint/eslintrc/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"websites/wpgraphql.com/node_modules/@eslint/js": {
+			"version": "9.39.5",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+			"integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://eslint.org/donate"
+			}
+		},
+		"websites/wpgraphql.com/node_modules/@eslint/object-schema": {
+			"version": "2.1.7",
+			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+			"integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"websites/wpgraphql.com/node_modules/@eslint/plugin-kit": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+			"integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@eslint/core": "^0.17.0",
+				"levn": "^0.4.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
 		"websites/wpgraphql.com/node_modules/@next/eslint-plugin-next": {
@@ -48051,6 +48228,29 @@
 				"url": "https://github.com/sponsors/epoberezkin"
 			}
 		},
+		"websites/wpgraphql.com/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"websites/wpgraphql.com/node_modules/argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true,
+			"license": "Python-2.0"
+		},
 		"websites/wpgraphql.com/node_modules/balanced-match": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -48074,34 +48274,51 @@
 				"node": "18 || 20 || >=22"
 			}
 		},
-		"websites/wpgraphql.com/node_modules/eslint": {
-			"version": "10.8.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
-			"integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
+		"websites/wpgraphql.com/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
 			"dev": true,
 			"license": "MIT",
-			"workspaces": [
-				"packages/*"
-			],
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"websites/wpgraphql.com/node_modules/eslint": {
+			"version": "9.39.5",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+			"integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
+			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
-				"@eslint-community/regexpp": "^4.12.2",
-				"@eslint/config-array": "^0.23.5",
-				"@eslint/config-helpers": "^0.7.0",
-				"@eslint/core": "^1.2.1",
-				"@eslint/plugin-kit": "^0.7.2",
+				"@eslint-community/regexpp": "^4.12.1",
+				"@eslint/config-array": "^0.21.2",
+				"@eslint/config-helpers": "^0.4.2",
+				"@eslint/core": "^0.17.0",
+				"@eslint/eslintrc": "^3.3.6",
+				"@eslint/js": "9.39.5",
+				"@eslint/plugin-kit": "^0.4.1",
 				"@humanfs/node": "^0.16.6",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@humanwhocodes/retry": "^0.4.2",
 				"@types/estree": "^1.0.6",
 				"ajv": "^6.14.0",
+				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.6",
 				"debug": "^4.3.2",
 				"escape-string-regexp": "^4.0.0",
-				"eslint-scope": "^9.1.2",
-				"eslint-visitor-keys": "^5.0.1",
-				"espree": "^11.2.0",
-				"esquery": "^1.7.0",
+				"eslint-scope": "^8.4.0",
+				"eslint-visitor-keys": "^4.2.1",
+				"espree": "^10.4.0",
+				"esquery": "^1.5.0",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^8.0.0",
@@ -48111,7 +48328,8 @@
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
-				"minimatch": "^10.2.5",
+				"lodash.merge": "^4.6.2",
+				"minimatch": "^3.1.5",
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.9.3"
 			},
@@ -48119,7 +48337,7 @@
 				"eslint": "bin/eslint.js"
 			},
 			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"url": "https://eslint.org/donate"
@@ -48423,19 +48641,17 @@
 			}
 		},
 		"websites/wpgraphql.com/node_modules/eslint-scope": {
-			"version": "9.1.2",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
-			"integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+			"version": "8.4.0",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+			"integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"@types/esrecurse": "^4.3.1",
-				"@types/estree": "^1.0.8",
 				"esrecurse": "^4.3.0",
 				"estraverse": "^5.2.0"
 			},
 			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
@@ -48454,19 +48670,76 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
+		"websites/wpgraphql.com/node_modules/eslint/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"websites/wpgraphql.com/node_modules/eslint/node_modules/brace-expansion": {
+			"version": "1.1.18",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"websites/wpgraphql.com/node_modules/eslint/node_modules/eslint-visitor-keys": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"websites/wpgraphql.com/node_modules/eslint/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
 		"websites/wpgraphql.com/node_modules/espree": {
-			"version": "11.2.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
-			"integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+			"integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"acorn": "^8.16.0",
+				"acorn": "^8.15.0",
 				"acorn-jsx": "^5.3.2",
-				"eslint-visitor-keys": "^5.0.1"
+				"eslint-visitor-keys": "^4.2.1"
 			},
 			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"websites/wpgraphql.com/node_modules/espree/node_modules/eslint-visitor-keys": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
@@ -48576,6 +48849,29 @@
 				"hermes-estree": "0.25.1"
 			}
 		},
+		"websites/wpgraphql.com/node_modules/js-yaml": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+			"integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"argparse": "^2.0.1"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
 		"websites/wpgraphql.com/node_modules/json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -48660,6 +48956,19 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"websites/wpgraphql.com/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		}
 	}

--- a/websites/wpgraphql.com/eslint.config.js
+++ b/websites/wpgraphql.com/eslint.config.js
@@ -1,9 +1,15 @@
 /**
  * ESLint flat config for wpgraphql.com (Next.js app).
  *
- * Flat config for ESLint 10 — the legacy `.eslintrc` format and the
- * `next lint` command were both removed, so we run the ESLint CLI directly
- * (`eslint .`) against a flat config, mirroring the wp-graphql-acf migration.
+ * Flat config, run via the ESLint CLI directly (`eslint .`) rather than the
+ * removed `next lint` command, mirroring the wp-graphql-acf migration.
+ *
+ * ESLint is pinned to v9 for now: v10 requires @typescript-eslint v8+
+ * everywhere, but npm hoists @typescript-eslint v6 to the monorepo root
+ * (via @wordpress/scripts in the plugin workspaces), and ESLint 10 crashes
+ * loading its scope-manager (`scopeManager.addGlobals is not a function`).
+ * Unpin when @wordpress/scripts ships a typescript-eslint v8+ tree. The
+ * dependabot ignore for the eslint major lives in .github/dependabot.yml.
  *
  * Layers:
  *   - eslint-config-next/core-web-vitals — Next's React / hooks / a11y /

--- a/websites/wpgraphql.com/package.json
+++ b/websites/wpgraphql.com/package.json
@@ -67,7 +67,7 @@
   "devDependencies": {
     "@next/eslint-plugin-next": "^16.2.12",
     "@playwright/test": "^1.62.0",
-    "eslint": "^10.8.0",
+    "eslint": "^9.39.5",
     "eslint-config-next": "^16.2.10",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-unused-imports": "^4.4.1",


### PR DESCRIPTION
## What

Unbreaks the Website Lint check, red on every PR since #4140, by pinning the wpgraphql.com workspace to eslint ^9.39.5 and adding a dependabot ignore for the eslint semver-major.

## Why

eslint 10 crashes before linting a single file:

```
TypeError: scopeManager.addGlobals is not a function
```

This is a monorepo hoisting conflict, not a config problem. eslint 10 requires @typescript-eslint v8+ across the whole install, but npm hoists @typescript-eslint v6 to the repo root via @wordpress/scripts in the plugin workspaces:

```
├─┬ @wordpress/scripts@27.9.0
│ └─┬ @wordpress/eslint-plugin@18.1.0
│   └── @typescript-eslint/parser@6.21.0   <- hoisted to root
└─┬ @wpgraphql/wpgraphql-com
  └─┬ eslint-config-next@16.2.x
    └── typescript-eslint@8.x              <- what the website needs
```

eslint 10 ends up loading the v6 scope-manager, which predates the `addGlobals` API. Bumping eslint-config-next to 16.3 was tested and does not help, the stray v6 tree is still hoisted.

## How

- `websites/wpgraphql.com/package.json`: eslint pinned to `^9.39.5`, the last working version. The flat config is unchanged and works on v9.
- `.github/dependabot.yml`: ignore `version-update:semver-major` for eslint, in the same documented style as the existing graphql v17 ignore.
- Both changes carry comments stating the unpin condition: @wordpress/scripts shipping a typescript-eslint v8+ tree.

## Verification

- On this branch before the pin: `npm run -w @wpgraphql/wpgraphql-com test:lint` reproduces the crash with eslint 10.8.
- After the pin: lint completes with 0 errors and 3 pre-existing react-hooks warnings, which do not fail the check (no `--max-warnings` in the script or workflow). Exit code 0.
