### PR TITLE
test: adapt WPUnit suites to WordPress 7.1 trunk changes

### DIFF
--- a/plugins/wp-graphql-ide/tests/wpunit/ScriptEnqueueTest.php
+++ b/plugins/wp-graphql-ide/tests/wpunit/ScriptEnqueueTest.php
@@ -26,6 +26,20 @@ class ScriptEnqueueTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 			$this->setExpectedIncorrectUsage( 'WP_Block_Bindings_Registry::register' );
 		}
 
+		// WordPress 7.1 introduces the Icons API and registers the core icon
+		// collection during `init`. This suite fires `init` again below (to
+		// ensure WPGraphQL registration has run), which re-registers it and
+		// produces "already registered" incorrect usage notices (added in
+		// 7.1.0) for both registries. Unrelated to the IDE, so declare them as
+		// expected, scoped to just these two notices. The boundary is
+		// '7.1-alpha' (not '7.1') so the expectation also applies to trunk
+		// builds, whose version strings like '7.1-alpha-12345' compare lower
+		// than plain '7.1'.
+		if ( version_compare( $GLOBALS['wp_version'], '7.1-alpha', '>=' ) ) {
+			$this->setExpectedIncorrectUsage( 'WP_Icon_Collections_Registry::register' );
+			$this->setExpectedIncorrectUsage( 'WP_Icons_Registry::register' );
+		}
+
 		// Suppress doing_it_wrong notices before parent::setUp() to catch theme notices early.
 		//
 		// This prevents false failures from theme-related notices that are unrelated to

