### PR TITLE
fix: return memoized model field values as data instead of re-invoking them

### DIFF
--- a/plugins/wp-graphql/src/Model/Model.php
+++ b/plugins/wp-graphql/src/Model/Model.php
@@ -142,8 +142,12 @@ abstract class Model {
 			return null;
 		}
 
-		// If the property is a callable, we need to process it.
-		if ( is_callable( $this->fields[ $key ] ) ) {
+		// Unresolved fields are closures (see wrap_fields()); resolve and memoize them.
+		// Anything else is already-resolved data, including strings that happen to
+		// collide with a defined function name ("Max" vs max()), which is_callable()
+		// would match case-insensitively and invoke the builtin instead of returning
+		// the value.
+		if ( $this->fields[ $key ] instanceof \Closure ) {
 			$data       = call_user_func( $this->fields[ $key ] );
 			$this->$key = $data;
 

--- a/plugins/wp-graphql/tests/wpunit/ModelFieldMemoizationTest.php
+++ b/plugins/wp-graphql/tests/wpunit/ModelFieldMemoizationTest.php
@@ -94,4 +94,108 @@ class ModelFieldMemoizationTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestC
 		$this->assertSame( 'Time', $model->lastName );
 		$this->assertSame( 'Time', $model->lastName );
 	}
+
+	/**
+	 * A field that resolves to a falsey value must return that same value on
+	 * every read, not null on the second one.
+	 *
+	 * This guards a separate historical fix in the same method (the guard was
+	 * once `! empty()`, which failed after a falsey value was memoized and
+	 * dropped the field to null on re-read). It shipped without a test, so this
+	 * locks the contract alongside the memoization fix.
+	 *
+	 * @see https://github.com/wp-graphql/wp-graphql/issues/4240
+	 */
+	public function testMemoizedFalseyValuesSurviveReRead() {
+		$author_id = $this->create_max_time_user();
+
+		wp_set_current_user( $author_id );
+
+		$falsey = [
+			'falseField'       => false,
+			'zeroField'        => 0,
+			'emptyStringField' => '',
+			'nullField'        => null,
+		];
+
+		add_filter(
+			'graphql_model_prepare_fields',
+			static function ( $fields, $model_name ) use ( $falsey ) {
+				if ( 'UserObject' !== $model_name ) {
+					return $fields;
+				}
+				foreach ( $falsey as $key => $value ) {
+					$fields[ $key ] = static function () use ( $value ) {
+						return $value;
+					};
+				}
+				return $fields;
+			},
+			10,
+			2
+		);
+
+		$model = new \WPGraphQL\Model\User( get_user_by( 'id', $author_id ) );
+
+		foreach ( $falsey as $key => $expected ) {
+			// First read resolves and memoizes the falsey value; the second read
+			// must return the same value rather than treating the field as unset.
+			$this->assertSame( $expected, $model->$key, "First read of {$key} should be the resolved falsey value." );
+			$this->assertSame( $expected, $model->$key, "Re-read of {$key} should return the memoized falsey value." );
+		}
+	}
+
+	/**
+	 * A field registered with a non-closure callback (a callable array, or the
+	 * `[ 'callback' => ... ]` shape) still resolves through the model.
+	 *
+	 * __get() only invokes Closures, which is safe because wrap_fields() wraps
+	 * every field definition in one and the original callback is invoked by
+	 * prepare_field(). This locks that coupling from the extension-author side:
+	 * if wrap_fields() ever stopped wrapping already-callable definitions, this
+	 * would catch it.
+	 */
+	public function testNonClosureCallbackFieldsResolveAndMemoize() {
+		$author_id = $this->create_max_time_user();
+
+		wp_set_current_user( $author_id );
+
+		add_filter(
+			'graphql_model_prepare_fields',
+			static function ( $fields, $model_name ) {
+				if ( 'UserObject' !== $model_name ) {
+					return $fields;
+				}
+				// Callable array definition (not a Closure).
+				$fields['callableArrayField'] = [ self::class, 'resolve_callable_array_field' ];
+				// The `callback` array shape prepare_field() unwraps, pointing at a
+				// non-closure callable.
+				$fields['callbackArrayField'] = [ 'callback' => [ self::class, 'resolve_callback_array_field' ] ];
+				return $fields;
+			},
+			10,
+			2
+		);
+
+		$model = new \WPGraphQL\Model\User( get_user_by( 'id', $author_id ) );
+
+		$this->assertSame( 'resolved-via-callable-array', $model->callableArrayField );
+		$this->assertSame( 'resolved-via-callable-array', $model->callableArrayField );
+		$this->assertSame( 'resolved-via-callback-array', $model->callbackArrayField );
+		$this->assertSame( 'resolved-via-callback-array', $model->callbackArrayField );
+	}
+
+	/**
+	 * Zero-argument resolver for the callable-array field above.
+	 */
+	public static function resolve_callable_array_field(): string {
+		return 'resolved-via-callable-array';
+	}
+
+	/**
+	 * Zero-argument resolver for the `callback` array field above.
+	 */
+	public static function resolve_callback_array_field(): string {
+		return 'resolved-via-callback-array';
+	}
 }

