### PR TITLE
docs: fix markdown that breaks MDX rendering on wpgraphql.com

### DIFF
--- a/plugins/wp-graphql-acf/docs/adding-acf-fields-to-the-wpgraphql-schema.md
+++ b/plugins/wp-graphql-acf/docs/adding-acf-fields-to-the-wpgraphql-schema.md
@@ -63,7 +63,7 @@ Some Location Rules are easily mapped to the GraphQL Schema, but some are not. I
 
 Take the following Location Rules as an example:
 
--   “Post Author is equal to ${Name of Author}”
+-   “Post Author is equal to `${Name of Author}`”
 
 In the WordPress admin, this rule will conditionally hide/show the ACF Field Group if the author of a post is not a specific author.  
   
@@ -73,7 +73,7 @@ The GraphQL Schema needs to represent the ACF Field Group in association with a 
 
 Or consider another rule such as:
 
--   “Taxonomy Term Slug is equal to ${term-slug}”  
+-   “Taxonomy Term Slug is equal to `${term-slug}`”  
       
     Again, this rule requires context that is available in the WordPress admin and the field group can show/hide, but it’s not available when the GraphQL Schema is generated. What type of term? Category? Tag? This would be another rule that would require manual assigning of “graphql\_types” the ACF Field Group should show on.
 

--- a/plugins/wp-graphql-ide/docs/api-surface.md
+++ b/plugins/wp-graphql-ide/docs/api-surface.md
@@ -162,7 +162,7 @@ Registered in `includes/UserMeta.php`. All keys are `show_in_rest` with an `auth
 | `wpgraphql_ide_theme` | string (`'' \| 'light' \| 'dark'`) | `''` | GraphiQL theme override. Empty string defers to system / GraphiQL default. |
 | `wpgraphql_ide_persist_headers` | boolean | `false` | Whether HTTP headers persist between sessions / across docs. |
 | `wpgraphql_ide_collection_order` | integer[] | `[]` | Manual ordering of the saved-queries panel — array of collection term IDs. |
-| `wpgraphql_ide_collection_sort_modes` | object<string,enum> | `{}` | Per-collection sort mode. Values: `'manual' \| 'title_asc' \| 'modified_desc' \| 'status'`. |
+| `wpgraphql_ide_collection_sort_modes` | `object<string,enum>` | `{}` | Per-collection sort mode. Values: `'manual' \| 'title_asc' \| 'modified_desc' \| 'status'`. |
 | `wpgraphql_ide_section_states` | string (JSON-encoded object) | `'{}'` | Per-user UI state for collapsible sections (collections + Documents bucket + Unsaved + personal collections). Stored as a JSON string so we can add per-section fields client-side without server releases; UI owns the shape. |
 | `wpgraphql_ide_seen_shared_collections` | string[] | `[]` | IDs of shared personal collections the user has already been notified about (suppresses the "X shared a collection with you" snackbar on subsequent loads). |
 | `wpgraphql_ide_collapsed_notices` | string[] | `[]` | IDs of document notices the user has collapsed. Notices not present here render expanded. |

--- a/plugins/wp-graphql-smart-cache/docs/development.md
+++ b/plugins/wp-graphql-smart-cache/docs/development.md
@@ -132,7 +132,7 @@ Use these steps to run a network cache (varnish) to similate the caching behavio
 
 The varnish app starts and listens at http://localhost:8081/ for requests.
 
-Test a graphql query to load post #1 "Hello World" at this 'http://localhost:8081/graphql?query={ post(id: "1", idType: DATABASE_ID) { title } }'
+Test a graphql query to load post #1 "Hello World" at this url: `http://localhost:8081/graphql?query={ post(id: "1", idType: DATABASE_ID) { title } }`
 
 ### Cache Requests
 

--- a/plugins/wp-graphql-smart-cache/docs/network-cache.md
+++ b/plugins/wp-graphql-smart-cache/docs/network-cache.md
@@ -93,7 +93,7 @@ This significantly reduces the load on your WordPress server, and significantly 
 
 ### GET Requests In Action
 
-Visit the following URL in your browser: [https://content.wpgraphql.com/graphql?query={posts{nodes{id,title}}}](https://content.wpgraphql.com/graphql?query={posts{nodes{id,title}}})
+Visit the following URL in your browser: `https://content.wpgraphql.com/graphql?query={posts{nodes{id,title}}}`
 
 If you inspect the "Network" tab in your browser's developer tools, you should see either an `X-Cache: MISS` header or a `X-Cache: Hit #` header, showing the number of times this query has been served from cache.
 


### PR DESCRIPTION
## What

wpgraphql.com renders docs markdown through MDX, where raw braces and angle-bracket sequences in prose parse as expressions and JSX. Four files across three plugins failed MDX compilation, and one of them (the IDE's `api-surface.md`) failed the site's Vercel build once the docs portal (#4227) started rendering plugin docs.

## Fixes

- `plugins/wp-graphql-acf/docs/adding-acf-fields-to-the-wpgraphql-schema.md`: `${placeholder}` braces in two list items
- `plugins/wp-graphql-ide/docs/api-surface.md`: an `object<string,enum>` table cell
- `plugins/wp-graphql-smart-cache/docs/network-cache.md` and `development.md`: GraphQL query URLs carrying braces in prose/links

Each construct is now inline code, which MDX treats literally. Verified by compiling every `.md` file across all four plugins' docs folders (core, ACF, IDE, Smart Cache): all clean.

Pairs with the build-resilience fix on #4227, which isolates any future MDX-hostile page to a logged 404 instead of a failed deployment.