### PR TITLE
feat(wpgraphql.com): field types in the ACF docs nav with provider badges

### DIFF
--- a/plugins/wp-graphql-acf/docs/docs_nav.json
+++ b/plugins/wp-graphql-acf/docs/docs_nav.json
@@ -20,7 +20,197 @@
 		},
 		{
 			"title": "ACF Field Types",
-			"href": "/field-types"
+			"href": "/field-types",
+			"items": [
+				{
+					"title": "Advanced Link",
+					"href": "/field-types/advanced-link"
+				},
+				{
+					"title": "Button",
+					"href": "/field-types/button"
+				},
+				{
+					"title": "Button Group",
+					"href": "/field-types/button-group"
+				},
+				{
+					"title": "Checkbox",
+					"href": "/field-types/checkbox"
+				},
+				{
+					"title": "Clone Field",
+					"href": "/field-types/clone-field"
+				},
+				{
+					"title": "Code Editor",
+					"href": "/field-types/code-editor"
+				},
+				{
+					"title": "Color Picker",
+					"href": "/field-types/color-picker"
+				},
+				{
+					"title": "Countries",
+					"href": "/field-types/countries"
+				},
+				{
+					"title": "Currencies",
+					"href": "/field-types/currencies"
+				},
+				{
+					"title": "Date Picker",
+					"href": "/field-types/date-picker"
+				},
+				{
+					"title": "Date Range Picker",
+					"href": "/field-types/date-range-picker"
+				},
+				{
+					"title": "DateTimePicker",
+					"href": "/field-types/datetimepicker"
+				},
+				{
+					"title": "Email",
+					"href": "/field-types/email"
+				},
+				{
+					"title": "File",
+					"href": "/field-types/file"
+				},
+				{
+					"title": "Flexible Content",
+					"href": "/field-types/flexible-content"
+				},
+				{
+					"title": "Gallery",
+					"href": "/field-types/gallery"
+				},
+				{
+					"title": "Google Map",
+					"href": "/field-types/google-map"
+				},
+				{
+					"title": "Group",
+					"href": "/field-types/group"
+				},
+				{
+					"title": "Image",
+					"href": "/field-types/image"
+				},
+				{
+					"title": "Image Selector",
+					"href": "/field-types/image-selector"
+				},
+				{
+					"title": "Image Sizes",
+					"href": "/field-types/image-sizes"
+				},
+				{
+					"title": "Languages",
+					"href": "/field-types/languages"
+				},
+				{
+					"title": "Link",
+					"href": "/field-types/link"
+				},
+				{
+					"title": "Menu Locations",
+					"href": "/field-types/menu-locations"
+				},
+				{
+					"title": "Menus",
+					"href": "/field-types/menus"
+				},
+				{
+					"title": "Number",
+					"href": "/field-types/number"
+				},
+				{
+					"title": "Oembed",
+					"href": "/field-types/oembed"
+				},
+				{
+					"title": "PageLink",
+					"href": "/field-types/pagelink"
+				},
+				{
+					"title": "Password",
+					"href": "/field-types/password"
+				},
+				{
+					"title": "Phone Number",
+					"href": "/field-types/phone-number"
+				},
+				{
+					"title": "Post Object",
+					"href": "/field-types/post-object"
+				},
+				{
+					"title": "Radio Button",
+					"href": "/field-types/radio-button"
+				},
+				{
+					"title": "Range",
+					"href": "/field-types/range"
+				},
+				{
+					"title": "Relationship",
+					"href": "/field-types/relationship"
+				},
+				{
+					"title": "Repeater",
+					"href": "/field-types/repeater"
+				},
+				{
+					"title": "Select",
+					"href": "/field-types/select"
+				},
+				{
+					"title": "Taxonomies",
+					"href": "/field-types/taxonomies"
+				},
+				{
+					"title": "Taxonomy",
+					"href": "/field-types/taxonomy"
+				},
+				{
+					"title": "Taxonomy Terms",
+					"href": "/field-types/taxonomy-terms"
+				},
+				{
+					"title": "Text",
+					"href": "/field-types/text"
+				},
+				{
+					"title": "Text Area",
+					"href": "/field-types/text-area"
+				},
+				{
+					"title": "Time Picker",
+					"href": "/field-types/time-picker"
+				},
+				{
+					"title": "True / False",
+					"href": "/field-types/true-false"
+				},
+				{
+					"title": "Url",
+					"href": "/field-types/url"
+				},
+				{
+					"title": "User",
+					"href": "/field-types/user"
+				},
+				{
+					"title": "User Roles",
+					"href": "/field-types/user-roles"
+				},
+				{
+					"title": "WYSIWYG",
+					"href": "/field-types/wysiwyg"
+				}
+			]
 		},
 		{
 			"title": "Adding ACF Post Types and Taxonomies to the GraphQL Schema",

--- a/plugins/wp-graphql-acf/docs/field-types/advanced-link.md
+++ b/plugins/wp-graphql-acf/docs/field-types/advanced-link.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/advanced-link/"
 title: "Advanced Link"
+provider: "ACF Extended"
 ---
 
 `acfe_advanced_link`

--- a/plugins/wp-graphql-acf/docs/field-types/button-group.md
+++ b/plugins/wp-graphql-acf/docs/field-types/button-group.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/button-group/"
 title: "Button Group"
+provider: "ACF"
 ---
 
 `button_group`

--- a/plugins/wp-graphql-acf/docs/field-types/button.md
+++ b/plugins/wp-graphql-acf/docs/field-types/button.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/button/"
 title: "Button"
+provider: "ACF Extended"
 ---
 
 `acfe_button`

--- a/plugins/wp-graphql-acf/docs/field-types/checkbox.md
+++ b/plugins/wp-graphql-acf/docs/field-types/checkbox.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/checkbox/"
 title: "Checkbox"
+provider: "ACF"
 ---
 
 `checkbox`

--- a/plugins/wp-graphql-acf/docs/field-types/clone-field.md
+++ b/plugins/wp-graphql-acf/docs/field-types/clone-field.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/clone-field/"
 title: "Clone Field"
+provider: "ACF Pro"
 ---
 
 > This field type does not have full documentation yet. Contributions are welcome: edit this file and open a pull request on the [WPGraphQL monorepo](https://github.com/wp-graphql/wp-graphql).

--- a/plugins/wp-graphql-acf/docs/field-types/code-editor.md
+++ b/plugins/wp-graphql-acf/docs/field-types/code-editor.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/code-editor/"
 title: "Code Editor"
+provider: "ACF Extended"
 ---
 
 `acfe_code_editor`

--- a/plugins/wp-graphql-acf/docs/field-types/color-picker.md
+++ b/plugins/wp-graphql-acf/docs/field-types/color-picker.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/color-picker/"
 title: "Color Picker"
+provider: "ACF"
 ---
 
 `color_picker`

--- a/plugins/wp-graphql-acf/docs/field-types/countries.md
+++ b/plugins/wp-graphql-acf/docs/field-types/countries.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/countries/"
 title: "Countries"
+provider: "ACF Extended Pro"
 ---
 
 `acfe_countries`

--- a/plugins/wp-graphql-acf/docs/field-types/currencies.md
+++ b/plugins/wp-graphql-acf/docs/field-types/currencies.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/currencies/"
 title: "Currencies"
+provider: "ACF Extended Pro"
 ---
 
 `acfe_currencies`

--- a/plugins/wp-graphql-acf/docs/field-types/date-picker.md
+++ b/plugins/wp-graphql-acf/docs/field-types/date-picker.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/date-picker/"
 title: "Date Picker"
+provider: "ACF"
 ---
 
 `date_picker`

--- a/plugins/wp-graphql-acf/docs/field-types/date-range-picker.md
+++ b/plugins/wp-graphql-acf/docs/field-types/date-range-picker.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/date-range-picker/"
 title: "Date Range Picker"
+provider: "ACF Extended Pro"
 ---
 
 `date_range_picker`

--- a/plugins/wp-graphql-acf/docs/field-types/datetimepicker.md
+++ b/plugins/wp-graphql-acf/docs/field-types/datetimepicker.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/datetimepicker/"
 title: "DateTimePicker"
+provider: "ACF"
 ---
 
 `date_time_picker`

--- a/plugins/wp-graphql-acf/docs/field-types/email.md
+++ b/plugins/wp-graphql-acf/docs/field-types/email.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/email/"
 title: "Email"
+provider: "ACF"
 ---
 
 `email`

--- a/plugins/wp-graphql-acf/docs/field-types/file.md
+++ b/plugins/wp-graphql-acf/docs/field-types/file.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/file/"
 title: "File"
+provider: "ACF"
 ---
 
 `file`

--- a/plugins/wp-graphql-acf/docs/field-types/flexible-content.md
+++ b/plugins/wp-graphql-acf/docs/field-types/flexible-content.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/flexible-content/"
 title: "Flexible Content"
+provider: "ACF Pro"
 ---
 
 > This field type does not have full documentation yet. Contributions are welcome: edit this file and open a pull request on the [WPGraphQL monorepo](https://github.com/wp-graphql/wp-graphql).

--- a/plugins/wp-graphql-acf/docs/field-types/gallery.md
+++ b/plugins/wp-graphql-acf/docs/field-types/gallery.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/gallery/"
 title: "Gallery"
+provider: "ACF Pro"
 ---
 
 `gallery`

--- a/plugins/wp-graphql-acf/docs/field-types/google-map.md
+++ b/plugins/wp-graphql-acf/docs/field-types/google-map.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/google-map/"
 title: "Google Map"
+provider: "ACF"
 ---
 
 `google_map`

--- a/plugins/wp-graphql-acf/docs/field-types/group.md
+++ b/plugins/wp-graphql-acf/docs/field-types/group.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/group/"
 title: "Group"
+provider: "ACF"
 ---
 
 `group`

--- a/plugins/wp-graphql-acf/docs/field-types/image-selector.md
+++ b/plugins/wp-graphql-acf/docs/field-types/image-selector.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/image-selector/"
 title: "Image Selector"
+provider: "ACF Extended Pro"
 ---
 
 `acfe_image_selector`

--- a/plugins/wp-graphql-acf/docs/field-types/image-sizes.md
+++ b/plugins/wp-graphql-acf/docs/field-types/image-sizes.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/image-sizes/"
 title: "Image Sizes"
+provider: "ACF Extended Pro"
 ---
 
 `acfe_image_sizes`

--- a/plugins/wp-graphql-acf/docs/field-types/image.md
+++ b/plugins/wp-graphql-acf/docs/field-types/image.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/image/"
 title: "Image"
+provider: "ACF"
 ---
 
 `image`

--- a/plugins/wp-graphql-acf/docs/field-types/languages.md
+++ b/plugins/wp-graphql-acf/docs/field-types/languages.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/languages/"
 title: "Languages"
+provider: "ACF Extended Pro"
 ---
 
 `acfe_languages`

--- a/plugins/wp-graphql-acf/docs/field-types/link.md
+++ b/plugins/wp-graphql-acf/docs/field-types/link.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/link/"
 title: "Link"
+provider: "ACF"
 ---
 
 `link`

--- a/plugins/wp-graphql-acf/docs/field-types/menu-locations.md
+++ b/plugins/wp-graphql-acf/docs/field-types/menu-locations.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/menu-locations/"
 title: "Menu Locations"
+provider: "ACF Extended Pro"
 ---
 
 > This field type does not have full documentation yet. Contributions are welcome: edit this file and open a pull request on the [WPGraphQL monorepo](https://github.com/wp-graphql/wp-graphql).

--- a/plugins/wp-graphql-acf/docs/field-types/menus.md
+++ b/plugins/wp-graphql-acf/docs/field-types/menus.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/menus/"
 title: "Menus"
+provider: "ACF Extended Pro"
 ---
 
 > This field type does not have full documentation yet. Contributions are welcome: edit this file and open a pull request on the [WPGraphQL monorepo](https://github.com/wp-graphql/wp-graphql).

--- a/plugins/wp-graphql-acf/docs/field-types/number.md
+++ b/plugins/wp-graphql-acf/docs/field-types/number.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/number/"
 title: "Number"
+provider: "ACF"
 ---
 
 > This field type does not have full documentation yet. Contributions are welcome: edit this file and open a pull request on the [WPGraphQL monorepo](https://github.com/wp-graphql/wp-graphql).

--- a/plugins/wp-graphql-acf/docs/field-types/oembed.md
+++ b/plugins/wp-graphql-acf/docs/field-types/oembed.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/oembed/"
 title: "Oembed"
+provider: "ACF"
 ---
 
 > This field type does not have full documentation yet. Contributions are welcome: edit this file and open a pull request on the [WPGraphQL monorepo](https://github.com/wp-graphql/wp-graphql).

--- a/plugins/wp-graphql-acf/docs/field-types/pagelink.md
+++ b/plugins/wp-graphql-acf/docs/field-types/pagelink.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/pagelink/"
 title: "PageLink"
+provider: "ACF"
 ---
 
 > This field type does not have full documentation yet. Contributions are welcome: edit this file and open a pull request on the [WPGraphQL monorepo](https://github.com/wp-graphql/wp-graphql).

--- a/plugins/wp-graphql-acf/docs/field-types/password.md
+++ b/plugins/wp-graphql-acf/docs/field-types/password.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/password/"
 title: "Password"
+provider: "ACF"
 ---
 
 > This field type does not have full documentation yet. Contributions are welcome: edit this file and open a pull request on the [WPGraphQL monorepo](https://github.com/wp-graphql/wp-graphql).

--- a/plugins/wp-graphql-acf/docs/field-types/phone-number.md
+++ b/plugins/wp-graphql-acf/docs/field-types/phone-number.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/phone-number/"
 title: "Phone Number"
+provider: "ACF Extended Pro"
 ---
 
 > This field type does not have full documentation yet. Contributions are welcome: edit this file and open a pull request on the [WPGraphQL monorepo](https://github.com/wp-graphql/wp-graphql).

--- a/plugins/wp-graphql-acf/docs/field-types/post-object.md
+++ b/plugins/wp-graphql-acf/docs/field-types/post-object.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/post-object/"
 title: "Post Object"
+provider: "ACF"
 ---
 
 > This field type does not have full documentation yet. Contributions are welcome: edit this file and open a pull request on the [WPGraphQL monorepo](https://github.com/wp-graphql/wp-graphql).

--- a/plugins/wp-graphql-acf/docs/field-types/radio-button.md
+++ b/plugins/wp-graphql-acf/docs/field-types/radio-button.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/radio-button/"
 title: "Radio Button"
+provider: "ACF"
 ---
 
 `radio_button`

--- a/plugins/wp-graphql-acf/docs/field-types/range.md
+++ b/plugins/wp-graphql-acf/docs/field-types/range.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/range/"
 title: "Range"
+provider: "ACF"
 ---
 
 `range`

--- a/plugins/wp-graphql-acf/docs/field-types/relationship.md
+++ b/plugins/wp-graphql-acf/docs/field-types/relationship.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/relationship/"
 title: "Relationship"
+provider: "ACF"
 ---
 
 > This field type does not have full documentation yet. Contributions are welcome: edit this file and open a pull request on the [WPGraphQL monorepo](https://github.com/wp-graphql/wp-graphql).

--- a/plugins/wp-graphql-acf/docs/field-types/repeater.md
+++ b/plugins/wp-graphql-acf/docs/field-types/repeater.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/repeater/"
 title: "Repeater"
+provider: "ACF Pro"
 ---
 
 > This field type does not have full documentation yet. Contributions are welcome: edit this file and open a pull request on the [WPGraphQL monorepo](https://github.com/wp-graphql/wp-graphql).

--- a/plugins/wp-graphql-acf/docs/field-types/select.md
+++ b/plugins/wp-graphql-acf/docs/field-types/select.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/select/"
 title: "Select"
+provider: "ACF"
 ---
 
 > This field type does not have full documentation yet. Contributions are welcome: edit this file and open a pull request on the [WPGraphQL monorepo](https://github.com/wp-graphql/wp-graphql).

--- a/plugins/wp-graphql-acf/docs/field-types/taxonomies.md
+++ b/plugins/wp-graphql-acf/docs/field-types/taxonomies.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/taxonomies/"
 title: "Taxonomies"
+provider: "ACF Extended"
 ---
 
 `acfe_taxonomies`

--- a/plugins/wp-graphql-acf/docs/field-types/taxonomy-terms.md
+++ b/plugins/wp-graphql-acf/docs/field-types/taxonomy-terms.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/taxonomy-terms/"
 title: "Taxonomy Terms"
+provider: "ACF Extended"
 ---
 
 `acfe_taxonomy_terms`

--- a/plugins/wp-graphql-acf/docs/field-types/taxonomy.md
+++ b/plugins/wp-graphql-acf/docs/field-types/taxonomy.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/taxonomy/"
 title: "Taxonomy"
+provider: "ACF"
 ---
 
 > This field type does not have full documentation yet. Contributions are welcome: edit this file and open a pull request on the [WPGraphQL monorepo](https://github.com/wp-graphql/wp-graphql).

--- a/plugins/wp-graphql-acf/docs/field-types/text-area.md
+++ b/plugins/wp-graphql-acf/docs/field-types/text-area.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/text-area/"
 title: "Text Area"
+provider: "ACF"
 ---
 
 `text_area`

--- a/plugins/wp-graphql-acf/docs/field-types/text.md
+++ b/plugins/wp-graphql-acf/docs/field-types/text.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/text/"
 title: "Text"
+provider: "ACF"
 ---
 
 `text`

--- a/plugins/wp-graphql-acf/docs/field-types/time-picker.md
+++ b/plugins/wp-graphql-acf/docs/field-types/time-picker.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/time-picker/"
 title: "Time Picker"
+provider: "ACF"
 ---
 
 `time_picker`

--- a/plugins/wp-graphql-acf/docs/field-types/true-false.md
+++ b/plugins/wp-graphql-acf/docs/field-types/true-false.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/true-false/"
 title: "True / False"
+provider: "ACF"
 ---
 
 `true_false`

--- a/plugins/wp-graphql-acf/docs/field-types/url.md
+++ b/plugins/wp-graphql-acf/docs/field-types/url.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/url/"
 title: "Url"
+provider: "ACF"
 ---
 
 `url`

--- a/plugins/wp-graphql-acf/docs/field-types/user-roles.md
+++ b/plugins/wp-graphql-acf/docs/field-types/user-roles.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/user-roles/"
 title: "User Roles"
+provider: "ACF Extended"
 ---
 
 The User Roles Field Type is a custom ACF Field Type made available by the Advanced Custom Fields Extended plugin.

--- a/plugins/wp-graphql-acf/docs/field-types/user.md
+++ b/plugins/wp-graphql-acf/docs/field-types/user.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/user/"
 title: "User"
+provider: "ACF"
 ---
 
 `user`

--- a/plugins/wp-graphql-acf/docs/field-types/wysiwyg.md
+++ b/plugins/wp-graphql-acf/docs/field-types/wysiwyg.md
@@ -1,6 +1,7 @@
 ---
 uri: "/field-types/wysiwyg/"
 title: "WYSIWYG"
+provider: "ACF"
 ---
 
 `wysiwyg`

--- a/websites/wpgraphql.com/src/components/Docs/DocsNav.js
+++ b/websites/wpgraphql.com/src/components/Docs/DocsNav.js
@@ -58,13 +58,18 @@ function NavLink({ item, currentPath, className }) {
  */
 function NavGroup({ item, currentPath }) {
   const isWithin = containsPath(item, currentPath)
-  const [open, setOpen] = useState(isWithin)
-
-  useEffect(() => {
-    if (isWithin) {
-      setOpen(true)
-    }
-  }, [isWithin, currentPath])
+  // The route decides the default (open when the reader is inside the
+  // subtree); a manual toggle overrides it until the next navigation.
+  // The override resets via state-adjustment-during-render rather than an
+  // effect (react.dev/learn/you-might-not-need-an-effect).
+  const [override, setOverride] = useState(null)
+  const [lastPath, setLastPath] = useState(currentPath)
+  if (lastPath !== currentPath) {
+    setLastPath(currentPath)
+    setOverride(null)
+  }
+  const open = override ?? isWithin
+  const setOpen = (next) => setOverride(next)
 
   return (
     <>
@@ -76,7 +81,7 @@ function NavGroup({ item, currentPath }) {
           type="button"
           aria-expanded={open}
           aria-label={`${open ? "Collapse" : "Expand"} ${item.title}`}
-          onClick={() => setOpen((value) => !value)}
+          onClick={() => setOpen(!open)}
           className="flex h-6 w-6 flex-none items-center justify-center rounded text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
           <ChevronRightIcon

--- a/websites/wpgraphql.com/src/components/Docs/DocsNav.js
+++ b/websites/wpgraphql.com/src/components/Docs/DocsNav.js
@@ -1,6 +1,7 @@
-import { useEffect, useMemo, useRef } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import Link from "next/link"
 import { useRouter } from "next/router"
+import { ChevronRightIcon } from "@heroicons/react/20/solid"
 import { cn } from "@/lib/utils"
 
 function normalizePath(path) {
@@ -18,17 +19,97 @@ function findScrollParent(el) {
   return null
 }
 
+/** Whether the current path is this item's page or inside its subtree. */
+function containsPath(item, currentPath) {
+  if (!item) return false
+  const itemPath = normalizePath(item.href)
+  if (itemPath && itemPath === currentPath) return true
+  return Array.isArray(item.items)
+    ? item.items.some((child) => containsPath(child, currentPath))
+    : false
+}
+
+function NavLink({ item, currentPath, className }) {
+  const itemPath = normalizePath(item.href)
+  const isActive = itemPath && itemPath === currentPath
+  return (
+    <Link href={item.href} legacyBehavior>
+      <a
+        aria-current={isActive ? "page" : undefined}
+        className={cn(
+          "-ml-px block border-l py-1 pl-4 text-sm transition-colors",
+          isActive
+            ? "border-primary text-primary"
+            : "border-transparent text-muted-foreground hover:border-primary/50 hover:text-foreground",
+          className
+        )}
+      >
+        {item.title}
+      </a>
+    </Link>
+  )
+}
+
+/**
+ * A nav entry with nested children (e.g. the ACF field types under "ACF
+ * Field Types"): the entry itself stays a link, with a disclosure toggle
+ * beside it. The subtree starts open when the reader is inside it and
+ * re-opens if they navigate into it.
+ */
+function NavGroup({ item, currentPath }) {
+  const isWithin = containsPath(item, currentPath)
+  const [open, setOpen] = useState(isWithin)
+
+  useEffect(() => {
+    if (isWithin) {
+      setOpen(true)
+    }
+  }, [isWithin, currentPath])
+
+  return (
+    <>
+      <div className="flex items-center">
+        <div className="min-w-0 flex-1">
+          <NavLink item={item} currentPath={currentPath} />
+        </div>
+        <button
+          type="button"
+          aria-expanded={open}
+          aria-label={`${open ? "Collapse" : "Expand"} ${item.title}`}
+          onClick={() => setOpen((value) => !value)}
+          className="flex h-6 w-6 flex-none items-center justify-center rounded text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <ChevronRightIcon
+            aria-hidden="true"
+            className={cn("h-4 w-4 transition-transform", open && "rotate-90")}
+          />
+        </button>
+      </div>
+      {open && (
+        <ul className="ml-4 border-l border-border">
+          {item.items.map((child) => (
+            <li key={child.href}>
+              <NavLink item={child} currentPath={currentPath} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </>
+  )
+}
+
 export default function DocsNav({ docsNavData }) {
   const { asPath } = useRouter()
   const currentPath = normalizePath(asPath)
 
   // Which section (Getting Started / Beginner Guides / ...) contains the
-  // current page. We scroll this section to the top of the nav so the
-  // section header is always visible above the active link.
+  // current page (nested subtrees included). We scroll this section to the
+  // top of the nav so the section header is always visible above the
+  // active link.
   const activeSectionKey = useMemo(() => {
     if (!docsNavData) return null
     for (const [key, children] of Object.entries(docsNavData)) {
-      if (children?.some((c) => normalizePath(c.href) === currentPath)) {
+      if (children?.some((c) => containsPath(c, currentPath))) {
         return key
       }
     }
@@ -75,27 +156,15 @@ export default function DocsNav({ docsNavData }) {
               {key}
             </h3>
             <ul className="border-l border-border space-y-1">
-              {children.map((child) => {
-                const childPath = normalizePath(child.href)
-                const isActive = childPath && childPath === currentPath
-                return (
-                  <li key={child.href}>
-                    <Link href={child.href} legacyBehavior>
-                      <a
-                        aria-current={isActive ? "page" : undefined}
-                        className={cn(
-                          "-ml-px block border-l py-1 pl-4 text-sm transition-colors",
-                          isActive
-                            ? "border-primary text-primary"
-                            : "border-transparent text-muted-foreground hover:border-primary/50 hover:text-foreground"
-                        )}
-                      >
-                        {child.title}
-                      </a>
-                    </Link>
-                  </li>
-                )
-              })}
+              {children.map((child) => (
+                <li key={child.href ?? child.title}>
+                  {Array.isArray(child.items) && child.items.length > 0 ? (
+                    <NavGroup item={child} currentPath={currentPath} />
+                  ) : (
+                    <NavLink item={child} currentPath={currentPath} />
+                  )}
+                </li>
+              ))}
             </ul>
           </div>
         )

--- a/websites/wpgraphql.com/src/lib/docs-products.ts
+++ b/websites/wpgraphql.com/src/lib/docs-products.ts
@@ -145,31 +145,51 @@ export function normalizeNavHref(product: DocsProduct, href: string): string {
   return slug ? `${product.basePath}/${slug}` : product.basePath
 }
 
+/** A docs sidebar entry; `items` nests child pages under a parent entry. */
+export type DocsNavItem = {
+  title?: string
+  href?: string
+  items?: DocsNavItem[]
+}
+
+function normalizeNavItem(
+  product: DocsProduct,
+  item: DocsNavItem
+): DocsNavItem {
+  if (!item || typeof item !== "object") {
+    return item
+  }
+  const normalized: DocsNavItem = { ...item }
+  if (typeof normalized.href === "string") {
+    normalized.href = normalizeNavHref(product, normalized.href)
+  }
+  if (Array.isArray(normalized.items)) {
+    normalized.items = normalized.items.map((child) =>
+      normalizeNavItem(product, child)
+    )
+  }
+  return normalized
+}
+
 /**
- * Normalize a whole grouped docs nav ({ section: [{ title, href }] }) for a
- * product, returning the same shape with site-ready hrefs.
+ * Normalize a whole grouped docs nav ({ section: [{ title, href, items? }] })
+ * for a product, returning the same shape with site-ready hrefs (nested
+ * items included).
  */
 export function normalizeDocsNav(
   product: DocsProduct,
-  nav: Record<string, Array<{ title?: string; href?: string }>>
-): Record<string, Array<{ title?: string; href?: string }>> {
+  nav: Record<string, DocsNavItem[]>
+): Record<string, DocsNavItem[]> {
   if (!nav || typeof nav !== "object") {
     return nav
   }
 
-  const normalized: Record<
-    string,
-    Array<{ title?: string; href?: string }>
-  > = {}
+  const normalized: Record<string, DocsNavItem[]> = {}
   for (const [section, items] of Object.entries(nav)) {
     if (!Array.isArray(items)) {
       continue
     }
-    normalized[section] = items.map((item) =>
-      item && typeof item.href === "string"
-        ? { ...item, href: normalizeNavHref(product, item.href) }
-        : item
-    )
+    normalized[section] = items.map((item) => normalizeNavItem(product, item))
   }
   return normalized
 }

--- a/websites/wpgraphql.com/src/lib/parse-mdx-docs.ts
+++ b/websites/wpgraphql.com/src/lib/parse-mdx-docs.ts
@@ -305,22 +305,34 @@ export async function getDocsNav(product: DocsProduct = CORE_PRODUCT) {
  * prev/next footer on docs pages.
  */
 export function flattenDocsNav(
-  nav: Record<string, Array<{ title?: string; href?: string }>>
+  nav: Record<
+    string,
+    Array<{ title?: string; href?: string; items?: unknown[] }>
+  >
 ): Array<{ href: string; label: string }> {
   if (!nav || typeof nav !== "object") {
     return []
   }
 
   const items: Array<{ href: string; label: string }> = []
+  const push = (item: any) => {
+    if (!item || typeof item !== "object") {
+      return
+    }
+    if (typeof item.href === "string") {
+      items.push({ href: item.href, label: item.title ?? item.href })
+    }
+    // Nested children follow their parent, so prev/next walks into and out
+    // of a subtree (e.g. the ACF field types) in reading order.
+    if (Array.isArray(item.items)) {
+      item.items.forEach(push)
+    }
+  }
   for (const group of Object.values(nav)) {
     if (!Array.isArray(group)) {
       continue
     }
-    for (const item of group) {
-      if (item && typeof item.href === "string") {
-        items.push({ href: item.href, label: item.title ?? item.href })
-      }
-    }
+    group.forEach(push)
   }
   return items
 }

--- a/websites/wpgraphql.com/src/pages/docs/[[...slug]].js
+++ b/websites/wpgraphql.com/src/pages/docs/[[...slug]].js
@@ -57,16 +57,37 @@ function toSlugParams(uri) {
 }
 
 /**
- * Find the sidebar-nav entry (and its section heading) for a doc URI.
+ * Find the sidebar-nav entry (and its section heading) for a doc URI,
+ * searching nested subtrees. `parents` is the chain of nav entries above a
+ * nested hit (e.g. "ACF Field Types" above an individual field type), used
+ * to render them as linked crumbs.
  */
 function findNavEntry(docsNavData, uri) {
+  const search = (entries, parents) => {
+    for (const entry of entries) {
+      if (!entry || typeof entry !== "object") {
+        continue
+      }
+      if (entry.href === uri) {
+        return { item: entry, parents }
+      }
+      if (Array.isArray(entry.items)) {
+        const nested = search(entry.items, [...parents, entry])
+        if (nested) {
+          return nested
+        }
+      }
+    }
+    return null
+  }
+
   for (const [section, group] of Object.entries(docsNavData ?? {})) {
     if (!Array.isArray(group)) {
       continue
     }
-    const item = group.find((entry) => entry?.href === uri)
-    if (item) {
-      return { section, item }
+    const found = search(group, [])
+    if (found) {
+      return { section, ...found }
     }
   }
   return null
@@ -99,6 +120,15 @@ function buildDocBreadcrumbs({
   const direct = findNavEntry(docsNavData, requestedUri)
   if (direct) {
     items.push({ label: direct.section })
+    for (const parent of direct.parents) {
+      if (typeof parent.title !== "string") {
+        continue
+      }
+      items.push({
+        label: parent.title,
+        ...(typeof parent.href === "string" ? { href: parent.href } : {}),
+      })
+    }
     items.push({ label: direct.item.title ?? pageTitle ?? fallbackLabel })
     return items
   }
@@ -153,6 +183,15 @@ export default function Doc({
             <header className="relative z-20">
               <h1>{source.frontmatter.title}</h1>
             </header>
+          )}
+          {/* Which plugin provides the documented feature (e.g. an ACF
+              field type from ACF Pro or ACF Extended), from frontmatter. */}
+          {typeof source?.frontmatter?.provider === "string" && (
+            <p className="not-prose -mt-4 mb-8">
+              <span className="inline-block rounded-full border border-primary/35 bg-primary/10 px-3 py-0.5 text-xs font-semibold text-primary">
+                {source.frontmatter.provider}
+              </span>
+            </p>
           )}
           <MDXRemote {...source} components={components} />
           <PrevNext prev={nav?.prev} next={nav?.next} />


### PR DESCRIPTION
## What

Two acf.wpgraphql.com parity items the docs port dropped:

- **All 47 field types in the left nav.** The docs nav schema now supports nested `items`: an entry with children renders as a collapsible subtree (the entry itself stays a link, with a disclosure toggle beside it) that starts open when the reader is inside it and resets on navigation. `docs_nav.json` nests every field-type page under "ACF Field Types", alphabetical. Href normalization, prev/next ordering (which now walks into and out of the subtree in reading order), the active-section scroll, and breadcrumbs are all nesting-aware, so a field-type page's trail reads `Docs / WPGraphQL for ACF / Using WPGraphQL for ACF / ACF Field Types / Button Group` with the parent linked.
- **Provider badges.** Each field-type page now has a `provider` frontmatter key (ACF / ACF Pro / ACF Extended / ACF Extended Pro), derived from the tier groupings in `field-types/index.md`, and the docs template renders it as an accent pill under the title, like the old site's badge. The mechanism is generic frontmatter, so any future doc can carry one.

## Testing

Verified locally in the browser:

- `/docs/acf/field-types/button-group`: nav shows the expanded Field Types subtree with the active item highlighted, breadcrumb includes the linked ACF Field Types crumb, and the emerald ACF pill renders under the title.
- Tier spot checks: `countries` badges ACF Extended Pro, `repeater`/`clone-field` badge ACF Pro, `installation-and-activation` has no badge.
- Core docs pages unaffected (no nested entries, no badges).
- eslint and prettier clean.