### PR TITLE
fix: repair wp-env image builds (Debian bullseye EOL + flaky global phpunit install)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
 	"packages": {
 		"": {
 			"name": "wpgraphql-monorepo",
+			"hasInstallScript": true,
 			"workspaces": [
 				"plugins/*",
 				"websites/*"
@@ -34630,13 +34631,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/postinstall-postinstall": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/postinstall-postinstall/-/postinstall-postinstall-2.1.0.tgz",
-			"integrity": "sha512-7hQX6ZlZXIoRiWNrbMQaLzUUfH+sSx39u8EJ9HYuDc1kLo9IXKWjM5RSquZN1ad5GnH8CGFM78fsAAQi3OKEEQ==",
-			"hasInstallScript": true,
-			"license": "MIT"
-		},
 		"node_modules/prelude-ls": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -42229,7 +42223,7 @@
 		},
 		"plugins/wp-graphql-acf": {
 			"name": "@wpgraphql/wp-graphql-acf",
-			"version": "2.8.0",
+			"version": "3.0.0",
 			"license": "GPL-3.0-or-later",
 			"devDependencies": {
 				"@eslint/js": "^10.0.1",
@@ -45858,7 +45852,6 @@
 				"next-sitemap": "4.2.3",
 				"next-themes": "^0.4.6",
 				"octokit": "^5.0.5",
-				"postinstall-postinstall": "^2.1.0",
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
 				"react-icons": "^4.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,12 @@
 				"websites/*"
 			],
 			"devDependencies": {
-				"@wordpress/env": "^11.13.0",
+				"@wordpress/env": "11.14.0",
 				"@wordpress/prettier-config": "^4.53.0",
 				"@wordpress/scripts": "^27.9.0",
 				"husky": "^9.1.7",
 				"lint-staged": "^17.3.0",
+				"patch-package": "8.0.1",
 				"turbo": "^2.10.12",
 				"turndown": "^7.2.4"
 			},
@@ -2756,6 +2757,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@emnapi/wasi-threads": "1.2.1",
 				"tslib": "^2.4.0"
@@ -2778,6 +2780,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.4.0"
 			}
@@ -5422,6 +5425,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@emnapi/core": "^1.4.3",
 				"@emnapi/runtime": "^1.4.3",
@@ -5482,9 +5486,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5500,9 +5501,6 @@
 			"integrity": "sha512-W7viwCk9JY/cAkdz/A273rd5bb3RgT/IHwR7Upv90tunjBWNtAAhGhoecHh+teRNRSinuAFmE+l7fwZ4YKkrXg==",
 			"cpu": [
 				"arm64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -5520,9 +5518,6 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5538,9 +5533,6 @@
 			"integrity": "sha512-H4mBso8ZTMBPtdT0PN0pBx2ayTvQuTuvS6qT13d77yVFJXAPCxkyIhLTmdMaGTJs0krQYI/qpzdHijCeihXhbg==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -6703,7 +6695,7 @@
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.6.0.tgz",
 			"integrity": "sha512-7FNeNl8NCE7aINx7WXiKQrPYZWC/hvrTsmk6zmxbI7LTXE7hVek/n8AfVgpe2y82zl3w0HvCHN0bVKMBoJcC0w==",
-			"devOptional": true,
+			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6741,6 +6733,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -6761,6 +6754,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -6781,6 +6775,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -6801,6 +6796,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -6821,9 +6817,7 @@
 			"cpu": [
 				"arm"
 			],
-			"libc": [
-				"glibc"
-			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -6844,9 +6838,7 @@
 			"cpu": [
 				"arm"
 			],
-			"libc": [
-				"musl"
-			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -6867,9 +6859,7 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -6890,9 +6880,7 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"musl"
-			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -6913,9 +6901,7 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -6936,9 +6922,7 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"musl"
-			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -6959,6 +6943,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -6979,6 +6964,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -9282,6 +9268,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.4.0"
 			}
@@ -10362,7 +10349,8 @@
 			"optional": true,
 			"os": [
 				"android"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-android-arm64": {
 			"version": "1.11.1",
@@ -10376,7 +10364,8 @@
 			"optional": true,
 			"os": [
 				"android"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-darwin-arm64": {
 			"version": "1.11.1",
@@ -10390,7 +10379,8 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-darwin-x64": {
 			"version": "1.11.1",
@@ -10404,7 +10394,8 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-freebsd-x64": {
 			"version": "1.11.1",
@@ -10418,7 +10409,8 @@
 			"optional": true,
 			"os": [
 				"freebsd"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
 			"version": "1.11.1",
@@ -10432,7 +10424,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
 			"version": "1.11.1",
@@ -10446,7 +10439,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
 			"version": "1.11.1",
@@ -10460,7 +10454,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-linux-arm64-musl": {
 			"version": "1.11.1",
@@ -10474,7 +10469,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
 			"version": "1.11.1",
@@ -10488,7 +10484,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
 			"version": "1.11.1",
@@ -10502,7 +10499,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
 			"version": "1.11.1",
@@ -10516,7 +10514,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
 			"version": "1.11.1",
@@ -10530,7 +10529,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-linux-x64-gnu": {
 			"version": "1.11.1",
@@ -10544,7 +10544,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-linux-x64-musl": {
 			"version": "1.11.1",
@@ -10558,7 +10559,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-wasm32-wasi": {
 			"version": "1.11.1",
@@ -10570,6 +10572,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@napi-rs/wasm-runtime": "^0.2.11"
 			},
@@ -10589,7 +10592,8 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
 			"version": "1.11.1",
@@ -10603,7 +10607,8 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-win32-x64-msvc": {
 			"version": "1.11.1",
@@ -10617,7 +10622,8 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@use-gesture/core": {
 			"version": "10.3.1",
@@ -11790,15 +11796,15 @@
 			}
 		},
 		"node_modules/@wordpress/env": {
-			"version": "11.13.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-11.13.0.tgz",
-			"integrity": "sha512-ZBhCf1N1Qgh5U//WXsK9d5rgXtjkWMBHuKrpC3KgoiqEVwalYw+H5jfbGqBzjZtHJeM1SbkSumxRTRhApQPqjg==",
+			"version": "11.14.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-11.14.0.tgz",
+			"integrity": "sha512-Q/XUhGjFJtlfybw/mq+7H5MsF2u3zWH5YxNR5y473+CeIjZx20wt5Dx0RDHAJcG2ICTky4pJevNlIq/EFnUwIQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@inquirer/prompts": "^7.2.0",
 				"@wp-playground/cli": "^3.0.48",
-				"adm-zip": "^0.5.9",
+				"adm-zip": "^0.6.0",
 				"chalk": "^4.1.1",
 				"copy-dir": "^1.3.0",
 				"cross-spawn": "^7.0.6",
@@ -11816,6 +11822,16 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/env/node_modules/adm-zip": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+			"integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0"
 			}
 		},
 		"node_modules/@wordpress/env/node_modules/ansi-styles": {
@@ -15382,6 +15398,13 @@
 			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
 			"dev": true,
 			"license": "Apache-2.0"
+		},
+		"node_modules/@yarnpkg/lockfile": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+			"integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+			"dev": true,
+			"license": "BSD-2-Clause"
 		},
 		"node_modules/@zip.js/zip.js": {
 			"version": "2.7.57",
@@ -22716,6 +22739,16 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/find-yarn-workspace-root": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+			"integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"micromatch": "^4.0.2"
+			}
+		},
 		"node_modules/flat": {
 			"version": "5.0.2",
 			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
@@ -22983,6 +23016,21 @@
 			},
 			"engines": {
 				"node": ">= 8.0.0"
+			}
+		},
+		"node_modules/fs-extra": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/fs-monkey": {
@@ -28244,6 +28292,26 @@
 			"devOptional": true,
 			"license": "MIT"
 		},
