### PR TITLE
fix(security): do not invoke bare callable-string field definitions in Model

### DIFF
--- a/plugins/wp-graphql/src/Model/Model.php
+++ b/plugins/wp-graphql/src/Model/Model.php
@@ -416,7 +416,12 @@ abstract class Model {
 			$field = null;
 		}
 
-		if ( is_callable( $field ) ) {
+		// Invoke Closures and callable arrays (the resolver shapes WPGraphQL installs),
+		// but never a bare callable string. A field definition that is a string is data,
+		// not a resolver we registered (for example a value that happens to match a PHP
+		// function name), so it must be returned rather than invoked. This mirrors the
+		// Closure gate in __get(). Defense in depth for GHSA-7922 / CVE-2026-18944.
+		if ( is_callable( $field ) && ! is_string( $field ) ) {
 			$this->setup();
 			$field = call_user_func( $field );
 			$this->tear_down();

--- a/plugins/wp-graphql/src/Mutation/PostObjectUpdate.php
+++ b/plugins/wp-graphql/src/Mutation/PostObjectUpdate.php
@@ -114,6 +114,18 @@ class PostObjectUpdate {
 				throw new UserError( esc_html( sprintf( __( 'Sorry, you are not allowed to update another author\'s %1$s', 'wp-graphql' ), $post_type_object->graphql_single_name ) ) );
 			}
 
+			/**
+			 * Enforce the object-level edit capability for this specific post. WordPress maps
+			 * the `edit_post` meta capability to `edit_published_posts` once a post is
+			 * published, so a user who can create and edit drafts (e.g. a Contributor) cannot
+			 * edit a post after it has been published. This mirrors the WordPress REST API,
+			 * which returns `rest_cannot_edit` for the same request.
+			 */
+			if ( ! isset( $post_type_object->cap->edit_post ) || ! current_user_can( $post_type_object->cap->edit_post, $post_id ) ) {
+				// translators: the placeholder is the singular name of the post type being mutated
+				throw new UserError( esc_html( sprintf( __( 'Sorry, you are not allowed to update this %1$s', 'wp-graphql' ), $post_type_object->graphql_single_name ) ) );
+			}
+
 			$author_id = absint( $existing_post->post_author );
 
 			/**
@@ -160,6 +172,21 @@ class PostObjectUpdate {
 			 */
 			$post_args       = PostObjectMutation::prepare_post_object( $input, $post_type_object, $mutation_name );
 			$post_args['ID'] = $post_id;
+
+			/**
+			 * If the update requests a status that requires publishing capability (anything
+			 * other than draft or pending) and the current user cannot publish, reject the
+			 * request rather than silently changing the post's visibility. This mirrors the
+			 * WordPress REST API, which returns `rest_cannot_publish` for the same request.
+			 */
+			if (
+				isset( $post_args['post_status'] ) &&
+				! in_array( $post_args['post_status'], [ 'draft', 'pending' ], true ) &&
+				( ! isset( $post_type_object->cap->publish_posts ) || ! current_user_can( $post_type_object->cap->publish_posts ) )
+			) {
+				// translators: the placeholder is the singular name of the post type being mutated
+				throw new UserError( esc_html( sprintf( __( 'Sorry, you are not allowed to publish this %1$s', 'wp-graphql' ), $post_type_object->graphql_single_name ) ) );
+			}
 
 			$clean_args = wp_slash( (array) $post_args );
 

--- a/plugins/wp-graphql/tests/wpunit/ModelFieldMemoizationTest.php
+++ b/plugins/wp-graphql/tests/wpunit/ModelFieldMemoizationTest.php
@@ -198,4 +198,102 @@ class ModelFieldMemoizationTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestC
 	public static function resolve_callback_array_field(): string {
 		return 'resolved-via-callback-array';
 	}
+
+	/**
+	 * Flips when ghsa_7922_rce_marker() is actually invoked. Lets the test below
+	 * distinguish "the memoized string was executed" from "it was returned as data."
+	 *
+	 * @var bool
+	 */
+	public static $rce_marker_invoked = false;
+
+	/**
+	 * Zero-argument function with an observable side effect, standing in for the
+	 * arbitrary zero-arg callables (phpinfo, session_destroy, ...) the report abuses.
+	 */
+	public static function ghsa_7922_rce_marker(): string {
+		self::$rce_marker_invoked = true;
+		return 'MARKER_EXECUTED';
+	}
+
+	/**
+	 * Direct reproduction of the reported RCE (CVE-2026-18944 / GHSA-7922). When a
+	 * field resolves to a string that names a real PHP callable (an attacker-controlled
+	 * value such as a display name of "phpinfo"), re-reading the field via a GraphQL
+	 * alias must return the string as data, never invoke it. Unlike the "Max"/"Time"
+	 * tests (which rely on a builtin fataling on a zero-arg call), this uses a callable
+	 * with an observable side effect, so mere invocation, not just is_callable() matching,
+	 * is caught. If Model::__get() ever invokes the memoized string again, the marker
+	 * flips and this fails.
+	 */
+	public function testMemoizedCallableStringIsNeverInvokedOnReRead() {
+		self::$rce_marker_invoked = false;
+
+		$author_id = $this->create_max_time_user();
+		wp_set_current_user( $author_id );
+
+		$callable_name = self::class . '::ghsa_7922_rce_marker';
+
+		add_filter(
+			'graphql_model_prepare_fields',
+			static function ( $fields, $model_name ) use ( $callable_name ) {
+				if ( 'UserObject' !== $model_name ) {
+					return $fields;
+				}
+				// The resolver returns a STRING naming a real callable, mimicking an
+				// attacker-controlled value read from the database.
+				$fields['attackerControlledField'] = static function () use ( $callable_name ) {
+					return $callable_name;
+				};
+				return $fields;
+			},
+			10,
+			2
+		);
+
+		$model = new \WPGraphQL\Model\User( get_user_by( 'id', $author_id ) );
+
+		// First read resolves and memoizes the string.
+		$this->assertSame( $callable_name, $model->attackerControlledField );
+		// Second read (what a GraphQL alias triggers) must return the string as data.
+		$this->assertSame( $callable_name, $model->attackerControlledField );
+		// And the callable must never have executed.
+		$this->assertFalse( self::$rce_marker_invoked, 'A memoized callable string must never be invoked on re-read (RCE guard).' );
+	}
+
+	/**
+	 * Defense in depth for CVE-2026-18944 / GHSA-7922 at the prepare_field() site.
+	 * A field defined as a bare callable string must be returned as data, never
+	 * invoked. WPGraphQL resolvers are Closures or callable arrays, so a string field
+	 * definition can only be data (for example a value matching a PHP function name).
+	 * Callable arrays still resolve, see testNonClosureCallbackFieldsResolveAndMemoize.
+	 */
+	public function testCallableStringFieldDefinitionIsReturnedAsData() {
+		self::$rce_marker_invoked = false;
+
+		$author_id = $this->create_max_time_user();
+		wp_set_current_user( $author_id );
+
+		$callable_name = self::class . '::ghsa_7922_rce_marker';
+
+		add_filter(
+			'graphql_model_prepare_fields',
+			static function ( $fields, $model_name ) use ( $callable_name ) {
+				if ( 'UserObject' !== $model_name ) {
+					return $fields;
+				}
+				// A bare callable string as the field definition (not a Closure or a
+				// callable array), standing in for attacker-controlled data.
+				$fields['stringCallableField'] = $callable_name;
+				return $fields;
+			},
+			10,
+			2
+		);
+
+		$model = new \WPGraphQL\Model\User( get_user_by( 'id', $author_id ) );
+
+		$this->assertSame( $callable_name, $model->stringCallableField );
+		$this->assertFalse( self::$rce_marker_invoked, 'A bare callable-string field definition must never be invoked (prepare_field guard).' );
+	}
 }

--- a/plugins/wp-graphql/tests/wpunit/PostObjectMutationsTest.php
+++ b/plugins/wp-graphql/tests/wpunit/PostObjectMutationsTest.php
@@ -960,6 +960,153 @@ class PostObjectMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCas
 		$this->assertEquals( $page_id, $actual['data']['updatePage']['page']['databaseId'] );
 	}
 
