### PR TITLE
fix(smart-cache): allow a max-age of 0 on saved documents

### DIFF
--- a/plugins/wp-graphql-smart-cache/src/Document/MaxAge.php
+++ b/plugins/wp-graphql-smart-cache/src/Document/MaxAge.php
@@ -165,7 +165,6 @@ class MaxAge {
 	 * @return bool
 	 */
 	public function valid( $value ) {
-		// TODO: terms won't save 0, as considers that empty and removes the term. Consider 'zero' or 'stale' or greater than zero.
 		return ( is_numeric( $value ) && $value >= 0 );
 	}
 
@@ -182,7 +181,9 @@ class MaxAge {
 			throw new RequestError( sprintf( __( 'Invalid max age header value "%s". Must be greater than or equal to zero', 'wp-graphql-smart-cache' ), $value ) );
 		}
 
-		return wp_set_post_terms( $post_id, $value, self::TAXONOMY_NAME );
+		// Pass the term as an array. wp_set_post_terms() treats a scalar "0" as
+		// empty and would remove the term instead of storing a max-age of zero.
+		return wp_set_post_terms( $post_id, [ (string) $value ], self::TAXONOMY_NAME );
 	}
 
 	/**
@@ -227,8 +228,9 @@ class MaxAge {
 			if ( $post ) {
 				// If this saved query has a specified max-age, use it. Make sure to keep the smallest value.
 				$value = $this->get( $post->ID );
-				if ( $value ) {
-					$age = ( null === $age ) ? $value : min( $age, $value );
+				if ( is_string( $value ) && $this->valid( $value ) ) {
+					$value = intval( $value );
+					$age   = ( null === $age ) ? $value : min( $age, $value );
 				}
 			}
 		}
@@ -241,10 +243,11 @@ class MaxAge {
 		// Cache-Control max-age directive should be a positive integer, no decimals.
 		// A value of zero indicates that caching should be disabled.
 		if ( $this->valid( $age ) ) {
+			$age = intval( $age );
 			if ( 0 === $age ) {
 				$headers['Cache-Control'] = 'no-store';
 			} else {
-				$headers['Cache-Control'] = sprintf( 'max-age=%1$s, s-maxage=%1$s, must-revalidate', intval( $age ) );
+				$headers['Cache-Control'] = sprintf( 'max-age=%1$s, s-maxage=%1$s, must-revalidate', $age );
 			}
 		}
 

--- a/plugins/wp-graphql-smart-cache/tests/wpunit/MaxAgeZeroTest.php
+++ b/plugins/wp-graphql-smart-cache/tests/wpunit/MaxAgeZeroTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace WPGraphQL\SmartCache;
+
+use WPGraphQL\SmartCache\Document\MaxAge;
+
+/**
+ * A saved document's max-age can be set to 0, meaning "do not cache".
+ *
+ * Regression tests for the zero value being dropped: WordPress treats a scalar
+ * "0" passed to wp_set_post_terms() as empty and removes the term, and the
+ * header logic used truthy checks that ignored a stored "0".
+ */
+class MaxAgeZeroTest extends \Codeception\TestCase\WPTestCase {
+
+	public $admin;
+
+	public $created_post_ids = [];
+
+	public function setUp(): void {
+		parent::setUp();
+
+		\WPGraphQL::clear_schema();
+		delete_option( 'graphql_cache_section' );
+
+		$this->admin = self::factory()->user->create(
+			[
+				'role' => 'administrator',
+			]
+		);
+	}
+
+	public function tearDown(): void {
+		foreach ( $this->created_post_ids as $post_id ) {
+			if ( $post_id > 0 ) {
+				wp_delete_post( $post_id, true );
+			}
+		}
+		delete_option( 'graphql_cache_section' );
+		\WPGraphQL::clear_schema();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Save a persisted query and return its post id.
+	 *
+	 * @param string $alias The alias / query id to save the document under.
+	 *
+	 * @return int
+	 */
+	private function save_document( string $alias ): int {
+		$document = new Document();
+		$post_id  = $document->save( $alias, sprintf( 'query %s { posts { nodes { id title } } }', $alias ) );
+
+		$this->created_post_ids[] = $post_id;
+
+		return $post_id;
+	}
+
+	public function testZeroMaxAgeIsPersisted() {
+		$post_id = $this->save_document( uniqid( 'query_posts_', false ) );
+
+		$max_age = new MaxAge();
+		$max_age->save( $post_id, '0' );
+
+		$this->assertSame( '0', $max_age->get( $post_id ) );
+		$this->assertSame( [ '0' ], wp_list_pluck( get_the_terms( $post_id, MaxAge::TAXONOMY_NAME ), 'name' ) );
+	}
+
+	public function testZeroMaxAgeSendsNoStoreHeader() {
+		$alias   = uniqid( 'query_posts_', false );
+		$post_id = $this->save_document( $alias );
+
+		$max_age = new MaxAge();
+		$max_age->save( $post_id, '0' );
+
+		$request = [ 'params' => [ 'queryId' => $alias ] ];
+		$max_age->peek_at_executing_query_cb( '', json_decode( json_encode( $request ) ) );
+
+		$headers = $max_age->http_headers_cb( [] );
+
+		$this->assertSame( 'no-store', $headers['Cache-Control'] );
+	}
+
+	public function testZeroWinsAsTheMinimumInABatch() {
+		$alias_zero = uniqid( 'query_posts_', false );
+		$alias_ten  = uniqid( 'query_posts_', false );
+
+		$max_age = new MaxAge();
+		$max_age->save( $this->save_document( $alias_ten ), '10' );
+		$max_age->save( $this->save_document( $alias_zero ), '0' );
+
+		$request = [
+			'params' => [
+				[ 'queryId' => $alias_ten ],
+				[ 'queryId' => $alias_zero ],
+			],
+		];
+		$max_age->peek_at_executing_query_cb( '', json_decode( json_encode( $request ) ) );
+
+		$headers = $max_age->http_headers_cb( [] );
+
+		$this->assertSame( 'no-store', $headers['Cache-Control'] );
+	}
+
+	public function testZeroGlobalMaxAgeSettingSendsNoStoreHeader() {
+		// Settings are stored as strings; a global max-age of "0" must also mean no-store.
+		update_option( 'graphql_cache_section', [ 'global_max_age' => '0' ] );
+
+		$max_age = new MaxAge();
+		$headers = $max_age->http_headers_cb( [] );
+
+		$this->assertSame( 'no-store', $headers['Cache-Control'] );
+	}
+
+	public function testNonZeroMaxAgeStillSendsMaxAgeHeader() {
+		$alias   = uniqid( 'query_posts_', false );
+		$post_id = $this->save_document( $alias );
+
+		$max_age = new MaxAge();
+		$max_age->save( $post_id, '600' );
+
+		$request = [ 'params' => [ 'queryId' => $alias ] ];
+		$max_age->peek_at_executing_query_cb( '', json_decode( json_encode( $request ) ) );
+
+		$headers = $max_age->http_headers_cb( [] );
+
+		$this->assertSame( 'max-age=600, s-maxage=600, must-revalidate', $headers['Cache-Control'] );
+	}
+
+	public function testCreateDocumentMutationWithZeroMaxAgeHeader() {
+		wp_set_current_user( $this->admin );
+
+		$mutation = 'mutation CreateDocument($input: CreateGraphqlDocumentInput!) {
+			createGraphqlDocument(input: $input) {
+				graphqlDocument {
+					databaseId
+					maxAgeHeader
+				}
+			}
+		}';
+
+		$variables = [
+			'input' => [
+				'content'      => 'query max_age_zero { __typename }',
+				'status'       => 'PUBLISH',
+				'maxAgeHeader' => 0,
+			],
+		];
+
+		$actual = do_graphql_request( $mutation, 'CreateDocument', $variables );
+
+		codecept_debug( $actual );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+
+		$this->created_post_ids[] = (int) $actual['data']['createGraphqlDocument']['graphqlDocument']['databaseId'];
+
+		$this->assertSame( 0, $actual['data']['createGraphqlDocument']['graphqlDocument']['maxAgeHeader'] );
+	}
+}