+		"node_modules/json-stable-stringify": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+			"integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.4",
+				"isarray": "^2.0.5",
+				"jsonify": "^0.0.1",
+				"object-keys": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -28304,6 +28372,16 @@
 			},
 			"optionalDependencies": {
 				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/jsonify": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+			"integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+			"dev": true,
+			"license": "Public Domain",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/jsonwebtoken": {
@@ -28402,6 +28480,16 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/klaw-sync": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+			"integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.1.11"
 			}
 		},
 		"node_modules/kleur": {
@@ -31659,7 +31747,7 @@
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
 			"integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/node-exports-info": {
@@ -33273,6 +33361,154 @@
 				"tslib": "^2.0.3"
 			}
 		},
+		"node_modules/patch-package": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+			"integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@yarnpkg/lockfile": "^1.1.0",
+				"chalk": "^4.1.2",
+				"ci-info": "^3.7.0",
+				"cross-spawn": "^7.0.3",
+				"find-yarn-workspace-root": "^2.0.0",
+				"fs-extra": "^10.0.0",
+				"json-stable-stringify": "^1.0.2",
+				"klaw-sync": "^6.0.0",
+				"minimist": "^1.2.6",
+				"open": "^7.4.2",
+				"semver": "^7.5.3",
+				"slash": "^2.0.0",
+				"tmp": "^0.2.4",
+				"yaml": "^2.2.2"
+			},
+			"bin": {
+				"patch-package": "index.js"
+			},
+			"engines": {
+				"node": ">=14",
+				"npm": ">5"
+			}
+		},
+		"node_modules/patch-package/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/patch-package/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/patch-package/node_modules/ci-info": {
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+			"integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/patch-package/node_modules/open": {
+			"version": "7.4.2",
+			"resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+			"integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-docker": "^2.0.0",
+				"is-wsl": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/patch-package/node_modules/semver": {
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/patch-package/node_modules/slash": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+			"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/patch-package/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/patch-package/node_modules/yaml": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
+			}
+		},
 		"node_modules/path-case": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
