### PR TITLE
fix(deps-dev): bump typescript from 5.9.3 to 6.0.3 for wpgraphql.com

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42332,9 +42332,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.9.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
 			"devOptional": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -44443,7 +44443,7 @@
 		},
 		"plugins/wp-graphql": {
 			"name": "@wpgraphql/wp-graphql",
-			"version": "2.19.0",
+			"version": "2.20.0",
 			"dependencies": {
 				"@ant-design/icons": "6.3.2",
 				"@apollo/client": "3.14.1",
@@ -44491,7 +44491,7 @@
 		},
 		"plugins/wp-graphql-acf": {
 			"name": "@wpgraphql/wp-graphql-acf",
-			"version": "2.7.0",
+			"version": "2.7.1",
 			"license": "GPL-3.0-or-later",
 			"devDependencies": {
 				"@eslint/js": "^10.0.1",
@@ -44787,7 +44787,7 @@
 		},
 		"plugins/wp-graphql-ide": {
 			"name": "@wpgraphql/wp-graphql-ide",
-			"version": "5.4.1",
+			"version": "5.4.2",
 			"dependencies": {
 				"@codemirror/autocomplete": "^6.20.3",
 				"@codemirror/commands": "^6.10.4",
@@ -46387,7 +46387,7 @@
 		},
 		"plugins/wp-graphql-smart-cache": {
 			"name": "@wpgraphql/wp-graphql-smart-cache",
-			"version": "2.3.0",
+			"version": "2.3.1",
 			"license": "GPL-3.0-or-later"
 		},
 		"plugins/wp-graphql/node_modules/@babel/code-frame": {
@@ -47956,7 +47956,7 @@
 				"postcss-import": "^16.1.1",
 				"prettier": "^3.9.6",
 				"tailwindcss": "^4.2.4",
-				"typescript": "^5.9.3"
+				"typescript": "^6.0.3"
 			}
 		},
 		"websites/wpgraphql.com/node_modules/@eslint/config-array": {

--- a/websites/wpgraphql.com/package.json
+++ b/websites/wpgraphql.com/package.json
@@ -78,7 +78,7 @@
     "postcss-import": "^16.1.1",
     "prettier": "^3.9.6",
     "tailwindcss": "^4.2.4",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "overrides": {
     "@babel/runtime": "^7.27.6",

--- a/websites/wpgraphql.com/tsconfig.json
+++ b/websites/wpgraphql.com/tsconfig.json
@@ -14,10 +14,9 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
-    "baseUrl": "./",
     "paths": {
-      "@/*": ["src/*"],
-      "*": ["src/*"]
+      "@/*": ["./src/*"],
+      "*": ["./src/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],


### PR DESCRIPTION
Supersedes #4205.

TypeScript 7.0.2 is the new Go-based native compiler, and the website's lint toolchain doesn't support it yet. typescript-eslint (through the current 8.67.0) declares a typescript peer range of >=4.8.4 <6.1.0, and eslint crashes with `TypeError: Cannot read properties of undefined (reading 'Cjs')` when it loads TS 7. That's the Website Lint failure on #4205.

TypeScript 6.0.3 is the current supported release line with the same feature set, so this bumps to that instead. TS 6 also deprecates the `baseUrl` compiler option, so this migrates the `paths` mappings to be explicitly relative, which is the forward-compatible form for TS 7 whenever the toolchain catches up.

Verified locally with Node 22: `eslint .` passes (0 errors), `tsc --noEmit` passes, and `next build` compiles and generates all 99 pages.

We should revisit TS 7 once typescript-eslint ships support for it.