### PR TITLE
fix(wpgraphql.com): make docs cross-links resolve on the site

### DIFF
--- a/plugins/wp-graphql-acf/docs/adding-acf-fields-to-the-wpgraphql-schema.md
+++ b/plugins/wp-graphql-acf/docs/adding-acf-fields-to-the-wpgraphql-schema.md
@@ -5,7 +5,7 @@ title: "Adding ACF Fields to the WPGraphQL Schema"
 
 On this page, you will find documentation about how to add ACF Fields to the WPGraphQL Schema.
 
-In order to follow along with the documentation below, you should have the latest versions of each of the following plugins [installed and activated](/installation-and-activation/):
+In order to follow along with the documentation below, you should have the latest versions of each of the following plugins [installed and activated](./installation-and-activation.md):
 
 -   WPGraphQL for ACF
 -   WPGraphQL
@@ -32,7 +32,7 @@ With WPGraphQL for ACF active, each ACF Field Group will have a “GraphQL” se
 Within this tab are the following settings that impact how the field group is added (or not added) to the GraphQL Schema:
 
 -   **Show in GraphQL (show\_in\_graphql):** Checked (`true`), if the field group should be shown in the GraphQL Schema. Unchecked (`false`) if the field group should not be shown in the GraphQL Schema.
-    -   **NOTE**: Field Groups that are “inactive” but set to Show in GraphQL will be exposed to the Schema. i.e. inactive field groups that are then used to “[clone](/field-types/clone-field/)” onto other field groups.
+    -   **NOTE**: Field Groups that are “inactive” but set to Show in GraphQL will be exposed to the Schema. i.e. inactive field groups that are then used to “[clone](./field-types/clone-field.md)” onto other field groups.
 -   **GraphQL Type Name** (**graphql\_type\_name):** The Type name that should be used in the GraphQL Schema to represent the field group. This must be unique across the entire GraphQL Schema. The Type cannot be already be present in the GraphQL Schema. It’s recommended to use Pascal casing to name the type (i.e. MyFieldGroupTypeName). This will also serve as the field name (with a lowercase first letter) to access the fields from.
 -   **Manually Set GraphQL Types for Field Group (map\_graphql\_types\_from\_location\_rules**): Checked (true) to use the “graphql\_types” value to add the field group to the Schema. Unchecked (false) to let WPGraphQL for ACF map the Field Group to the Schema based on the Location Rules (read more about how [location rules](#location-rules) work below)
 -   **GraphQL Types (graphql\_types):** Array of Type Names the ACF Field Group should be accessible from in the Schema.
@@ -46,7 +46,7 @@ Each ACF Field has its own “GraphQL” settings tab.
 
 ![](images/CleanShot-2023-11-22-at-15.10.23-1024x449.png)
 
-Each [field type](/field-types/) might have different settings, but the most common GraphQL Settings for each field type are:
+Each [field type](./field-types/index.md) might have different settings, but the most common GraphQL Settings for each field type are:
 
 -   **Show in GraphQL (show\_in\_graphql)**: Whether the field should show in the GraphQL Schema. If the Field Group is not shown in the GraphQL Schema, the individual fields will also not be. If the Field Group is shown in the GraphQL Schema, fields are default to “true” and will be shown in the schema unless disabled.
 -   **GraphQL Description (graphql\_description):** This is how the field is documented in the Schema and will show in tools such as the GraphiQL IDE.

--- a/plugins/wp-graphql-acf/docs/adding-support-for-3rd-party-acf-field-type.md
+++ b/plugins/wp-graphql-acf/docs/adding-support-for-3rd-party-acf-field-type.md
@@ -7,7 +7,7 @@ This guide provides developers with information on how to add support for custom
 
 ## Initial Setup
 
-1.  **Plugin Installation**: Ensure WPGraphQL and WPGraphQL for ACF are active in your WordPress environment. For detailed installation and activation instructions, visit the [Installation and Activation guide](/installation-and-activation/).
+1.  **Plugin Installation**: Ensure WPGraphQL and WPGraphQL for ACF are active in your WordPress environment. For detailed installation and activation instructions, visit the [Installation and Activation guide](./installation-and-activation.md).
 
 ## Registering Custom ACF Field Types
 
@@ -49,7 +49,7 @@ This guide provides developers with information on how to add support for custom
 ## Verifying and Debugging
 
 5.  **Verification**: After registering a custom ACF Field Type, verify its functionality by creating a new field group or adding it to an existing group, then use the GraphiQL IDE to ensure the field appears in the schema and returns data correctly.
-6.  **Debugging**: If issues arise, consult the debugging guides at [WPGraphQL for ACF Debugging](/debugging/) and [WPGraphQL Debugging](https://www.wpgraphql.com/docs/debugging).
+6.  **Debugging**: If issues arise, consult the debugging guides at [WPGraphQL for ACF Debugging](./debugging.md) and [WPGraphQL Debugging](https://www.wpgraphql.com/docs/debugging).
 
 ## Best Practices and Security
 

--- a/plugins/wp-graphql-acf/docs/debugging.md
+++ b/plugins/wp-graphql-acf/docs/debugging.md
@@ -5,7 +5,7 @@ title: "Debugging"
 
 On this page you will find information to help debug when things are not working as you might expect when using WPGraphQL for ACF v2.0+.
 
-If, after trying suggestions documented on this page, you are still having problems, check out our [various channels for support](/support/).
+If, after trying suggestions documented on this page, you are still having problems, check out our [various channels for support](./support.md).
 
 ## General WPGraphQL Debugging
 
@@ -59,7 +59,7 @@ Is your ACF Field Group active?
 
 If your ACF Field Group is set to `active:false` this does not mean that the ACF Field Group will be excluded from the GraphQL Schema.
 
-Inactive ACF Field Groups that are set to “Show in GraphQL” will not have a direct field added to the schema to access it, _but_ they will have a GraphQL Object Type registered to the Schema and can be referenced via [Clone](/field-types/clone-field/) fields.
+Inactive ACF Field Groups that are set to “Show in GraphQL” will not have a direct field added to the schema to access it, _but_ they will have a GraphQL Object Type registered to the Schema and can be referenced via [Clone](./field-types/clone-field.md) fields.
 
 #### Show in GraphQL
 
@@ -99,10 +99,10 @@ Is the field set to show in graphql? By default, if a field group is set to show
 
 ### Supported Field Types
 
-Is the ACF Field Type a [supported field type](/field-types/)?
+Is the ACF Field Type a [supported field type](./field-types/index.md)?
 
-If you’re using a 3rd party ACF Extension that adds a custom ACF Field Type, it won’t be shown in the GraphQL Schema unless [support is added for the custom ACF Field type](/adding-support-for-3rd-party-acf-field-type/).
+If you’re using a 3rd party ACF Extension that adds a custom ACF Field Type, it won’t be shown in the GraphQL Schema unless [support is added for the custom ACF Field type](./adding-support-for-3rd-party-acf-field-type.md).
 
 ## Next Steps
 
-This guide covers the some common steps for debugging WPGraphQL for ACF v2.0+. If you’re still encountering issues after following these steps, please refer to our [support page](/support/) for further assistance.
+This guide covers the some common steps for debugging WPGraphQL for ACF v2.0+. If you’re still encountering issues after following these steps, please refer to our [support page](./support.md) for further assistance.

--- a/plugins/wp-graphql-acf/docs/field-types/index.md
+++ b/plugins/wp-graphql-acf/docs/field-types/index.md
@@ -7,59 +7,59 @@ WPGraphQL for ACF provides GraphQL Schema support for the field types of ACF, AC
 
 ## ACF
 
-- [Button Group](/field-types/button-group)
-- [Checkbox](/field-types/checkbox)
-- [Color Picker](/field-types/color-picker)
-- [Date Picker](/field-types/date-picker)
-- [DateTimePicker](/field-types/datetimepicker)
-- [Email](/field-types/email)
-- [File](/field-types/file)
-- [Google Map](/field-types/google-map)
-- [Group](/field-types/group)
-- [Image](/field-types/image)
-- [Link](/field-types/link)
-- [Number](/field-types/number) *(docs needed)*
-- [Oembed](/field-types/oembed) *(docs needed)*
-- [PageLink](/field-types/pagelink) *(docs needed)*
-- [Password](/field-types/password) *(docs needed)*
-- [Post Object](/field-types/post-object) *(docs needed)*
-- [Radio Button](/field-types/radio-button)
-- [Range](/field-types/range)
-- [Relationship](/field-types/relationship) *(docs needed)*
-- [Select](/field-types/select) *(docs needed)*
-- [Taxonomy](/field-types/taxonomy) *(docs needed)*
-- [Text](/field-types/text)
-- [Text Area](/field-types/text-area)
-- [Time Picker](/field-types/time-picker)
-- [True / False](/field-types/true-false)
-- [Url](/field-types/url)
-- [User](/field-types/user)
-- [WYSIWYG](/field-types/wysiwyg)
+- [Button Group](./button-group.md)
+- [Checkbox](./checkbox.md)
+- [Color Picker](./color-picker.md)
+- [Date Picker](./date-picker.md)
+- [DateTimePicker](./datetimepicker.md)
+- [Email](./email.md)
+- [File](./file.md)
+- [Google Map](./google-map.md)
+- [Group](./group.md)
+- [Image](./image.md)
+- [Link](./link.md)
+- [Number](./number.md) *(docs needed)*
+- [Oembed](./oembed.md) *(docs needed)*
+- [PageLink](./pagelink.md) *(docs needed)*
+- [Password](./password.md) *(docs needed)*
+- [Post Object](./post-object.md) *(docs needed)*
+- [Radio Button](./radio-button.md)
+- [Range](./range.md)
+- [Relationship](./relationship.md) *(docs needed)*
+- [Select](./select.md) *(docs needed)*
+- [Taxonomy](./taxonomy.md) *(docs needed)*
+- [Text](./text.md)
+- [Text Area](./text-area.md)
+- [Time Picker](./time-picker.md)
+- [True / False](./true-false.md)
+- [Url](./url.md)
+- [User](./user.md)
+- [WYSIWYG](./wysiwyg.md)
 
 ## ACF Pro
 
-- [Clone Field](/field-types/clone-field) *(docs needed)*
-- [Flexible Content](/field-types/flexible-content) *(docs needed)*
-- [Gallery](/field-types/gallery)
-- [Repeater](/field-types/repeater) *(docs needed)*
+- [Clone Field](./clone-field.md) *(docs needed)*
+- [Flexible Content](./flexible-content.md) *(docs needed)*
+- [Gallery](./gallery.md)
+- [Repeater](./repeater.md) *(docs needed)*
 
 ## ACF Extended
 
-- [Advanced Link](/field-types/advanced-link)
-- [Button](/field-types/button)
-- [Code Editor](/field-types/code-editor)
-- [Taxonomies](/field-types/taxonomies)
-- [Taxonomy Terms](/field-types/taxonomy-terms)
-- [User Roles](/field-types/user-roles)
+- [Advanced Link](./advanced-link.md)
+- [Button](./button.md)
+- [Code Editor](./code-editor.md)
+- [Taxonomies](./taxonomies.md)
+- [Taxonomy Terms](./taxonomy-terms.md)
+- [User Roles](./user-roles.md)
 
 ## ACF Extended Pro
 
-- [Countries](/field-types/countries)
-- [Currencies](/field-types/currencies)
-- [Date Range Picker](/field-types/date-range-picker)
-- [Image Selector](/field-types/image-selector)
-- [Image Sizes](/field-types/image-sizes)
-- [Languages](/field-types/languages)
-- [Menu Locations](/field-types/menu-locations) *(docs needed)*
-- [Menus](/field-types/menus) *(docs needed)*
-- [Phone Number](/field-types/phone-number) *(docs needed)*
+- [Countries](./countries.md)
+- [Currencies](./currencies.md)
+- [Date Range Picker](./date-range-picker.md)
+- [Image Selector](./image-selector.md)
+- [Image Sizes](./image-sizes.md)
+- [Languages](./languages.md)
+- [Menu Locations](./menu-locations.md) *(docs needed)*
+- [Menus](./menus.md) *(docs needed)*
+- [Phone Number](./phone-number.md) *(docs needed)*

--- a/plugins/wp-graphql-acf/docs/installation-and-activation.md
+++ b/plugins/wp-graphql-acf/docs/installation-and-activation.md
@@ -5,7 +5,7 @@ title: "Installation and Activation"
 
 In this guide, we will show how to get started using WPGraphQL for Advanced Custom Fields.
 
-_If you are upgrading from another version, we recommend heading over to the [Upgrade Guide](/upgrade-guide/)._
+_If you are upgrading from another version, we recommend heading over to the [Upgrade Guide](./upgrade-guide.md)._
 
 In order to use [WPGraphQL for ACF,](https://wordpress.org/plugins/wpgraphql-acf/) you will need a supported version of [WPGraphQL](https://www.wpgraphql.com/docs/quick-start#install) and [Advanced Custom Fields](https://www.advancedcustomfields.com/resources/getting-started-with-acf/) installed and activated.
 

--- a/plugins/wp-graphql-acf/docs/kitchen-sink.md
+++ b/plugins/wp-graphql-acf/docs/kitchen-sink.md
@@ -5,7 +5,7 @@ title: "Kitchen Sink"
 
 The saying “Everything but the Kitchen Sink” is a [phrase that originated in the early 1900s](https://www.theidioms.com/everything-but-the-kitchen-sink/) to describe “almost everything that one can think of”.  
   
-The "Kitchen Sink" field groups below include just about every [ACF field type](/field-types/), so a page with these field groups assigned (and data saved to the fields) can be used to execute GraphQL queries that demonstrate the functionality of the WPGraphQL for ACF plugin.
+The "Kitchen Sink" field groups below include just about every [ACF field type](./field-types/index.md), so a page with these field groups assigned (and data saved to the fields) can be used to execute GraphQL queries that demonstrate the functionality of the WPGraphQL for ACF plugin.
 
 ## “Kitchen Sink” Field Groups
 
@@ -26,7 +26,7 @@ This page has the following ACF Field Groups associated with it:
 
 ## Using the Field Groups in your own environment
 
-The [Field Type documentation](/field-types/) demonstrates GraphQL queries against a page with these field groups assigned, as an example of how to use GraphQL to query ACF Fields of various field types.
+The [Field Type documentation](./field-types/index.md) demonstrates GraphQL queries against a page with these field groups assigned, as an example of how to use GraphQL to query ACF Fields of various field types.
 
 If you want to setup the same ACF Field Groups in your environment, you can download the JSON exports above and import them to your WordPress install using the Advanced Custom Fields importer under the “ACF > Tools” menu.
 

--- a/plugins/wp-graphql-acf/docs/querying-acf-fields-with-graphql.md
+++ b/plugins/wp-graphql-acf/docs/querying-acf-fields-with-graphql.md
@@ -7,7 +7,7 @@ Once you have created ACF Field Groups and configured them to show in GraphQL, i
   
 In this document, we’ll cover how ACF Field Groups are mapped to the Schema, how you can use tools like the GraphiQL IDE to understand how you can access the data stored in your ACF Fields using GraphQL Queries and Fragments.
 
-For consistency, we will be showing examples and referencing the ACF Field Groups documented on the “[Kitchen Sink”](/kitchen-sink/) page. You should be able to translate that and apply the knowledge to your own ACF Field Groups and Fields.
+For consistency, we will be showing examples and referencing the ACF Field Groups documented on the “[Kitchen Sink”](./kitchen-sink.md) page. You should be able to translate that and apply the knowledge to your own ACF Field Groups and Fields.
 
 ## Understanding how ACF Field Groups map to the GraphQL Schema
 

--- a/plugins/wp-graphql-acf/docs/upgrade-guide.md
+++ b/plugins/wp-graphql-acf/docs/upgrade-guide.md
@@ -71,7 +71,7 @@ One of the biggest pain points with the previous versions of WPGraphQL for ACF w
 
 In the old WPGraphQL for ACF, ACF Field Groups would be mapped to the Schema with a Type Name that was prefixed with its parent location.
 
-For example, if we use the [ACF Free Kitchen Sink Field Group](field-groups/kitchen-sink-acf-free.json) ([learn more about the kitchen sink field groups](/kitchen-sink/)), which is assigned to the following ACF Locations:
+For example, if we use the [ACF Free Kitchen Sink Field Group](field-groups/kitchen-sink-acf-free.json) ([learn more about the kitchen sink field groups](./kitchen-sink.md)), which is assigned to the following ACF Locations:
 
 -   Post Type is equal to Page
 -   Taxonomy is equal to Category
@@ -175,7 +175,7 @@ To learn how to update your code to be compatible with WPGraphQL for ACF 2.0+, p
 
 Relationship fields have changed to be represented in the Schema as a GraphQL Connection. This means the shape of data to be queried has changed and your queries will need to be updated to reflect.
 
-For ACF fields of the “[relationship](/field-types/relationship/)“, “[post\_object](/field-types/post-object/)” and “[page\_link](/field-types/pagelink/)” field type, there are some general changes that apply to each of these field types.
+For ACF fields of the “[relationship](./field-types/relationship.md)“, “[post\_object](./field-types/post-object.md)” and “[page\_link](./field-types/pagelink.md)” field type, there are some general changes that apply to each of these field types.
 
 **Before:**
 

--- a/websites/wpgraphql.com/src/lib/parse-mdx-docs.ts
+++ b/websites/wpgraphql.com/src/lib/parse-mdx-docs.ts
@@ -362,7 +362,15 @@ export async function getAllDocUri(
   }, [])
 }
 
-export async function getDocContent(slug, product: DocsProduct = CORE_PRODUCT) {
+/**
+ * Fetch a doc's markdown along with the file slug it actually resolved to
+ * (which differs from the requested slug when the content lives in a
+ * directory index file). The file slug anchors relative-link resolution.
+ */
+async function getDocContentWithFileSlug(
+  slug,
+  product: DocsProduct = CORE_PRODUCT
+): Promise<{ content: string; fileSlug: string }> {
   // Normalize and validate the incoming slug before constructing the URL
   const safeSlug = normalizeSlug(slug)
 
@@ -374,7 +382,11 @@ export async function getDocContent(slug, product: DocsProduct = CORE_PRODUCT) {
 
   for (const candidate of candidates) {
     try {
-      return await fs.readFile(localDocPathFromSlug(candidate, product), "utf8")
+      const content = await fs.readFile(
+        localDocPathFromSlug(candidate, product),
+        "utf8"
+      )
+      return { content, fileSlug: candidate }
     } catch (_error) {
       // Fall through to the next candidate, then the remote source.
     }
@@ -384,7 +396,7 @@ export async function getDocContent(slug, product: DocsProduct = CORE_PRODUCT) {
     const resp = await fetch(docUrlFromSlug(candidate, product))
 
     if (resp.ok) {
-      return resp.text()
+      return { content: await resp.text(), fileSlug: candidate }
     }
 
     // 4xx means this candidate doesn't exist — try the next; anything else
@@ -397,8 +409,13 @@ export async function getDocContent(slug, product: DocsProduct = CORE_PRODUCT) {
   throw { notFound: true }
 }
 
+export async function getDocContent(slug, product: DocsProduct = CORE_PRODUCT) {
+  const { content } = await getDocContentWithFileSlug(slug, product)
+  return content
+}
+
 export async function getParsedDoc(url, product: DocsProduct = CORE_PRODUCT) {
-  const content = await getDocContent(url, product)
+  const { content, fileSlug } = await getDocContentWithFileSlug(url, product)
   const normalizedContent = sanitizeMarkdownForMdx(content)
 
   // An empty markdown file (e.g. a placeholder committed before the content
@@ -410,7 +427,7 @@ export async function getParsedDoc(url, product: DocsProduct = CORE_PRODUCT) {
   const hasMarkdownH1 = hasTopLevelHeading(normalizedContent)
 
   const [source, toc] = await Promise.all([
-    getSourceFromMd(normalizedContent, product),
+    getSourceFromMd(normalizedContent, product, fileSlug),
     getTOCFromMd(normalizedContent),
   ])
 
@@ -450,13 +467,96 @@ function rehypeRewriteRelativeImageSrc(options: { product: DocsProduct }) {
   }
 }
 
-async function getSourceFromMd(mdContent, product: DocsProduct = CORE_PRODUCT) {
+/**
+ * Rewrite relative `<a href>` links that point at markdown files (the shape
+ * the docs use to cross-link on GitHub, e.g. "./network-cache.md" or
+ * "../previews.md#nonces") onto their site URLs. Left alone, these render as
+ * literal hrefs the site can't serve — the docs route rejects the ".md"
+ * extension — so every such cross-link 404s.
+ *
+ * Resolution is anchored on the source file's directory (fileSlug), not the
+ * page URL: a page served from a directory index (field-types/index.md at
+ * /docs/acf/field-types) has links relative to the directory, which browser
+ * URL semantics would resolve against the wrong base. Index targets collapse
+ * onto their directory URL, matching how the docs route serves them.
+ * Fragments are preserved. Non-markdown relative links (images have their
+ * own rewrite in rehypeRewriteRelativeImageSrc, plain extensionless paths
+ * already resolve) and absolute/root-relative/fragment links pass through
+ * untouched.
+ */
+function rehypeRewriteRelativeDocLinks(options: {
+  product: DocsProduct
+  fileSlug: string
+}) {
+  const { product, fileSlug } = options
+  const fileDir = fileSlug.includes("/")
+    ? fileSlug.slice(0, fileSlug.lastIndexOf("/"))
+    : ""
+
+  return (tree) => {
+    visit(tree, "element", (node: any) => {
+      if (node.tagName !== "a") {
+        return
+      }
+
+      const href = node.properties?.href
+      if (typeof href !== "string" || href.length === 0) {
+        return
+      }
+
+      // Only relative links: skip absolute URLs, protocol links (mailto:),
+      // root-relative paths, and in-page fragments.
+      if (/^(?:[a-z][a-z0-9+.-]*:|\/|#)/i.test(href)) {
+        return
+      }
+
+      const [pathPart, ...fragmentParts] = href.split("#")
+      if (!/\.mdx?$/i.test(pathPart)) {
+        return
+      }
+
+      // Resolve ./ and ../ segments against the source file's directory.
+      const segments: string[] = []
+      for (const segment of `${fileDir}/${pathPart}`.split("/")) {
+        if (segment === "" || segment === ".") {
+          continue
+        }
+        if (segment === "..") {
+          if (segments.length === 0) {
+            // Escapes the docs folder (e.g. a link into the plugin source);
+            // no site URL exists for it, so leave the href as-is.
+            return
+          }
+          segments.pop()
+          continue
+        }
+        segments.push(segment)
+      }
+
+      let slug = segments.join("/").replace(/\.mdx?$/i, "")
+      slug = slug === "index" ? "" : slug.replace(/\/index$/, "")
+
+      const fragment =
+        fragmentParts.length > 0 ? `#${fragmentParts.join("#")}` : ""
+      node.properties.href = `${
+        slug ? `${product.basePath}/${slug}` : product.basePath
+      }${fragment}`
+    })
+  }
+}
+
+async function getSourceFromMd(
+  mdContent,
+  product: DocsProduct = CORE_PRODUCT,
+  fileSlug = ""
+) {
   return serialize(mdContent, {
     parseFrontmatter: true,
     mdxOptions: {
       remarkPlugins: [[remarkGfm, { singleTilde: false }], withSmartQuotes],
       rehypePlugins: [
         [rehypeRewriteRelativeImageSrc, { product }],
+        [rehypeRewriteRelativeDocLinks, { product, fileSlug }],
         [
           rehypeExternalLinks,
           { target: "_blank", rel: ["noopener", "noreferrer"] },


### PR DESCRIPTION
## What

Two halves of the same bug, found while preparing the Smart Cache docs for the portal: cross-links between docs pages 404 on wpgraphql.com.

- **Site pipeline**: docs cross-link each other with relative `.md` hrefs (`./network-cache.md#supported-hosts`), the shape that renders on GitHub. The site rendered them untouched, and the docs route rejects the `.md` extension, so every such link (56 across the ACF and IDE docs alone) was a 404. A new rehype plugin resolves them against the source file's directory and rewrites them onto the product's docs base path, preserving fragments. Resolution is anchored on the file that actually served the page, so links inside directory-index pages (like the ACF field-types overview) resolve correctly too.
- **ACF content**: the ported ACF docs also carried 65 root-relative links in the old acf.wpgraphql.com URL shape (`/field-types/repeater`), which resolve nowhere on wpgraphql.com or GitHub. They are now relative `.md` links, verified against the actual files (every rewritten target exists), so they render on GitHub and the pipeline above maps them to site URLs.

Links that leave the docs folder (`../src/...`), root-relative site links (`/docs/...`), absolute URLs, and in-page fragments all pass through untouched.

## Testing

Verified on the local dev server:

- `/docs/ide/extending-the-ide` renders `./access-functions.md` style links as `/docs/ide/access-functions`.
- `/docs/acf/field-types` (served from `field-types/index.md`) renders all 47 field-type links as `/docs/acf/field-types/<type>`, with zero old-shape hrefs remaining.
- Fragments survive the rewrite (`/docs/acf/field-types#acf-pro`).
- Core docs pages are unchanged.
- eslint and prettier clean.