### PR TITLE
ci: report required website checks on PRs without website changes

### DIFF
--- a/.github/workflows/website-e2e-tests.yml
+++ b/.github/workflows/website-e2e-tests.yml
@@ -10,15 +10,14 @@ on:
       - '.github/workflows/website-e2e-tests.yml'
       - 'package.json'
       - 'package-lock.json'
+  # No `paths` filter on pull_request: the `Website E2E Tests` status-check job
+  # is a required check, so it must report on every PR. Change detection happens
+  # in the detect-changes job below; PRs without website changes skip the e2e
+  # job and the status check passes.
   pull_request:
     branches:
       - main
       - release/*
-    paths:
-      - 'websites/wpgraphql.com/**'
-      - '.github/workflows/website-e2e-tests.yml'
-      - 'package.json'
-      - 'package-lock.json'
   workflow_dispatch:
 
 # Cancel previous workflow run groups that have not completed.
@@ -172,13 +171,22 @@ jobs:
     steps:
       - name: Check website e2e test results
         run: |
-          # Check if any required jobs failed (excluding skipped)
-          if [ "${{ needs.wpgraphql-com.result }}" == "failure" ]; then
-            echo "❌ wpgraphql.com e2e tests failed"
+          # Allowlist the outcomes that mean success. Anything else (failure,
+          # cancelled, or a broken detect-changes job) must fail this required
+          # check rather than silently passing.
+          if [ "${{ needs.detect-changes.result }}" != "success" ]; then
+            echo "❌ Change detection did not succeed (${{ needs.detect-changes.result }})"
             exit 1
           fi
-          # Allow skipped jobs (expected when files don't change)
-          if [ "${{ needs.wpgraphql-com.result }}" == "skipped" ]; then
-            echo "ℹ️ wpgraphql.com e2e tests skipped (no changes detected)"
-          fi
-          echo "✅ All required website e2e tests passed"
+          case "${{ needs.wpgraphql-com.result }}" in
+            success)
+              echo "✅ wpgraphql.com e2e tests passed"
+              ;;
+            skipped)
+              echo "ℹ️ wpgraphql.com e2e tests skipped (no changes detected)"
+              ;;
+            *)
+              echo "❌ wpgraphql.com e2e tests did not succeed (${{ needs.wpgraphql-com.result }})"
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/website-lint.yml
+++ b/.github/workflows/website-lint.yml
@@ -10,15 +10,14 @@ on:
       - '.github/workflows/website-lint.yml'
       - 'package.json'
       - 'package-lock.json'
+  # No `paths` filter on pull_request: the `Website Lint` status-check job is a
+  # required check, so it must report on every PR. Change detection happens in
+  # the detect-changes job below; PRs without website changes skip the lint job
+  # and the status check passes.
   pull_request:
     branches:
       - main
       - release/*
-    paths:
-      - 'websites/wpgraphql.com/**'
-      - '.github/workflows/website-lint.yml'
-      - 'package.json'
-      - 'package-lock.json'
   workflow_dispatch:
 
 # Cancel previous workflow run groups that have not completed.
@@ -110,13 +109,22 @@ jobs:
     steps:
       - name: Check website lint results
         run: |
-          # Check if any required jobs failed (excluding skipped)
-          if [ "${{ needs.wpgraphql-com.result }}" == "failure" ]; then
-            echo "❌ wpgraphql.com lint failed"
+          # Allowlist the outcomes that mean success. Anything else (failure,
+          # cancelled, or a broken detect-changes job) must fail this required
+          # check rather than silently passing.
+          if [ "${{ needs.detect-changes.result }}" != "success" ]; then
+            echo "❌ Change detection did not succeed (${{ needs.detect-changes.result }})"
             exit 1
           fi
-          # Allow skipped jobs (expected when files don't change)
-          if [ "${{ needs.wpgraphql-com.result }}" == "skipped" ]; then
-            echo "ℹ️ wpgraphql.com lint skipped (no changes detected)"
-          fi
-          echo "✅ All required website lint checks passed"
+          case "${{ needs.wpgraphql-com.result }}" in
+            success)
+              echo "✅ wpgraphql.com lint passed"
+              ;;
+            skipped)
+              echo "ℹ️ wpgraphql.com lint skipped (no changes detected)"
+              ;;
+            *)
+              echo "❌ wpgraphql.com lint did not succeed (${{ needs.wpgraphql-com.result }})"
+              exit 1
+              ;;
+          esac


### PR DESCRIPTION
## What does this fix?

\`Website Lint\` and \`Website E2E Tests\` are required status checks on \`main\`, but both workflows had a top-level \`paths:\` filter on their \`pull_request\` trigger. On any PR that does not touch those paths (for example #4169), the workflows never run, the required contexts never report, and the PR blocks forever on "Expected — Waiting for status to be reported."

Both workflows already do change detection internally (the \`detect-changes\` job gates the real lint/e2e jobs, and the \`status-check\` aggregate passes when they are skipped), so the top-level filter was redundant on PRs and is the only thing preventing the required check from reporting.

## Changes

- Remove the \`paths:\` filter from the \`pull_request\` trigger in both workflows, with a comment explaining why it must stay off. The \`push\` trigger keeps its filter since no required check depends on push events.
- Harden both \`status-check\` jobs while touching them: they previously failed only on \`result == "failure"\`, so a failed \`detect-changes\` job (which skips the downstream job) or a cancelled job would let the required check pass green with nothing having run. They now allowlist \`success\` and \`skipped\` and fail on everything else.

On a PR with no website changes the workflows now cost two ~15 second jobs (\`detect-changes\` + \`status-check\`) and report passing, which unblocks merges.

## Notes / follow-ups

- The internal \`detect-changes\` file lists don't include \`.nvmrc\` (a Node version bump wouldn't re-run website lint/e2e). The \`js-*\` workflows share that gap, so leaving it for a follow-up rather than fixing it inconsistently here.
- The other six required checks (Integration Tests, Lint, Schema Linter, Smoke Test, JS Unit/E2E Tests) already run unfiltered with internal change detection; the two website workflows were the only required checks with this problem.