### PR TITLE
fix(wpgraphql.com): emit absolute URLs in wordpress-sitemap.xml

### DIFF
--- a/websites/wpgraphql.com/src/pages/wordpress-sitemap.xml.ts
+++ b/websites/wpgraphql.com/src/pages/wordpress-sitemap.xml.ts
@@ -3,6 +3,8 @@ import { getServerSideSitemapLegacy } from "next-sitemap"
 
 import { request } from "lib/wpgraphql-client"
 
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL
+
 const SITEMAP_QUERY = /* GraphQL */ `
   query SitemapQuery($after: String) {
     contentNodes(
@@ -57,9 +59,16 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
 
   const allRoutes = nodes.reduce((acc: any[], node: any) => {
     if (!node.uri) return acc
+
+    // Sitemap <loc> values must be absolute URLs; the WP-relative uri broke
+    // every consumer that honors the spec (notably the Algolia crawler,
+    // which failed on each entry and blocked its crawls).
+    const lastmod = node.modifiedGmt ? new Date(node.modifiedGmt) : null
     acc.push({
-      loc: node.uri,
-      lastmod: new Date(node.modifiedGmt).toISOString(),
+      loc: `${SITE_URL}${node.uri}`,
+      ...(lastmod && !Number.isNaN(lastmod.getTime())
+        ? { lastmod: lastmod.toISOString() }
+        : {}),
     })
     return acc
   }, [])


### PR DESCRIPTION
## What

Found while working on the docs portal's search phase: the Algolia crawler has been **blocked since July 25** ("Too many missing records", 315 of 443 URLs failed, production index down to 80 records), so site search has been badly degraded for a month.

Root cause: `wordpress-sitemap.xml` emits WP-relative `<loc>` values (`/filters/graphql_field_definition/`, `/2024/12/16/...`), which the sitemap spec requires to be absolute. The crawler fails on every one of those entries, which is the bulk of the failures, and its missing-records safety guard then refuses to replace the production index.

The fix prefixes each entry with `NEXT_PUBLIC_SITE_URL`, matching what `docs-sitemap.xml.ts` already does, and hardens `lastmod`: an entry with a missing or invalid modified date omits the field instead of throwing (`new Date(undefined).toISOString()` would 500 the whole sitemap).

## Verification

- Local dev renders `<loc>http://localhost:3000/2026/01/22/...</loc>` (absolute against the env's site URL; production resolves to https://www.wpgraphql.com).
- `docs-sitemap.xml` entries were already absolute and unaffected.

After this deploys, the crawler needs a manual "Restart crawling" in the Algolia dashboard to clear the blocked state.