### PR TITLE
fix(wpgraphql.com): strip trailing slashes from wordpress-sitemap URLs

### DIFF
--- a/websites/wpgraphql.com/src/pages/wordpress-sitemap.xml.ts
+++ b/websites/wpgraphql.com/src/pages/wordpress-sitemap.xml.ts
@@ -63,9 +63,14 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
     // Sitemap <loc> values must be absolute URLs; the WP-relative uri broke
     // every consumer that honors the spec (notably the Algolia crawler,
     // which failed on each entry and blocked its crawls).
+    //
+    // WordPress URIs carry a trailing slash, but the site's canonical URLs
+    // don't (Next redirects the slash variants), so the slash is stripped to
+    // keep crawlers from bouncing through a redirect per entry.
+    const uri = node.uri === "/" ? node.uri : node.uri.replace(/\/+$/, "")
     const lastmod = node.modifiedGmt ? new Date(node.modifiedGmt) : null
     acc.push({
-      loc: `${SITE_URL}${node.uri}`,
+      loc: `${SITE_URL}${uri}`,
       ...(lastmod && !Number.isNaN(lastmod.getTime())
         ? { lastmod: lastmod.toISOString() }
         : {}),


### PR DESCRIPTION
## What

Follow-up to #4232, from reviewing the first healthy Algolia crawl: 271 URLs were ignored as "HTTP redirect (301, 302)", mostly trailing-slash variants. WordPress URIs carry a trailing slash but the site's canonical URLs do not (Next redirects the slash variants), so every WP-sourced sitemap entry bounced crawlers through a redirect before reaching the real page.

The sitemap now strips the trailing slash from each entry (the root `/` is kept), so crawlers hit canonical URLs directly. Nothing was missing from the index because the crawler follows redirects; this just removes the noise and the extra hop.

Remaining redirect-ignored entries after this will come from the crawler's own trailing-slash `startUrls` (fixable in the crawler config) and old in-content links, which are harmless.

## Verification

Local dev: all entries render without trailing slashes except the root; `grep -c '/</loc>'` = 1 (the root).