--- a/plugins/wp-graphql/docs/testing.md
+++ b/plugins/wp-graphql/docs/testing.md
@@ -103,6 +103,27 @@ npm run -w @wpgraphql/wp-graphql test:codecept:wpunit -- --debug
 TEST_THEME=twentytwentyfive npm run -w @wpgraphql/wp-graphql test:codecept:wpunit
 ```
 
+## Mocking Outbound HTTP in Tests
+
+Tests that exercise code which fetches remote URLs (for example, media sideloading) must never make real network requests. The convention is:
+
+- **Use RFC 5737 TEST-NET addresses** for any URL the test fabricates: `192.0.2.0/24` (TEST-NET-1), `198.51.100.0/24` (TEST-NET-2), or `203.0.113.0/24` (TEST-NET-3). These ranges are reserved for documentation and are guaranteed never to route to a real host, so even if a mock fails to intercept, no traffic leaves the machine.
+- **Intercept the request** with the `pre_http_request` filter and return a fabricated response.
+- **Allow the host through URL validation.** Since WordPress 7.1, `wp_http_validate_url()` rejects reserved and documentation IP ranges (including the TEST-NET blocks), so any URL that passes through `wp_safe_remote_get()` / `download_url()` is rejected before your `pre_http_request` mock ever runs. Explicitly allow the specific test host via the `http_request_host_is_external` filter:
+
+```php
+$allow_test_net = static function ( $external, $host ) {
+	return '203.0.113.42' === $host ? true : $external;
+};
+add_filter( 'http_request_host_is_external', $allow_test_net, 10, 2 );
+
+// ... run the code under test ...
+
+remove_filter( 'http_request_host_is_external', $allow_test_net, 10 );
+```
+
+Scope the filter to the exact host the test uses (don't return `true` unconditionally), and remove it when the test is done. See `tests/wpunit/MediaItemMutationsTest.php::testCreateMediaItemSideloadFailureIsSurfaced` for a complete example.
+
 ## Smoke Tests
 
 Smoke tests are lightweight tests that verify the plugin works correctly without running the full test suite. They're useful for quickly validating builds.

--- a/plugins/wp-graphql/tests/wpunit/I18nTest.php
+++ b/plugins/wp-graphql/tests/wpunit/I18nTest.php
@@ -34,6 +34,19 @@ class I18nTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 			$this->setExpectedIncorrectUsage( 'WP_Block_Type_Registry::register' );
 		}
 
+		// WordPress 7.1 introduces the Icons API and registers the core icon
+		// collection during `init`. The second `init` fire in this suite
+		// re-registers it, producing "already registered" incorrect usage
+		// notices (added in 7.1.0) for both registries. Unrelated to WPGraphQL
+		// i18n, so declare them as expected, again scoped to just these two
+		// notices. The boundary is '7.1-alpha' (not '7.1') so the expectation
+		// also applies to trunk builds, whose version strings like
+		// '7.1-alpha-12345' compare lower than plain '7.1'.
+		if ( version_compare( $GLOBALS['wp_version'], '7.1-alpha', '>=' ) ) {
+			$this->setExpectedIncorrectUsage( 'WP_Icon_Collections_Registry::register' );
+			$this->setExpectedIncorrectUsage( 'WP_Icons_Registry::register' );
+		}
+
 		// Suppress doing_it_wrong notices before parent::setUp() to catch theme notices early.
 		//
 		// This prevents false failures from theme-related notices that are unrelated to

--- a/plugins/wp-graphql/tests/wpunit/MediaItemMutationsTest.php
+++ b/plugins/wp-graphql/tests/wpunit/MediaItemMutationsTest.php
@@ -1599,15 +1599,28 @@ class MediaItemMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 	 * check rejects it. The mutation must surface the error and create no
 	 * attachment.
 	 *
-	 * Uses RFC 5737 documentation IP 203.0.113.42 to avoid any chance of
-	 * real network traffic; a higher-priority pre_http_request filter
-	 * fires before the setUp mock and serves the bad bytes.
+	 * Uses RFC 5737 documentation IP 203.0.113.42 (TEST-NET-3) to avoid any
+	 * chance of real network traffic; a higher-priority pre_http_request
+	 * filter fires before the setUp mock and serves the bad bytes.
+	 *
+	 * Since WordPress 7.1, wp_http_validate_url() rejects reserved and
+	 * documentation IP ranges — including the RFC 5737 TEST-NET blocks
+	 * (192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24) — so any test using a
+	 * TEST-NET address must explicitly allow the host via the
+	 * `http_request_host_is_external` filter. That keeps the no-real-traffic
+	 * guarantee (pre_http_request still intercepts) while letting the URL
+	 * reach the code under test. See docs/testing.md.
 	 */
 	public function testCreateMediaItemSideloadFailureIsSurfaced() {
 		wp_set_current_user( $this->admin );
 
 		$bad_url   = 'http://203.0.113.42/looks-like-jpeg-but-is-text.jpg';
 		$delivered = false;
+
+		$allow_test_net = static function ( $external, $host ) {
+			return '203.0.113.42' === $host ? true : $external;
+		};
+		add_filter( 'http_request_host_is_external', $allow_test_net, 10, 2 );
 
 		$bad_bytes_filter = static function ( $preempt, $args, $url ) use ( $bad_url, &$delivered ) {
 			if ( $url !== $bad_url ) {
@@ -1636,6 +1649,7 @@ class MediaItemMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		$actual = $this->createMediaItemMutation();
 
 		remove_filter( 'pre_http_request', $bad_bytes_filter, 5 );
+		remove_filter( 'http_request_host_is_external', $allow_test_net, 10 );
 
 		$this->assertTrue(
 			$delivered,


### PR DESCRIPTION
## What

The experimental WP trunk integration jobs (core and IDE) have been failing since the 7.1 dev cycle opened. This PR gets them green again. All 15 failures trace to two WordPress 7.1 changes, both are test-harness interactions, neither indicates that 7.1 will break WPGraphQL for users.

## Why the trunk jobs were failing

**1. The new Icons API (14 of 15 failures).** WordPress 7.1 registers the core icon collection on `init` via the new Icons API ([make/core post](https://make.wordpress.org/core/2026/07/24/registering-and-rendering-svg-icons-in-wordpress-7-1/)). Core's `I18nTest` and the IDE's `ScriptEnqueueTest` fire `init` a second time, which re-registers the collection and trips "already registered" `_doing_it_wrong` notices (new in 7.1.0) that `WP_UnitTestCase` converts into failures. Real requests fire `init` once, so production is unaffected.

**2. `wp_http_validate_url()` hardening (1 failure).** Trunk now rejects reserved and documentation IP ranges, including the RFC 5737 TEST-NET blocks ([source](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/http.php)). `MediaItemMutationsTest::testCreateMediaItemSideloadFailureIsSurfaced` uses TEST-NET-3 (`203.0.113.42`) precisely because it can never route to a real host, but on trunk the URL is now rejected before the test's `pre_http_request` mock runs, so the branch under test is never exercised.

## Changes

- `I18nTest` (core) and `ScriptEnqueueTest` (IDE): declare the two icon-registry notices as expected on WP 7.1+, following the existing `WP_Block_Type_Registry::register` precedent in the same files. Scoped to exactly these notices so any other incorrect-usage notice a future WP release introduces still surfaces. The version gate uses `7.1-alpha` so it matches trunk builds, whose version strings compare lower than plain `7.1`.
- `MediaItemMutationsTest`: allow the single TEST-NET host through `http_request_host_is_external` (the rejection branch in trunk applies this filter). The `pre_http_request` mock still intercepts, so the no-real-traffic guarantee holds on every WP version.
- `docs/testing.md`: new "Mocking Outbound HTTP in Tests" section documenting the TEST-NET convention and the need for the `http_request_host_is_external` filter on WP 7.1+.

## Validation

The experimental trunk jobs run on this PR, so the fix is validated directly by CI. The changes are no-ops on WP 7.0 and below (version-gated expectations, and the filter is not consulted for TEST-NET on older versions), which the stable matrix verifies.