### PR TITLE
feat(wpgraphql.com): product-faceted search

### DIFF
--- a/websites/wpgraphql.com/src/components/Docs/DocsLayout.js
+++ b/websites/wpgraphql.com/src/components/Docs/DocsLayout.js
@@ -1,8 +1,11 @@
+import Head from "next/head"
+
 import DocsNav from "./DocsNav"
 import ProductSwitcher from "./ProductSwitcher"
 import SiteLayout from "components/Site/SiteLayout"
 import TableOfContents from "components/Docs/TableOfContents"
 import DocsSidebar from "./DocsNavSideBar"
+import { CORE_PRODUCT_KEY } from "lib/docs-products"
 
 export default function DocsLayout({ children, toc, docsNavData, product }) {
   // Sibling-brand theme scope: each product's docs section re-tints the
@@ -10,8 +13,17 @@ export default function DocsLayout({ children, toc, docsNavData, product }) {
   // IDE); core renders the default orange with no scope class.
   const themeClass = product?.themeClass ?? ""
 
+  // Which product's docs this page belongs to, for the Algolia crawler: the
+  // crawler extracts this meta tag onto each search record as its `product`
+  // attribute, which the search modal facets on. Pages rendered without a
+  // product (the core developer reference) are core docs.
+  const searchProduct = product?.key ?? CORE_PRODUCT_KEY
+
   return (
     <SiteLayout>
+      <Head>
+        <meta name="docsearch:product" content={searchProduct} />
+      </Head>
       <div className={themeClass}>
         {/* Mobile: floating button + slide-over panel */}
         <aside className="z-20 lg:hidden">

--- a/websites/wpgraphql.com/src/components/Site/SearchButton.js
+++ b/websites/wpgraphql.com/src/components/Site/SearchButton.js
@@ -13,10 +13,36 @@ import { DocSearchModal } from "@docsearch/react"
 import clsx from "clsx"
 import Link from "next/link"
 import useActionKey from "../../hooks/useActionKey"
+import { CORE_PRODUCT_KEY, enabledProducts } from "lib/docs-products"
 
 const INDEX_NAME = "wpgraphql"
 const API_KEY = "0c11d662dad18e8a18d20c969b25c65f"
 const APP_ID = "HB50HVJDY8"
+
+// Paths whose search records carry the core product attribute: the core docs
+// plus the developer reference (which renders in the docs chrome).
+const CORE_SEARCH_SECTIONS =
+  /^\/(docs|actions|filters|functions|recipes|developer-reference)(\/|$)/
+
+/**
+ * Which product's docs the given URL path is inside, for preseeding the
+ * search modal's product filter. Outside the docs area there is no preseed
+ * (family-wide search).
+ */
+function productKeyFromPath(path) {
+  const withoutQuery = path.split(/[?#]/)[0]
+  const docsMatch = withoutQuery.match(/^\/docs\/([^/]+)/)
+  if (
+    docsMatch &&
+    enabledProducts().some(
+      (product) =>
+        product.key !== CORE_PRODUCT_KEY && product.key === docsMatch[1]
+    )
+  ) {
+    return docsMatch[1]
+  }
+  return CORE_SEARCH_SECTIONS.test(withoutQuery) ? CORE_PRODUCT_KEY : null
+}
 
 const SearchContext = createContext()
 
@@ -24,10 +50,15 @@ export function SearchProvider({ children }) {
   const router = useRouter()
   const [isOpen, setIsOpen] = useState(false)
   const [initialQuery, setInitialQuery] = useState(null)
+  // null = family-wide (no facet filter); otherwise a product key. Preseeded
+  // from the section the reader opened search from, switchable via the chip
+  // row in the modal.
+  const [productFilter, setProductFilter] = useState(null)
 
   const onOpen = useCallback(() => {
+    setProductFilter(productKeyFromPath(router.asPath))
     setIsOpen(true)
-  }, [setIsOpen])
+  }, [setIsOpen, router.asPath])
 
   const onClose = useCallback(() => {
     setIsOpen(false)
@@ -35,10 +66,22 @@ export function SearchProvider({ children }) {
 
   const onInput = useCallback(
     (e) => {
+      setProductFilter(productKeyFromPath(router.asPath))
       setIsOpen(true)
       setInitialQuery(e.key)
     },
-    [setIsOpen, setInitialQuery]
+    [setIsOpen, setInitialQuery, router.asPath]
+  )
+
+  // Switching product mid-search remounts the modal (the filter is baked
+  // into its search client), so carry the typed query over.
+  const onFilterChange = useCallback(
+    (key) => {
+      const query = document.querySelector(".DocSearch-Input")?.value ?? ""
+      setInitialQuery(query)
+      setProductFilter(key)
+    },
+    [setInitialQuery, setProductFilter]
   )
 
   useDocSearchKeyboardEvents({
@@ -61,11 +104,18 @@ export function SearchProvider({ children }) {
       </SearchContext.Provider>
       {isOpen &&
         createPortal(
+          // Keyed by the product filter: the filter is baked into the modal's
+          // search parameters at mount, so switching products remounts it
+          // (initialQuery carries the typed query across).
           <DocSearchModal
+            key={productFilter ?? "all"}
             initialQuery={initialQuery}
             initialScrollY={window.scrollY}
             searchParameters={{
               distinct: 1,
+              ...(productFilter
+                ? { facetFilters: [`product:${productFilter}`] }
+                : {}),
             }}
             onClose={onClose}
             indexName={INDEX_NAME}
@@ -82,7 +132,76 @@ export function SearchProvider({ children }) {
           />,
           document.body
         )}
+      {isOpen && (
+        <ProductFilterChips
+          key={`chips-${productFilter ?? "all"}`}
+          value={productFilter}
+          onChange={onFilterChange}
+        />
+      )}
     </>
+  )
+}
+
+/**
+ * The product filter chips, injected into the DocSearch modal below its
+ * search bar. DocSearch has no slot for filter UI, so this renders into a
+ * container inserted after the modal's search bar; it mounts alongside each
+ * modal instance (both are keyed by the active filter).
+ */
+function ProductFilterChips({ value, onChange }) {
+  // The container is created up front (this only renders client-side, with
+  // the modal open) and attached into the modal's DOM after mount, so the
+  // effect only synchronizes with the external DOM — no state involved.
+  const [container] = useState(() => {
+    const el = document.createElement("div")
+    el.className = "DocSearch-ProductFilter"
+    return el
+  })
+
+  useEffect(() => {
+    const searchBar = document.querySelector(
+      ".DocSearch-Modal .DocSearch-SearchBar"
+    )
+    if (!searchBar) {
+      return undefined
+    }
+    searchBar.insertAdjacentElement("afterend", container)
+    return () => {
+      container.remove()
+    }
+  }, [container])
+
+  const options = [
+    { key: null, shortLabel: "All" },
+    ...enabledProducts().map(({ key, shortLabel }) => ({ key, shortLabel })),
+  ]
+
+  return createPortal(
+    <div
+      role="group"
+      aria-label="Filter results by product"
+      className="DocSearch-ProductFilter-Chips"
+    >
+      {options.map((option) => (
+        <button
+          key={option.key ?? "all"}
+          type="button"
+          aria-pressed={value === option.key}
+          className={clsx("DocSearch-ProductFilter-Chip", {
+            "DocSearch-ProductFilter-Chip--active": value === option.key,
+          })}
+          onClick={() => {
+            if (value !== option.key) {
+              onChange(option.key)
+            }
+          }}
+        >
+          {option.shortLabel}
+        </button>
+      ))}
+    </div>,
+    container
   )
 }
 

--- a/websites/wpgraphql.com/src/components/Site/SearchButton.js
+++ b/websites/wpgraphql.com/src/components/Site/SearchButton.js
@@ -173,8 +173,12 @@ function ProductFilterChips({ value, onChange }) {
   }, [container])
 
   const options = [
-    { key: null, shortLabel: "All" },
-    ...enabledProducts().map(({ key, shortLabel }) => ({ key, shortLabel })),
+    { key: null, shortLabel: "All", themeClass: null },
+    ...enabledProducts().map(({ key, shortLabel, themeClass }) => ({
+      key,
+      shortLabel,
+      themeClass,
+    })),
   ]
 
   return createPortal(
@@ -188,7 +192,10 @@ function ProductFilterChips({ value, onChange }) {
           key={option.key ?? "all"}
           type="button"
           aria-pressed={value === option.key}
-          className={clsx("DocSearch-ProductFilter-Chip", {
+          // Each chip is scoped with its product's sibling-brand theme class
+          // (the modal portals outside the docs theme scopes), so the
+          // hover/active primary hue below is that product's accent.
+          className={clsx("DocSearch-ProductFilter-Chip", option.themeClass, {
             "DocSearch-ProductFilter-Chip--active": value === option.key,
           })}
           onClick={() => {

--- a/websites/wpgraphql.com/src/lib/docs-products.ts
+++ b/websites/wpgraphql.com/src/lib/docs-products.ts
@@ -19,6 +19,8 @@ export type DocsProduct = {
   key: string
   /** Full product name, used in the switcher and page chrome. */
   label: string
+  /** Compact name for tight chrome (search filter chips). */
+  shortLabel: string
   /** Site base path for the product's docs. */
   basePath: string
   /** Monorepo folder holding the product's markdown + docs_nav.json. */
@@ -39,6 +41,7 @@ export const DOCS_PRODUCTS: Record<string, DocsProduct> = {
   [CORE_PRODUCT_KEY]: {
     key: CORE_PRODUCT_KEY,
     label: "WPGraphQL",
+    shortLabel: "WPGraphQL",
     basePath: "/docs",
     docsFolder: "plugins/wp-graphql/docs",
     themeClass: null,
@@ -47,6 +50,7 @@ export const DOCS_PRODUCTS: Record<string, DocsProduct> = {
   acf: {
     key: "acf",
     label: "WPGraphQL for ACF",
+    shortLabel: "ACF",
     basePath: "/docs/acf",
     docsFolder: "plugins/wp-graphql-acf/docs",
     themeClass: "theme-acf",
@@ -55,6 +59,7 @@ export const DOCS_PRODUCTS: Record<string, DocsProduct> = {
   "smart-cache": {
     key: "smart-cache",
     label: "WPGraphQL Smart Cache",
+    shortLabel: "Smart Cache",
     basePath: "/docs/smart-cache",
     docsFolder: "plugins/wp-graphql-smart-cache/docs",
     themeClass: "theme-smart-cache",
@@ -65,6 +70,7 @@ export const DOCS_PRODUCTS: Record<string, DocsProduct> = {
   ide: {
     key: "ide",
     label: "WPGraphQL IDE",
+    shortLabel: "IDE",
     basePath: "/docs/ide",
     docsFolder: "plugins/wp-graphql-ide/docs",
     themeClass: "theme-ide",

--- a/websites/wpgraphql.com/src/styles/docsearch.css
+++ b/websites/wpgraphql.com/src/styles/docsearch.css
@@ -456,3 +456,52 @@
   color: hsl(var(--primary));
   font-weight: 600;
 }
+
+/* ------------------------------------------------------------
+   Product filter chips (injected below the search bar by
+   SearchButton.js) — filter results to one product's docs
+   ------------------------------------------------------------ */
+
+.DocSearch-ProductFilter {
+  flex: none;
+  padding: 0.625rem 1rem;
+  border-bottom: 1px solid hsl(var(--border));
+}
+
+.DocSearch-ProductFilter-Chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+}
+
+.DocSearch-ProductFilter-Chip {
+  border: 1px solid hsl(var(--border));
+  border-radius: 9999px;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1.25;
+  color: hsl(var(--muted-foreground));
+  background: transparent;
+  cursor: pointer;
+  transition:
+    color 0.15s ease,
+    border-color 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.DocSearch-ProductFilter-Chip:hover {
+  color: hsl(var(--foreground));
+  border-color: hsl(var(--primary) / 0.5);
+}
+
+.DocSearch-ProductFilter-Chip:focus-visible {
+  outline: 2px solid hsl(var(--ring));
+  outline-offset: 1px;
+}
+
+.DocSearch-ProductFilter-Chip--active {
+  color: hsl(var(--primary));
+  border-color: hsl(var(--primary) / 0.4);
+  background: hsl(var(--primary) / 0.1);
+}


### PR DESCRIPTION
## What

Phase 4 of the docs portal: search understands products.

- **Product metadata**: every docs-chrome page (product docs and the core developer reference) emits `<meta name="docsearch:product" content="<key>">` (`wp-graphql`, `acf`, `smart-cache`, `ide`) for the Algolia crawler to extract onto search records.
- **Filter chips in the search modal**: a chip row below the search bar (All / WPGraphQL / ACF / Smart Cache / IDE) filters results to one product via a `product` facet filter. Opening search from inside a product's docs preseeds that product's chip; anywhere else defaults to All. Chips render in their sub-brand accents (emerald ACF, rose Smart Cache, violet IDE). Switching chips mid-search keeps the typed query.

Verified in the browser: chips render below the search bar, ACF preseeds (in emerald) when opened from `/docs/acf/**`, switching to All keeps the query and returns unfiltered results. Product-filtered chips return results once the index carries the `product` attribute (crawler steps below); until then All behaves exactly like search today.

## Algolia crawler changes (dashboard, after this deploys)

1. **Add the product attribute** to the `recordProps` of the six docs-area actions (`/docs/**`, `/developer-reference/**`, `/actions/**`, `/filters/**`, `/functions/**`, `/recipes/**`):
   ```js
   product: {
     selectors: 'head > meta[name="docsearch:product"]',
   },
   ```
   Leave the extensions and blog actions without it, so those records only appear under All.
2. **Make it a facet**: the crawler's `initialIndexSettings` only applies when an index is first created, so add the facet on the live index directly: index `wpgraphql` → Configuration → Facets → add `product` as `filterOnly`. (Also add `"product"` to `attributesForFaceting` in the crawler config so a from-scratch rebuild matches.)
3. **Fix the missing 2026 blog posts** while in there: the blog action's `startUrls`/`pathsToMatch` stop at `/2025/`, so 2026 posts currently match no action and are not indexed at all. Replacing the year list in `pathsToMatch` with `"https://www.wpgraphql.com/2[0-9][0-9][0-9]/**"` ends the yearly maintenance.
4. **Restart crawling** to clear the blocked state — after #4232 (absolute sitemap URLs) has deployed, since those invalid entries are what tripped the missing-records guard.

## Order of operations

#4232 merge + deploy → this PR merge + deploy → crawler config + facet + restart → verify records carry `product` and the chips filter on production.