### PR TITLE
fix(acf)!: require explicit show_in_graphql opt-in for ACF options pages

### DIFF
--- a/plugins/wp-graphql-acf/docs/acf-options-pages.md
+++ b/plugins/wp-graphql-acf/docs/acf-options-pages.md
@@ -30,17 +30,9 @@ acf_add_options_page( [
 ] );
 ```
 
-**NOTE:** Options Pages registered with PHP are treated as `show_in_graphql => true` unless you explicitly set `show_in_graphql => false`. This differs from UI-registered pages, which default to off. If you register an Options Page in PHP and do not want it in the schema, opt it out explicitly:
+**NOTE:** Options Pages are an explicit opt-in. A page is only added to the schema when it is registered with `show_in_graphql => true`, whether registered in PHP or via the UI. Pages that don't declare the setting are excluded, and with `GRAPHQL_DEBUG` enabled the response includes a debug message identifying pages that were excluded because they didn't opt in. (Prior to v3.0, PHP-registered pages were included by default; see the [Upgrade Guide](/upgrade-guide/).)
 
-```php
-acf_add_options_page( [
-	'page_title'      => 'Internal Settings',
-	'menu_slug'       => 'internal-settings',
-	'show_in_graphql' => false,
-] );
-```
-
-The default for pages that don't declare a value can also be controlled with the `wpgraphql/acf/options_page/show_in_graphql` filter.
+The default for pages that don't declare a value can be controlled with the `wpgraphql/acf/options_page/show_in_graphql` filter.
 
 ## How Options Pages map to the Schema
 
@@ -102,10 +94,10 @@ The `capability` argument on `acf_add_options_page()` controls who can see the a
 
 ### Do not expose sensitive data
 
-Be aware that the defaults are permissive: Options Pages registered in PHP and field groups (registered in PHP or via the UI) are included in the schema unless explicitly opted out. If an Options Page holds data that should not be public (API keys, credentials, internal configuration), do not show it in GraphQL:
+Note the difference in defaults: Options Pages require an explicit `show_in_graphql => true` to enter the schema, while field groups are included unless explicitly opted out. If an Options Page holds data that should not be public (API keys, credentials, internal configuration), do not show it in GraphQL:
 
-- Leave **Show in GraphQL** off (UI), or set `show_in_graphql => false` (PHP) on the Options Page.
-- Alternatively, keep the page in the schema but exclude a sensitive field group (`show_in_graphql => false` on the field group) or an individual field (`show_in_graphql => false` on the field).
+- Don't register the Options Page with `show_in_graphql => true` (pages that don't opt in are excluded).
+- If the page must be in the schema, exclude a sensitive field group (`show_in_graphql => false` on the field group) or an individual field (`show_in_graphql => false` on the field).
 
 More granular, capability-based access control for fields, field groups, and Options Pages (a `graphql_capability` setting, enforced when values resolve) is being designed in [wp-graphql/wp-graphql#4275](https://github.com/wp-graphql/wp-graphql/issues/4275).
 

--- a/plugins/wp-graphql-acf/docs/upgrade-guide.md
+++ b/plugins/wp-graphql-acf/docs/upgrade-guide.md
@@ -3,6 +3,32 @@ uri: "/upgrade-guide/"
 title: "Upgrade Guide"
 ---
 
+## Upgrading to v3.0
+
+WPGraphQL for ACF v3.0 changes ACF Options Pages to be an **explicit opt-in** to the GraphQL Schema.
+
+Previously, Options Pages registered with `acf_add_options_page()` were added to the schema (and made publicly queryable) by default, unless registered with `show_in_graphql => false`. This was inconsistent with the ACF UI registration screen, where "Show in GraphQL" defaults to off, and it meant Options Page data could be exposed without anyone choosing to expose it.
+
+As of v3.0, an Options Page is only added to the schema when it is registered with `show_in_graphql => true`:
+
+```php
+acf_add_options_page( [
+	'page_title'      => 'Site Settings',
+	'menu_slug'       => 'site-settings',
+	'show_in_graphql' => true,
+] );
+```
+
+**To upgrade:** add `show_in_graphql => true` to each Options Page you want in the schema. Pages that don't declare the setting will no longer appear, and any queries against them will return errors until the page is opted in. With `GRAPHQL_DEBUG` enabled, the response includes a debug message identifying Options Pages that were excluded because they didn't opt in.
+
+To restore the old behavior globally (not recommended), filter the default for pages that don't declare a value:
+
+```php
+add_filter( 'wpgraphql/acf/options_page/show_in_graphql', '__return_true' );
+```
+
+## Upgrading from v0.6 to v2.0
+
 This guide is intended to help users using [WPGraphQL for ACF ~v0.6.\*](https://github.com/wp-graphql/wp-graphql-acf/releases/) that want to update their site(s) to use [WPGraphQL for ACF v2.0+](https://github.com/wp-graphql/wp-graphql/releases) (yes, we skipped v1.0 altogether).
 
 In this guide you will find details about breaking changes between versions and how we recommend you update your sites to work with the new version.

--- a/plugins/wp-graphql-acf/src/Admin/OptionsPageRegistration.php
+++ b/plugins/wp-graphql-acf/src/Admin/OptionsPageRegistration.php
@@ -26,9 +26,6 @@ class OptionsPageRegistration {
 
 		// Render the graphql settings tab in the ACF post type registration screen
 		add_action( 'acf/ui_options_page/render_settings_tab/graphql', [ $this, 'render_settings_tab' ] );
-
-		// Hook into acf_get_options_pages to preserve show_in_graphql for programmatically registered pages
-		add_filter( 'acf_get_options_pages', [ $this, 'preserve_show_in_graphql' ], 10, 1 );
 	}
 
 	/**
@@ -119,35 +116,6 @@ class OptionsPageRegistration {
 			],
 			'div',
 			'field'
-		);
-	}
-
-	/**
-	 * Preserve show_in_graphql value for programmatically registered options pages.
-	 * ACF doesn't store custom fields like show_in_graphql when pages are registered programmatically,
-	 * so we need to restore it from the registration args.
-	 *
-	 * @param array<mixed> $options_pages The options pages from ACF
-	 *
-	 * @return array<mixed>
-	 */
-	public function preserve_show_in_graphql( array $options_pages ): array {
-		if ( empty( $options_pages ) || ! is_array( $options_pages ) ) {
-			return $options_pages;
-		}
-
-		// For each options page, check if show_in_graphql was set during registration
-		// and restore it if ACF didn't preserve it
-		return array_map(
-			static function ( $option_page ) {
-				// If show_in_graphql is not set, allow it to be filtered
-				// This allows programmatic registrations to set show_in_graphql => false
-				if ( ! isset( $option_page['show_in_graphql'] ) ) {
-					$option_page['show_in_graphql'] = apply_filters( 'wpgraphql/acf/options_page/show_in_graphql', true, $option_page );
-				}
-				return $option_page;
-			},
-			$options_pages
 		);
 	}
 

--- a/plugins/wp-graphql-acf/src/Utils.php
+++ b/plugins/wp-graphql-acf/src/Utils.php
@@ -136,14 +136,25 @@ class Utils {
 			return $options_pages;
 		}
 
-		// For programmatically registered options pages, ACF may not preserve show_in_graphql.
-		// Allow it to be filtered to restore the value if it was set during registration.
+		// Options Pages are an explicit opt-in: only pages registered with
+		// `show_in_graphql => true` are added to the GraphQL Schema, matching the
+		// default of the ACF UI registration screen. Pages that don't declare a
+		// value are excluded. The default for undeclared pages can be changed
+		// with the `wpgraphql/acf/options_page/show_in_graphql` filter.
 		$acf_options_pages = array_map(
 			static function ( $option_page ) {
-				// If show_in_graphql is not set, allow it to be filtered to restore the value
-				// This allows tests and programmatic registrations to set show_in_graphql => false
 				if ( ! isset( $option_page['show_in_graphql'] ) ) {
-					$option_page['show_in_graphql'] = apply_filters( 'wpgraphql/acf/options_page/show_in_graphql', true, $option_page );
+					$option_page['show_in_graphql'] = apply_filters( 'wpgraphql/acf/options_page/show_in_graphql', false, $option_page );
+
+					if ( false === $option_page['show_in_graphql'] && function_exists( 'graphql_debug' ) && ! empty( $option_page['menu_slug'] ) ) {
+						graphql_debug(
+							sprintf(
+								// translators: %s is the menu_slug of the ACF Options Page.
+								__( 'The ACF Options Page "%s" is not in the GraphQL Schema because it was registered without `show_in_graphql => true`.', 'wpgraphql-acf' ),
+								$option_page['menu_slug']
+							)
+						);
+					}
 				}
 				return $option_page;
 			},
@@ -274,26 +285,18 @@ class Utils {
 	/**
 	 * Whether the ACF Field Group should show in the GraphQL Schema
 	 *
+	 * Field groups, fields, and options pages are shown in GraphQL unless
+	 * explicitly configured with `show_in_graphql => false`. The `show_in_rest`
+	 * setting has no effect on GraphQL visibility.
+	 *
 	 * @param array<mixed> $acf_field_group
 	 */
 	public static function should_field_group_show_in_graphql( array $acf_field_group ): bool {
 		$should = true;
 
-		$show_in_rest = $acf_field_group['show_in_rest'] ?? false;
-
-
-		// if the field group was configured with no "show_in_graphql" value, default to the "show_in_rest" value
-		// to determine if the group should be available in an API
-		if (
-			( isset( $acf_field_group['is_options_page'] ) && false === $acf_field_group['is_options_page'] ) &&
-			! isset( $acf_field_group['show_in_graphql'] ) ) {
-			$acf_field_group['show_in_graphql'] = $show_in_rest;
-		}
-
 		if ( isset( $acf_field_group['show_in_graphql'] ) && false === (bool) $acf_field_group['show_in_graphql'] ) {
 			$should = false;
 		}
-
 
 		return (bool) apply_filters( 'wpgraphql/acf/should_field_group_show_in_graphql', $should, $acf_field_group );
 	}

--- a/plugins/wp-graphql-acf/tests/acceptance.suite.yml
+++ b/plugins/wp-graphql-acf/tests/acceptance.suite.yml
@@ -1,12 +1,11 @@
 # Codeception Test Suite Configuration
 # Auto-generated - includes detected ACF plugins
-# Uses WPWebDriver (Chrome) so ACF admin UI and import work with JavaScript
 actor: AcceptanceTester
 modules:
   enabled:
     - Asserts
     - REST
-    - lucatume\WPBrowser\Module\WPWebDriver
+    - lucatume\WPBrowser\Module\WPBrowser
     - lucatume\WPBrowser\Module\WPDb
     - lucatume\WPBrowser\Module\WPLoader
     - Helper\Utils
@@ -28,28 +27,13 @@ modules:
       theme: '%TEST_THEME%'
       plugins:
         - wp-graphql/wp-graphql.php
+        - advanced-custom-fields-pro/acf.php
         - wp-graphql-acf/wpgraphql-acf.php
+        - wp-graphql-content-blocks/wp-graphql-content-blocks.php
       activatePlugins:
         - wp-graphql/wp-graphql.php
+        - advanced-custom-fields-pro/acf.php
         - wp-graphql-acf/wpgraphql-acf.php
+        - wp-graphql-content-blocks/wp-graphql-content-blocks.php
       configFile: 'tests/_data/config.php'
-    lucatume\WPBrowser\Module\WPWebDriver:
-      url: '%TEST_WP_URL%'
-      adminUsername: '%TEST_ADMIN_USERNAME%'
-      adminPassword: '%TEST_ADMIN_PASSWORD%'
-      adminPath: '%TEST_ADMIN_PATH%'
-      browser: chrome
-      host: localhost
-      port: 9515
-      path: /
-      window_size: 1920,1080
-      capabilities:
-        goog:chromeOptions:
-          args:
-            - "--headless=new"
-            - "--disable-gpu"
-            - "--disable-dev-shm-usage"
-            - "--no-sandbox"
-            - "--proxy-server='direct://'"
-            - "--proxy-bypass-list=*"
 bootstrap: bootstrap.php

--- a/plugins/wp-graphql-acf/tests/wpunit/Admin/OptionsPageRegistrationTest.php
+++ b/plugins/wp-graphql-acf/tests/wpunit/Admin/OptionsPageRegistrationTest.php
@@ -61,30 +61,6 @@ class OptionsPageRegistrationTest extends \Tests\WPGraphQL\Acf\WPUnit\WPGraphQLA
 		$this->assertFalse( $result['show_in_graphql'] );
 	}
 
-	public function test_preserve_show_in_graphql_returns_empty_unchanged(): void {
-		$options_pages = [];
-		$result = apply_filters( 'acf_get_options_pages', $options_pages );
-		$this->assertSame( [], $result );
-	}
-
-	public function test_preserve_show_in_graphql_sets_default_when_not_set(): void {
-		$options_pages = [
-			[ 'page_title' => 'General', 'menu_slug' => 'general' ],
-		];
-		$result = apply_filters( 'acf_get_options_pages', $options_pages );
-		$this->assertCount( 1, $result );
-		$this->assertArrayHasKey( 'show_in_graphql', $result[0] );
-		$this->assertTrue( $result[0]['show_in_graphql'] );
-	}
-
-	public function test_preserve_show_in_graphql_leaves_existing_show_in_graphql(): void {
-		$options_pages = [
-			[ 'page_title' => 'Hidden', 'menu_slug' => 'hidden', 'show_in_graphql' => false ],
-		];
-		$result = apply_filters( 'acf_get_options_pages', $options_pages );
-		$this->assertFalse( $result[0]['show_in_graphql'] );
-	}
-
 	public function test_render_graphql_columns_early_return_when_no_options_page(): void {
 		$post_id = 0;
 		ob_start();

--- a/plugins/wp-graphql-acf/tests/wpunit/OptionsPageTest.php
+++ b/plugins/wp-graphql-acf/tests/wpunit/OptionsPageTest.php
@@ -28,8 +28,8 @@ class OptionsPageTest extends \Tests\WPGraphQL\Acf\WPUnit\WPGraphQLAcfTestCase {
 				'menu_title' => __( 'My Options Page' ),
 				'menu_slug'  => 'my-options-page',
 				'capability' => 'edit_posts',
-				// options pages will show in the Schema unless set to false
-				//          'show_in_graphql'   => false,
+				// options pages must opt in to be shown in the Schema
+				'show_in_graphql' => true,
 			], $config )
 		);
 	}
@@ -107,28 +107,15 @@ class OptionsPageTest extends \Tests\WPGraphQL\Acf\WPUnit\WPGraphQLAcfTestCase {
 	 * @throws Exception
 	 */
 	public function testOptionsPageNotInSchemaIfShowInGraphqlIsFalse() {
-		$this->markTestSkipped( 'ACF does not preserve show_in_graphql for programmatically registered options pages. Needs investigation into how to properly filter this behavior.' );
-
 		$this->registerOptionsPage(
 			[
 				'page_title' => 'ShowInGraphQLFalse',
 				'menu_title' => __( 'Show in GraphQL False' ),
 				'menu_slug'  => 'show-in-graphql-false',
 				'capability' => 'edit_posts',
-				// options pages will show in the Schema unless set to false
 				'show_in_graphql'   => false,
 			]
 		);
-
-		// ACF doesn't preserve show_in_graphql for programmatically registered options pages,
-		// so we need to restore it via filter. The filter is applied in Utils::get_acf_options_pages()
-		// but only when show_in_graphql is not set. We need to ensure it's checked for our specific page.
-		add_filter( 'wpgraphql/acf/should_field_group_show_in_graphql', function( $should, $field_group ) {
-			if ( isset( $field_group['menu_slug'] ) && 'show-in-graphql-false' === $field_group['menu_slug'] ) {
-				return false;
-			}
-			return $should;
-		}, 10, 2 );
 
 		$options_pages = acf_get_options_pages();
 
@@ -183,7 +170,9 @@ class OptionsPageTest extends \Tests\WPGraphQL\Acf\WPUnit\WPGraphQLAcfTestCase {
 			]
 		]);
 
-		$this->assertQueryError( $actual, [
+		// Introspecting a type that is not in the schema returns a successful
+		// response with a null __type, not an error.
+		$this->assertQuerySuccessful( $actual, [
 			$this->expectedField( '__type', self::IS_NULL )
 		]);
 
@@ -199,7 +188,6 @@ class OptionsPageTest extends \Tests\WPGraphQL\Acf\WPUnit\WPGraphQLAcfTestCase {
 				'menu_slug'  => 'custom-graphql-name',
 				'capability' => 'edit_posts',
 				'post_id'   => 'custom-graphql-name',
-				// options pages will show in the Schema unless set to false
 				'graphql_type_name'   => 'MyCustomOptionsName',
 			]
 		);

--- a/plugins/wp-graphql-acf/tests/wpunit/ShowInGraphqlDefaultsTest.php
+++ b/plugins/wp-graphql-acf/tests/wpunit/ShowInGraphqlDefaultsTest.php
@@ -1,0 +1,168 @@
+<?php
+
+use WPGraphQL\Acf\Utils;
+
+/**
+ * Characterization tests for the `show_in_graphql` visibility contract.
+ *
+ * The contract: field groups, fields, and options pages are shown in GraphQL
+ * unless explicitly configured with `show_in_graphql => false`. In particular,
+ * `show_in_rest` has no effect on GraphQL visibility, and options pages are
+ * shown regardless of their `post_id` (see the custom post_id regression below).
+ *
+ * Explicit `show_in_graphql => true/false` handling is covered in RegistryTest.
+ */
+class ShowInGraphqlDefaultsTest extends \Tests\WPGraphQL\Acf\WPUnit\WPGraphQLAcfTestCase {
+
+	public function setUp(): void {
+		WPGraphQL::clear_schema();
+		parent::setUp();
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+	}
+
+	public function testFieldGroupWithNoShowInGraphqlIsShownByDefault(): void {
+		$this->assertTrue(
+			Utils::should_field_group_show_in_graphql(
+				[
+					'key'   => 'group_default_visibility',
+					'title' => 'Default Visibility Group',
+				]
+			)
+		);
+	}
+
+	public function testShowInRestHasNoEffectOnFieldGroupVisibility(): void {
+		// A field group opted out of REST is still shown in GraphQL.
+		$this->assertTrue(
+			Utils::should_field_group_show_in_graphql(
+				[
+					'key'          => 'group_rest_false',
+					'title'        => 'Rest False Group',
+					'show_in_rest' => false,
+				]
+			)
+		);
+
+		// A field group opted into REST is shown in GraphQL (unchanged).
+		$this->assertTrue(
+			Utils::should_field_group_show_in_graphql(
+				[
+					'key'          => 'group_rest_true',
+					'title'        => 'Rest True Group',
+					'show_in_rest' => true,
+				]
+			)
+		);
+	}
+
+	public function testOptionsPageConfigWithNoShowInGraphqlIsShownByDefault(): void {
+		// As Registry::register_options_pages() sees it (is_options_page flag applied).
+		$this->assertTrue(
+			Utils::should_field_group_show_in_graphql(
+				[
+					'page_title'      => 'Default Options Page',
+					'menu_slug'       => 'default-options-page',
+					'post_id'         => 'options',
+					'is_options_page' => true,
+				]
+			)
+		);
+	}
+
+	public function testOptionsPageWithCustomPostIdIsShownByDefault(): void {
+		// Regression guard: options pages registered with a custom post_id were
+		// once hidden by a show_in_rest fallback keyed off `'options' !== post_id`.
+		$this->assertTrue(
+			Utils::should_field_group_show_in_graphql(
+				[
+					'page_title'      => 'Custom PostId Options Page',
+					'menu_slug'       => 'custom-post-id-options-page',
+					'post_id'         => 'custom_settings',
+					'is_options_page' => true,
+				]
+			)
+		);
+
+		// The raw config as acf_get_options_pages() returns it, before the
+		// is_options_page flag is applied.
+		$this->assertTrue(
+			Utils::should_field_group_show_in_graphql(
+				[
+					'page_title' => 'Custom PostId Options Page',
+					'menu_slug'  => 'custom-post-id-options-page',
+					'post_id'    => 'custom_settings',
+				]
+			)
+		);
+	}
+
+	public function testFieldGroupWithNoShowInGraphqlIsQueryable(): void {
+		// Register a field group and field directly (not via the test helpers,
+		// which set show_in_graphql) so neither declares a show_in_graphql value.
+		acf_add_local_field_group(
+			[
+				'key'                => 'group_default_shown',
+				'title'              => 'Default Shown Group',
+				'graphql_field_name' => 'defaultShownFields',
+				'location'           => [
+					[
+						[
+							'param'    => 'post_type',
+							'operator' => '==',
+							'value'    => 'post',
+						],
+					],
+				],
+			]
+		);
+
+		acf_add_local_field(
+			[
+				'parent' => 'group_default_shown',
+				'key'    => 'field_default_shown_text',
+				'label'  => 'Default Shown Text',
+				'name'   => 'default_shown_text',
+				'type'   => 'text',
+			]
+		);
+
+		$post_id = self::factory()->post->create(
+			[
+				'post_type'    => 'post',
+				'post_status'  => 'publish',
+				'post_title'   => 'Default Visibility Test Post',
+				'post_content' => 'test',
+			]
+		);
+
+		$expected = 'default visibility value';
+		update_field( 'field_default_shown_text', $expected, $post_id );
+
+		$query = '
+		query GetPostWithDefaultShownFields( $postId: Int ) {
+			postBy( postId: $postId ) {
+				defaultShownFields {
+					defaultShownText
+				}
+			}
+		}
+		';
+
+		$actual = graphql(
+			[
+				'query'     => $query,
+				'variables' => [
+					'postId' => $post_id,
+				],
+			]
+		);
+
+		codecept_debug( $actual );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertSame( $expected, $actual['data']['postBy']['defaultShownFields']['defaultShownText'] );
+	}
+}

--- a/plugins/wp-graphql-acf/tests/wpunit/ShowInGraphqlDefaultsTest.php
+++ b/plugins/wp-graphql-acf/tests/wpunit/ShowInGraphqlDefaultsTest.php
@@ -3,14 +3,17 @@
 use WPGraphQL\Acf\Utils;
 
 /**
- * Characterization tests for the `show_in_graphql` visibility contract.
+ * Tests for the `show_in_graphql` visibility contract.
  *
- * The contract: field groups, fields, and options pages are shown in GraphQL
- * unless explicitly configured with `show_in_graphql => false`. In particular,
- * `show_in_rest` has no effect on GraphQL visibility, and options pages are
- * shown regardless of their `post_id` (see the custom post_id regression below).
+ * The contract:
+ * - Field groups and fields are shown in GraphQL unless explicitly configured
+ *   with `show_in_graphql => false`. `show_in_rest` has no effect.
+ * - Options Pages are an explicit opt-in: only pages registered with
+ *   `show_in_graphql => true` are added to the schema, matching the default of
+ *   the ACF UI registration screen.
  *
- * Explicit `show_in_graphql => true/false` handling is covered in RegistryTest.
+ * Explicit `show_in_graphql => true/false` handling for field groups is covered
+ * in RegistryTest.
  */
 class ShowInGraphqlDefaultsTest extends \Tests\WPGraphQL\Acf\WPUnit\WPGraphQLAcfTestCase {
 
@@ -58,45 +61,103 @@ class ShowInGraphqlDefaultsTest extends \Tests\WPGraphQL\Acf\WPUnit\WPGraphQLAcf
 		);
 	}
 
-	public function testOptionsPageConfigWithNoShowInGraphqlIsShownByDefault(): void {
-		// As Registry::register_options_pages() sees it (is_options_page flag applied).
-		$this->assertTrue(
-			Utils::should_field_group_show_in_graphql(
-				[
-					'page_title'      => 'Default Options Page',
-					'menu_slug'       => 'default-options-page',
-					'post_id'         => 'options',
-					'is_options_page' => true,
-				]
-			)
+	public function testOptionsPageWithNoShowInGraphqlIsExcludedByDefault(): void {
+		if ( ! function_exists( 'acf_add_options_page' ) ) {
+			$this->markTestSkipped( 'ACF Options Pages are not available in this test environment' );
+		}
+
+		acf_add_options_page(
+			[
+				'page_title' => 'Default Unset Page',
+				'menu_slug'  => 'default-unset-page',
+			]
 		);
+
+		$this->assertArrayNotHasKey( 'default-unset-page', Utils::get_acf_options_pages() );
 	}
 
-	public function testOptionsPageWithCustomPostIdIsShownByDefault(): void {
-		// Regression guard: options pages registered with a custom post_id were
-		// once hidden by a show_in_rest fallback keyed off `'options' !== post_id`.
-		$this->assertTrue(
-			Utils::should_field_group_show_in_graphql(
-				[
-					'page_title'      => 'Custom PostId Options Page',
-					'menu_slug'       => 'custom-post-id-options-page',
-					'post_id'         => 'custom_settings',
-					'is_options_page' => true,
-				]
-			)
+	public function testOptionsPageWithShowInGraphqlTrueIsIncluded(): void {
+		if ( ! function_exists( 'acf_add_options_page' ) ) {
+			$this->markTestSkipped( 'ACF Options Pages are not available in this test environment' );
+		}
+
+		acf_add_options_page(
+			[
+				'page_title'      => 'Opted In Page',
+				'menu_slug'       => 'opted-in-page',
+				'show_in_graphql' => true,
+			]
 		);
 
-		// The raw config as acf_get_options_pages() returns it, before the
-		// is_options_page flag is applied.
-		$this->assertTrue(
-			Utils::should_field_group_show_in_graphql(
-				[
-					'page_title' => 'Custom PostId Options Page',
-					'menu_slug'  => 'custom-post-id-options-page',
-					'post_id'    => 'custom_settings',
-				]
-			)
+		// Regression guard: options pages registered with a custom post_id were
+		// once hidden by a show_in_rest fallback keyed off `'options' !== post_id`.
+		acf_add_options_page(
+			[
+				'page_title'      => 'Opted In Custom PostId Page',
+				'menu_slug'       => 'opted-in-custom-post-id-page',
+				'post_id'         => 'custom_settings',
+				'show_in_graphql' => true,
+			]
 		);
+
+		$graphql_pages = Utils::get_acf_options_pages();
+
+		$this->assertArrayHasKey( 'opted-in-page', $graphql_pages );
+		$this->assertArrayHasKey( 'opted-in-custom-post-id-page', $graphql_pages );
+	}
+
+	public function testAcfPreservesShowInGraphqlOnProgrammaticOptionsPages(): void {
+		if ( ! function_exists( 'acf_add_options_page' ) ) {
+			$this->markTestSkipped( 'ACF Options Pages are not available in this test environment' );
+		}
+
+		// Calls acf_get_options_pages() directly (not Utils::get_acf_options_pages())
+		// to observe what ACF itself preserves from the registration args.
+		acf_add_options_page(
+			[
+				'page_title'      => 'Probe False',
+				'menu_slug'       => 'probe-false',
+				'show_in_graphql' => false,
+			]
+		);
+
+		acf_add_options_page(
+			[
+				'page_title'      => 'Probe True',
+				'menu_slug'       => 'probe-true',
+				'show_in_graphql' => true,
+			]
+		);
+
+		$pages = acf_get_options_pages();
+
+		codecept_debug( $pages['probe-false'] ?? 'probe-false missing' );
+
+		$this->assertArrayHasKey( 'probe-false', $pages );
+		$this->assertArrayHasKey( 'show_in_graphql', $pages['probe-false'] );
+		$this->assertFalse( (bool) $pages['probe-false']['show_in_graphql'] );
+
+		$this->assertArrayHasKey( 'probe-true', $pages );
+		$this->assertArrayHasKey( 'show_in_graphql', $pages['probe-true'] );
+		$this->assertTrue( (bool) $pages['probe-true']['show_in_graphql'] );
+	}
+
+	public function testOptionsPageWithShowInGraphqlFalseIsExcluded(): void {
+		if ( ! function_exists( 'acf_add_options_page' ) ) {
+			$this->markTestSkipped( 'ACF Options Pages are not available in this test environment' );
+		}
+
+		acf_add_options_page(
+			[
+				'page_title'      => 'Opted Out Page',
+				'menu_slug'       => 'opted-out-page',
+				'show_in_graphql' => false,
+			]
+		);
+
+		$graphql_pages = Utils::get_acf_options_pages();
+
+		$this->assertArrayNotHasKey( 'opted-out-page', $graphql_pages );
 	}
 
 	public function testFieldGroupWithNoShowInGraphqlIsQueryable(): void {


### PR DESCRIPTION
## What does this do?

Makes ACF Options Pages an **explicit opt-in** to the GraphQL Schema: only pages registered with `show_in_graphql => true` are added. Previously, PHP-registered Options Pages were exposed by default (opt-out), while UI-registered pages defaulted to off. This aligns both registration paths, and aligns Options Pages with how WPGraphQL treats post types and taxonomies (explicit opt-in).

⚠️⚠️⚠️
 **This is a **breaking change** for sites that relied on the silent default exposure.** 

Sites that explicitly registered pages with `show_in_graphql => true` are unaffected (ACF preserves the arg, proven by a test in this PR). The upgrade guide documents the migration, the `wpgraphql/acf/options_page/show_in_graphql` filter restores the old default if needed, and with `GRAPHQL_DEBUG` enabled the response identifies pages excluded because they didn't opt in.

## Why?

Options Pages are where site builders keep site-wide data, sometimes sensitive. Exposing them to the public GraphQL endpoint without anyone choosing that is the wrong default (CWE-276, incorrect default permissions). The ACF UI registration screen already defaulted "Show in GraphQL" to off; PHP registration now matches.

## Dead code discovered and removed along the way

Investigating the defaults surfaced three things that had accreted around a misdiagnosis ("ACF does not preserve show_in_graphql for programmatically registered options pages", which a new test proves false, at least as of ACF 6.3.11, whose `validate_page()` runs registration args through `wp_parse_args` and preserves extra keys):

1. `Utils::should_field_group_show_in_graphql()` contained a `show_in_rest` fallback branch gated on `is_options_page === false`, a value nothing ever sets. The branch was unreachable in every released version (its pre-monorepo ancestor keyed off `post_id` and was equally unreachable for regular field groups). Removed; field group behavior is unchanged and now pinned by tests.
2. `OptionsPageRegistration::preserve_show_in_graphql()` was hooked to a filter named `acf_get_options_pages`. ACF's actual filter is `acf/get_options_pages`, so the callback never ran. Removed along with its tests (the behavior it intended is covered at the real integration point in `Utils::get_acf_options_pages()` and tested in `ShowInGraphqlDefaultsTest`).
3. `OptionsPageTest::testOptionsPageNotInSchemaIfShowInGraphqlIsFalse` was skipped citing the preservation misdiagnosis. It is now un-skipped, simplified, and passing (with one assertion corrected: introspecting an absent type returns a null `__type` without errors).

## Behavior summary

| Registration | Before | After |
| --- | --- | --- |
| PHP page, `show_in_graphql` unset | in schema | **not in schema** (breaking ⚠️) |
| PHP page, `show_in_graphql => true` | in schema | in schema |
| PHP page, `show_in_graphql => false` | not in schema | not in schema |
| UI page (defaults off) | not in schema | not in schema |
| Field groups / fields | shown unless opted out | unchanged |

## Testing

- New `ShowInGraphqlDefaultsTest` (7 tests): field group defaults (unchanged, including a schema-level query), `show_in_rest` non-effect, options page opt-in/opt-out at the `Utils::get_acf_options_pages()` level, custom `post_id` regression guard, and a probe proving ACF preserves the `show_in_graphql` arg.
- The first commit adds the field-group characterization tests passing against the untouched code, pinning that the dead-branch removal is behavior-neutral.
- Full `wp-graphql-acf` wpunit suite: 1055 tests, 0 failures. PHPStan and PHPCS clean.

## Docs

- Upgrade guide gains an "Upgrading to v3.0" section with the migration steps and filter escape hatch.
- The Options Pages docs page from #4279 will be corrected in this PR (once #4279 merges) to describe the opt-in behavior.

Related: #4275 (proposed `graphql_capability` for granular, capability-based resolution control).