--- a/plugins/wp-graphql/tests/wpunit/ModelFieldMemoizationTest.php
+++ b/plugins/wp-graphql/tests/wpunit/ModelFieldMemoizationTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * Regression tests for Model::__get() memoization.
+ *
+ * Field values resolve through closures and are memoized onto the model
+ * instance. A memoized value must be treated as data on later reads, even
+ * when the value is a string that collides with the name of a defined PHP
+ * function ("Max" vs max(), "Time" vs time(), ...). Before the fix,
+ * re-reading such a field ran is_callable() on the raw string, which matches
+ * function names case-insensitively and invoked the builtin with no
+ * arguments, causing a fatal.
+ *
+ * A query triggers the re-read whenever the same field on the same model
+ * instance resolves more than once, e.g. requesting a field twice through an
+ * alias.
+ *
+ * @see https://github.com/wp-graphql/wp-graphql/issues/4240
+ */
+class ModelFieldMemoizationTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
+
+	/**
+	 * Clear the cached schema before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->clearSchema();
+	}
+
+	/**
+	 * Clear the cached schema after each test.
+	 */
+	public function tearDown(): void {
+		$this->clearSchema();
+		parent::tearDown();
+	}
+
+	/**
+	 * Create an author whose name parts collide with PHP builtins (max(), time()).
+	 */
+	private function create_max_time_user(): int {
+		return self::factory()->user->create(
+			[
+				'role'       => 'author',
+				'first_name' => 'Max',
+				'last_name'  => 'Time',
+			]
+		);
+	}
+
+	/**
+	 * Widest surface: a GraphQL query that resolves the same field twice on one
+	 * model instance via an alias, where the value collides with a PHP builtin
+	 * function name. The aliased (second) read returns the memoized string.
+	 */
+	public function testAliasedFieldReReadResolvesMemoizedValueAsData() {
+		$author_id = $this->create_max_time_user();
+
+		wp_set_current_user( $author_id );
+
+		$query = '
+		{
+			viewer {
+				firstName
+				firstNameAgain: firstName
+				lastName
+				lastNameAgain: lastName
+			}
+		}
+		';
+
+		$actual = $this->graphql( [ 'query' => $query ] );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertSame( 'Max', $actual['data']['viewer']['firstName'] );
+		$this->assertSame( 'Max', $actual['data']['viewer']['firstNameAgain'] );
+		$this->assertSame( 'Time', $actual['data']['viewer']['lastName'] );
+		$this->assertSame( 'Time', $actual['data']['viewer']['lastNameAgain'] );
+	}
+
+	/**
+	 * Precise surface: reading the same model property twice returns the
+	 * memoized value instead of invoking the PHP builtin it collides with.
+	 */
+	public function testModelReReadReturnsMemoizedStringValue() {
+		$author_id = $this->create_max_time_user();
+
+		wp_set_current_user( $author_id );
+
+		$model = new \WPGraphQL\Model\User( get_user_by( 'id', $author_id ) );
+
+		$this->assertSame( 'Max', $model->firstName );
+		$this->assertSame( 'Max', $model->firstName );
+		$this->assertSame( 'Time', $model->lastName );
+		$this->assertSame( 'Time', $model->lastName );
+	}
+}


### PR DESCRIPTION
## What bug does this fix? Explain your changes.

`Model::__get()` memoizes a field's resolved value back into the fields array. On a later read of the same field on the same model instance, `is_callable()` matched memoized string values against defined PHP function names case-insensitively, so a value like `"Max"` (a first name) invoked the builtin `max()` with zero arguments and caused a fatal:

```
max() expects at least 1 argument, 0 given
```

Unresolved fields are always closures, because `wrap_fields()` wraps every field definition in one, so the invoke path now requires an actual `Closure` and everything else is returned as data. This restores the type guard that was removed in the `__get()` simplification first shipped in v2.3.3.

Any string value colliding with a function name ("Max", "Time", "Date", "List", "Sort", ...) could trigger this whenever the same field on the same model instance resolved more than once, for example a query requesting a field twice through an alias.

## Does this close any currently open issues?

Fixes #4240

## Testing Strategy

TDD: added `tests/wpunit/ModelFieldMemoizationTest.php` with two tests, confirmed both fail against the unfixed code (the model-level test with the `ArgumentCountError` fatal, the query-level test with `errors` in the response), then implemented the fix and confirmed both pass.

- Widest surface: a GraphQL query resolving `viewer.firstName` twice via an alias, for a user named "Max Time" (both name parts collide with builtins)
- Model layer: reading `$model->firstName` twice directly

### Test Results

- [x] Failing tests added and verified against unfixed code
- [x] Fix implemented, tests pass
- [x] Full wpunit suite passing (1192 tests, 7309 assertions, 0 failures)
- [x] PHPCS and PHPStan (level 8) clean

## Additional Context

Credit to @davidvexel for an excellent report, including pinpointing the regression to the `__get()` refactor in #3381. The suggested fix in the issue would still invoke callable-shaped arrays; since `wrap_fields()` guarantees unresolved fields are closures, this PR uses the tighter `instanceof \Closure` guard so memoized arrays and strings are always treated as data.
