### PR TITLE
feat(wpgraphql.com): redirect acf.wpgraphql.com onto the docs portal

### DIFF
--- a/websites/wpgraphql.com/redirects.json
+++ b/websites/wpgraphql.com/redirects.json
@@ -1,12 +1,100 @@
 [
   {
+    "source": "/style-guide",
+    "has": [
+      {
+        "type": "host",
+        "value": "acf.wpgraphql.com"
+      }
+    ],
+    "destination": "https://www.wpgraphql.com/docs/acf",
+    "permanent": true
+  },
+  {
+    "source": "/block-style-guide",
+    "has": [
+      {
+        "type": "host",
+        "value": "acf.wpgraphql.com"
+      }
+    ],
+    "destination": "https://www.wpgraphql.com/docs/acf",
+    "permanent": true
+  },
+  {
+    "source": "/preview",
+    "has": [
+      {
+        "type": "host",
+        "value": "acf.wpgraphql.com"
+      }
+    ],
+    "destination": "https://www.wpgraphql.com/docs/acf",
+    "permanent": true
+  },
+  {
+    "source": "/sitemap.xml",
+    "has": [
+      {
+        "type": "host",
+        "value": "acf.wpgraphql.com"
+      }
+    ],
+    "destination": "https://www.wpgraphql.com/sitemap.xml",
+    "permanent": true
+  },
+  {
+    "source": "/wordpress-sitemap.xml",
+    "has": [
+      {
+        "type": "host",
+        "value": "acf.wpgraphql.com"
+      }
+    ],
+    "destination": "https://www.wpgraphql.com/sitemap.xml",
+    "permanent": true
+  },
+  {
+    "source": "/robots.txt",
+    "has": [
+      {
+        "type": "host",
+        "value": "acf.wpgraphql.com"
+      }
+    ],
+    "destination": "https://www.wpgraphql.com/robots.txt",
+    "permanent": true
+  },
+  {
+    "source": "/",
+    "has": [
+      {
+        "type": "host",
+        "value": "acf.wpgraphql.com"
+      }
+    ],
+    "destination": "https://www.wpgraphql.com/docs/acf",
+    "permanent": true
+  },
+  {
+    "source": "/:path*",
+    "has": [
+      {
+        "type": "host",
+        "value": "acf.wpgraphql.com"
+      }
+    ],
+    "destination": "https://www.wpgraphql.com/docs/acf/:path*",
+    "permanent": true
+  },
+  {
     "source": "/discord",
     "destination": "https://discord.gg/AGVBqqyaUY",
     "permanent": true
   },
   {
     "source": "/acf",
-    "destination": "https://acf.wpgraphql.com",
+    "destination": "/docs/acf",
     "permanent": true
   },
   {

--- a/websites/wpgraphql.com/src/pages/extensions/wp-graphql-acf.js
+++ b/websites/wpgraphql.com/src/pages/extensions/wp-graphql-acf.js
@@ -23,7 +23,7 @@ const GITHUB_URL = "https://github.com/wp-graphql/wp-graphql"
 // The ACF plugin's own directory in the monorepo — the "source" / "View on GitHub" target.
 const GITHUB_ACF_URL =
   "https://github.com/wp-graphql/wp-graphql/tree/main/plugins/wp-graphql-acf"
-const DOCS_URL = "https://acf.wpgraphql.com"
+const DOCS_URL = "/docs/acf"
 
 // ACF sections use the field-group-table glyph in the eyebrow.
 function SectionHeading(props) {
@@ -378,9 +378,7 @@ function OpenSource() {
         </p>
         <div className="mt-10">
           <Button asChild variant="outline">
-            <a href={DOCS_URL} target="_blank" rel="noreferrer">
-              Read the docs
-            </a>
+            <a href={DOCS_URL}>Read the docs</a>
           </Button>
         </div>
       </div>
@@ -418,7 +416,7 @@ function Faq() {
     {
       question: "Do I have to use Faust.js?",
       answer:
-        "No. While wpgraphql.com and acf.wpgraphql.com are built with Faust.js and Next.js, you can use WPGraphQL for ACF with any GraphQL client — Apollo, Relay, urql, and more.",
+        "No. You can use WPGraphQL for ACF with any GraphQL client — Apollo, Relay, urql, Faust.js, and more.",
     },
   ]
 


### PR DESCRIPTION
## What

Phase 5 of the docs portal: the redirect layer that retires acf.wpgraphql.com.

**Redirect inventory** (from the subdomain's sitemaps, 61 unique paths): the old site's structure mirrors the portal exactly — guides at `/{slug}`, field types at `/field-types/{slug}` — so all **56 content paths map 1:1** onto `/docs/acf/...`, and every target was verified to resolve 200 on production. The remaining paths are three Faust-starter template pages (`/style-guide`, `/block-style-guide`, `/preview`) with no portal equivalent, which land on the ACF docs home, plus sitemap/robots plumbing that hands off to the main site's.

**Rules** (host-scoped to `acf.wpgraphql.com`, permanent):
- `/` → `/docs/acf`
- template pages → `/docs/acf`
- `/sitemap.xml`, `/wordpress-sitemap.xml` → the main sitemap; `/robots.txt` → the main robots
- `/:path*` catch-all → `/docs/acf/:path*`

Also in this diff: the www-side `/acf` shortlink now points at `/docs/acf` instead of the subdomain (avoiding a bounce chain once the subdomain redirects back), and the ACF extension page's "Read the docs" link is internal now, with the Faust FAQ copy updated.

**These rules are inert until the domain moves** — they only fire for requests carrying the `acf.wpgraphql.com` host header, which requires pointing that domain at the wpgraphql-com Vercel project (runbook below).

## Testing

Verified locally with spoofed Host headers: `/`, guides, field types, template pages, and sitemap all 308 to their targets; trailing-slash variants normalize then redirect; requests without the acf host header are completely unaffected; `/acf` on www 308s to `/docs/acf`.

## Rollout runbook (after merge + deploy)

1. Vercel: remove `acf.wpgraphql.com` from the Faust project, add it to the wpgraphql-com project (DNS already points at Vercel, so this is a project-assignment change).
2. Spot-check: `curl -sI https://acf.wpgraphql.com/field-types/repeater/` should chain to `https://www.wpgraphql.com/docs/acf/field-types/repeater` with 308s.
3. Then decommission: archive the acf.wpgraphql.com GitHub repo, delete the Faust Vercel project, and retire the docs content on its WP backend once nothing reads from it.