@@ -33432,7 +33668,7 @@
 			"version": "4.0.5",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
 			"integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -33533,12 +33769,14 @@
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
 			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
@@ -41943,7 +42181,7 @@
 		},
 		"plugins/wp-graphql": {
 			"name": "@wpgraphql/wp-graphql",
-			"version": "2.21.1",
+			"version": "2.22.3",
 			"dependencies": {
 				"@ant-design/icons": "6.3.2",
 				"@apollo/client": "3.14.1",
@@ -45615,7 +45853,7 @@
 				"graphql-tag": "^2.12.7",
 				"http-status-codes": "^2.2.0",
 				"lucide-react": "^1.34.0",
-				"next": "^16.3.3",
+				"next": "16.3.3",
 				"next-mdx-remote": "^6.0.0",
 				"next-sitemap": "4.2.3",
 				"next-themes": "^0.4.6",

--- a/package.json
+++ b/package.json
@@ -33,14 +33,16 @@
 		"wp-env:start": "wp-env start",
 		"wp-env:stop": "wp-env stop",
 		"wp-env:destroy": "wp-env destroy",
+		"postinstall": "patch-package",
 		"prepare": "husky install"
 	},
 	"devDependencies": {
-		"@wordpress/env": "^11.13.0",
+		"@wordpress/env": "11.14.0",
 		"@wordpress/prettier-config": "^4.53.0",
 		"@wordpress/scripts": "^27.9.0",
 		"husky": "^9.1.7",
 		"lint-staged": "^17.3.0",
+		"patch-package": "8.0.1",
 		"turbo": "^2.10.12",
 		"turndown": "^7.2.4"
 	}

--- a/patches/@wordpress+env+11.14.0.patch
+++ b/patches/@wordpress+env+11.14.0.patch
@@ -1,0 +1,18 @@
+diff --git a/node_modules/@wordpress/env/lib/runtime/docker/docker-config.js b/node_modules/@wordpress/env/lib/runtime/docker/docker-config.js
+index a6c0f30..8adf071 100644
+--- a/node_modules/@wordpress/env/lib/runtime/docker/docker-config.js
++++ b/node_modules/@wordpress/env/lib/runtime/docker/docker-config.js
+@@ -95,6 +95,13 @@ RUN sed -i 's|deb.debian.org/debian buster|archive.debian.org/debian buster|g' /
+ RUN sed -i 's|security.debian.org/debian-security buster/updates|archive.debian.org/debian-security buster/updates|g' /etc/apt/sources.list
+ RUN sed -i '/buster-updates/d' /etc/apt/sources.list
+ 
++# bullseye (https://www.debian.org/News/2026/20260831)
++# The security suite is not on archive.debian.org yet, so it is dropped rather
++# than rewritten.
++RUN sed -i 's|deb.debian.org/debian bullseye|archive.debian.org/debian bullseye|g' /etc/apt/sources.list
++RUN sed -i '/bullseye-security/d' /etc/apt/sources.list
++RUN sed -i '/bullseye-updates/d' /etc/apt/sources.list
++
+ # Create the host's user so that we can match ownership in the container.
+ ARG HOST_USERNAME
+ ARG HOST_UID

--- a/patches/@wordpress+env+11.14.0.patch
+++ b/patches/@wordpress+env+11.14.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@wordpress/env/lib/runtime/docker/docker-config.js b/node_modules/@wordpress/env/lib/runtime/docker/docker-config.js
-index a6c0f30..8adf071 100644
+index a6c0f30..633ad8f 100644
 --- a/node_modules/@wordpress/env/lib/runtime/docker/docker-config.js
 +++ b/node_modules/@wordpress/env/lib/runtime/docker/docker-config.js
 @@ -95,6 +95,13 @@ RUN sed -i 's|deb.debian.org/debian buster|archive.debian.org/debian buster|g' /
@@ -16,3 +16,14 @@ index a6c0f30..8adf071 100644
  # Create the host's user so that we can match ownership in the container.
  ARG HOST_USERNAME
  ARG HOST_UID
+@@ -223,7 +230,9 @@ RUN rm /tmp/composer-setup.php`;
+ 	dockerFileContent += `
+ USER $HOST_UID:$HOST_GID
+ ENV PATH="\${PATH}:/home/$HOST_USERNAME/.composer/vendor/bin"
+-RUN composer global require --dev phpunit/phpunit:"^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0"
++# NOTE(wp-graphql): the global phpunit install is removed. This repo's tests run
++# each plugin's own vendor/bin/codecept (which bundles phpunit), and the install's
++# GitHub zipball downloads were a recurring CI flake (wp-graphql/wp-graphql#4268).
+ USER root`;
+ 
+ 	return dockerFileContent;

--- a/websites/wpgraphql.com/package.json
+++ b/websites/wpgraphql.com/package.json
@@ -45,7 +45,6 @@
     "next-sitemap": "4.2.3",
     "next-themes": "^0.4.6",
     "octokit": "^5.0.5",
-    "postinstall-postinstall": "^2.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.6.0",


### PR DESCRIPTION
## What does this do?

Fixes both wp-env image-build failure modes that have been taking down CI, via a `patch-package` patch on `@wordpress/env` (upgraded to 11.14.0) applied by a root `postinstall` script.

### 1. Deterministic: Debian bullseye EOL (every WP 6.2 / PHP 7.4 lane, every PR, since ~Sept 7)

```
E: Release file for http://deb.debian.org/debian-security/dists/bullseye-security/InRelease is expired
ERROR: process "/bin/sh -c apt-get -qy update" did not complete successfully: exit code: 100
```

Debian bullseye reached end of life on 2026-08-31 ([announcement](https://www.debian.org/News/2026/20260831)) and the `bullseye-security` Release file has since expired permanently. The `wordpress:php7.4` image is bullseye-based, so `apt-get update` in wp-env's generated Dockerfile fails every time; reruns cannot clear it.

**Fix**: backports, verbatim, the upstream wp-env fix from Gutenberg trunk (WordPress/gutenberg#82478, merged 2026-09-05, not yet in any released `@wordpress/env`): repoint bullseye sources at `archive.debian.org` and drop the `bullseye-security` / `bullseye-updates` entries.

### 2. Intermittent: GitHub 504s during the global phpunit install (all lanes, the failures #4268 originally tracked)

```
Failed to download sebastian/diff from dist: The "https://api.github.com/repos/.../zipball/..." file could not be downloaded (HTTP/2 504)
ERROR: process "/bin/sh -c composer global require --dev phpunit/phpunit:..." did not complete successfully: exit code: 100
```

wp-env's image build installs a global phpunit whose dependency zipballs download unauthenticated from api.github.com, which intermittently 504s from CI runner IPs. The workflow's 3 retries all fire within about a minute against the same struggling endpoint, so a bad window fails the lane. Confirmed from the Sept 1 logs, and confirmed it hit modern (bookworm) lanes too, so it is unrelated to the bullseye issue.

**Fix**: remove the install from the generated Dockerfile. This repo never uses it: every test suite in every plugin runs the plugin's own `vendor/bin/codecept`, which bundles phpunit, and no workflow invokes bare `phpunit`. Removing it eliminates the flake at its source and drops ~26 package downloads from every image build in every lane. The generated Dockerfile carries a comment explaining the removal.

## Patch lifecycle

The bullseye portion is temporary: once a released `@wordpress/env` includes WordPress/gutenberg#82478, we bump the dependency and re-generate the patch with only the phpunit removal (or drop patching entirely if upstream also makes the phpunit install optional, which is worth proposing).

## Verification

- Patched-template docker build `FROM wordpress:php7.4` (the exact failing image) through all the template's apt steps: **succeeds**.
- Same build without the patch: reproduces the exact CI error (expired Release, exit 100) — negative control.
- Fresh `npm ci --prefer-offline --no-audit --no-fund` (CI's invocation) runs `postinstall` and the resulting `node_modules` contains both patch hunks.
- The patched template module loads and generates the expected Dockerfile (bullseye seds present, composer install absent).
- This PR's own CI is the end-to-end proof: the WP 6.2 / PHP 7.4 lanes fail on every other PR and should pass here, and all lanes build without the phpunit step and still run their codecept suites.

Fixes #4268