### PR TITLE
fix(security): guard root plugin files against direct file access

### DIFF
--- a/plugins/wp-graphql/access-functions.php
+++ b/plugins/wp-graphql/access-functions.php
@@ -12,6 +12,11 @@ use WPGraphQL\Request;
 use WPGraphQL\Router;
 use WPGraphQL\Utils\Utils;
 
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Formats a string for use as a GraphQL name.
  *

--- a/plugins/wp-graphql/activation.php
+++ b/plugins/wp-graphql/activation.php
@@ -1,5 +1,16 @@
 <?php
 /**
+ * Activation routines for WPGraphQL.
+ *
+ * @package WPGraphQL
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
  * Runs when WPGraphQL is activated
  */
 function graphql_activation_callback(): void {

--- a/plugins/wp-graphql/constants.php
+++ b/plugins/wp-graphql/constants.php
@@ -1,5 +1,16 @@
 <?php
 /**
+ * Constant definitions for WPGraphQL.
+ *
+ * @package WPGraphQL
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
  * Sets up constants for use throughout the plugin and by other extending plugins.
  *
  * This is in its own file so that it can be used via the autoloaded classes, but also

--- a/plugins/wp-graphql/deactivation.php
+++ b/plugins/wp-graphql/deactivation.php
@@ -1,5 +1,16 @@
 <?php
 /**
+ * Deactivation routines for WPGraphQL.
+ *
+ * @package WPGraphQL
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
  * Runs when WPGraphQL is de-activated
  *
  * This cleans up data that WPGraphQL stores


### PR DESCRIPTION
## Summary

Adds the standard direct-file-access guard (`defined( 'ABSPATH' ) || exit;`) to the four root PHP files that lacked it: `access-functions.php`, `activation.php`, `constants.php`, and `deactivation.php`. This matches the guard the main `wp-graphql.php` already uses.

## Why

While running the [Plugin Check (PCP)](https://wordpress.org/plugins/plugin-check/) plugin against 2.22.2 (in response to a plugin directory review), the only actionable finding in the distributed source was that these four files were missing direct-file-access protection. Everything else PCP surfaced was either out of scope (test-only escaping notices, `vendor/`, hidden files) or an accepted architectural warning for a namespaced JSON API (naming-prefix conventions, batched direct DB queries in loaders).

## Notes

- The three files that only had a function-level docblock (`activation.php`, `constants.php`, `deactivation.php`) now also carry a proper file-level docblock with `@package`, so the guard's placement keeps WordPress Coding Standards happy (a bare guard between the docblock and the function would orphan the function's doc comment).
- No behavior change: these files only define functions, so the guard is defense-in-depth for direct access.

## Verification

- Plugin Check: the direct-file-access findings for all four files are resolved.
- PHPCS (WordPress Coding Standards): clean.
- `php -l`: no syntax errors.
