### PR TITLE
fix(wpgraphql.com): search modal action buttons and per-hit product badges

### DIFF
--- a/websites/wpgraphql.com/src/components/Site/SearchButton.js
+++ b/websites/wpgraphql.com/src/components/Site/SearchButton.js
@@ -13,7 +13,11 @@ import { DocSearchModal } from "@docsearch/react"
 import clsx from "clsx"
 import Link from "next/link"
 import useActionKey from "../../hooks/useActionKey"
-import { CORE_PRODUCT_KEY, enabledProducts } from "lib/docs-products"
+import {
+  CORE_PRODUCT_KEY,
+  DOCS_PRODUCTS,
+  enabledProducts,
+} from "lib/docs-products"
 
 const INDEX_NAME = "wpgraphql"
 const API_KEY = "0c11d662dad18e8a18d20c969b25c65f"
@@ -132,6 +136,24 @@ export function SearchProvider({ children }) {
             initialScrollY={window.scrollY}
             searchParameters={{
               distinct: 1,
+              // DocSearch replaces its default retrieve list when one is
+              // provided, so this is its default plus the corpus attributes
+              // (product, tags) the per-hit badge renders from.
+              attributesToRetrieve: [
+                "hierarchy.lvl0",
+                "hierarchy.lvl1",
+                "hierarchy.lvl2",
+                "hierarchy.lvl3",
+                "hierarchy.lvl4",
+                "hierarchy.lvl5",
+                "hierarchy.lvl6",
+                "content",
+                "type",
+                "url",
+                "anchor",
+                "product",
+                "tags",
+              ],
               ...(productFilter
                 ? { facetFilters: [facetFilterFor(productFilter)] }
                 : {}),
@@ -232,19 +254,54 @@ function ProductFilterChips({ value, onChange }) {
   )
 }
 
+/**
+ * Which corpus a search record belongs to, for the per-hit badge: the
+ * product attribute (extracted from the docsearch:product meta by the
+ * crawler) maps through the product registry for its display name and
+ * sibling-brand accent; blog records are identified by their tags.
+ * Records with neither (e.g. extension marketing pages) get no badge.
+ */
+function hitBadge(hit) {
+  const product = typeof hit.product === "string" ? hit.product : null
+  if (product && DOCS_PRODUCTS[product]) {
+    const { shortLabel, themeClass } = DOCS_PRODUCTS[product]
+    return { label: shortLabel, themeClass }
+  }
+  if (Array.isArray(hit.tags) && hit.tags.includes("blog")) {
+    return { label: "Blog", themeClass: null }
+  }
+  return null
+}
+
 function Hit({ hit, children }) {
+  const badge = hitBadge(hit)
+  // Child rows sit indented under their page's row; badging every child
+  // would be noise, the page-level row carries the context.
+  const showBadge = Boolean(badge) && !hit.__is_child?.()
+
   return (
     <Link href={hit.url} legacyBehavior>
       <a
-        className={clsx({
-          "DocSearch-Hit--Result": hit.__is_result?.(),
-          "DocSearch-Hit--Parent": hit.__is_parent?.(),
-          "DocSearch-Hit--FirstChild": hit.__is_first?.(),
-          "DocSearch-Hit--LastChild": hit.__is_last?.(),
-          "DocSearch-Hit--Child": hit.__is_child?.(),
-        })}
+        className={clsx(
+          {
+            "DocSearch-Hit--Result": hit.__is_result?.(),
+            "DocSearch-Hit--Parent": hit.__is_parent?.(),
+            "DocSearch-Hit--FirstChild": hit.__is_first?.(),
+            "DocSearch-Hit--LastChild": hit.__is_last?.(),
+            "DocSearch-Hit--Child": hit.__is_child?.(),
+          },
+          showBadge && "DocSearch-Hit--withBadge"
+        )}
       >
         {children}
+        {showBadge && (
+          <span
+            aria-hidden="true"
+            className={clsx("DocSearch-Hit-ProductBadge", badge.themeClass)}
+          >
+            {badge.label}
+          </span>
+        )}
       </a>
     </Link>
   )

--- a/websites/wpgraphql.com/src/styles/docsearch.css
+++ b/websites/wpgraphql.com/src/styles/docsearch.css
@@ -210,6 +210,71 @@
   display: none;
 }
 
+/* DocSearch v4 search-bar actions: a "Clear" text button (hidden until a
+   query is typed) and an X close button, grouped right of the input. */
+.DocSearch-Actions {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.DocSearch-Clear {
+  appearance: none;
+  border: 0;
+  background: none;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.375rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: hsl(var(--muted-foreground));
+  cursor: pointer;
+  transition: color 0.15s ease;
+}
+.DocSearch-Clear:hover {
+  color: hsl(var(--foreground));
+}
+.DocSearch-Clear:focus-visible {
+  outline: 2px solid hsl(var(--ring));
+  outline-offset: 1px;
+}
+/* Keep the [hidden] attribute effective (it hides Clear while the query is
+   empty); a display value here would override it. */
+.DocSearch-Clear[hidden] {
+  display: none;
+}
+
+.DocSearch-Close {
+  appearance: none;
+  flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  padding: 0;
+  border-radius: 0.375rem;
+  border: 1px solid hsl(var(--border));
+  background: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+  cursor: pointer;
+  transition:
+    color 0.15s ease,
+    border-color 0.15s ease;
+}
+.DocSearch-Close:hover {
+  color: hsl(var(--foreground));
+  border-color: hsl(var(--primary) / 0.5);
+}
+.DocSearch-Close:focus-visible {
+  outline: 2px solid hsl(var(--ring));
+  outline-offset: 1px;
+}
+.DocSearch-Close svg {
+  width: 0.875rem;
+  height: 0.875rem;
+}
+
 .DocSearch-Cancel {
   appearance: none;
   flex: none;
@@ -504,4 +569,30 @@
   color: hsl(var(--primary));
   border-color: hsl(var(--primary) / 0.4);
   background: hsl(var(--primary) / 0.1);
+}
+
+/* ------------------------------------------------------------
+   Per-hit product badge (rendered by SearchButton's Hit) — names
+   which corpus a result belongs to, in that product's accent
+   ------------------------------------------------------------ */
+
+a.DocSearch-Hit--withBadge {
+  padding-right: 7rem;
+}
+
+.DocSearch-Hit-ProductBadge {
+  position: absolute;
+  right: 0.75rem;
+  top: 50%;
+  transform: translateY(-50%);
+  border: 1px solid hsl(var(--primary) / 0.35);
+  background: hsl(var(--primary) / 0.1);
+  color: hsl(var(--primary));
+  font-size: 0.625rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  padding: 0.125rem 0.5rem;
+  border-radius: 9999px;
+  pointer-events: none;
+  white-space: nowrap;
 }


### PR DESCRIPTION
## What

Two search-modal polish items from reviewing the shipped product facets:

- **Search-bar actions restyled for DocSearch v4.** The v4 upgrade renamed the controls (`.DocSearch-Actions` wrapping a `.DocSearch-Clear` text button and a `.DocSearch-Close` X button); our stylesheet only covered v3's `.DocSearch-Reset`/`.DocSearch-Cancel`, so the v4 buttons rendered unstyled and floated at the modal's top right. They now sit inline in the search bar: Clear as a subtle text button (its `hidden` state while the query is empty is preserved), Close as a bordered icon button matching the old treatment.
- **Per-hit product badges.** Each page-level result carries a pill naming its corpus — WPGraphQL / ACF / Smart Cache / IDE (from the `product` attribute) or Blog (from `tags`) — rendered in that product's sibling-brand accent, so mixed results under the All filter are attributable at a glance. Child rows stay unbadged; their page row carries the context. Records without either attribute (extension marketing pages) get no badge.

## Index/infra notes

- DocSearch v4 hardcodes its own `attributesToRetrieve` unless `searchParameters` provides one, so the modal now requests DocSearch's default list plus `product` and `tags`.
- The live index's `attributesToRetrieve` setting was updated (via the API) to include `product` and `tags`. To keep the crawler config's `initialIndexSettings` in parity for a from-scratch rebuild, add `"product", "tags"` to its `attributesToRetrieve` array next time you're in the crawler editor (not urgent, and no recrawl needed).

## Testing

Verified in the browser against the live index: Clear/Close render inline and styled; `cache` under All shows orange WPGraphQL pills on dev-reference hits and rose Smart Cache pills on Smart Cache docs; filtered chips unchanged.