+	/**
+	 * A Contributor lacks `publish_posts`, so updatePost must not let them push their
+	 * own draft to a public status. Regression for GHSA-5mmc-8pc9-wggg. The REST API
+	 * rejects the equivalent operation.
+	 */
+	public function testContributorCannotPublishOwnDraftViaUpdatePost() {
+		$post_id = $this->factory()->post->create(
+			[
+				'post_type'   => 'post',
+				'post_status' => 'draft',
+				'post_author' => $this->contributor,
+				'post_title'  => 'Contributor draft',
+			]
+		);
+
+		$query = '
+		mutation updatePost( $input:UpdatePostInput! ) {
+			updatePost( input:$input ) {
+				post { databaseId status }
+			}
+		}';
+
+		$variables = [
+			'input' => [
+				'id'     => \GraphQLRelay\Relay::toGlobalId( 'post', $post_id ),
+				'status' => 'PUBLISH',
+			],
+		];
+
+		wp_set_current_user( $this->contributor );
+
+		$actual = graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayHasKey( 'errors', $actual, 'A Contributor must not be able to publish via updatePost.' );
+		$this->assertEquals( 'draft', get_post_status( $post_id ), 'The post must remain a draft after the rejected publish.' );
+	}
+
+	/**
+	 * A Contributor lacks `edit_published_posts`, so updatePost must not let them edit
+	 * their own post after it has been published. Regression for GHSA-5mmc-8pc9-wggg.
+	 * The REST API returns 403 rest_cannot_edit for this.
+	 */
+	public function testContributorCannotEditOwnPublishedPostViaUpdatePost() {
+		$post_id = $this->factory()->post->create(
+			[
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+				'post_author' => $this->contributor,
+				'post_title'  => 'Editorially approved title',
+			]
+		);
+
+		$query = '
+		mutation updatePost( $input:UpdatePostInput! ) {
+			updatePost( input:$input ) {
+				post { databaseId title }
+			}
+		}';
+
+		$variables = [
+			'input' => [
+				'id'    => \GraphQLRelay\Relay::toGlobalId( 'post', $post_id ),
+				'title' => 'Unauthorized change after approval',
+			],
+		];
+
+		wp_set_current_user( $this->contributor );
+
+		$actual = graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayHasKey( 'errors', $actual, 'A Contributor must not be able to edit their own published post via updatePost.' );
+		$this->assertEquals( 'Editorially approved title', get_post( $post_id )->post_title, 'The published post title must be unchanged.' );
+	}
+
+	/**
+	 * Guardrail: the GHSA-5mmc fix must not break the legitimate case. A Contributor
+	 * may still update their own draft (without changing it to a public status).
+	 */
+	public function testContributorCanUpdateOwnDraftViaUpdatePost() {
+		$post_id = $this->factory()->post->create(
+			[
+				'post_type'   => 'post',
+				'post_status' => 'draft',
+				'post_author' => $this->contributor,
+				'post_title'  => 'Original draft title',
+			]
+		);
+
+		$query = '
+		mutation updatePost( $input:UpdatePostInput! ) {
+			updatePost( input:$input ) {
+				post { databaseId title status }
+			}
+		}';
+
+		$variables = [
+			'input' => [
+				'id'    => \GraphQLRelay\Relay::toGlobalId( 'post', $post_id ),
+				'title' => 'Revised draft title',
+			],
+		];
+
+		wp_set_current_user( $this->contributor );
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual, 'A Contributor must still be able to update their own draft.' );
+		$this->assertEquals( apply_filters( 'the_title', 'Revised draft title' ), $actual['data']['updatePost']['post']['title'] );
+		$this->assertEquals( 'draft', get_post_status( $post_id ) );
+	}
+
+	/**
+	 * Guardrail: an Author has `publish_posts`, so updatePost must still let them publish
+	 * their own draft. Ensures the GHSA-5mmc fix does not over-restrict.
+	 */
+	public function testAuthorCanPublishOwnDraftViaUpdatePost() {
+		$post_id = $this->factory()->post->create(
+			[
+				'post_type'   => 'post',
+				'post_status' => 'draft',
+				'post_author' => $this->author,
+				'post_title'  => 'Author draft',
+			]
+		);
+
+		$query = '
+		mutation updatePost( $input:UpdatePostInput! ) {
+			updatePost( input:$input ) {
+				post { databaseId status }
+			}
+		}';
+
+		$variables = [
+			'input' => [
+				'id'     => \GraphQLRelay\Relay::toGlobalId( 'post', $post_id ),
+				'status' => 'PUBLISH',
+			],
+		];
+
+		wp_set_current_user( $this->author );
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual, 'An Author must still be able to publish their own draft.' );
+		$this->assertEquals( 'publish', get_post_status( $post_id ) );
+	}
+
 	public function testUpdatePostWithInvalidId() {
 
 		$query = '


### PR DESCRIPTION
Follow-up hardening for GHSA-7922-x8p4-55p9 / CVE-2026-18944 (the `Model::__get()` `is_callable()` RCE fixed in 2.21.1).

## Background

2.21.1 fixed the reported RCE by gating `Model::__get()` on `instanceof \Closure` instead of `is_callable()`, so a database-supplied string is always returned as data and never invoked. The Wordfence report recommended the same change in `Model::prepare_field()`. This PR addresses that second site as defense in depth, and adds explicit regression coverage.

## Is `prepare_field()` exploitable?

Not today. `prepare_field()` only ever receives the original, developer-defined field resolver (a Closure or a callable array), never the memoized DB value, and no model defines a field as a raw database string. But it is the same latent pattern the report flagged, so we harden it.

## Change

Harden `prepare_field()` to invoke Closures and callable arrays but never a bare callable string. Wordfence suggested `instanceof \Closure` there too, but WPGraphQL legitimately supports non-Closure callable resolvers (callable arrays and the `['callback' => ...]` shape), which that change would break. Excluding bare strings closes the latent pattern while preserving every legitimate resolver, and mirrors the intent of the `__get()` fix.

## Tests

- `testMemoizedCallableStringIsNeverInvokedOnReRead` — direct reproduction of the reported RCE using a zero-argument function with an observable side effect; proves the memoized string is never invoked on re-read (this fails against the pre-2.21.1 `is_callable()` gate, i.e. it reproduces the RCE).
- `testCallableStringFieldDefinitionIsReturnedAsData` — a bare callable-string field definition is returned as data, not invoked (fails without this PR's `prepare_field()` guard).
- The existing callable-array test confirms non-Closure resolvers still resolve after the change.

Both new tests were teeth-verified by reverting each guard and observing the marker function execute.

## Verification

- Full core wpunit suite: 1203 tests, 7343 assertions, 0 failures.
- PHPStan level 8 (strict): clean.
- PHPCS (WordPress Coding Standards): clean.

Ref: GHSA-7922-x8p4-55p9, CVE-2026-18944