### PR DESCRIPTION
## What

Setting a saved document's max-age header to `0` (meaning "do not cache") never took effect. This ports wp-graphql/wp-graphql-smart-cache#307 by @kpoelhekke into the monorepo, with a regression test.

## Why

Two separate problems dropped the zero:

1. `wp_set_post_terms()` treats a scalar `"0"` as empty and removes the term instead of saving it, so the value was never persisted.
2. The header logic used truthy checks (`if ( $value )`) that ignored a stored `"0"`, and compared the final value with `0 === $age` while `$age` was still a string, so even a global max-age setting of `0` produced `max-age=0` instead of `no-store`.

## How

- `MaxAge::save()` passes the term as an array so `"0"` persists. This matches how the IDE's Document Settings already write this taxonomy, so the two stay compatible without a sentinel value.
- `MaxAge::http_headers_cb()` validates the stored value instead of truthy-checking it, compares parsed integers when picking the smallest max-age in a batch, and coerces the final value to an integer before the zero check.

The original PR used a sentinel term name (`zero`). This port stores the literal `"0"` instead, because the IDE reads and writes the same taxonomy term names directly and would otherwise display or save the sentinel.

## Tests

New `tests/wpunit/MaxAgeZeroTest.php` (all six fail before the fix, pass after):

- `0` persists as a term and reads back as `"0"`
- a document with max-age `0` sends `Cache-Control: no-store`
- `0` wins as the minimum in a batch request
- a global max-age setting of `"0"` sends `no-store`
- a non-zero max-age still sends `max-age=N, s-maxage=N, must-revalidate`
- `createGraphqlDocument` with `maxAgeHeader: 0` returns `0` (goes through the mutation path end to end)

PHPCS clean. PHPStan reports no errors in the changed file (the remaining errors it lists are pre-existing in untouched files).
