### PR TITLE
fix: extensions page detects installed plugins by file and restores the card grid on WordPress 7

### DIFF
--- a/plugins/wp-graphql/docs/submit-extension.md
+++ b/plugins/wp-graphql/docs/submit-extension.md
@@ -54,6 +54,7 @@ public static function get_extensions(): array {
 			'description' => 'This is a new extension that I created.', // Required: Brief description (limit: 150 characters)
 			'plugin_url' => 'https://example.com/my-new-extension', // Required: URL to the plugin repository or download
 			'repo_url' => 'https://wordpress.org/plugins/my-new-extension', // Optional: URL to the plugin's source repository
+			'plugin_file' => 'my-new-extension.php', // Optional but recommended: the plugin's main file name, so the Extensions page can tell the plugin is installed and active no matter which directory it was installed into
 			'support_url' => 'https://example.com/my-new-extension/support', // Required: URL for user support
 			'documentation_url' => 'https://example.com/my-new-extension/docs', // Required: URL to the plugin's documentation
 			'author' => [

--- a/plugins/wp-graphql/packages/extensions/PluginCard.js
+++ b/plugins/wp-graphql/packages/extensions/PluginCard.js
@@ -12,7 +12,11 @@ const PluginCard = ({ plugin }) => {
 		error,
 		installPlugin,
 		activatePlugin,
-	} = useInstallPlugin(plugin.plugin_url, plugin.plugin_path);
+	} = useInstallPlugin(
+		plugin.plugin_url,
+		plugin.plugin_path,
+		plugin.plugin_file
+	);
 	const [isInstalled, setIsInstalled] = useState(plugin.installed);
 	const [isActive, setIsActive] = useState(plugin.active);
 	const [isErrorVisible, setIsErrorVisible] = useState(true);

--- a/plugins/wp-graphql/packages/extensions/index.scss
+++ b/plugins/wp-graphql/packages/extensions/index.scss
@@ -1,3 +1,25 @@
+/*
+ * Lay the cards out in columns. WordPress core styles `.plugin-card` widths
+ * (50% / 33% / 25% by viewport) but, since WordPress 7.0, only makes the
+ * container a flex row on its own plugin-install screen
+ * (`.plugin-install-php #the-list`). Mirror that here for our wrapper so the
+ * cards do not stack in a single column.
+ */
+.plugin-cards {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+}
+
+.plugin-cards .plugin-card {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    /* Older WordPress versions float the card with a right/bottom margin; the gap handles spacing here. */
+    float: none;
+    margin: 0;
+}
+
 .plugin-card .name, .plugin-card .desc, /* For WP <6.5 versions */
 .plugin-card .desc > p {
     margin-left: 0;

--- a/plugins/wp-graphql/packages/extensions/useInstallPlugin.js
+++ b/plugins/wp-graphql/packages/extensions/useInstallPlugin.js
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 
-const useInstallPlugin = (pluginUrl, pluginPath) => {
+const useInstallPlugin = (pluginUrl, pluginPath, pluginFile) => {
 	const [installing, setInstalling] = useState(false);
 	const [activating, setActivating] = useState(false);
 	const [status, setStatus] = useState('');
@@ -33,7 +33,8 @@ const useInstallPlugin = (pluginUrl, pluginPath) => {
 				.split('/')
 				.filter(Boolean)
 				.pop();
-			path = `${slug}/${slug}.php`;
+			// Prefer the declared main file: the directory slug and the file name differ for some plugins.
+			path = `${slug}/${pluginFile || `${slug}.php`}`;
 		}
 
 		try {
@@ -97,7 +98,13 @@ const useInstallPlugin = (pluginUrl, pluginPath) => {
 				throw new Error(__('Installation failed', 'wp-graphql'));
 			}
 
-			await activatePlugin(pluginPath);
+			// The REST response names the installed plugin ("dir/file" without the .php suffix),
+			// which is more reliable than guessing the path from the slug.
+			const installedPath = installResult.plugin
+				? `${installResult.plugin}.php`
+				: pluginPath;
+
+			await activatePlugin(installedPath);
 		} catch (err) {
 			if (err.message.includes('destination folder already exists')) {
 				await activatePlugin(pluginPath);

--- a/plugins/wp-graphql/src/Admin/Extensions/Extensions.php
+++ b/plugins/wp-graphql/src/Admin/Extensions/Extensions.php
@@ -21,6 +21,8 @@ use WP_REST_Response;
  *   support_url: non-empty-string,
  *   documentation_url: non-empty-string,
  *   repo_url?: string,
+ *   plugin_file?: string,
+ *   plugin_path?: string,
  *   author: ExtensionAuthor,
  *   installed: bool,
  *   active: bool,
@@ -210,6 +212,8 @@ final class Extensions {
 	 *
 	 * @return array<string,array{
 	 *  is_active: bool,
+	 *  file: string,
+	 *  path: string,
 	 *  name: string,
 	 *  description: string,
 	 *  author: string,
@@ -229,6 +233,8 @@ final class Extensions {
 
 			$installed_plugins[ $slug ] = [
 				'is_active'   => in_array( $plugin_path, $active_plugins, true ),
+				'file'        => basename( $plugin_path ),
+				'path'        => $plugin_path,
 				'name'        => $plugin_info['Name'],
 				'description' => $plugin_info['Description'],
 				'author'      => $plugin_info['Author'],
@@ -249,6 +255,7 @@ final class Extensions {
 	 *  support_url: string|null,
 	 *  documentation_url: string|null,
 	 *  repo_url: string|null,
+	 *  plugin_file: string|null,
 	 *  author: array{
 	 *    name: string|null,
 	 *    homepage: string|null,
@@ -263,6 +270,7 @@ final class Extensions {
 			'support_url'       => ! empty( $extension['support_url'] ) ? esc_url_raw( $extension['support_url'] ) : null,
 			'documentation_url' => ! empty( $extension['documentation_url'] ) ? esc_url_raw( $extension['documentation_url'] ) : null,
 			'repo_url'          => ! empty( $extension['repo_url'] ) ? esc_url_raw( $extension['repo_url'] ) : null,
+			'plugin_file'       => ! empty( $extension['plugin_file'] ) && is_string( $extension['plugin_file'] ) ? sanitize_file_name( basename( $extension['plugin_file'] ) ) : null,
 			'author'            => [
 				'name'     => ! empty( $extension['author']['name'] ) ? sanitize_text_field( $extension['author']['name'] ) : null,
 				'homepage' => ! empty( $extension['author']['homepage'] ) ? esc_url_raw( $extension['author']['homepage'] ) : null,
@@ -331,17 +339,19 @@ final class Extensions {
 		$populated_extensions = [];
 
 		foreach ( $extensions as $extension ) {
-			$slug                   = basename( rtrim( $extension['plugin_url'], '/' ) );
 			$extension['installed'] = false;
 			$extension['active']    = false;
 
-			// If the plugin is installed, populate the installation data.
-			if ( isset( $installed_plugins[ $slug ] ) ) {
-				$extension['installed'] = true;
-				$extension['active']    = $installed_plugins[ $slug ]['is_active'];
+			$installed_plugin = $this->find_installed_plugin( $extension, $installed_plugins );
 
-				if ( ! empty( $installed_plugins[ $slug ]['author'] ) ) {
-					$extension['author']['name'] = $installed_plugins[ $slug ]['author'];
+			// If the plugin is installed, populate the installation data.
+			if ( null !== $installed_plugin ) {
+				$extension['installed']   = true;
+				$extension['active']      = $installed_plugin['is_active'];
+				$extension['plugin_path'] = $installed_plugin['path'];
+
+				if ( ! empty( $installed_plugin['author'] ) ) {
+					$extension['author']['name'] = $installed_plugin['author'];
 				}
 			}
 
@@ -380,6 +390,36 @@ final class Extensions {
 		);
 
 		return $populated_extensions;
+	}
+
+	/**
+	 * Finds the installed plugin that corresponds to an extension.
+	 *
+	 * When the extension declares a `plugin_file`, the match is made on the plugin's main file name,
+	 * which is stable across install methods. Otherwise the last segment of `plugin_url` is compared
+	 * with the plugin's directory name, which only holds when the plugin was installed from
+	 * WordPress.org under that exact slug.
+	 *
+	 * @param array<string,mixed>                                                                                      $extension         The (sanitized) extension.
+	 * @param array<string,array{is_active:bool,file:string,path:string,name:string,description:string,author:string}> $installed_plugins Installed plugins, keyed by directory.
+	 *
+	 * @return array{is_active:bool,file:string,path:string,name:string,description:string,author:string}|null The installed plugin, or null if not installed.
+	 */
+	private function find_installed_plugin( array $extension, array $installed_plugins ): ?array {
+		if ( ! empty( $extension['plugin_file'] ) && is_string( $extension['plugin_file'] ) ) {
+			foreach ( $installed_plugins as $installed_plugin ) {
+				if ( $installed_plugin['file'] === $extension['plugin_file'] ) {
+					return $installed_plugin;
+				}
+			}
+
+			return null;
+		}
+
+		$plugin_url = isset( $extension['plugin_url'] ) && is_string( $extension['plugin_url'] ) ? $extension['plugin_url'] : '';
+		$slug       = basename( rtrim( $plugin_url, '/' ) );
+
+		return '' !== $slug && isset( $installed_plugins[ $slug ] ) ? $installed_plugins[ $slug ] : null;
 	}
 
 	/**

--- a/plugins/wp-graphql/src/Admin/Extensions/Registry.php
+++ b/plugins/wp-graphql/src/Admin/Extensions/Registry.php
@@ -25,6 +25,7 @@ namespace WPGraphQL\Admin\Extensions;
  *  support_url: non-empty-string,
  *  documentation_url: non-empty-string,
  *  repo_url?: string,
+ *  plugin_file?: string,
  *  author: ExtensionAuthor,
  * }
  * phpcs:enable
@@ -40,6 +41,7 @@ final class Registry {
 	 * - description: Required. A description of the extension.
 	 * - plugin_url: Required. The URL to the plugin.
 	 * - repo_url: Optional. The URL to the repository for the plugin.
+	 * - plugin_file: Optional. The file name of the plugin's main file (e.g. `wp-graphql-smart-cache.php`). When set, the extension is detected as installed/active by this file regardless of the directory it was installed into (WordPress.org installs and git checkouts often differ). Without it, detection falls back to matching the directory name against the last segment of `plugin_url`.
 	 * - support_url: Required. The URL to the support page for the plugin.
 	 * - documentation_url: Required. The URL to the documentation for the plugin.
 	 * - author: Required. An array with the following fields:
@@ -57,6 +59,7 @@ final class Registry {
 				'description'       => 'GraphQL IDE for WPGraphQL',
 				'documentation_url' => 'https://github.com/wp-graphql/wpgraphql-ide',
 				'plugin_url'        => 'https://wordpress.org/plugins/wpgraphql-ide/',
+				'plugin_file'       => 'wpgraphql-ide.php',
 				'support_url'       => 'https://github.com/wp-graphql/wpgraphql-ide/issues/new/choose',
 				'author'            => [
 					'name'     => 'WPGraphQL',
@@ -67,7 +70,8 @@ final class Registry {
 				'name'              => 'WPGraphQL Smart Cache',
 				'description'       => 'A smart cache for WPGraphQL that caches only the data you need.',
 				'documentation_url' => 'https://github.com/wp-graphql/wp-graphql/tree/main/plugins/wp-graphql-smart-cache',
-				'plugin_url'        => 'https://wordpress.org/plugins/wp-graphql-smart-cache/',
+				'plugin_url'        => 'https://wordpress.org/plugins/wpgraphql-smart-cache/',
+				'plugin_file'       => 'wp-graphql-smart-cache.php',
 				'support_url'       => 'https://github.com/wp-graphql/wp-graphql-smart-cache/issues/new/choose',
 				'author'            => [
 					'name'     => 'WPGraphQL',
@@ -79,6 +83,7 @@ final class Registry {
 				'description'       => 'WPGraphQL for ACF is a FREE, open source WordPress plugin that exposes ACF Field Groups and Fields to the WPGraphQL Schema, enabling powerful decoupled solutions with modern frontends.',
 				'documentation_url' => 'https://www.wpgraphql.com/docs/acf',
 				'plugin_url'        => 'https://wordpress.org/plugins/wpgraphql-acf/',
+				'plugin_file'       => 'wpgraphql-acf.php',
 				'support_url'       => 'https://github.com/wp-graphql/wpgraphql-acf/issues/new/choose',
 				'author'            => [
 					'name'     => 'WPGraphQL',

--- a/plugins/wp-graphql/tests/wpunit/ExtensionsInstalledDetectionTest.php
+++ b/plugins/wp-graphql/tests/wpunit/ExtensionsInstalledDetectionTest.php
@@ -1,0 +1,179 @@
+<?php
+
+use WPGraphQL\Admin\Extensions\Extensions;
+use WPGraphQL\Admin\Extensions\Registry;
+
+/**
+ * Tests that the Extensions admin page detects installed and active extensions
+ * regardless of the directory the plugin was installed into.
+ *
+ * In the test environment WPGraphQL itself is installed as
+ * `wp-graphql/wp-graphql.php` and is active, so it doubles as the "installed extension".
+ */
+class ExtensionsInstalledDetectionTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
+
+	/**
+	 * @var callable|null
+	 */
+	private $filter;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function tearDown(): void {
+		if ( null !== $this->filter ) {
+			remove_filter( 'graphql_get_extensions', $this->filter );
+			$this->filter = null;
+		}
+		parent::tearDown();
+	}
+
+	/**
+	 * Replace the registry with a single test extension and return the populated result.
+	 *
+	 * @param array<string,mixed> $extension
+	 * @return array<string,mixed>
+	 */
+	private function get_populated_extension( array $extension ): array {
+		$this->filter = static function () use ( $extension ) {
+			return [ 'test/extension' => $extension ];
+		};
+		add_filter( 'graphql_get_extensions', $this->filter );
+
+		$extensions = ( new Extensions() )->get_extensions();
+
+		$this->assertCount( 1, $extensions );
+
+		return $extensions[0];
+	}
+
+	/**
+	 * A minimal valid extension config without plugin_url / plugin_file.
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function base_extension(): array {
+		return [
+			'name'              => 'Test Extension',
+			'description'       => 'An extension used to test installed detection.',
+			'support_url'       => 'https://example.com/support',
+			'documentation_url' => 'https://example.com/docs',
+			'author'            => [
+				'name' => 'Tester',
+			],
+		];
+	}
+
+	/**
+	 * A declared plugin_file finds the installed plugin even when the plugin_url slug is not the directory name.
+	 */
+	public function testPluginFileDetectsInstalledPluginWhenDirectoryDoesNotMatchSlug(): void {
+		$extension = $this->get_populated_extension(
+			array_merge(
+				$this->base_extension(),
+				[
+					// The slug in the URL does NOT match the installed directory (wp-graphql).
+					'plugin_url'  => 'https://wordpress.org/plugins/some-other-slug/',
+					'plugin_file' => 'wp-graphql.php',
+				]
+			)
+		);
+
+		$this->assertTrue( $extension['installed'] );
+		$this->assertTrue( $extension['active'] );
+		$this->assertSame( 'wp-graphql/wp-graphql.php', $extension['plugin_path'] );
+		$this->assertSame( 'wp-graphql.php', $extension['plugin_file'] );
+	}
+
+	/**
+	 * Without plugin_file, the directory name is matched against the plugin_url slug (previous behavior).
+	 */
+	public function testSlugFallbackDetectsInstalledPluginWithoutPluginFile(): void {
+		$extension = $this->get_populated_extension(
+			array_merge(
+				$this->base_extension(),
+				[
+					'plugin_url' => 'https://wordpress.org/plugins/wp-graphql/',
+				]
+			)
+		);
+
+		$this->assertTrue( $extension['installed'] );
+		$this->assertTrue( $extension['active'] );
+		$this->assertSame( 'wp-graphql/wp-graphql.php', $extension['plugin_path'] );
+	}
+
+	/**
+	 * Without plugin_file, a slug that is not the directory name is reported as not installed.
+	 */
+	public function testSlugMismatchWithoutPluginFileIsReportedAsNotInstalled(): void {
+		$extension = $this->get_populated_extension(
+			array_merge(
+				$this->base_extension(),
+				[
+					'plugin_url' => 'https://wordpress.org/plugins/some-other-slug/',
+				]
+			)
+		);
+
+		$this->assertFalse( $extension['installed'] );
+		$this->assertFalse( $extension['active'] );
+		$this->assertArrayNotHasKey( 'plugin_path', $extension );
+	}
+
+	/**
+	 * A declared plugin_file that matches nothing wins over the slug fallback and reports not installed.
+	 */
+	public function testUnknownPluginFileIsReportedAsNotInstalled(): void {
+		$extension = $this->get_populated_extension(
+			array_merge(
+				$this->base_extension(),
+				[
+					'plugin_url'  => 'https://wordpress.org/plugins/wp-graphql/',
+					'plugin_file' => 'definitely-not-installed.php',
+				]
+			)
+		);
+
+		// A declared plugin_file takes precedence over the slug fallback.
+		$this->assertFalse( $extension['installed'] );
+		$this->assertFalse( $extension['active'] );
+	}
+
+	/**
+	 * The plugin_file value is reduced to a file name, so path segments cannot reach the lookup.
+	 */
+	public function testPluginFileIsSanitizedToABasename(): void {
+		$extension = $this->get_populated_extension(
+			array_merge(
+				$this->base_extension(),
+				[
+					'plugin_url'  => 'https://wordpress.org/plugins/some-other-slug/',
+					'plugin_file' => '../../wp-graphql/wp-graphql.php',
+				]
+			)
+		);
+
+		$this->assertSame( 'wp-graphql.php', $extension['plugin_file'] );
+		$this->assertTrue( $extension['installed'] );
+	}
+
+	/**
+	 * The first-party registry entries use their real WordPress.org slugs and declare their main files.
+	 */
+	public function testFirstPartyRegistryEntriesUseWordPressOrgSlugsAndDeclarePluginFiles(): void {
+		$registry = Registry::get_extensions();
+
+		$expected = [
+			'wp-graphql/wpgraphql-ide'          => [ 'https://wordpress.org/plugins/wpgraphql-ide/', 'wpgraphql-ide.php' ],
+			'wp-graphql/wp-graphql-smart-cache' => [ 'https://wordpress.org/plugins/wpgraphql-smart-cache/', 'wp-graphql-smart-cache.php' ],
+			'wp-graphql/wpgraphql-acf'          => [ 'https://wordpress.org/plugins/wpgraphql-acf/', 'wpgraphql-acf.php' ],
+		];
+
+		foreach ( $expected as $key => [ $plugin_url, $plugin_file ] ) {
+			$this->assertArrayHasKey( $key, $registry );
+			$this->assertSame( $plugin_url, $registry[ $key ]['plugin_url'], "Unexpected plugin_url for $key" );
+			$this->assertSame( $plugin_file, $registry[ $key ]['plugin_file'], "Unexpected plugin_file for $key" );
+		}
+	}
+}

--- a/plugins/wp-graphql/tests/wpunit/ExtensionsInstalledDetectionTest.php
+++ b/plugins/wp-graphql/tests/wpunit/ExtensionsInstalledDetectionTest.php
@@ -7,15 +7,60 @@ use WPGraphQL\Admin\Extensions\Registry;
  * Tests that the Extensions admin page detects installed and active extensions
  * regardless of the directory the plugin was installed into.
  *
- * In the test environment WPGraphQL itself is installed as
- * `wp-graphql/wp-graphql.php` and is active, so it doubles as the "installed extension".
+ * The installed plugin list is seeded into the `plugins` cache that get_plugins()
+ * reads from, so the assertions do not depend on which plugins happen to be
+ * mounted in the test environment. Two fixtures cover both lookup paths:
+ *
+ * - Smart Cache lives in a directory (`wp-graphql-smart-cache`) that does NOT
+ *   match its WordPress.org slug (`wpgraphql-smart-cache`), and is active.
+ * - The IDE lives in a directory that matches its slug, and is inactive.
  */
 class ExtensionsInstalledDetectionTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
+
+	private const SMART_CACHE_PATH = 'wp-graphql-smart-cache/wp-graphql-smart-cache.php';
+	private const IDE_PATH         = 'wpgraphql-ide/wpgraphql-ide.php';
 
 	/**
 	 * @var callable|null
 	 */
 	private $filter;
+
+	/**
+	 * @var mixed The active_plugins option before the test seeded it.
+	 */
+	private $original_active_plugins;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->original_active_plugins = get_option( 'active_plugins' );
+
+		// get_plugins() returns the cached list (keyed by plugin folder, '' = the plugins root)
+		// when one is present, so seeding it makes the installed list deterministic.
+		wp_cache_set(
+			'plugins',
+			[
+				'' => [
+					self::SMART_CACHE_PATH => [
+						'Name'        => 'WPGraphQL Smart Cache',
+						'Description' => 'Caching for WPGraphQL.',
+						'Author'      => 'WPGraphQL',
+					],
+					self::IDE_PATH         => [
+						'Name'        => 'WPGraphQL IDE',
+						'Description' => 'An IDE for WPGraphQL.',
+						'Author'      => 'WPGraphQL',
+					],
+				],
+			],
+			'plugins'
+		);
+
+		update_option( 'active_plugins', [ self::SMART_CACHE_PATH ] );
+	}
 
 	/**
 	 * {@inheritDoc}
@@ -25,6 +70,10 @@ class ExtensionsInstalledDetectionTest extends \Tests\WPGraphQL\TestCase\WPGraph
 			remove_filter( 'graphql_get_extensions', $this->filter );
 			$this->filter = null;
 		}
+
+		wp_cache_delete( 'plugins', 'plugins' );
+		update_option( 'active_plugins', $this->original_active_plugins );
+
 		parent::tearDown();
 	}
 
@@ -72,17 +121,17 @@ class ExtensionsInstalledDetectionTest extends \Tests\WPGraphQL\TestCase\WPGraph
 			array_merge(
 				$this->base_extension(),
 				[
-					// The slug in the URL does NOT match the installed directory (wp-graphql).
-					'plugin_url'  => 'https://wordpress.org/plugins/some-other-slug/',
-					'plugin_file' => 'wp-graphql.php',
+					// The WordPress.org slug does NOT match the installed directory (wp-graphql-smart-cache).
+					'plugin_url'  => 'https://wordpress.org/plugins/wpgraphql-smart-cache/',
+					'plugin_file' => 'wp-graphql-smart-cache.php',
 				]
 			)
 		);
 
 		$this->assertTrue( $extension['installed'] );
 		$this->assertTrue( $extension['active'] );
-		$this->assertSame( 'wp-graphql/wp-graphql.php', $extension['plugin_path'] );
-		$this->assertSame( 'wp-graphql.php', $extension['plugin_file'] );
+		$this->assertSame( self::SMART_CACHE_PATH, $extension['plugin_path'] );
+		$this->assertSame( 'wp-graphql-smart-cache.php', $extension['plugin_file'] );
 	}
 
 	/**
@@ -93,25 +142,28 @@ class ExtensionsInstalledDetectionTest extends \Tests\WPGraphQL\TestCase\WPGraph
 			array_merge(
 				$this->base_extension(),
 				[
-					'plugin_url' => 'https://wordpress.org/plugins/wp-graphql/',
+					'plugin_url' => 'https://wordpress.org/plugins/wpgraphql-ide/',
 				]
 			)
 		);
 
 		$this->assertTrue( $extension['installed'] );
-		$this->assertTrue( $extension['active'] );
-		$this->assertSame( 'wp-graphql/wp-graphql.php', $extension['plugin_path'] );
+		$this->assertFalse( $extension['active'] );
+		$this->assertSame( self::IDE_PATH, $extension['plugin_path'] );
 	}
 
 	/**
 	 * Without plugin_file, a slug that is not the directory name is reported as not installed.
+	 *
+	 * This is the original bug: Smart Cache is installed and active, but its
+	 * WordPress.org slug is not its directory name, so the slug fallback misses it.
 	 */
 	public function testSlugMismatchWithoutPluginFileIsReportedAsNotInstalled(): void {
 		$extension = $this->get_populated_extension(
 			array_merge(
 				$this->base_extension(),
 				[
-					'plugin_url' => 'https://wordpress.org/plugins/some-other-slug/',
+					'plugin_url' => 'https://wordpress.org/plugins/wpgraphql-smart-cache/',
 				]
 			)
 		);
@@ -129,7 +181,7 @@ class ExtensionsInstalledDetectionTest extends \Tests\WPGraphQL\TestCase\WPGraph
 			array_merge(
 				$this->base_extension(),
 				[
-					'plugin_url'  => 'https://wordpress.org/plugins/wp-graphql/',
+					'plugin_url'  => 'https://wordpress.org/plugins/wpgraphql-ide/',
 					'plugin_file' => 'definitely-not-installed.php',
 				]
 			)
@@ -148,13 +200,13 @@ class ExtensionsInstalledDetectionTest extends \Tests\WPGraphQL\TestCase\WPGraph
 			array_merge(
 				$this->base_extension(),
 				[
-					'plugin_url'  => 'https://wordpress.org/plugins/some-other-slug/',
-					'plugin_file' => '../../wp-graphql/wp-graphql.php',
+					'plugin_url'  => 'https://wordpress.org/plugins/wpgraphql-smart-cache/',
+					'plugin_file' => '../../wp-graphql-smart-cache/wp-graphql-smart-cache.php',
 				]
 			)
 		);
 
-		$this->assertSame( 'wp-graphql.php', $extension['plugin_file'] );
+		$this->assertSame( 'wp-graphql-smart-cache.php', $extension['plugin_file'] );
 		$this->assertTrue( $extension['installed'] );
 	}
 


### PR DESCRIPTION
## What

The Extensions admin page derived both the install slug and the installed/active check from the last segment of each extension's `plugin_url`. That fails in two directions:

- On a WordPress.org install, the Smart Cache entry pointed at `wp-graphql-smart-cache`, but the real slug is `wpgraphql-smart-cache`. The card offered "Install & Activate" for an active plugin, and the install request asked WordPress.org for a plugin it does not know ("Plugin not found").
- On a git or wp-env checkout, plugin directories are the repository folder names (`wp-graphql-acf`, `wp-graphql-ide`), so ACF and the IDE showed "Install & Activate" while active. Smart Cache only looked right there by accident.

## Changes

- Registry entries can declare `plugin_file`, the plugin's main file name. Detection matches on that, which is stable across install methods. Entries without it keep the old directory-name fallback.
- The three first-party entries declare `plugin_file`, and the Smart Cache `plugin_url` is corrected.
- The populated extension now carries `plugin_path`. The JS card already passed `plugin.plugin_path` to activation, but nothing ever set it.
- After a fresh install, activation uses the path returned by core's REST install response instead of guessing `<slug>/<slug>.php`. That fixes "Plugin file does not exist" for plugins whose main file is not named after the slug, which is Smart Cache again.
- `docs/submit-extension.md` documents the new key.

Related to #3934. This covers the slug and detection defects reported there. The `array_map` fatal on the ACF card did not reproduce on current `main`, so I have left that issue open for confirmation rather than closing it from here.

## Also: card grid on WordPress 7

While testing on WordPress 7.1 the cards rendered in a single column. Core 7.0 moved the plugin-card column layout from float rules to a flex container that only exists on its own plugin-install screen (`.plugin-install-php #the-list`), and our `.plugin-cards` wrapper was never styled by core. A few lines of our own SCSS give the wrapper the same flex layout, so core's width rules (2, 3, or 4 columns by viewport) apply again. Older WordPress versions still float the card, so the float and margins are neutralized inside the wrapper.

## Testing

- New `tests/wpunit/ExtensionsInstalledDetectionTest.php` (6 tests): detection by `plugin_file` when the slug does not match the directory, the slug fallback, the not-installed cases, basename sanitization of `plugin_file`, and a guard that the first-party registry entries use their real WordPress.org slugs and declare their main files.
- PHPCS and PHPStan clean for the changed files. The JS lint errors in `packages/extensions` are pre-existing and unchanged.
- Verified on wp-env (WordPress 7.1) with all three plugins active: before, ACF and IDE cards showed "Install & Activate" and the cards stacked in one column; after, all three show "Active" and the cards lay out in three columns.
