### PR TITLE
chore: add a plugin dropdown to the issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,6 +11,19 @@ body:
         Please remember, a bug report is _not the place to ask questions_. You can
         use [Slack](https://join.slack.com/t/wp-graphql/shared_invite/zt-3vloo60z-PpJV2PFIwEathWDOxCTTLA) for that, or start a topic in [GitHub
         Discussions](https://github.com/wp-graphql/wp-graphql/discussions).
+  - type: dropdown
+    id: plugin
+    attributes:
+      label: Which plugin?
+      description: The plugin this report is about. Pick "Not sure" if you don't know.
+      options:
+        - WPGraphQL (core)
+        - WPGraphQL Smart Cache
+        - WPGraphQL for ACF
+        - WPGraphQL IDE
+        - Not sure
+    validations:
+      required: true
   - type: textarea
     attributes:
       label: Description

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -10,6 +10,19 @@ body:
         Please make sure to search the repo for [existing feature
         requests](https://github.com/wp-graphql/wp-graphql/issues)
         before creating a new one.
+  - type: dropdown
+    id: plugin
+    attributes:
+      label: Which plugin?
+      description: The plugin this report is about. Pick "Not sure" if you don't know.
+      options:
+        - WPGraphQL (core)
+        - WPGraphQL Smart Cache
+        - WPGraphQL for ACF
+        - WPGraphQL IDE
+        - Not sure
+    validations:
+      required: true
   - type: textarea
     attributes:
       label: What problem does this address?


### PR DESCRIPTION
## What

Adds a required "Which plugin?" dropdown to the bug report and feature request issue forms, with the options WPGraphQL (core), WPGraphQL Smart Cache, WPGraphQL for ACF, WPGraphQL IDE, and Not sure.

## Why

This repo now hosts four plugins, but the issue forms only ask for the WPGraphQL version, so triage has to work out which plugin a report is about from the description. Asking up front makes that explicit. It also lines up with the `plugin:` labels we are adding as the open issues from the old Smart Cache and ACF repositories get moved into this tracker.

Issue forms cannot apply a label from a dropdown value on their own, so the label is still applied during triage. Automating that is a possible follow-up.

## Testing

Both forms pass `yaml-lint`. The dropdown sits right after the intro text and before the first textarea in each form, and no other field changed.
